### PR TITLE
Fix deletegated auth generation and align comments

### DIFF
--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -9357,7 +9357,6 @@ properties:
         node_type: setting
         type: boolean
         default: false
-        comment: Logon Duration config (macOS)
   metadata_endpoints_max_hostname_size:
     node_type: setting
     type: integer
@@ -9543,15 +9542,15 @@ properties:
         env_parser: json
         items:
           type: object
-        comment: List of HTTP SD endpoints to poll. Each entry must specify url and
-          check_template.
+        comment: |-
+          List of HTTP SD endpoints to poll. Each entry must specify url and check_template.
+          DD_PROMETHEUS_HTTP_SD_CONFIGS is a JSON-encoded list-of-objects.
       url:
         node_type: setting
         type: string
         default: ''
-        comment: |-
-          DD_PROMETHEUS_HTTP_SD_CONFIGS is a JSON-encoded list-of-objects.
-          [DEPRECATED] URL of the Prometheus HTTP SD endpoint. Use prometheus_http_sd.configs instead.
+        comment: '[DEPRECATED] URL of the Prometheus HTTP SD endpoint. Use prometheus_http_sd.configs
+          instead.'
     tags:
     - full-agent-only:true
   provider_kind:

--- a/pkg/config/schema/yaml/private_action_runner.yaml
+++ b/pkg/config/schema/yaml/private_action_runner.yaml
@@ -18,7 +18,6 @@ properties:
     visibility: public
     description: Set to true to enable the Private Action Runner.
     example: 'true'
-    comment: Enable/disable private action runner
   self_enroll:
     node_type: setting
     type: boolean
@@ -29,14 +28,12 @@ properties:
       Requires an app_key with Actions API Enable and the following permissions:
         - Connection Write
         - Private Action Write
-    comment: Identity / enrollment configuration
   task_concurrency:
     node_type: setting
     type: integer
     default: 5
     visibility: public
     description: Maximum number of actions that can be executed concurrently.
-    comment: General config
   task_timeout_seconds:
     node_type: setting
     type: integer
@@ -76,7 +73,6 @@ properties:
     visibility: public
     description: Maximum time in seconds for HTTP actions before timing out. Must
       be > 1.
-    comment: HTTP action
   http_allowlist:
     node_type: setting
     type: array
@@ -105,7 +101,9 @@ properties:
       socket_path:
         node_type: setting
         type: string
-        default: ${run_path}/par-executor.sock
+        platform_default:
+          windows: \\.\pipe\dd-par-executor
+          other: ${run_path}/par-executor.sock
   identity_file_path:
     node_type: setting
     type: string
@@ -122,7 +120,6 @@ properties:
     node_type: setting
     type: string
     default: ${log_path}/private-action-runner.log
-    comment: Log file
   opms_extra_headers:
     node_type: setting
     type: object

--- a/pkg/config/schema/yaml/process_config.yaml
+++ b/pkg/config/schema/yaml/process_config.yaml
@@ -151,9 +151,6 @@ properties:
         visibility: public
         description: Toggles the `process_discovery` check. If enabled, this check
           gathers information about running integrations.
-        comment: |-
-          Process Discovery Check
-          We also bind old environment variables for this setting
       interval:
         node_type: setting
         type: string

--- a/pkg/config/schema/yaml/runtime_security_config.yaml
+++ b/pkg/config/schema/yaml/runtime_security_config.yaml
@@ -233,10 +233,6 @@ properties:
     platform_default:
       windows: localhost:3335
       other: ${install_path}/run/runtime-security.sock
-    comment: |-
-      the following entries are platform specific
-      - runtime_security_config.policies.dir
-      - runtime_security_config.socket
   use_secruntime_track:
     node_type: setting
     type: boolean

--- a/pkg/config/setup/apm_settings.go
+++ b/pkg/config/setup/apm_settings.go
@@ -53,6 +53,7 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("apm_config.watchdog_check_delay", 0)
 	config.BindEnvAndSetDefault("apm_config.sync_flushing", false, "DD_APM_SYNC_FLUSHING")
 	config.BindEnvAndSetDefault("apm_config.features", []string{}, "DD_APM_FEATURES")
+	pkgconfighelper.ParseEnvSplitCommaThenSpace("apm_config.features", config)
 	config.BindEnvAndSetDefault("apm_config.max_catalog_entries", 0)
 
 	// Vector options for traces
@@ -64,11 +65,11 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("apm_config.enabled", true, "DD_APM_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.receiver_enabled", true, "DD_APM_RECEIVER_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.receiver_port", 8126, "DD_APM_RECEIVER_PORT", "DD_RECEIVER_PORT")
-	config.BindEnvAndSetDefault("apm_config.windows_pipe_buffer_size", 1_000_000, "DD_APM_WINDOWS_PIPE_BUFFER_SIZE")                          //nolint:errcheck
-	config.BindEnvAndSetDefault("apm_config.windows_pipe_security_descriptor", "D:AI(A;;GA;;;WD)", "DD_APM_WINDOWS_PIPE_SECURITY_DESCRIPTOR") //nolint:errcheck
-	config.BindEnvAndSetDefault("apm_config.peer_service_aggregation", true, "DD_APM_PEER_SERVICE_AGGREGATION")                               //nolint:errcheck
-	config.BindEnvAndSetDefault("apm_config.peer_tags_aggregation", true, "DD_APM_PEER_TAGS_AGGREGATION")                                     //nolint:errcheck
-	config.BindEnvAndSetDefault("apm_config.compute_stats_by_span_kind", true, "DD_APM_COMPUTE_STATS_BY_SPAN_KIND")                           //nolint:errcheck
+	config.BindEnvAndSetDefault("apm_config.windows_pipe_buffer_size", 1000000, "DD_APM_WINDOWS_PIPE_BUFFER_SIZE")
+	config.BindEnvAndSetDefault("apm_config.windows_pipe_security_descriptor", "D:AI(A;;GA;;;WD)", "DD_APM_WINDOWS_PIPE_SECURITY_DESCRIPTOR")
+	config.BindEnvAndSetDefault("apm_config.peer_service_aggregation", true, "DD_APM_PEER_SERVICE_AGGREGATION")
+	config.BindEnvAndSetDefault("apm_config.peer_tags_aggregation", true, "DD_APM_PEER_TAGS_AGGREGATION")
+	config.BindEnvAndSetDefault("apm_config.compute_stats_by_span_kind", true, "DD_APM_COMPUTE_STATS_BY_SPAN_KIND")
 	config.BindEnvAndSetDefault("apm_config.instrumentation.enabled", false, "DD_APM_INSTRUMENTATION_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.workload_selection", true, "DD_APM_WORKLOAD_SELECTION")
 	config.BindEnvAndSetDefault("apm_config.instrumentation.injection_mode", "auto", "DD_APM_INSTRUMENTATION_INJECTION_MODE")
@@ -111,8 +112,7 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("apm_config.probabilistic_sampler.sampling_percentage", float64(0), "DD_APM_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE")
 	config.BindEnvAndSetDefault("apm_config.probabilistic_sampler.hash_seed", 0, "DD_APM_PROBABILISTIC_SAMPLER_HASH_SEED")
 	config.BindEnvAndSetDefault("apm_config.error_tracking_standalone.enabled", false, "DD_APM_ERROR_TRACKING_STANDALONE_ENABLED")
-
-	config.BindEnvAndSetDefault("apm_config.max_memory", float64(5e8), "DD_APM_MAX_MEMORY")
+	config.BindEnvAndSetDefault("apm_config.max_memory", float64(5e+08), "DD_APM_MAX_MEMORY")
 	config.BindEnvAndSetDefault("apm_config.max_cpu_percent", float64(50), "DD_APM_MAX_CPU_PERCENT")
 	config.BindEnvAndSetDefault("apm_config.env", "", "DD_APM_ENV")
 	config.BindEnvAndSetDefault("apm_config.apm_non_local_traffic", false, "DD_APM_NON_LOCAL_TRAFFIC")
@@ -129,8 +129,11 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("apm_config.additional_profile_tags", map[string]string{}, "DD_APM_ADDITIONAL_PROFILE_TAGS")
 	config.BindEnvAndSetDefault("apm_config.additional_endpoints", map[string][]string{}, "DD_APM_ADDITIONAL_ENDPOINTS")
 	config.BindEnvAndSetDefault("apm_config.replace_tags", []map[string]string{}, "DD_APM_REPLACE_TAGS")
+	config.ParseEnvJSON("apm_config.replace_tags", []map[string]string{})
 	config.BindEnvAndSetDefault("apm_config.analyzed_spans", map[string]interface{}{}, "DD_APM_ANALYZED_SPANS")
+	pkgconfighelper.ParseEnvTraceSpan("apm_config.analyzed_spans", config)
 	config.BindEnvAndSetDefault("apm_config.ignore_resources", []string{}, "DD_APM_IGNORE_RESOURCES", "DD_IGNORE_RESOURCE")
+	pkgconfighelper.ParseEnvCSVSplit("apm_config.ignore_resources", config)
 	config.BindEnvAndSetDefault("apm_config.instrumentation.targets", []interface{}{}, "DD_APM_INSTRUMENTATION_TARGETS")
 	config.ParseEnvJSON("apm_config.instrumentation.targets", []interface{}{})
 	config.BindEnvAndSetDefault("apm_config.receiver_socket", GetPlatformDefault(map[string]interface{}{
@@ -140,9 +143,13 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	}), "DD_APM_RECEIVER_SOCKET")
 	config.BindEnvAndSetDefault("apm_config.windows_pipe_name", "", "DD_APM_WINDOWS_PIPE_NAME")
 	config.BindEnvAndSetDefault("apm_config.filter_tags.require", []string{}, "DD_APM_FILTER_TAGS_REQUIRE")
+	pkgconfighelper.ParseEnvJSONOrSpace("apm_config.filter_tags.require", config)
 	config.BindEnvAndSetDefault("apm_config.filter_tags.reject", []string{}, "DD_APM_FILTER_TAGS_REJECT")
+	pkgconfighelper.ParseEnvJSONOrSpace("apm_config.filter_tags.reject", config)
 	config.BindEnvAndSetDefault("apm_config.filter_tags_regex.reject", []string{}, "DD_APM_FILTER_TAGS_REGEX_REJECT")
+	pkgconfighelper.ParseEnvJSONOrSpace("apm_config.filter_tags_regex.reject", config)
 	config.BindEnvAndSetDefault("apm_config.filter_tags_regex.require", []string{}, "DD_APM_FILTER_TAGS_REGEX_REQUIRE")
+	pkgconfighelper.ParseEnvJSONOrSpace("apm_config.filter_tags_regex.require", config)
 	config.BindEnvAndSetDefault("apm_config.internal_profiling.enabled", false, "DD_APM_INTERNAL_PROFILING_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.debugger_dd_url", "", "DD_APM_DEBUGGER_DD_URL")
 	config.BindEnvAndSetDefault("apm_config.debugger_api_key", "", "DD_APM_DEBUGGER_API_KEY")
@@ -163,25 +170,15 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("apm_config.obfuscation.credit_cards.enabled", true, "DD_APM_OBFUSCATION_CREDIT_CARDS_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.obfuscation.credit_cards.luhn", false, "DD_APM_OBFUSCATION_CREDIT_CARDS_LUHN")
 	config.BindEnvAndSetDefault("apm_config.obfuscation.credit_cards.keep_values", []string{}, "DD_APM_OBFUSCATION_CREDIT_CARDS_KEEP_VALUES")
+	pkgconfighelper.ParseEnvJSONOrSpace("apm_config.obfuscation.credit_cards.keep_values", config)
 	config.BindEnvAndSetDefault("apm_config.sql_obfuscation_mode", "", "DD_APM_SQL_OBFUSCATION_MODE")
 	config.BindEnvAndSetDefault("apm_config.debug.port", 5012, "DD_APM_DEBUG_PORT")
 	config.BindEnvAndSetDefault("apm_config.debug_v1_payloads", false, "DD_APM_DEBUG_V1_PAYLOADS")
 	config.BindEnvAndSetDefault("apm_config.send_all_internal_stats", false, "DD_APM_SEND_ALL_INTERNAL_STATS")
 	config.BindEnvAndSetDefault("apm_config.enable_container_tags_buffer", true, "DD_APM_ENABLE_CONTAINER_TAGS_BUFFER")
-	pkgconfighelper.ParseEnvSplitCommaThenSpace("apm_config.features", config)
-	pkgconfighelper.ParseEnvCSVSplit("apm_config.ignore_resources", config)
-
-	pkgconfighelper.ParseEnvJSONOrSpace("apm_config.filter_tags.require", config)
-	pkgconfighelper.ParseEnvJSONOrSpace("apm_config.filter_tags.reject", config)
-	pkgconfighelper.ParseEnvJSONOrSpace("apm_config.filter_tags_regex.require", config)
-	pkgconfighelper.ParseEnvJSONOrSpace("apm_config.filter_tags_regex.reject", config)
-	pkgconfighelper.ParseEnvJSONOrSpace("apm_config.obfuscation.credit_cards.keep_values", config)
-	config.ParseEnvJSON("apm_config.replace_tags", []map[string]string{})
-
-	pkgconfighelper.ParseEnvTraceSpan("apm_config.analyzed_spans", config)
-
 	config.BindEnvAndSetDefault("apm_config.peer_tags", []string{}, "DD_APM_PEER_TAGS")
 	config.ParseEnvJSON("apm_config.peer_tags", []string{})
+	config.BindEnvAndSetDefault("apm_config.mode", "", "DD_APM_MODE")
 
 	// Deprecated/Experimental: DD_APM_SPAN_DERIVED_PRIMARY_TAGS is only honored when
 	// the agent runs in a serverless context (the Datadog Azure App Services
@@ -190,8 +187,6 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	// use in new deployments.
 	config.BindEnvAndSetDefault("apm_config.span_derived_primary_tags", []string{}, "DD_APM_SPAN_DERIVED_PRIMARY_TAGS")
 	config.ParseEnvJSON("apm_config.span_derived_primary_tags", []string{})
-
-	config.BindEnvAndSetDefault("apm_config.mode", "", "DD_APM_MODE")
 
 	// trace-agent's evp_proxy. Registered here (in setupAPM, which is part of
 	// initCommonConfigComponents) so the defaults are reachable under both the

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -39,7 +39,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("metric_lookback.monitor.mode", "disabled")
 	config.BindEnvAndSetDefault("metric_lookback.monitor.metric_name", "")
 	config.BindEnvAndSetDefault("metric_lookback.monitor.evaluation_interval", 30*time.Second)
-	config.BindEnvAndSetDefault("metric_lookback.monitor.range_epsilon", 0.0)
+	config.BindEnvAndSetDefault("metric_lookback.monitor.range_epsilon", float64(0))
 	config.BindEnvAndSetDefault("metric_lookback.monitor.partition_tags", []string{})
 	config.BindEnvAndSetDefault("metric_lookback.egress.pre_trigger_window", 0*time.Second)
 	config.BindEnvAndSetDefault("metric_lookback.egress.post_recovery_window", 30*time.Second)
@@ -54,7 +54,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 
 	// Python 3 linter timeout, in seconds
 	// NOTE: linter is notoriously slow, in the absence of a better solution we
-	//       can only increase this timeout value. Linting operation is async.
+	// can only increase this timeout value. Linting operation is async.
 	config.BindEnvAndSetDefault("python3_linter_timeout", 120)
 
 	// Whether to honour the value of PYTHONPATH, if set, on Windows. On other OSes we always do.
@@ -145,22 +145,28 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("flare.profile_overhead_runtime", 10*time.Second)
 	config.BindEnvAndSetDefault("flare.rc_profiling.blocking_rate", 0)
 	config.BindEnvAndSetDefault("flare.rc_profiling.mutex_fraction", 0)
-
 	config.BindEnvAndSetDefault("flare.rc_streamlogs.duration", 60*time.Second)
 
 	config.BindEnvAndSetDefault("docker_query_timeout", int64(5))
 	config.BindEnvAndSetDefault("kubernetes_node_annotations_as_host_aliases", []string{"cluster.k8s.io/machine"})
 	config.BindEnvAndSetDefault("kubernetes_node_label_as_cluster_name", "")
 
-	config.BindEnvAndSetDefault("prometheus_scrape.enabled", false)           // Enables the prometheus config provider
-	config.BindEnvAndSetDefault("prometheus_scrape.service_endpoints", false) // Enables Service Endpoints checks in the prometheus config provider
-	config.BindEnvAndSetDefault("prometheus_scrape.checks", "")               // Defines any extra prometheus/openmetrics check configurations to be handled by the prometheus config provider
-	config.BindEnvAndSetDefault("prometheus_scrape.version", 1)               // Version of the openmetrics check to be scheduled by the Prometheus auto-discovery
-
-	config.BindEnvAndSetDefault("prometheus_http_sd.configs", []map[string]interface{}{}) // List of HTTP SD endpoints to poll. Each entry must specify url and check_template.
-	config.ParseEnvJSON("prometheus_http_sd.configs", []map[string]interface{}{})         // DD_PROMETHEUS_HTTP_SD_CONFIGS is a JSON-encoded list-of-objects.
-	config.BindEnvAndSetDefault("prometheus_http_sd.url", "")                             // [DEPRECATED] URL of the Prometheus HTTP SD endpoint. Use prometheus_http_sd.configs instead.
-	config.BindEnvAndSetDefault("prometheus_http_sd.check_template", "")                  // [DEPRECATED] JSON check template applied to each discovered target. Use prometheus_http_sd.configs instead.
+	// Enables the prometheus config provider
+	config.BindEnvAndSetDefault("prometheus_scrape.enabled", false)
+	// Enables Service Endpoints checks in the prometheus config provider
+	config.BindEnvAndSetDefault("prometheus_scrape.service_endpoints", false)
+	// Defines any extra prometheus/openmetrics check configurations to be handled by the prometheus config provider
+	config.BindEnvAndSetDefault("prometheus_scrape.checks", "")
+	// Version of the openmetrics check to be scheduled by the Prometheus auto-discovery
+	config.BindEnvAndSetDefault("prometheus_scrape.version", 1)
+	// List of HTTP SD endpoints to poll. Each entry must specify url and check_template.
+	// DD_PROMETHEUS_HTTP_SD_CONFIGS is a JSON-encoded list-of-objects.
+	config.BindEnvAndSetDefault("prometheus_http_sd.configs", []map[string]interface{}{})
+	config.ParseEnvJSON("prometheus_http_sd.configs", []map[string]interface{}{})
+	// [DEPRECATED] URL of the Prometheus HTTP SD endpoint. Use prometheus_http_sd.configs instead.
+	config.BindEnvAndSetDefault("prometheus_http_sd.url", "")
+	// [DEPRECATED] JSON check template applied to each discovered target. Use prometheus_http_sd.configs instead.
+	config.BindEnvAndSetDefault("prometheus_http_sd.check_template", "")
 
 	bindEnvAndSetLogsConfigKeys(config, "network_devices.metadata.")
 	config.BindEnvAndSetDefault("network_devices.namespace", "default")
@@ -217,14 +223,15 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("network_devices.snmp_traps.port", 9162)
 	config.BindEnvAndSetDefault("network_devices.snmp_traps.community_strings", []string{})
 	config.BindEnvAndSetDefault("network_devices.snmp_traps.bind_host", "0.0.0.0")
-	config.BindEnvAndSetDefault("network_devices.snmp_traps.stop_timeout", 5) // in seconds
+	// in seconds
+	config.BindEnvAndSetDefault("network_devices.snmp_traps.stop_timeout", 5)
 	config.BindEnvAndSetDefault("network_devices.snmp_traps.users", []map[string]string{})
 	config.BindEnvAndSetDefault("network_devices.snmp_traps.tags", []string{})
 
 	config.BindEnvAndSetDefault("network_devices.netflow.enabled", false)
 	config.SetDefault("network_devices.netflow.listeners", []map[string]interface{}{})
 	config.BindEnvAndSetDefault("network_devices.netflow.stop_timeout", 5)
