### PR TITLE
[ABLD-388] Bazelify `whydeadcode` execution

### DIFF
--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import NamedTuple
+from typing import IO, NamedTuple
 
 from invoke import Exit
 from invoke.context import Context
@@ -99,6 +99,7 @@ def bazel(
     capture_output: bool = False,
     capture_stderr: bool = False,
     ignore_errors: bool = False,
+    input_stream: IO[str] | bool = False,
     sudo: bool = False,
 ) -> str:
     """Execute a bazel command.
@@ -127,7 +128,7 @@ def bazel(
         kwargs["hide"] = "err"
     elif not sudo and sys.stdout.isatty() and sys.platform != "win32":
         kwargs["pty"] = True
-    result = ctx.run(cmdline, echo=False, in_stream=False, warn=ignore_errors, **kwargs)
+    result = ctx.run(cmdline, echo=False, in_stream=input_stream, warn=ignore_errors, **kwargs)
     captured = []
     if capture_output and result.ok:
         captured.append(result.stdout)

--- a/tasks/libs/common/go.py
+++ b/tasks/libs/common/go.py
@@ -16,6 +16,7 @@ from invoke.exceptions import Exit
 from invoke.runners import Local, Result
 
 from tasks.libs.build.bazel import bazel
+from tasks.libs.common.color import color_message
 from tasks.libs.common.retry import run_command_with_retry
 from tasks.libs.common.utils import timed
 
@@ -132,6 +133,10 @@ def go_build(
     coverage: bool = False,
     trimpath: bool = True,
 ) -> Result:
+    if check_deadcode and sys.platform == "aix":
+        print(color_message("Ignoring check_deadcode on AIX", "orange"), file=sys.stderr)
+        check_deadcode = False
+
     # When targeting Windows with a known output path, ensure the parent
     # directory exists and ask mingw ld to emit a PDB next to the binary
     # so cdb/WPA/xperf can resolve Go symbols. ld writes the PDB during
@@ -206,26 +211,24 @@ def _handle_pipe_to_whydeadcode(ctx: Context, name: str, cmd: str, env: dict[str
     _ = runner.input_sleep  # please linters
 
     # -dumpdep is very verbose so we hide that
-    # any unrecognized log line is shown by whydeadcode anyway
     result = cast(Result, runner.run(cmd, env=env, hide="stderr"))
 
-    # worst case it's already installed and nothing happens
-    with ctx.cd("internal/tools"):
-        # pass the env to the command so that it can check GOPATH/GOBIN if provided
-        # ensure GOOS and GOARCH will be resolved to the host's values to avoid cross-compiling whydeadcode itself
-        local_env = {**(env or {}), "GOOS": "", "GOARCH": ""}
-        ctx.run("go install github.com/aarzilli/whydeadcode", env=local_env)
-
-    # whydeadcode prints unexpected input on stderr (eg. build warnings), and
-    # dead code call stack on stdout
-    # it returns non-zero if non-expected input is passed, and 0 otherwise, even if dead code elimination is disabled
+    # whydeadcode --ignore-unrecognized-input prints dead code call stack on stdout
+    # it returns 0, even if dead code elimination is disabled
     # so we check whether stdout is empty to know if dead code elimination is disabled
-    whydeadcoderes = cast(
-        Result, runner.run("whydeadcode", in_stream=CustomReader(result.stderr), warn=True, hide="out", env=env)
+    whydeadcode_out = bazel(
+        runner,
+        "run",
+        *(f"--run_env={k}={v}" for k, v in (env or {}).items()),
+        "@com_github_aarzilli_whydeadcode//:whydeadcode",
+        "--",
+        "--ignore-unrecognized-input",
+        input_stream=CustomReader(result.stderr),
+        capture_output=True,
     )
-    if whydeadcoderes.stdout:
+    if whydeadcode_out:
         print(
-            f"dead code elimination is disabled for {name} on {sys.platform} {platform.machine()} by the following call stack (only the first one is guaranteed to be a true positive):\n{whydeadcoderes.stdout}"
+            f"dead code elimination is disabled for {name} on {sys.platform} {platform.machine()} by the following call stack (only the first one is guaranteed to be a true positive):\n{whydeadcode_out}"
         )
 
     return result

--- a/tasks/unit_tests/libs/build/bazel_tests.py
+++ b/tasks/unit_tests/libs/build/bazel_tests.py
@@ -1,3 +1,4 @@
+import io
 import os
 import unittest
 from unittest.mock import MagicMock, patch
@@ -44,6 +45,19 @@ class TestBazel(unittest.TestCase):
         self.assertEqual(
             bazel(self._ctx(exit=1), "info", ignore_errors=True, capture_output=True, capture_stderr=True), "err\n"
         )
+
+    @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
+    def test_input_stream_disabled_by_default(self, _):
+        ctx = self._ctx()
+        bazel(ctx, "info")
+        self.assertIs(ctx.run.call_args.kwargs["in_stream"], False)
+
+    @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
+    def test_input_stream_forwarding(self, _):
+        ctx = self._ctx()
+        stdin = io.StringIO("some input")
+        bazel(ctx, "info", input_stream=stdin)
+        self.assertIs(ctx.run.call_args.kwargs["in_stream"], stdin)
 
     @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
     @patch.dict(os.environ, {}, clear=True)


### PR DESCRIPTION
### What does this PR do?
Run `whydeadcode` through `bazel run` against its own pinned Bazel target instead of a bare binary call preceded by `go install`.

Fail-fast: pass `--ignore-unrecognized-input` to `whydeadcode` and drop the blanket `warn=True` that used to wrap the call, so a genuine error now fails the build instead of being silently treated as a clean dead-code result.

Extend the shared `bazel()` helper with an `input_stream` parameter so its stdin can carry the piped `-dumpdep` output.

Skip `check_deadcode` on AIX (which has no `bazel` at all) with a visible warning, checked once in `go_build` itself rather than in each of the ~15 `check_deadcode=...` callers.

### Motivation
[ABLD-388](https://datadoghq.atlassian.net/browse/ABLD-388) flagged that `tasks/libs/common/go.py`
> [...] does some non-hermetic stuff like downloading and building a tool in the middle of the run.

The idea is that, instead of potentially installing `whydeadcode` from the network on every build for which `$DEPLOY_AGENT` is `true`, we leverage Bazel's hermetically resolved (built and cached) binary.

### Describe how you validated your changes
Added unit tests for the `input_stream` forwarding on `bazel()`.

Verified the construction, the dead-code-found path, and the fail-fast behavior on a genuine Bazel failure by running
`DEPLOY_AGENT=true dda inv dogstatsd.build` end to end and exercising following cases:
- a synthetic `reflect.MethodByName` caught by `whydeadcode`,
- an unresolvable target label caught by `bazel`.

Verified on Windows:
```
G:\datadog-agent>(echo line1& echo line2& echo line3) | bazel.exe run @com_github_aarzilli_whydeadcode//:whydeadcode
INFO: Invocation ID: a6019a3c-aa3a-41ce-b3ef-ac1b5ca6f7b4
INFO: Analyzed target @@gazelle++go_deps+com_github_aarzilli_whydeadcode//:whydeadcode (164 packages loaded, 23106 targets configured).
INFO: Found 1 target...
Target @@gazelle++go_deps+com_github_aarzilli_whydeadcode//:whydeadcode up-to-date:
  bazel-bin/external/gazelle++go_deps+com_github_aarzilli_whydeadcode/whydeadcode_/whydeadcode.exe
INFO: Elapsed time: 12.439s, Critical Path: 0.30s
INFO: 1 process: 17 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/external/gazelle++go_deps+com_github_aarzilli_whydeadcode/whydeadcode_/whydeadcode.exe
Unrecognized input:

line1
line2
line3
```

Verified the AIX skip too, by mocking `sys.platform` to simulate that host and confirming the build runs a plain go build (no `-dumpdep`, no `bazel`) instead of failing or leaking the verbose dumpdep graph to the console.

### Additional Notes
The new `cross-compile-for-AIX-from-Linux` job does **not** hit our AIX skip guard, **correctly**: that guard checks `sys.platform` (the host running the `invoke` process), and this job runs on a normal Linux buildimage where `bazel` is available.
Only genuinely-AIX hosts trip it (`packaging/aix/stages/04-agent.sh`).
So even if `DEPLOY_AGENT=true` combined with this cross-compile job, `check_deadcode` would run correctly on the Linux host, unaffected by the `GOOS=aix` / `GOARCH=ppc64` target settings.

[ABLD-388]: https://datadoghq.atlassian.net/browse/ABLD-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