### PR TITLE
Set proper env and build flags when cross compiling Go binaries

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -27,7 +27,6 @@ from tasks.libs.common.go import download_go_dependencies
 from tasks.libs.common.gomodules import Configuration, GoModule, get_default_modules
 from tasks.libs.common.user_interactions import yes_no_question
 from tasks.libs.common.utils import TimedOperationResult, get_build_flags, timed
-from tasks.libs.types.arch import Arch
 from tasks.licenses import get_licenses_list
 from tasks.modules import generate_dummy_package
 
@@ -57,8 +56,6 @@ def run_golangci_lint(
     golangci_lint_kwargs="",
     headless_mode: bool = False,
     recursive: bool = True,
-    goos=None,
-    goarch=None,
 ):
     if isinstance(targets, str):
         # when this function is called from the command line, targets are passed
@@ -78,49 +75,6 @@ def run_golangci_lint(
         headless_mode=headless_mode,
         include_python="python" in tags,
     )
-
-    # Cross-OS linting setup: configure cross-compilation environment
-    if goos:
-        native_goos = GOOS_MAPPING.get(sys.platform, sys.platform)
-        if goos != native_goos:
-            goarch = goarch or "amd64"
-            arch = Arch.from_str(goarch)
-
-            env["GOOS"] = goos
-            env["GOARCH"] = goarch
-            env["CGO_ENABLED"] = "1"
-
-            prefix = arch.gcc_prefix(platform=goos)
-            cc = f"{prefix}-gcc"
-            cxx = f"{prefix}-g++"
-
-            # Fall back to clang/clang++ (e.g. osxcross provides clang, not gcc)
-            if not shutil.which(cc):
-                cc_clang = f"{prefix}-clang"
-                cxx_clang = f"{prefix}-clang++"
-                if shutil.which(cc_clang):
-                    cc = cc_clang
-                    cxx = cxx_clang
-                else:
-                    if goos == "darwin":
-                        instr = "cloning https://github.com/tpoechtrager/osxcross.git, pulling the macos SDK from https://github.com/joseluisq/macosx-sdks/releases, building OSXcross and adding it to your PATH"
-                    elif goos == "windows":
-                        instr = "the mingw-w64 toolchain (eg. `apt install gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64`)"
-                    elif goos == "aix":
-                        instr = "the AIX cross-compiler from dd/experimental/teams/agent-build/aix/toolchain/build-aix-cross.sh (requires an AIX sysroot)"
-                    else:
-                        instr = "the appropriate cross-compilation toolchain"
-                    print(
-                        color_message(
-                            f"Error: Cross-compiler '{prefix}-gcc' (or '{prefix}-clang') not found. "
-                            f"Cross-linting for GOOS={goos} requires {instr}.",
-                            "red",
-                        )
-                    )
-                    raise Exit(code=1)
-
-            env["CC"] = cc
-            env["CXX"] = cxx
 
     verbosity = "-v" if verbose else ""
     concurrency_arg = "" if concurrency is None else f"--concurrency {concurrency}"

--- a/tasks/libs/common/gomodules.py
+++ b/tasks/libs/common/gomodules.py
@@ -14,7 +14,7 @@ from invoke.context import Context
 
 import tasks
 from tasks.libs.build.bazel import bazel
-from tasks.libs.common.utils import agent_working_directory, _resolve_target_platform
+from tasks.libs.common.utils import _resolve_target_platform, agent_working_directory
 
 
 class ConfigDumper(yaml.SafeDumper):

--- a/tasks/libs/common/gomodules.py
+++ b/tasks/libs/common/gomodules.py
@@ -14,7 +14,7 @@ from invoke.context import Context
 
 import tasks
 from tasks.libs.build.bazel import bazel
-from tasks.libs.common.utils import agent_working_directory
+from tasks.libs.common.utils import agent_working_directory, _resolve_target_platform
 
 
 class ConfigDumper(yaml.SafeDumper):
