### PR TITLE
fix(aix): drop redundant stage-level sentinels

### DIFF
--- a/packaging/aix/stages/01-native-libs.sh
+++ b/packaging/aix/stages/01-native-libs.sh
@@ -7,7 +7,6 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 . "$SCRIPT_DIR/../lib/env.sh"
 
 STAGE_NAME="01-native-libs"
-SENTINEL="$BUILD_DIR/.done/$STAGE_NAME"
 LOG="$BUILD_DIR/logs/$STAGE_NAME.log"
 
 # Redirect all output to log file (follow with: tail -f "$LOG")
@@ -16,11 +15,9 @@ exec > "$LOG" 2>&1
 
 log "=== Stage: $STAGE_NAME ==="
 
-# --- Idempotency check ---
-if [ -f "$SENTINEL" ]; then
-    log "Already complete (sentinel: $SENTINEL) — skipping."
-    exit 0
-fi
+# No stage-level sentinel: every library below has its own lib_done/lib_mark
+# sentinel (see below), so a hot rerun already skips everything in well under
+# a second without one.
 
 # --- Input validation ---
 : "${AGENT_VERSION:?AGENT_VERSION must be set}"
@@ -556,7 +553,4 @@ mkdir -p "$EMBEDDED_DESTDIR/lib"
 mkdir -p "$EMBEDDED_DESTDIR/include"
 mkdir -p "$EMBEDDED_DESTDIR/share"
 
-# --- Mark complete ---
-mkdir -p "$(dirname "$SENTINEL")"
-touch "$SENTINEL"
 log "=== $STAGE_NAME complete ==="

--- a/packaging/aix/stages/01-native-libs.sh
+++ b/packaging/aix/stages/01-native-libs.sh
@@ -15,10 +15,6 @@ exec > "$LOG" 2>&1
 
 log "=== Stage: $STAGE_NAME ==="
 
-# No stage-level sentinel: every library below has its own lib_done/lib_mark
-# sentinel (see below), so a hot rerun already skips everything in well under
-# a second without one.
-
 # --- Input validation ---
 : "${AGENT_VERSION:?AGENT_VERSION must be set}"
 : "${STAGING:?STAGING must be set}"

--- a/packaging/aix/stages/06-python-extensions.sh
+++ b/packaging/aix/stages/06-python-extensions.sh
@@ -7,7 +7,6 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 . "$SCRIPT_DIR/../lib/env.sh"
 
 STAGE_NAME="06-python-extensions"
-SENTINEL="$BUILD_DIR/.done/$STAGE_NAME"
 LOG="$BUILD_DIR/logs/$STAGE_NAME.log"
 
 # Redirect all output to log file (follow with: tail -f "$LOG")
@@ -16,11 +15,11 @@ exec > "$LOG" 2>&1
 
 log "=== Stage: $STAGE_NAME ==="
 
-# --- Idempotency check ---
-if [ -f "$SENTINEL" ]; then
-    log "Already complete (sentinel: $SENTINEL) — skipping."
-    exit 0
-fi
+# No stage-level sentinel: every package here is installed via a version-pinned
+# `pip install pkg==X`, which pip already treats as a no-op ("Requirement
+# already satisfied") when the exact version is present, and cryptography's
+# Rust build has its own wheel cache keyed on version (see below) that skips
+# the expensive rebuild independently of this stage running at all.
 
 # --- Input validation ---
 : "${AGENT_VERSION:?AGENT_VERSION must be set}"
@@ -71,9 +70,7 @@ fi
 # --- Cleanup on failure ---
 cleanup() {
     if [ $? -ne 0 ]; then
-        log "ERROR: $STAGE_NAME failed."
-        log "       Re-run after fixing the error by deleting the sentinel:"
-        log "       rm $SENTINEL"
+        log "ERROR: $STAGE_NAME failed. Re-run this stage to retry."
     fi
 }
 trap cleanup EXIT
@@ -334,7 +331,4 @@ fi
 # matches Linux behaviour — customers install it via the embedded pip after
 # deployment: sudo -Hu dd-agent pip install ibm_db==<version>
 
