### PR TITLE
bump memory allotment for quality_gate_idle and quality_gate_idle_all_features

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -9,8 +9,8 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  # Set to 20% higher than the memory_usage check value
-  memory_allotment: 185 MiB
+  # Set to 30% higher than the memory_usage check value
+  memory_allotment: 200 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -37,7 +37,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_pss_bytes
-      # When updating this, update the memory_allotment in the target section to 20% higher
+      # When updating this, update the memory_allotment in the target section to 30% higher
       upper_bound: "154 MiB"
 
   - name: intake_connections

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -9,8 +9,8 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  # Set to 20% higher than the memory_usage check value
-  memory_allotment: 594 MiB
+  # Set to 30% higher than the memory_usage check value
+  memory_allotment: 644 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -63,7 +63,7 @@ checks:
       # the Limit Adjustments confluence page.
       #
       # When updating this, update the memory_allotment in the target section to
-      # 20% higher
+      # 30% higher
       upper_bound: "495 MiB"
 
   - name: intake_connections


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Changes the memory allotment overhead for `quality_gate_idle` and `quality_gate_idle_all_features` from 20% overhead to 30% overhead

### Motivation

Once we get close to the limit we start to see oomkills, causing changed behavior (eg. system probe getting oomkilled and restarted), extended job duration (replicates retried after agent oomkills), and alert fatigue (SMP report surfacing "retried replicates" with no actionable steps).