### PR TITLE
[AGENTRUN-1405] snmp: change session default cryptosx to FIPS 140-3 compatible

### DIFF
--- a/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
+++ b/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
@@ -54,7 +54,7 @@ instances:
     ## @param authProtocol - string - optional
     ## Authentication type to use when connecting to your SNMP devices.
     ## Available options are: MD5, SHA, SHA224, SHA256, SHA384, SHA512
-    ## Default to SHA256 when `authKey` is specified.
+    ## Default to MD5 when `authKey` is specified, or SHA256 in FIPS mode.
     #
     authProtocol: "%%extra_auth_protocol%%"
 
@@ -66,7 +66,7 @@ instances:
     ## @param privProtocol - string - optional
     ## Privacy type to use when connecting to your SNMP devices.
     ## Available options are: DES, AES (128 bits), AES192, AES192C, AES256, AES256C
-    ## Default to AES when `privKey` is specified.
+    ## Default to DES when `privKey` is specified, or AES in FIPS mode.
     #
     privProtocol: "%%extra_priv_protocol%%"
 

--- a/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
+++ b/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
@@ -54,7 +54,7 @@ instances:
     ## @param authProtocol - string - optional
     ## Authentication type to use when connecting to your SNMP devices.
     ## Available options are: MD5, SHA, SHA224, SHA256, SHA384, SHA512
-    ## Default to MD5 when `authKey` is specified.
+    ## Default to SHA256 when `authKey` is specified.
     #
     authProtocol: "%%extra_auth_protocol%%"
 
@@ -66,7 +66,7 @@ instances:
     ## @param privProtocol - string - optional
     ## Privacy type to use when connecting to your SNMP devices.
     ## Available options are: DES, AES (128 bits), AES192, AES192C, AES256, AES256C
-    ## Default to DES when `privKey` is specified.
+    ## Default to AES when `privKey` is specified.
     #
     privProtocol: "%%extra_priv_protocol%%"
 

--- a/pkg/collector/corechecks/snmp/internal/session/BUILD.bazel
+++ b/pkg/collector/corechecks/snmp/internal/session/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/collector/corechecks/snmp/internal/checkconfig",
         "//pkg/collector/corechecks/snmp/internal/valuestore",
+        "//pkg/fips",
         "//pkg/snmp/gosnmplib",
         "//pkg/util/log",
         "@com_github_gosnmp_gosnmp//:gosnmp",
