### PR TITLE
Fix flaky TestContainerTagsBufferManyTracerPayload

### DIFF
--- a/pkg/trace/writer/stats_test.go
+++ b/pkg/trace/writer/stats_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/timing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tinylib/msgp/msgp"
 )
 
@@ -575,12 +576,12 @@ func TestContainerTagsBufferManyTracerPayload(t *testing.T) {
 			sw.Write(payload)
 
 			// wait for result
-			assert.Eventually(func() bool { return len(srv.Payloads()) == 1 }, time.Second, 10*time.Millisecond)
+			require.Eventually(t, func() bool { return len(srv.Payloads()) == 1 }, 5*time.Second, 10*time.Millisecond)
 
 			var statsPayload pb.StatsPayload
 			r, err := gzip.NewReader(srv.Payloads()[0].body)
-			assert.NoError(err)
-			assert.NoError(msgp.Decode(r, &statsPayload))
+			require.NoError(t, err)
+			require.NoError(t, msgp.Decode(r, &statsPayload))
 
 			receivedStats := statsPayload.Stats
 			assert.Equal(3, len(receivedStats))


### PR DESCRIPTION
### What does this PR do?
Uses `require` instead of `assert` when waiting for and decoding the sent payload in `TestContainerTagsBufferManyTracerPayload`, and bumps the wait timeout to 5s.

### Motivation
The subtest waits for an async payload with a non-fatal `assert.Eventually` and then unconditionally dereferences `srv.Payloads()[0]` and the gzip reader. Under CI load a delayed or corrupt payload made `gzip.NewReader` return a nil reader, so `msgp.Decode(nil, …)` panicked. The panic aborted gotestsum's reruns (`rerun aborted because previous run had a suspected panic`), turning a rare flake into a hard job failure ([job 1874742831](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1874742831)). Switching to `require` makes a transient miss fail cleanly so rerun-fails can retry it.

### Describe how you validated your changes
Ran the test 50x under `-race` locally; passes.

### Additional Notes
Test-only change.