-	config.BindEnvAndSetDefault("network_devices.netflow.aggregator_buffer_size", 10_000)
+	config.BindEnvAndSetDefault("network_devices.netflow.aggregator_buffer_size", 10000)
 	config.BindEnvAndSetDefault("network_devices.netflow.aggregator_flush_interval", 300)
 	// The default behavior for this value is to copy the "aggregator_flush_interval" when absent/zero. This is to avoid
 	// expiring flows too early when the flush interval is increased, while still allowing to set a custom TTL when needed.
@@ -243,7 +250,8 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("network_path.collector.input_chan_size", 1000)
 	config.BindEnvAndSetDefault("network_path.collector.processing_chan_size", 1000)
 	config.BindEnvAndSetDefault("network_path.collector.pathtest_contexts_limit", 1000)
-	config.BindEnvAndSetDefault("network_path.collector.pathtest_ttl", "70m") // with 30min interval, 70m will allow running a test 3 times (t0, t30, t60)
+	// with 30min interval, 70m will allow running a test 3 times (t0, t30, t60)
+	config.BindEnvAndSetDefault("network_path.collector.pathtest_ttl", "70m")
 	config.BindEnvAndSetDefault("network_path.collector.pathtest_interval", "30m")
 	config.BindEnvAndSetDefault("network_path.collector.flush_interval", "10s")
 	config.BindEnvAndSetDefault("network_path.collector.pathtest_max_per_minute", 150)
@@ -385,7 +393,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	//
 	// if this value is larger than `agent_ipc.grpc_max_message_size`, it will still be honoured by the agent gRPC
 	// server instead of `agent_ipc.grpc_max_message_size`.
-	config.BindEnvAndSetDefault("cluster_agent.cluster_tagger.grpc_max_message_size", 4<<20)
+	config.BindEnvAndSetDefault("cluster_agent.cluster_tagger.grpc_max_message_size", 4194304)
 
 	// Check that the trust chain is valid for Agent cross-node communications (NodeAgent->DCA / CLC->DCA / DCA->CLC).
 	config.BindEnvAndSetDefault("cluster_trust_chain.enable_tls_verification", false)
@@ -404,21 +412,27 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("metadata_endpoints_max_hostname_size", 255)
 
 	config.BindEnvAndSetDefault("ec2_use_windows_prefix_detection", false)
-	config.BindEnvAndSetDefault("ec2_metadata_timeout", 300)          // value in milliseconds
-	config.BindEnvAndSetDefault("ec2_metadata_token_lifetime", 21600) // value in seconds
+	// value in milliseconds
+	config.BindEnvAndSetDefault("ec2_metadata_timeout", 300)
+	// value in seconds
+	config.BindEnvAndSetDefault("ec2_metadata_token_lifetime", 21600)
 	config.BindEnvAndSetDefault("ec2_prefer_imdsv2", false)
-	config.BindEnvAndSetDefault("ec2_prioritize_instance_id_as_hostname", false) // used to bypass the hostname detection logic and force the EC2 instance ID as a hostname.
-	config.BindEnvAndSetDefault("ec2_use_dmi", true)                             // should the agent leverage DMI information to know if it's running on EC2 or not. Enabling this will add the instance ID from DMI to the host alias list.
+	// used to bypass the hostname detection logic and force the EC2 instance ID as a hostname.
+	config.BindEnvAndSetDefault("ec2_prioritize_instance_id_as_hostname", false)
+	// should the agent leverage DMI information to know if it's running on EC2 or not. Enabling this will add the instance ID from DMI to the host alias list.
+	config.BindEnvAndSetDefault("ec2_use_dmi", true)
 	config.BindEnvAndSetDefault("collect_ec2_tags", false)
 	config.BindEnvAndSetDefault("collect_ec2_instance_info", false)
 	config.BindEnvAndSetDefault("collect_ec2_tags_use_imds", false)
 	config.BindEnvAndSetDefault("exclude_ec2_tags", []string{})
 	config.BindEnvAndSetDefault("ec2_imdsv2_transition_payload_enabled", true)
 
-	config.BindEnvAndSetDefault("ecs_agent_url", "") // Will be autodetected
+	// Will be autodetected
+	config.BindEnvAndSetDefault("ecs_agent_url", "")
 	config.BindEnvAndSetDefault("ecs_agent_container_name", "ecs-agent")
 	config.BindEnvAndSetDefault("ecs_resource_tags_replace_colon", false)
-	config.BindEnvAndSetDefault("ecs_metadata_timeout", 1000) // value in milliseconds
+	// value in milliseconds
+	config.BindEnvAndSetDefault("ecs_metadata_timeout", 1000)
 	config.BindEnvAndSetDefault("ecs_metadata_retry_initial_interval", 100*time.Millisecond)
 	config.BindEnvAndSetDefault("ecs_metadata_retry_max_elapsed_time", 3000*time.Millisecond)
 	config.BindEnvAndSetDefault("ecs_metadata_retry_timeout_factor", 3)
@@ -437,7 +451,8 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 		"startup-script", "user-data", "windows-keys", "windows-startup-script-ps1",
 	})
 	config.BindEnvAndSetDefault("gce_send_project_id_tag", false)
-	config.BindEnvAndSetDefault("gce_metadata_timeout", 1000) // value in milliseconds
+	// value in milliseconds
+	config.BindEnvAndSetDefault("gce_metadata_timeout", 1000)
 
 	config.BindEnvAndSetDefault("collect_gpu_tags", true)
 	config.BindEnvAndSetDefault("gpu.enabled", false)
@@ -475,17 +490,14 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("cloud_foundry_bbs.key_file", "")
 	config.BindEnvAndSetDefault("cloud_foundry_bbs.env_include", []string{})
 	config.BindEnvAndSetDefault("cloud_foundry_bbs.env_exclude", []string{})
-
 	config.BindEnvAndSetDefault("cloud_foundry_cc.url", "https://cloud-controller-ng.service.cf.internal:9024")
 	config.BindEnvAndSetDefault("cloud_foundry_cc.client_id", "")
 	config.BindEnvAndSetDefault("cloud_foundry_cc.client_secret", "")
 	config.BindEnvAndSetDefault("cloud_foundry_cc.poll_interval", 60)
 	config.BindEnvAndSetDefault("cloud_foundry_cc.skip_ssl_validation", false)
 	config.BindEnvAndSetDefault("cloud_foundry_cc.apps_batch_size", 5000)
-
 	config.BindEnvAndSetDefault("cloud_foundry_garden.listen_network", "unix")
 	config.BindEnvAndSetDefault("cloud_foundry_garden.listen_address", "/var/vcap/data/garden/garden.sock")
-
 	config.BindEnvAndSetDefault("cloud_foundry_container_tagger.shell_path", "/bin/sh")
 	config.BindEnvAndSetDefault("cloud_foundry_container_tagger.retry_count", 10)
 	config.BindEnvAndSetDefault("cloud_foundry_container_tagger.retry_interval", 10)
@@ -495,13 +507,14 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("azure_metadata_api_version", "2021-02-01")
 
 	// We use a long timeout here since the metadata and token API can be very slow sometimes.
-	config.BindEnvAndSetDefault("ibm_metadata_timeout", 5) // value in seconds
+	// value in seconds
+	config.BindEnvAndSetDefault("ibm_metadata_timeout", 5)
 
 	config.BindEnvAndSetDefault("jmx_custom_jars", []string{})
 	config.BindEnvAndSetDefault("jmx_java_tool_options", "")
 	config.BindEnvAndSetDefault("jmx_use_cgroup_memory_limit", false)
 	config.BindEnvAndSetDefault("jmx_use_container_support", false)
-	config.BindEnvAndSetDefault("jmx_max_ram_percentage", float64(25.0))
+	config.BindEnvAndSetDefault("jmx_max_ram_percentage", float64(25))
 	config.BindEnvAndSetDefault("jmx_max_restarts", int64(3))
 	config.BindEnvAndSetDefault("jmx_restart_interval", int64(5))
 	config.BindEnvAndSetDefault("jmx_thread_pool_size", 3)
@@ -525,7 +538,8 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 
 	config.BindEnvAndSetDefault("internal_profiling.enabled", false)
 	config.BindEnvAndSetDefault("internal_profiling.profile_dd_url", "")
-	config.BindEnvAndSetDefault("internal_profiling.unix_socket", "") // file system path to a unix socket, e.g. `/var/run/datadog/apm.socket`
+	// file system path to a unix socket, e.g. `/var/run/datadog/apm.socket`
+	config.BindEnvAndSetDefault("internal_profiling.unix_socket", "")
 	config.BindEnvAndSetDefault("internal_profiling.period", 5*time.Minute)
 	config.BindEnvAndSetDefault("internal_profiling.cpu_duration", 1*time.Minute)
 	config.BindEnvAndSetDefault("internal_profiling.block_profile_rate", 0)
@@ -540,59 +554,95 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("internal_profiling.capture_all_allocations", false)
 
 	config.BindEnvAndSetDefault("hpa_watcher_polling_freq", 10)
-	config.BindEnvAndSetDefault("hpa_watcher_gc_period", 60*5) // 5 minutes
+	// 5 minutes
+	config.BindEnvAndSetDefault("hpa_watcher_gc_period", 60*5)
 	config.BindEnvAndSetDefault("hpa_configmap_name", "datadog-custom-metrics")
 	config.BindEnvAndSetDefault("external_metrics_provider.enabled", false)
 	config.BindEnvAndSetDefault("external_metrics_provider.port", 8443)
-	config.BindEnvAndSetDefault("external_metrics_provider.endpoint", "")                          // Override the Datadog API endpoint to query external metrics from
-	config.BindEnvAndSetDefault("external_metrics_provider.api_key", "")                           // Override the Datadog API Key for external metrics endpoint
-	config.BindEnvAndSetDefault("external_metrics_provider.app_key", "")                           // Override the Datadog APP Key for external metrics endpoint
-	config.SetDefault("external_metrics_provider.endpoints", []interface{}{})                      // List of redundant endpoints to query external metrics from
-	config.BindEnvAndSetDefault("external_metrics_provider.refresh_period", 30)                    // value in seconds. Frequency of calls to Datadog to refresh metric values
-	config.BindEnvAndSetDefault("external_metrics_provider.batch_window", 10)                      // value in seconds. Batch the events from the Autoscalers informer to push updates to the ConfigMap (GlobalStore)
-	config.BindEnvAndSetDefault("external_metrics_provider.max_age", 120)                          // value in seconds. 4 cycles from the Autoscaler controller (up to Kubernetes 1.11) is enough to consider a metric stale
-	config.BindEnvAndSetDefault("external_metrics_provider.query_validity_period", 30)             // value in seconds. Represents grace period to account for delay between metric is resolved and when autoscaling controllers query for it
-	config.BindEnvAndSetDefault("external_metrics.aggregator", "avg")                              // aggregator used for the external metrics. Choose from [avg,sum,max,min]
-	config.BindEnvAndSetDefault("external_metrics_provider.max_time_window", 60*60*24)             // Maximum window to query to get the metric from Datadog.
-	config.BindEnvAndSetDefault("external_metrics_provider.bucket_size", 60*5)                     // Window to query to get the metric from Datadog.
-	config.BindEnvAndSetDefault("external_metrics_provider.rollup", 30)                            // Bucket size to circumvent time aggregation side effects.
-	config.BindEnvAndSetDefault("external_metrics_provider.wpa_controller", false)                 // Activates the controller for Watermark Pod Autoscalers.
-	config.BindEnvAndSetDefault("external_metrics_provider.use_datadogmetric_crd", false)          // Use DatadogMetric CRD with custom Datadog Queries instead of ConfigMap
-	config.BindEnvAndSetDefault("external_metrics_provider.enable_datadogmetric_autogen", true)    // Enables autogeneration of DatadogMetrics when the DatadogMetric CRD is in use
-	config.BindEnvAndSetDefault("external_metrics_provider.autoscaler_autogen_label_selector", "") // Label selector to filter which HPAs and WPAs the DCA generates DatadogMetrics for (e.g. "app.kubernetes.io/managed-by!=keda-operator")
-	config.BindEnvAndSetDefault("kubernetes_event_collection_timeout", 100)                        // timeout between two successful event collections in milliseconds.
-	config.BindEnvAndSetDefault("kubernetes_informers_resync_period", 60*5)                        // value in seconds. Default to 5 minutes
-	config.BindEnvAndSetDefault("external_metrics_provider.config", map[string]string{})           // list of options that can be used to configure the external metrics server
-	config.BindEnvAndSetDefault("external_metrics_provider.local_copy_refresh_rate", 30)           // value in seconds
-	config.BindEnvAndSetDefault("external_metrics_provider.chunk_size", 35)                        // Maximum number of queries to batch when querying Datadog.
-	config.BindEnvAndSetDefault("external_metrics_provider.split_batches_with_backoff", false)     // Splits batches and runs queries with errors individually with an exponential backoff
-	config.BindEnvAndSetDefault("external_metrics_provider.num_workers", 2)                        // Number of workers spawned by controller (only when CRD is used)
-	config.BindEnvAndSetDefault("external_metrics_provider.max_parallel_queries", 10)              // Maximum number of parallel queries sent to Datadog simultaneously
+	// Override the Datadog API endpoint to query external metrics from
+	config.BindEnvAndSetDefault("external_metrics_provider.endpoint", "")
+	// Override the Datadog API Key for external metrics endpoint
+	config.BindEnvAndSetDefault("external_metrics_provider.api_key", "")
+	// Override the Datadog APP Key for external metrics endpoint
+	config.BindEnvAndSetDefault("external_metrics_provider.app_key", "")
+	// List of redundant endpoints to query external metrics from
+	config.SetDefault("external_metrics_provider.endpoints", []interface{}{})
+	// value in seconds. Frequency of calls to Datadog to refresh metric values
+	config.BindEnvAndSetDefault("external_metrics_provider.refresh_period", 30)
+	// value in seconds. Batch the events from the Autoscalers informer to push updates to the ConfigMap (GlobalStore)
+	config.BindEnvAndSetDefault("external_metrics_provider.batch_window", 10)
+	// value in seconds. 4 cycles from the Autoscaler controller (up to Kubernetes 1.11) is enough to consider a metric stale
+	config.BindEnvAndSetDefault("external_metrics_provider.max_age", 120)
+	// value in seconds. Represents grace period to account for delay between metric is resolved and when autoscaling controllers query for it
+	config.BindEnvAndSetDefault("external_metrics_provider.query_validity_period", 30)
+	// aggregator used for the external metrics. Choose from [avg,sum,max,min]
+	config.BindEnvAndSetDefault("external_metrics.aggregator", "avg")
+	// Maximum window to query to get the metric from Datadog.
+	config.BindEnvAndSetDefault("external_metrics_provider.max_time_window", 60*60*24)
+	// Window to query to get the metric from Datadog.
+	config.BindEnvAndSetDefault("external_metrics_provider.bucket_size", 60*5)
+	// Bucket size to circumvent time aggregation side effects.
+	config.BindEnvAndSetDefault("external_metrics_provider.rollup", 30)
+	// Activates the controller for Watermark Pod Autoscalers.
+	config.BindEnvAndSetDefault("external_metrics_provider.wpa_controller", false)
+	// Use DatadogMetric CRD with custom Datadog Queries instead of ConfigMap
+	config.BindEnvAndSetDefault("external_metrics_provider.use_datadogmetric_crd", false)
+	// Enables autogeneration of DatadogMetrics when the DatadogMetric CRD is in use
+	config.BindEnvAndSetDefault("external_metrics_provider.enable_datadogmetric_autogen", true)
+	// Label selector to filter which HPAs and WPAs the DCA generates DatadogMetrics for (e.g. "app.kubernetes.io/managed-by!=keda-operator")
+	config.BindEnvAndSetDefault("external_metrics_provider.autoscaler_autogen_label_selector", "")
+	// timeout between two successful event collections in milliseconds.
+	config.BindEnvAndSetDefault("kubernetes_event_collection_timeout", 100)
+	// value in seconds. Default to 5 minutes
+	config.BindEnvAndSetDefault("kubernetes_informers_resync_period", 60*5)
+	// list of options that can be used to configure the external metrics server
+	config.BindEnvAndSetDefault("external_metrics_provider.config", map[string]string{})
+	// value in seconds
+	config.BindEnvAndSetDefault("external_metrics_provider.local_copy_refresh_rate", 30)
+	// Maximum number of queries to batch when querying Datadog.
+	config.BindEnvAndSetDefault("external_metrics_provider.chunk_size", 35)
+	// Splits batches and runs queries with errors individually with an exponential backoff
+	config.BindEnvAndSetDefault("external_metrics_provider.split_batches_with_backoff", false)
+	// Number of workers spawned by controller (only when CRD is used)
+	config.BindEnvAndSetDefault("external_metrics_provider.num_workers", 2)
+	// Maximum number of parallel queries sent to Datadog simultaneously
+	config.BindEnvAndSetDefault("external_metrics_provider.max_parallel_queries", 10)
 	config.BindEnvAndSetDefault("instrumentation_crd_controller.enabled", false)
-	config.BindEnvAndSetDefault("cluster_checks.support_hybrid_ignore_ad_tags", false) // TODO(CINT)(Agent 7.53+) Remove this flag when hybrid ignore_ad_tags is fully deprecated
+	// TODO(CINT)(Agent 7.53+) Remove this flag when hybrid ignore_ad_tags is fully deprecated
+	config.BindEnvAndSetDefault("cluster_checks.support_hybrid_ignore_ad_tags", false)
 	config.BindEnvAndSetDefault("cluster_checks.enabled", false)
-	config.BindEnvAndSetDefault("cluster_checks.node_expiration_timeout", 30)     // value in seconds
-	config.BindEnvAndSetDefault("cluster_checks.warmup_duration", 30)             // value in seconds
-	config.BindEnvAndSetDefault("cluster_checks.unscheduled_check_threshold", 60) // value in seconds
+	// value in seconds
+	config.BindEnvAndSetDefault("cluster_checks.node_expiration_timeout", 30)
+	// value in seconds
+	config.BindEnvAndSetDefault("cluster_checks.warmup_duration", 30)
+	// value in seconds
+	config.BindEnvAndSetDefault("cluster_checks.unscheduled_check_threshold", 60)
 	config.BindEnvAndSetDefault("cluster_checks.cluster_tag_name", "cluster_name")
 	config.BindEnvAndSetDefault("cluster_checks.extra_tags", []string{})
 	config.BindEnvAndSetDefault("cluster_checks.advanced_dispatching_enabled", true)
 	config.BindEnvAndSetDefault("cluster_checks.rebalance_with_utilization", true)
-	config.BindEnvAndSetDefault("cluster_checks.rebalance_min_percentage_improvement", 10) // Experimental. Subject to change. Rebalance only if the distribution found improves the current one by this.
+	// Experimental. Subject to change. Rebalance only if the distribution found improves the current one by this.
+	config.BindEnvAndSetDefault("cluster_checks.rebalance_min_percentage_improvement", 10)
 	config.BindEnvAndSetDefault("cluster_checks.clc_runners_port", 5005)
 	config.BindEnvAndSetDefault("cluster_checks.exclude_checks", []string{})
 	config.BindEnvAndSetDefault("cluster_checks.exclude_checks_from_dispatching", []string{})
 	config.BindEnvAndSetDefault("cluster_checks.rebalance_period", 10*time.Minute)
-	config.BindEnvAndSetDefault("cluster_checks.ksm_sharding_enabled", false) // KSM resource sharding: splits KSM check by resource type (pods, nodes, others)
+	// KSM resource sharding: splits KSM check by resource type (pods, nodes, others)
+	config.BindEnvAndSetDefault("cluster_checks.ksm_sharding_enabled", false)
 	config.BindEnvAndSetDefault("cluster_checks.crd_collection", false)
