### PR TITLE
Add cross-platform AIX Go build jobs

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -57,6 +57,9 @@ build_windows_container_entrypoint   @DataDog/windows-products
 generate_config_schema-linux         @DataDog/agent-configuration
 generate_config_schema-macos         @DataDog/agent-configuration
 generate_config_schema-windows       @DataDog/agent-configuration
+# Cross-compiled binary builds for validation purpose
+cross_build_agent-binary_aix_ppc64        @DataDog/agent-build
+cross_build_trace_agent-binary_aix_ppc64  @DataDog/agent-build
 
 # Package deps build
 generate_minimized_btfs_*            @DataDog/ebpf-platform

--- a/.gitlab/build/binary_build/aix_cross.yml
+++ b/.gitlab/build/binary_build/aix_cross.yml
@@ -11,7 +11,7 @@
   tags: ["arch:amd64", "specific:true"]
   needs: ["go_deps"]
   variables:
-    PATH: /opt/aix-cross/bin:$PATH
+    PATH: "/opt/aix-cross/bin:${PATH}"
     GOOS: aix
     GOARCH: ppc64
   before_script:

--- a/.gitlab/build/binary_build/aix_cross.yml
+++ b/.gitlab/build/binary_build/aix_cross.yml
@@ -1,17 +1,6 @@
 ---
 # Cross-compiles the AIX/ppc64 trace-agent and core-agent from a Linux amd64
 # runner, using the GNU cross-toolchain baked into the linux buildimage
-# (dd/experimental/teams/agent-build/aix/toolchain). See
-# AIX-CROSS-BUILD-NOTES.md at the repo root for the full writeup of what
-# this validates and what's still missing (notably: no python/cgo-python
-# support yet, see tasks/libs/common/utils.py).
-.aix_cross_before_script:
-  - !reference [.retrieve_linux_go_deps]
-  # Workaround for a Go linker bug: cmd/link/internal/ld/lib.go hardcodes
-  # "/lib/crt0_64.o" path instead of resolving it through the compiler
-  # Fix upstream: https://go-review.googlesource.com/c/go/+/800880
-  # Remove this step once we're on a Go version that has it.
-  - ln -sf /opt/aix-cross/sysroot/usr/lib/crt0_64.o /lib/crt0_64.o
 
 .cross_build_aix_ppc64:
   stage: binary_build
@@ -26,7 +15,12 @@
     GOOS: aix
     GOARCH: ppc64
   before_script:
-    - !reference [.aix_cross_before_script]
+    - !reference [.retrieve_linux_go_deps]
+    # Workaround for a Go linker bug: cmd/link/internal/ld/lib.go hardcodes
+    # "/lib/crt0_64.o" path instead of resolving it through the compiler
+    # Fix upstream: https://go-review.googlesource.com/c/go/+/800880
+    # Remove this step once we're on a Go version that has it.
+    - ln -sf /opt/aix-cross/sysroot/usr/lib/crt0_64.o /lib/crt0_64.o
 
 cross_build_agent-binary_aix_ppc64:
   extends: .cross_build_aix_ppc64

--- a/.gitlab/build/binary_build/aix_cross.yml
+++ b/.gitlab/build/binary_build/aix_cross.yml
@@ -1,0 +1,43 @@
+---
+# Cross-compiles the AIX/ppc64 trace-agent and core-agent from a Linux amd64
+# runner, using the GNU cross-toolchain baked into the linux buildimage
+# (dd/experimental/teams/agent-build/aix/toolchain). See
+# AIX-CROSS-BUILD-NOTES.md at the repo root for the full writeup of what
+# this validates and what's still missing (notably: no python/cgo-python
+# support yet, see tasks/libs/common/utils.py).
+.aix_cross_before_script:
+  - !reference [.retrieve_linux_go_deps]
+  # Workaround for a Go linker bug: cmd/link/internal/ld/lib.go hardcodes
+  # "/lib/crt0_64.o" path instead of resolving it through the compiler
+  # Fix upstream: https://go-review.googlesource.com/c/go/+/800880
+  # Remove this step once we're on a Go version that has it.
+  - ln -sf /opt/aix-cross/sysroot/usr/lib/crt0_64.o /lib/crt0_64.o
+
+.cross_build_aix_ppc64:
+  stage: binary_build
+  timeout: 20m
+  rules:
+    - when: on_success
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
+  tags: ["arch:amd64", "specific:true"]
+  needs: ["go_deps"]
+  variables:
+    PATH: /opt/aix-cross/bin:$PATH
+    GOOS: aix
+    GOARCH: ppc64
+  before_script:
+    - !reference [.aix_cross_before_script]
+
+cross_build_agent-binary_aix_ppc64:
+  extends: .cross_build_aix_ppc64
+  script:
+    # python/cgo-python is not supported for AIX cross builds yet (no AIX-native
+    # libpython to link against on a Linux host) - see tasks/libs/common/utils.py.
+    - dda inv -- -e agent.build --build-exclude=python
+    - file $CI_PROJECT_DIR/bin/agent/agent
+
+cross_build_trace_agent-binary_aix_ppc64:
+  extends: .cross_build_aix_ppc64
+  script:
+    - dda inv -- -e trace-agent.build
+    - file $CI_PROJECT_DIR/bin/trace-agent/trace-agent

