### PR TITLE
Fix `remove_inactive_versions` never deleting stale Go installs

### DIFF
--- a/tasks/macos.py
+++ b/tasks/macos.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import shutil
 import time
 
 from invoke import task
@@ -143,4 +144,4 @@ def remove_inactive_versions(ctx, lang, target_version="", n_days=30, dry_run=Fa
                     elif lang == "go":
                         install_dir = glob.glob(f"{os.environ['HOME']}/.gimme/versions/go{version}*")
                         assert len(install_dir) == 1, f"Expected one Go version for {version}: {install_dir}"
-                        ctx.run(f"rm -rf {install_dir}")
+                        shutil.rmtree(install_dir[0])

--- a/tasks/unit_tests/macos_tests.py
+++ b/tasks/unit_tests/macos_tests.py
@@ -1,7 +1,10 @@
+import os
+import tempfile
 import unittest
 import unittest.mock
+from pathlib import Path
 
-from invoke import MockContext
+from invoke import Context, MockContext
 
 from tasks.macos import remove_inactive_versions
 
@@ -52,3 +55,21 @@ class TestRemoveInactiveVersions(unittest.TestCase):
         print_mock.assert_any_call('Removing python version 2.7.18')
         print_mock.assert_any_call('Removing python version 3.13.42')
         self.assertEqual(print_mock.call_count, 3)
+
+    @unittest.mock.patch("tasks.macos.list_runner_active_versions")
+    @unittest.mock.patch("tasks.macos.list_ci_active_versions")
+    def test_remove_go_deletes_only_inactive_version(self, ci_active_versions, runner_active_versions):
+        ci_active_versions.return_value = {"1.26"}  # 1.25 is inactive
+        runner_active_versions.return_value = {"1.25.9", "1.26.0", "1.26.5"}
+
+        with tempfile.TemporaryDirectory() as home:
+            versions_dir = Path(home, ".gimme", "versions")
+            for arch_dir in ("go1.25.9.darwin.amd64", "go1.26.0.darwin.amd64", "go1.26.5.darwin.amd64"):
+                (versions_dir / arch_dir).mkdir(parents=True)
+
+            with unittest.mock.patch.dict(os.environ, {"HOME": home}):
+                remove_inactive_versions(Context(), "go")
+
+            remaining = {p.name for p in versions_dir.iterdir()}
+
+        self.assertEqual(remaining, {"go1.26.0.darwin.amd64", "go1.26.5.darwin.amd64"})


### PR DESCRIPTION
### What does this PR do?
Fix `remove_inactive_versions` for Go so it actually deletes the stale `~/.gimme/versions` directory it identifies, instead of silently doing nothing.

### Motivation
`glob.glob()` returns a list, but the `go` branch interpolated it unindexed into the f-string building the `rm -rf` command:
```
rm -rf ['/Users/ec2-user/.gimme/versions/go1.25.9.darwin.amd64']
```

Bash consumes the surrounding quotes as shell quoting, leaving a literal bracketed argument that never matches an existing file, so `-f` swallows the resulting error and the directory is never removed.

Stale Go versions have accumulated unpruned on macOS CI runners as a result.

### Describe how you validated your changes
Added `test_remove_go_deletes_only_inactive_version`, which builds a temp `.gimme/versions` tree with one inactive and two active Go versions, runs `remove_inactive_versions` against it with a real `invoke.Context` so `rm -rf` actually executes, and asserts only the active versions remain on disk afterward.

### Additional Notes
Additional `assert`s will tell us whether there's something left to do.