### PR TITLE
pkg/gpu/testutil: gate mocks.go behind the test build tag

### DIFF
--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
-//go:build linux && nvml
+//go:build linux && nvml && test
 
 package testutil
 


### PR DESCRIPTION
### What does this PR do?
Adds the missing `test` build tag to `pkg/gpu/testutil/mocks.go`'s `//go:build` constraint.

### Motivation
`mocks.go` calls `comp/core`'s test-only mock APIs (`MockBundle`, `telemetry.Mock`, `fxutil.Test`), which only exist under `//go:build test`. Its own constraint (`linux && nvml`) didn't require `test`, so any real build with the `nvml` tag set would fail to compile it. Plain `go build` never hits this — it drops files with unsatisfied constraints (and their imports) before resolving dependencies, so nothing outside a test binary ever reached this package. It surfaced while wiring real Bazel build tags into `cmd/agent`.

### Describe how you validated your changes
- `bazel build --@rules_go//go/config:tags=nvml //pkg/gpu/testutil` — fails before the fix, succeeds after.
- `bazel test //pkg/gpu/... //pkg/collector/corechecks/gpu/...`

### Additional Notes