### PR TITLE
fix(ci): stop dropping cached Bazel test results from JUnit collection

### DIFF
--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -147,6 +147,35 @@ def _test_xml_funcs(paths: list[Path]) -> set[str]:
     raise FileNotFoundError(f"no readable test.xml found among candidates: {paths}")
 
 
+class _BepContext:
+    """Tracks the workspace/configuration state needed to resolve BEP test.xml paths.
+
+    The convenience symlink `bazel-testlogs` doesn't exist on CI
+    (--noexperimental_convenience_symlinks), so test.xml paths are
+    reconstructed from `localExecRoot` and each configuration's BINDIR
+    instead ("bazel-out/<config-mnemonic>/bin" -> ".../testlogs").
+    """
+
+    def __init__(self):
+        self.local_exec_root: str | None = None
+        self.config_testlogs: dict[str, Path] = {}
+
+    def observe(self, eid: dict, event: dict) -> bool:
+        """Update state from a workspace/configuration event. Returns True if handled."""
+        match eid:
+            case {"workspace": _}:
+                self.local_exec_root = event.get("workspaceInfo", {}).get("localExecRoot")
+                return True
+            case {"configuration": {"id": cfg_id}}:
+                bindir = event.get("configuration", {}).get("makeVariable", {}).get("BINDIR", "")
+                bindir_path = Path(bindir)
+                if bindir_path.name == "bin":
+                    self.config_testlogs[cfg_id] = bindir_path.parent / "testlogs"
+                return True
+            case _:
+                return False
+
+
 def _bazel_test_funcs_from_bep(bep_path: Path) -> dict[str, set[str]]:
     """Parse a Build Event Protocol JSON stream into {import_path: {Test* funcs}}.
 
@@ -155,14 +184,8 @@ def _bazel_test_funcs_from_bep(bep_path: Path) -> dict[str, set[str]]:
     `dd_agent_go_test` tag) are ignored.
     """
     dd_agent_labels: set[str] = set()
-    # (uri, config_id) per label so we can recover test.xml even when Bazel
-    # writes only a bytestream:// URI to the BEP. The convenience symlink
-    # `bazel-testlogs` doesn't exist on CI (--noexperimental_convenience_symlinks),
-    # so we reconstruct the absolute path from `localExecRoot` and the
-    # configuration's BINDIR.
     test_action: dict[str, tuple[str, str]] = {}
-    local_exec_root: str | None = None
-    config_testlogs: dict[str, Path] = {}
+    ctx = _BepContext()
 
     with open(bep_path) as fh:
         for line in fh:
@@ -170,17 +193,9 @@ def _bazel_test_funcs_from_bep(bep_path: Path) -> dict[str, set[str]]:
                 continue
             event = json.loads(line)
             eid = event.get("id", {})
-            if "workspace" in eid:
-                local_exec_root = event.get("workspaceInfo", {}).get("localExecRoot")
-            elif "configuration" in eid:
-                cfg_id = eid["configuration"].get("id", "")
-                bindir = event.get("configuration", {}).get("makeVariable", {}).get("BINDIR", "")
-                # BINDIR is "bazel-out/<config-mnemonic>/bin"; testlogs lives
-                # alongside as "bazel-out/<config-mnemonic>/testlogs".
-                bindir_path = Path(bindir)
-                if bindir_path.name == "bin":
-                    config_testlogs[cfg_id] = bindir_path.parent / "testlogs"
-            elif "targetConfigured" in eid:
+            if ctx.observe(eid, event):
+                continue
+            if "targetConfigured" in eid:
                 label = eid["targetConfigured"].get("label", "")
                 cfg = event.get("configured", {})
                 if cfg.get("targetKind") != "go_test rule":
@@ -201,7 +216,7 @@ def _bazel_test_funcs_from_bep(bep_path: Path) -> dict[str, set[str]]:
         if label not in test_action:
             continue
         uri, cfg_id = test_action[label]
-        funcs = _test_xml_funcs(_test_xml_candidates(label, uri, cfg_id, local_exec_root, config_testlogs))
+        funcs = _test_xml_funcs(_test_xml_candidates(label, uri, cfg_id, ctx.local_exec_root, ctx.config_testlogs))
         covered.setdefault(_label_to_import_path(label), set()).update(funcs)
 
     return covered
