### PR TITLE
[ABLD-324] Fix name of systray binary to be ddtray.exe

### DIFF
--- a/cmd/systray/BUILD.bazel
+++ b/cmd/systray/BUILD.bazel
@@ -41,6 +41,7 @@ SUBSYSTEM = "windows"
 
 dd_agent_go_binary(
     name = "systray",
+    out = "ddtray.exe",
     cgo = True,
     embed = [":systray_lib"],
     # Subtle: This should be passed to the C linker, so the -Wl is redundant,


### PR DESCRIPTION
### What does this PR do?

Builds systray as ddtray.exe instead of systray.exe.
