### PR TITLE
fix(aix): drop stage-level sentinels for 01-native-libs and 08-checks-base

### DIFF
--- a/packaging/aix/stages/01-native-libs.sh
+++ b/packaging/aix/stages/01-native-libs.sh
@@ -7,7 +7,6 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 . "$SCRIPT_DIR/../lib/env.sh"
 
 STAGE_NAME="01-native-libs"
-SENTINEL="$BUILD_DIR/.done/$STAGE_NAME"
 LOG="$BUILD_DIR/logs/$STAGE_NAME.log"
 
 # Redirect all output to log file (follow with: tail -f "$LOG")
@@ -16,11 +15,9 @@ exec > "$LOG" 2>&1
 
 log "=== Stage: $STAGE_NAME ==="
 
-# --- Idempotency check ---
-if [ -f "$SENTINEL" ]; then
-    log "Already complete (sentinel: $SENTINEL) — skipping."
-    exit 0
-fi
+# No stage-level sentinel: every library below has its own lib_done/lib_mark
+# sentinel (see below), so a hot rerun already skips everything in well under
+# a second without one.
 
 # --- Input validation ---
 : "${AGENT_VERSION:?AGENT_VERSION must be set}"
@@ -556,7 +553,4 @@ mkdir -p "$EMBEDDED_DESTDIR/lib"
 mkdir -p "$EMBEDDED_DESTDIR/include"
 mkdir -p "$EMBEDDED_DESTDIR/share"
 
-# --- Mark complete ---
-mkdir -p "$(dirname "$SENTINEL")"
-touch "$SENTINEL"
 log "=== $STAGE_NAME complete ==="

--- a/packaging/aix/stages/08-checks-base.sh
+++ b/packaging/aix/stages/08-checks-base.sh
@@ -7,7 +7,6 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 . "$SCRIPT_DIR/../lib/env.sh"
 
 STAGE_NAME="08-checks-base"
-SENTINEL="$BUILD_DIR/.done/$STAGE_NAME"
 LOG="$BUILD_DIR/logs/$STAGE_NAME.log"
 
 # Redirect all output to log file (follow with: tail -f "$LOG")
@@ -16,11 +15,9 @@ exec > "$LOG" 2>&1
 
 log "=== Stage: $STAGE_NAME ==="
 
-# --- Idempotency check ---
-if [ -f "$SENTINEL" ]; then
-    log "Already complete (sentinel: $SENTINEL) — skipping."
-    exit 0
-fi
+# No stage-level sentinel: the [deps] extra packages below are version-pinned
+# (pip no-ops if satisfied), and re-installing datadog-checks-base itself from
+# its local source directory is cheap (pure Python, no compilation).
 
 # --- Input validation ---
 : "${STAGING:?STAGING must be set}"
@@ -43,13 +40,9 @@ if [ ! -f "$INTEGRATIONS_CORE/datadog_checks_base/pyproject.toml" ]; then
 fi
 
 # --- Cleanup on failure ---
-# pip installs are not easy to roll back; the sentinel not being written is
-# sufficient to trigger a re-run.
 cleanup() {
     if [ $? -ne 0 ]; then
-        log "ERROR: $STAGE_NAME failed."
-        log "       Re-run after fixing the error by deleting the sentinel:"
-        log "       rm $SENTINEL"
+        log "ERROR: $STAGE_NAME failed. Re-run this stage to retry."
         log "       Common causes:"
         log "         - Native deps (pydantic-core, cryptography) not installed: ensure Stages 06 and 07 completed"
         log "         - Network access required for transitive pure-Python deps from PyPI"
@@ -121,7 +114,4 @@ log "Freezing installed packages to $STAGING/constraints.txt"
 $PIP freeze > "$STAGING/constraints.txt"
 log "Constraints written to $STAGING/constraints.txt ($(wc -l < "$STAGING/constraints.txt") packages)"
 
-# --- Mark complete ---
-mkdir -p "$(dirname "$SENTINEL")"
-touch "$SENTINEL"
 log "=== $STAGE_NAME complete ==="


### PR DESCRIPTION
### What does this PR do?

Removes the stage-level sentinel from `01-native-libs.sh` and `08-checks-base.sh`.

### Motivation

Same rationale as #53932. `01-native-libs` already has a per-library sentinel for each of its 11 libraries, so the stage-level one was pure redundancy. `08-checks-base`'s `[deps]` packages are version-pinned (pip no-ops if satisfied); only the initial `datadog-checks-base` install unconditionally re-runs, but it's pure Python so cheap.

### Describe how you validated your changes

Verified hot reruns on an AIX host: `01-native-libs` in ~0.2s, `08-checks-base` in ~13s.

### Additional Notes