### PR TITLE
fix(ci): only merge go_test targets into the Bazel JUnit report

### DIFF
--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -335,6 +335,17 @@ def _parse_bep(bep_path: Path) -> tuple[list[Path], dict[str, bool]]:
     return xml_paths, cache_status
 
 
+def _is_gotestsum_shaped(suite: ET.Element) -> bool:
+    """True if every testcase in this testsuite has a classname attribute.
+
+    Bazel synthesizes a minimal single-testcase XML (no classname) for test
+    rules that don't emit their own JUnit report (diff_test, sh_test, rust
+    tests, ...); downstream JUnit processing assumes gotestsum's schema,
+    where classname is always present.
+    """
+    return all("classname" in tc.attrib for tc in suite.iter("testcase"))
+
+
 def _annotate_junit_cache_status(xml_path: Path, cache_status: dict[str, bool]) -> None:
     """Add a bazel.cached <property> to each <testsuite> whose import path is known.
 
@@ -407,6 +418,8 @@ def collect_junit(ctx, flavor, output_tgz, bep_file):
             )
             for ts in suites:
                 if int(ts.get("tests", "0")) == 0:
+                    continue
+                if not _is_gotestsum_shaped(ts):
                     continue
                 merged.append(ts)
                 collected += 1

--- a/tasks/unit_tests/bazel_tests.py
+++ b/tasks/unit_tests/bazel_tests.py
@@ -2,6 +2,7 @@ import json
 import subprocess
 import tempfile
 import unittest
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from unittest.mock import patch
 
@@ -9,6 +10,7 @@ from tasks.bazel import (
     _IMPORT_PREFIX,
     _bazel_test_funcs_from_bep,
     _go_test_packages,
+    _is_gotestsum_shaped,
     _label_to_import_path,
     _test_xml_candidates,
     _test_xml_funcs,
@@ -94,6 +96,23 @@ class TestTestXmlFuncs(unittest.TestCase):
             missing = Path(tmpdir) / "missing.xml"
             with self.assertRaises(FileNotFoundError):
                 _test_xml_funcs([missing])
+
+
+class TestIsGotestsumShaped(unittest.TestCase):
+    def test_true_when_every_testcase_has_classname(self):
+        suite = ET.fromstring(
+            '<testsuite tests="2">'
+            '<testcase name="TestFoo" classname="pkg/foo"></testcase>'
+            '<testcase name="TestBar" classname="pkg/foo"></testcase>'
+            "</testsuite>"
+        )
+        self.assertTrue(_is_gotestsum_shaped(suite))
+
+    def test_false_when_classname_missing(self):
+        # Shape Bazel synthesizes for a test rule with no JUnit XML of its own
+        # (diff_test, sh_test, rust tests, ...): one testcase, no classname.
+        suite = ET.fromstring('<testsuite tests="1"><testcase name="some_check" status="run"></testcase></testsuite>')
+        self.assertFalse(_is_gotestsum_shaped(suite))
 
 
 def _bep_line(event: dict) -> str:


### PR DESCRIPTION
### What does this PR do?
Restricts Bazel JUnit collection (`_parse_bep` in `tasks/bazel.py`) to `go_test` rule targets, and fixes cached (`bytestream://`) `test.xml` results being silently dropped.

### Motivation
`bazel:test:linux-arm64` (and similar `--config=no-dd-agent-go-tests` jobs) crashed in `junit_upload.sh`'s `split_junitxml` with `KeyError: 'classname'` (example failure: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1881341670). Bazel synthesizes a classname-less `test.xml` for targets that don't emit their own JUnit XML (`diff_test`, `sh_test`, rust tests, ...); merging those in crashed downstream processing built for gotestsum-shaped Go test output.

### Describe how you validated your changes
- Added unit tests for `_parse_bep` (tagged/untagged go_test inclusion, non-go_test exclusion, cached-result reconstruction, no duplicate merging of local results)

### Additional Notes