--- a/.gitlab/build/binary_build/aix_cross.yml
+++ b/.gitlab/build/binary_build/aix_cross.yml
@@ -11,7 +11,6 @@
   tags: ["arch:amd64", "specific:true"]
   needs: ["go_deps"]
   variables:
-    PATH: "/opt/aix-cross/bin:${PATH}"
     GOOS: aix
     GOARCH: ppc64
   before_script:
@@ -27,11 +26,11 @@ cross_build_agent-binary_aix_ppc64:
   script:
     # python/cgo-python is not supported for AIX cross builds yet (no AIX-native
     # libpython to link against on a Linux host) - see tasks/libs/common/utils.py.
-    - dda inv -- -e agent.build --build-exclude=python
+    - PATH="/opt/aix-cross/bin:$PATH" dda inv -- -e agent.build --build-exclude=python
     - file $CI_PROJECT_DIR/bin/agent/agent
 
 cross_build_trace_agent-binary_aix_ppc64:
   extends: .cross_build_aix_ppc64
   script:
-    - dda inv -- -e trace-agent.build
+    - PATH="/opt/aix-cross/bin:$PATH" dda inv -- -e trace-agent.build
     - file $CI_PROJECT_DIR/bin/trace-agent/trace-agent

--- a/.gitlab/build/binary_build/aix_cross.yml
+++ b/.gitlab/build/binary_build/aix_cross.yml
@@ -3,6 +3,7 @@
 # runner, using the GNU cross-toolchain baked into the linux buildimage
 
 .cross_build_aix_ppc64:
+  extends: .bazel:defs:cache:progressive
   stage: binary_build
   timeout: 20m
   rules:
@@ -13,6 +14,9 @@
   variables:
     GOOS: aix
     GOARCH: ppc64
+    KUBERNETES_MEMORY_REQUEST: "16Gi"
+    KUBERNETES_MEMORY_LIMIT: "16Gi"
+    KUBERNETES_CPU_REQUEST: 6
   before_script:
     - !reference [.retrieve_linux_go_deps]
     # Workaround for a Go linker bug: cmd/link/internal/ld/lib.go hardcodes
@@ -24,6 +28,7 @@
 cross_build_agent-binary_aix_ppc64:
   extends: .cross_build_aix_ppc64
   script:
+    - dda inv -- check-go-version
     # python/cgo-python is not supported for AIX cross builds yet (no AIX-native
     # libpython to link against on a Linux host) - see tasks/libs/common/utils.py.
     - PATH="/opt/aix-cross/bin:$PATH" dda inv -- -e agent.build --build-exclude=python
@@ -32,5 +37,6 @@ cross_build_agent-binary_aix_ppc64:
 cross_build_trace_agent-binary_aix_ppc64:
   extends: .cross_build_aix_ppc64
   script:
+    - dda inv -- check-go-version
     - PATH="/opt/aix-cross/bin:$PATH" dda inv -- -e trace-agent.build
     - file $CI_PROJECT_DIR/bin/trace-agent/trace-agent


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Add cross-platform AIX Go build jobs.

### Motivation
Validate core-agent and trace-agent compilation on AIX, from a Linux runner, which is much cheaper and more reliable.

### Describe how you validated your changes
CI

### Additional Notes
