### PR TITLE
docs(aix): explain why Python is built --without-mimalloc

### DIFF
--- a/packaging/aix/stages/02-python.sh
+++ b/packaging/aix/stages/02-python.sh
@@ -334,6 +334,11 @@ log "AIX patching complete."
 #   headers and libs ARE during the build, not $EMBEDDED which is the final path)
 # --with-dbmliborder=gdbm : use gdbm built in Stage 1
 # --without-ensurepip : we bootstrap pip manually below (step 7)
+# --without-mimalloc : mimalloc keeps a per-thread arena cache using native TLS
+#   (thread_local/__thread), which hits the same AIX local-exec/shared-library
+#   incompatibility that Step 3 above patches around in pystate.c. Rather than
+#   patch mimalloc too, disable it; Python falls back to its default pymalloc
+#   allocator.
 # ac_cv_header_libintl_h=no / ac_cv_lib_intl_textdomain=no : suppress libintl link.
 #   Python's configure tests for libintl.h (ac_cv_header_libintl_h) and then
 #   textdomain() in -lintl (ac_cv_lib_intl_textdomain). If both pass, it adds


### PR DESCRIPTION
### What does this PR do?

Adds a comment explaining why the AIX Python build passes `--without-mimalloc`.

### Motivation

Every other AIX-specific configure flag in this block has an explanatory comment; this one didn't, making it look like unexplained drift. mimalloc keeps a per-thread arena cache using native TLS, which hits the same local-exec/shared-library incompatibility already patched around for `pystate.c`.

### Describe how you validated your changes
Comment-only change, no behavior change.

### Additional Notes

