### PR TITLE
feat(agenttelemetry): preserve emitter on retry counters

### DIFF
--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -2247,6 +2247,29 @@ func TestAgentTelemetryParseDefaultConfiguration(t *testing.T) {
 	assert.True(t, len(atCfg.events) > 0)
 	assert.True(t, len(atCfg.schedule) > 0)
 	assert.True(t, len(atCfg.Profiles) > len(atCfg.events))
+
+	var logsAndMetricsProfile *Profile
+	for _, profile := range atCfg.Profiles {
+		if profile.Name == "logs-and-metrics" {
+			logsAndMetricsProfile = profile
+			break
+		}
+	}
+	require.NotNil(t, logsAndMetricsProfile)
+	require.NotNil(t, logsAndMetricsProfile.Metric)
+
+	for _, metricName := range []string{"transactions.requeued", "transactions.retries"} {
+		var metricConfig *MetricConfig
+		for i := range logsAndMetricsProfile.Metric.Metrics {
+			metric := &logsAndMetricsProfile.Metric.Metrics[i]
+			if metric.Name == metricName {
+				metricConfig = metric
+				break
+			}
+		}
+		require.NotNilf(t, metricConfig, "default profile metric %q not found", metricName)
+		assert.Equal(t, []string{"emitter"}, metricConfig.PreserveTags)
+	}
 }
 
 func TestAgentTelemetryEventConfiguration(t *testing.T) {

--- a/comp/core/agenttelemetry/impl/defaultProfiles.yaml
+++ b/comp/core/agenttelemetry/impl/defaultProfiles.yaml
@@ -75,7 +75,11 @@ profiles:
         aggregate_tags:
           - endpoint
       - name: transactions.requeued
+        preserve_tags:
+          - emitter
       - name: transactions.retries
+        preserve_tags:
+          - emitter
       - name: transactions.http_errors
         preserve_tags:
           - code


### PR DESCRIPTION
## Summary

- preserve the `emitter` tag for `transactions.requeued` and `transactions.retries` in the default Agent Telemetry profile
- aggregate away the native `domain` and `endpoint` dimensions while keeping Core Agent and Agent Data Plane series separate
- add regression coverage for the embedded default profile configuration

## Dependency

This PR is stacked on draft PR #50648, which injects `emitter:agent` for local metrics and preserves emitter identity across Agent Telemetry aggregation. That behavior is required so preserving `emitter` does not filter out the Core Agent's own retry counters.

Retarget this PR to `main` after #50648 lands.

## Test plan

- [x] `dda inv test --targets=./comp/core/agenttelemetry/impl` — 51 passed
- [x] `git diff --check origin/jszwedko/coat-default-tags...HEAD`

## Related work

- Saluki emission and RAR mappings: DataDog/saluki#2178
- DADP-155