-# --- Mark complete ---
-mkdir -p "$(dirname "$SENTINEL")"
-touch "$SENTINEL"
 log "=== $STAGE_NAME complete ==="

--- a/packaging/aix/stages/06-python-extensions.sh
+++ b/packaging/aix/stages/06-python-extensions.sh
@@ -15,12 +15,6 @@ exec > "$LOG" 2>&1
 
 log "=== Stage: $STAGE_NAME ==="
 
-# No stage-level sentinel: every package here is installed via a version-pinned
-# `pip install pkg==X`, which pip already treats as a no-op ("Requirement
-# already satisfied") when the exact version is present, and cryptography's
-# Rust build has its own wheel cache keyed on version (see below) that skips
-# the expensive rebuild independently of this stage running at all.
-
 # --- Input validation ---
 : "${AGENT_VERSION:?AGENT_VERSION must be set}"
 : "${STAGING:?STAGING must be set}"

--- a/packaging/aix/stages/07-pydantic.sh
+++ b/packaging/aix/stages/07-pydantic.sh
@@ -15,12 +15,6 @@ exec > "$LOG" 2>&1
 
 log "=== Stage: $STAGE_NAME ==="
 
-# No stage-level sentinel: pydantic/typing_extensions are installed via
-# version-pinned `pip install pkg==X` (a no-op if already satisfied), and
-# pydantic-core's Rust build has its own wheel cache keyed on version (see
-# below) that skips the ~52-minute rebuild independently of this stage
-# running at all.
-
 # --- Input validation ---
 : "${STAGING:?STAGING must be set}"
 : "${EMBEDDED_DESTDIR:?EMBEDDED_DESTDIR must be set}"

--- a/packaging/aix/stages/07-pydantic.sh
+++ b/packaging/aix/stages/07-pydantic.sh
@@ -7,7 +7,6 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 . "$SCRIPT_DIR/../lib/env.sh"
 
 STAGE_NAME="07-pydantic"
-SENTINEL="$BUILD_DIR/.done/$STAGE_NAME"
 LOG="$BUILD_DIR/logs/$STAGE_NAME.log"
 
 # Redirect all output to log file (follow with: tail -f "$LOG")
@@ -16,11 +15,11 @@ exec > "$LOG" 2>&1
 
 log "=== Stage: $STAGE_NAME ==="
 
-# --- Idempotency check ---
-if [ -f "$SENTINEL" ]; then
-    log "Already complete (sentinel: $SENTINEL) — skipping."
-    exit 0
-fi
+# No stage-level sentinel: pydantic/typing_extensions are installed via
+# version-pinned `pip install pkg==X` (a no-op if already satisfied), and
+# pydantic-core's Rust build has its own wheel cache keyed on version (see
+# below) that skips the ~52-minute rebuild independently of this stage
+# running at all.
 
 # --- Input validation ---
 : "${STAGING:?STAGING must be set}"
@@ -60,13 +59,9 @@ if [ ! -f "$PYPROJECT" ]; then
 fi
 
 # --- Cleanup on failure ---
