### PR TITLE
chore: remove no-op `//nolint:lostcancel` (noisy warnings)

### DIFF
--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -179,7 +179,7 @@ func (t *evpProxyTransport) RoundTrip(req *http.Request) (rresp *http.Response, 
 	timeout := getConfiguredEVPRequestTimeoutDuration(t.conf)
 	req.Header.Set("X-Datadog-Timeout", strconv.Itoa((int(timeout.Seconds()))))
 	deadline := time.Now().Add(timeout)
-	//nolint:govet,lostcancel // we don't need to manually cancel this context, we can rely on the parent context being cancelled
+	//nolint:govet // we don't need to manually cancel this context, we can rely on the parent context being cancelled
 	ctx, _ := context.WithDeadline(req.Context(), deadline)
 	req = req.WithContext(ctx)
 


### PR DESCRIPTION
### Motivation
Unlike #53786's `deadcode` or #53861's `gosimple` (both real linters that `golangci-lint` later dropped), `lostcancel` was never a `golangci-lint` linter name to begin with, neither in v2 nor in the earlier v2.

It's a `go vet` sub-analyzer, and its own diagnostic text happens to start with `lostcancel:` (reported under `(govet)`), which is almost certainly why #30183 added it to the directive: a reasonable but incorrect guess that, like a `staticcheck` check ID, it would also work as a `//nolint` target.

The `,lostcancel` token in that one `//nolint:govet,lostcancel` directive has therefore been a no-op since the day it was written, contributing to the `Found unknown linters in //nolint directives` warning noise for about [6500 times a week in CI](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%22Found%20unknown%20linters%22%20lostcancel&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2Cci.node.name&fromUser=true&index=ci-app-pipeline-logs-gitlab-datadog-agent&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1783720320007&to_ts=1784325120007&live=true).

### Describe how you validated your changes
Removed the whole directive and re-ran `dda inv linter.go`: `govet` reports the real, still-applicable `lostcancel` finding under its own name, confirming `//nolint:govet` alone (already present) is what suppresses it, and the removed token contributed nothing.