@@ -222,8 +222,9 @@ class GoModule:
         """
 
         function = GoModule.SHOULD_TEST_CONDITIONS[self.should_test_condition]
+        target_platform = _resolve_target_platform(platform)
 
-        return function(platform=platform)
+        return function(platform=target_platform)
 
     def __version(self, agent_version):
         """Return the module version for a given Agent version.

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -416,14 +416,13 @@ def get_build_flags(
         env["CGO_ENABLED"] = "1"  # If we're cross-compiling, CGO is disabled by default. Ensure it's always enabled
         env["GOARCH"] = arch.go_arch
 
-        prefix = arch.gcc_prefix(platform=target_platform)
-        cc = f"{prefix}-gcc"
-        cxx = f"{prefix}-g++"
+        cc = arch.compiler_name("gcc", platform=target_platform)
+        cxx = arch.compiler_name("g++", platform=target_platform)
 
         # Fall back to clang/clang++ (e.g. osxcross provides clang, not gcc)
         if not shutil.which(cc):
-            cc_clang = f"{prefix}-clang"
-            cxx_clang = f"{prefix}-clang++"
+            cc_clang = arch.compiler_name(compiler="clang", platform=target_platform)
+            cxx_clang = arch.compiler_name(compiler="clang++", platform=target_platform)
             if shutil.which(cc_clang):
                 cc = cc_clang
                 cxx = cxx_clang
@@ -438,7 +437,7 @@ def get_build_flags(
                     instr = "the appropriate cross-compilation toolchain"
                 print(
                     color_message(
-                        f"Error: Cross-compiler '{prefix}-gcc' (or '{prefix}-clang') not found. "
+                        f"Error: Cross-compiler '{cc}' (or '{cc_clang}') not found. "
                         f"Cross-linting for {target_platform} requires {instr}.",
                         "red",
                     )

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -282,7 +282,7 @@ def get_build_flags(
     Context object.
     """
     if arch is None:
-        arch = Arch.local()
+        arch = Arch.from_str(os.getenv("GOARCH") or "local")
     target_platform = _resolve_target_platform(platform)
 
     gcflags = ""
@@ -403,20 +403,61 @@ def get_build_flags(
         # Use lazy symbol resolution to fix NVML issues on distributions with --enable-host-bind-now
         extldflags += "-Wl,-z,lazy "
 
-    if os.getenv("DD_CC"):
-        env["CC"] = os.getenv("DD_CC")
-    if os.getenv("DD_CXX"):
-        env["CXX"] = os.getenv("DD_CXX")
-
-    if arch.is_cross_compiling():
-        # For cross-compilation we need to be explicit about certain Go settings
-        env["GOARCH"] = arch.go_arch
-        env["CGO_ENABLED"] = "1"  # If we're cross-compiling, CGO is disabled by default. Ensure it's always enabled
-        env["CC"] = os.getenv("DD_CC_CROSS", arch.gcc_compiler())
-        env["CXX"] = os.getenv("DD_CXX_CROSS", arch.gpp_compiler())
+    if cc := os.getenv("DD_CC"):
+        env["CC"] = cc
+    if cxx := os.getenv("DD_CXX"):
+        env["CXX"] = cxx
 
     if extldflags:
         ldflags += f"'-extldflags={extldflags}' "
+
+    # Cross-OS lint/build setup: configure cross-compilation environment
+    if target_platform != sys.platform or arch.is_cross_compiling():
+        env["CGO_ENABLED"] = "1" # If we're cross-compiling, CGO is disabled by default. Ensure it's always enabled
+
+        prefix = arch.gcc_prefix(platform=target_platform)
+        cc = f"{prefix}-gcc"
+        cxx = f"{prefix}-g++"
+
+        # Fall back to clang/clang++ (e.g. osxcross provides clang, not gcc)
+        if not shutil.which(cc):
+            cc_clang = f"{prefix}-clang"
+            cxx_clang = f"{prefix}-clang++"
+            if shutil.which(cc_clang):
+                cc = cc_clang
+                cxx = cxx_clang
+            else:
+                if target_platform == "darwin":
+                    instr = "cloning https://github.com/tpoechtrager/osxcross.git, pulling the macos SDK from https://github.com/joseluisq/macosx-sdks/releases, building OSXcross and adding it to your PATH"
+                elif target_platform == "win32":
+                    instr = "the mingw-w64 toolchain (eg. `apt install gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64`)"
+                elif target_platform == "aix":
+                    instr = "the AIX cross-compiler from dd/experimental/teams/agent-build/aix/toolchain/build-aix-cross.sh (requires an AIX sysroot)"
+                else:
+                    instr = "the appropriate cross-compilation toolchain"
+                print(
+                    color_message(
+                        f"Error: Cross-compiler '{prefix}-gcc' (or '{prefix}-clang') not found. "
+                        f"Cross-linting for {target_platform} requires {instr}.",
+                        "red",
+                    )
+                )
+                raise Exit(code=1)
+
+        env["CC"] = cc
+        env["CXX"] = cxx
+
+        if target_platform == "aix":
+            # Set the sysroot flag for the cross compiler
+            sysroot = "/opt/aix-cross/sysroot"
+            env["CGO_CFLAGS"] = env.get("CGO_CFLAGS", "") + f" --sysroot={sysroot} -maix64"
+            env["CGO_LDFLAGS"] = env.get("CGO_LDFLAGS", "") + f" --sysroot={sysroot} -maix64 -Wl,-brtl -Wl,-bbigtoc"
+
+            # Go's DWARF-on-AIX support probes the external linker but fails to parse the output of
+            # our gcc based cross compiler. -w skips the probe outright
+            ldflags += "-w "
+            # Ignore multiple definition errors
+            ldflags += "-extldflags=-Wl,--allow-multiple-definition "
 
     return ldflags, gcflags, env
 

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -413,7 +413,7 @@ def get_build_flags(
 
     # Cross-OS lint/build setup: configure cross-compilation environment
     if target_platform != sys.platform or arch.is_cross_compiling():
-        env["CGO_ENABLED"] = "1" # If we're cross-compiling, CGO is disabled by default. Ensure it's always enabled
+        env["CGO_ENABLED"] = "1"  # If we're cross-compiling, CGO is disabled by default. Ensure it's always enabled
         env["GOARCH"] = arch.go_arch
 
         prefix = arch.gcc_prefix(platform=target_platform)

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -414,6 +414,7 @@ def get_build_flags(
     # Cross-OS lint/build setup: configure cross-compilation environment
     if target_platform != sys.platform or arch.is_cross_compiling():
         env["CGO_ENABLED"] = "1" # If we're cross-compiling, CGO is disabled by default. Ensure it's always enabled
+        env["GOARCH"] = arch.go_arch
 
         prefix = arch.gcc_prefix(platform=target_platform)
         cc = f"{prefix}-gcc"

--- a/tasks/libs/linter/go.py
+++ b/tasks/libs/linter/go.py
@@ -24,15 +24,12 @@ def run_lint_go(
     headless_mode=False,
     verbose=False,
     recursive=True,
-    goos=None,
-    goarch=None,
 ):
     linter_tags = build_tags or compute_build_tags_for_flavor(
         flavor=flavor,
         build=build,
         build_include=build_include,
         build_exclude=build_exclude,
-        platform=goos,
     )
 
     lint_result, execution_times = lint_flavor(
@@ -47,8 +44,6 @@ def run_lint_go(
         headless_mode=headless_mode,
         verbose=verbose,
         recursive=recursive,
-        goos=goos,
-        goarch=goarch,
     )
 
     return lint_result, execution_times
@@ -66,8 +61,6 @@ def lint_flavor(
     headless_mode: bool = False,
     verbose: bool = False,
     recursive: bool = True,
-    goos=None,
-    goarch=None,
 ):
     """Runs linters for given flavor, build tags, and modules."""
 
@@ -75,7 +68,7 @@ def lint_flavor(
     targets = []
     for module in modules:
         # FIXME: Linters also use the `should_test()` condition. Is this expected?
-        if not module.should_test(platform=goos):
+        if not module.should_test():
             continue
         for target in module.lint_targets:
             target_path = posixpath.normpath(posixpath.join(module.path, target))
@@ -97,8 +90,6 @@ def lint_flavor(
         headless_mode=headless_mode,
         verbose=verbose,
         recursive=recursive,
-        goos=goos,
-        goarch=goarch,
     )
     for lint_result in lint_results:
         result.lint_outputs.append(lint_result)

--- a/tasks/libs/types/arch.py
+++ b/tasks/libs/types/arch.py
@@ -60,7 +60,7 @@ class Arch:
             return f"{self.gcc_arch}-apple-darwin23"
         elif platform == "linux":
             return f"{self.gcc_arch}-linux-gnu"
-        elif platform == "windows":
+        elif platform in {"windows", "win32"}:
             return f"{self.gcc_arch}-w64-mingw32"
         elif platform == "aix":
             # AIX cross-compiler triplet uses "powerpc" (not "powerpc64"); 64-bit mode

--- a/tasks/libs/types/arch.py
+++ b/tasks/libs/types/arch.py
@@ -50,8 +50,8 @@ class Arch:
         """Check whether this architecture is different from one this code is running on."""
         return self != Arch.local()
 
-    def gcc_prefix(self, platform: str = sys.platform) -> str:
-        """Return the GCC prefix to use for this architecture, takes into account
+    def compiler_prefix(self, platform: str = sys.platform) -> str:
+        """Return the compiler prefix to use for this architecture, takes into account
         the platform we are running on (linux/darwin/windows).
 
         Raises ValueError if the platform is not recognized.
@@ -70,21 +70,13 @@ class Arch:
         else:
             raise ValueError(f"Unknown platform: {platform}")
 
-    def gcc_compiler(self, platform: str = sys.platform) -> str:
+    def compiler_name(self, compiler: str, platform: str = sys.platform) -> str:
         """Return the GCC compiler to use for this architecture, takes into account
         the platform we are running on (linux/darwin/windows).
 
         Raises ValueError if the platform is not recognized.
         """
-        return f"{self.gcc_prefix(platform)}-gcc"
-
-    def gpp_compiler(self, platform: str = sys.platform) -> str:
-        """Return the G++ compiler to use for this architecture, takes into account
-        the platform we are running on (linux/darwin/windows).
-
-        Raises ValueError if the platform is not recognized.
-        """
-        return f"{self.gcc_prefix(platform)}-g++"
+        return f"{self.compiler_prefix(platform)}-{compiler}"
 
     @property
     def kmt_arch(self) -> KMTArchName:

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -117,10 +117,6 @@ def go(
         print(color_message("No modules to lint", "yellow"))
         return
 
-    # Detect cross-OS linting from environment variables
-    goos = os.getenv("GOOS")
-    goarch = os.getenv("GOARCH")
-
     lint_result, execution_times = run_lint_go(
         ctx=ctx,
         modules=modules,
@@ -136,8 +132,6 @@ def go(
         headless_mode=headless_mode,
         verbose=verbose,
         recursive=not only_modified_packages,  # Disable recursive linting when only modified packages is enabled, to avoid linting a package and all its subpackages
-        goos=goos,
-        goarch=goarch,
     )
 
     if not headless_mode:


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Move cross-compiling setup logic from lint task to the common `get_build_flags`, to be reused by build as well.
Add various flags to fix cross-compiling Go binaries for AIX.

### Motivation
Enable cross-compiling Go binaries for AIX.

### Describe how you validated your changes
CI (NB: this PR shouldn't change any behavior when not cross compiling)

Locally cross-compiling Go binaries.

### Additional Notes
A follow-up PR will add the jobs cross-compiling core-agent and trace-agent for AIX.
