### PR TITLE
fix(aix): add /usr/bin/datadog-agent convenience symlink

### DIFF
--- a/CHANGELOG-AIX.md
+++ b/CHANGELOG-AIX.md
@@ -10,6 +10,8 @@
 
 <!-- Add entries here for changes not yet in a release. -->
 
+- Add a `/usr/bin/datadog-agent` convenience symlink to the agent wrapper on install, matching the Linux packages
+
 
 ---
 

--- a/packaging/aix/package-scripts/postinst
+++ b/packaging/aix/package-scripts/postinst
@@ -70,6 +70,12 @@ if [ -f /etc/datadog-agent/datadog.yaml ]; then
     startsrc -s datadog-agent-data-plane 2>/dev/null || true
 fi
 
+# Convenience symlink so operators can run `datadog-agent` without the full
+# path, matching the Linux packages' /usr/bin/datadog-agent symlink. Not part
+# of the package file manifest (see unconfig for removal) since /usr/bin is
+# owned by the base AIX filesets, not this package.
+ln -sf /opt/datadog-agent/bin/agent/agent /usr/bin/datadog-agent 2>/dev/null || true
+
 # Compile Python bytecode.
 # LIBPATH must include the embedded Python libs; the installp shell context does not
 # set LIBPATH, so we set it explicitly here.

--- a/packaging/aix/package-scripts/unconfig
+++ b/packaging/aix/package-scripts/unconfig
@@ -22,6 +22,9 @@ rm -rf /var/run/datadog 2>/dev/null || true
 # Remove files written at runtime or by preinst that are not in the package
 # file list and would otherwise prevent installp from removing the directories.
 rm -f /opt/datadog-agent/.profile 2>/dev/null || true
+# Convenience symlink created by postinst (see there) — not in the package
+# file manifest since /usr/bin is owned by the base AIX filesets.
+rm -f /usr/bin/datadog-agent 2>/dev/null || true
 # Python stdlib __pycache__ .pyc files created at runtime (not in package).
 find /opt/datadog-agent -name "*.pyc" -type f -exec rm -f {} \; 2>/dev/null || true
 rm -rf /opt/datadog-agent/run 2>/dev/null || true


### PR DESCRIPTION
### What does this PR do?

Adds a `/usr/bin/datadog-agent` symlink to the agent wrapper, created in `postinst` and removed in `unconfig`.

### Motivation

Linux packages create `/usr/bin/datadog-agent` (and `/usr/bin/datadog-installer`) convenience symlinks. On AIX, operators previously always had to use the full `/opt/datadog-agent/bin/agent/agent` path.

### Describe how you validated your changes

A full AIX build was made and validated on an AIX host.

### Additional Notes