### PR TITLE
[FA] Fix DC credential precondition and categorize installer OOM errors

### DIFF
--- a/pkg/fleet/installer/exec/BUILD.bazel
+++ b/pkg/fleet/installer/exec/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "exec",
@@ -17,5 +17,14 @@ go_library(
         "//pkg/fleet/installer/paths",
         "//pkg/fleet/installer/repository",
         "//pkg/fleet/installer/telemetry",
+        "//pkg/util/log",
     ],
+)
+
+go_test(
+    name = "exec_test",
+    srcs = ["installer_exec_test.go"],
+    embed = [":exec"],
+    gotags = ["test"],
+    deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/pkg/fleet/installer/exec/installer_exec.go
+++ b/pkg/fleet/installer/exec/installer_exec.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -24,7 +25,41 @@ import (
 	installerErrors "github.com/DataDog/datadog-agent/pkg/fleet/installer/errors"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+// ErrResourceExhausted indicates that the installer subprocess crashed at Go-runtime bootstrap
+// because the host ran out of memory, threads, or paging capacity, rather than failing for some
+// other reason. Use errors.Is(err, ErrResourceExhausted) to distinguish this case from other
+// "run failed" errors.
+var ErrResourceExhausted = errors.New("installer subprocess crashed due to host resource exhaustion (memory/thread limit)")
+
+// resourceExhaustionSignatures are known Go-runtime crash signatures produced when a process fails
+// to bootstrap because the host is out of memory, threads, or paging capacity.
+var resourceExhaustionSignatures = []string{
+	"pageAlloc: out of memory",
+	"out of memory allocating heap arena",
+	"cannot allocate memory",
+	"failed to create new OS thread",
+	"VirtualAlloc",
+	"paging file is too small",
+}
+
+// isResourceExhaustionCrash returns true if the given subprocess output matches a known
+// Go-runtime crash signature for host memory/thread/paging exhaustion, e.g.:
+//   - "fatal error: pageAlloc: out of memory"
+//   - "out of memory allocating heap arena metadata"
+//   - "runtime: failed to create new OS thread (have N already; errno=11)"
+//   - "VirtualAlloc ... errno=1455"
+//   - "paging file is too small"
+func isResourceExhaustionCrash(output []byte) bool {
+	for _, sig := range resourceExhaustionSignatures {
+		if bytes.Contains(output, []byte(sig)) {
+			return true
+		}
+	}
+	return false
+}
 
 // InstallerExec is an implementation of the Installer interface that uses the installer binary.
 type InstallerExec struct {
@@ -374,6 +409,14 @@ func (iCmd *installerCmd) Run() error {
 	err := iCmd.Cmd.Run()
 	if err == nil {
 		return nil
+	}
+
+	if isResourceExhaustionCrash(errBuf.Bytes()) {
+		// The full Go-runtime crash output can be a multi-KB stack trace with no actionable
+		// signal beyond "the host ran out of memory/threads". Keep that off the primary error
+		// (which surfaces to users and Error Tracking) and only log it at debug level.
+		log.Debugf("installer subprocess crashed due to host resource exhaustion, full output:\n%s", errBuf.String())
+		return fmt.Errorf("run failed: %w: %w", ErrResourceExhausted, err)
 	}
 
 	if len(errBuf.Bytes()) == 0 {

--- a/pkg/fleet/installer/exec/installer_exec_test.go
+++ b/pkg/fleet/installer/exec/installer_exec_test.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package exec
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsResourceExhaustionCrash(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name:   "pageAlloc out of memory",
+			output: "fatal error: pageAlloc: out of memory\n",
+			want:   true,
+		},
+		{
+			name:   "heap arena metadata",
+			output: "fatal error: out of memory allocating heap arena metadata\n",
+			want:   true,
+		},
+		{
+			name:   "cannot allocate memory",
+			output: "runtime: cannot allocate memory\n",
+			want:   true,
+		},
+		{
+			name:   "failed to create new OS thread",
+			output: "runtime: failed to create new OS thread (have 10000 already; errno=11)\n",
+			want:   true,
+		},
+		{
+			name:   "VirtualAlloc failure on windows",
+			output: "runtime: VirtualAlloc of 8192 bytes failed with errno=1455\n",
+			want:   true,
+		},
+		{
+			name:   "paging file too small",
+			output: "The paging file is too small for this operation to complete.\n",
+			want:   true,
+		},
+		{
+			name:   "unrelated error",
+			output: "exit status 1: package not found",
+			want:   false,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isResourceExhaustionCrash([]byte(tt.output)))
+		})
+	}
+}
+
+func TestErrResourceExhaustedIsWrappedWithMultiErrorf(t *testing.T) {
+	// Mirrors the fmt.Errorf("run failed: %w: %w", ErrResourceExhausted, err) wrapping used in
+	// installerCmd.Run, to confirm errors.Is still finds the sentinel through the wrap.
+	underlying := errors.New("exit status 2")
+	err := fmt.Errorf("run failed: %w: %w", ErrResourceExhausted, underlying)
+
+	assert.True(t, errors.Is(err, ErrResourceExhausted))
+	assert.True(t, errors.Is(err, underlying))
+}

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/ProcessUserCustomActionsDomainControllerTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/ProcessUserCustomActionsDomainControllerTests.cs
@@ -1,5 +1,6 @@
 using AutoFixture.Xunit2;
 using FluentAssertions;
+using Moq;
 using WixToolset.Dtf.WindowsInstaller;
 using Xunit;
 
@@ -20,6 +21,25 @@ namespace CustomActions.Tests.ProcessUserCustomActions
                 .ProcessDdAgentUserCredentials()
                 .Should()
                 .Be(ActionResult.Failure);
+
+            Test.Properties.Should()
+                .BeEmpty();
+        }
+
+        [Theory]
+        [AutoData]
+        public void ProcessDdAgentUserCredentials_Skips_LsaSecretLookup_With_No_Username_On_DomainController()
+        {
+            // Regression test: on a Domain Controller with no DDAGENTUSER_NAME provided, we must fail
+            // fast before attempting to read the password from the LSA secret store. Otherwise the LSA
+            // lookup fails and logs a misleading "system cannot find the file specified" error that
+            // obscures the real problem (missing required username on DCs).
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Failure);
+
+            Test.NativeMethods.Verify(n => n.FetchSecret(It.IsAny<string>()), Times.Never());
 
             Test.Properties.Should()
                 .BeEmpty();

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
@@ -410,6 +410,17 @@ namespace Datadog.CustomActions
                 }
 
                 var ddAgentUserName = _session.Property("DDAGENTUSER_NAME");
