### PR TITLE
docs(aix): remove stale python patch validation comment

### DIFF
--- a/packaging/aix/stages/02-python.sh
+++ b/packaging/aix/stages/02-python.sh
@@ -92,16 +92,15 @@ log "Extraction complete."
 
 # ─── Step 3: Apply AIX patches ───────────────────────────────────────────────
 #
-# NOTE: These patches were identified from datadog-unix-agent's AIX patches for
-# Python 3.8 (omnibus/config/patches/python3/). For Python 3.13, patch offsets
-# will have shifted and some may no longer apply or may not be needed at all.
-# We use sed-based substitutions rather than patch(1) files to avoid offset
-# sensitivity. If a patch no longer applies (pattern not found), we log a
-# warning rather than failing — it may mean the upstream fixed the issue.
+# NOTE: These patches were originally identified from datadog-unix-agent's AIX
+# patches for Python 3.8 (omnibus/config/patches/python3/). We use sed-based
+# substitutions rather than patch(1) files to avoid offset sensitivity. If a
+# patch no longer applies (pattern not found), we log a warning rather than
+# failing — it may mean the upstream fixed the issue.
 #
-# IMPORTANT: Validate all patches by doing a trial build of Python 3.13.12 on
-# AIX before finalising this script. Add or remove sed substitutions based on
-# actual configure/compile errors encountered.
+# Validated end-to-end on AIX 7.2 TL2 (POWER8): this stage builds
+# $PYTHON_VERSION successfully, and the resulting embedded interpreter runs
+# checks (rtloader + psutil + cpu/disk checks) correctly under the full agent.
 
 log "Applying AIX-specific patches to Python ${PYTHON_VERSION} source"
 

--- a/packaging/aix/stages/02-python.sh
+++ b/packaging/aix/stages/02-python.sh
@@ -92,15 +92,9 @@ log "Extraction complete."
 
 # ─── Step 3: Apply AIX patches ───────────────────────────────────────────────
 #
-# NOTE: These patches were originally identified from datadog-unix-agent's AIX
-# patches for Python 3.8 (omnibus/config/patches/python3/). We use sed-based
-# substitutions rather than patch(1) files to avoid offset sensitivity. If a
-# patch no longer applies (pattern not found), we log a warning rather than
-# failing — it may mean the upstream fixed the issue.
-#
-# Validated end-to-end on AIX 7.2 TL2 (POWER8): this stage builds
-# $PYTHON_VERSION successfully, and the resulting embedded interpreter runs
-# checks (rtloader + psutil + cpu/disk checks) correctly under the full agent.
+# NOTE: We use sed-based substitutions rather than patch(1) files to avoid offset
+# sensitivity. If a patch no longer applies (pattern not found), we log a warning
+# rather than failing — it may mean the upstream fixed the issue.
 
 log "Applying AIX-specific patches to Python ${PYTHON_VERSION} source"
 


### PR DESCRIPTION
### What does this PR do?

Updates the stale comment above the AIX Python source patches to reflect that they've now been validated on real hardware.

### Motivation

The comment carried an unresolved "IMPORTANT: validate all patches by doing a trial build... before finalising this script" warning and a hardcoded reference to an old Python version. A full AIX build now confirms the patches apply cleanly and produce a working embedded interpreter.

### Describe how you validated your changes

A full AIX build was made and validated on an AIX host.

### Additional Notes

Comment-only change, no behavior change.