### PR TITLE
fix(ci): move e2e pre-tests to pre-test subdir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -923,7 +923,6 @@
 /test/fakeintake/aggregator/agenthealthAggregator_test.go @DataDog/fleet-remediation
 /test/fakeintake/client/fixtures/api_v2_agenthealth_response @DataDog/fleet-remediation
 /test/new-e2e/                                 @DataDog/agent-devx
-/test/new-e2e/test-infra-definition           @DataDog/agent-devx
 /test/new-e2e/system-probe                    @DataDog/ebpf-platform
 /test/new-e2e/system-probe/config/vmconfig-security-agent.json @DataDog/ebpf-platform @DataDog/agent-security
 /test/new-e2e/scenarios/system-probe          @DataDog/ebpf-platform

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1016,7 +1016,7 @@ workflow:
   - !reference [.on_e2e_main_release_or_rc]
   - changes:
       paths:
-        - test/new-e2e/test-infra-definition/*
+        - test/new-e2e/tests/agent-devx/pre-test/*
       compare_to: $COMPARE_TO_BRANCH
     when: on_success
   - when: manual

--- a/.gitlab/test/e2e_pre_test/e2e_pre_test.yml
+++ b/.gitlab/test/e2e_pre_test/e2e_pre_test.yml
@@ -17,7 +17,7 @@ e2e_pre_test:
     - job: publish_fakeintake_pinned
       optional: true
   script:
-    - dda inv -- -e new-e2e-tests.run --targets ./test-infra-definition --result-json $E2E_RESULT_JSON --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password)
+    - dda inv -- -e new-e2e-tests.run $PRE_BUILT_BINARIES_FLAG --targets ./test-infra-definition --result-json $E2E_RESULT_JSON --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password)
   after_script:
     - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "junit-${CI_JOB_ID}.tgz" "$E2E_RESULT_JSON"
   variables:

--- a/.gitlab/test/e2e_pre_test/e2e_pre_test.yml
+++ b/.gitlab/test/e2e_pre_test/e2e_pre_test.yml
@@ -16,11 +16,8 @@ e2e_pre_test:
       optional: true
     - job: publish_fakeintake_pinned
       optional: true
-  script:
-    - dda inv -- -e new-e2e-tests.run $PRE_BUILT_BINARIES_FLAG --targets ./test-infra-definition --result-json $E2E_RESULT_JSON --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password)
-  after_script:
-    - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "junit-${CI_JOB_ID}.tgz" "$E2E_RESULT_JSON"
   variables:
+    TARGETS: ./tests/agent-devx/pre-test
     TEAM: "agent-devx"
     KUBERNETES_MEMORY_REQUEST: 24Gi
     KUBERNETES_MEMORY_LIMIT: 24Gi

--- a/.gitlab/test/e2e_pre_test/e2e_pre_test.yml
+++ b/.gitlab/test/e2e_pre_test/e2e_pre_test.yml
@@ -10,6 +10,7 @@ e2e_pre_test:
     - job: go_e2e_test_binaries
       artifacts: false
     - go_tools_deps
+    - agent_deb-x64-a7
     # PR pipelines run against v<sha> (publish_fakeintake); main uses the pinned
     # tag (publish_fakeintake_pinned). Both optional: absent otherwise.
     - job: publish_fakeintake

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -71,7 +71,6 @@ exports_files(["go.mod"])
 # gazelle:exclude test/new-e2e/examples
 # gazelle:exclude test/new-e2e/system-probe/config
 # gazelle:exclude test/new-e2e/system-probe/test
-# gazelle:exclude test/new-e2e/test-infra-definition
 # gazelle:exclude test/new-e2e/tests/agent-configuration
 # gazelle:exclude test/new-e2e/tests/agent-devx
 # gazelle:exclude test/new-e2e/tests/agent-health

--- a/tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS
+++ b/tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS
@@ -678,7 +678,6 @@
 /test/new-e2e/                                @DataDog/agent-e2e-testing @DataDog/agent-devx
 /test/new-e2e/pkg/components/datadog-installer @DataDog/windows-products
 /test/new-e2e/pkg/testcommon/check            @DataDog/agent-runtimes
-/test/new-e2e/test-infra-definition           @DataDog/agent-devx
 /test/new-e2e/system-probe                    @DataDog/ebpf-platform
 /test/new-e2e/scenarios/system-probe          @DataDog/ebpf-platform
 /test/new-e2e/tests/agent-platform            @DataDog/agent-onboarding @DataDog/agent-delivery @DataDog/agent-devx

--- a/test/new-e2e/tests/agent-devx/pre-test/agent_test.go
+++ b/test/new-e2e/tests/agent-devx/pre-test/agent_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package testinfradefinition
+package pretest
 
 import (
 	"testing"

--- a/test/new-e2e/tests/agent-devx/pre-test/docker_test.go
+++ b/test/new-e2e/tests/agent-devx/pre-test/docker_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package testinfradefinition
+package pretest
 
 import (
 	"fmt"

--- a/test/new-e2e/tests/agent-devx/pre-test/kind_test.go
+++ b/test/new-e2e/tests/agent-devx/pre-test/kind_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package testinfradefinition
+package pretest
 
 import (
 	"context"

--- a/test/new-e2e/tests/agent-devx/pre-test/loadbalancer_test.go
+++ b/test/new-e2e/tests/agent-devx/pre-test/loadbalancer_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package testinfradefinition
+package pretest
 
 import (
 	"testing"

--- a/test/new-e2e/tests/agent-devx/pre-test/vm_test.go
+++ b/test/new-e2e/tests/agent-devx/pre-test/vm_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package testinfradefinition
+package pretest
 
 import (
 	"testing"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"dd416110-1afd-413b-8ff9-930d94615bc8","source":"chat","resourceId":"dfdb5734-bba6-405a-af6e-6d39b01db22c","workflowId":"9d68ec70-df8f-4c67-a51b-c1895d43c09a","codeChangeId":"9d68ec70-df8f-4c67-a51b-c1895d43c09a","sourceType":"slack"} -->
### What does this PR do?

Moves `test/new-e2e/test-infra-definition/` into `test/new-e2e/tests/agent-devx/pre-test/` so the e2e pre-tests are treated identically to other e2e tests — including using prebuilt test binaries via the standard `.new_e2e_template` script — without mixing with other tests already in `agent-devx/`.

### Motivation

The `e2e_pre_test` job was overriding the template `script` and missing `--use-prebuilt-binaries`, causing it to rebuild binaries from scratch and get OOM-killed on `main`. By moving the tests into `./tests/agent-devx/pre-test/` and dropping the script override, the job now inherits the full template behavior (prebuilt binaries, image pull, logs post-processing, etc.).

### Describe how you validated your changes

- Confirmed all moved files parse cleanly (`gofmt -e`)
- Package renamed to `pretest` to match the new directory
- Updated all references: CI trigger rule (`.gitlab-ci.yml`), CODEOWNERS, `BUILD.bazel` gazelle exclude, test data
- `new-e2e-base` jobs are unaffected (they target `./tests/agent-devx` with `--run TestAgentBaselineSuite`)
- `e2e_pre_test` now targets `./tests/agent-devx/pre-test` via the standard template

### Additional Notes

Supersedes the memory bump approach in #53911 — this addresses the root cause.
Tracked in ACIX-1899.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/dfdb5734-bba6-405a-af6e-6d39b01db22c)

Comment @datadog to request changes