-	config.BindEnvAndSetDefault("cluster_checks.stickiness_enabled", true)              // Biases check placement toward the runner where a check previously ran.
-	config.BindEnvAndSetDefault("cluster_checks.stickiness_factor", float64(4))         // Multiplier applied to workersNeeded when computing the stickiness bias.
-	config.BindEnvAndSetDefault("cluster_checks.stickiness_upper_limit", float64(1))    // Maximum stickiness bias applied regardless of workersNeeded.
-	config.BindEnvAndSetDefault("cluster_checks.stickiness_lower_limit", float64(0.05)) // Minimum stickiness bias applied when stickiness is enabled.
+	// Biases check placement toward the runner where a check previously ran.
+	config.BindEnvAndSetDefault("cluster_checks.stickiness_enabled", true)
+	// Multiplier applied to workersNeeded when computing the stickiness bias.
+	config.BindEnvAndSetDefault("cluster_checks.stickiness_factor", float64(4))
+	// Maximum stickiness bias applied regardless of workersNeeded.
+	config.BindEnvAndSetDefault("cluster_checks.stickiness_upper_limit", float64(1))
+	// Minimum stickiness bias applied when stickiness is enabled.
+	config.BindEnvAndSetDefault("cluster_checks.stickiness_lower_limit", float64(0.05))
 
 	config.BindEnvAndSetDefault("clc_runner_enabled", false)
 	config.BindEnvAndSetDefault("clc_runner_id", "")
-	config.BindEnvAndSetDefault("clc_runner_host", "") // must be set using the Kubernetes downward API
+	// must be set using the Kubernetes downward API
+	config.BindEnvAndSetDefault("clc_runner_host", "")
 	config.BindEnvAndSetDefault("clc_runner_port", 5005)
 	config.BindEnvAndSetDefault("clc_runner_server_write_timeout", 15)
 	config.BindEnvAndSetDefault("clc_runner_server_readheader_timeout", 10)
@@ -613,10 +663,10 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	// running in the cluster check runner to gain better tagging coverage
 	// on emitted metrics:
 	//
-	//		* KSM check running in CLC runner needs the remote tagger to ensure
-	//		  namespace labels and annotations as tags are applied to emitted KSM
-	//		  metrics in case the check is partitioned to multiple instances, each
-	//		  emitting different resource metrics.
+	// * KSM check running in CLC runner needs the remote tagger to ensure
+	// namespace labels and annotations as tags are applied to emitted KSM
+	// metrics in case the check is partitioned to multiple instances, each
+	// emitting different resource metrics.
 	config.BindEnvAndSetDefault("clc_runner_remote_tagger_enabled", true)
 
 	config.BindEnvAndSetDefault("remote_tagger.max_concurrent_sync", 3)
@@ -630,15 +680,20 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("admission_controller.mutate_unlabelled", false)
 	config.BindEnvAndSetDefault("admission_controller.port", 8000)
 	config.BindEnvAndSetDefault("admission_controller.container_registry", "gcr.io/datadoghq")
-	config.BindEnvAndSetDefault("admission_controller.timeout_seconds", 10) // in seconds (see kubernetes/kubernetes#71508)
+	// in seconds (see kubernetes/kubernetes#71508)
+	config.BindEnvAndSetDefault("admission_controller.timeout_seconds", 10)
 	config.BindEnvAndSetDefault("admission_controller.service_name", "datadog-admission-controller")
-	config.BindEnvAndSetDefault("admission_controller.certificate.validity_bound", 365*24)             // validity bound of the certificate created by the controller (in hours, default 1 year)
-	config.BindEnvAndSetDefault("admission_controller.certificate.expiration_threshold", 30*24)        // how long before its expiration a certificate should be refreshed (in hours, default 1 month)
-	config.BindEnvAndSetDefault("admission_controller.certificate.secret_name", "webhook-certificate") // name of the Secret object containing the webhook certificate
+	// validity bound of the certificate created by the controller (in hours, default 1 year)
+	config.BindEnvAndSetDefault("admission_controller.certificate.validity_bound", 365*24)
+	// how long before its expiration a certificate should be refreshed (in hours, default 1 month)
+	config.BindEnvAndSetDefault("admission_controller.certificate.expiration_threshold", 30*24)
+	// name of the Secret object containing the webhook certificate
+	config.BindEnvAndSetDefault("admission_controller.certificate.secret_name", "webhook-certificate")
 	config.BindEnvAndSetDefault("admission_controller.webhook_name", "datadog-webhook")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.inject_config.endpoint", "/injectconfig")
-	config.BindEnvAndSetDefault("admission_controller.inject_config.mode", "hostip") // possible values: hostip / service / socket / csi
+	// possible values: hostip / service / socket / csi
+	config.BindEnvAndSetDefault("admission_controller.inject_config.mode", "hostip")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.local_service_name", "datadog")
 	config.BindEnvAndSetDefault("trace_agent_host_socket_path", "/var/run/datadog")
 	config.BindEnvAndSetDefault("dogstatsd_host_socket_path", "/var/run/datadog")
@@ -646,15 +701,20 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("admission_controller.inject_config.type_socket_volumes", false)
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.endpoint", "/injecttags")
-	config.BindEnvAndSetDefault("admission_controller.inject_tags.pod_owners_cache_validity", 10) // in minutes
-	config.BindEnvAndSetDefault("admission_controller.pod_owners_cache_validity", 10)             // deprecated alias for `admission_controller.inject_tags.pod_owners_cache_validity`
+	// in minutes
+	config.BindEnvAndSetDefault("admission_controller.inject_tags.pod_owners_cache_validity", 10)
+	// deprecated alias for `admission_controller.inject_tags.pod_owners_cache_validity`
+	config.BindEnvAndSetDefault("admission_controller.pod_owners_cache_validity", 10)
 	config.BindEnvAndSetDefault("admission_controller.namespace_selector_fallback", false)
 	config.BindEnvAndSetDefault("admission_controller.failure_policy", "Ignore")
 	config.BindEnvAndSetDefault("admission_controller.reinvocation_policy", "IfNeeded")
-	config.BindEnvAndSetDefault("admission_controller.add_aks_selectors", false) // adds in the webhook some selectors that are required in AKS
+	// adds in the webhook some selectors that are required in AKS
+	config.BindEnvAndSetDefault("admission_controller.add_aks_selectors", false)
 	config.BindEnvAndSetDefault("admission_controller.probe.enabled", false)
-	config.BindEnvAndSetDefault("admission_controller.probe.interval", 60)     // in seconds
-	config.BindEnvAndSetDefault("admission_controller.probe.grace_period", 60) // in seconds
+	// in seconds
+	config.BindEnvAndSetDefault("admission_controller.probe.interval", 60)
+	// in seconds
+	config.BindEnvAndSetDefault("admission_controller.probe.grace_period", 60)
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.endpoint", "/injectlib")
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.container_registry", "")
@@ -672,18 +732,26 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.gradual_rollout.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.gradual_rollout.cache_ttl", "1h")
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.enabled", false)
-	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider", false)                                // to be enabled only in e2e tests
-	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.file_provider_path", "/etc/datadog-agent/patch/auto-instru.json") // to be used only in e2e tests
-	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.inject_auto_detected_libraries", true)                                    // allows injecting libraries for languages detected by automatic language detection feature
-	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.container_registry_allow_list", []string{})                               // restricts which registries can be used for library injection
+	// to be enabled only in e2e tests
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider", false)
+	// to be used only in e2e tests
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.file_provider_path", "/etc/datadog-agent/patch/auto-instru.json")
+	// allows injecting libraries for languages detected by automatic language detection feature
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.inject_auto_detected_libraries", true)
+	// restricts which registries can be used for library injection
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.container_registry_allow_list", []string{})
+	config.ParseEnvSplitComma("admission_controller.auto_instrumentation.container_registry_allow_list")
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.init_resources.cpu", "")
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.init_resources.memory", "")
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.init_security_context", "")
-	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.asm.enabled", false, "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_ENABLED")         // config for ASM which is implemented in the client libraries
-	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.iast.enabled", false, "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_IAST_ENABLED")          // config for IAST which is implemented in the client libraries
-	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.asm_sca.enabled", false, "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_SCA_ENABLED") // config for SCA
-	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.profiling.enabled", "", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_PROFILING_ENABLED")   // config for profiling
-	config.ParseEnvSplitComma("admission_controller.auto_instrumentation.container_registry_allow_list")
+	// config for ASM which is implemented in the client libraries
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.asm.enabled", false, "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_ENABLED")
+	// config for IAST which is implemented in the client libraries
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.iast.enabled", false, "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_IAST_ENABLED")
+	// config for SCA
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.asm_sca.enabled", false, "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_SCA_ENABLED")
+	// config for profiling
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.profiling.enabled", "", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_PROFILING_ENABLED")
 	config.BindEnvAndSetDefault("admission_controller.nccl_profiler.enabled", false, "DD_ADMISSION_CONTROLLER_NCCL_PROFILER_ENABLED")
 	config.BindEnvAndSetDefault("admission_controller.nccl_profiler.injector_image", "", "DD_ADMISSION_CONTROLLER_NCCL_PROFILER_INJECTOR_IMAGE")
 	// When true, the webhook injects into every pod that does not have the
@@ -783,15 +851,19 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("sbom.compute_dependencies", true)
 	config.BindEnvAndSetDefault("sbom.simplify_bom_refs", true)
 	config.BindEnvAndSetDefault("sbom.clear_cache_on_exit", false)
-	config.BindEnvAndSetDefault("sbom.cache.max_disk_size", 1000*1000*100) // used by custom cache: max disk space used by cached objects. Not equal to max disk usage
-	config.BindEnvAndSetDefault("sbom.cache.clean_interval", "1h")         // used by custom cache.
+	// used by custom cache: max disk space used by cached objects. Not equal to max disk usage
+	config.BindEnvAndSetDefault("sbom.cache.max_disk_size", 1000*1000*100)
+	// used by custom cache.
+	config.BindEnvAndSetDefault("sbom.cache.clean_interval", "1h")
 	config.BindEnvAndSetDefault("sbom.scan_queue.base_backoff", "5m")
 	config.BindEnvAndSetDefault("sbom.scan_queue.max_backoff", "1h")
 
 	config.BindEnvAndSetDefault("sbom.container_image.enabled", false)
 	config.BindEnvAndSetDefault("sbom.container_image.use_mount", false)
-	config.BindEnvAndSetDefault("sbom.container_image.scan_interval", 0)    // Integer seconds
-	config.BindEnvAndSetDefault("sbom.container_image.scan_timeout", 10*60) // Integer seconds
+	// Integer seconds
+	config.BindEnvAndSetDefault("sbom.container_image.scan_interval", 0)
+	// Integer seconds
+	config.BindEnvAndSetDefault("sbom.container_image.scan_timeout", 10*60)
 	config.BindEnvAndSetDefault("sbom.container_image.analyzers", []string{"os"})
 	config.BindEnvAndSetDefault("sbom.container_image.check_disk_usage", true)
 	config.BindEnvAndSetDefault("sbom.container_image.min_available_disk", "10Mb")
@@ -825,8 +897,10 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 
 	config.BindEnvAndSetDefault("otelcollector.enabled", false)
 	config.BindEnvAndSetDefault("otelcollector.extension_url", "https://localhost:7777")
-	config.BindEnvAndSetDefault("otelcollector.extension_timeout", 0)         // in seconds, 0 for default value
-	config.BindEnvAndSetDefault("otelcollector.submit_dummy_metadata", false) // dev flag - to be removed
+	// in seconds, 0 for default value
+	config.BindEnvAndSetDefault("otelcollector.extension_timeout", 0)
+	// dev flag - to be removed
+	config.BindEnvAndSetDefault("otelcollector.submit_dummy_metadata", false)
 	config.BindEnvAndSetDefault("otelcollector.converter.enabled", true)
 	config.BindEnvAndSetDefault("otelcollector.flare.timeout", 60)
 	config.BindEnvAndSetDefault("otelcollector.converter.features", []string{"infraattributes", "prometheus", "pprof", "zpages", "health_check", "ddflare", "datadog"})
@@ -842,11 +916,14 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("inventories_checks_configuration_enabled", true)
 	config.BindEnvAndSetDefault("inventories_collect_cloud_provider_account_id", true)
 	// when updating the default here also update pkg/metadata/inventories/README.md
-	config.BindEnvAndSetDefault("inventories_max_interval", 0) // 0 == default interval from inventories
-	config.BindEnvAndSetDefault("inventories_min_interval", 0) // 0 == default interval from inventories
+	// 0 == default interval from inventories
+	config.BindEnvAndSetDefault("inventories_max_interval", 0)
+	// 0 == default interval from inventories
+	config.BindEnvAndSetDefault("inventories_min_interval", 0)
 	// Seconds to wait to sent metadata payload to the backend after startup
 	config.BindEnvAndSetDefault("inventories_first_run_delay", 60)
-	config.BindEnvAndSetDefault("metadata_ip_resolution_from_hostname", false) // resolve the hostname to get the IP address
+	// resolve the hostname to get the IP address
+	config.BindEnvAndSetDefault("metadata_ip_resolution_from_hostname", false)
 
 	config.BindEnvAndSetDefault("security_agent.cmd_port", DefaultSecurityAgentCmdPort)
 	config.BindEnvAndSetDefault("security_agent.expvar_port", 5011)
@@ -874,7 +951,8 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 
 	config.BindEnvAndSetDefault("compliance_config.enabled", false)
 	config.BindEnvAndSetDefault("compliance_config.run_in_system_probe", false)
-	config.BindEnvAndSetDefault("compliance_config.xccdf.enabled", false) // deprecated, use host_benchmarks instead
+	// deprecated, use host_benchmarks instead
+	config.BindEnvAndSetDefault("compliance_config.xccdf.enabled", false)
 	config.BindEnvAndSetDefault("compliance_config.host_benchmarks.enabled", true)
 	config.BindEnvAndSetDefault("compliance_config.database_benchmarks.enabled", false)
 	config.BindEnvAndSetDefault("compliance_config.check_interval", 20*time.Minute)
@@ -968,7 +1046,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("reverse_dns_enrichment.cache.clean_interval", 2*time.Hour)
 	config.BindEnvAndSetDefault("reverse_dns_enrichment.cache.persist_interval", 2*time.Hour)
 	config.BindEnvAndSetDefault("reverse_dns_enrichment.cache.max_retries", 10)
-	config.BindEnvAndSetDefault("reverse_dns_enrichment.cache.max_size", 1_000_000)
+	config.BindEnvAndSetDefault("reverse_dns_enrichment.cache.max_size", 1000000)
 	config.BindEnvAndSetDefault("reverse_dns_enrichment.rate_limiter.limit_per_sec", 1000)
 	config.BindEnvAndSetDefault("reverse_dns_enrichment.rate_limiter.limit_throttled_per_sec", 1)
 	config.BindEnvAndSetDefault("reverse_dns_enrichment.rate_limiter.throttle_error_threshold", 10)
@@ -1057,7 +1135,6 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 
 func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("api_key", "")
-
 	config.BindEnvAndSetDefault("site", DefaultSite)
 	config.BindEnvAndSetDefault("convert_dd_site_fqdn.enabled", true)
 	config.BindEnvAndSetDefault("dd_url", "https://app.datadoghq.com", "DD_DD_URL", "DD_URL")
@@ -1098,7 +1175,8 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("disable_file_logging", false)
 	config.BindEnvAndSetDefault("syslog_uri", "")
 	config.BindEnvAndSetDefault("syslog_rfc", false)
-	config.BindEnvAndSetDefault("ipc_address", "localhost") // deprecated: use `cmd_host` instead
+	// deprecated: use `cmd_host` instead
+	config.BindEnvAndSetDefault("ipc_address", "localhost")
 	config.BindEnvAndSetDefault("cmd_host", "localhost")
 	config.BindEnvAndSetDefault("cmd_port", 5001)
 	config.BindEnvAndSetDefault("agent_ipc.socket_path", "${run_path}/agent_ipc.socket")
@@ -1126,7 +1204,8 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("check_runner_utilization_warning_cooldown", 10*time.Minute)
 	config.BindEnvAndSetDefault("check_system_probe_startup_time", 5*time.Minute)
 	config.BindEnvAndSetDefault("check_system_probe_timeout", 60*time.Second)
-	config.BindEnvAndSetDefault("check_watchdog_warning_timeout", 0*time.Second) // If not zero, the agent will log a warning if a check is running for longer than this timeout
+	// If not zero, the agent will log a warning if a check is running for longer than this timeout
+	config.BindEnvAndSetDefault("check_watchdog_warning_timeout", 0*time.Second)
 	config.BindEnvAndSetDefault("auth_token_file_path", "")
 	// used to override the path where the IPC cert/key files are stored/retrieved
 	config.BindEnvAndSetDefault("ipc_cert_file_path", "")
