### PR TITLE
fix(e2e): increase e2e pre-test memory

### DIFF
--- a/.gitlab/test/e2e_pre_test/e2e_pre_test.yml
+++ b/.gitlab/test/e2e_pre_test/e2e_pre_test.yml
@@ -18,5 +18,7 @@ e2e_pre_test:
     - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "junit-${CI_JOB_ID}.tgz" "$E2E_RESULT_JSON"
   variables:
     TEAM: "agent-devx"
+    KUBERNETES_MEMORY_REQUEST: 24Gi
+    KUBERNETES_MEMORY_LIMIT: 24Gi
     # override to use latest stable agent
     E2E_PIPELINE_ID: ""


### PR DESCRIPTION
### What does this PR do?

Increase the `e2e_pre_test` GitLab job memory request and limit to `24Gi` so the new-e2e framework pre-test has enough memory to complete.

### Motivation

The `e2e_pre_test` job is [often being OOMKilled](https://app.datadoghq.com/ci/ci-cd/explorer?query=ci_level%3Ajob%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%40git.branch%3Amain%20%40ci.job.name%3Ae2e_pre_test%20%40ci.status%3Aerror%20-%40ci.allowed_to_fail%3Atrue&agg_m=count&agg_m_source=base&agg_t=count&ci_cd_explorer_tab=pipelines&fromUser=true&index=cipipeline&refresh_mode=sliding&start=1776857277458&end=1784633277458&paused=false) on `main`. Increasing the memory blindly like this is maybe not the right way to proceed, opening this PR to start a discussion.