### PR TITLE
tests: ignore missing fallback constants for recent `task_struct` offsets

### DIFF
--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -23,6 +23,9 @@ var BTFHubVsFallbackPossiblyMissingConstants = []string{
 	constantfetch.OffsetNameNFConnStructCTNet,
 	constantfetch.OffsetNameTaskStructPID,
 	constantfetch.OffsetNameTaskStructPIDLink,
+	constantfetch.OffsetNameTaskStructCred,
+	constantfetch.OffsetNameTaskStructRealCred,
+	constantfetch.OffsetNameTaskStructSignal,
 	constantfetch.OffsetNameDeviceStructNdNet,
 	constantfetch.OffsetNameSockStructSKProtocol,
 }


### PR DESCRIPTION
### What does this PR do?

Ignore missing fallback constants for recently added `task_struct` offsets.

### Motivation

It is hard to reliably provide fallback offsets for the `task_struct` struct.

### Describe how you validated your changes

### Additional Notes