@@ -1316,7 +1395,8 @@ func autoscaling(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("autoscaling.failover.enabled", false)
 	config.BindEnvAndSetDefault("autoscaling.workload.limit", 1000)
 	config.BindEnvAndSetDefault("autoscaling.workload.num_workers", 2)
-	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.enabled", false) // Enables the external recommender feature.
+	// Enables the external recommender feature.
+	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.enabled", false)
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.ca_file", "")
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.cert_file", "")
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.key_file", "")
@@ -1400,9 +1480,12 @@ func autoconfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("container_exclude_metrics", []string{})
 	config.BindEnvAndSetDefault("container_include_logs", []string{})
 	config.BindEnvAndSetDefault("container_exclude_logs", []string{})
-	config.BindEnvAndSetDefault("container_exclude_stopped_age", DefaultAuditorTTL-1) // in hours
-	config.BindEnvAndSetDefault("ad_config_poll_interval", int64(10))                 // in seconds
-	config.BindEnvAndSetDefault("ad_tag_completeness_max_wait", 0)                    // in seconds, 0 means disabled
+	// in hours
+	config.BindEnvAndSetDefault("container_exclude_stopped_age", DefaultAuditorTTL-1)
+	// in seconds
+	config.BindEnvAndSetDefault("ad_config_poll_interval", int64(10))
+	// in seconds, 0 means disabled
+	config.BindEnvAndSetDefault("ad_tag_completeness_max_wait", 0)
 	config.BindEnvAndSetDefault("ad_allowed_env_vars", []string{})
 	config.BindEnvAndSetDefault("ad_disable_env_var_resolution", false)
 	config.BindEnvAndSetDefault("extra_listeners", []string{})
@@ -1437,8 +1520,10 @@ func debugging(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("tracemalloc_debug", false)
 	config.BindEnvAndSetDefault("tracemalloc_include", "")
 	config.BindEnvAndSetDefault("tracemalloc_exclude", "")
-	config.BindEnvAndSetDefault("tracemalloc_whitelist", "") // deprecated
-	config.BindEnvAndSetDefault("tracemalloc_blacklist", "") // deprecated
+	// deprecated
+	config.BindEnvAndSetDefault("tracemalloc_whitelist", "")
+	// deprecated
+	config.BindEnvAndSetDefault("tracemalloc_blacklist", "")
 	config.BindEnvAndSetDefault("run_path", "${run_path}")
 	config.BindEnvAndSetDefault("no_proxy_nonexact_match", false)
 }
@@ -1520,7 +1605,8 @@ func aggregator(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("aggregator_tag_filter_cache_capacity", 1000)
 	// ADP can cache more efficiently so we use a higher default
 	config.BindEnvAndSetDefault("data_plane.dogstatsd.aggregator_tag_filter_cache_capacity", 100000)
-	config.BindEnvAndSetDefault("basic_telemetry_add_container_tags", false) // configure adding the agent container tags to the basic agent telemetry metrics (e.g. `datadog.agent.running`)
+	// configure adding the agent container tags to the basic agent telemetry metrics (e.g. `datadog.agent.running`)
+	config.BindEnvAndSetDefault("basic_telemetry_add_container_tags", false)
 	config.BindEnvAndSetDefault("aggregator_flush_metrics_and_serialize_in_parallel_chan_size", 200)
 	config.BindEnvAndSetDefault("aggregator_flush_metrics_and_serialize_in_parallel_buffer_size", 4000)
 }
@@ -1537,10 +1623,13 @@ func serverless(config pkgconfigmodel.Setup) {
 func forwarder(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("additional_endpoints", map[string][]string{})
 	config.BindEnvAndSetDefault("forwarder_timeout", 20)
-	config.BindEnvAndSetDefault("forwarder_retry_queue_max_size", 0) // Deprecated in favor of `forwarder_retry_queue_payloads_max_size`
+	// Deprecated in favor of `forwarder_retry_queue_payloads_max_size`
+	config.BindEnvAndSetDefault("forwarder_retry_queue_max_size", 0)
 	config.BindEnvAndSetDefault("forwarder_retry_queue_payloads_max_size", 15*1024*1024)
-	config.BindEnvAndSetDefault("forwarder_connection_reset_interval", 0)                                // in seconds, 0 means disabled
-	config.BindEnvAndSetDefault("forwarder_apikey_validation_interval", DefaultAPIKeyValidationInterval) // in minutes
+	// in seconds, 0 means disabled
+	config.BindEnvAndSetDefault("forwarder_connection_reset_interval", 0)
+	// in minutes
+	config.BindEnvAndSetDefault("forwarder_apikey_validation_interval", DefaultAPIKeyValidationInterval)
 	config.BindEnvAndSetDefault("forwarder_num_workers", 1)
 	config.BindEnvAndSetDefault("forwarder_stop_timeout", 2)
 	// forwarder_stop_wait_for_inflight controls whether Worker.Stop waits for
@@ -1557,9 +1646,12 @@ func forwarder(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("forwarder_storage_path", "${run_path}/transactions_to_retry")
 	config.BindEnvAndSetDefault("forwarder_outdated_file_in_days", 10)
 	config.BindEnvAndSetDefault("forwarder_flush_to_disk_mem_ratio", float64(0.5))
-	config.BindEnvAndSetDefault("forwarder_storage_max_size_in_bytes", 0)                // 0 means disabled. This is a BETA feature.
-	config.BindEnvAndSetDefault("forwarder_storage_max_disk_ratio", float64(0.80))       // Do not store transactions on disk when the disk usage exceeds 80% of the disk capacity. Use 80% as some applications do not behave well when the disk space is very small.
-	config.BindEnvAndSetDefault("forwarder_retry_queue_capacity_time_interval_sec", 900) // 15 mins
+	// 0 means disabled. This is a BETA feature.
+	config.BindEnvAndSetDefault("forwarder_storage_max_size_in_bytes", 0)
+	// Do not store transactions on disk when the disk usage exceeds 80% of the disk capacity. Use 80% as some applications do not behave well when the disk space is very small.
+	config.BindEnvAndSetDefault("forwarder_storage_max_disk_ratio", float64(0.80))
+	// 15 mins
+	config.BindEnvAndSetDefault("forwarder_retry_queue_capacity_time_interval_sec", 900)
 
 	config.BindEnvAndSetDefault("forwarder_high_prio_buffer_size", 100)
 	config.BindEnvAndSetDefault("forwarder_low_prio_buffer_size", 100)
@@ -1569,7 +1661,8 @@ func forwarder(config pkgconfigmodel.Setup) {
 
 func dogstatsd(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("use_dogstatsd", true)
-	config.BindEnvAndSetDefault("dogstatsd_port", 8125) // Notice: 0 means UDP port closed
+	// Notice: 0 means UDP port closed
+	config.BindEnvAndSetDefault("dogstatsd_port", 8125)
 	config.BindEnvAndSetDefault("dogstatsd_pipe_name", "")
 	// https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-string-format
 	// https://learn.microsoft.com/en-us/windows/win32/secauthz/ace-strings
@@ -1623,7 +1716,8 @@ func dogstatsd(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("dogstatsd_flush_incomplete_buckets", false)
 	// Control how long we keep dogstatsd contexts in memory.
 	config.BindEnvAndSetDefault("dogstatsd_context_expiry_seconds", 20)
-	config.BindEnvAndSetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic
+	// Only supported for socket traffic
+	config.BindEnvAndSetDefault("dogstatsd_origin_detection", false)
 	config.BindEnvAndSetDefault("dogstatsd_origin_detection_client", false)
 	config.BindEnvAndSetDefault("dogstatsd_origin_optout_enabled", true)
 	config.BindEnvAndSetDefault("dogstatsd_so_rcvbuf", 0)
@@ -1655,7 +1749,8 @@ func dogstatsd(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("dogstatsd_mem_based_rate_limiter.enabled", false)
 	config.BindEnvAndSetDefault("dogstatsd_mem_based_rate_limiter.low_soft_limit", float64(0.7))
 	config.BindEnvAndSetDefault("dogstatsd_mem_based_rate_limiter.high_soft_limit", float64(0.8))
-	config.BindEnvAndSetDefault("dogstatsd_mem_based_rate_limiter.go_gc", 1) // 0 means don't call SetGCPercent
+	// 0 means don't call SetGCPercent
+	config.BindEnvAndSetDefault("dogstatsd_mem_based_rate_limiter.go_gc", 1)
 	config.BindEnvAndSetDefault("dogstatsd_mem_based_rate_limiter.memory_ballast", int64(1024*1024*1024*8))
 	config.BindEnvAndSetDefault("dogstatsd_mem_based_rate_limiter.rate_check.min", float64(0.01))
 	config.BindEnvAndSetDefault("dogstatsd_mem_based_rate_limiter.rate_check.max", 1)
@@ -1682,7 +1777,8 @@ func logsagent(config pkgconfigmodel.Setup) {
 	// External Use: modify those parameters to configure the logs-agent.
 	// enable the logs-agent:
 	config.BindEnvAndSetDefault("logs_enabled", false)
-	config.BindEnvAndSetDefault("log_enabled", false) // deprecated, use logs_enabled instead
+	// deprecated, use logs_enabled instead
+	config.BindEnvAndSetDefault("log_enabled", false)
 	// collect all logs from all containers:
 	config.BindEnvAndSetDefault("logs_config.container_collect_all", false)
 	// add a socks5 proxy:
@@ -1716,7 +1812,8 @@ func logsagent(config pkgconfigmodel.Setup) {
 	bindDelegatedAuthConfig(config, "logs_config")
 
 	// Duration during which the host tags will be submitted with log events.
-	config.BindEnvAndSetDefault("logs_config.expected_tags_duration", time.Duration(0)) // duration-formatted string (parsed by `time.ParseDuration`)
+	// duration-formatted string (parsed by `time.ParseDuration`)
+	config.BindEnvAndSetDefault("logs_config.expected_tags_duration", time.Duration(0))
 	// send the logs to the port 443 of the logs-backend via TCP:
 	config.BindEnvAndSetDefault("logs_config.use_port_443", false)
 	// increase the read buffer size of the UDP sockets:
@@ -1751,7 +1848,8 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logs_config.validate_pod_container_id", true)
 	// additional config to ensure initial logs are tagged with kubelet tags
 	// wait (seconds) for tagger before start fetching tags of new AD services
-	config.BindEnvAndSetDefault("logs_config.tagger_warmup_duration", 0) // Disabled by default (0 seconds)
+	// Disabled by default (0 seconds)
+	config.BindEnvAndSetDefault("logs_config.tagger_warmup_duration", 0)
 	// Configurable docker client timeout while communicating with the docker daemon.
 	// It could happen that the docker daemon takes a lot of time gathering timestamps
 	// before starting to send any data when it has stored several large log files.
@@ -1797,7 +1895,8 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("database_monitoring.autodiscovery.rds.global_view_db_tag", "datadoghq.com/global_view_db")
 
 	bindEnvAndSetLogsConfigKeys(config, "data_streams.forwarder.")
-	config.BindEnvAndSetDefault("data_streams.forwarder.batch_wait", float64(0.1)) // 100ms for low-latency forwarding
+	// 100ms for low-latency forwarding
+	config.BindEnvAndSetDefault("data_streams.forwarder.batch_wait", float64(0.1))
 
 	config.BindEnvAndSetDefault("logs_config.dd_port", 10516)
 	config.BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)
@@ -1868,7 +1967,8 @@ func logsagent(config pkgconfigmodel.Setup) {
 	// The following auto_multi_line settings are settings for auto multiline detection v1
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_extra_patterns", []string{})
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_default_sample_size", 500)
-	config.BindEnvAndSetDefault("logs_config.auto_multi_line_default_match_timeout", 30) // Seconds
+	// Seconds
+	config.BindEnvAndSetDefault("logs_config.auto_multi_line_default_match_timeout", 30)
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_default_match_threshold", float64(0.48))
 
 	// Add a tag to logs that are multiline aggregated
@@ -1905,7 +2005,8 @@ func logsagent(config pkgconfigmodel.Setup) {
 	// Timeout is in seconds.
 	config.BindEnvAndSetDefault("logs_config.container_runtime_waiting_timeout", "3s")
 
-	config.BindEnvAndSetDefault("logs_config.auditor_ttl", DefaultAuditorTTL) // in hours
+	// in hours
+	config.BindEnvAndSetDefault("logs_config.auditor_ttl", DefaultAuditorTTL)
 	// Timeout in milliseonds used when performing agreggation operations,
 	// including multi-line log processing rules and chunked line reaggregation.
 	// It may be useful to increase it when logs writing is slowed down, that
@@ -1994,16 +2095,20 @@ func cloudfoundry(config pkgconfigmodel.Setup) {
 
 func containerd(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("containerd_namespace", []string{})
-	config.BindEnvAndSetDefault("containerd_namespaces", []string{}) // alias for containerd_namespace
+	// alias for containerd_namespace
+	config.BindEnvAndSetDefault("containerd_namespaces", []string{})
 	config.BindEnvAndSetDefault("containerd_exclude_namespaces", []string{"moby"})
 	config.BindEnvAndSetDefault("container_env_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("container_labels_as_tags", map[string]string{})
 }
 
 func cri(config pkgconfigmodel.Setup) {
-	config.BindEnvAndSetDefault("cri_socket_path", "")              // empty is disabled
-	config.BindEnvAndSetDefault("cri_connection_timeout", int64(1)) // in seconds
-	config.BindEnvAndSetDefault("cri_query_timeout", int64(5))      // in seconds
+	// empty is disabled
+	config.BindEnvAndSetDefault("cri_socket_path", "")
+	// in seconds
+	config.BindEnvAndSetDefault("cri_connection_timeout", int64(1))
+	// in seconds
+	config.BindEnvAndSetDefault("cri_query_timeout", int64(5))
 }
 
 func kubernetes(config pkgconfigmodel.Setup) {
@@ -2024,21 +2129,25 @@ func kubernetes(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("kubelet_client_crt", "")
 	config.BindEnvAndSetDefault("kubelet_client_key", "")
 
-	config.BindEnvAndSetDefault("kubernetes_pod_expiration_duration", 15*60) // in seconds, default 15 minutes
+	// in seconds, default 15 minutes
+	config.BindEnvAndSetDefault("kubernetes_pod_expiration_duration", 15*60)
 	// Cache TTL for pod lists in the kubelet client. Set to 0 because it's only
 	// used by workloadmeta that already defines its own pull frequency and has
 	// its own storage, so no need for an extra cache.
 	config.BindEnvAndSetDefault("kubelet_cache_pods_duration", 0)
-	config.BindEnvAndSetDefault("kubelet_collector_pull_interval", 0) // not exposed yet. In seconds. 0 means use workloadmeta default
+	// not exposed yet. In seconds. 0 means use workloadmeta default
+	config.BindEnvAndSetDefault("kubelet_collector_pull_interval", 0)
 	config.BindEnvAndSetDefault("kubernetes_collect_metadata_tags", true)
 	config.BindEnvAndSetDefault("kubernetes_use_endpoint_slices", false)
-	config.BindEnvAndSetDefault("kubernetes_metadata_tag_update_freq", 60) // Polling frequency of the Agent to the DCA in seconds (gets the local cache if the DCA is disabled)
+	// Polling frequency of the Agent to the DCA in seconds (gets the local cache if the DCA is disabled)
+	config.BindEnvAndSetDefault("kubernetes_metadata_tag_update_freq", 60)
 	config.BindEnvAndSetDefault("kubernetes_metadata_streaming", true)
 	config.BindEnvAndSetDefault("kubernetes_apiserver_client_timeout", 10)
 	config.BindEnvAndSetDefault("kubernetes_apiserver_informer_client_timeout", 0)
 	config.BindEnvAndSetDefault("kubernetes_apiserver_client_qps", 40)
 	config.BindEnvAndSetDefault("kubernetes_apiserver_client_burst", 200)
-	config.BindEnvAndSetDefault("kubernetes_map_services_on_ip", false) // temporary opt-out of the new mapping logic
+	// temporary opt-out of the new mapping logic
+	config.BindEnvAndSetDefault("kubernetes_map_services_on_ip", false)
 	config.BindEnvAndSetDefault("kubernetes_apiserver_use_protobuf", false)
 	config.BindEnvAndSetDefault("kubernetes_ad_tags_disabled", []string{})
 	config.BindEnvAndSetDefault("kubernetes_kube_service_ignore_readiness", false)
@@ -2073,19 +2182,22 @@ func anomalyDetection(config pkgconfigmodel.Setup) {
 	// high_priority = warn/error/critical, medium_priority = info, low_priority = debug.
 	config.BindEnvAndSetDefault("anomaly_detection.logs.internal.enabled", true)
 	config.BindEnvAndSetDefault("anomaly_detection.logs.internal.min_severity", "warn")
-	config.BindEnvAndSetDefault("anomaly_detection.logs.internal.max_rate_high_priority", float64(-1)) // unlimited
+	// unlimited
+	config.BindEnvAndSetDefault("anomaly_detection.logs.internal.max_rate_high_priority", float64(-1))
 	config.BindEnvAndSetDefault("anomaly_detection.logs.internal.max_rate_medium_priority", float64(100))
 	config.BindEnvAndSetDefault("anomaly_detection.logs.internal.max_rate_low_priority", float64(1))
 
 	// Kubelet journald log rate limits (enabled flag already set above).
 	config.BindEnvAndSetDefault("anomaly_detection.logs.kubelet.min_severity", "warn")
-	config.BindEnvAndSetDefault("anomaly_detection.logs.kubelet.max_rate_high_priority", float64(-1)) // unlimited
+	// unlimited
+	config.BindEnvAndSetDefault("anomaly_detection.logs.kubelet.max_rate_high_priority", float64(-1))
 	config.BindEnvAndSetDefault("anomaly_detection.logs.kubelet.max_rate_medium_priority", float64(100))
 	config.BindEnvAndSetDefault("anomaly_detection.logs.kubelet.max_rate_low_priority", float64(1))
 
 	// Container log rate limits (enabled flag already set above).
 	config.BindEnvAndSetDefault("anomaly_detection.logs.containers.min_severity", "warn")
-	config.BindEnvAndSetDefault("anomaly_detection.logs.containers.max_rate_high_priority", float64(-1)) // unlimited
+	// unlimited
+	config.BindEnvAndSetDefault("anomaly_detection.logs.containers.max_rate_high_priority", float64(-1))
 	config.BindEnvAndSetDefault("anomaly_detection.logs.containers.max_rate_medium_priority", float64(100))
 	config.BindEnvAndSetDefault("anomaly_detection.logs.containers.max_rate_low_priority", float64(1))
 

--- a/pkg/config/setup/fixup_init.go
+++ b/pkg/config/setup/fixup_init.go
@@ -8,7 +8,9 @@ package setup
 
 import (
 	"os"
+	"path"
 	"runtime"
+	"strings"
 
 	pkgconfigenv "github.com/DataDog/datadog-agent/pkg/config/env"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
@@ -116,5 +118,18 @@ func fixupInitFullAgentOnlyComponents(_ pkgconfigmodel.Config) {
 }
 
 // called only for system-probe, after declaring settings
-func fixupInitSystemProbe(_ pkgconfigmodel.Config) {
+func fixupInitSystemProbe(config pkgconfigmodel.Config) {
+	if value, _ := os.LookupEnv("HOST_ETC"); value != "" {
+		for _, name := range []string{
+			"system_probe_config.apt_config_dir",
+			"system_probe_config.yum_repos_dir",
+			"system_probe_config.zypper_repos_dir",
+		} {
+			if config.GetSource(name) == pkgconfigmodel.SourceDefault {
+				oldVal := config.GetString(name)
+				newVal := path.Join(value, strings.TrimPrefix(oldVal, "/etc"))
+				config.Set(name, newVal, pkgconfigmodel.SourceDefault)
+			}
+		}
+	}
 }

--- a/pkg/config/setup/privateactionrunner.go
+++ b/pkg/config/setup/privateactionrunner.go
@@ -25,9 +25,6 @@ const (
 	PARActionsAllowlist      = "private_action_runner.actions_allowlist"
 	PARDefaultActionsEnabled = "private_action_runner.default_actions_enabled"
 
-	// Executor mode (split deployment)
-	PARExecutorSocketPath = "private_action_runner.executor.socket_path"
-
 	// HTTP Action related
 	PARHttpTimeoutSeconds    = "private_action_runner.http_timeout_seconds"
 	PARHttpAllowlist         = "private_action_runner.http_allowlist"

--- a/pkg/config/setup/privateactionrunner_settings.go
+++ b/pkg/config/setup/privateactionrunner_settings.go
@@ -12,13 +12,10 @@ import (
 
 // setupPrivateActionRunner registers all configuration keys for the private action runner
 func setupPrivateActionRunner(config pkgconfigmodel.Setup) {
-	// Enable/disable private action runner
 	config.BindEnvAndSetDefault("private_action_runner.enabled", false)
 
-	// Log file
 	config.BindEnvAndSetDefault("private_action_runner.log_file", "${log_path}/private-action-runner.log")
 
-	// Identity / enrollment configuration
 	config.BindEnvAndSetDefault("private_action_runner.self_enroll", true)
 	config.BindEnvAndSetDefault("private_action_runner.api_key_only_enrollment", false)
 	config.BindEnvAndSetDefault("private_action_runner.identity_file_path", "")
@@ -28,20 +25,16 @@ func setupPrivateActionRunner(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("private_action_runner.urn", "")
 	config.BindEnvAndSetDefault("private_action_runner.skip_connection_creation", false)
 
-	// General config
 	config.BindEnvAndSetDefault("private_action_runner.task_concurrency", 5)
 	config.BindEnvAndSetDefault("private_action_runner.task_timeout_seconds", 60)
 	config.BindEnvAndSetDefault("private_action_runner.actions_allowlist", []string{})
-	config.BindEnvAndSetDefault("private_action_runner.default_actions_enabled", true)
 	config.ParseEnvSplitComma("private_action_runner.actions_allowlist")
-
-	// Executor mode (split deployment)
-	config.BindEnvAndSetDefault(PARExecutorSocketPath, GetPlatformDefault(map[string]interface{}{
+	config.BindEnvAndSetDefault("private_action_runner.default_actions_enabled", true)
+	config.BindEnvAndSetDefault("private_action_runner.executor.socket_path", GetPlatformDefault(map[string]interface{}{
 		"windows": `\\.\pipe\dd-par-executor`,
 		"other":   "${run_path}/par-executor.sock",
 	}))
 
-	// HTTP action
 	config.BindEnvAndSetDefault("private_action_runner.http_timeout_seconds", 30)
 	config.BindEnvAndSetDefault("private_action_runner.http_allowlist", []string{})
 	config.ParseEnvSplitComma("private_action_runner.http_allowlist")

--- a/pkg/config/setup/process.go
+++ b/pkg/config/setup/process.go
@@ -64,18 +64,6 @@ const (
 // we need to make sure it is only applied once
 var processesAddOverrideOnce sync.Once
 
-// procBindEnvAndSetDefault is a helper function that generates both "DD_PROCESS_CONFIG_" and "DD_PROCESS_AGENT_" prefixes from a key.
-// We need this helper function because the standard BindEnvAndSetDefault can only generate one prefix from a key.
-func procBindEnvAndSetDefault(config pkgconfigmodel.Setup, key string, val interface{}) {
-	// Uppercase, replace "." with "_" and add "DD_" prefix to key so that we follow the same environment
-	// variable convention as the core agent.
-	processConfigKey := "DD_" + strings.ReplaceAll(strings.ToUpper(key), ".", "_")
-	processAgentKey := strings.Replace(processConfigKey, "PROCESS_CONFIG", "PROCESS_AGENT", 1)
-
-	envs := []string{processConfigKey, processAgentKey}
-	config.BindEnvAndSetDefault(key, val, envs...)
-}
-
 // loadProcessTransforms loads transforms associated with process config settings.
 func loadProcessTransforms(config pkgconfigmodel.Config) {
 	if config.IsConfigured("process_config.enabled") {

--- a/pkg/config/setup/process_settings.go
+++ b/pkg/config/setup/process_settings.go
@@ -17,85 +17,51 @@ func setupProcesses(config pkgconfigmodel.Setup) {
 	// or container_collection.enabled and process_collection.enabled.
 	//
 	// It's a string as the possible values are "disabled", "false", "true"...
-	procBindEnvAndSetDefault(config, "process_config.enabled", "false")
-
-	procBindEnvAndSetDefault(config, "process_config.container_collection.enabled", true)
-	procBindEnvAndSetDefault(config, "process_config.process_collection.enabled", false)
-
-	config.BindEnvAndSetDefault("process_config.process_dd_url", "",
-		"DD_PROCESS_CONFIG_PROCESS_DD_URL",
-		"DD_PROCESS_AGENT_PROCESS_DD_URL",
-		"DD_PROCESS_AGENT_URL",
-		"DD_PROCESS_CONFIG_URL",
-	)
-	procBindEnvAndSetDefault(config, "process_config.dd_agent_env", "")
-	procBindEnvAndSetDefault(config, "process_config.queue_size", DefaultProcessQueueSize)
-	procBindEnvAndSetDefault(config, "process_config.process_queue_bytes", DefaultProcessQueueBytes)
-	procBindEnvAndSetDefault(config, "process_config.rt_queue_size", DefaultProcessRTQueueSize)
-	procBindEnvAndSetDefault(config, "process_config.max_per_message", DefaultProcessMaxPerMessage)
-	procBindEnvAndSetDefault(config, "process_config.max_message_bytes", DefaultProcessMaxMessageBytes)
-	procBindEnvAndSetDefault(config, "process_config.cmd_port", DefaultProcessCmdPort)
-	procBindEnvAndSetDefault(config, "process_config.blacklist_patterns", []string{})
+	config.BindEnvAndSetDefault("process_config.enabled", "false", "DD_PROCESS_CONFIG_ENABLED", "DD_PROCESS_AGENT_ENABLED")
+	config.BindEnvAndSetDefault("process_config.container_collection.enabled", true, "DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", "DD_PROCESS_AGENT_CONTAINER_COLLECTION_ENABLED")
+	config.BindEnvAndSetDefault("process_config.process_collection.enabled", false, "DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", "DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED")
+	config.BindEnvAndSetDefault("process_config.process_dd_url", "", "DD_PROCESS_CONFIG_PROCESS_DD_URL", "DD_PROCESS_AGENT_PROCESS_DD_URL", "DD_PROCESS_AGENT_URL", "DD_PROCESS_CONFIG_URL")
+	config.BindEnvAndSetDefault("process_config.dd_agent_env", "", "DD_PROCESS_CONFIG_DD_AGENT_ENV", "DD_PROCESS_AGENT_DD_AGENT_ENV")
+	config.BindEnvAndSetDefault("process_config.queue_size", DefaultProcessQueueSize, "DD_PROCESS_CONFIG_QUEUE_SIZE", "DD_PROCESS_AGENT_QUEUE_SIZE")
+	config.BindEnvAndSetDefault("process_config.process_queue_bytes", DefaultProcessQueueBytes, "DD_PROCESS_CONFIG_PROCESS_QUEUE_BYTES", "DD_PROCESS_AGENT_PROCESS_QUEUE_BYTES")
+	config.BindEnvAndSetDefault("process_config.rt_queue_size", DefaultProcessRTQueueSize, "DD_PROCESS_CONFIG_RT_QUEUE_SIZE", "DD_PROCESS_AGENT_RT_QUEUE_SIZE")
+	config.BindEnvAndSetDefault("process_config.max_per_message", DefaultProcessMaxPerMessage, "DD_PROCESS_CONFIG_MAX_PER_MESSAGE", "DD_PROCESS_AGENT_MAX_PER_MESSAGE")
+	config.BindEnvAndSetDefault("process_config.max_message_bytes", DefaultProcessMaxMessageBytes, "DD_PROCESS_CONFIG_MAX_MESSAGE_BYTES", "DD_PROCESS_AGENT_MAX_MESSAGE_BYTES")
+	config.BindEnvAndSetDefault("process_config.cmd_port", DefaultProcessCmdPort, "DD_PROCESS_CONFIG_CMD_PORT", "DD_PROCESS_AGENT_CMD_PORT")
+	config.BindEnvAndSetDefault("process_config.blacklist_patterns", []string{}, "DD_PROCESS_CONFIG_BLACKLIST_PATTERNS", "DD_PROCESS_AGENT_BLACKLIST_PATTERNS")
 
 	// The interval, in seconds, at which we will run each check. If you want consistent
 	// behavior between real-time you may set the Container/ProcessRT intervals to 10.
 	// Defaults to 10s for normal checks and 2s for others.
-	procBindEnvAndSetDefault(config, "process_config.intervals.process", 10)
-	procBindEnvAndSetDefault(config, "process_config.intervals.process_realtime", 2)
-	procBindEnvAndSetDefault(config, "process_config.intervals.container", 10)
-	procBindEnvAndSetDefault(config, "process_config.intervals.container_realtime", 2)
-	procBindEnvAndSetDefault(config, "process_config.intervals.connections", 30)
-
-	procBindEnvAndSetDefault(config, "process_config.dd_agent_bin", GetPlatformDefault(map[string]interface{}{
+	config.BindEnvAndSetDefault("process_config.intervals.process", 10, "DD_PROCESS_CONFIG_INTERVALS_PROCESS", "DD_PROCESS_AGENT_INTERVALS_PROCESS")
+	config.BindEnvAndSetDefault("process_config.intervals.process_realtime", 2, "DD_PROCESS_CONFIG_INTERVALS_PROCESS_REALTIME", "DD_PROCESS_AGENT_INTERVALS_PROCESS_REALTIME")
+	config.BindEnvAndSetDefault("process_config.intervals.container", 10, "DD_PROCESS_CONFIG_INTERVALS_CONTAINER", "DD_PROCESS_AGENT_INTERVALS_CONTAINER")
+	config.BindEnvAndSetDefault("process_config.intervals.container_realtime", 2, "DD_PROCESS_CONFIG_INTERVALS_CONTAINER_REALTIME", "DD_PROCESS_AGENT_INTERVALS_CONTAINER_REALTIME")
+	config.BindEnvAndSetDefault("process_config.intervals.connections", 30, "DD_PROCESS_CONFIG_INTERVALS_CONNECTIONS", "DD_PROCESS_AGENT_INTERVALS_CONNECTIONS")
+	config.BindEnvAndSetDefault("process_config.dd_agent_bin", GetPlatformDefault(map[string]interface{}{
 		"linux":   "${install_path}/bin/agent/agent",
 		"darwin":  "${install_path}/bin/agent/agent",
 		"aix":     "${install_path}/bin/agent/agent",
 		"windows": "${install_path}/bin/agent.exe",
-	}))
-
-	config.BindEnvAndSetDefault("process_config.custom_sensitive_words", []string{},
-		"DD_CUSTOM_SENSITIVE_WORDS",
-		"DD_PROCESS_CONFIG_CUSTOM_SENSITIVE_WORDS",
-		"DD_PROCESS_AGENT_CUSTOM_SENSITIVE_WORDS")
+	}),
+		"DD_PROCESS_CONFIG_DD_AGENT_BIN", "DD_PROCESS_AGENT_DD_AGENT_BIN")
+	config.BindEnvAndSetDefault("process_config.custom_sensitive_words", []string{}, "DD_CUSTOM_SENSITIVE_WORDS", "DD_PROCESS_CONFIG_CUSTOM_SENSITIVE_WORDS", "DD_PROCESS_AGENT_CUSTOM_SENSITIVE_WORDS")
 	pkgconfighelper.ParseEnvJSONOrComma("process_config.custom_sensitive_words", config)
-
-	config.BindEnvAndSetDefault("process_config.scrub_args", true,
-		"DD_SCRUB_ARGS",
-		"DD_PROCESS_CONFIG_SCRUB_ARGS",
-		"DD_PROCESS_AGENT_SCRUB_ARGS")
-	config.BindEnvAndSetDefault("process_config.strip_proc_arguments", false,
-		"DD_STRIP_PROCESS_ARGS",
-		"DD_PROCESS_CONFIG_STRIP_PROC_ARGUMENTS",
-		"DD_PROCESS_AGENT_STRIP_PROC_ARGUMENTS")
+	config.BindEnvAndSetDefault("process_config.scrub_args", true, "DD_SCRUB_ARGS", "DD_PROCESS_CONFIG_SCRUB_ARGS", "DD_PROCESS_AGENT_SCRUB_ARGS")
+	config.BindEnvAndSetDefault("process_config.strip_proc_arguments", false, "DD_STRIP_PROCESS_ARGS", "DD_PROCESS_CONFIG_STRIP_PROC_ARGUMENTS", "DD_PROCESS_AGENT_STRIP_PROC_ARGUMENTS")
 	// Use PDH API to collect performance counter data for process check on Windows
-	procBindEnvAndSetDefault(config, "process_config.windows.use_perf_counters", false)
-	config.BindEnvAndSetDefault("process_config.additional_endpoints", make(map[string][]string),
-		"DD_PROCESS_CONFIG_ADDITIONAL_ENDPOINTS",
-		"DD_PROCESS_AGENT_ADDITIONAL_ENDPOINTS",
-		"DD_PROCESS_ADDITIONAL_ENDPOINTS",
-	)
-	procBindEnvAndSetDefault(config, "process_config.expvar_port", DefaultProcessExpVarPort)
-	procBindEnvAndSetDefault(config, "process_config.log_file", "${log_path}/process-agent.log")
-	procBindEnvAndSetDefault(config, "process_config.internal_profiling.enabled", false)
-	procBindEnvAndSetDefault(config, "process_config.grpc_connection_timeout_secs", DefaultGRPCConnectionTimeoutSecs)
-	procBindEnvAndSetDefault(config, "process_config.disable_realtime_checks", false)
-	procBindEnvAndSetDefault(config, "process_config.ignore_zombie_processes", false)
-
-	// Process Discovery Check
-	// We also bind old environment variables for this setting
-	config.BindEnvAndSetDefault("process_config.process_discovery.enabled", true,
-		"DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED",
-		"DD_PROCESS_AGENT_PROCESS_DISCOVERY_ENABLED",
-		"DD_PROCESS_CONFIG_DISCOVERY_ENABLED",
-		"DD_PROCESS_AGENT_DISCOVERY_ENABLED",
-	)
-	procBindEnvAndSetDefault(config, "process_config.process_discovery.interval", 4*time.Hour)
-
-	procBindEnvAndSetDefault(config, "process_config.process_discovery.hint_frequency", DefaultProcessDiscoveryHintFrequency)
-
-	procBindEnvAndSetDefault(config, "process_config.drop_check_payloads", []string{})
-
-	procBindEnvAndSetDefault(config, "process_config.cache_lookupid", false)
-
-	procBindEnvAndSetDefault(config, "process_config.language_detection.grpc_port", DefaultProcessEntityStreamPort)
+	config.BindEnvAndSetDefault("process_config.windows.use_perf_counters", false, "DD_PROCESS_CONFIG_WINDOWS_USE_PERF_COUNTERS", "DD_PROCESS_AGENT_WINDOWS_USE_PERF_COUNTERS")
+	config.BindEnvAndSetDefault("process_config.additional_endpoints", map[string][]string{}, "DD_PROCESS_CONFIG_ADDITIONAL_ENDPOINTS", "DD_PROCESS_AGENT_ADDITIONAL_ENDPOINTS", "DD_PROCESS_ADDITIONAL_ENDPOINTS")
+	config.BindEnvAndSetDefault("process_config.expvar_port", DefaultProcessExpVarPort, "DD_PROCESS_CONFIG_EXPVAR_PORT", "DD_PROCESS_AGENT_EXPVAR_PORT")
+	config.BindEnvAndSetDefault("process_config.log_file", "${log_path}/process-agent.log", "DD_PROCESS_CONFIG_LOG_FILE", "DD_PROCESS_AGENT_LOG_FILE")
+	config.BindEnvAndSetDefault("process_config.internal_profiling.enabled", false, "DD_PROCESS_CONFIG_INTERNAL_PROFILING_ENABLED", "DD_PROCESS_AGENT_INTERNAL_PROFILING_ENABLED")
+	config.BindEnvAndSetDefault("process_config.grpc_connection_timeout_secs", DefaultGRPCConnectionTimeoutSecs, "DD_PROCESS_CONFIG_GRPC_CONNECTION_TIMEOUT_SECS", "DD_PROCESS_AGENT_GRPC_CONNECTION_TIMEOUT_SECS")
+	config.BindEnvAndSetDefault("process_config.disable_realtime_checks", false, "DD_PROCESS_CONFIG_DISABLE_REALTIME_CHECKS", "DD_PROCESS_AGENT_DISABLE_REALTIME_CHECKS")
+	config.BindEnvAndSetDefault("process_config.ignore_zombie_processes", false, "DD_PROCESS_CONFIG_IGNORE_ZOMBIE_PROCESSES", "DD_PROCESS_AGENT_IGNORE_ZOMBIE_PROCESSES")
+	config.BindEnvAndSetDefault("process_config.process_discovery.enabled", true, "DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", "DD_PROCESS_AGENT_PROCESS_DISCOVERY_ENABLED", "DD_PROCESS_CONFIG_DISCOVERY_ENABLED", "DD_PROCESS_AGENT_DISCOVERY_ENABLED")
+	config.BindEnvAndSetDefault("process_config.process_discovery.interval", 4*time.Hour, "DD_PROCESS_CONFIG_PROCESS_DISCOVERY_INTERVAL", "DD_PROCESS_AGENT_PROCESS_DISCOVERY_INTERVAL")
+	config.BindEnvAndSetDefault("process_config.process_discovery.hint_frequency", DefaultProcessDiscoveryHintFrequency, "DD_PROCESS_CONFIG_PROCESS_DISCOVERY_HINT_FREQUENCY", "DD_PROCESS_AGENT_PROCESS_DISCOVERY_HINT_FREQUENCY")
+	config.BindEnvAndSetDefault("process_config.drop_check_payloads", []string{}, "DD_PROCESS_CONFIG_DROP_CHECK_PAYLOADS", "DD_PROCESS_AGENT_DROP_CHECK_PAYLOADS")
+	config.BindEnvAndSetDefault("process_config.cache_lookupid", false, "DD_PROCESS_CONFIG_CACHE_LOOKUPID", "DD_PROCESS_AGENT_CACHE_LOOKUPID")
+	config.BindEnvAndSetDefault("process_config.language_detection.grpc_port", DefaultProcessEntityStreamPort, "DD_PROCESS_CONFIG_LANGUAGE_DETECTION_GRPC_PORT", "DD_PROCESS_AGENT_LANGUAGE_DETECTION_GRPC_PORT")
 }

--- a/pkg/config/setup/process_test.go
+++ b/pkg/config/setup/process_test.go
@@ -447,26 +447,6 @@ func TestEnvVarCustomSensitiveWords(t *testing.T) {
 	}
 }
 
-func TestProcBindEnvAndSetDefault(t *testing.T) {
-	cfg := newTestConf(t)
-	procBindEnvAndSetDefault(cfg, "process_config.foo.bar", "asdf")
-	cfg.BuildSchema()
-
-	envs := map[string]struct{}{}
-	for _, env := range cfg.GetEnvVars() {
-		envs[env] = struct{}{}
-	}
-
-	_, ok := envs["DD_PROCESS_CONFIG_FOO_BAR"]
-	assert.True(t, ok)
-
-	_, ok = envs["DD_PROCESS_AGENT_FOO_BAR"]
-	assert.True(t, ok)
-
-	// Make sure the default is set properly
-	assert.Equal(t, "asdf", cfg.GetString("process_config.foo.bar"))
-}
-
 func TestProcConfigEnabledTransform(t *testing.T) {
 	for _, tc := range []struct {
 		procConfigEnabled                                      string

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -6,43 +6,7 @@
 package setup
 
 import (
-	"os"
-	"path"
-	"strings"
-
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-)
-
-const (
-	defaultConnsMessageBatchSize = 600
-
-	// defaultRuntimeCompilerOutputDir is the default path for output from the system-probe runtime compiler
-	defaultRuntimeCompilerOutputDir = "/var/tmp/datadog-agent/system-probe/build"
-
-	// defaultKernelHeadersDownloadDir is the default path for downloading kernel headers for runtime compilation
-	defaultKernelHeadersDownloadDir = "/var/tmp/datadog-agent/system-probe/kernel-headers"
-
-	// defaultBTFOutputDir is the default path for extracted BTF
-	defaultBTFOutputDir = "/var/tmp/datadog-agent/system-probe/btf"
-
-	// defaultDynamicInstrumentationDebugInfoDir is the default path for debug
-	// info for Dynamic Instrumentation. This is the directory where the DWARF
-	// data from analyzed binaries is decompressed into during processing.
-	defaultDynamicInstrumentationDebugInfoDir = "${run_path}/system-probe/dynamic-instrumentation/decompressed-debug-info"
-
-	// defaultAptConfigDirSuffix is the default path under `/etc` to the apt config directory
-	defaultAptConfigDirSuffix = "/apt"
-
-	// defaultYumReposDirSuffix is the default path under `/etc` to the yum repository directory
-	defaultYumReposDirSuffix = "/yum.repos.d"
-
-	// defaultZypperReposDirSuffix is the default path under `/etc` to the zypper repository directory
-	defaultZypperReposDirSuffix = "/zypp/repos.d"
-
-	defaultOffsetThreshold = 400
-
-	// defaultEnvoyPath is the default path for envoy binary
-	defaultEnvoyPath = "/bin/envoy"
 )
 
 // InitSystemProbeConfig declares all the configuration values normally read from system-probe.yaml.
@@ -50,48 +14,4 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	initMainSystemProbeConfig(cfg)
 	initCWSSystemProbeConfig(cfg)
 	initUSMSystemProbeConfig(cfg)
-}
-
-func suffixHostEtc(suffix string) string {
-	if value, _ := os.LookupEnv("HOST_ETC"); value != "" {
-		return path.Join(value, suffix)
-	}
-	return path.Join("/etc", suffix)
-}
-
-// eventMonitorBindEnvAndSetDefault is a helper function that generates both "DD_RUNTIME_SECURITY_CONFIG_" and "DD_EVENT_MONITORING_CONFIG_"
-// prefixes from a key. We need this helper function because the standard BindEnvAndSetDefault can only generate one prefix, but we want to
-// support both for backwards compatibility.
-func eventMonitorBindEnvAndSetDefault(config pkgconfigmodel.Setup, key string, val interface{}) {
-	// Uppercase, replace "." with "_" and add "DD_" prefix to key so that we follow the same environment
-	// variable convention as the core agent.
-	emConfigKey := "DD_" + strings.ReplaceAll(strings.ToUpper(key), ".", "_")
-	runtimeSecKey := strings.Replace(emConfigKey, "EVENT_MONITORING_CONFIG", "RUNTIME_SECURITY_CONFIG", 1)
-
-	config.BindEnvAndSetDefault(key, val, emConfigKey, runtimeSecKey)
-}
-
-// DefaultPrivateIPCIDRs is a list of private IP CIDRs that are used to determine if an IP is private or not.
-var DefaultPrivateIPCIDRs = []string{
-	// IETF RPC 1918
-	"10.0.0.0/8",
-	"172.16.0.0/12",
-	"192.168.0.0/16",
-	// IETF RFC 5735
-	"0.0.0.0/8",
-	"127.0.0.0/8",
-	"169.254.0.0/16",
-	"192.0.0.0/24",
-	"192.0.2.0/24",
-	"198.18.0.0/15",
-	"198.51.100.0/24",
-	"203.0.113.0/24",
-	"224.0.0.0/4",
-	"240.0.0.0/4",
-	// IETF RFC 6598
-	"100.64.0.0/10",
-	// IETF RFC 4193
-	"fc00::/7",
-	// IPv6 loopback address
-	"::1/128",
 }

--- a/pkg/config/setup/system_probe_settings.go
+++ b/pkg/config/setup/system_probe_settings.go
@@ -16,14 +16,11 @@ func initMainSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("ignore_host_etc", false)
 	config.BindEnvAndSetDefault("go_core_dump", false)
 	config.BindEnvAndSetDefault("system_probe_config.disable_thp", true)
-
 	config.BindEnvAndSetDefault("auto_exit.validation_period", 60)
 	config.BindEnvAndSetDefault("auto_exit.noprocess.enabled", false)
 	config.BindEnvAndSetDefault("auto_exit.noprocess.excluded_processes", []string{})
-
 	config.BindEnvAndSetDefault("bind_host", "localhost")
 	config.BindEnvAndSetDefault("dogstatsd_port", 8125)
-
 	config.BindEnvAndSetDefault("system_probe_config.log_file", "")
 	config.BindEnvAndSetDefault("system_probe_config.log_level", "")
 	config.BindEnvAndSetDefault("log_file", "${log_path}/system-probe.log")
@@ -37,14 +34,12 @@ func initMainSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("log_file_max_rolls", 1)
 	config.BindEnvAndSetDefault("disable_file_logging", false)
 	config.BindEnvAndSetDefault("log_format_rfc3339", false)
-
 	config.BindEnvAndSetDefault("secret_backend_command", "")
 	config.BindEnvAndSetDefault("secret_backend_arguments", []string{})
 	config.BindEnvAndSetDefault("secret_backend_output_max_size", 1024*1024)
 	config.BindEnvAndSetDefault("secret_backend_timeout", 30)
 	config.BindEnvAndSetDefault("secret_backend_command_allow_group_exec_perm", false)
 	config.BindEnvAndSetDefault("secret_backend_skip_checks", false)
-
 	config.BindEnvAndSetDefault("system_probe_config.enabled", false, "DD_SYSTEM_PROBE_ENABLED")
 	config.BindEnvAndSetDefault("system_probe_config.external", false, "DD_SYSTEM_PROBE_EXTERNAL")
 	config.SetDefault("system_probe_config.adjusted", false)
@@ -55,13 +50,11 @@ func initMainSystemProbeConfig(config pkgconfigmodel.Setup) {
 		"aix":     "${run_path}/sysprobe.sock",
 		"windows": `\\.\pipe\dd_system_probe`,
 	}), "DD_SYSPROBE_SOCKET")
-	config.BindEnvAndSetDefault("system_probe_config.max_conns_per_message", defaultConnsMessageBatchSize)
-
+	config.BindEnvAndSetDefault("system_probe_config.max_conns_per_message", 600)
 	config.BindEnvAndSetDefault("system_probe_config.debug_port", 0)
 	config.BindEnvAndSetDefault("system_probe_config.telemetry_enabled", false, "DD_TELEMETRY_ENABLED")
 	config.BindEnvAndSetDefault("system_probe_config.telemetry_perf_buffer_emit_per_cpu", false)
 	config.BindEnvAndSetDefault("system_probe_config.health_port", int64(0), "DD_SYSTEM_PROBE_HEALTH_PORT")
-
 	config.BindEnvAndSetDefault("system_probe_config.internal_profiling.enabled", false, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_ENABLED")
 	config.BindEnvAndSetDefault("system_probe_config.internal_profiling.site", DefaultSite, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_SITE", "DD_SITE")
 	config.BindEnvAndSetDefault("system_probe_config.internal_profiling.profile_dd_url", "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_DD_URL", "DD_APM_INTERNAL_PROFILING_DD_URL")
@@ -78,34 +71,34 @@ func initMainSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("system_probe_config.internal_profiling.custom_attributes", []string{"module", "rule_id"})
 	config.BindEnvAndSetDefault("system_probe_config.internal_profiling.unix_socket", "")
 	config.BindEnvAndSetDefault("system_probe_config.internal_profiling.extra_tags", []string{})
-
 	config.BindEnvAndSetDefault("system_probe_config.memory_controller.enabled", false)
 	config.BindEnvAndSetDefault("system_probe_config.memory_controller.hierarchy", "v1")
 	config.BindEnvAndSetDefault("system_probe_config.memory_controller.pressure_levels", map[string]string{})
 	config.BindEnvAndSetDefault("system_probe_config.memory_controller.thresholds", map[string]string{})
-
 	config.BindEnvAndSetDefault("system_probe_config.bpf_debug", false, "DD_SYSTEM_PROBE_CONFIG_BPF_DEBUG", "BPF_DEBUG")
 	config.BindEnvAndSetDefault("system_probe_config.bpf_dir", "${install_path}/embedded/share/system-probe/ebpf", "DD_SYSTEM_PROBE_BPF_DIR")
 	config.BindEnvAndSetDefault("system_probe_config.excluded_linux_versions", []string{})
 	config.BindEnvAndSetDefault("system_probe_config.enable_tracepoints", false)
 	config.BindEnvAndSetDefault("system_probe_config.enable_co_re", true, "DD_ENABLE_CO_RE")
 	config.BindEnvAndSetDefault("system_probe_config.btf_path", "", "DD_SYSTEM_PROBE_BTF_PATH")
-	config.BindEnvAndSetDefault("system_probe_config.btf_output_dir", defaultBTFOutputDir, "DD_SYSTEM_PROBE_BTF_OUTPUT_DIR")
+	config.BindEnvAndSetDefault("system_probe_config.btf_output_dir", "/var/tmp/datadog-agent/system-probe/btf", "DD_SYSTEM_PROBE_BTF_OUTPUT_DIR")
 	config.BindEnvAndSetDefault("system_probe_config.remote_config_btf_enabled", true, "DD_SYSTEM_PROBE_REMOTE_CONFIG_BTF_ENABLED")
 	config.BindEnvAndSetDefault("system_probe_config.enable_runtime_compiler", false, "DD_ENABLE_RUNTIME_COMPILER")
-	// deprecated in favor of allow_prebuilt_fallback below
+	// deprecated in favor of allow_prebuilt_fallback
 	config.BindEnvAndSetDefault("system_probe_config.allow_precompiled_fallback", false, "DD_ALLOW_PRECOMPILED_FALLBACK")
 	config.BindEnvAndSetDefault("system_probe_config.allow_prebuilt_fallback", false, "DD_ALLOW_PREBUILT_FALLBACK")
 	config.BindEnvAndSetDefault("system_probe_config.allow_runtime_compiled_fallback", true, "DD_ALLOW_RUNTIME_COMPILED_FALLBACK")
-	config.BindEnvAndSetDefault("system_probe_config.runtime_compiler_output_dir", defaultRuntimeCompilerOutputDir, "DD_RUNTIME_COMPILER_OUTPUT_DIR")
+	config.BindEnvAndSetDefault("system_probe_config.runtime_compiler_output_dir", "/var/tmp/datadog-agent/system-probe/build", "DD_RUNTIME_COMPILER_OUTPUT_DIR")
 	config.BindEnvAndSetDefault("system_probe_config.enable_kernel_header_download", false, "DD_ENABLE_KERNEL_HEADER_DOWNLOAD")
 	config.BindEnvAndSetDefault("system_probe_config.kernel_header_dirs", []string{}, "DD_KERNEL_HEADER_DIRS")
-	config.BindEnvAndSetDefault("system_probe_config.kernel_header_download_dir", defaultKernelHeadersDownloadDir, "DD_KERNEL_HEADER_DOWNLOAD_DIR")
-	config.BindEnvAndSetDefault("system_probe_config.apt_config_dir", suffixHostEtc(defaultAptConfigDirSuffix), "DD_APT_CONFIG_DIR")
-	config.BindEnvAndSetDefault("system_probe_config.yum_repos_dir", suffixHostEtc(defaultYumReposDirSuffix), "DD_YUM_REPOS_DIR")
-	config.BindEnvAndSetDefault("system_probe_config.zypper_repos_dir", suffixHostEtc(defaultZypperReposDirSuffix), "DD_ZYPPER_REPOS_DIR")
+	config.BindEnvAndSetDefault("system_probe_config.kernel_header_download_dir", "/var/tmp/datadog-agent/system-probe/kernel-headers", "DD_KERNEL_HEADER_DOWNLOAD_DIR")
+	// Actual path will be update to use HOST_ETC is present
+	config.BindEnvAndSetDefault("system_probe_config.apt_config_dir", "/etc/apt", "DD_APT_CONFIG_DIR")
+	// Actual path will be update to use HOST_ETC is present
+	config.BindEnvAndSetDefault("system_probe_config.yum_repos_dir", "/etc/yum.repos.d", "DD_YUM_REPOS_DIR")
+	// Actual path will be update to use HOST_ETC is present
+	config.BindEnvAndSetDefault("system_probe_config.zypper_repos_dir", "/etc/zypp/repos.d", "DD_ZYPPER_REPOS_DIR")
 	config.BindEnvAndSetDefault("system_probe_config.attach_kprobes_with_kprobe_events_abi", false, "DD_ATTACH_KPROBES_WITH_KPROBE_EVENTS_ABI")
-
 	config.BindEnvAndSetDefault("dynamic_instrumentation.enabled", false, "DD_DYNAMIC_INSTRUMENTATION_ENABLED")
 	config.BindEnvAndSetDefault("dynamic_instrumentation.offline_mode", false, "DD_DYNAMIC_INSTRUMENTATION_OFFLINE_MODE")
 	config.BindEnvAndSetDefault("dynamic_instrumentation.probes_file_path", false, "DD_DYNAMIC_INSTRUMENTATION_PROBES_FILE_PATH")
@@ -113,27 +106,24 @@ func initMainSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("dynamic_instrumentation.diagnostics_output_file_path", false, "DD_DYNAMIC_INSTRUMENTATION_DIAGNOSTICS_FILE_PATH")
 	config.BindEnvAndSetDefault("dynamic_instrumentation.symdb_upload_enabled", true, "DD_SYMBOL_DATABASE_UPLOAD_ENABLED")
 	config.BindEnvAndSetDefault("dynamic_instrumentation.debug_info_disk_cache.enabled", true)
-	config.BindEnvAndSetDefault("dynamic_instrumentation.debug_info_disk_cache.dir", defaultDynamicInstrumentationDebugInfoDir)
+	config.BindEnvAndSetDefault("dynamic_instrumentation.debug_info_disk_cache.dir", "${run_path}/system-probe/dynamic-instrumentation/decompressed-debug-info")
 	config.BindEnvAndSetDefault("dynamic_instrumentation.debug_info_disk_cache.max_total_bytes", int64(2<<30 /* 2GiB */))
-	config.BindEnvAndSetDefault("dynamic_instrumentation.debug_info_disk_cache.required_disk_space_bytes", int64(512<<20 /* 512MiB */))
-	config.BindEnvAndSetDefault("dynamic_instrumentation.debug_info_disk_cache.required_disk_space_percent", float64(0.0))
+	// 512MiB
+	config.BindEnvAndSetDefault("dynamic_instrumentation.debug_info_disk_cache.required_disk_space_bytes", int64(512<<20))
+	config.BindEnvAndSetDefault("dynamic_instrumentation.debug_info_disk_cache.required_disk_space_percent", float64(0))
 	config.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breaker.interval", 1*time.Second)
 	config.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breaker.per_probe_cpu_limit", float64(0.1))
 	config.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breaker.all_probes_cpu_limit", float64(0.5))
 	config.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breaker.interrupt_overhead", 2*time.Microsecond)
-
 	config.BindEnvAndSetDefault("network_config.enabled", false, "DD_SYSTEM_PROBE_NETWORK_ENABLED")
 	config.BindEnvAndSetDefault("system_probe_config.disable_tcp", false, "DD_DISABLE_TCP_TRACING")
 	config.BindEnvAndSetDefault("system_probe_config.disable_udp", false, "DD_DISABLE_UDP_TRACING")
 	config.BindEnvAndSetDefault("system_probe_config.disable_ipv6", false, "DD_DISABLE_IPV6_TRACING")
-
 	config.SetDefault("network_config.collect_tcp_v4", true)
 	config.SetDefault("network_config.collect_tcp_v6", true)
 	config.SetDefault("network_config.collect_udp_v4", true)
 	config.SetDefault("network_config.collect_udp_v6", true)
-
-	config.BindEnvAndSetDefault("system_probe_config.offset_guess_threshold", int64(defaultOffsetThreshold))
-
+	config.BindEnvAndSetDefault("system_probe_config.offset_guess_threshold", int64(400))
 	config.BindEnvAndSetDefault("system_probe_config.max_tracked_connections", int64(65536))
 	config.BindEnvAndSetDefault("system_probe_config.max_closed_connections_buffered", int64(0))
 	config.BindEnvAndSetDefault("network_config.max_failed_connections_buffered", int64(0))
@@ -143,7 +133,6 @@ func initMainSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("network_config.closed_channel_size", 500)
 	config.BindEnvAndSetDefault("network_config.closed_buffer_wakeup_count", 4)
 	config.BindEnvAndSetDefault("system_probe_config.max_connection_state_buffered", 75000)
-
 	config.BindEnvAndSetDefault("system_probe_config.disable_dns_inspection", false, "DD_DISABLE_DNS_INSPECTION")
 	config.BindEnvAndSetDefault("system_probe_config.collect_dns_stats", true, "DD_COLLECT_DNS_STATS")
 	config.BindEnvAndSetDefault("system_probe_config.collect_local_dns", false, "DD_COLLECT_LOCAL_DNS")
@@ -151,7 +140,6 @@ func initMainSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("system_probe_config.max_dns_stats", 20000)
 	config.BindEnvAndSetDefault("system_probe_config.dns_timeout_in_s", 15)
 	config.BindEnvAndSetDefault("network_config.dns_monitoring_ports", []int{53})
-
 	config.BindEnvAndSetDefault("system_probe_config.enable_conntrack", true)
 	config.BindEnvAndSetDefault("system_probe_config.conntrack_max_state_size", 65536*2)
 	config.BindEnvAndSetDefault("system_probe_config.conntrack_rate_limit", 500)
@@ -164,14 +152,10 @@ func initMainSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("network_config.allow_netlink_conntracker_fallback", true)
 	config.BindEnvAndSetDefault("network_config.enable_ebpf_conntracker", true)
 	config.BindEnvAndSetDefault("network_config.enable_cilium_lb_conntracker", true)
-
 	config.BindEnvAndSetDefault("system_probe_config.source_excludes", map[string][]string{})
 	config.BindEnvAndSetDefault("system_probe_config.dest_excludes", map[string][]string{})
-
 	config.BindEnvAndSetDefault("system_probe_config.language_detection.enabled", false)
-
 	config.BindEnvAndSetDefault("system_probe_config.process_service_inference.use_improved_algorithm", false)
-
 	// For backward compatibility. Default is false because the canonical key
 	// (system_probe_config.process_service_inference.enabled, below) is the
 	// authoritative source; deprecateBool only forwards this deprecated alias
@@ -181,7 +165,6 @@ func initMainSystemProbeConfig(config pkgconfigmodel.Setup) {
 		"windows": true,
 		"other":   false,
 	}))
-
 	// For backward compatibility. Default is false because the canonical key
 	// (system_probe_config.process_service_inference.use_windows_service_name,
 	// below) is the authoritative source; deprecateBool only forwards this
@@ -189,32 +172,23 @@ func initMainSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("service_monitoring_config.process_service_inference.use_windows_service_name", false, "DD_SYSTEM_PROBE_PROCESS_SERVICE_INFERENCE_USE_WINDOWS_SERVICE_NAME")
 	// default on windows is now enabled; default on linux is still disabled
 	config.BindEnvAndSetDefault("system_probe_config.process_service_inference.use_windows_service_name", true)
-
 	// network_config namespace only
 	config.BindEnvAndSetDefault("network_config.enable_gateway_lookup", true, "DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP")
-
 	config.BindEnvAndSetDefault("system_probe_config.expected_tags_duration", 30*time.Minute, "DD_SYSTEM_PROBE_EXPECTED_TAGS_DURATION")
-
 	// list of DNS query types to be recorded
 	config.BindEnvAndSetDefault("network_config.dns_recorded_query_types", []string{})
 	// (temporary) enable submitting DNS stats by query type.
 	config.BindEnvAndSetDefault("network_config.enable_dns_by_querytype", false)
 	// connection aggregation with port rollups
 	config.BindEnvAndSetDefault("network_config.enable_connection_rollup", false)
-
 	config.BindEnvAndSetDefault("network_config.enable_ebpfless", false, "DD_ENABLE_EBPFLESS", "DD_NETWORK_CONFIG_ENABLE_EBPFLESS")
-
 	config.BindEnvAndSetDefault("network_config.enable_co_re", true)
 	config.BindEnvAndSetDefault("network_config.enable_fentry", false)
 	config.BindEnvAndSetDefault("network_config.enable_sk_tracer", false)
-
 	config.BindEnvAndSetDefault("network_config.enable_cert_collection", false)
 	config.BindEnvAndSetDefault("network_config.cert_collection_map_cleaner_interval", 30*time.Second)
-
 	config.BindEnvAndSetDefault("system_probe_config.windows.enable_monotonic_count", false)
-
 	config.BindEnvAndSetDefault("system_probe_config.enable_oom_kill", false)
-
 	config.BindEnvAndSetDefault("system_probe_config.enable_tcp_queue_length", false)
 	// nested within system_probe_config to not conflict with process-agent's process_config
 	config.BindEnvAndSetDefault("system_probe_config.process_config.enabled", false, "DD_SYSTEM_PROBE_PROCESS_ENABLED")
@@ -230,7 +204,6 @@ func initMainSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("noisy_neighbor.pmu_metrics.itlb_misses", false)
 	config.BindEnvAndSetDefault("noisy_neighbor.pmu_metrics.branch_misses", false)
 	config.BindEnvAndSetDefault("noisy_neighbor.pmu_metrics.cpu_migrations", false)
-
 	// control the size of the buffers used for the batch lookups of the ebpf maps
 	config.BindEnvAndSetDefault("ebpf_check.entry_count.max_keys_buffer_size_bytes", 512*1024)
 	config.BindEnvAndSetDefault("ebpf_check.entry_count.max_values_buffer_size_bytes", 1024*1024)
@@ -240,74 +213,88 @@ func initMainSystemProbeConfig(config pkgconfigmodel.Setup) {
 	// How many entries we should keep track of in the entry count map to detect restarts in the
 	// single-item iteration
 	config.BindEnvAndSetDefault("ebpf_check.entry_count.entries_for_iteration_restart_detection", 100)
-
 	config.BindEnvAndSetDefault("event_monitoring_config.network_process.enabled", true, "DD_SYSTEM_PROBE_EVENT_MONITORING_NETWORK_PROCESS_ENABLED")
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.enable_all_probes", false)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.enable_kernel_filters", true)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.enable_approvers", false)  // will be set to true by sanitize() if enable_kernel_filters is true
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.enable_discarders", false) // will be set to true by sanitize() if enable_kernel_filters is true
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.basename_approvers_size", 4096)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.flush_discarder_window", 3)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.pid_cache_size", 10000)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.dns_resolution.cache_size", 1024)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.dns_resolution.enabled", true)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.dns_resolution.cname_max_depth", 2)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.events_stats.tags_cardinality", "high")
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.custom_sensitive_words", []string{})
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.custom_sensitive_regexps", []string{})
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.erpc_dentry_resolution_enabled", true)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.map_dentry_resolution_enabled", true)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.dentry_cache_size", 8000)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.network.lazy_interface_prefixes", []string{})
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.network.classifier_priority", 10)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.network.classifier_handle", 0)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.network.flow_monitor.enabled", false)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.network.flow_monitor.sk_storage.enabled", false)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.network.flow_monitor.period", "10s")
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.network.raw_classifier_handle", 0)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.event_stream.use_ring_buffer", true)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.event_stream.use_fentry", false)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.event_stream.use_kprobe_fallback", true)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.event_stream.buffer_size", 0)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.event_stream.kretprobe_max_active", 512)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.envs_with_value", []string{"LD_PRELOAD", "LD_LIBRARY_PATH", "PATH", "HISTSIZE", "HISTFILESIZE", "GLIBC_TUNABLES", "SSH_CLIENT", "DD_SERVICE", "OTEL_SERVICE_NAME", "CLAUDECODE", "RUNNER_TRACKING_ID"})
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.runtime_compilation.enabled", false)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.network.enabled", true)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.network.ingress.enabled", true)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.network.raw_packet.enabled", true)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.network.raw_packet.limiter_rate", 10)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.network.raw_packet.filter", "no_pid_tcp_syn")
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.network.private_ip_ranges", DefaultPrivateIPCIDRs)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.network.extra_private_ip_ranges", []string{})
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.events_stats.polling_interval", 20)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.syscalls_monitor.enabled", false)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.span_tracking.enabled", false)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.span_tracking.cache_size", 4096)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.capabilities_monitoring.enabled", false)
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.capabilities_monitoring.period", "5s")
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.snapshot_using_listmount", false)
+	config.BindEnvAndSetDefault("event_monitoring_config.enable_all_probes", false, "DD_EVENT_MONITORING_CONFIG_ENABLE_ALL_PROBES", "DD_RUNTIME_SECURITY_CONFIG_ENABLE_ALL_PROBES")
+	config.BindEnvAndSetDefault("event_monitoring_config.enable_kernel_filters", true, "DD_EVENT_MONITORING_CONFIG_ENABLE_KERNEL_FILTERS", "DD_RUNTIME_SECURITY_CONFIG_ENABLE_KERNEL_FILTERS")
+	// will be set to true by sanitize() if enable_kernel_filters is true
+	config.BindEnvAndSetDefault("event_monitoring_config.enable_approvers", false, "DD_EVENT_MONITORING_CONFIG_ENABLE_APPROVERS", "DD_RUNTIME_SECURITY_CONFIG_ENABLE_APPROVERS")
+	// will be set to true by sanitize() if enable_kernel_filters is true
+	config.BindEnvAndSetDefault("event_monitoring_config.enable_discarders", false, "DD_EVENT_MONITORING_CONFIG_ENABLE_DISCARDERS", "DD_RUNTIME_SECURITY_CONFIG_ENABLE_DISCARDERS")
+	config.BindEnvAndSetDefault("event_monitoring_config.basename_approvers_size", 4096, "DD_EVENT_MONITORING_CONFIG_BASENAME_APPROVERS_SIZE", "DD_RUNTIME_SECURITY_CONFIG_BASENAME_APPROVERS_SIZE")
+	config.BindEnvAndSetDefault("event_monitoring_config.flush_discarder_window", 3, "DD_EVENT_MONITORING_CONFIG_FLUSH_DISCARDER_WINDOW", "DD_RUNTIME_SECURITY_CONFIG_FLUSH_DISCARDER_WINDOW")
+	config.BindEnvAndSetDefault("event_monitoring_config.pid_cache_size", 10000, "DD_EVENT_MONITORING_CONFIG_PID_CACHE_SIZE", "DD_RUNTIME_SECURITY_CONFIG_PID_CACHE_SIZE")
+	config.BindEnvAndSetDefault("event_monitoring_config.dns_resolution.cache_size", 1024, "DD_EVENT_MONITORING_CONFIG_DNS_RESOLUTION_CACHE_SIZE", "DD_RUNTIME_SECURITY_CONFIG_DNS_RESOLUTION_CACHE_SIZE")
+	config.BindEnvAndSetDefault("event_monitoring_config.dns_resolution.enabled", true, "DD_EVENT_MONITORING_CONFIG_DNS_RESOLUTION_ENABLED", "DD_RUNTIME_SECURITY_CONFIG_DNS_RESOLUTION_ENABLED")
+	config.BindEnvAndSetDefault("event_monitoring_config.dns_resolution.cname_max_depth", 2, "DD_EVENT_MONITORING_CONFIG_DNS_RESOLUTION_CNAME_MAX_DEPTH", "DD_RUNTIME_SECURITY_CONFIG_DNS_RESOLUTION_CNAME_MAX_DEPTH")
+	config.BindEnvAndSetDefault("event_monitoring_config.events_stats.tags_cardinality", "high", "DD_EVENT_MONITORING_CONFIG_EVENTS_STATS_TAGS_CARDINALITY", "DD_RUNTIME_SECURITY_CONFIG_EVENTS_STATS_TAGS_CARDINALITY")
+	config.BindEnvAndSetDefault("event_monitoring_config.custom_sensitive_words", []string{}, "DD_EVENT_MONITORING_CONFIG_CUSTOM_SENSITIVE_WORDS", "DD_RUNTIME_SECURITY_CONFIG_CUSTOM_SENSITIVE_WORDS")
+	config.BindEnvAndSetDefault("event_monitoring_config.custom_sensitive_regexps", []string{}, "DD_EVENT_MONITORING_CONFIG_CUSTOM_SENSITIVE_REGEXPS", "DD_RUNTIME_SECURITY_CONFIG_CUSTOM_SENSITIVE_REGEXPS")
+	config.BindEnvAndSetDefault("event_monitoring_config.erpc_dentry_resolution_enabled", true, "DD_EVENT_MONITORING_CONFIG_ERPC_DENTRY_RESOLUTION_ENABLED", "DD_RUNTIME_SECURITY_CONFIG_ERPC_DENTRY_RESOLUTION_ENABLED")
+	config.BindEnvAndSetDefault("event_monitoring_config.map_dentry_resolution_enabled", true, "DD_EVENT_MONITORING_CONFIG_MAP_DENTRY_RESOLUTION_ENABLED", "DD_RUNTIME_SECURITY_CONFIG_MAP_DENTRY_RESOLUTION_ENABLED")
+	config.BindEnvAndSetDefault("event_monitoring_config.dentry_cache_size", 8000, "DD_EVENT_MONITORING_CONFIG_DENTRY_CACHE_SIZE", "DD_RUNTIME_SECURITY_CONFIG_DENTRY_CACHE_SIZE")
+	config.BindEnvAndSetDefault("event_monitoring_config.network.lazy_interface_prefixes", []string{}, "DD_EVENT_MONITORING_CONFIG_NETWORK_LAZY_INTERFACE_PREFIXES", "DD_RUNTIME_SECURITY_CONFIG_NETWORK_LAZY_INTERFACE_PREFIXES")
+	config.BindEnvAndSetDefault("event_monitoring_config.network.classifier_priority", 10, "DD_EVENT_MONITORING_CONFIG_NETWORK_CLASSIFIER_PRIORITY", "DD_RUNTIME_SECURITY_CONFIG_NETWORK_CLASSIFIER_PRIORITY")
+	config.BindEnvAndSetDefault("event_monitoring_config.network.classifier_handle", 0, "DD_EVENT_MONITORING_CONFIG_NETWORK_CLASSIFIER_HANDLE", "DD_RUNTIME_SECURITY_CONFIG_NETWORK_CLASSIFIER_HANDLE")
+	config.BindEnvAndSetDefault("event_monitoring_config.network.flow_monitor.enabled", false, "DD_EVENT_MONITORING_CONFIG_NETWORK_FLOW_MONITOR_ENABLED", "DD_RUNTIME_SECURITY_CONFIG_NETWORK_FLOW_MONITOR_ENABLED")
+	config.BindEnvAndSetDefault("event_monitoring_config.network.flow_monitor.sk_storage.enabled", false, "DD_EVENT_MONITORING_CONFIG_NETWORK_FLOW_MONITOR_SK_STORAGE_ENABLED", "DD_RUNTIME_SECURITY_CONFIG_NETWORK_FLOW_MONITOR_SK_STORAGE_ENABLED")
+	config.BindEnvAndSetDefault("event_monitoring_config.network.flow_monitor.period", "10s", "DD_EVENT_MONITORING_CONFIG_NETWORK_FLOW_MONITOR_PERIOD", "DD_RUNTIME_SECURITY_CONFIG_NETWORK_FLOW_MONITOR_PERIOD")
+	config.BindEnvAndSetDefault("event_monitoring_config.network.raw_classifier_handle", 0, "DD_EVENT_MONITORING_CONFIG_NETWORK_RAW_CLASSIFIER_HANDLE", "DD_RUNTIME_SECURITY_CONFIG_NETWORK_RAW_CLASSIFIER_HANDLE")
+	config.BindEnvAndSetDefault("event_monitoring_config.event_stream.use_ring_buffer", true, "DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_USE_RING_BUFFER", "DD_RUNTIME_SECURITY_CONFIG_EVENT_STREAM_USE_RING_BUFFER")
+	config.BindEnvAndSetDefault("event_monitoring_config.event_stream.use_fentry", false, "DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_USE_FENTRY", "DD_RUNTIME_SECURITY_CONFIG_EVENT_STREAM_USE_FENTRY")
+	config.BindEnvAndSetDefault("event_monitoring_config.event_stream.use_kprobe_fallback", true, "DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_USE_KPROBE_FALLBACK", "DD_RUNTIME_SECURITY_CONFIG_EVENT_STREAM_USE_KPROBE_FALLBACK")
+	config.BindEnvAndSetDefault("event_monitoring_config.event_stream.buffer_size", 0, "DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_BUFFER_SIZE", "DD_RUNTIME_SECURITY_CONFIG_EVENT_STREAM_BUFFER_SIZE")
+	config.BindEnvAndSetDefault("event_monitoring_config.event_stream.kretprobe_max_active", 512, "DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_KRETPROBE_MAX_ACTIVE", "DD_RUNTIME_SECURITY_CONFIG_EVENT_STREAM_KRETPROBE_MAX_ACTIVE")
+	config.BindEnvAndSetDefault("event_monitoring_config.envs_with_value", []string{"LD_PRELOAD", "LD_LIBRARY_PATH", "PATH", "HISTSIZE", "HISTFILESIZE", "GLIBC_TUNABLES", "SSH_CLIENT", "DD_SERVICE", "OTEL_SERVICE_NAME", "CLAUDECODE", "RUNNER_TRACKING_ID"}, "DD_EVENT_MONITORING_CONFIG_ENVS_WITH_VALUE", "DD_RUNTIME_SECURITY_CONFIG_ENVS_WITH_VALUE")
+	config.BindEnvAndSetDefault("event_monitoring_config.runtime_compilation.enabled", false, "DD_EVENT_MONITORING_CONFIG_RUNTIME_COMPILATION_ENABLED", "DD_RUNTIME_SECURITY_CONFIG_RUNTIME_COMPILATION_ENABLED")
+	config.BindEnvAndSetDefault("event_monitoring_config.network.enabled", true, "DD_EVENT_MONITORING_CONFIG_NETWORK_ENABLED", "DD_RUNTIME_SECURITY_CONFIG_NETWORK_ENABLED")
+	config.BindEnvAndSetDefault("event_monitoring_config.network.ingress.enabled", true, "DD_EVENT_MONITORING_CONFIG_NETWORK_INGRESS_ENABLED", "DD_RUNTIME_SECURITY_CONFIG_NETWORK_INGRESS_ENABLED")
+	config.BindEnvAndSetDefault("event_monitoring_config.network.raw_packet.enabled", true, "DD_EVENT_MONITORING_CONFIG_NETWORK_RAW_PACKET_ENABLED", "DD_RUNTIME_SECURITY_CONFIG_NETWORK_RAW_PACKET_ENABLED")
+	config.BindEnvAndSetDefault("event_monitoring_config.network.raw_packet.limiter_rate", 10, "DD_EVENT_MONITORING_CONFIG_NETWORK_RAW_PACKET_LIMITER_RATE", "DD_RUNTIME_SECURITY_CONFIG_NETWORK_RAW_PACKET_LIMITER_RATE")
+	config.BindEnvAndSetDefault("event_monitoring_config.network.raw_packet.filter", "no_pid_tcp_syn", "DD_EVENT_MONITORING_CONFIG_NETWORK_RAW_PACKET_FILTER", "DD_RUNTIME_SECURITY_CONFIG_NETWORK_RAW_PACKET_FILTER")
+	// Includes:
+	// - IETF RPC 1918
+	// - IETF RFC 5735
+	// - IETF RFC 6598
+	// - IETF RFC 4193
+	// - IPv6 loopback address
+	config.BindEnvAndSetDefault("event_monitoring_config.network.private_ip_ranges", []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"0.0.0.0/8",
+		"127.0.0.0/8",
+		"169.254.0.0/16",
+		"192.0.0.0/24",
+		"192.0.2.0/24",
+		"198.18.0.0/15",
+		"198.51.100.0/24",
+		"203.0.113.0/24",
+		"224.0.0.0/4",
+		"240.0.0.0/4",
+		"100.64.0.0/10",
+		"fc00::/7",
+		"::1/128",
+	}, "DD_EVENT_MONITORING_CONFIG_NETWORK_PRIVATE_IP_RANGES", "DD_RUNTIME_SECURITY_CONFIG_NETWORK_PRIVATE_IP_RANGES")
+	config.BindEnvAndSetDefault("event_monitoring_config.network.extra_private_ip_ranges", []string{}, "DD_EVENT_MONITORING_CONFIG_NETWORK_EXTRA_PRIVATE_IP_RANGES", "DD_RUNTIME_SECURITY_CONFIG_NETWORK_EXTRA_PRIVATE_IP_RANGES")
+	config.BindEnvAndSetDefault("event_monitoring_config.events_stats.polling_interval", 20, "DD_EVENT_MONITORING_CONFIG_EVENTS_STATS_POLLING_INTERVAL", "DD_RUNTIME_SECURITY_CONFIG_EVENTS_STATS_POLLING_INTERVAL")
+	config.BindEnvAndSetDefault("event_monitoring_config.syscalls_monitor.enabled", false, "DD_EVENT_MONITORING_CONFIG_SYSCALLS_MONITOR_ENABLED", "DD_RUNTIME_SECURITY_CONFIG_SYSCALLS_MONITOR_ENABLED")
+	config.BindEnvAndSetDefault("event_monitoring_config.span_tracking.enabled", false, "DD_EVENT_MONITORING_CONFIG_SPAN_TRACKING_ENABLED", "DD_RUNTIME_SECURITY_CONFIG_SPAN_TRACKING_ENABLED")
+	config.BindEnvAndSetDefault("event_monitoring_config.span_tracking.cache_size", 4096, "DD_EVENT_MONITORING_CONFIG_SPAN_TRACKING_CACHE_SIZE", "DD_RUNTIME_SECURITY_CONFIG_SPAN_TRACKING_CACHE_SIZE")
+	config.BindEnvAndSetDefault("event_monitoring_config.capabilities_monitoring.enabled", false, "DD_EVENT_MONITORING_CONFIG_CAPABILITIES_MONITORING_ENABLED", "DD_RUNTIME_SECURITY_CONFIG_CAPABILITIES_MONITORING_ENABLED")
+	config.BindEnvAndSetDefault("event_monitoring_config.capabilities_monitoring.period", "5s", "DD_EVENT_MONITORING_CONFIG_CAPABILITIES_MONITORING_PERIOD", "DD_RUNTIME_SECURITY_CONFIG_CAPABILITIES_MONITORING_PERIOD")
+	config.BindEnvAndSetDefault("event_monitoring_config.snapshot_using_listmount", false, "DD_EVENT_MONITORING_CONFIG_SNAPSHOT_USING_LISTMOUNT", "DD_RUNTIME_SECURITY_CONFIG_SNAPSHOT_USING_LISTMOUNT")
 	config.BindEnvAndSetDefault("event_monitoring_config.env_vars_resolution.enabled", true)
-
 	// process event monitoring data limits for network tracer
 	// 1024 mirrors defaultMaxProcessesTracked enforced by validateInt in pkg/system-probe/config/adjust_npm.go
-	eventMonitorBindEnvAndSetDefault(config, "event_monitoring_config.network_process.max_processes_tracked", 1024)
-
+	config.BindEnvAndSetDefault("event_monitoring_config.network_process.max_processes_tracked", 1024, "DD_EVENT_MONITORING_CONFIG_NETWORK_PROCESS_MAX_PROCESSES_TRACKED", "DD_RUNTIME_SECURITY_CONFIG_NETWORK_PROCESS_MAX_PROCESSES_TRACKED")
 	config.BindEnvAndSetDefault("event_monitoring_config.network_process.container_store.enabled", true)
 	config.BindEnvAndSetDefault("event_monitoring_config.network_process.container_store.max_containers_tracked", 1024)
-
 	config.BindEnvAndSetDefault("compliance_config.database_benchmarks.enabled", false)
-
-	// enable/disable use of root net namespace
 	config.BindEnvAndSetDefault("network_config.enable_root_netns", true)
-
 	config.BindEnvAndSetDefault("windows_crash_detection.enabled", false)
-
 	config.BindEnvAndSetDefault("ping.enabled", false)
-
 	config.BindEnvAndSetDefault("traceroute.enabled", false)
-
 	config.BindEnvAndSetDefault("ccm_network_config.enabled", false)
-
 	config.BindEnvAndSetDefault("discovery.enabled", GetPlatformDefault(map[string]interface{}{
 		"fargate": false,
 		"linux":   true,
@@ -323,14 +310,9 @@ func initMainSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("discovery.service_collection_max_consecutive_timeouts", 5)
 	config.BindEnvAndSetDefault("discovery.service_collection_min_process_age", time.Minute)
 	config.BindEnvAndSetDefault("discovery.service_map.enabled", false)
-
 	config.BindEnvAndSetDefault("privileged_logs.enabled", false)
-
-	// Logon Duration config (macOS)
 	config.BindEnvAndSetDefault("logon_duration.enabled", false)
-
 	config.BindEnvAndSetDefault("fleet_policies_dir", "")
-
 	config.BindEnvAndSetDefault("gpu_monitoring.enabled", false)
 	config.BindEnvAndSetDefault("gpu_monitoring.enable_ebpf_probes", true)
 	config.BindEnvAndSetDefault("gpu_monitoring.nvml_lib_path", "")
@@ -340,31 +322,27 @@ func initMainSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("gpu_monitoring.prm_endpoint_enabled", true)
 	config.BindEnvAndSetDefault("gpu_monitoring.enable_fatbin_parsing", false)
 	config.BindEnvAndSetDefault("gpu_monitoring.fatbin_request_queue_size", 100)
-	config.BindEnvAndSetDefault("gpu_monitoring.ring_buffer_pages_per_device", 32) // 32 pages = 128KB by default per device
-	config.BindEnvAndSetDefault("gpu_monitoring.ringbuffer_wakeup_size", 3000)     // 3000 bytes is about ~10-20 events depending on the specific type
+	// 32 pages = 128KB by default per device
+	config.BindEnvAndSetDefault("gpu_monitoring.ring_buffer_pages_per_device", 32)
+	// 3000 bytes is about ~10-20 events depending on the specific type
+	config.BindEnvAndSetDefault("gpu_monitoring.ringbuffer_wakeup_size", 3000)
 	config.BindEnvAndSetDefault("gpu_monitoring.attacher_detailed_logs", false)
 	config.BindEnvAndSetDefault("gpu_monitoring.ringbuffer_flush_interval", 1*time.Second)
 	config.BindEnvAndSetDefault("gpu_monitoring.device_cache_refresh_interval", 5*time.Second)
 	config.BindEnvAndSetDefault("gpu_monitoring.cgroup_reapply_interval", 30*time.Second)
 	config.BindEnvAndSetDefault("gpu_monitoring.cgroup_reapply_infinitely", false)
-
-	// Windows Injector telemetry, enabled by default
 	config.BindEnvAndSetDefault("injector.enable_telemetry", true)
-
 	config.BindEnvAndSetDefault("gpu_monitoring.streams.max_kernel_launches", 1000)
 	config.BindEnvAndSetDefault("gpu_monitoring.streams.max_mem_alloc_events", 1000)
 	config.BindEnvAndSetDefault("gpu_monitoring.streams.max_pending_kernel_spans", 1000)
 	config.BindEnvAndSetDefault("gpu_monitoring.streams.max_pending_memory_spans", 1000)
 	config.BindEnvAndSetDefault("gpu_monitoring.streams.max_active", 100)
-	config.BindEnvAndSetDefault("gpu_monitoring.streams.timeout_seconds", 30) // 30 seconds by default, includes two checks at the default interval of 15 seconds
-
+	// 30 seconds by default, includes two checks at the default interval of 15 seconds
+	config.BindEnvAndSetDefault("gpu_monitoring.streams.timeout_seconds", 30)
 	config.BindEnvAndSetDefault("network_config.direct_send", false)
 }
 
 func initCWSSystemProbeConfig(config pkgconfigmodel.Setup) {
-	// the following entries are platform specific
-	// - runtime_security_config.policies.dir
-	// - runtime_security_config.socket
 	config.BindEnvAndSetDefault("runtime_security_config.socket", GetPlatformDefault(map[string]interface{}{
 		"windows": "localhost:3335",
 		"other":   "${install_path}/run/runtime-security.sock",
@@ -373,17 +351,18 @@ func initCWSSystemProbeConfig(config pkgconfigmodel.Setup) {
 		"other":   DefaultRuntimePoliciesDir,
 		"windows": "${conf_path}/runtime-security.d",
 	}))
-
 	config.BindEnvAndSetDefault("runtime_security_config.enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.fim_enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.policies.monitor.enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.policies.monitor.per_rule_enabled", false)
+	// deprecated in favor of dump_duration
 	config.BindEnvAndSetDefault("runtime_security_config.policies.monitor.report_internal_policies", false)
 	config.BindEnvAndSetDefault("runtime_security_config.policies.rule_cache_enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.event_server.burst", 40)
 	config.BindEnvAndSetDefault("runtime_security_config.event_server.retention", "6s")
 	config.BindEnvAndSetDefault("runtime_security_config.event_server.rate", 10)
 	config.BindEnvAndSetDefault("runtime_security_config.event_retry_queue_threshold", 512)
+	// Disabled for now - waiting for another PR to be merged
 	config.BindEnvAndSetDefault("runtime_security_config.cookie_cache_size", 100)
 	config.BindEnvAndSetDefault("runtime_security_config.internal_monitoring.enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.log_patterns", []string{})
@@ -404,15 +383,12 @@ func initCWSSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("runtime_security_config.container_include", []string{})
 	config.BindEnvAndSetDefault("runtime_security_config.exclude_pause_container", true)
 	config.BindEnvAndSetDefault("runtime_security_config.cmd_socket", "")
-
 	config.SetDefault("runtime_security_config.windows_filename_cache_max", 16384)
 	config.SetDefault("runtime_security_config.windows_registry_cache_max", 4096)
-	// windows specific channel size for etw events
 	config.SetDefault("runtime_security_config.etw_events_channel_size", 16384)
 	config.SetDefault("runtime_security_config.windows_probe_block_on_channel_send", false)
 	config.SetDefault("runtime_security_config.windows_write_event_rate_limiter_max_allowed", 4096)
 	config.SetDefault("runtime_security_config.windows_write_event_rate_limiter_period", "1s")
-
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.trace_systemd_cgroups", false)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cleanup_period", "30s")
@@ -422,7 +398,7 @@ func initCWSSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.max_dump_size", 1750)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.traced_cgroups_count", 5)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.traced_event_types", []string{"exec", "open", "dns", "imds"})
-	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_dump_timeout", 900) // deprecated in favor of dump_duration
+	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_dump_timeout", 900)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.dump_duration", "900s")
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.rate_limiter", 500)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_wait_list_timeout", "4500s")
@@ -438,7 +414,6 @@ func initCWSSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.silent_workloads.ticker", "10s")
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.workload_deny_list", []string{})
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.auto_suppression.enabled", true)
-
 	config.BindEnvAndSetDefault("runtime_security_config.sbom.enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.sbom.workloads_cache_size", 10)
 	config.BindEnvAndSetDefault("runtime_security_config.sbom.enrichment_interval", "1m")
@@ -446,7 +421,6 @@ func initCWSSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("runtime_security_config.sbom.forward_interval", "20s")
 	config.BindEnvAndSetDefault("runtime_security_config.sbom.host.enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.sbom.generate_policies", false)
-
 	config.BindEnvAndSetDefault("runtime_security_config.event_sampling.open.enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.event_sampling.open.rate", 500)
 	config.BindEnvAndSetDefault("runtime_security_config.event_sampling.connect.enabled", false)
@@ -455,7 +429,6 @@ func initCWSSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("runtime_security_config.event_sampling.bind.rate", 500)
 	config.BindEnvAndSetDefault("runtime_security_config.event_sampling.dns.enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.event_sampling.dns.rate", 500)
-
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.max_image_tags", 20)
@@ -464,17 +437,14 @@ func initCWSSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.cache_size", 10)
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.max_count", 400)
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.dns_match_max_depth", 3)
-	config.BindEnvAndSetDefault("runtime_security_config.security_profile.node_eviction_timeout", "0s") // Disabled for now - waiting for another PR to be merged
+	config.BindEnvAndSetDefault("runtime_security_config.security_profile.node_eviction_timeout", "0s")
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.profile_cleanup_delay", "60m")
-
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.event_types", []string{"exec", "dns", "bind", "connect", "open"})
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.sample_refresh_period", "30s")
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.excluded_images", []string{})
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.max_dump_size", 5120)
-
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.auto_suppression.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.auto_suppression.event_types", []string{"exec", "dns"})
-
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.anomaly_detection.event_types", []string{"exec"})
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.anomaly_detection.default_minimum_stable_period", "900s")
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.anomaly_detection.minimum_stable_period.exec", "900s")
@@ -488,34 +458,28 @@ func initCWSSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.anomaly_detection.tag_rules.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.anomaly_detection.silent_rule_events.enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.anomaly_detection.enabled", true)
-
 	config.BindEnvAndSetDefault("runtime_security_config.hash_resolver.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.hash_resolver.event_types", []string{"exec", "open"})
-	config.BindEnvAndSetDefault("runtime_security_config.hash_resolver.max_file_size", (1<<20)*5) // 5 MB
+	// 5 MB
+	config.BindEnvAndSetDefault("runtime_security_config.hash_resolver.max_file_size", (1<<20)*5)
 	config.BindEnvAndSetDefault("runtime_security_config.hash_resolver.max_hash_rate", 500)
 	config.BindEnvAndSetDefault("runtime_security_config.hash_resolver.hash_algorithms", []string{"sha1", "sha256", "ssdeep"})
 	config.BindEnvAndSetDefault("runtime_security_config.hash_resolver.cache_size", 500)
 	config.BindEnvAndSetDefault("runtime_security_config.hash_resolver.replace", map[string]string{})
-
 	config.BindEnvAndSetDefault("runtime_security_config.sysctl.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.sysctl.ebpf.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.sysctl.snapshot.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.sysctl.snapshot.period", "1h")
 	config.BindEnvAndSetDefault("runtime_security_config.sysctl.snapshot.ignored_base_names", []string{"netdev_rss_key", "stable_secret"})
 	config.BindEnvAndSetDefault("runtime_security_config.sysctl.snapshot.kernel_compilation_flags", []string{})
-
 	config.BindEnvAndSetDefault("runtime_security_config.user_sessions.ssh.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.user_sessions.cache_size", 1024)
-
 	// When enabled, the eBPF IS_UNHANDLED_ERROR filter treats every negative syscall
 	// return as handled (constant patched at probe load). Defaults to false.
 	config.BindEnvAndSetDefault("runtime_security_config.syscalls.capture_all_errors.enabled", false)
-
 	config.BindEnvAndSetDefault("runtime_security_config.ebpfless.enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.ebpfless.socket", constants.DefaultEBPFLessProbeAddr)
-
 	config.BindEnvAndSetDefault("runtime_security_config.imds_ipv4", "169.254.169.254")
-
 	config.BindEnvAndSetDefault("runtime_security_config.enforcement.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.enforcement.raw_syscall.enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.enforcement.exclude_binaries", []string{})
@@ -526,9 +490,7 @@ func initCWSSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("runtime_security_config.enforcement.disarmer.executable.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.enforcement.disarmer.executable.max_allowed", 5)
 	config.BindEnvAndSetDefault("runtime_security_config.enforcement.disarmer.executable.period", "1m")
-
 	config.BindEnvAndSetDefault("runtime_security_config.file_metadata_resolver.enabled", false)
-
 	config.BindEnvAndSetDefault("runtime_security_config.network_monitoring.enabled", false)
 }
 
@@ -552,85 +514,68 @@ func initUSMSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("service_monitoring_config.disable_map_preallocation", true)
 	config.BindEnvAndSetDefault("service_monitoring_config.direct_consumer.buffer_wakeup_count_per_cpu", 8)
 	config.BindEnvAndSetDefault("service_monitoring_config.direct_consumer.channel_size", 1000)
-	config.BindEnvAndSetDefault("service_monitoring_config.direct_consumer.kernel_buffer_size_per_cpu", 65536) // 64KB per CPU base size
-
+	config.BindEnvAndSetDefault("service_monitoring_config.direct_consumer.kernel_buffer_size_per_cpu", 65536)
 	// New tree structure with backward compatibility
 	config.BindEnvAndSetDefault("service_monitoring_config.http.enabled", true)
 	// Deprecated flat keys for backward compatibility
 	config.BindEnvAndSetDefault("service_monitoring_config.enable_http_monitoring", true)
 	config.BindEnvAndSetDefault("network_config.enable_http_monitoring", true, "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING")
-
 	config.BindEnvAndSetDefault("service_monitoring_config.http.max_stats_buffered", 100000)
 	// Deprecated flat keys for backward compatibility
 	config.BindEnvAndSetDefault("service_monitoring_config.max_http_stats_buffered", 100000)
 	config.BindEnvAndSetDefault("network_config.max_http_stats_buffered", 100000, "DD_SYSTEM_PROBE_NETWORK_MAX_HTTP_STATS_BUFFERED")
-
 	config.BindEnvAndSetDefault("service_monitoring_config.http.max_tracked_connections", 1024)
 	// Deprecated flat keys for backward compatibility
 	config.BindEnvAndSetDefault("service_monitoring_config.max_tracked_http_connections", 1024)
 	config.BindEnvAndSetDefault("network_config.max_tracked_http_connections", 1024)
-
 	config.BindEnvAndSetDefault("service_monitoring_config.http.notification_threshold", 512)
 	// Deprecated flat keys for backward compatibility
 	config.BindEnvAndSetDefault("service_monitoring_config.http_notification_threshold", 512)
 	config.BindEnvAndSetDefault("network_config.http_notification_threshold", 512)
-
-	config.BindEnvAndSetDefault("service_monitoring_config.http.max_request_fragment", 512) // matches hard limit currently imposed in NPM driver
+	// matches hard limit currently imposed in NPM driver
+	config.BindEnvAndSetDefault("service_monitoring_config.http.max_request_fragment", 512)
 	// Deprecated flat keys for backward compatibility
 	config.BindEnvAndSetDefault("service_monitoring_config.http_max_request_fragment", 512)
 	config.BindEnvAndSetDefault("network_config.http_max_request_fragment", 512)
-
 	config.BindEnvAndSetDefault("service_monitoring_config.http.map_cleaner_interval_seconds", 300)
 	// Deprecated flat keys for backward compatibility
 	config.BindEnvAndSetDefault("service_monitoring_config.http_map_cleaner_interval_in_s", 300)
 	config.BindEnvAndSetDefault("system_probe_config.http_map_cleaner_interval_in_s", 300)
-
 	config.BindEnvAndSetDefault("service_monitoring_config.http.idle_connection_ttl_seconds", 30)
 	// Deprecated flat keys for backward compatibility
 	config.BindEnvAndSetDefault("service_monitoring_config.http_idle_connection_ttl_in_s", 30)
 	config.BindEnvAndSetDefault("system_probe_config.http_idle_connection_ttl_in_s", 30)
-
 	config.BindEnvAndSetDefault("service_monitoring_config.http.use_direct_consumer", true)
-
 	config.BindEnvAndSetDefault("service_monitoring_config.http.replace_rules", []map[string]string{})
+	config.ParseEnvJSON("service_monitoring_config.http.replace_rules", []map[string]string{})
 	// Deprecated flat keys for backward compatibility
 	config.BindEnvAndSetDefault("service_monitoring_config.http_replace_rules", []map[string]string{})
-	config.BindEnvAndSetDefault("network_config.http_replace_rules", []map[string]string{}, "DD_SYSTEM_PROBE_NETWORK_HTTP_REPLACE_RULES")
-
-	config.ParseEnvJSON("service_monitoring_config.http.replace_rules", []map[string]string{})
 	config.ParseEnvJSON("service_monitoring_config.http_replace_rules", []map[string]string{})
+	config.BindEnvAndSetDefault("network_config.http_replace_rules", []map[string]string{}, "DD_SYSTEM_PROBE_NETWORK_HTTP_REPLACE_RULES")
 	config.ParseEnvJSON("network_config.http_replace_rules", []map[string]string{})
-
 	config.BindEnvAndSetDefault("service_monitoring_config.http2.enabled", false)
 	config.BindEnvAndSetDefault("service_monitoring_config.http2.dynamic_table_map_cleaner_interval_seconds", 30)
-
 	// Legacy bindings for backward compatibility (deprecated)
 	config.BindEnvAndSetDefault("service_monitoring_config.enable_http2_monitoring", false)
 	config.BindEnvAndSetDefault("service_monitoring_config.http2_dynamic_table_map_cleaner_interval_seconds", 30)
-
 	config.BindEnvAndSetDefault("service_monitoring_config.kafka.enabled", false)
 	// For backward compatibility
 	config.BindEnvAndSetDefault("service_monitoring_config.enable_kafka_monitoring", false)
-
 	config.BindEnvAndSetDefault("service_monitoring_config.kafka.max_stats_buffered", 100000)
 	// For backward compatibility
 	config.BindEnvAndSetDefault("service_monitoring_config.max_kafka_stats_buffered", 100000)
-
 	config.BindEnvAndSetDefault("service_monitoring_config.postgres.enabled", false)
 	config.BindEnvAndSetDefault("service_monitoring_config.postgres.max_stats_buffered", 100000)
 	config.BindEnvAndSetDefault("service_monitoring_config.postgres.max_telemetry_buffer", 160)
-
 	config.BindEnvAndSetDefault("service_monitoring_config.redis.enabled", false)
 	config.BindEnvAndSetDefault("service_monitoring_config.redis.track_resources", false)
 	config.BindEnvAndSetDefault("service_monitoring_config.redis.max_stats_buffered", 100000)
-
 	config.BindEnvAndSetDefault("service_monitoring_config.tls.native.enabled", true)
 	// For backward compatibility. Default is false because the canonical key
 	// (service_monitoring_config.tls.native.enabled, defaulted to true above)
 	// is the authoritative source; deprecateBool only forwards the deprecated
 	// alias when it is explicitly configured.
 	config.BindEnvAndSetDefault("network_config.enable_https_monitoring", false, "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTPS_MONITORING")
-
 	config.BindEnvAndSetDefault("service_monitoring_config.tls.go.enabled", true)
 	// For backward compatibility. Default is false because the canonical key
 	// (service_monitoring_config.tls.go.enabled, defaulted to true above) is
@@ -638,9 +583,7 @@ func initUSMSystemProbeConfig(config pkgconfigmodel.Setup) {
 	// alias when it is explicitly configured.
 	config.BindEnvAndSetDefault("service_monitoring_config.enable_go_tls_support", false)
 	config.BindEnvAndSetDefault("service_monitoring_config.tls.go.exclude_self", true)
-
 	config.BindEnvAndSetDefault("service_monitoring_config.tls.istio.enabled", true)
-	config.BindEnvAndSetDefault("service_monitoring_config.tls.istio.envoy_path", defaultEnvoyPath)
-
+	config.BindEnvAndSetDefault("service_monitoring_config.tls.istio.envoy_path", "/bin/envoy")
 	config.BindEnvAndSetDefault("service_monitoring_config.tls.nodejs.enabled", false)
 }

--- a/pkg/security/probe/BUILD.bazel
+++ b/pkg/security/probe/BUILD.bazel
@@ -351,7 +351,7 @@ go_test(
     gotags = ["test"],
     deps = select({
         "@rules_go//go/platform:android": [
-            "//pkg/config/setup",
+            "//pkg/config/mock",
             "//pkg/security/config",
             "//pkg/security/events",
             "//pkg/security/probe/config",
@@ -385,7 +385,7 @@ go_test(
             "@org_uber_go_atomic//:atomic",
         ],
         "@rules_go//go/platform:linux": [
-            "//pkg/config/setup",
+            "//pkg/config/mock",
             "//pkg/security/config",
             "//pkg/security/events",
             "//pkg/security/probe/config",
@@ -419,7 +419,7 @@ go_test(
             "@org_uber_go_atomic//:atomic",
         ],
         "@rules_go//go/platform:windows": [
-            "//pkg/config/setup",
+            "//pkg/config/mock",
             "//pkg/ebpf/ebpftest",
             "//pkg/security/config",
             "//pkg/security/events",

--- a/pkg/security/probe/field_handlers_test.go
+++ b/pkg/security/probe/field_handlers_test.go
@@ -14,14 +14,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/pkg/config/setup"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
 func TestIsIPPublic(t *testing.T) {
 	bfh := BaseFieldHandlers{}
-	for _, cidr := range setup.DefaultPrivateIPCIDRs {
+	cfg := configmock.NewSystemProbe(t)
+	for _, cidr := range cfg.GetStringSlice("event_monitoring_config.network.private_ip_ranges") {
 		if err := bfh.privateCIDRs.AppendCIDR(cidr); err != nil {
 			t.Fatalf("failed to append CIDR %s: %v", cidr, err)
 		}

--- a/tasks/schema/codegen_init_settings.py
+++ b/tasks/schema/codegen_init_settings.py
@@ -442,7 +442,6 @@ def get_suffixes_for_pattern(pattern):
             'delegated_auth.refresh_interval_mins',
             'delegated_auth.provider',
             'delegated_auth.aws.region',
-            'api_key',
         ]
     else:
         raise RuntimeError(f"unknown pattern: {pattern}")


### PR DESCRIPTION
### What does this PR do?

This reduce heavily the diff with the generated code, allowing for a simpler comparaison.

This also:
- fix `private_action_runner.executor.socket_path` missing from the generated code
- fix `api_key` for delegated_auth being outputed twice
- Remove `procBindEnvAndSetDefault` in favor of explicit declaration
- Fix post processing mechanism for `system_probe_config.apt_config_dir` / `system_probe_config.yum_repos_dir` / `system_probe_config.zypper_repos_dir`
- Remove useless const from system-probe
- Fix tests relying on hardcoded value instead of the config