### PR TITLE
Fix gazelle warnings for pkg/fleet/installer/packages/embedded

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -73,8 +73,6 @@ exports_files(["go.mod"])
 # gazelle:exclude pkg/ebpf/ebpftest/cgo_align.go
 # gazelle:resolve go github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest //pkg/ebpf/ebpftest
 # gazelle:exclude pkg/ebpf/uprobes/testutil/standalone_attacher
-# Parent BUILD.bazel reaches into tmpl/ via intra-package paths; a local stub would split the package and break those refs.
-# gazelle:exclude pkg/fleet/installer/packages/embedded/tmpl
 # gazelle:exclude pkg/network/tracer/testutil/proxy/external_unix_proxy_server
 # gazelle:exclude pkg/network/usm/testutil/grpc/grpc_external_server
 # gazelle:exclude pkg/serverless/otlp

--- a/pkg/fleet/installer/packages/embedded/BUILD.bazel
+++ b/pkg/fleet/installer/packages/embedded/BUILD.bazel
@@ -1,5 +1,8 @@
 """Scripts and configuration embedded into the installer as data."""
 
+# Don't try to make a package for the generator functions. We do that here as :tmpl_lib.
+# gazelle:exclude tmpl/*.go
+
 load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 exports_files(


### PR DESCRIPTION
### What does this PR do?

Adds the right gazelle directive to stop warnings about the embedded files.

### Motivation
The warning is annoying.

### Describe how you validated your changes
`bazel run //:gazelle` works without warnings.
