### PR TITLE
Make DDOT experiment collector read experiment otel-config and add co…

### DIFF
--- a/pkg/fleet/installer/config/config_test.go
+++ b/pkg/fleet/installer/config/config_test.go
@@ -650,6 +650,101 @@ func TestConfig_SimpleStartStop(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+// otelConfigSeed is a minimal but realistic DDOT collector config (a subset of
+// cmd/otel-agent/dist/otel-config.yaml) used to exercise config experiments against the deeply
+// nested /otel-config.yaml file.
+const otelConfigSeed = `receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+exporters:
+  debug:
+    verbosity: detailed
+processors:
+  infraattributes:
+    cardinality: 2
+service:
+  pipelines:
+    traces:
+      receivers:
+      - otlp
+      processors:
+      - infraattributes
+      exporters:
+      - debug
+`
+
+func TestConfig_OTelConfigStartPromote(t *testing.T) {
+	stableDir := t.TempDir()
+	experimentDir := t.TempDir()
+
+	assert.NoError(t, os.WriteFile(filepath.Join(stableDir, "otel-config.yaml"), []byte(otelConfigSeed), 0640))
+
+	dirs := &Directories{StablePath: stableDir, ExperimentPath: experimentDir}
+
+	err := dirs.WriteExperiment(context.Background(), Operations{
+		DeploymentID: "otel-exp-001",
+		FileOperations: []FileOperation{
+			// Deep-merge a nested collector value without clobbering sibling keys.
+			{FileOperationType: FileOperationMergePatch, FilePath: "/otel-config.yaml", Patch: []byte(`{"processors":{"infraattributes":{"cardinality":1}}}`)},
+			// jq transform on the same nested config.
+			{FileOperationType: FileOperationJQ, FilePath: "/otel-config.yaml", Transform: `.exporters.debug.verbosity = "normal"`},
+		},
+	})
+	assert.NoError(t, err)
+
+	err = dirs.PromoteExperiment(context.Background())
+	assert.NoError(t, err)
+
+	// After promote the stable config reflects the merge-patch + jq transform with sibling keys preserved.
+	// (Asserted on the stable dir so the test is OS-agnostic: nix applies the ops in the experiment
+	// dir and swaps on promote, Windows applies them in place to the stable dir.)
+	stableContent, err := os.ReadFile(filepath.Join(stableDir, "otel-config.yaml"))
+	assert.NoError(t, err)
+	assertOTelExperimentConfig(t, string(stableContent))
+}
+
+func TestConfig_OTelConfigStartStop(t *testing.T) {
+	stableDir := t.TempDir()
+	experimentDir := t.TempDir()
+
+	assert.NoError(t, os.WriteFile(filepath.Join(stableDir, "otel-config.yaml"), []byte(otelConfigSeed), 0640))
+	original, err := os.ReadFile(filepath.Join(stableDir, "otel-config.yaml"))
+	assert.NoError(t, err)
+
+	dirs := &Directories{StablePath: stableDir, ExperimentPath: experimentDir}
+
+	err = dirs.WriteExperiment(context.Background(), Operations{
+		DeploymentID: "otel-exp-002",
+		FileOperations: []FileOperation{
+			{FileOperationType: FileOperationMergePatch, FilePath: "/otel-config.yaml", Patch: []byte(`{"processors":{"infraattributes":{"cardinality":1}}}`)},
+		},
+	})
+	assert.NoError(t, err)
+
+	// Rolling back restores the stable config to its original content (OS-agnostic).
+	err = dirs.RemoveExperiment(context.Background())
+	assert.NoError(t, err)
+
+	stableContent, err := os.ReadFile(filepath.Join(stableDir, "otel-config.yaml"))
+	assert.NoError(t, err)
+	assert.Equal(t, string(original), string(stableContent))
+}
+
+// assertOTelExperimentConfig checks that both the merge-patch (cardinality 2 -> 1) and the jq
+// transform (verbosity detailed -> normal) were applied while the untouched sibling sections
+// (receivers, service pipelines) survived the deep merge.
+func assertOTelExperimentConfig(t *testing.T, content string) {
+	t.Helper()
+	assert.Contains(t, content, "cardinality: 1")
+	assert.NotContains(t, content, "cardinality: 2")
+	assert.Contains(t, content, "verbosity: normal")
+	assert.NotContains(t, content, "verbosity: detailed")
+	assert.Contains(t, content, "otlp:")
+	assert.Contains(t, content, "pipelines:")
+}
+
 func TestOperationApply_MultipleAPIKeysWithDuplicateKeys(t *testing.T) {
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "datadog.yaml")

--- a/pkg/fleet/installer/packages/BUILD.bazel
+++ b/pkg/fleet/installer/packages/BUILD.bazel
@@ -88,6 +88,7 @@ go_test(
     name = "packages_test",
     srcs = [
         "apm_inject_windows_test.go",
+        "datadog_agent_ddot_linux_test.go",
         "datadog_agent_eudm_windows_test.go",
         "datadog_agent_extensions_test.go",
         "otel_config_common_test.go",

--- a/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
@@ -307,6 +307,11 @@ func copyFile(src, dst string, perm os.FileMode) error {
 	return os.WriteFile(dst, data, perm)
 }
 
+// writeDDOTProcmgrConfig writes the dd-procmgr config for DDOT into the package processes.d. The
+// config's --config/--core-config reference ${DD_CONF_DIR}, which the supervising dd-procmgr
+// substitutes at launch with its own config directory (/etc/datadog-agent for the stable procmgr,
+// /etc/datadog-agent-exp for the experiment procmgr), so the experiment collector reads the
+// experiment config without the process definition itself changing.
 func writeDDOTProcmgrConfig(installRoot string) error {
 	otelAgentPath := filepath.Join(installRoot, "ext", "ddot", "embedded", "bin", "otel-agent")
 	if _, err := os.Stat(otelAgentPath); err != nil {

--- a/pkg/fleet/installer/packages/datadog_agent_ddot_linux_test.go
+++ b/pkg/fleet/installer/packages/datadog_agent_ddot_linux_test.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package packages
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWriteDDOTProcmgrConfig verifies the DDOT dd-procmgr config is written to the package
+// processes.d with a version-specific binary path (rewritten to installRoot) and config paths left
+// as the ${DD_CONF_DIR} placeholder, which the supervising dd-procmgr substitutes at launch with
+// its stable or experiment config directory. It must be a no-op when DDOT is not installed.
+func TestWriteDDOTProcmgrConfig(t *testing.T) {
+	installRoot := t.TempDir()
+	configPath := filepath.Join(installRoot, "processes.d", ddotProcmgrConfigName)
+
+	// No-op when DDOT is not installed (the otel-agent binary is absent).
+	require.NoError(t, writeDDOTProcmgrConfig(installRoot))
+	_, err := os.Stat(configPath)
+	assert.True(t, os.IsNotExist(err), "must not write a procmgr config when DDOT is not installed")
+
+	// Simulate an installed DDOT extension so the writer runs.
+	otelAgentDir := filepath.Join(installRoot, "ext", "ddot", "embedded", "bin")
+	require.NoError(t, os.MkdirAll(otelAgentDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(otelAgentDir, "otel-agent"), []byte("#!/bin/true\n"), 0755))
+
+	require.NoError(t, writeDDOTProcmgrConfig(installRoot))
+	content, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	// Config paths stay as the placeholder (resolved by dd-procmgr per stable/experiment).
+	assert.Contains(t, string(content), "${DD_CONF_DIR}/otel-config.yaml")
+	assert.Contains(t, string(content), "${DD_CONF_DIR}/datadog.yaml")
+	// The binary path is version-specific: rewritten to this installRoot, never left at /opt/datadog-agent.
+	assert.Contains(t, string(content), filepath.Join(installRoot, "ext", "ddot", "embedded", "bin", "otel-agent"))
+	assert.NotContains(t, string(content), "/opt/datadog-agent/")
+
+	// Removal clears the file.
+	require.NoError(t, removeDDOTProcmgrConfig(installRoot))
+	_, err = os.Stat(configPath)
+	assert.True(t, os.IsNotExist(err))
+}

--- a/pkg/fleet/installer/packages/embedded/embed.go
+++ b/pkg/fleet/installer/packages/embedded/embed.go
@@ -30,7 +30,9 @@ var ScriptDDHostInstall []byte
 //go:embed tmpl/gen/debrpm/*.service
 var systemdUnits embed.FS
 
-// DDOTProcessConfig is the rendered process manager config for DDOT (deb/rpm layout).
+// DDOTProcessConfig is the rendered process manager config for DDOT (deb/rpm layout). Its
+// --config/--core-config reference ${DD_CONF_DIR}, which the supervising dd-procmgr substitutes at
+// launch with its config directory (stable or experiment).
 //
 //go:embed tmpl/gen/debrpm/datadog-agent-ddot.yaml
 var DDOTProcessConfig string

--- a/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-ddot.yaml.tmpl
+++ b/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-ddot.yaml.tmpl
@@ -3,9 +3,9 @@ command: {{.InstallDir}}/ext/ddot/embedded/bin/otel-agent
 args:
   - run
   - --config
-  - {{.EtcDir}}/otel-config.yaml
+  - ${DD_CONF_DIR}/otel-config.yaml
   - --core-config
-  - {{.EtcDir}}/datadog.yaml
+  - ${DD_CONF_DIR}/datadog.yaml
   - --pidfile
   - {{.PIDDir}}/run/otel-agent.pid
 auto_start: true
@@ -14,9 +14,9 @@ restart: on-failure
 restart_sec: 2
 start_limit_interval_sec: 10
 start_limit_burst: 5
-environment_file: -{{.EtcDir}}/environment
+environment_file: -${DD_CONF_DIR}/environment
 env:
-  DD_FLEET_POLICIES_DIR: {{.FleetPoliciesDir}}
+  DD_FLEET_POLICIES_DIR: ${DD_CONF_DIR}/managed/datadog-agent/stable
   DD_OTELCOLLECTOR_INSTALLATION_METHOD: bare-metal
 {{- if not .Stable}}
   DD_INVENTORIES_FIRST_RUN_DELAY: "5"

--- a/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-procmgr.service.tmpl
+++ b/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-procmgr.service.tmpl
@@ -18,6 +18,7 @@ User=dd-agent
 Restart=on-failure
 EnvironmentFile=-{{.EtcDir}}/environment
 Environment="DD_PM_CONFIG_DIR={{.InstallDir}}/processes.d"
+Environment="DD_CONF_DIR={{.EtcDir}}"
 RuntimeDirectory=datadog-procmgrd
 ExecStart={{.InstallDir}}/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-ddot-exp.yaml
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-ddot-exp.yaml
@@ -3,9 +3,9 @@ command: /opt/datadog-agent/ext/ddot/embedded/bin/otel-agent
 args:
   - run
   - --config
-  - /etc/datadog-agent-exp/otel-config.yaml
+  - ${DD_CONF_DIR}/otel-config.yaml
   - --core-config
-  - /etc/datadog-agent-exp/datadog.yaml
+  - ${DD_CONF_DIR}/datadog.yaml
   - --pidfile
   - /opt/datadog-agent/run/otel-agent.pid
 auto_start: true
@@ -14,9 +14,9 @@ restart: on-failure
 restart_sec: 2
 start_limit_interval_sec: 10
 start_limit_burst: 5
-environment_file: -/etc/datadog-agent-exp/environment
+environment_file: -${DD_CONF_DIR}/environment
 env:
-  DD_FLEET_POLICIES_DIR: /etc/datadog-agent-exp/managed/datadog-agent/stable
+  DD_FLEET_POLICIES_DIR: ${DD_CONF_DIR}/managed/datadog-agent/stable
   DD_OTELCOLLECTOR_INSTALLATION_METHOD: bare-metal
   DD_INVENTORIES_FIRST_RUN_DELAY: "5"
 stdout: inherit

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-ddot.yaml
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-ddot.yaml
@@ -3,9 +3,9 @@ command: /opt/datadog-agent/ext/ddot/embedded/bin/otel-agent
 args:
   - run
   - --config
-  - /etc/datadog-agent/otel-config.yaml
+  - ${DD_CONF_DIR}/otel-config.yaml
   - --core-config
-  - /etc/datadog-agent/datadog.yaml
+  - ${DD_CONF_DIR}/datadog.yaml
   - --pidfile
   - /opt/datadog-agent/run/otel-agent.pid
 auto_start: true
@@ -14,9 +14,9 @@ restart: on-failure
 restart_sec: 2
 start_limit_interval_sec: 10
 start_limit_burst: 5
-environment_file: -/etc/datadog-agent/environment
+environment_file: -${DD_CONF_DIR}/environment
 env:
-  DD_FLEET_POLICIES_DIR: /etc/datadog-agent/managed/datadog-agent/stable
+  DD_FLEET_POLICIES_DIR: ${DD_CONF_DIR}/managed/datadog-agent/stable
   DD_OTELCOLLECTOR_INSTALLATION_METHOD: bare-metal
 stdout: inherit
 stderr: inherit

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-procmgr-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-procmgr-exp.service
@@ -11,6 +11,7 @@ User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
 Environment="DD_PM_CONFIG_DIR=/opt/datadog-agent/processes.d"
+Environment="DD_CONF_DIR=/etc/datadog-agent-exp"
 RuntimeDirectory=datadog-procmgrd
 ExecStart=/opt/datadog-agent/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-procmgr.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-procmgr.service
@@ -11,6 +11,7 @@ User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
 Environment="DD_PM_CONFIG_DIR=/opt/datadog-agent/processes.d"
+Environment="DD_CONF_DIR=/etc/datadog-agent"
 RuntimeDirectory=datadog-procmgrd
 ExecStart=/opt/datadog-agent/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-ddot-exp.yaml
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-ddot-exp.yaml
@@ -3,9 +3,9 @@ command: /opt/datadog-agent/ext/ddot/embedded/bin/otel-agent
 args:
   - run
   - --config
-  - /etc/datadog-agent-exp/otel-config.yaml
+  - ${DD_CONF_DIR}/otel-config.yaml
   - --core-config
-  - /etc/datadog-agent-exp/datadog.yaml
+  - ${DD_CONF_DIR}/datadog.yaml
   - --pidfile
   - /opt/datadog-agent/run/otel-agent.pid
 auto_start: true
@@ -14,9 +14,9 @@ restart: on-failure
 restart_sec: 2
 start_limit_interval_sec: 10
 start_limit_burst: 5
-environment_file: -/etc/datadog-agent-exp/environment
+environment_file: -${DD_CONF_DIR}/environment
 env:
-  DD_FLEET_POLICIES_DIR: /etc/datadog-agent-exp/managed/datadog-agent/stable
+  DD_FLEET_POLICIES_DIR: ${DD_CONF_DIR}/managed/datadog-agent/stable
   DD_OTELCOLLECTOR_INSTALLATION_METHOD: bare-metal
   DD_INVENTORIES_FIRST_RUN_DELAY: "5"
 stdout: inherit

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-ddot.yaml
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-ddot.yaml
@@ -3,9 +3,9 @@ command: /opt/datadog-agent/ext/ddot/embedded/bin/otel-agent
 args:
   - run
   - --config
-  - /etc/datadog-agent/otel-config.yaml
+  - ${DD_CONF_DIR}/otel-config.yaml
   - --core-config
-  - /etc/datadog-agent/datadog.yaml
+  - ${DD_CONF_DIR}/datadog.yaml
   - --pidfile
   - /opt/datadog-agent/run/otel-agent.pid
 auto_start: true
@@ -14,9 +14,9 @@ restart: on-failure
 restart_sec: 2
 start_limit_interval_sec: 10
 start_limit_burst: 5
-environment_file: -/etc/datadog-agent/environment
+environment_file: -${DD_CONF_DIR}/environment
 env:
-  DD_FLEET_POLICIES_DIR: /etc/datadog-agent/managed/datadog-agent/stable
+  DD_FLEET_POLICIES_DIR: ${DD_CONF_DIR}/managed/datadog-agent/stable
   DD_OTELCOLLECTOR_INSTALLATION_METHOD: bare-metal
 stdout: inherit
 stderr: inherit

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-procmgr-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-procmgr-exp.service
@@ -11,6 +11,7 @@ User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
 Environment="DD_PM_CONFIG_DIR=/opt/datadog-agent/processes.d"
+Environment="DD_CONF_DIR=/etc/datadog-agent-exp"
 RuntimeDirectory=datadog-procmgrd
 ExecStart=/opt/datadog-agent/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-procmgr.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-procmgr.service
@@ -11,6 +11,7 @@ User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
 Environment="DD_PM_CONFIG_DIR=/opt/datadog-agent/processes.d"
+Environment="DD_CONF_DIR=/etc/datadog-agent"
 RuntimeDirectory=datadog-procmgrd
 ExecStart=/opt/datadog-agent/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-ddot-exp.yaml
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-ddot-exp.yaml
@@ -3,9 +3,9 @@ command: /opt/datadog-packages/datadog-agent/experiment/ext/ddot/embedded/bin/ot
 args:
   - run
   - --config
-  - /etc/datadog-agent-exp/otel-config.yaml
+  - ${DD_CONF_DIR}/otel-config.yaml
   - --core-config
-  - /etc/datadog-agent-exp/datadog.yaml
+  - ${DD_CONF_DIR}/datadog.yaml
   - --pidfile
   - /opt/datadog-packages/datadog-agent/experiment/run/otel-agent.pid
 auto_start: true
@@ -14,9 +14,9 @@ restart: on-failure
 restart_sec: 2
 start_limit_interval_sec: 10
 start_limit_burst: 5
-environment_file: -/etc/datadog-agent-exp/environment
+environment_file: -${DD_CONF_DIR}/environment
 env:
-  DD_FLEET_POLICIES_DIR: /etc/datadog-agent-exp/managed/datadog-agent/stable
+  DD_FLEET_POLICIES_DIR: ${DD_CONF_DIR}/managed/datadog-agent/stable
   DD_OTELCOLLECTOR_INSTALLATION_METHOD: bare-metal
   DD_INVENTORIES_FIRST_RUN_DELAY: "5"
 stdout: inherit

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-ddot.yaml
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-ddot.yaml
@@ -3,9 +3,9 @@ command: /opt/datadog-packages/datadog-agent/stable/ext/ddot/embedded/bin/otel-a
 args:
   - run
   - --config
-  - /etc/datadog-agent/otel-config.yaml
+  - ${DD_CONF_DIR}/otel-config.yaml
   - --core-config
-  - /etc/datadog-agent/datadog.yaml
+  - ${DD_CONF_DIR}/datadog.yaml
   - --pidfile
   - /opt/datadog-packages/datadog-agent/stable/run/otel-agent.pid
 auto_start: true
@@ -14,9 +14,9 @@ restart: on-failure
 restart_sec: 2
 start_limit_interval_sec: 10
 start_limit_burst: 5
-environment_file: -/etc/datadog-agent/environment
+environment_file: -${DD_CONF_DIR}/environment
 env:
-  DD_FLEET_POLICIES_DIR: /etc/datadog-agent/managed/datadog-agent/stable
+  DD_FLEET_POLICIES_DIR: ${DD_CONF_DIR}/managed/datadog-agent/stable
   DD_OTELCOLLECTOR_INSTALLATION_METHOD: bare-metal
 stdout: inherit
 stderr: inherit

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-procmgr-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-procmgr-exp.service
@@ -11,6 +11,7 @@ User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
 Environment="DD_PM_CONFIG_DIR=/opt/datadog-packages/datadog-agent/experiment/processes.d"
+Environment="DD_CONF_DIR=/etc/datadog-agent-exp"
 RuntimeDirectory=datadog-procmgrd
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-procmgr.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-procmgr.service
@@ -11,6 +11,7 @@ User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
 Environment="DD_PM_CONFIG_DIR=/opt/datadog-packages/datadog-agent/stable/processes.d"
+Environment="DD_CONF_DIR=/etc/datadog-agent"
 RuntimeDirectory=datadog-procmgrd
 ExecStart=/opt/datadog-packages/datadog-agent/stable/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-ddot-exp.yaml
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-ddot-exp.yaml
@@ -3,9 +3,9 @@ command: /opt/datadog-packages/datadog-agent/experiment/ext/ddot/embedded/bin/ot
 args:
   - run
   - --config
-  - /etc/datadog-agent-exp/otel-config.yaml
+  - ${DD_CONF_DIR}/otel-config.yaml
   - --core-config
-  - /etc/datadog-agent-exp/datadog.yaml
+  - ${DD_CONF_DIR}/datadog.yaml
   - --pidfile
   - /opt/datadog-packages/datadog-agent/experiment/run/otel-agent.pid
 auto_start: true
@@ -14,9 +14,9 @@ restart: on-failure
 restart_sec: 2
 start_limit_interval_sec: 10
 start_limit_burst: 5
-environment_file: -/etc/datadog-agent-exp/environment
+environment_file: -${DD_CONF_DIR}/environment
 env:
-  DD_FLEET_POLICIES_DIR: /etc/datadog-agent-exp/managed/datadog-agent/stable
+  DD_FLEET_POLICIES_DIR: ${DD_CONF_DIR}/managed/datadog-agent/stable
   DD_OTELCOLLECTOR_INSTALLATION_METHOD: bare-metal
   DD_INVENTORIES_FIRST_RUN_DELAY: "5"
 stdout: inherit

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-ddot.yaml
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-ddot.yaml
@@ -3,9 +3,9 @@ command: /opt/datadog-packages/datadog-agent/stable/ext/ddot/embedded/bin/otel-a
 args:
   - run
   - --config
-  - /etc/datadog-agent/otel-config.yaml
+  - ${DD_CONF_DIR}/otel-config.yaml
   - --core-config
-  - /etc/datadog-agent/datadog.yaml
+  - ${DD_CONF_DIR}/datadog.yaml
   - --pidfile
   - /opt/datadog-packages/datadog-agent/stable/run/otel-agent.pid
 auto_start: true
@@ -14,9 +14,9 @@ restart: on-failure
 restart_sec: 2
 start_limit_interval_sec: 10
 start_limit_burst: 5
-environment_file: -/etc/datadog-agent/environment
+environment_file: -${DD_CONF_DIR}/environment
 env:
-  DD_FLEET_POLICIES_DIR: /etc/datadog-agent/managed/datadog-agent/stable
+  DD_FLEET_POLICIES_DIR: ${DD_CONF_DIR}/managed/datadog-agent/stable
   DD_OTELCOLLECTOR_INSTALLATION_METHOD: bare-metal
 stdout: inherit
 stderr: inherit

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-procmgr-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-procmgr-exp.service
@@ -11,6 +11,7 @@ User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
 Environment="DD_PM_CONFIG_DIR=/opt/datadog-packages/datadog-agent/experiment/processes.d"
+Environment="DD_CONF_DIR=/etc/datadog-agent-exp"
 RuntimeDirectory=datadog-procmgrd
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-procmgr.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-procmgr.service
@@ -11,6 +11,7 @@ User=dd-agent
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
 Environment="DD_PM_CONFIG_DIR=/opt/datadog-packages/datadog-agent/stable/processes.d"
+Environment="DD_CONF_DIR=/etc/datadog-agent"
 RuntimeDirectory=datadog-procmgrd
 ExecStart=/opt/datadog-packages/datadog-agent/stable/embedded/bin/dd-procmgrd
 StartLimitInterval=10

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -196,11 +196,12 @@ impl ManagedProcess {
             info!("[{}] auto_start=false, skipping", self.name);
             return false;
         }
-        if let Some(ref path) = self.config.condition_path_exists
-            && !std::path::Path::new(path).exists()
-        {
-            info!("[{}] condition_path_exists not met: {path}", self.name);
-            return false;
+        if let Some(ref raw) = self.config.condition_path_exists {
+            let path = expand_env_vars(raw);
+            if !std::path::Path::new(&path).exists() {
+                info!("[{}] condition_path_exists not met: {path}", self.name);
+                return false;
+            }
         }
         true
     }
@@ -270,13 +271,13 @@ impl ManagedProcess {
     }
 
     fn build_command(&self) -> Result<Command> {
-        let mut cmd = Command::new(&self.config.command);
-        cmd.args(&self.config.args);
+        let mut cmd = Command::new(expand_env_vars(&self.config.command));
+        cmd.args(self.config.args.iter().map(|a| expand_env_vars(a)));
 
         apply_child_environment(&mut cmd, self.name(), &self.config)?;
 
         if let Some(ref dir) = self.config.working_dir {
-            cmd.current_dir(dir);
+            cmd.current_dir(expand_env_vars(dir));
         }
 
         apply_child_stdio(&mut cmd, &self.config);
@@ -519,6 +520,7 @@ fn apply_child_environment(cmd: &mut Command, name: &str, config: &ProcessConfig
     platform::apply_child_baseline_env(cmd);
 
     if let Some(ref raw_path) = config.environment_file {
+        let raw_path = expand_env_vars(raw_path);
         let (optional, path) = if let Some(stripped) = raw_path.strip_prefix('-') {
             (true, stripped)
         } else {
@@ -535,9 +537,55 @@ fn apply_child_environment(cmd: &mut Command, name: &str, config: &ProcessConfig
         }
     }
     for (k, v) in &config.env {
-        cmd.env(k, v);
+        cmd.env(k, expand_env_vars(v));
     }
     Ok(())
+}
+
+/// Expand `${VAR}` references in `input` using dd-procmgr's own environment.
+///
+/// This lets a single process definition be pointed at the stable or experiment configuration
+/// directory by the supervising dd-procmgr, which exports the target directory in its own
+/// environment (the stable and experiment procmgr units export different values). It mirrors how
+/// the datadog-agent stable/experiment units each select their own config directory, so the
+/// experiment collector reads the experiment config while the process definition stays identical.
+/// Unknown variables are left as the literal `${VAR}` and logged, so a misconfiguration surfaces
+/// as a startup failure rather than silently resolving to an empty path.
+fn expand_env_vars(input: &str) -> String {
+    expand_vars_with(input, |name| std::env::var(name).ok())
+}
+
+/// Core of [`expand_env_vars`] with the variable lookup injected, so it can be unit-tested without
+/// mutating the process environment.
+fn expand_vars_with(input: &str, lookup: impl Fn(&str) -> Option<String>) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(start) = rest.find("${") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        match after.find('}') {
+            Some(end) => {
+                let name = &after[..end];
+                match lookup(name) {
+                    Some(val) => out.push_str(&val),
+                    None => {
+                        warn!(
+                            "process config references unset variable ${{{name}}}, leaving it literal"
+                        );
+                        out.push_str(&rest[start..start + 2 + end + 1]);
+                    }
+                }
+                rest = &after[end + 1..];
+            }
+            None => {
+                // No closing brace: emit the remainder verbatim.
+                out.push_str(&rest[start..]);
+                return out;
+            }
+        }
+    }
+    out.push_str(rest);
+    out
 }
 
 fn apply_child_stdio(cmd: &mut Command, config: &ProcessConfig) {
@@ -595,6 +643,44 @@ pub mod tests {
     use crate::test_helpers;
     #[cfg(unix)]
     use nix::sys::signal::Signal;
+
+    // -- ${VAR} expansion tests --
+
+    #[test]
+    fn test_expand_vars_substitutes_known() {
+        let lookup = |name: &str| match name {
+            "DD_CONF_DIR" => Some("/etc/datadog-agent-exp".to_string()),
+            _ => None,
+        };
+        assert_eq!(
+            expand_vars_with("${DD_CONF_DIR}/otel-config.yaml", lookup),
+            "/etc/datadog-agent-exp/otel-config.yaml"
+        );
+        // Multiple references and a leading dash (optional environment_file form) are preserved.
+        assert_eq!(
+            expand_vars_with("-${DD_CONF_DIR}/environment", lookup),
+            "-/etc/datadog-agent-exp/environment"
+        );
+    }
+
+    #[test]
+    fn test_expand_vars_leaves_unknown_literal() {
+        let lookup = |_: &str| None;
+        assert_eq!(
+            expand_vars_with("${MISSING}/x", lookup),
+            "${MISSING}/x",
+            "unset variables must be left literal so misconfiguration fails loudly"
+        );
+    }
+
+    #[test]
+    fn test_expand_vars_no_placeholder_untouched() {
+        let lookup = |_: &str| Some("should-not-be-used".to_string());
+        let path = "/opt/datadog-packages/datadog-agent/stable/embedded/bin/otel-agent";
+        assert_eq!(expand_vars_with(path, lookup), path);
+        // A dangling `${` with no closing brace is emitted verbatim.
+        assert_eq!(expand_vars_with("a ${ b", lookup), "a ${ b");
+    }
 
     // -- state lifecycle tests --
 

--- a/pkg/procmgr/rust/tests/e2e.rs
+++ b/pkg/procmgr/rust/tests/e2e.rs
@@ -1882,20 +1882,13 @@ fn test_cli_invalid_yaml_skipped() {
 }
 
 #[cfg(unix)]
-fn render_ddot_template(
-    install_dir: &str,
-    etc_dir: &str,
-    pid_dir: &str,
-    fleet_dir: &str,
-) -> Option<String> {
+fn render_ddot_template(install_dir: &str, pid_dir: &str) -> Option<String> {
     let tmpl_path = std::path::PathBuf::from(option_env!("DDOT_TEMPLATE_PATH")?);
     let tmpl = std::fs::read_to_string(&tmpl_path)
         .unwrap_or_else(|e| panic!("failed to read {}: {e}", tmpl_path.display()));
     let rendered = tmpl
         .replace("{{.InstallDir}}", install_dir)
-        .replace("{{.EtcDir}}", etc_dir)
-        .replace("{{.PIDDir}}", pid_dir)
-        .replace("{{.FleetPoliciesDir}}", fleet_dir);
+        .replace("{{.PIDDir}}", pid_dir);
     Some(
         rendered
             .lines()
@@ -1914,17 +1907,24 @@ fn test_ddot_template_starts_with_env_and_optional_envfile() {
     let bin_dir = install_dir.join("ext/ddot/embedded/bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
 
+    let conf_dir = dir.path().join("conf");
+    std::fs::create_dir_all(&conf_dir).unwrap();
+    let fleet_policies_dir = conf_dir.join("managed/datadog-agent/stable");
+
     let script = bin_dir.join("otel-agent");
     std::fs::write(
         &script,
-        concat!(
-            "#!/bin/sh\n",
-            "if [ \"$DD_FLEET_POLICIES_DIR\" = \"/etc/dd/policies\" ]; then\n",
-            "  exit 0\n",
-            "else\n",
-            "  echo \"DD_FLEET_POLICIES_DIR=$DD_FLEET_POLICIES_DIR\" >&2\n",
-            "  exit 1\n",
-            "fi\n",
+        format!(
+            concat!(
+                "#!/bin/sh\n",
+                "if [ \"$DD_FLEET_POLICIES_DIR\" = \"{expected}\" ]; then\n",
+                "  exit 0\n",
+                "else\n",
+                "  echo \"DD_FLEET_POLICIES_DIR=$DD_FLEET_POLICIES_DIR\" >&2\n",
+                "  exit 1\n",
+                "fi\n",
+            ),
+            expected = fleet_policies_dir.to_str().unwrap(),
         ),
     )
     .unwrap();
@@ -1934,27 +1934,25 @@ fn test_ddot_template_starts_with_env_and_optional_envfile() {
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
     }
 
-    let etc_dir = dir.path().join("etc");
-    std::fs::create_dir_all(&etc_dir).unwrap();
     let pid_dir = dir.path().join("pid");
     std::fs::create_dir_all(pid_dir.join("run")).unwrap();
 
     let config_dir = dir.path().join("processes.d");
     std::fs::create_dir_all(&config_dir).unwrap();
 
-    let Some(yaml) = render_ddot_template(
-        install_dir.to_str().unwrap(),
-        etc_dir.to_str().unwrap(),
-        pid_dir.to_str().unwrap(),
-        "/etc/dd/policies",
-    ) else {
+    let Some(yaml) = render_ddot_template(install_dir.to_str().unwrap(), pid_dir.to_str().unwrap())
+    else {
         eprintln!("DDOT_TEMPLATE_PATH not set at compile time, skipping");
         return;
     };
     std::fs::write(config_dir.join("datadog-agent-ddot.yaml"), &yaml).unwrap();
 
     let sock = dir.path().join("daemon.sock");
-    let mut daemon = helpers::DaemonHandle::start(&config_dir, &sock);
+    let mut daemon = helpers::DaemonHandle::start_with_env(
+        &config_dir,
+        &sock,
+        &[("DD_CONF_DIR", conf_dir.to_str().unwrap())],
+    );
     assert!(
         daemon.wait_for_log_default(
             "[datadog-agent-ddot] optional environment file not found, skipping"
@@ -1987,12 +1985,7 @@ fn test_ddot_template_skipped_when_binary_missing() {
     let config_dir = dir.path().join("processes.d");
     std::fs::create_dir_all(&config_dir).unwrap();
 
-    let Some(yaml) = render_ddot_template(
-        "/nonexistent/install",
-        "/nonexistent/etc",
-        "/nonexistent/pid",
-        "/nonexistent/policies",
-    ) else {
+    let Some(yaml) = render_ddot_template("/nonexistent/install", "/nonexistent/pid") else {
         eprintln!("DDOT_TEMPLATE_PATH not set at compile time, skipping");
         return;
     };

--- a/pkg/procmgr/rust/tests/helpers/mod.rs
+++ b/pkg/procmgr/rust/tests/helpers/mod.rs
@@ -31,6 +31,16 @@ impl DaemonHandle {
     /// Start the daemon with the given config directory and socket path.
     /// Sets `DD_PM_CONFIG_DIR` and `DD_PM_SOCKET_PATH` environment variables.
     pub fn start(config_dir: &Path, socket_path: &Path) -> Self {
+        Self::start_with_env(config_dir, socket_path, &[])
+    }
+
+    /// Like [`start`](Self::start), but also sets the given extra environment variables on the
+    /// daemon process.
+    pub fn start_with_env(
+        config_dir: &Path,
+        socket_path: &Path,
+        extra_env: &[(&str, &str)],
+    ) -> Self {
         let bin = env!("CARGO_BIN_EXE_dd-procmgrd");
 
         let mut cmd = Command::new(bin);
@@ -38,6 +48,9 @@ impl DaemonHandle {
             .env("DD_PM_SOCKET_PATH", socket_path)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        for (k, v) in extra_env {
+            cmd.env(k, v);
+        }
         #[cfg(windows)]
         {
             use std::os::windows::process::CommandExt as _;

--- a/test/new-e2e/tests/fleet/config_test.go
+++ b/test/new-e2e/tests/fleet/config_test.go
@@ -8,6 +8,7 @@ package fleet
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/ddot"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/fleet/agent"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/fleet/backend"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/fleet/suite"
@@ -499,4 +501,157 @@ func (s *configSuite) TestConfigRollbackDeploymentID() {
 		agentStateAfterRollback.StableConfigVersion, initialStableConfigVersion)
 	require.Empty(s.T(), agentStateAfterRollback.ExperimentConfigVersion,
 		"experiment_config_version should be empty after rollback")
+}
+
+// DDOT config-experiment tests: install the DDOT extension on the datadog-agent package and drive
+// config experiments that patch /otel-config.yaml, verifying the collector is relaunched with the
+// experiment config during the experiment and with the promoted config after promotion.
+
+// ddotCardinalityPatch flips processors.infraattributes.cardinality (2 -> 1) in the DDOT collector
+// config. It is a benign, valid change that keeps the collector pipeline healthy.
+const ddotCardinalityPatch = `{"processors":{"infraattributes":{"cardinality":1}}}`
+
+// ddotBrokenPatch sets an invalid debug-exporter verbosity, which the collector rejects at startup.
+// It breaks DDOT without affecting the core agent (which does not read otel-config.yaml).
+const ddotBrokenPatch = `{"exporters":{"debug":{"verbosity":"not-a-valid-verbosity"}}}`
+
+// TestDDOTConfigUpdateAndPromote installs DDOT, updates its otel-config.yaml through a config
+// experiment, and verifies the collector runs the experiment config during the experiment and the
+// promoted config after promotion.
+func (s *configSuite) TestDDOTConfigUpdateAndPromote() {
+	s.Agent.MustInstall()
+	defer s.Agent.MustUninstall()
+
+	s.Installer.MustInstallExtension(getAgentPackageURL(s.T(), ""), "ddot")
+	defer func() { _, _ = s.Installer.RemoveExtension("datadog-agent", "ddot") }()
+	verifyDDOTRunning(s.T(), s.Agent)
+
+	err := s.Backend.StartConfigExperiment(backend.ConfigOperations{
+		DeploymentID:   "ddot-config-1",
+		FileOperations: []backend.FileOperation{{FileOperationType: backend.FileOperationMergePatch, FilePath: "/otel-config.yaml", Patch: []byte(ddotCardinalityPatch)}},
+	}, nil)
+	s.Require().NoError(err)
+
+	// The experiment config carries the patch and the collector is relaunched reading it.
+	s.Require().Contains(s.readActiveOTelConfig(true), "cardinality: 1")
+	verifyDDOTRunning(s.T(), s.Agent)
+	s.assertCollectorConfigPath(true)
+
+	err = s.Backend.PromoteConfigExperiment()
+	s.Require().NoError(err)
+
+	// After promotion the collector runs the promoted config from the stable location.
+	s.Require().Contains(s.readActiveOTelConfig(false), "cardinality: 1")
+	verifyDDOTRunning(s.T(), s.Agent)
+	s.assertCollectorConfigPath(false)
+}
+
+// TestDDOTConfigUpdateRollback verifies that stopping a DDOT config experiment restores the stable
+// otel-config.yaml and the collector runs it again.
+func (s *configSuite) TestDDOTConfigUpdateRollback() {
+	s.Agent.MustInstall()
+	defer s.Agent.MustUninstall()
+
+	s.Installer.MustInstallExtension(getAgentPackageURL(s.T(), ""), "ddot")
+	defer func() { _, _ = s.Installer.RemoveExtension("datadog-agent", "ddot") }()
+	verifyDDOTRunning(s.T(), s.Agent)
+
+	stableBefore := s.readActiveOTelConfig(false)
+
+	err := s.Backend.StartConfigExperiment(backend.ConfigOperations{
+		DeploymentID:   "ddot-config-rollback",
+		FileOperations: []backend.FileOperation{{FileOperationType: backend.FileOperationMergePatch, FilePath: "/otel-config.yaml", Patch: []byte(ddotCardinalityPatch)}},
+	}, nil)
+	s.Require().NoError(err)
+	s.Require().Contains(s.readActiveOTelConfig(true), "cardinality: 1")
+	verifyDDOTRunning(s.T(), s.Agent)
+
+	err = s.Backend.StopConfigExperiment()
+	s.Require().NoError(err)
+
+	// The stable otel-config.yaml is restored byte-for-byte and the collector is healthy on it again.
+	s.Require().Equal(stableBefore, s.readActiveOTelConfig(false))
+	verifyDDOTRunning(s.T(), s.Agent)
+	s.assertCollectorConfigPath(false)
+}
+
+// TestDDOTConfigBadConfigRollsBack verifies that a config experiment carrying a broken
+// otel-config.yaml reaches the experiment collector (breaking it) and that stopping the experiment
+// restores a healthy collector on the stable config. This exercises the failure path: the broken
+// config must actually be applied to the running DDOT, proving the experiment collector reads the
+// experiment config rather than the stable one.
+func (s *configSuite) TestDDOTConfigBadConfigRollsBack() {
+	s.Agent.MustInstall()
+	defer s.Agent.MustUninstall()
+
+	s.Installer.MustInstallExtension(getAgentPackageURL(s.T(), ""), "ddot")
+	defer func() { _, _ = s.Installer.RemoveExtension("datadog-agent", "ddot") }()
+	verifyDDOTRunning(s.T(), s.Agent)
+
+	err := s.Backend.StartConfigExperiment(backend.ConfigOperations{
+		DeploymentID:   "ddot-config-broken",
+		FileOperations: []backend.FileOperation{{FileOperationType: backend.FileOperationMergePatch, FilePath: "/otel-config.yaml", Patch: []byte(ddotBrokenPatch)}},
+	}, nil)
+	s.Require().NoError(err)
+
+	// The broken experiment config reaches DDOT and prevents the collector from running.
+	s.Require().EventuallyWithT(func(c *assert.CollectT) {
+		status, err := s.Agent.Status()
+		assert.NoError(c, err)
+		assert.True(c, status.OtelAgent.Error != "" || status.OtelAgent.AgentVersion == "",
+			"DDOT should be unhealthy while running the broken experiment config")
+	}, 2*time.Minute, 5*time.Second)
+
+	err = s.Backend.StopConfigExperiment()
+	s.Require().NoError(err)
+
+	// Rolling back restores the stable config and a healthy collector.
+	s.Require().NotContains(s.readActiveOTelConfig(false), "not-a-valid-verbosity")
+	verifyDDOTRunning(s.T(), s.Agent)
+}
+
+// readActiveOTelConfig returns the contents of the otel-config.yaml the collector is (or will be)
+// running. On Linux the experiment config lives in a separate directory (/etc/datadog-agent-exp);
+// on Windows config experiments are applied in place to the stable data directory (the -exp
+// directory only holds the rollback backup), so the active config is always at the stable path.
+func (s *configSuite) readActiveOTelConfig(experiment bool) string {
+	switch s.Env().RemoteHost.OSFamily {
+	case e2eos.LinuxFamily:
+		path := "/etc/datadog-agent/otel-config.yaml"
+		if experiment {
+			path = "/etc/datadog-agent-exp/otel-config.yaml"
+		}
+		out, err := s.Env().RemoteHost.Execute("sudo cat " + path)
+		s.Require().NoError(err)
+		return out
+	case e2eos.WindowsFamily:
+		out, err := s.Env().RemoteHost.Execute(`Get-Content -Raw 'C:\ProgramData\Datadog\otel-config.yaml'`)
+		s.Require().NoError(err)
+		return out
+	default:
+		s.T().Fatalf("unsupported OS family: %v", s.Env().RemoteHost.OSFamily)
+		return ""
+	}
+}
+
+// assertCollectorConfigPath asserts (on Linux, where DDOT runs under dd-procmgr) that the running
+// otel-agent process was launched with the experiment or stable otel-config.yaml as its --config.
+// This is the direct proof that the experiment collector reads the experiment config. On Windows the
+// in-place config model means the collector always reads the stable path, so only DDOT liveness and
+// file contents are asserted (in the callers).
+func (s *configSuite) assertCollectorConfigPath(experiment bool) {
+	if s.Env().RemoteHost.OSFamily != e2eos.LinuxFamily {
+		return
+	}
+	want := "/etc/datadog-agent/otel-config.yaml"
+	if experiment {
+		want = "/etc/datadog-agent-exp/otel-config.yaml"
+	}
+	ddot.AssertDDOTManagedByProcmgr(s.T(), s.Env().RemoteHost)
+	s.Require().EventuallyWithT(func(c *assert.CollectT) {
+		out, err := s.Env().RemoteHost.Execute(`sudo ps -eo args | grep '[o]tel-agent' | grep -o -- '--config [^ ]*' | head -1`)
+		assert.NoError(c, err)
+		assert.Equal(c, "--config "+want, strings.TrimSpace(out),
+			"the running collector should read %s", want)
+	}, 2*time.Minute, 5*time.Second)
 }

--- a/test/new-e2e/tests/fleet/extensions_test.go
+++ b/test/new-e2e/tests/fleet/extensions_test.go
@@ -173,19 +173,19 @@ func (s *extensionsSuite) TestExtensionSurvivesExperiment() {
 	defer func() {
 		_, _ = s.Installer.RemoveExtension("datadog-agent", "ddot")
 	}()
-	s.verifyDDOTRunning()
+	verifyDDOTRunning(s.T(), s.Agent)
 	initialDDOTVersion := s.getDDOTAgentVersion()
 	s.setInstallerRegistryConfig()
 
 	targetVersion := s.Backend.Catalog().Latest(backend.BranchTesting, "datadog-agent")
 	err := s.Backend.StartExperiment("datadog-agent", targetVersion)
 	s.Require().NoError(err)
-	s.verifyDDOTRunning()
+	verifyDDOTRunning(s.T(), s.Agent)
 	s.Require().NotEqual(initialDDOTVersion, s.getDDOTAgentVersion(), "DDOT should be running on experiment version after start experiment")
 
 	err = s.Backend.PromoteExperiment("datadog-agent")
 	s.Require().NoError(err)
-	s.verifyDDOTRunning()
+	verifyDDOTRunning(s.T(), s.Agent)
 	s.Require().NotEqual(initialDDOTVersion, s.getDDOTAgentVersion(), "DDOT should remain on promoted version after promote experiment")
 }
 
@@ -206,7 +206,7 @@ func (s *extensionsSuite) TestExtensionSurvivesExperimentManagedByProcmgr() {
 	}()
 
 	// Staging deb/rpm (7.78.0-beta) predates dd-procmgr; DDOT runs via systemd there.
-	s.verifyDDOTRunning()
+	verifyDDOTRunning(s.T(), s.Agent)
 	initialDDOTVersion := s.getDDOTAgentVersion()
 	s.setInstallerRegistryConfig()
 
@@ -241,7 +241,7 @@ func (s *extensionsSuite) TestExtensionRestoredAfterExperimentRollback() {
 		_, _ = s.Installer.RemoveExtension("datadog-agent", "ddot")
 	}()
 
-	s.verifyDDOTRunning()
+	verifyDDOTRunning(s.T(), s.Agent)
 	initialDDOTVersion := s.getDDOTAgentVersion()
 	// Use the pipeline registry so restoreAgentExtensions can find the experiment OCI during StartExperiment.
 	s.setInstallerRegistryConfig()
@@ -249,7 +249,7 @@ func (s *extensionsSuite) TestExtensionRestoredAfterExperimentRollback() {
 	targetVersion := s.Backend.Catalog().Latest(backend.BranchTesting, "datadog-agent")
 	err := s.Backend.StartExperiment("datadog-agent", targetVersion)
 	s.Require().NoError(err)
-	s.verifyDDOTRunning()
+	verifyDDOTRunning(s.T(), s.Agent)
 	s.Require().NotEqual(initialDDOTVersion, s.getDDOTAgentVersion(), "DDOT should be running on experiment version after start experiment")
 
 	// Switch to the staging registry so restoreAgentExtensions can find the stable OCI
@@ -259,7 +259,7 @@ func (s *extensionsSuite) TestExtensionRestoredAfterExperimentRollback() {
 
 	err = s.Backend.StopExperiment("datadog-agent")
 	s.Require().NoError(err)
-	s.verifyDDOTRunning()
+	verifyDDOTRunning(s.T(), s.Agent)
 	s.Require().Equal(initialDDOTVersion, s.getDDOTAgentVersion(), "DDOT should be restored to initial version after rollback")
 }
 
@@ -272,7 +272,7 @@ func (s *extensionsSuite) TestDDOTAutoInstalledWithEnvVar() {
 
 	ddot.AssertDDOTAutoInstallUnderProcmgr(s.T(), s.Env().RemoteHost)
 
-	s.verifyDDOTRunning()
+	verifyDDOTRunning(s.T(), s.Agent)
 }
 
 // TestDDOTExtension tests installing DDOT as an extension on all platforms
@@ -281,13 +281,13 @@ func (s *extensionsSuite) TestDDOTExtension() {
 	s.Agent.MustInstall()
 	defer s.Agent.MustUninstall()
 
-	s.Installer.MustInstallExtension(s.getAgentPackageURL(""), "ddot")
+	s.Installer.MustInstallExtension(getAgentPackageURL(s.T(), ""), "ddot")
 	defer func() {
 		_, _ = s.Installer.RemoveExtension("datadog-agent", "ddot")
 	}()
 
 	// Verify DDOT is running via status
-	s.verifyDDOTRunning()
+	verifyDDOTRunning(s.T(), s.Agent)
 
 	// Remove extension
 	s.Installer.MustRemoveExtension("datadog-agent", "ddot")
@@ -353,13 +353,13 @@ func (s *extensionsSuite) getStagingAgentPackageURL() string {
 	return "oci://install.datad0g.com.internal.dda-testing.com/agent-package:" + stagingAgentOCIVersion
 }
 
-// getAgentPackageURL returns the platform-specific agent package URL
-func (s *extensionsSuite) getAgentPackageURL(version string) string {
+// getAgentPackageURL returns the pipeline agent package OCI URL for E2E tests.
+func getAgentPackageURL(t *testing.T, version string) string {
 	if version == "" {
 		// Use pipeline-specific URL for E2E tests
 		version = os.Getenv("E2E_PIPELINE_ID")
 		if version == "" {
-			s.T().Fatal("E2E_PIPELINE_ID environment variable not set")
+			t.Fatal("E2E_PIPELINE_ID environment variable not set")
 		}
 	}
 	return "oci://installtesting.datad0g.com.internal.dda-testing.com/agent-package:pipeline-" + version
@@ -374,34 +374,34 @@ func (s *extensionsSuite) getDDOTAgentVersion() string {
 }
 
 // verifyDDOTRunning verifies DDOT is running via agent status
-func (s *extensionsSuite) verifyDDOTRunning() {
-	isDDOTRunning := assert.Eventually(s.T(), func() bool {
-		status, err := s.Agent.Status()
+func verifyDDOTRunning(t *testing.T, a *agent.Agent) {
+	isDDOTRunning := assert.Eventually(t, func() bool {
+		status, err := a.Status()
 		if err != nil {
 			return false
 		}
 
 		// Check that DDOT is not in error state
 		if status.OtelAgent.Error != "" {
-			s.T().Logf("DDOT error: %s", status.OtelAgent.Error)
+			t.Logf("DDOT error: %s", status.OtelAgent.Error)
 			return false
 		}
 
 		// Verify required fields are present
 		if status.OtelAgent.AgentVersion == "" || status.OtelAgent.CollectorVersion == "" {
-			s.T().Logf("Missing DDOT version info")
+			t.Logf("Missing DDOT version info")
 			return false
 		}
 
 		return true
 	}, 2*time.Minute, 1*time.Second, "DDOT should be running and reporting status")
 	if !isDDOTRunning {
-		s.T().Fatalf("DDOT is not running")
+		t.Fatalf("DDOT is not running")
 	}
 
 	// Log version info for debugging
-	status, _ := s.Agent.Status()
-	s.T().Logf("DDOT AgentVersion: %s, CollectorVersion: %s",
+	status, _ := a.Status()
+	t.Logf("DDOT AgentVersion: %s, CollectorVersion: %s",
 		status.OtelAgent.AgentVersion, status.OtelAgent.CollectorVersion)
 }
 


### PR DESCRIPTION
…nfig-update tests (#53502)

Backport bb4d090 from #53502 (https://github.com/DataDog/datadog-agent/pull/53502)

### What does this PR do?

- Fixes a Fleet Automation bug where a **config experiment** that updates `otel-config.yaml` did not take effect on the running DDOT collector when DDOT is supervised by `dd-procmgr` (the modern pipeline OCI build): the experiment collector kept reading the **stable** config, so a new collector config could not be validated during the experiment, only after promotion.
- Adds e2e coverage for the DDOT config-update flow and unit coverage for `otel-config.yaml` config experiments.

**Mechanism.** `dd-procmgr` now points its managed services at the config folder for its own context — the same way `datadog-agent-exp.service` runs `agent -c /etc/datadog-agent-exp`:

- `dd-procmgr` expands `${VAR}` references in a managed process's config (args/command/working_dir/environment_file/env), resolved from `dd-procmgr`'s own environment at launch.
- The stable and experiment procmgr units export `DD_CONF_DIR=/etc/datadog-agent` and `DD_CONF_DIR=/etc/datadog-agent-exp` respectively.
- The DDOT process config is a **single, unchanged** definition: `command` keeps the version-specific package path, while `--config`/`--core-config`/`environment_file`/fleet-policies use `${DD_CONF_DIR}`.

So the experiment procmgr launches the collector against `/etc/datadog-agent-exp` and the stable procmgr against `/etc/datadog-agent`. The stable procmgr config is never mutated, so promote, rollback and the systemd timeout/`OnFailure` revert all restart the stable collector on the untouched stable config. It is correct for both config **and** version experiments (`/etc/datadog-agent-exp` is a symlink to the stable config dir during a version experiment, and the package tree still carries the version-specific binary).

Linux-only: on Windows, config experiments are applied in place to the stable data directory (the `-exp` dir holds the rollback backup), so the collector already reads the experiment config on service restart.

### Motivation

DDOT recently gained the ability to update its `otel-config.yaml` through Fleet Automation config experiments. While adding e2e coverage for that flow, we found the experiment collector never actually ran the experiment config under `dd-procmgr`, which defeats the point of a config experiment (validate the new config before promoting it).

### Describe how you validated your changes

- Rust unit tests (`pkg/procmgr/rust/src/process.rs`): `${VAR}` expands from the procmgr environment; unset vars are left literal; strings without `${}` are untouched. (Compiled/tested on Linux in CI — `cargo` isn't available locally and the crate is Linux/Windows-only.)
- Go unit: `dda inv test --targets=./pkg/fleet/installer/config` (incl. `TestConfig_OTelConfig*`) and `--targets=./pkg/fleet/installer/packages` (incl. `TestWriteDDOTProcmgrConfig`) — green.
- E2E in `test/new-e2e/tests/fleet/config_test.go` (run under `TestFleetConfig`, Linux + Windows): `TestDDOTConfigUpdateAndPromote`, `TestDDOTConfigUpdateRollback`, `TestDDOTConfigBadConfigRollsBack`. On Linux they assert the running `otel-agent --config` resolves to `/etc/datadog-agent-exp/...` during the experiment (procmgr substitutes `${DD_CONF_DIR}` before spawn) and `/etc/datadog-agent/...` after promotion.
- Regenerated the procmgr units and DDOT process config via `go generate`; the `validate-experiment-systemd-units` pre-commit hook passes. Cross-compiled the fleet installer packages for `GOOS=linux`; `go vet` clean on the fleet e2e package.

### Additional Notes

- Running the e2e tests requires a pipeline agent build: `E2E_PIPELINE_ID=<id> dda inv new-e2e-tests.run --targets=./tests/fleet/... --run 'TestFleetConfig/.*DDOTConfig.*'`.
- `${VAR}` expansion applies to all `dd-procmgr`-managed process configs; it is safe today (no generated procmgr config uses `${...}`) and is a general capability going forward (unset vars are left literal so a misconfiguration fails loudly).
- The shared DDOT e2e helpers `verifyDDOTRunning` and `getAgentPackageURL` were converted from `extensionsSuite` methods to package-level functions so both the extensions and config suites can use them.


(cherry picked from commit bb4d090dff5a91708cb146c6dacb709a68642def)

<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
