### PR TITLE
[FA] Fix DC credential precondition on Windows installer

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/ProcessUserCustomActionsDomainControllerTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/ProcessUserCustomActionsDomainControllerTests.cs
@@ -1,5 +1,6 @@
 using AutoFixture.Xunit2;
 using FluentAssertions;
+using Moq;
 using WixToolset.Dtf.WindowsInstaller;
 using Xunit;
 
@@ -20,6 +21,25 @@ namespace CustomActions.Tests.ProcessUserCustomActions
                 .ProcessDdAgentUserCredentials()
                 .Should()
                 .Be(ActionResult.Failure);
+
+            Test.Properties.Should()
+                .BeEmpty();
+        }
+
+        [Theory]
+        [AutoData]
+        public void ProcessDdAgentUserCredentials_Skips_LsaSecretLookup_With_No_Username_On_DomainController()
+        {
+            // Regression test: on a Domain Controller with no DDAGENTUSER_NAME provided, we must fail
+            // fast before attempting to read the password from the LSA secret store. Otherwise the LSA
+            // lookup fails and logs a misleading "system cannot find the file specified" error that
+            // obscures the real problem (missing required username on DCs).
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Failure);
+
+            Test.NativeMethods.Verify(n => n.FetchSecret(It.IsAny<string>()), Times.Never());
 
             Test.Properties.Should()
                 .BeEmpty();

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
@@ -410,6 +410,17 @@ namespace Datadog.CustomActions
                 }
 
                 var ddAgentUserName = _session.Property("DDAGENTUSER_NAME");
+
+                // Check this precondition before fetching the password from the LSA secret store.
+                // On Domain Controllers, a username is always required, and FetchAgentPassword's LSA lookup
+                // will otherwise fail and log a misleading "LSA retrieve failed... system cannot find the file
+                // specified" error that obscures the real problem and is the most prominent thing on-call sees.
+                if (_isDomainController && string.IsNullOrEmpty(ddAgentUserName))
+                {
+                    _session.Log("Aborting before LSA secret lookup: no DDAGENTUSER_NAME was provided and a username is required when installing on Domain Controllers.");
+                    throw new InvalidAgentUserConfigurationException("A username was not provided. A username is a required when installing on Domain Controllers.");
+                }
+
                 var ddAgentUserPassword = FetchAgentPassword();
                 var datadogAgentServiceExists = _serviceController.ServiceExists(Constants.AgentServiceName);
 
@@ -430,13 +441,7 @@ namespace Datadog.CustomActions
 
                 if (string.IsNullOrEmpty(ddAgentUserName))
                 {
-                    if (_isDomainController)
-                    {
-                        // require user to provide a username on domain controllers so that the customer is explicit
-                        // about the username/password that will be created on their domain if it does not exist.
-                        throw new InvalidAgentUserConfigurationException("A username was not provided. A username is a required when installing on Domain Controllers.");
-                    }
-
+                    // _isDomainController is already handled above, before the LSA secret lookup.
                     // Creds are not in registry and user did not pass a value, use default account name
                     ddAgentUserName = $"{GetDefaultDomainPart()}\\ddagentuser";
                     _session.Log($"No creds provided, using default {ddAgentUserName}");


### PR DESCRIPTION
## Summary

A week-long Error Tracking sweep of installer error categories surfaced this: when installing/upgrading the Agent on a Windows Domain Controller without an explicit `DDAGENTUSER_NAME`, `ProcessDdAgentUserCredentials` first calls `FetchAgentPassword()`, which does an LSA secret lookup. On DCs without an explicit username, that lookup always fails and logs a misleading `LSA retrieve failed... system cannot find the file specified` line. Only afterward does the code discover it actually needs an explicit username on DCs and throw `InvalidAgentUserConfigurationException("A username was not provided...")`. Support/on-call end up staring at an opaque MSI exit code 1603 with the LSA red herring as the most prominent line in the log, obscuring the real, simple cause.

## Change

`tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs`:
- Added an early precondition check in `ProcessDdAgentUserCredentials`: if `_isDomainController` is true and no username was provided, throw `InvalidAgentUserConfigurationException` immediately — before `FetchAgentPassword()` is ever called — with a `session.Log(...)` line documenting why.
- Removed the now-redundant duplicate DC check that previously ran after the LSA lookup.
- Non-DC hosts, and DC hosts that do supply a username, are unaffected — this is a pure early-exit precondition, not a behavior change for the working case.

`tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/ProcessUserCustomActionsDomainControllerTests.cs`:
- New regression test asserting `NativeMethods.FetchSecret` (the LSA lookup) is never invoked when installing on a DC with no `DDAGENTUSER_NAME`.

## Status

Draft, pending review/testing. This is split out of #53904, which combined this fix with an unrelated Go-side fix; splitting per the reviewer's request since the two are independent.

## Test plan

- [x] Manual review of C# syntax/style consistency with the surrounding file
- [x] `dotnet-format-installer` pre-commit hook passed
- [ ] Windows MSI build/test (`CustomActions.Tests`) — **not run**; this dev machine lacks the .NET Framework 4.7.2 targeting pack/reference assemblies, and there's no Windows CI/dev box available in this session
- [ ] Manual verification on an actual Domain Controller install without `DDAGENTUSER_NAME` (should now fail fast with the correct message and no LSA log line)