### PR TITLE
Disable omnibus git cache on CI macos builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -280,9 +280,6 @@ variables:
   ## build to succeed with S3 caching disabled.
   S3_OMNIBUS_CACHE_BUCKET: dd-ci-datadog-agent-omnibus-cache-build-stable
   S3_OMNIBUS_GIT_CACHE_BUCKET: dd-ci-datadog-agent-omnibus-git-cache-build-stable
-  # This value is not used on windows, a specific value is provided to
-  # our build containers in the windows build jobs
-  OMNIBUS_GIT_CACHE_DIR: /tmp/omnibus-git-cache
   S3_DD_AGENT_OMNIBUS_LLVM_URI: s3://dd-agent-omnibus/llvm
   S3_DD_AGENT_OMNIBUS_BTFS_URI: s3://dd-agent-omnibus/btfs
   S3_DD_AGENT_OMNIBUS_JAVA_URI: s3://dd-agent-omnibus/openjdk

--- a/.gitlab/build/package_build/dmg.yml
+++ b/.gitlab/build/package_build/dmg.yml
@@ -61,7 +61,6 @@
   before_script:
     # Since there is no virtualization on the macOS runners, we need to unmount the Agent dmg volume to avoid conflicts
     - sudo umount /Volumes/Agent || true
-    - rm -rf "$OMNIBUS_GIT_CACHE_DIR" || true
   after_script:
     - sudo umount /Volumes/Agent || true
   script:

--- a/.gitlab/build/package_build/heroku.yml
+++ b/.gitlab/build/package_build/heroku.yml
@@ -23,6 +23,7 @@
     PACKAGE_ARCH: "amd64"
     DD_CC: "x86_64-unknown-linux-gnu-gcc"
     DD_CXX: "x86_64-unknown-linux-gnu-g++"
+    OMNIBUS_GIT_CACHE_DIR: /tmp/omnibus-git-cache
   artifacts:
     expire_in: 2 weeks
     paths:

--- a/.gitlab/build/package_build/linux.yml
+++ b/.gitlab/build/package_build/linux.yml
@@ -27,6 +27,7 @@
     KUBERNETES_CPU_REQUEST: 16
     KUBERNETES_MEMORY_REQUEST: "32Gi"
     KUBERNETES_MEMORY_LIMIT: "32Gi"
+    OMNIBUS_GIT_CACHE_DIR: /tmp/omnibus-git-cache
   artifacts:
     expire_in: 2 weeks
     paths:


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

It disables the use of the Omnibus git cache for macos on CI.

### Motivation

The cache has remained actually unused on macos for almost a year due to PATH being different on every build (to point at different copies of dda).

On top of that, at the current state of the migration to Bazel, the Omnibus git cache is offering ever diminishing returns, such that it's not worth fixing it. And we want to start to phase this mechanism out.

### Describe how you validated your changes

Apart from green CI, confirm by looking at the logs that no cache-related steps run on macos builds, while they keep running for other platforms.

### Additional Notes

Other platforms will follow after this one, because they're also at a state where the git cache doesn't really help (at least on Linux, on Windows it may require a more careful study).

The git cache related operations on macos builds only take a handful of seconds, so we don't expect this to be an improvement in performance.