### PR TITLE
Add KubernetesNode workloadmeta entity backed by full node reflector

### DIFF
--- a/cmd/cluster-agent/api/v1/BUILD.bazel
+++ b/cmd/cluster-agent/api/v1/BUILD.bazel
@@ -34,7 +34,6 @@ go_library(
         "//pkg/util/kubernetes/apiserver/controllers",
         "//pkg/util/log",
         "@com_github_datadog_dd_trace_go_v2//ddtrace/tracer",
-        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/util/sets",
         "@io_k8s_client_go//kubernetes/typed/core/v1:core",
     ],

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -21,7 +21,6 @@ import (
 	apicommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
@@ -51,7 +50,7 @@ func installKubernetesMetadataEndpoints(r *http.ServeMux, wmeta workloadmeta.Com
 func installCloudFoundryMetadataEndpoints(r *http.ServeMux) {}
 
 // getNodeMetadata is only used when the node agent hits the DCA for the list of labels or annotations
-func getNodeMetadata(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.Component, f func(*workloadmeta.KubernetesMetadata) map[string]string, what string, filterList []string) {
+func getNodeMetadata(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.Component, f func(*workloadmeta.KubernetesNode) map[string]string, what string, filterList []string) {
 	/*
 		Input
 			localhost:5001/api/v1/tags/node/localhost
@@ -80,8 +79,7 @@ func getNodeMetadata(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.
 	)
 	defer func() { span.Finish(tracer.WithError(spanErr)) }()
 
-	entityID := util.GenerateKubeMetadataEntityID("", "nodes", "", nodeName)
-	nodeMetadata, err := wmeta.GetKubernetesMetadata(entityID)
+	nodeEntity, err := wmeta.GetKubernetesNode(nodeName)
 	if err != nil {
 		log.Errorf("Could not retrieve the node %s of %s: %v", what, nodeName, err.Error()) //nolint:errcheck
 		spanErr = err
@@ -90,7 +88,7 @@ func getNodeMetadata(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.
 		return
 	}
 
-	nodeData := f(nodeMetadata)
+	nodeData := f(nodeEntity)
 
 	// Filter data to avoid returning too big useless data
 	if filterList != nil {
@@ -121,12 +119,12 @@ func getNodeMetadata(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.
 }
 
 func getNodeLabels(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.Component) {
-	getNodeMetadata(w, r, wmeta, func(km *workloadmeta.KubernetesMetadata) map[string]string { return km.Labels }, "labels", nil)
+	getNodeMetadata(w, r, wmeta, func(n *workloadmeta.KubernetesNode) map[string]string { return n.Labels }, "labels", nil)
 }
 
 func getNodeUID(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.Component) {
-	getNodeMetadata(w, r, wmeta, func(km *workloadmeta.KubernetesMetadata) map[string]string {
-		return map[string]string{"uid": string(km.UID)}
+	getNodeMetadata(w, r, wmeta, func(n *workloadmeta.KubernetesNode) map[string]string {
+		return map[string]string{"uid": n.UID}
 	}, "uid", nil)
 }
 
@@ -149,48 +147,31 @@ func getNodeAnnotations(w http.ResponseWriter, r *http.Request, wmeta workloadme
 		finalFilter = clientFilter
 	}
 
-	getNodeMetadata(w, r, wmeta, func(km *workloadmeta.KubernetesMetadata) map[string]string { return km.Annotations }, "annotations", finalFilter)
+	getNodeMetadata(w, r, wmeta, func(n *workloadmeta.KubernetesNode) map[string]string { return n.Annotations }, "annotations", finalFilter)
 }
 
-func getNodeInfo(w http.ResponseWriter, r *http.Request, _ workloadmeta.Component) {
+func getNodeInfo(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.Component) {
 	nodeName := r.PathValue("nodeName")
 
 	var spanErr error
-	span, ctx := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.node_info",
+	span, _ := tracer.StartSpanFromContext(r.Context(), "cluster_agent.metadata.node_info",
 		tracer.ResourceName("nodeInfo"),
 		tracer.Tag("node_name", nodeName),
 	)
 	defer func() { span.Finish(tracer.WithError(spanErr)) }()
 
-	cl, err := as.GetAPIClient()
+	nodeEntity, err := wmeta.GetKubernetesNode(nodeName)
 	if err != nil {
-		log.Errorf("getNodeInfo: unable to get apiserver: %v", err)
-		spanErr = err
-		api.SetSpanError(w, err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	nodeCl := cl.Cl.CoreV1().Nodes()
-
-	node, err := nodeCl.Get(ctx, nodeName, metav1.GetOptions{})
-	if err != nil {
-		log.Errorf("getNodeInfo: unable to get self node: %v", err)
+		log.Errorf("getNodeInfo: unable to get node from cache: %v", err)
 		spanErr = err
 		api.SetSpanError(w, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	if node == nil {
-		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintf(w, "Could not find node %s", nodeName)
-		return
-	}
-
-	// Marshal whole struct, unmarshal only takes what is needed on caller side.
-	data, err := json.Marshal(&node.Status.NodeInfo)
+	data, err := json.Marshal(&nodeEntity.Status)
 	if err != nil {
-		log.Errorf("getNodeInfo: failed to marshal node %s info %+v: %s", nodeName, &node.Status.NodeInfo, err.Error()) //nolint:errcheck
+		log.Errorf("getNodeInfo: failed to marshal node %s status %+v: %s", nodeName, nodeEntity.Status, err.Error()) //nolint:errcheck
 		spanErr = err
 		api.SetSpanError(w, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_test.go
@@ -36,10 +36,10 @@ func TestGetNodeAnnotations(t *testing.T) {
 		core.MockBundle(),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 	))
-	mockStore.Set(&workloadmeta.KubernetesMetadata{
+	mockStore.Set(&workloadmeta.KubernetesNode{
 		EntityID: workloadmeta.EntityID{
-			Kind: workloadmeta.KindKubernetesMetadata,
-			ID:   "/nodes//" + testNode,
+			Kind: workloadmeta.KindKubernetesNode,
+			ID:   testNode,
 		},
 		EntityMeta: workloadmeta.EntityMeta{
 			Annotations: map[string]string{
@@ -132,10 +132,10 @@ func TestGetNodeUID(t *testing.T) {
 		core.MockBundle(),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 	))
-	mockStore.Set(&workloadmeta.KubernetesMetadata{
+	mockStore.Set(&workloadmeta.KubernetesNode{
 		EntityID: workloadmeta.EntityID{
-			Kind: workloadmeta.KindKubernetesMetadata,
-			ID:   "/nodes//" + testNode,
+			Kind: workloadmeta.KindKubernetesNode,
+			ID:   testNode,
 		},
 		EntityMeta: workloadmeta.EntityMeta{
 			UID: "uid-12345",
@@ -198,10 +198,10 @@ func TestGetNodeMetadata_SpanCreation(t *testing.T) {
 		core.MockBundle(),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 	))
-	mockStore.Set(&workloadmeta.KubernetesMetadata{
+	mockStore.Set(&workloadmeta.KubernetesNode{
 		EntityID: workloadmeta.EntityID{
-			Kind: workloadmeta.KindKubernetesMetadata,
-			ID:   "/nodes//" + testNode,
+			Kind: workloadmeta.KindKubernetesNode,
+			ID:   testNode,
 		},
 		EntityMeta: workloadmeta.EntityMeta{
 			Labels: map[string]string{"label1": "value1"},
@@ -499,6 +499,6 @@ func TestGetNodeInfo_SpanCreation(t *testing.T) {
 	assert.Equal(t, "cluster_agent.metadata.node_info", span.OperationName())
 	assert.Equal(t, "nodeInfo", span.Tag("resource.name"))
 	assert.Equal(t, testNode, span.Tag("node_name"))
-	// Without a real apiserver, GetAPIClient fails, so the span should capture the error
+	// No node entity in the store, so the cache lookup fails and the span captures the error
 	assert.NotNil(t, span.Tag("error.message"))
 }

--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -133,7 +133,8 @@ func (c *WorkloadMetaCollector) processEvents(evBundle workloadmeta.EventBundle)
 		switch ev.Type {
 		case workloadmeta.EventTypeSet:
 			if entityID.Kind == workloadmeta.KindKubeletMetrics ||
-				entityID.Kind == workloadmeta.KindKubelet {
+				entityID.Kind == workloadmeta.KindKubelet ||
+				entityID.Kind == workloadmeta.KindKubernetesNode {
 				// No tags. Ignore
 				continue
 			}

--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -130,15 +130,15 @@ func (c *WorkloadMetaCollector) processEvents(evBundle workloadmeta.EventBundle)
 		entity := ev.Entity
 		entityID := entity.GetID()
 
+		if entityID.Kind == workloadmeta.KindKubeletMetrics ||
+			entityID.Kind == workloadmeta.KindKubelet ||
+			entityID.Kind == workloadmeta.KindKubernetesNode {
+			// No tags. Ignore
+			continue
+		}
+
 		switch ev.Type {
 		case workloadmeta.EventTypeSet:
-			if entityID.Kind == workloadmeta.KindKubeletMetrics ||
-				entityID.Kind == workloadmeta.KindKubelet ||
-				entityID.Kind == workloadmeta.KindKubernetesNode {
-				// No tags. Ignore
-				continue
-			}
-
 			taggerEntityID := common.BuildTaggerEntityID(entityID)
 
 			// keep track of children of this entity from previous

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -4082,6 +4082,45 @@ func TestHandleDelete(t *testing.T) {
 	assert.Empty(t, collector.children)
 }
 
+func TestHandleDeleteKubernetesNode(t *testing.T) {
+	// KubernetesNode entities carry no tags and are excluded from tagging in
+	// processEvents. Deleting one must not panic by falling through to
+	// common.BuildTaggerEntityID, which has no case for KindKubernetesNode.
+
+	node := &workloadmeta.KubernetesNode{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesNode,
+			ID:   "node-foobar",
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name: "node-foobar",
+		},
+	}
+
+	store := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		fx.Provide(func() log.Component { return logmock.New(t) }),
+		fx.Provide(func() config.Component { return config.NewMock(t) }),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+
+	cfg := configmock.New(t)
+	collector := NewWorkloadMetaCollector(context.Background(), cfg, store, nil)
+
+	eventBundle := workloadmeta.EventBundle{
+		Events: []workloadmeta.Event{
+			{
+				Type:   workloadmeta.EventTypeUnset,
+				Entity: node,
+			},
+		},
+		Ch: make(chan struct{}),
+	}
+
+	assert.NotPanics(t, func() {
+		collector.processEvents(eventBundle)
+	})
+}
+
 type fakeProcessor struct {
 	ch chan []*types.TagInfo
 }

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/BUILD.bazel
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "kubeapiserver_nop.go",
         "kueue.go",
         "metadata.go",
+        "node.go",
         "pod.go",
         "reflector_store.go",
         "stub.go",

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -86,7 +86,8 @@ func resourcesWithMetadataCollectionEnabled(cfg config.Reader) []string {
 // resourcesWithRequiredMetadataCollection returns the list of resources that we
 // need to collect metadata from in order to make other enabled features work
 func resourcesWithRequiredMetadataCollection(cfg config.Reader) []string {
-	res := []string{"nodes"} // nodes are always needed
+	// resources that we need to collect metadata from in order to make other enabled features work
+	var res []string
 
 	metadataAsTags := configutils.GetMetadataAsTags(cfg)
 
@@ -239,6 +240,10 @@ func (c *collector) Start(ctx context.Context, wlmetaStore workloadmeta.Componen
 			go reflector.Run(ctx.Done())
 		}
 	}
+
+	nodeReflector, nodeStore := newNodeStore(ctx, wlmetaStore, c.config, client)
+	objectStores = append(objectStores, nodeStore)
+	go nodeReflector.Run(ctx.Done())
 
 	if shouldHavePodStore(c.config) {
 		autoscalingEnabled := c.config.GetBool("autoscaling.workload.enabled")

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -132,7 +132,7 @@ func resourcesWithRequiredMetadataCollection(cfg config.Reader) []string {
 // resourcesWithExplicitMetadataCollectionEnabled returns the list of resources
 // to collect metadata from according to the config options that configure
 // metadata collection
-// Pods and/or Deployments are excluded if they have their separate stores and informers
+// Pods, Deployments and Nodes are excluded if they have their separate stores and informers
 // in order to avoid having two collectors collecting the same data.
 func resourcesWithExplicitMetadataCollectionEnabled(cfg config.Reader) []string {
 	if !cfg.GetBool("cluster_agent.kube_metadata_collection.enabled") {
@@ -149,6 +149,11 @@ func resourcesWithExplicitMetadataCollectionEnabled(cfg config.Reader) []string 
 
 		if strings.HasSuffix(resource, "deployments") {
 			log.Debugf("skipping deployments from metadata collection because a separate deployment store is initialised in workload metadata store.")
+			continue
+		}
+
+		if strings.HasSuffix(resource, "nodes") {
+			log.Debugf("skipping nodes from metadata collection because a separate node store is initialised in workload metadata store.")
 			continue
 		}
 

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -152,7 +152,7 @@ func resourcesWithExplicitMetadataCollectionEnabled(cfg config.Reader) []string 
 			continue
 		}
 
-		if strings.HasSuffix(resource, "nodes") {
+		if group, _, resourceName := parseRequestedResource(resource); group == "" && resourceName == "nodes" {
 			log.Debugf("skipping nodes from metadata collection because a separate node store is initialised in workload metadata store.")
 			continue
 		}

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -693,6 +693,14 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 			expectedResources: []string{"//nodes", "apps//statefulsets", "example.com//custom"},
 		},
 		{
+			name: "non-core resources whose name merely ends in nodes should not be excluded",
+			cfg: map[string]interface{}{
+				"cluster_agent.kube_metadata_collection.enabled":   true,
+				"cluster_agent.kube_metadata_collection.resources": "storage.k8s.io/csinodes metrics.k8s.io/nodes",
+			},
+			expectedResources: []string{"//nodes", "storage.k8s.io//csinodes", "metrics.k8s.io//nodes"},
+		},
+		{
 			name: "namespaces needed for namespace labels as tags",
 			cfg: map[string]interface{}{
 				"kubernetes_namespace_labels_as_tags": map[string]string{

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/node.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/node.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package kubeapiserver
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	kubernetesresourceparsers "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+func newNodeStore(ctx context.Context, wlm workloadmeta.Component, _ config.Reader, client kubernetes.Interface) (*cache.Reflector, *reflectorStore) {
+	nodeListerWatcher := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return client.CoreV1().Nodes().List(ctx, options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return client.CoreV1().Nodes().Watch(ctx, options)
+		},
+	}
+
+	nodeStore := &reflectorStore{
+		wlmetaStore: wlm,
+		seen:        make(map[string]workloadmeta.EntityID),
+		parser:      kubernetesresourceparsers.NewNodeParser(),
+	}
+	nodeReflector := cache.NewNamedReflector(
+		componentName,
+		nodeListerWatcher,
+		&corev1.Node{},
+		nodeStore,
+		noResync,
+	)
+	return nodeReflector, nodeStore
+}

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go
@@ -153,6 +153,8 @@ func (r *reflectorStore) Delete(obj interface{}) error {
 		uid = v.UID
 	case *appsv1.Deployment:
 		uid = v.UID
+	case *corev1.Node:
+		uid = v.UID
 	case *metav1.PartialObjectMetadata:
 		uid = v.UID
 	case *unstructured.Unstructured:
@@ -218,6 +220,11 @@ func entityFromEntityID(entityID workloadmeta.EntityID) (workloadmeta.Entity, er
 	switch entityID.Kind {
 	case workloadmeta.KindKubernetesDeployment:
 		return &workloadmeta.KubernetesDeployment{
+			EntityID: entityID,
+		}, nil
+
+	case workloadmeta.KindKubernetesNode:
+		return &workloadmeta.KubernetesNode{
 			EntityID: entityID,
 		}, nil
 

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
@@ -186,31 +186,21 @@ func Test_AddDelete_PartialObjectMetadata(t *testing.T) {
 // This is a regression test. Unset events notified from Replace() had the
 // expected workloadmeta kind but were always of type
 // *workloadmeta.KubernetesPod instead of the expected type. This mismatch
-// caused a panic in workloadmeta filters like the one used in this test
-// (workloadmeta.IsNodeMetadata).
+// caused a panic in workloadmeta filters like the one used in this test.
 func TestReplace(t *testing.T) {
 	t.Parallel()
-	gvr := schema.GroupVersionResource{
-		Group:    "",
-		Version:  "v1",
-		Resource: "nodes",
-	}
 
-	testNodeMetadata := workloadmeta.KubernetesMetadata{
+	testNodeEntity := workloadmeta.KubernetesNode{
 		EntityID: workloadmeta.EntityID{
-			Kind: workloadmeta.KindKubernetesMetadata,
-			ID:   string(util.GenerateKubeMetadataEntityID("", "nodes", "", "test-node")),
+			Kind: workloadmeta.KindKubernetesNode,
+			ID:   "test-node",
 		},
 		EntityMeta: workloadmeta.EntityMeta{
 			Name: "test-node",
 		},
-		GVR: &gvr,
 	}
 
 	workloadmetaComponent := mockedWorkloadmeta(t)
-
-	parser, err := kubernetesresourceparsers.NewMetadataParser(gvr, nil)
-	require.NoError(t, err)
 
 	ctx, cancel := context.WithDeadline(context.TODO(), time.Now().Add(10*time.Second))
 	defer cancel()
@@ -224,13 +214,7 @@ func TestReplace(t *testing.T) {
 	// the expected type.
 	go func() {
 		defer wg.Done()
-		filter := workloadmeta.NewFilterBuilder().AddKindWithEntityFilter(
-			workloadmeta.KindKubernetesMetadata,
-			func(entity workloadmeta.Entity) bool {
-				metadata := entity.(*workloadmeta.KubernetesMetadata)
-				return workloadmeta.IsNodeMetadata(metadata)
-			},
-		).Build()
+		filter := workloadmeta.NewFilterBuilder().AddKind(workloadmeta.KindKubernetesNode).Build()
 
 		wmetaEventsCh := workloadmetaComponent.Subscribe("test-subscriber", workloadmeta.NormalPriority, filter)
 		defer workloadmetaComponent.Unsubscribe(wmetaEventsCh)
@@ -256,12 +240,12 @@ func TestReplace(t *testing.T) {
 		expectedEvents := []workloadmeta.Event{
 			{
 				Type:       workloadmeta.EventTypeSet,
-				Entity:     &testNodeMetadata,
+				Entity:     &testNodeEntity,
 				IsComplete: true,
 			},
 			{
 				Type:       workloadmeta.EventTypeUnset,
-				Entity:     &testNodeMetadata,
+				Entity:     &testNodeEntity,
 				IsComplete: true,
 			},
 		}
@@ -269,13 +253,13 @@ func TestReplace(t *testing.T) {
 		require.ElementsMatch(t, expectedEvents, events)
 	}()
 
-	metadataStore := &reflectorStore{
+	nodeStore := &reflectorStore{
 		wlmetaStore: workloadmetaComponent,
 		seen:        make(map[string]workloadmeta.EntityID),
-		parser:      parser,
+		parser:      kubernetesresourceparsers.NewNodeParser(),
 	}
 
-	partialObjMetadata := metav1.PartialObjectMetadata{
+	testNode := corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-node",
 		},
@@ -289,10 +273,10 @@ func TestReplace(t *testing.T) {
 	// events, and we would not be able to check what we want in this test.
 	<-receivedInitialBundle
 
-	err = metadataStore.Add(&partialObjMetadata)
+	err := nodeStore.Add(&testNode)
 	require.NoError(t, err)
 
-	err = metadataStore.Replace(nil, "")
+	err = nodeStore.Replace(nil, "")
 	require.NoError(t, err)
 
 	wg.Wait()

--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/BUILD.bazel
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "deployment.go",
         "kueue.go",
         "metadata.go",
+        "node.go",
         "parser.go",
         "pod.go",
         "utils.go",

--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/node.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/node.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package kubernetesresourceparsers
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+type nodeParser struct{}
+
+// NewNodeParser returns an ObjectParser for corev1.Node objects.
+func NewNodeParser() ObjectParser {
+	return nodeParser{}
+}
+
+func (p nodeParser) Parse(obj interface{}) workloadmeta.Entity {
+	node := obj.(*corev1.Node)
+	return &workloadmeta.KubernetesNode{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesNode,
+			ID:   node.Name,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:        node.Name,
+			Labels:      node.Labels,
+			Annotations: node.Annotations,
+			UID:         string(node.UID),
+		},
+		Status: workloadmeta.KubernetesNodeStatus{
+			KubeletVersion:          node.Status.NodeInfo.KubeletVersion,
+			KernelVersion:           node.Status.NodeInfo.KernelVersion,
+			OSImage:                 node.Status.NodeInfo.OSImage,
+			ContainerRuntimeVersion: node.Status.NodeInfo.ContainerRuntimeVersion,
+			Architecture:            node.Status.NodeInfo.Architecture,
+			OperatingSystem:         node.Status.NodeInfo.OperatingSystem,
+		},
+	}
+}

--- a/comp/core/workloadmeta/def/component.go
+++ b/comp/core/workloadmeta/def/component.go
@@ -74,6 +74,13 @@ type Component interface {
 	// the entity with kind KindKubernetesDeployment and the given ID.
 	GetKubernetesDeployment(id string) (*KubernetesDeployment, error)
 
+	// GetKubernetesNode returns metadata about a Kubernetes node. It fetches
+	// the entity with kind KindKubernetesNode and the given node name as ID.
+	GetKubernetesNode(name string) (*KubernetesNode, error)
+
+	// ListKubernetesNodes returns metadata about all known Kubernetes nodes.
+	ListKubernetesNodes() []*KubernetesNode
+
 	// GetKubernetesKueueQueue returns metadata about a Kubernetes Kueue queue. It fetches
 	// the entity with kind KindKubernetesKueueQueue and the given ID. The ID includes
 	// the queue type, so LocalQueue and ClusterQueue entities are distinct.

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -49,6 +49,7 @@ const (
 	KindKubeletMetrics                Kind = "kubelet_metrics"
 	KindKubeCapabilities              Kind = "kubernetes_capabilities"
 	KindKubernetesDeployment          Kind = "kubernetes_deployment"
+	KindKubernetesNode                Kind = "kubernetes_node"
 	KindKubernetesKueueQueue          Kind = "kubernetes_kueue_queue"
 	KindKubernetesKueueResourceFlavor Kind = "kubernetes_kueue_resource_flavor"
 	KindKubernetesKueueWorkload       Kind = "kubernetes_kueue_workload"
@@ -1202,6 +1203,66 @@ func (m *KubernetesMetadata) Merge(e Entity) error {
 
 	return merge(m, mm)
 }
+
+// KubernetesNodeStatus contains status information for a Kubernetes node.
+// Field names mirror the json tags of corev1.NodeSystemInfo for wire compatibility.
+type KubernetesNodeStatus struct {
+	KubeletVersion          string `json:"kubeletVersion"`
+	KernelVersion           string `json:"kernelVersion"`
+	OSImage                 string `json:"osImage"`
+	ContainerRuntimeVersion string `json:"containerRuntimeVersion"`
+	Architecture            string `json:"architecture"`
+	OperatingSystem         string `json:"operatingSystem"`
+}
+
+// KubernetesNode is an Entity representing a Kubernetes Node.
+type KubernetesNode struct {
+	EntityID
+	EntityMeta
+	Status KubernetesNodeStatus
+}
+
+// GetID implements Entity#GetID.
+func (n *KubernetesNode) GetID() EntityID {
+	return n.EntityID
+}
+
+// Merge implements Entity#Merge.
+func (n *KubernetesNode) Merge(e Entity) error {
+	nn, ok := e.(*KubernetesNode)
+	if !ok {
+		return fmt.Errorf("cannot merge KubernetesNode with different kind %T", e)
+	}
+
+	return merge(n, nn)
+}
+
+// DeepCopy implements Entity#DeepCopy.
+func (n KubernetesNode) DeepCopy() Entity {
+	cn := deepcopy.Copy(n).(KubernetesNode)
+	return &cn
+}
+
+// String implements Entity#String.
+func (n KubernetesNode) String(verbose bool) string {
+	var sb strings.Builder
+	_, _ = fmt.Fprintln(&sb, "----------- Entity ID -----------")
+	_, _ = fmt.Fprint(&sb, n.EntityID.String(verbose))
+	_, _ = fmt.Fprintln(&sb, "----------- Entity Meta -----------")
+	_, _ = fmt.Fprint(&sb, n.EntityMeta.String(verbose))
+	if verbose {
+		_, _ = fmt.Fprintln(&sb, "----------- Node Status -----------")
+		_, _ = fmt.Fprintln(&sb, "KubeletVersion:", n.Status.KubeletVersion)
+		_, _ = fmt.Fprintln(&sb, "KernelVersion:", n.Status.KernelVersion)
+		_, _ = fmt.Fprintln(&sb, "OSImage:", n.Status.OSImage)
+		_, _ = fmt.Fprintln(&sb, "ContainerRuntimeVersion:", n.Status.ContainerRuntimeVersion)
+		_, _ = fmt.Fprintln(&sb, "Architecture:", n.Status.Architecture)
+		_, _ = fmt.Fprintln(&sb, "OperatingSystem:", n.Status.OperatingSystem)
+	}
+	return sb.String()
+}
+
+var _ Entity = &KubernetesNode{}
 
 // KubeletMetrics contains collection-level metrics from the kubelet
 type KubeletMetrics struct {

--- a/comp/core/workloadmeta/impl/dump.go
+++ b/comp/core/workloadmeta/impl/dump.go
@@ -35,6 +35,8 @@ func (w *workloadmeta) Dump(verbose bool) wmdef.WorkloadDumpResponse {
 			info = e.String(verbose)
 		case *wmdef.KubernetesMetadata:
 			info = e.String(verbose)
+		case *wmdef.KubernetesNode:
+			info = e.String(verbose)
 		case *wmdef.GPU:
 			info = e.String(verbose)
 		case *wmdef.Kubelet:

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -422,6 +422,28 @@ func (w *workloadmeta) GetKubernetesPodForContainer(containerID string) (*wmdef.
 	return pod.cached.(*wmdef.KubernetesPod), nil
 }
 
+// GetKubernetesNode implements Store#GetKubernetesNode.
+func (w *workloadmeta) GetKubernetesNode(name string) (*wmdef.KubernetesNode, error) {
+	entity, err := w.getEntityByKind(wmdef.KindKubernetesNode, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return entity.(*wmdef.KubernetesNode), nil
+}
+
+// ListKubernetesNodes implements Store#ListKubernetesNodes.
+func (w *workloadmeta) ListKubernetesNodes() []*wmdef.KubernetesNode {
+	entities := w.listEntitiesByKind(wmdef.KindKubernetesNode)
+
+	nodes := make([]*wmdef.KubernetesNode, 0, len(entities))
+	for _, entity := range entities {
+		nodes = append(nodes, entity.(*wmdef.KubernetesNode))
+	}
+
+	return nodes
+}
+
 // GetKubernetesDeployment implements Store#GetKubernetesDeployment
 func (w *workloadmeta) GetKubernetesDeployment(id string) (*wmdef.KubernetesDeployment, error) {
 	entity, err := w.getEntityByKind(wmdef.KindKubernetesDeployment, id)

--- a/comp/core/workloadmeta/impl/store_test.go
+++ b/comp/core/workloadmeta/impl/store_test.go
@@ -128,10 +128,10 @@ func TestSubscribe(t *testing.T) {
 		},
 	}
 
-	testNodeMetadata := wmdef.KubernetesMetadata{
+	testNodeMetadata := wmdef.KubernetesNode{
 		EntityID: wmdef.EntityID{
-			Kind: wmdef.KindKubernetesMetadata,
-			ID:   string(util.GenerateKubeMetadataEntityID("", "nodes", "", "test-node")),
+			Kind: wmdef.KindKubernetesNode,
+			ID:   "test-node",
 		},
 		EntityMeta: wmdef.EntityMeta{
 			Name: "test-node",
@@ -141,10 +141,6 @@ func TestSubscribe(t *testing.T) {
 			Annotations: map[string]string{
 				"test-annotation": "test-value",
 			},
-		},
-		GVR: &schema.GroupVersionResource{
-			Version:  "v1",
-			Resource: "nodes",
 		},
 	}
 
@@ -638,24 +634,16 @@ func TestSubscribe(t *testing.T) {
 						Source: fooSource,
 						// Notice that this unset event does not contain the
 						// full entity.
-						Entity: &wmdef.KubernetesMetadata{
+						Entity: &wmdef.KubernetesNode{
 							EntityID: wmdef.EntityID{
-								Kind: wmdef.KindKubernetesMetadata,
+								Kind: wmdef.KindKubernetesNode,
 								ID:   testNodeMetadata.ID,
 							},
 						},
 					},
 				},
 			},
-			filter: wmdef.NewFilterBuilder().AddKindWithEntityFilter(
-				wmdef.KindKubernetesMetadata,
-				func(entity wmdef.Entity) bool {
-					metadata := entity.(*wmdef.KubernetesMetadata)
-					// Notice that this filter relies on data that is not
-					// available in the unset event.
-					return wmdef.IsNodeMetadata(metadata)
-				},
-			).Build(),
+			filter: wmdef.NewFilterBuilder().AddKind(wmdef.KindKubernetesNode).Build(),
 			expected: []wmdef.EventBundle{
 				{},
 				{
@@ -1806,22 +1794,6 @@ func TestGetKubernetesNodeByName(t *testing.T) {
 func TestListKubernetesMetadata(t *testing.T) {
 	wmeta := newWorkloadmetaObject(t)
 
-	nodeMetadata := wmdef.KubernetesMetadata{
-		EntityID: wmdef.EntityID{
-			Kind: wmdef.KindKubernetesMetadata,
-			ID:   string(util.GenerateKubeMetadataEntityID("", "nodes", "", "node1")),
-		},
-		EntityMeta: wmdef.EntityMeta{
-			Name:        "node1",
-			Annotations: map[string]string{"a1": "v1"},
-			Labels:      map[string]string{"l1": "v2"},
-		},
-		GVR: &schema.GroupVersionResource{
-			Version:  "v1",
-			Resource: "nodes",
-		},
-	}
-
 	deploymentMetadata := wmdef.KubernetesMetadata{
 		EntityID: wmdef.EntityID{
 			Kind: wmdef.KindKubernetesMetadata,
@@ -1840,11 +1812,23 @@ func TestListKubernetesMetadata(t *testing.T) {
 		},
 	}
 
+	nodeEntity := wmdef.KubernetesNode{
+		EntityID: wmdef.EntityID{
+			Kind: wmdef.KindKubernetesNode,
+			ID:   "node1",
+		},
+		EntityMeta: wmdef.EntityMeta{
+			Name:        "node1",
+			Annotations: map[string]string{"a1": "v1"},
+			Labels:      map[string]string{"l1": "v2"},
+		},
+	}
+
 	wmeta.handleEvents([]wmdef.CollectorEvent{
 		{
 			Type:   wmdef.EventTypeSet,
 			Source: fooSource,
-			Entity: &nodeMetadata,
+			Entity: &nodeEntity,
 		},
 		{
 			Type:   wmdef.EventTypeSet,
@@ -1853,7 +1837,8 @@ func TestListKubernetesMetadata(t *testing.T) {
 		},
 	})
 
-	assert.ElementsMatch(t, []*wmdef.KubernetesMetadata{&nodeMetadata}, wmeta.ListKubernetesMetadata(wmdef.IsNodeMetadata))
+	assert.ElementsMatch(t, []*wmdef.KubernetesNode{&nodeEntity}, wmeta.ListKubernetesNodes())
+	assert.ElementsMatch(t, []*wmdef.KubernetesMetadata{&deploymentMetadata}, wmeta.ListKubernetesMetadata(nil))
 }
 
 func TestReset(t *testing.T) {

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/BUILD.bazel
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "//cmd/cluster-agent/admission",
         "//comp/core/config",
         "//comp/core/workloadfilter/def",
-        "//comp/core/workloadmeta/collectors/util",
         "//comp/core/workloadmeta/def",
         "//pkg/clusteragent/admission/common",
         "//pkg/clusteragent/admission/metrics",

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -35,7 +35,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
@@ -416,11 +415,9 @@ func (ci *CWSInstrumentation) resolveNodeArchMeasured(nodeName string, apiClient
 func (ci *CWSInstrumentation) resolveNodeArch(nodeName string, apiClient kubernetes.Interface) (string, error) {
 	var arch string
 	// try with the wmeta
-	entityID := util.GenerateKubeMetadataEntityID("", "nodes", "", nodeName)
-
-	out, err := ci.wmeta.GetKubernetesMetadata(entityID)
+	out, err := ci.wmeta.GetKubernetesNode(nodeName)
 	if err == nil && out != nil {
-		arch = out.Labels["kubernetes.io/arch"]
+		arch = out.Status.Architecture
 	}
 
 	if out == nil {

--- a/pkg/util/kubernetes/apiserver/controllers/metadata_controller.go
+++ b/pkg/util/kubernetes/apiserver/controllers/metadata_controller.go
@@ -128,13 +128,7 @@ func (m *metadataController) run(stopCh <-chan struct{}) {
 		return
 	}
 
-	filter := workloadmeta.NewFilterBuilder().AddKindWithEntityFilter(
-		workloadmeta.KindKubernetesMetadata,
-		func(entity workloadmeta.Entity) bool {
-			metadata := entity.(*workloadmeta.KubernetesMetadata)
-			return workloadmeta.IsNodeMetadata(metadata)
-		},
-	).Build()
+	filter := workloadmeta.NewFilterBuilder().AddKind(workloadmeta.KindKubernetesNode).Build()
 
 	wmetaEventsCh := m.wmeta.Subscribe(
 		"metadata-controller",
@@ -174,7 +168,7 @@ func (m *metadataController) processWorkloadmetaNodeMetadataEvents(wmetaEventsCh
 		eventBundle.Acknowledge()
 
 		for _, event := range eventBundle.Events {
-			node := event.Entity.(*workloadmeta.KubernetesMetadata)
+			node := event.Entity.(*workloadmeta.KubernetesNode)
 
 			switch event.Type {
 			case workloadmeta.EventTypeSet:
@@ -549,7 +543,7 @@ func (m *metadataController) getCachedServiceName(namespace, sliceName string) s
 
 // deleteService removes a service's metadata from all nodes.
 func (m *metadataController) deleteService(namespace, svc string) error {
-	nodes := m.wmeta.ListKubernetesMetadata(workloadmeta.IsNodeMetadata)
+	nodes := m.wmeta.ListKubernetesNodes()
 
 	// Delete the service from the metadata bundle for each node.
 	for _, node := range nodes {

--- a/pkg/util/kubernetes/apiserver/controllers/metadata_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/controllers/metadata_controller_test.go
@@ -20,7 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
@@ -79,17 +78,13 @@ func TestMetadataControllerSyncEndpoints(t *testing.T) {
 			"metadata-controller",
 			workloadmeta.Event{
 				Type: workloadmeta.EventTypeSet,
-				Entity: &workloadmeta.KubernetesMetadata{
+				Entity: &workloadmeta.KubernetesNode{
 					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindKubernetesMetadata,
+						Kind: workloadmeta.KindKubernetesNode,
 						ID:   nodeName,
 					},
 					EntityMeta: workloadmeta.EntityMeta{
 						Name: nodeName,
-					},
-					GVR: &schema.GroupVersionResource{
-						Version:  "v1",
-						Resource: "nodes",
 					},
 				},
 			},
@@ -99,7 +94,7 @@ func TestMetadataControllerSyncEndpoints(t *testing.T) {
 
 	// Wait until the workloadmeta events have been processed
 	require.Eventually(t, func() bool {
-		return len(metaController.wmeta.ListKubernetesMetadata(workloadmeta.IsNodeMetadata)) == 3
+		return len(metaController.wmeta.ListKubernetesNodes()) == 3
 	}, 5*time.Second, 100*time.Millisecond)
 
 	tests := []struct {
@@ -401,17 +396,13 @@ func TestMetadataControllerSyncEndpointSlices(t *testing.T) {
 			"metadata-controller",
 			workloadmeta.Event{
 				Type: workloadmeta.EventTypeSet,
-				Entity: &workloadmeta.KubernetesMetadata{
+				Entity: &workloadmeta.KubernetesNode{
 					EntityID: workloadmeta.EntityID{
-						Kind: workloadmeta.KindKubernetesMetadata,
+						Kind: workloadmeta.KindKubernetesNode,
 						ID:   nodeName,
 					},
 					EntityMeta: workloadmeta.EntityMeta{
 						Name: nodeName,
-					},
-					GVR: &schema.GroupVersionResource{
-						Version:  "v1",
-						Resource: "nodes",
 					},
 				},
 			},
@@ -420,7 +411,7 @@ func TestMetadataControllerSyncEndpointSlices(t *testing.T) {
 	}
 
 	require.Eventually(t, func() bool {
-		return len(metaController.wmeta.ListKubernetesMetadata(workloadmeta.IsNodeMetadata)) == 3
+		return len(metaController.wmeta.ListKubernetesNodes()) == 3
 	}, 5*time.Second, 100*time.Millisecond)
 
 	tests := []struct {

--- a/releasenotes-dca/notes/kubernetes-node-single-listwatch-4b280ce5eb6bdde6.yaml
+++ b/releasenotes-dca/notes/kubernetes-node-single-listwatch-4b280ce5eb6bdde6.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The Cluster Agent now uses a single ``ListWatch`` call to track Kubernetes
+    Node metadata, instead of one call per node.


### PR DESCRIPTION
### What does this PR do?

Replace the per-node-request API Server calls with a single corev1.Node reflector that populates a new KubernetesNode workloadmeta entity. This entity stores labels, annotations, UID, and NodeStatus (kubelet version, kernel version, OS image, container runtime, architecture, OS).

The new typed reflector replaces the existing PartialObjectMetadata reflector for nodes, keeping a single node reflector. All four Cluster Agent node HTTP handlers (labels, annotations, UID, info) now read from the workloadmeta cache. The metadata_controller is updated to subscribe to KindKubernetesNode instead of filtering KubernetesMetadata by GVR.

### Motivation

The Cluster Agent's /info/node/{nodeName} endpoint was making a live CoreV1().Nodes().Get() call per request. On 10k-node clusters this flooded the rate-limited API Server client queue at startup.

Closes CONTP-1805

### Describe how you validated your changes

Unit tests and CI

Test on internal cluster:

<img width="1476" height="682" alt="image" src="https://github.com/user-attachments/assets/c296377a-3f79-4d02-af0c-6c173bcdfc14" />

### Additional Notes

Note, I think that we might end up building 2 reflectors for the nodes still with this PR. There are more involved changes that need to be made to fix the functionality of nodeLabelsAsTags to not create a separate reflector via the deprecated generic KuberetesMetadata wmeta object. A subsequent PR will be made to cover these cases.