### PR TITLE
fix(tasks): make `_with_hermetic_mingw_path` fail fast

### DIFF
--- a/tasks/libs/common/go.py
+++ b/tasks/libs/common/go.py
@@ -98,23 +98,19 @@ def _with_pdb_extldflag(ldflags: str, bin_path: str) -> str:
     return (ldflags + suffix) if ldflags else suffix.lstrip()
 
 
-def _with_hermetic_mingw_path(ctx: Context, env: dict[str, str] | None) -> dict[str, str] | None:
+def _with_hermetic_mingw_path(ctx: Context, env: dict[str, str] | None) -> dict[str, str]:
     """
     Prepend the Bazel hermetic MinGW (GNU ld >= 2.44) to PATH for a Windows cgo
     build, so the linker emits PDBs that Microsoft dbghelp/symstore can read. The
     build image's default mingw is ld 2.43, whose `--pdb` output those tools
-    can't parse (WINA-2770). Returns env unchanged if it can't be resolved.
+    can't parse (WINA-2770).
 
     TODO: remove once migrated fully to the Bazel MinGW toolchain.
     """
     # bazel cquery is idempotent: it fetches/extracts @winlibs_mingw64 only if missing.
-    if not (
-        gcc := bazel(ctx, "cquery", "@winlibs_mingw64//:gcc", "--output=files", capture_output=True, ignore_errors=True)
-    ):
-        return env
-    if not (output_base := bazel(ctx, "info", "output_base", capture_output=True, ignore_errors=True)):
-        return env
-    mingw_bin = Path(output_base.strip(), gcc.strip()).parent
+    gcc = bazel(ctx, "cquery", "@winlibs_mingw64//:gcc", "--output=files", capture_output=True).strip()
+    output_base = bazel(ctx, "info", "output_base", capture_output=True).strip()
+    mingw_bin = Path(output_base, gcc).parent
     path = (env or {}).get("PATH") or os.environ.get("PATH", "")
     return {**(env or {}), "PATH": f"{mingw_bin}{os.pathsep}{path}"}
 


### PR DESCRIPTION
### What does this PR do?
Make `_with_hermetic_mingw_path` in tasks/libs/common/go.py no longer pass `ignore_errors=True` to its `bazel` calls.

### Motivation
The previous code silently fell back to the build image's non-hermetic `mingw` whenever `bazel cquery`/`info` failed for any reason, with no diagnostic.

That could reintroduce the unreadable-PDB bug this function existed to prevent ([WINA-2770](https://datadoghq.atlassian.net/browse/WINA-2770)), and the build would appear to succeed.

### Additional Notes
Found by working on sibling code in the frame of [ABLD-388](https://datadoghq.atlassian.net/browse/ABLD-388).

[ABLD-388]: https://datadoghq.atlassian.net/browse/ABLD-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