### PR TITLE
[SYNTH-28016] Propagate test/location name to agent-polled synthetics test results

### DIFF
--- a/comp/syntheticstestscheduler/common/data.go
+++ b/comp/syntheticstestscheduler/common/data.go
@@ -84,6 +84,10 @@ type SyntheticsTestConfig struct {
 	PublicID string `json:"public_id"`
 	ResultID string `json:"result_id"`
 	RunType  string `json:"run_type"`
+
+	TestName            string `json:"test_name"`
+	LocationName        string `json:"location_name"`
+	LocationDisplayName string `json:"location_display_name"`
 }
 
 // Operator represents a comparison operator for assertions.
@@ -156,6 +160,10 @@ func (c *SyntheticsTestConfig) UnmarshalJSON(data []byte) error {
 		ResultID string `json:"result_id"`
 		RunType  string `json:"run_type"`
 		Interval int    `json:"tick_every"`
+
+		TestName            string `json:"test_name"`
+		LocationName        string `json:"location_name"`
+		LocationDisplayName string `json:"location_display_name"`
 	}
 
 	var tmp rawConfig
@@ -171,6 +179,9 @@ func (c *SyntheticsTestConfig) UnmarshalJSON(data []byte) error {
 	c.ResultID = tmp.ResultID
 	c.RunType = tmp.RunType
 	c.Interval = tmp.Interval
+	c.TestName = tmp.TestName
+	c.LocationName = tmp.LocationName
+	c.LocationDisplayName = tmp.LocationDisplayName
 	c.Config.Assertions = tmp.Config.Assertions
 
 	switch payload.Protocol(tmp.Subtype) {

--- a/comp/syntheticstestscheduler/common/result.go
+++ b/comp/syntheticstestscheduler/common/result.go
@@ -145,6 +145,7 @@ type Config struct {
 // Test represents the definition of a test including metadata and version.
 type Test struct {
 	ID      string `json:"id"`
+	Name    string `json:"name,omitempty"`
 	SubType string `json:"subType"`
 	Type    string `json:"type"`
 	Version int    `json:"version"`
@@ -153,7 +154,9 @@ type Test struct {
 // TestResult represents the full test execution result including metadata.
 type TestResult struct {
 	Location struct {
-		ID string `json:"id"`
+		ID          string `json:"id"`
+		Name        string `json:"name,omitempty"`
+		DisplayName string `json:"displayName,omitempty"`
 	} `json:"location"`
 	DD     map[string]interface{} `json:"_dd"` // TestRequestInternalFields
 	Result Result                 `json:"result"`

--- a/comp/syntheticstestscheduler/impl/worker.go
+++ b/comp/syntheticstestscheduler/impl/worker.go
@@ -374,6 +374,7 @@ func configRequestToResultRequest(req common.ConfigRequest) (common.ResultReques
 func (s *syntheticsTestScheduler) networkPathToTestResult(w *workerResult) (*common.TestResult, error) {
 	t := common.Test{
 		ID:      w.testCfg.cfg.PublicID,
+		Name:    w.testCfg.cfg.TestName,
 		SubType: strings.ToLower(string(w.testCfg.cfg.Config.Request.GetSubType())),
 		Type:    w.testCfg.cfg.Type,
 		Version: w.testCfg.cfg.Version,
@@ -444,8 +445,14 @@ func (s *syntheticsTestScheduler) networkPathToTestResult(w *workerResult) (*com
 
 	return &common.TestResult{
 		Location: struct {
-			ID string `json:"id"`
-		}{ID: "agent:" + w.hostname},
+			ID          string `json:"id"`
+			Name        string `json:"name,omitempty"`
+			DisplayName string `json:"displayName,omitempty"`
+		}{
+			ID:          "agent:" + w.hostname,
+			Name:        w.testCfg.cfg.LocationName,
+			DisplayName: w.testCfg.cfg.LocationDisplayName,
+		},
 		DD:     make(map[string]interface{}),
 		Result: result,
 		Test:   t,


### PR DESCRIPTION
### What does this PR do?

Threads `test_name`/`location_name`/`location_display_name` from the synthetics agent-polling endpoint response through `SyntheticsTestConfig` and into the reported test result (`Test.Name`, `Location.Name`, `Location.DisplayName`).

### Motivation

Agent-based Synthetics tests (Network Path/ICMP) rendered empty `{{synthetics.attributes.test.name}}` and `{{synthetics.attributes.location.name}}` in monitor notifications, because the agent never consumed or forwarded this data even though the polling endpoint now provides it (see ddoghq/dd-source#26268, gated behind the `synthetics-agent-polling-endpoint-enrich-test-config` experiment flag).

JIRA: [SYNTH-28016](https://datadoghq.atlassian.net/browse/SYNTH-28016)

### Describe how you validated your changes

Existing unit tests in `comp/syntheticstestscheduler` updated/passing (`dda inv test --targets=./comp/syntheticstestscheduler/...`).

### Additional Notes

No behavior change until the backend experiment flag above is enabled for an org.

[SYNTH-28016]: https://datadoghq.atlassian.net/browse/SYNTH-28016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