@@ -305,8 +320,10 @@ def _parse_bep(bep_path: Path) -> tuple[list[Path], dict[str, bool]]:
     produced by this specific invocation, and cache_status maps import_path →
     was_cached.
     """
-    xml_paths: list[Path] = []
+    ctx = _BepContext()
+    test_action: dict[str, list[tuple[str, str]]] = {}
     cache_status: dict[str, bool] = {}
+
     with bep_path.open() as f:
         for line in f:
             line = line.strip()
@@ -316,20 +333,29 @@ def _parse_bep(bep_path: Path) -> tuple[list[Path], dict[str, bool]]:
                 event = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            tr = event.get("testResult")
-            if not tr:
+            eid = event.get("id", {})
+            if ctx.observe(eid, event):
                 continue
-            label = event.get("id", {}).get("testResult", {}).get("label", "")
-            if not label:
-                continue
-            import_path = _label_to_import_path(label)
-            cached = bool(tr.get("cachedLocally") or tr.get("executionInfo", {}).get("cachedRemotely"))
-            cache_status[import_path] = cached
-            for output in tr.get("testActionOutput", []):
-                if output.get("name") == "test.xml":
-                    uri = output.get("uri", "")
-                    if uri.startswith("file://"):
-                        xml_paths.append(Path(uri[len("file://") :]))
+            match eid:
+                case {"testResult": {"label": label}} if label:
+                    tr = event.get("testResult", {})
+                    import_path = _label_to_import_path(label)
+                    cache_status[import_path] = bool(
+                        tr.get("cachedLocally") or tr.get("executionInfo", {}).get("cachedRemotely")
+                    )
+                    cfg_id = eid["testResult"].get("configuration", {}).get("id", "")
+                    for output in tr.get("testActionOutput", []):
+                        if output.get("name") == "test.xml":
+                            test_action.setdefault(label, []).append((output.get("uri", ""), cfg_id))
+                            break
+
+    xml_paths: list[Path] = []
+    for label, actions in test_action.items():
+        for uri, cfg_id in actions:
+            for candidate in _test_xml_candidates(label, uri, cfg_id, ctx.local_exec_root, ctx.config_testlogs):
+                if candidate.is_file():
+                    xml_paths.append(candidate)
+                    break
     return xml_paths, cache_status
 
 

--- a/tasks/unit_tests/bazel_tests.py
+++ b/tasks/unit_tests/bazel_tests.py
@@ -11,6 +11,7 @@ from tasks.bazel import (
     _go_test_packages,
     _is_gotestsum_shaped,
     _label_to_import_path,
+    _parse_bep,
     _test_xml_candidates,
     _test_xml_funcs,
 )
@@ -116,6 +117,119 @@ class TestIsGotestsumShaped(unittest.TestCase):
 
 def _bep_line(event: dict) -> str:
     return json.dumps(event) + "\n"
+
+
+class TestParseBep(unittest.TestCase):
+    def test_reconstructs_cached_result_via_testlogs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            exec_root = Path(tmpdir) / "exec_root"
+            reconstructed = exec_root / "bazel-out/k8-fastbuild/testlogs/pkg/foo/foo_test/test.xml"
+            reconstructed.parent.mkdir(parents=True)
+            reconstructed.write_text(_JUNIT_XML)
+
+            bep_path = Path(tmpdir) / "bep.json"
+            bep_path.write_text(
+                "".join(
+                    [
+                        _bep_line({"id": {"workspace": {}}, "workspaceInfo": {"localExecRoot": str(exec_root)}}),
+                        _bep_line(
+                            {
+                                "id": {"configuration": {"id": "cfg1"}},
+                                "configuration": {"makeVariable": {"BINDIR": "bazel-out/k8-fastbuild/bin"}},
+                            }
+                        ),
+                        _bep_line(
+                            {
+                                "id": {"testResult": {"label": "//pkg/foo:foo_test", "configuration": {"id": "cfg1"}}},
+                                "testResult": {
+                                    "cachedLocally": True,
+                                    "testActionOutput": [
+                                        {"name": "test.xml", "uri": "bytestream://example/blobs/abc/123"}
+                                    ],
+                                },
+                            }
+                        ),
+                    ]
+                )
+            )
+
+            xml_paths, cache_status = _parse_bep(bep_path)
+            self.assertEqual(xml_paths, [reconstructed])
+            self.assertEqual(cache_status, {f"{_IMPORT_PREFIX}/pkg/foo": True})
+
+    def test_local_result_not_duplicated_via_reconstructed_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            exec_root = Path(tmpdir) / "exec_root"
+            reconstructed = exec_root / "bazel-out/k8-fastbuild/testlogs/pkg/foo/foo_test/test.xml"
+            reconstructed.parent.mkdir(parents=True)
+            reconstructed.write_text(_JUNIT_XML)
+            # The file:// URI Bazel reports for a local (non-cached) action
+            # points at the same underlying file as the reconstructed path.
+            file_uri_path = reconstructed
+
+            bep_path = Path(tmpdir) / "bep.json"
+            bep_path.write_text(
+                "".join(
+                    [
+                        _bep_line({"id": {"workspace": {}}, "workspaceInfo": {"localExecRoot": str(exec_root)}}),
+                        _bep_line(
+                            {
+                                "id": {"configuration": {"id": "cfg1"}},
+                                "configuration": {"makeVariable": {"BINDIR": "bazel-out/k8-fastbuild/bin"}},
+                            }
+                        ),
+                        _bep_line(
+                            {
+                                "id": {"testResult": {"label": "//pkg/foo:foo_test", "configuration": {"id": "cfg1"}}},
+                                "testResult": {
+                                    "testActionOutput": [{"name": "test.xml", "uri": file_uri_path.as_uri()}]
+                                },
+                            }
+                        ),
+                    ]
+                )
+            )
+
+            xml_paths, _ = _parse_bep(bep_path)
+            self.assertEqual(xml_paths, [file_uri_path])
+
+    def test_repeated_test_result_for_same_label_all_kept(self):
+        # A sharded or retried target reports multiple testResult events for
+        # the same label, each with its own test.xml; none should be dropped.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            first = Path(tmpdir) / "shard_0.xml"
+            second = Path(tmpdir) / "shard_1.xml"
+            first.write_text(_JUNIT_XML)
+            second.write_text(_JUNIT_XML)
+
+            bep_path = Path(tmpdir) / "bep.json"
+            bep_path.write_text(
+                "".join(
+                    [
+                        _bep_line(
+                            {
+                                "id": {"testResult": {"label": "//pkg/foo:foo_test", "configuration": {"id": "cfg1"}}},
+                                "testResult": {"testActionOutput": [{"name": "test.xml", "uri": first.as_uri()}]},
+                            }
+                        ),
+                        _bep_line(
+                            {
+                                "id": {"testResult": {"label": "//pkg/foo:foo_test", "configuration": {"id": "cfg1"}}},
+                                "testResult": {"testActionOutput": [{"name": "test.xml", "uri": second.as_uri()}]},
+                            }
+                        ),
+                    ]
+                )
+            )
+
+            xml_paths, _ = _parse_bep(bep_path)
+            self.assertEqual(sorted(xml_paths), sorted([first, second]))
+
+    def test_no_test_result_events_produces_nothing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bep_path = Path(tmpdir) / "bep.json"
+            bep_path.write_text(_bep_line({"id": {"workspace": {}}, "workspaceInfo": {"localExecRoot": "/exec/root"}}))
+            self.assertEqual(_parse_bep(bep_path), ([], {}))
 
 
 class TestBazelTestFuncsFromBep(unittest.TestCase):


### PR DESCRIPTION
### What does this PR do?
`_parse_bep` (in `tasks/bazel.py`, used by `bazel.collect-junit`) now resolves cached (`bytestream://`) test results by reusing `_test_xml_candidates`, instead of only following `file://` BEP URIs.

### Motivation
When a Bazel test result is served from the remote cache, its BEP `test.xml` URI is `bytestream://` rather than `file://`. `_parse_bep` only ever accepted `file://` URIs, so cached results were silently dropped from the JUnit report — even though Bazel still materializes the file on disk under `<localExecRoot>/<testlogs-dir>/<label>/test.xml`, which `_test_xml_candidates` (already used by `ensure-test-parity`) knows how to reconstruct.

### Describe how you validated your changes
- Added unit tests for `_parse_bep` (cached-result reconstruction, no duplicate merging of local results, sharded/retried targets not dropped)

### Additional Notes
Split out of #53980 — unrelated bug found while fixing that one.