+
+                // Check this precondition before fetching the password from the LSA secret store.
+                // On Domain Controllers, a username is always required, and FetchAgentPassword's LSA lookup
+                // will otherwise fail and log a misleading "LSA retrieve failed... system cannot find the file
+                // specified" error that obscures the real problem and is the most prominent thing on-call sees.
+                if (_isDomainController && string.IsNullOrEmpty(ddAgentUserName))
+                {
+                    _session.Log("Aborting before LSA secret lookup: no DDAGENTUSER_NAME was provided and a username is required when installing on Domain Controllers.");
+                    throw new InvalidAgentUserConfigurationException("A username was not provided. A username is a required when installing on Domain Controllers.");
+                }
+
                 var ddAgentUserPassword = FetchAgentPassword();
                 var datadogAgentServiceExists = _serviceController.ServiceExists(Constants.AgentServiceName);
 
@@ -430,13 +441,7 @@ namespace Datadog.CustomActions
 
                 if (string.IsNullOrEmpty(ddAgentUserName))
                 {
-                    if (_isDomainController)
-                    {
-                        // require user to provide a username on domain controllers so that the customer is explicit
-                        // about the username/password that will be created on their domain if it does not exist.
-                        throw new InvalidAgentUserConfigurationException("A username was not provided. A username is a required when installing on Domain Controllers.");
-                    }
-
+                    // _isDomainController is already handled above, before the LSA secret lookup.
                     // Creds are not in registry and user did not pass a value, use default account name
                     ddAgentUserName = $"{GetDefaultDomainPart()}\\ddagentuser";
                     _session.Log($"No creds provided, using default {ddAgentUserName}");


### PR DESCRIPTION
## Summary

A week-long Error Tracking sweep of installer error categories surfaced two concrete, low-risk fixes:

**1. Windows MSI: misleading LSA error before the real Domain Controller error**

`ProcessUserCustomActions.cs` (`ProcessDdAgentUserCredentials`): when installing/upgrading on a Domain Controller without an explicit `DDAGENTUSER_NAME`, the code previously called `FetchAgentPassword()` (which does an LSA secret lookup) *before* checking that a username is required on DCs. The LSA lookup always fails in this case and logs a misleading `LSA retrieve failed... system cannot find the file specified` line, which becomes the most prominent thing in the log even though it's a red herring — the real cause (`InvalidAgentUserConfigurationException: "A username was not provided..."`) was only thrown afterward. On-call/support see an opaque MSI exit 1603 with the wrong error front-and-center.

Fix: added an early precondition check — if `_isDomainController` is true and no username was provided, throw `InvalidAgentUserConfigurationException` immediately, before `FetchAgentPassword()` is ever called, with a `session.Log(...)` line explaining why. Removed the now-redundant duplicate check further down. Non-DC hosts and DC hosts that do supply a username are unaffected — this is a pure early-exit precondition.

**2. Fleet installer: raw Go OOM/thread-exhaustion panics leak into the primary error**

`pkg/fleet/installer/exec/installer_exec.go` (`(*installerCmd).Run()`): when the daemon execs a fresh `datadog-installer` subprocess and it crashes at Go-runtime bootstrap because the host is out of memory/threads/paging capacity, the raw multi-line Go panic (e.g. `fatal error: pageAlloc: out of memory`, `runtime: failed to create new OS thread ... errno=11`, `VirtualAlloc ... errno=1455`, `paging file is too small`) gets wrapped verbatim into the returned error and surfaces to users/Error Tracking as an opaque wall of Go internals with no actionable signal.

Fix: added `isResourceExhaustionCrash([]byte) bool`, which pattern-matches the known signatures, and a sentinel `ErrResourceExhausted` error. When a subprocess run fails and its stderr matches one of the known signatures, the returned error now wraps `ErrResourceExhausted` (via `%w`, so `errors.Is` still works) instead of echoing the full stack trace into the primary error string; the full output still goes to a debug log (`pkg/util/log`).

## Status

This is a **draft PR pending review/testing**. The Go side (`pkg/fleet/installer/exec`) was fully compiled and unit-tested locally. The Windows MSI/C# side (`tools/windows/DatadogAgentInstaller`) could **not** be build-verified locally — this repo's installer targets full .NET Framework (net462/net472), and the required Framework reference assemblies/targeting packs aren't available on this (macOS) dev machine, nor is a Windows CI runner available in this session. The C# change was reviewed manually for syntax/style consistency with the surrounding file, and `dotnet-format` (run via this repo's pre-commit hook) passed on it.

## Changes

- `tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs`: move the Domain-Controller-requires-username check ahead of `FetchAgentPassword()`.
- `tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/ProcessUserCustomActionsDomainControllerTests.cs`: new regression test asserting `FetchSecret` (the LSA lookup) is never called when no username is provided on a DC.
- `pkg/fleet/installer/exec/installer_exec.go`: add `isResourceExhaustionCrash`, `ErrResourceExhausted`, and use them in `(*installerCmd).Run()`.
- `pkg/fleet/installer/exec/installer_exec_test.go` (new): unit tests for the signature matcher and for `errors.Is` unwrapping through the new `%w: %w` wrap.
- `pkg/fleet/installer/exec/BUILD.bazel`: add `go_test` target and the new `pkg/util/log` dependency.

## Test plan

- [x] `go build ./pkg/fleet/installer/...` passes
- [x] `go vet ./pkg/fleet/installer/exec/...` passes
- [x] `go test ./pkg/fleet/installer/exec/...` passes (new tests included)
- [x] Pre-commit hooks (`go-fmt`, `dotnet-format-installer`, `copyright`, `go-mod-tidy`) passed locally
- [ ] Windows MSI build/test (`CustomActions.Tests`) — **not run**, no .NET Framework 4.7.2 reference assemblies available on this machine; needs Windows CI or a Windows dev box
- [ ] Manual verification on an actual Domain Controller install without `DDAGENTUSER_NAME` (should now fail fast with the correct message and no LSA log line)
- [ ] Manual/synthetic verification that an installer subprocess OOM crash now returns an error satisfying `errors.Is(err, exec.ErrResourceExhausted)`