### PR TITLE
fix(aix): make the pymqi CMQC endian patch idempotent

### DIFF
--- a/packaging/aix/stages/06-python-extensions.sh
+++ b/packaging/aix/stages/06-python-extensions.sh
@@ -307,9 +307,13 @@ if [ ! -f "$PYMQI_CMQC" ]; then
     log "ERROR: pymqi CMQC.py not found at expected path: $PYMQI_CMQC"
     exit 1
 fi
-patch "$PYMQI_CMQC" < "$SCRIPT_DIR/../patches/pymqi-CMQC-aix-endian.patch"
+if grep -q 'MQENC_NATIVE = 0x00000111' "$PYMQI_CMQC" 2>/dev/null; then
+    log "pymqi CMQC.py already patched — skipping (pip left the previous install in place)"
+else
+    patch "$PYMQI_CMQC" < "$SCRIPT_DIR/../patches/pymqi-CMQC-aix-endian.patch"
+    log "pymqi CMQC.py patched: MQENC_NATIVE 0x222→0x111 (AIX big-endian)"
+fi
 find "$(dirname "$PYMQI_CMQC")/__pycache__" -name "CMQC.cpython-*.pyc" -delete 2>/dev/null || true
-log "pymqi CMQC.py patched: MQENC_NATIVE 0x222→0x111 (AIX big-endian)"
 
 # ─── Step 6: pyodbc (conditional — unixODBC headers required) ─────────────────
 #


### PR DESCRIPTION
### What does this PR do?

Skips re-applying the pymqi `CMQC.py` endianness patch if it's already applied.

### Motivation

Found while re-running the build during validation of other AIX fixes: if pip skips reinstalling pymqi (already satisfied from a previous run of this stage), `CMQC.py` is already patched and `patch(1)` fails with "Reversed (or previously applied) patch detected!", aborting the stage on any re-run.

### Describe how you validated your changes

A full AIX build was made and validated on an AIX host.

### Additional Notes