### PR TITLE
[DSEC-149] [DO NOT MERGE] Implement data security POC in autodiscovery

### DIFF
--- a/cmd/agent/subcommands/run/BUILD.bazel
+++ b/cmd/agent/subcommands/run/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//comp/core/autodiscovery/def",
         "//comp/core/autodiscovery/fx",
         "//comp/core/autodiscovery/providers",
+        "//comp/core/autodiscovery/providers/datasecurity",
         "//comp/core/autodiscovery/providers/datastreams",
         "//comp/core/autodiscovery/providers/networkpath",
         "//comp/core/config",

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -36,6 +36,7 @@ import (
 	reporterfx "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/fx"
 	agenttelemetry "github.com/DataDog/datadog-agent/comp/core/agenttelemetry/def"
 	agenttelemetryfx "github.com/DataDog/datadog-agent/comp/core/agenttelemetry/fx"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/datasecurity"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/datastreams"
 	networkpathprovider "github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/networkpath"
 	fxinstrumentation "github.com/DataDog/datadog-agent/comp/core/fxinstrumentation/fx"
@@ -705,6 +706,9 @@ func startAgent(
 		rcclient.SubscribeAgentTask()
 		actionsController := datastreams.NewActionsController(ac, rcclient)
 		ac.AddConfigProvider(actionsController, false, 0)
+
+		dataSecurityController := datasecurity.NewController(ac, rcclient)
+		ac.AddConfigProvider(dataSecurityController, false, 0)
 
 		if cfg.GetBool("remote_configuration.agent_integrations.enabled") {
 			// Spin up the config provider to schedule integrations through remote-config

--- a/comp/core/autodiscovery/providers/datasecurity/BUILD.bazel
+++ b/comp/core/autodiscovery/providers/datasecurity/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "datasecurity",
+    srcs = ["data_security.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/datasecurity",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/autodiscovery/def",
+        "//comp/core/autodiscovery/integration",
+        "//comp/core/autodiscovery/providers/names",
+        "//comp/core/autodiscovery/providers/types",
+        "//comp/remote-config/rcclient/def",
+        "//pkg/config/remote/data",
+        "//pkg/remoteconfig/state",
+        "//pkg/util/log",
+        "@in_yaml_go_yaml_v2//:yaml",
+    ],
+)

--- a/comp/core/autodiscovery/providers/datasecurity/data_security.go
+++ b/comp/core/autodiscovery/providers/datasecurity/data_security.go
@@ -1,0 +1,244 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package datasecurity schedules one-off Data Security checks triggered via Remote Configuration.
+package datasecurity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	autodiscovery "github.com/DataDog/datadog-agent/comp/core/autodiscovery/def"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
+	rcclient "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/def"
+	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	yaml "go.yaml.in/yaml/v2"
+)
+
+const (
+	// exampleCheckName is the Rust check scheduled on a scan task. See
+	// pkg/collector/sharedlibrary/rustchecks/checks/example.
+	exampleCheckName = "example"
+
+	postgresIntegrationName = "postgres"
+
+	// TODO(data-security): DATA_SECURITY_DB_SCAN_TASKS does not exist yet. We subscribe to
+	// the generic DEBUG product and gate on the `product` payload attribute matching this
+	// value. Subscribe to the dedicated product directly and drop the gate once provisioned.
+	dataSecurityDBScanTasksProduct = "DATA_SECURITY_DB_SCAN_TASKS"
+)
+
+// scanTaskPayload is the RC config received for a Data Security DB scan task.
+type scanTaskPayload struct {
+	Product      string       `json:"product"`
+	DBIdentifier dbIdentifier `json:"db_identifier"`
+}
+
+// dbIdentifier identifies the database a scan task targets. Matching is by host.
+type dbIdentifier struct {
+	Type string `json:"type"`
+	Host string `json:"host"`
+}
+
+// isConnectedToPostgres reports whether any postgres integration is configured.
+func isConnectedToPostgres(ac autodiscovery.Component) bool {
+	for _, config := range ac.GetUnresolvedConfigs() {
+		if config.Name == postgresIntegrationName {
+			return true
+		}
+	}
+	return false
+}
+
+// controller listens to Data Security DB scan task RC updates and schedules a one-off run
+// of the example Rust check (min_collection_interval: 0).
+type controller struct {
+	ac            autodiscovery.Component
+	rcclient      rcclient.Component
+	configChanges chan integration.ConfigChanges
+	closeMutex    sync.RWMutex
+	closed        bool
+}
+
+// NewController creates a new Data Security controller instance.
+func NewController(ac autodiscovery.Component, rcclient rcclient.Component) types.ConfigProvider {
+	c := &controller{
+		ac:            ac,
+		rcclient:      rcclient,
+		configChanges: make(chan integration.ConfigChanges, 10),
+	}
+	c.configChanges <- integration.ConfigChanges{}
+	go c.manageSubscriptionToRC()
+	log.Infof("poc datasecurity provider: controller created, waiting for postgres integration before subscribing to RC")
+	return c
+}
+
+// manageSubscriptionToRC waits until a postgres integration is configured before subscribing to RC.
+func (c *controller) manageSubscriptionToRC() {
+	ticker := time.NewTicker(time.Second * 10)
+	defer ticker.Stop()
+	for range ticker.C {
+		c.closeMutex.RLock()
+		if c.closed {
+			c.closeMutex.RUnlock()
+			return
+		}
+		c.closeMutex.RUnlock()
+		if isConnectedToPostgres(c.ac) {
+			// TODO(data-security): subscribe to the dedicated product once it exists; DEBUG is a stand-in.
+			log.Infof("poc datasecurity provider: postgres integration detected, subscribing to RC product %q", data.ProductDebug)
+			c.rcclient.Subscribe(data.ProductDebug, c.update)
+			return
+		}
+		log.Infof("poc datasecurity provider: no postgres integration yet, will retry subscription")
+	}
+}
+
+// String returns the provider name.
+func (c *controller) String() string {
+	return names.DataSecurity
+}
+
+// GetConfigErrors returns errors that occurred on the last update.
+func (c *controller) GetConfigErrors() map[string]types.ErrorMsgSet {
+	return map[string]types.ErrorMsgSet{}
+}
+
+// Stream sends configuration updates until the context is cancelled.
+func (c *controller) Stream(ctx context.Context) <-chan integration.ConfigChanges {
+	go func() {
+		<-ctx.Done()
+		c.closeMutex.Lock()
+		defer c.closeMutex.Unlock()
+		if c.closed {
+			return
+		}
+		c.closed = true
+		close(c.configChanges)
+	}()
+	return c.configChanges
+}
+
+// update resolves the target database's connection info and triggers the Data Security check.
+func (c *controller) update(updates map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
+	log.Infof("poc datasecurity provider: received RC update with %d config(s)", len(updates))
+	changes := integration.ConfigChanges{}
+	for path, rawConfig := range updates {
+		log.Infof("poc datasecurity provider: processing RC config %s", path)
+		var payload scanTaskPayload
+		if err := json.Unmarshal(rawConfig.Config, &payload); err != nil {
+			log.Errorf("poc datasecurity provider: can't decode Data Security scan task from remote-config: %v", err)
+			applyStateCallback(path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
+			continue
+		}
+
+		// TODO(data-security): gate on the `product` attribute to simulate the dedicated
+		// product; remove once we subscribe to it directly.
+		if payload.Product != dataSecurityDBScanTasksProduct {
+			log.Infof("poc datasecurity provider: ignoring RC config %s: product %q is not %q", path, payload.Product, dataSecurityDBScanTasksProduct)
+			continue
+		}
+
+		log.Infof("poc datasecurity provider: resolving postgres connection for scan task %s (db host=%q, type=%q)", path, payload.DBIdentifier.Host, payload.DBIdentifier.Type)
+		connInfo, err := c.resolvePostgresConnection(payload.DBIdentifier)
+		if err != nil {
+			log.Warnf("poc datasecurity provider: failed to resolve postgres connection for Data Security scan task %s: %v", path, err)
+			applyStateCallback(path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
+			continue
+		}
+
+		// TODO(data-security): trigger the datasecurity rust check once it consumes DB
+		// connection config. For now run `example` as a one-off, passing connInfo through
+		// to exercise the whole flow.
+		instance, err := yaml.Marshal(map[string]any{
+			"min_collection_interval": 0,
+			"remote_config_id":        rawConfig.Metadata.ID,
+			"database_connection":     connInfo,
+		})
+		if err != nil {
+			applyStateCallback(path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
+			continue
+		}
+
+		// TODO(data-security): remove this debug log.
+		log.Infof("Data Security would schedule check %q with instance:\n%s", exampleCheckName, string(instance))
+
+		changes.Schedule = append(changes.Schedule, integration.Config{
+			Name:      exampleCheckName,
+			Source:    c.String(),
+			Instances: []integration.Data{integration.Data(instance)},
+		})
+		log.Infof("poc datasecurity provider: scheduled check %q for scan task %s", exampleCheckName, path)
+		applyStateCallback(path, state.ApplyStatus{State: state.ApplyStateAcknowledged})
+	}
+
+	if len(changes.Schedule) == 0 {
+		log.Infof("poc datasecurity provider: no checks to schedule from this RC update")
+		return
+	}
+
+	c.closeMutex.RLock()
+	defer c.closeMutex.RUnlock()
+	if c.closed {
+		log.Infof("poc datasecurity provider: controller closed, dropping %d scheduled change(s)", len(changes.Schedule))
+		return
+	}
+	log.Infof("poc datasecurity provider: pushing %d scheduled change(s) to autodiscovery", len(changes.Schedule))
+	c.configChanges <- changes
+}
+
+// resolvePostgresConnection finds the local postgres instance matching dbID (by host) and
+// extracts its connection info.
+func (c *controller) resolvePostgresConnection(dbID dbIdentifier) (map[string]any, error) {
+	for _, cfg := range c.ac.GetUnresolvedConfigs() {
+		if cfg.Name != postgresIntegrationName {
+			continue
+		}
+		log.Infof("poc datasecurity provider: inspecting postgres config with %d instance(s)", len(cfg.Instances))
+		for _, instanceData := range cfg.Instances {
+			var instance map[string]any
+			if err := yaml.Unmarshal(instanceData, &instance); err != nil {
+				log.Warnf("poc datasecurity provider: skipping postgres instance, failed to unmarshal: %v", err)
+				continue
+			}
+			host, _ := instance["host"].(string)
+			// An empty target host matches the first postgres instance found.
+			if dbID.Host != "" && host != dbID.Host {
+				log.Infof("poc datasecurity provider: postgres instance host=%q does not match target host=%q, skipping", host, dbID.Host)
+				continue
+			}
+			log.Infof("poc datasecurity provider: matched postgres instance host=%q for target host=%q", host, dbID.Host)
+			return extractPostgresConnectionInfo(instance), nil
+		}
+	}
+	log.Warnf("poc datasecurity provider: no postgres integration found with host=%q", dbID.Host)
+	return nil, fmt.Errorf("postgres integration with host=%q not found", dbID.Host)
+}
+
+// extractPostgresConnectionInfo copies allow-listed connection fields out of a postgres instance.
+func extractPostgresConnectionInfo(instance map[string]any) map[string]any {
+	out := make(map[string]any)
+	allowList := []string{
+		"host",
+		"port",
+		"username",
+		"password",
+		"dbname",
+		"ssl",
+	}
+	for _, k := range allowList {
+		if v, ok := instance[k]; ok {
+			out[k] = v
+		}
+	}
+	return out
+}

--- a/comp/core/autodiscovery/providers/names/provider_names.go
+++ b/comp/core/autodiscovery/providers/names/provider_names.go
@@ -61,6 +61,8 @@ const (
 	GPU = "gpu"
 	// DataStreamsKafkaActions provides one-off Kafka action configurations for Data Streams Monitoring.
 	DataStreamsKafkaActions = "dsm-kafka-actions"
+	// DataSecurity provides one-off Data Security check configurations triggered via Remote Configuration.
+	DataSecurity = "data-security"
 	// DOQueryActions provides check configurations for Database Observability query-level actions.
 	DOQueryActions = "do-query-actions"
 	// PrometheusHTTPSD discovers check configurations from a Prometheus HTTP Service Discovery endpoint.

--- a/pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.yaml
+++ b/pkg/collector/sharedlibrary/rustchecks/shared_checks_manifest.yaml
@@ -1,6 +1,6 @@
 checks:
   - id: example
     crate: example
-    include_in_build: false
+    include_in_build: true
     platforms:
       - linux

--- a/pkg/config/remote/data/product.go
+++ b/pkg/config/remote/data/product.go
@@ -48,6 +48,8 @@ const (
 	ProductDOQueryActions Product = "DO_QUERY_ACTIONS"
 	// ProductNetworkPath is to configure Network Path scheduled tests
 	ProductNetworkPath Product = "NETWORK_PATH"
+	// ProductDebug is used to remotely trigger debug/diagnostic checks (e.g. Data Security)
+	ProductDebug Product = "DEBUG"
 )
 
 // ProductListToString converts a product list to string list

--- a/pkg/remoteconfig/state/products.go
+++ b/pkg/remoteconfig/state/products.go
@@ -48,6 +48,7 @@ var validProducts = map[string]struct{}{
 	ProductDOQueryActions:               {},
 	ProductK8SActions:                   {},
 	ProductNetworkPath:                  {},
+	ProductDebug:                        {},
 }
 
 const (
@@ -139,4 +140,6 @@ const (
 	ProductK8SActions = "K8S_ACTIONS"
 	// ProductNetworkPath configures Network Path scheduled tests
 	ProductNetworkPath = "NETWORK_PATH"
+	// ProductDebug remotely triggers debug/diagnostic checks (e.g. Data Security)
+	ProductDebug = "DEBUG"
 )


### PR DESCRIPTION
> [!WARNING]
> **This PR is NOT intended to be merged.** It is a throwaway proof-of-concept meant to align on the [RFC](https://datadoghq.atlassian.net/wiki/spaces/SDS/pages/6932758902/RFC+-+Data+Security+-+Implementing+Sensitive+Data+Scanning+For+Agent+Monitored+Postgres+Database).

## What does this PR do?

Implements a **proof-of-concept** of the Data Security component inside autodiscovery, modeled after the existing Kafka/Data Observability query-action providers. It demonstrates the full end-to-end flow:

1. The Data Security provider starts and **waits until at least one `postgres` integration is configured** before subscribing to Remote Configuration (RC).
2. Once a postgres integration is present, it **subscribes to an RC product** (the generic `DEBUG` product is used as a stand-in until the dedicated `DATA_SECURITY_DB_SCAN_TASKS` is used).
3. When an RC config is received, it is gated on the `product` attribute, then the provider **resolves the target database connection** by matching the RC payload's `db_identifier.host` against the locally-configured postgres instances.
4. On a match, it **builds and schedules a one-off check task**. In this POC the task is the `example` Rust shared-library check; in the real implementation it will be the `datasecurity` check.

## Motivation

In order to align on the [RFC](https://datadoghq.atlassian.net/wiki/spaces/SDS/pages/6932758902/RFC+-+Data+Security+-+Implementing+Sensitive+Data+Scanning+For+Agent+Monitored+Postgres+Database), this POC shows a concrete, working implementation of the Data Security component and walks through it step by step.

## Describe how you validated your changes

Validated manually against a local Agent talking to `datad0g.com` (staging), with a real RC config pushed through the RC admin console.

### Agent configuration (`datadog.yaml`)
```yaml
api_key: xxxxxxxx
hostname: dsec-149-test
site: datad0g.com
log_level: INFO
shared_library_check:
  enabled: true
  library_folder_path: /Users/aimene.belfodil/go/src/github.com/DataDog/datadog-agent/dev/dist/checks.d
```

### Integrations & checks setup

- **`conf.d/postgres.d/`**: a single postgres integration configured to connect to **`localhost`**. This is the integration the Data Security provider matches the RC scan task against.
- **`checks.d/`**: the `example` Rust check

### Remote Configuration used

The RC config that triggered the flow was pushed via the RC admin console:

[RC config `test-aimene-dsec-149` (DEBUG product, us1.staging)](https://remote-config-admin.us1.staging.dog/?product=DEBUG&datacenter=us1.staging.dog&orgId=2&version=1&config_id=test-aimene-dsec-149)

<img width="1149" height="733" alt="image" src="https://github.com/user-attachments/assets/da30e2cd-6e56-499e-9b0f-5269bec48415" />


### Emitted event

The scheduled check ran and emitted an event, visible in the Events Explorer:

[Emitted event for `host:dsec-149-test`](https://dd.datad0g.com/event/explorer?query=host%3Adsec-149-test&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=&fromUser=true&messageDisplay=expanded-lg&options=&refresh_mode=paused&sort=DESC&from_ts=1784628459264&to_ts=1784628648520&live=false)

### Agent logs walkthrough

<details>
<summary>Agent logs showing the full POC flow (subscribe → match → schedule → run)</summary>

```
2026-07-21 12:08:12 CEST | CORE | INFO | (comp/core/autodiscovery/providers/datasecurity/data_security.go:81 in NewController) | poc datasecurity provider: controller created, waiting for postgres integration before subscribing to RC

....
2026-07-21 12:08:22 CEST | CORE | INFO | (comp/core/autodiscovery/providers/datasecurity/data_security.go:98 in manageSubscriptionToRC) | poc datasecurity provider: postgres integration detected, subscribing to RC product "DEBUG"
....

2026-07-21 12:09:10 CEST | CORE | INFO | (comp/core/autodiscovery/providers/datasecurity/data_security.go:136 in update) | poc datasecurity provider: processing RC config datadog/2/DEBUG/ssi-targets-test/6ddab19b791f2459d09be299c9798efc50ad50c090806e2928ac372be5756d94
2026-07-21 12:09:10 CEST | CORE | INFO | (comp/core/autodiscovery/providers/datasecurity/data_security.go:147 in update) | poc datasecurity provider: ignoring RC config datadog/2/DEBUG/ssi-targets-test/6ddab19b791f2459d09be299c9798efc50ad50c090806e2928ac372be5756d94: product "" is not "DATA_SECURITY_DB_SCAN_TASKS"
2026-07-21 12:09:10 CEST | CORE | INFO | (comp/core/autodiscovery/providers/datasecurity/data_security.go:136 in update) | poc datasecurity provider: processing RC config datadog/2/DEBUG/test-aimene-dsec-149/44cc5e810b7666b671edf5656f2f3053123bb5092b378e4d80843954e8957f0f
2026-07-21 12:09:10 CEST | CORE | INFO | (comp/core/autodiscovery/providers/datasecurity/data_security.go:151 in update) | poc datasecurity provider: resolving postgres connection for scan task datadog/2/DEBUG/test-aimene-dsec-149/44cc5e810b7666b671edf5656f2f3053123bb5092b378e4d80843954e8957f0f (db host="localhost", type="postgres")
2026-07-21 12:09:10 CEST | CORE | INFO | (comp/core/autodiscovery/providers/datasecurity/data_security.go:206 in resolvePostgresConnection) | poc datasecurity provider: inspecting postgres config with 1 instance(s)
2026-07-21 12:09:10 CEST | CORE | INFO | (comp/core/autodiscovery/providers/datasecurity/data_security.go:219 in resolvePostgresConnection) | poc datasecurity provider: matched postgres instance host="localhost" for target host="localhost"
2026-07-21 12:09:10 CEST | CORE | INFO | (comp/core/autodiscovery/providers/datasecurity/data_security.go:173 in update) | Data Security would schedule check "example" with instance:
database_connection:
  dbname: dbm
  host: localhost
  password: "********"
  port: 5432
  username: datadog
min_collection_interval: 0
remote_config_id: test-aimene-dsec-149
2026-07-21 12:09:10 CEST | CORE | INFO | (comp/core/autodiscovery/providers/datasecurity/data_security.go:180 in update) | poc datasecurity provider: scheduled check "example" for scan task datadog/2/DEBUG/test-aimene-dsec-149/44cc5e810b7666b671edf5656f2f3053123bb5092b378e4d80843954e8957f0f
2026-07-21 12:09:10 CEST | CORE | INFO | (comp/core/autodiscovery/providers/datasecurity/data_security.go:195 in update) | poc datasecurity provider: pushing 1 scheduled change(s) to autodiscovery
2026-07-21 12:09:10 CEST | CORE | INFO | (comp/core/autodiscovery/impl/config_poller.go:108 in stream) | data-security provider: collected 1 new configurations, removed 0
2026-07-21 12:09:10 CEST | CORE | INFO | (pkg/collector/scheduler/scheduler.go:278 in enqueueOnce) | Scheduling check example for one-time execution
2026-07-21 12:09:10 CEST | CORE | INFO | (comp/collector/collector/impl/collector.go:241 in RunCheck) | Adding an extra runner for the 'example' long running check
2026-07-21 12:09:10 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:40 in CheckStarted) | check:example | Running check...
2026-07-21 12:09:10 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:59 in CheckFinished) | check:example | Done running check
2026-07-21 12:09:10 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:65 in CheckFinished) | check:example | Check's one time execution has finished
2026-07-21 12:09:12 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:40 in CheckStarted) | check:uptime | Running check...
2026-07-21 12:09:12 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:59 in CheckFinished) | check:uptime | Done running check
```

</details>

## Additional Notes

This is a POC to drive the RFC discussion and **must not be merged**.
