### PR TITLE
fix(aix): update stale libffi version-label to 3.4.8

### DIFF
--- a/packaging/aix/stages/01-native-libs.sh
+++ b/packaging/aix/stages/01-native-libs.sh
@@ -70,7 +70,8 @@ LIBXML2_VERSION="2.15.3"    # built from source (AIX Toolbox also available but 
 LIBXSLT_VERSION="1.1.45"   # from AIX Toolbox (yum install libxslt-devel; source build fails on AIX)
 
 # These are sourced from AIX Toolbox (build from source fails on AIX)
-LIBFFI_VERSION="3.4.4"     # yum install libffi-devel
+LIBFFI_VERSION="3.4.8"     # yum install libffi-devel; nominal label only — the
+                           # AIX Toolbox always wins regardless of this value
 NCURSES_VERSION="6.5"      # yum install ncurses-devel
 READLINE_VERSION="8.2"     # yum install readline-devel
 SQLITE_VERSION="3.53.2"    # built from source (amalgamation)


### PR DESCRIPTION
### What does this PR do?

Updates the libffi version label tracked in the AIX build script from 3.4.4 to 3.4.8.

### Motivation

The label had drifted from the libffi version tracked for other platforms (deps/repos.MODULE.bazel). This is cosmetic only: the actual library always comes from the AIX Toolbox regardless of this value.

### Describe how you validated your changes

A full AIX build was made and validated on an AIX host.

### Additional Notes