### PR TITLE
Fix `jsoniter` global-registry race in `kubelet` pod-list decoding

### DIFF
--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -285,6 +285,7 @@ use_repo(
     "com_github_moby_moby_api",
     "com_github_moby_moby_client",
     "com_github_moby_sys_mountinfo",
+    "com_github_modern_go_reflect2",
     "com_github_mohae_deepcopy",
     "com_github_netsampler_goflow2",
     "com_github_nvidia_go_nvml",

--- a/go.mod
+++ b/go.mod
@@ -337,6 +337,7 @@ require (
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.0
 	github.com/moby/sys/mountinfo v0.7.2
+	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/netsampler/goflow2 v1.3.8-0.20260412031118-ad727784ae6f
 	github.com/oliveagle/jsonpath v0.1.4
@@ -886,7 +887,6 @@ require (
 	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/BUILD.bazel
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/BUILD.bazel
@@ -62,7 +62,6 @@ dd_agent_go_test(
         "//pkg/config/mock",
         "//pkg/util/fxutil",
         "//pkg/util/kubernetes/kubelet",
-        "@com_github_json_iterator_go//:go",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@com_github_stretchr_testify//suite",

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -51,8 +50,6 @@ type ProviderTestSuite struct {
 }
 
 func (suite *ProviderTestSuite) SetupTest() {
-	jsoniter.RegisterTypeDecoder("kubelet.PodList", nil)
-
 	mockConfig := configmock.New(suite.T())
 
 	mockSender := mocksender.NewMockSender(suite.T(), checkid.ID(suite.T().Name()))
@@ -342,7 +339,7 @@ func (suite *ProviderTestSuite) fillWorkloadmetaStore(testDataFile string) error
 	}
 
 	var podList kubelet.PodList
-	if err := jsoniter.Unmarshal(data, &podList); err != nil {
+	if err := kubelet.NewPodUnmarshaller().Unmarshal(data, &podList); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/orchestrator/kubeletconfig/BUILD.bazel
+++ b/pkg/collector/corechecks/orchestrator/kubeletconfig/BUILD.bazel
@@ -58,7 +58,6 @@ dd_agent_go_test(
         "//pkg/util/fxutil",
         "//pkg/util/kubernetes/kubelet",
         "@com_github_datadog_agent_payload_v5//process",
-        "@com_github_json_iterator_go//:go",
         "@com_github_stretchr_testify//require",
         "@com_github_stretchr_testify//suite",
         "@org_uber_go_fx//:fx",

--- a/pkg/collector/corechecks/orchestrator/kubeletconfig/kubeletconfig_test.go
+++ b/pkg/collector/corechecks/orchestrator/kubeletconfig/kubeletconfig_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
@@ -67,7 +66,6 @@ type KubeletConfigTestSuite struct {
 func (suite *KubeletConfigTestSuite) SetupSuite() {
 	kubelet.ResetGlobalKubeUtil()
 	kubelet.ResetCache()
-	jsoniter.RegisterTypeDecoder("kubelet.PodList", nil)
 	mockConfig := configmock.New(suite.T())
 	mockConfig.SetInTest("cluster_agent.enabled", true)
 	mockConfig.SetInTest("kubernetes_kubelet_host", "127.0.0.1")

--- a/pkg/collector/corechecks/orchestrator/pod/BUILD.bazel
+++ b/pkg/collector/corechecks/orchestrator/pod/BUILD.bazel
@@ -65,7 +65,6 @@ dd_agent_go_test(
         "//pkg/util/kubernetes/kubelet",
         "//pkg/util/log",
         "@com_github_datadog_agent_payload_v5//process",
-        "@com_github_json_iterator_go//:go",
         "@com_github_stretchr_testify//require",
         "@com_github_stretchr_testify//suite",
         "@org_uber_go_fx//:fx",

--- a/pkg/collector/corechecks/orchestrator/pod/pod_test.go
+++ b/pkg/collector/corechecks/orchestrator/pod/pod_test.go
@@ -18,7 +18,6 @@ import (
 	"sync"
 	"testing"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
@@ -121,7 +120,6 @@ type PodTestSuite struct {
 func (suite *PodTestSuite) SetupSuite() {
 	kubelet.ResetGlobalKubeUtil()
 	kubelet.ResetCache()
-	jsoniter.RegisterTypeDecoder("kubelet.PodList", nil)
 
 	suite.dummyKubelet = newDummyKubelet()
 	ts, kubeletPort, err := suite.dummyKubelet.Start()

--- a/pkg/util/kubernetes/kubelet/BUILD.bazel
+++ b/pkg/util/kubernetes/kubelet/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/retry",
         "@com_github_json_iterator_go//:go",
+        "@com_github_modern_go_reflect2//:reflect2",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/api/resource",
         "@io_k8s_apimachinery//pkg/runtime",
@@ -57,6 +58,7 @@ dd_agent_go_test(
     name = "kubelet_test",
     srcs = [
         "deviceplugin_test.go",
+        "json_test.go",
         "kubelet_client_test.go",
         "kubelet_common_test.go",
         "kubelet_hosts_test.go",
@@ -78,7 +80,6 @@ dd_agent_go_test(
         "//pkg/errors",
         "//pkg/util/log",
         "//pkg/util/log/setup",
-        "@com_github_json_iterator_go//:go",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@com_github_stretchr_testify//suite",

--- a/pkg/util/kubernetes/kubelet/json.go
+++ b/pkg/util/kubernetes/kubelet/json.go
@@ -12,9 +12,13 @@ import (
 	"unsafe"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/modern-go/reflect2"
 
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
+
+// podListType mirrors jsoniter's own pattern of pre-computing a reflect2.Type
+var podListType = reflect2.TypeOfPtr((*PodList)(nil)).Elem()
 
 // jsoniterConfig mirrors jsoniter.ConfigFastest
 var jsonConfig = jsoniter.Config{
@@ -23,40 +27,47 @@ var jsonConfig = jsoniter.Config{
 	ObjectFieldMustBeSimpleString: true,
 }
 
-// podUnmarshaller handles unmarshalling and filtering the podlist contents
+// PodUnmarshaller handles unmarshalling and filtering the podlist contents
 // according to the kubernetes_pod_expiration_duration setting. It uses jsoniter
 // under the hood, with a custom decoder.
-type podUnmarshaller struct {
+type PodUnmarshaller struct {
 	jsonConfig            jsoniter.API
 	podExpirationDuration time.Duration
 	timeNowFunction       func() time.Time // Allows to mock time in tests
 }
 
-func newPodUnmarshaller() *podUnmarshaller {
-	pu := &podUnmarshaller{
+// podListDecoder adapts PodUnmarshaller.filteringDecoder to jsoniter.ValDecoder
+type podListDecoder struct {
+	pu *PodUnmarshaller
+}
+
+func (d *podListDecoder) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+	d.pu.filteringDecoder(ptr, iter)
+}
+
+// NewPodUnmarshaller creates a PodUnmarshaller with its own private jsoniter
+// config, so registering the pod-expiration decoder on it can't race with any
+// other jsoniter user in the process.
+func NewPodUnmarshaller() *PodUnmarshaller {
+	pu := &PodUnmarshaller{
 		podExpirationDuration: pkgconfigsetup.Datadog().GetDuration("kubernetes_pod_expiration_duration") * time.Second,
 		timeNowFunction:       time.Now,
 	}
 
+	cfg := jsonConfig.Froze()
 	if pu.podExpirationDuration > 0 {
-		jsoniter.RegisterTypeDecoderFunc("kubelet.PodList", pu.filteringDecoder)
-	} else {
-		// Force-unregister for unit tests to pick up the right state
-		jsoniter.RegisterTypeDecoder("kubelet.PodList", nil)
+		cfg.RegisterExtension(jsoniter.DecoderExtension{podListType: &podListDecoder{pu: pu}})
 	}
-
-	// Build a new frozen config to invalidate type decoder cache
-	pu.jsonConfig = jsonConfig.Froze()
-
+	pu.jsonConfig = cfg
 	return pu
 }
 
-// unmarshal is a drop-in replacement for json.Unmarshall
-func (pu *podUnmarshaller) unmarshal(data []byte, v interface{}) error {
+// Unmarshal is a drop-in replacement for json.Unmarshal
+func (pu *PodUnmarshaller) Unmarshal(data []byte, v interface{}) error {
 	return pu.jsonConfig.Unmarshal(data, v)
 }
 
-func (pu *podUnmarshaller) filteringDecoder(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+func (pu *PodUnmarshaller) filteringDecoder(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 	p := (*PodList)(ptr)
 	cutoffTime := pu.timeNowFunction().Add(-1 * pu.podExpirationDuration)
 

--- a/pkg/util/kubernetes/kubelet/json_test.go
+++ b/pkg/util/kubernetes/kubelet/json_test.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build kubelet
+
+package kubelet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+)
+
+// TestNewPodUnmarshallerIsolation guards against a regression where building
+// a PodUnmarshaller would silently clobber an earlier one's decoder.
+func TestNewPodUnmarshallerIsolation(t *testing.T) {
+	mockConfig := configmock.New(t)
+
+	mockConfig.SetInTest("kubernetes_pod_expiration_duration", 15*60)
+	pu1 := NewPodUnmarshaller()
+
+	mockConfig.SetInTest("kubernetes_pod_expiration_duration", 0)
+	NewPodUnmarshaller()
+
+	data := []byte(`{"items":[{"status":{"phase":"Succeeded","containerStatuses":[{"state":{"terminated":{"finishedAt":"2018-02-14T14:57:17Z"}}}]}}]}`)
+	var podList PodList
+	require.NoError(t, pu1.Unmarshal(data, &podList))
+
+	assert.Equal(t, 1, podList.ExpiredCount)
+}

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -67,7 +67,7 @@ type KubeUtil struct {
 	kubeletClient        *kubeletClient
 	rawConnectionInfo    map[string]string // kept to pass to the python kubelet check
 	podListCacheDuration time.Duration     // a duration of 0 disables the cache
-	podUnmarshaller      *podUnmarshaller
+	podUnmarshaller      *PodUnmarshaller
 	podResourcesClient   *PodResourcesClient
 	devicePluginsClient  DevicePluginClient
 
@@ -137,7 +137,7 @@ func NewKubeUtil() *KubeUtil {
 	return &KubeUtil{
 		rawConnectionInfo:    make(map[string]string),
 		podListCacheDuration: pkgconfigsetup.Datadog().GetDuration("kubelet_cache_pods_duration") * time.Second,
-		podUnmarshaller:      newPodUnmarshaller(),
+		podUnmarshaller:      NewPodUnmarshaller(),
 	}
 }
 
@@ -259,7 +259,7 @@ func (ku *KubeUtil) getLocalPodList(ctx context.Context) (*PodList, error) {
 		return nil, errors.NewRetriable("podlist", fmt.Errorf("unexpected status code %d on %s%s: %s", code, ku.kubeletClient.kubeletURL, kubeletPodPath, string(data)))
 	}
 
-	err = ku.podUnmarshaller.unmarshal(data, &pods)
+	err = ku.podUnmarshaller.Unmarshal(data, &pods)
 	if err != nil {
 		return nil, errors.NewRetriable("podlist", fmt.Errorf("unable to unmarshal podlist, invalid or null: %w", err))
 	}

--- a/pkg/util/kubernetes/kubelet/kubelet_orchestrator_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_orchestrator_test.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"testing"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -29,8 +28,6 @@ func (suite *KubeletOrchestratorTestSuite) SetupTest() {
 
 	ResetGlobalKubeUtil()
 	ResetCache()
-
-	jsoniter.RegisterTypeDecoder("kubelet.PodList", nil)
 
 	mockConfig.SetInTest("kubelet_client_crt", "")
 	mockConfig.SetInTest("kubelet_client_key", "")

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -234,8 +233,6 @@ func (suite *KubeletTestSuite) getCustomKubeUtil() KubeUtilInterface {
 func (suite *KubeletTestSuite) SetupTest() {
 	ResetGlobalKubeUtil()
 	ResetCache()
-
-	jsoniter.RegisterTypeDecoder("kubelet.PodList", nil)
 }
 
 func (suite *KubeletTestSuite) TestLocateKubeletHTTP() {


### PR DESCRIPTION
### What does this PR do?
Scope `PodUnmarshaller`'s pod-expiration decoder to its own private `jsoniter` config instead of `json-iterator`'s global, unsynchronized type-decoder registry, and export `PodUnmarshaller`, `NewPodUnmarshaller` and `Unmarshal` so other packages' tests can exercise the same filtering logic directly.

Drop the now-dead global-registry resets this made obsolete across 5 test files.

Add a deterministic regression test.

### Motivation
While working on something unrelated, [CI failed](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1874927066#L444) on repeated `DATA RACE`s affecting:
1. `TestProviderTestSuite/TestNoMetricNoKubeletData`,
2. `TestProviderTestSuite/TestTransformRunningPods`.

These tests have indeed been experiencing an increased [failure rate](https://app.datadoghq.com/ci/test-runs?query=%40git.repository.name%3A%22DataDog%2Fdatadog-agent%22+%40test.name%3A%28%22TestProviderTestSuite%2FTestNoMetricNoKubeletData%22+OR+%22TestProviderTestSuite%2FTestTransformRunningPods%22%29&from_ts=1782027577000&to_ts=1784619577000&live=false).

It turns out the global registry is racing between `workloadmeta`'s async `kubelet`-collector goroutine and `jsoniter.Unmarshal` in tests.

### Describe how you validated your changes
`dda inv test --race` is now clean on all four affected packages.

`TestNewPodUnmarshallerIsolation` reproduces the bug deterministically on the pre-fix code and passes on this fix.

### Additional Notes
Considered `reflect2.TypeByName("kubelet.PodList")` instead of `reflect2.TypeOfPtr((*PodList)(nil)).Elem()`, but it is string-keyed (silently breaks on a rename, unlike the type expression) and unavailable under `gccgo`.

**Update**: the fix coincides with `Solution A` from [CONTINT-5485](https://datadoghq.atlassian.net/browse/CONTINT-5485)'s embedded analysis (`kubelet-race.md`).

[CONTINT-5485]: https://datadoghq.atlassian.net/browse/CONTINT-5485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