@@ -32,6 +33,7 @@ dd_agent_go_test(
     embed = [":session"],
     deps = [
         "//pkg/collector/corechecks/snmp/internal/checkconfig",
+        "//pkg/snmp/gosnmplib",
         "//pkg/util/log",
         "@com_github_gosnmp_gosnmp//:gosnmp",
         "@com_github_stretchr_testify//assert",

--- a/pkg/collector/corechecks/snmp/internal/session/session.go
+++ b/pkg/collector/corechecks/snmp/internal/session/session.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gosnmp/gosnmp"
 
+	"github.com/DataDog/datadog-agent/pkg/fips"
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -123,10 +124,10 @@ func NewGosnmpSession(config *checkconfig.CheckConfig) (Session, error) {
 		s.gosnmpInst.Community = config.CommunityString
 	} else if config.User != "" {
 		if config.AuthKey != "" && config.AuthProtocol == "" {
-			config.AuthProtocol = "sha256"
+			config.AuthProtocol = defaultAuthProtocol()
 		}
 		if config.PrivKey != "" && config.PrivProtocol == "" {
-			config.PrivProtocol = "aes"
+			config.PrivProtocol = defaultPrivProtocol()
 		}
 
 		authProtocol, err := gosnmplib.GetAuthProtocol(config.AuthProtocol)
@@ -180,6 +181,24 @@ func NewGosnmpSession(config *checkconfig.CheckConfig) (Session, error) {
 		}
 	}
 	return s, nil
+}
+
+// defaultAuthProtocol returns the SNMPv3 authentication protocol to use when authKey
+// is set without an explicit authProtocol. Default to SHA256 in FIPS mode, MD5 otherwise.
+func defaultAuthProtocol() string {
+	if fipsEnabled, _ := fips.Enabled(); fipsEnabled {
+		return "sha256"
+	}
+	return "md5"
+}
+
+// defaultPrivProtocol returns the SNMPv3 privacy protocol to use when privKey is set
+// without an explicit privProtocol. Default to AES in FIPS mode, DES otherwise.
+func defaultPrivProtocol() string {
+	if fipsEnabled, _ := fips.Enabled(); fipsEnabled {
+		return "aes"
+	}
+	return "des"
 }
 
 // FetchSysObjectID fetches the sys object id from the device

--- a/pkg/collector/corechecks/snmp/internal/session/session.go
+++ b/pkg/collector/corechecks/snmp/internal/session/session.go
@@ -123,10 +123,10 @@ func NewGosnmpSession(config *checkconfig.CheckConfig) (Session, error) {
 		s.gosnmpInst.Community = config.CommunityString
 	} else if config.User != "" {
 		if config.AuthKey != "" && config.AuthProtocol == "" {
-			config.AuthProtocol = "md5"
+			config.AuthProtocol = "sha256"
 		}
 		if config.PrivKey != "" && config.PrivProtocol == "" {
-			config.PrivProtocol = "des"
+			config.PrivProtocol = "aes"
 		}
 
 		authProtocol, err := gosnmplib.GetAuthProtocol(config.AuthProtocol)

--- a/pkg/collector/corechecks/snmp/internal/session/session.go
+++ b/pkg/collector/corechecks/snmp/internal/session/session.go
@@ -186,7 +186,7 @@ func NewGosnmpSession(config *checkconfig.CheckConfig) (Session, error) {
 // defaultAuthProtocol returns the SNMPv3 authentication protocol to use when authKey
 // is set without an explicit authProtocol. Default to SHA256 in FIPS mode, MD5 otherwise.
 func defaultAuthProtocol() string {
-	if fipsEnabled, _ := fips.Enabled(); fipsEnabled {
+	if fips.BuiltForFIPS() {
 		return "sha256"
 	}
 	return "md5"
@@ -195,7 +195,7 @@ func defaultAuthProtocol() string {
 // defaultPrivProtocol returns the SNMPv3 privacy protocol to use when privKey is set
 // without an explicit privProtocol. Default to AES in FIPS mode, DES otherwise.
 func defaultPrivProtocol() string {
-	if fipsEnabled, _ := fips.Enabled(); fipsEnabled {
+	if fips.BuiltForFIPS() {
 		return "aes"
 	}
 	return "des"

--- a/pkg/collector/corechecks/snmp/internal/session/session_test.go
+++ b/pkg/collector/corechecks/snmp/internal/session/session_test.go
@@ -174,9 +174,9 @@ func Test_snmpSession_Configure(t *testing.T) {
 			expectedMsgFlags: gosnmp.AuthPriv,
 			expectedSecurityParameters: &gosnmp.UsmSecurityParameters{
 				UserName:                 "myUser",
-				AuthenticationProtocol:   gosnmp.MD5,
+				AuthenticationProtocol:   gosnmp.SHA256,
 				AuthenticationPassphrase: "myAuthKey",
-				PrivacyProtocol:          gosnmp.DES,
+				PrivacyProtocol:          gosnmp.AES,
 				PrivacyPassphrase:        "myPrivKey",
 			},
 		},
@@ -192,7 +192,7 @@ func Test_snmpSession_Configure(t *testing.T) {
 			expectedMsgFlags: gosnmp.AuthPriv,
 			expectedSecurityParameters: &gosnmp.UsmSecurityParameters{
 				UserName:                 "myUser",
-				AuthenticationProtocol:   gosnmp.MD5,
+				AuthenticationProtocol:   gosnmp.SHA256,
 				AuthenticationPassphrase: "myAuthKey",
 				PrivacyProtocol:          gosnmp.AES,
 				PrivacyPassphrase:        "myPrivKey",
@@ -212,7 +212,7 @@ func Test_snmpSession_Configure(t *testing.T) {
 				UserName:                 "myUser",
 				AuthenticationProtocol:   gosnmp.SHA,
 				AuthenticationPassphrase: "myAuthKey",
-				PrivacyProtocol:          gosnmp.DES,
+				PrivacyProtocol:          gosnmp.AES,
 				PrivacyPassphrase:        "myPrivKey",
 			},
 		},
@@ -494,4 +494,38 @@ func TestUseUnconnectedUDPSocketPropagation(t *testing.T) {
 				"UseUnconnectedUDPSocket should be propagated to gosnmp instance")
 		})
 	}
+}
+
+// Test_snmpSession_v3DefaultProtocols_FIPSCompatible documents that the
+// default v3 auth/priv protocols (sha256/aes) are usable under FIPS.
+//
+// NewGosnmpSession only fills the security-parameter struct; the sha256/aes
+// crypto is not exercised until USM key derivation runs. During a real
+// collection that happens lazily inside sess.GetNext (gosnmp's v3 discovery),
+// but that path needs a live device and would time out identically with or
+// without FIPS. So we drive the exact same key-derivation code directly via
+// InitSecurityKeys.
+//
+// The sha256/aes localization produces non-empty keys both in a normal build
+// and under GODEBUG=fips140=only, unlike the previous md5/des defaults whose
+// key derivation silently produced empty keys in FIPS mode.
+func Test_snmpSession_v3DefaultProtocols_FIPSCompatible(t *testing.T) {
+	config := checkconfig.CheckConfig{
+		IPAddress: "1.2.3.4",
+		Port:      uint16(1234),
+		User:      "myUser",
+		AuthKey:   "myAuthKey", // defaults AuthProtocol to sha256
+		PrivKey:   "myPrivKey", // defaults PrivProtocol to aes
+	}
+	s, err := NewGosnmpSession(&config)
+	require.NoError(t, err)
+
+	usm := s.(*GosnmpSession).gosnmpInst.SecurityParameters.(*gosnmp.UsmSecurityParameters)
+	// An authoritative engine ID is normally learned during discovery; set one
+	// so key localization runs without a live device.
+	usm.AuthoritativeEngineID = "myEngineID"
+
+	require.NoError(t, usm.InitSecurityKeys())
+	require.NotEmpty(t, usm.SecretKey, "sha256 auth key derivation produced no key")
+	require.NotEmpty(t, usm.PrivacyKey, "aes priv key derivation produced no key")
 }

--- a/pkg/collector/corechecks/snmp/internal/session/session_test.go
+++ b/pkg/collector/corechecks/snmp/internal/session/session_test.go
@@ -18,10 +18,23 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
 )
+
+func defaultAuthGosnmpProtocol(t *testing.T) gosnmp.SnmpV3AuthProtocol {
+	protocol, err := gosnmplib.GetAuthProtocol(defaultAuthProtocol())
+	require.NoError(t, err)
+	return protocol
+}
+
+func defaultPrivGosnmpProtocol(t *testing.T) gosnmp.SnmpV3PrivProtocol {
+	protocol, err := gosnmplib.GetPrivProtocol(defaultPrivProtocol())
+	require.NoError(t, err)
+	return protocol
+}
 
 func Test_snmpSession_Configure(t *testing.T) {
 	tests := []struct {
@@ -174,9 +187,9 @@ func Test_snmpSession_Configure(t *testing.T) {
 			expectedMsgFlags: gosnmp.AuthPriv,
 			expectedSecurityParameters: &gosnmp.UsmSecurityParameters{
 				UserName:                 "myUser",
-				AuthenticationProtocol:   gosnmp.SHA256,
+				AuthenticationProtocol:   defaultAuthGosnmpProtocol(t),
 				AuthenticationPassphrase: "myAuthKey",
-				PrivacyProtocol:          gosnmp.AES,
+				PrivacyProtocol:          defaultPrivGosnmpProtocol(t),
 				PrivacyPassphrase:        "myPrivKey",
 			},
 		},
@@ -192,7 +205,7 @@ func Test_snmpSession_Configure(t *testing.T) {
 			expectedMsgFlags: gosnmp.AuthPriv,
 			expectedSecurityParameters: &gosnmp.UsmSecurityParameters{
 				UserName:                 "myUser",
-				AuthenticationProtocol:   gosnmp.SHA256,
+				AuthenticationProtocol:   defaultAuthGosnmpProtocol(t),
 				AuthenticationPassphrase: "myAuthKey",
 				PrivacyProtocol:          gosnmp.AES,
 				PrivacyPassphrase:        "myPrivKey",
@@ -212,7 +225,7 @@ func Test_snmpSession_Configure(t *testing.T) {
 				UserName:                 "myUser",
 				AuthenticationProtocol:   gosnmp.SHA,
 				AuthenticationPassphrase: "myAuthKey",
-				PrivacyProtocol:          gosnmp.AES,
+				PrivacyProtocol:          defaultPrivGosnmpProtocol(t),
 				PrivacyPassphrase:        "myPrivKey",
 			},
 		},
@@ -496,26 +509,30 @@ func TestUseUnconnectedUDPSocketPropagation(t *testing.T) {
 	}
 }
 
-// Test_snmpSession_v3DefaultProtocols_FIPSCompatible documents that the
-// default v3 auth/priv protocols (sha256/aes) are usable under FIPS.
+// Test_snmpSession_v3DefaultProtocols_FIPSCompatible documents that the default
+// v3 auth/priv protocols always produce usable USM keys, whether or not FIPS
+// mode is active.
 //
-// NewGosnmpSession only fills the security-parameter struct; the sha256/aes
-// crypto is not exercised until USM key derivation runs. During a real
-// collection that happens lazily inside sess.GetNext (gosnmp's v3 discovery),
-// but that path needs a live device and would time out identically with or
-// without FIPS. So we drive the exact same key-derivation code directly via
-// InitSecurityKeys.
+// defaultAuthProtocol/defaultPrivProtocol select MD5/DES outside FIPS mode
+// and SHA256/AES under FIPS mode, since MD5/DES key derivation silently produces
+// an empty key under FIPS mode.
 //
-// The sha256/aes localization produces non-empty keys both in a normal build
-// and under GODEBUG=fips140=only, unlike the previous md5/des defaults whose
-// key derivation silently produced empty keys in FIPS mode.
+// NewGosnmpSession only fills the security-parameter struct; the crypto is not
+// exercised until USM key derivation runs. During a real collection that
+// happens lazily inside sess.GetNext (gosnmp's v3 discovery), but that path
+// needs a live device and would time out identically with or without FIPS. So
+// we drive the exact same key-derivation code directly via InitSecurityKeys.
+//
+// Run with GODEBUG=fips140=only to exercise the FIPS branch (SHA256/AES);
+// without it, this exercises the default branch (MD5/DES), which also
+// succeeds since MD5/DES work fine outside FIPS mode.
 func Test_snmpSession_v3DefaultProtocols_FIPSCompatible(t *testing.T) {
 	config := checkconfig.CheckConfig{
 		IPAddress: "1.2.3.4",
 		Port:      uint16(1234),
 		User:      "myUser",
-		AuthKey:   "myAuthKey", // defaults AuthProtocol to sha256
-		PrivKey:   "myPrivKey", // defaults PrivProtocol to aes
+		AuthKey:   "myAuthKey", // defaults AuthProtocol via defaultAuthProtocol()
+		PrivKey:   "myPrivKey", // defaults PrivProtocol via defaultPrivProtocol()
 	}
 	s, err := NewGosnmpSession(&config)
 	require.NoError(t, err)
@@ -526,6 +543,6 @@ func Test_snmpSession_v3DefaultProtocols_FIPSCompatible(t *testing.T) {
 	usm.AuthoritativeEngineID = "myEngineID"
 
 	require.NoError(t, usm.InitSecurityKeys())
-	require.NotEmpty(t, usm.SecretKey, "sha256 auth key derivation produced no key")
-	require.NotEmpty(t, usm.PrivacyKey, "aes priv key derivation produced no key")
+	require.NotEmpty(t, usm.SecretKey, "auth key derivation produced no key (FIPS mode?)")
+	require.NotEmpty(t, usm.PrivacyKey, "priv key derivation produced no key (FIPS mode?)")
 }

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4601,7 +4601,7 @@ api_key:
 #             # @param authProtocol - string - optional
 #             # The authentication protocol to use when connecting to your SNMP devices.
 #             # Available options are: MD5, SHA, SHA224, SHA256, SHA384, SHA512
-#             # Defaults to SHA256 when `authentication_key` is specified.
+#             # Defaults to MD5 when `authentication_key` is specified, or SHA256 in FIPS mode.
 #             # SNMPv3 only.
 #
 #             authProtocol: <AUTHENTICATION_PROTOCOL>
@@ -4615,7 +4615,7 @@ api_key:
 #             # @param privProtocol - string - optional
 #             # The privacy protocol to use when connecting to your SNMP devices.
 #             # Available options are: DES, AES (128 bits), AES192, AES192C, AES256, AES256C
-#             # Defaults to AES when `privacy_key` is specified.
+#             # Defaults to DES when `privacy_key` is specified, or AES in FIPS mode.
 #             # SNMPv3 only.
 #
 #             privProtocol: <PRIVACY_PROTOCOL>

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4601,7 +4601,7 @@ api_key:
 #             # @param authProtocol - string - optional
 #             # The authentication protocol to use when connecting to your SNMP devices.
 #             # Available options are: MD5, SHA, SHA224, SHA256, SHA384, SHA512
-#             # Defaults to MD5 when `authentication_key` is specified.
+#             # Defaults to SHA256 when `authentication_key` is specified.
 #             # SNMPv3 only.
 #
 #             authProtocol: <AUTHENTICATION_PROTOCOL>
@@ -4615,7 +4615,7 @@ api_key:
 #             # @param privProtocol - string - optional
 #             # The privacy protocol to use when connecting to your SNMP devices.
 #             # Available options are: DES, AES (128 bits), AES192, AES192C, AES256, AES256C
-#             # Defaults to DES when `privacy_key` is specified.
+#             # Defaults to AES when `privacy_key` is specified.
 #             # SNMPv3 only.
 #
 #             privProtocol: <PRIVACY_PROTOCOL>

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -4486,7 +4486,7 @@ properties:
                       # @param authProtocol - string - optional
                       # The authentication protocol to use when connecting to your SNMP devices.
                       # Available options are: MD5, SHA, SHA224, SHA256, SHA384, SHA512
-                      # Defaults to MD5 when `authentication_key` is specified.
+                      # Defaults to SHA256 when `authentication_key` is specified.
                       # SNMPv3 only.
 
                       authProtocol: <AUTHENTICATION_PROTOCOL>
@@ -4500,7 +4500,7 @@ properties:
                       # @param privProtocol - string - optional
                       # The privacy protocol to use when connecting to your SNMP devices.
                       # Available options are: DES, AES (128 bits), AES192, AES192C, AES256, AES256C
-                      # Defaults to DES when `privacy_key` is specified.
+                      # Defaults to AES when `privacy_key` is specified.
                       # SNMPv3 only.
 
                       privProtocol: <PRIVACY_PROTOCOL>

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -4486,7 +4486,7 @@ properties:
                       # @param authProtocol - string - optional
                       # The authentication protocol to use when connecting to your SNMP devices.
                       # Available options are: MD5, SHA, SHA224, SHA256, SHA384, SHA512
-                      # Defaults to SHA256 when `authentication_key` is specified.
+                      # Defaults to MD5 when `authentication_key` is specified, or SHA256 in FIPS mode.
                       # SNMPv3 only.
 
                       authProtocol: <AUTHENTICATION_PROTOCOL>
@@ -4500,7 +4500,7 @@ properties:
                       # @param privProtocol - string - optional
                       # The privacy protocol to use when connecting to your SNMP devices.
                       # Available options are: DES, AES (128 bits), AES192, AES192C, AES256, AES256C
-                      # Defaults to AES when `privacy_key` is specified.
+                      # Defaults to DES when `privacy_key` is specified, or AES in FIPS mode.
                       # SNMPv3 only.
 
                       privProtocol: <PRIVACY_PROTOCOL>

--- a/releasenotes/notes/fix-snmp-v3-fips-default-protocols-2bdc8ce9b8019bdc.yaml
+++ b/releasenotes/notes/fix-snmp-v3-fips-default-protocols-2bdc8ce9b8019bdc.yaml
@@ -1,0 +1,9 @@
+---
+security:
+  - |
+    The default SNMPv3 authentication and privacy protocols used when
+    ``authKey``/``privKey`` are set without an explicit ``authProtocol``/
+    ``privProtocol`` have changed from ``MD5``/``DES`` to ``SHA-256``/``AES``,
+    since ``MD5`` and ``DES`` are not FIPS 140-3 compatible. Users relying on
+    the previous defaults should set ``authProtocol: md5`` and
+    ``privProtocol: des`` explicitly to keep the old behavior.

--- a/releasenotes/notes/fix-snmp-v3-fips-default-protocols-2bdc8ce9b8019bdc.yaml
+++ b/releasenotes/notes/fix-snmp-v3-fips-default-protocols-2bdc8ce9b8019bdc.yaml
@@ -1,9 +1,8 @@
 ---
 security:
   - |
-    The default SNMPv3 authentication and privacy protocols used when
-    ``authKey``/``privKey`` are set without an explicit ``authProtocol``/
-    ``privProtocol`` have changed from ``MD5``/``DES`` to ``SHA-256``/``AES``,
-    since ``MD5`` and ``DES`` are not FIPS 140-3 compatible. Users relying on
-    the previous defaults should set ``authProtocol: md5`` and
-    ``privProtocol: des`` explicitly to keep the old behavior.
+    In FIPS mode, the default SNMPv3 authentication and privacy protocols
+    used when ``authKey``/``privKey`` are set without an explicit
+    ``authProtocol``/``privProtocol`` are now ``SHA-256``/``AES`` instead
+    of ``MD5``/``DES``, since ``MD5`` and ``DES`` are not FIPS 140-3
+    compatible. Outside FIPS mode, the defaults remain unchanged.


### PR DESCRIPTION
### What does this PR do?
Changes the default `AuthProtocol` from `md5` to `sha256`, and the default `PrivProtocol` from `des` to `aes`. The previous default values were not FIPS 140-3 compatible, and would fail at runtime.

### Motivation
FIPS 140-3 compliance (see https://datadoghq.atlassian.net/browse/AGENTRUN-1405).

### Describe how you validated your changes
The newly added `Test_snmpSession_v3DefaultProtocols_FIPSCompatible` test, was failing at runtime under `GODEBUG=fips140=only` but now passes.

### Additional Notes