-# pip installs are not easy to roll back; the sentinel not being written is
-# sufficient to trigger a re-run.
 cleanup() {
     if [ $? -ne 0 ]; then
-        log "ERROR: $STAGE_NAME failed."
-        log "       Re-run after fixing the error by deleting the sentinel:"
-        log "       rm $SENTINEL"
+        log "ERROR: $STAGE_NAME failed. Re-run this stage to retry."
         log "       Common causes:"
         log "         - Rust SDK not installed: yum install rust${RUST_VERSION}.ppc cargo${RUST_VERSION}.ppc rust${RUST_VERSION}-std-static.ppc"
         log "         - Insufficient disk space (need ~7 GB free in /tmp, ~4 GB in /)"
@@ -196,7 +191,4 @@ log "Installing typing_extensions==$TYPING_EXTENSIONS_VERSION (from integrations
 $PIP install "typing_extensions==$TYPING_EXTENSIONS_VERSION"
 log "typing_extensions installed successfully"
 
-# --- Mark complete ---
-mkdir -p "$(dirname "$SENTINEL")"
-touch "$SENTINEL"
 log "=== $STAGE_NAME complete ==="

--- a/packaging/aix/stages/08-checks-base.sh
+++ b/packaging/aix/stages/08-checks-base.sh
@@ -7,7 +7,6 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 . "$SCRIPT_DIR/../lib/env.sh"
 
 STAGE_NAME="08-checks-base"
-SENTINEL="$BUILD_DIR/.done/$STAGE_NAME"
 LOG="$BUILD_DIR/logs/$STAGE_NAME.log"
 
 # Redirect all output to log file (follow with: tail -f "$LOG")
@@ -16,11 +15,9 @@ exec > "$LOG" 2>&1
 
 log "=== Stage: $STAGE_NAME ==="
 
-# --- Idempotency check ---
-if [ -f "$SENTINEL" ]; then
-    log "Already complete (sentinel: $SENTINEL) — skipping."
-    exit 0
-fi
+# No stage-level sentinel: the [deps] extra packages below are version-pinned
+# (pip no-ops if satisfied), and re-installing datadog-checks-base itself from
+# its local source directory is cheap (pure Python, no compilation).
 
 # --- Input validation ---
 : "${STAGING:?STAGING must be set}"
@@ -43,13 +40,9 @@ if [ ! -f "$INTEGRATIONS_CORE/datadog_checks_base/pyproject.toml" ]; then
 fi
 
 # --- Cleanup on failure ---
-# pip installs are not easy to roll back; the sentinel not being written is
-# sufficient to trigger a re-run.
 cleanup() {
     if [ $? -ne 0 ]; then
-        log "ERROR: $STAGE_NAME failed."
-        log "       Re-run after fixing the error by deleting the sentinel:"
-        log "       rm $SENTINEL"
+        log "ERROR: $STAGE_NAME failed. Re-run this stage to retry."
         log "       Common causes:"
         log "         - Native deps (pydantic-core, cryptography) not installed: ensure Stages 06 and 07 completed"
         log "         - Network access required for transitive pure-Python deps from PyPI"
@@ -121,7 +114,4 @@ log "Freezing installed packages to $STAGING/constraints.txt"
 $PIP freeze > "$STAGING/constraints.txt"
 log "Constraints written to $STAGING/constraints.txt ($(wc -l < "$STAGING/constraints.txt") packages)"
 
-# --- Mark complete ---
-mkdir -p "$(dirname "$SENTINEL")"
-touch "$SENTINEL"
 log "=== $STAGE_NAME complete ==="

--- a/packaging/aix/stages/08-checks-base.sh
+++ b/packaging/aix/stages/08-checks-base.sh
@@ -15,10 +15,6 @@ exec > "$LOG" 2>&1
 
 log "=== Stage: $STAGE_NAME ==="
 
-# No stage-level sentinel: the [deps] extra packages below are version-pinned
-# (pip no-ops if satisfied), and re-installing datadog-checks-base itself from
-# its local source directory is cheap (pure Python, no compilation).
-
 # --- Input validation ---
 : "${STAGING:?STAGING must be set}"
 : "${EMBEDDED_DESTDIR:?EMBEDDED_DESTDIR must be set}"


### PR DESCRIPTION
### What does this PR do?

Removes the stage-level sentinel from `01-native-libs.sh`, `06-python-extensions.sh`, `07-pydantic.sh`, and `08-checks-base.sh`.

### Motivation

Each of these stages already skips expensive re-work on its own (per-library sentinels, pip's "already satisfied" check, or per-package wheel caches for the Rust builds) — the stage-level sentinel is redundant.

Depends on #53897 for `06-python-extensions` (fixes an unrelated pymqi patch bug this change would otherwise expose on hot reruns).

### Describe how you validated your changes
Ran those stages on an AIX host, they take seconds when hot.

### Additional Notes