### PR TITLE
Stop macOS jobs from prefetching Linux-built Go caches

### DIFF
--- a/.gitlab/.pre/common/macos.yml
+++ b/.gitlab/.pre/common/macos.yml
@@ -76,7 +76,7 @@
 
 .macos_gitlab:
   extends: [".bazel:defs:cache:macos"]
-  needs: ["go_deps", "go_tools_deps"]
+  needs: []
   id_tokens:
     CI_IDENTITIES_GITLAB_ID_TOKEN:
       aud: ci-identities
@@ -95,6 +95,4 @@
     # See there is no virtualization, we need to clean the environment regularly
     - !reference [.macos_runner_maintenance]
     - export GOCACHE="$TMPDIR/go-build"
-    - !reference [.retrieve_linux_go_deps]
-    - !reference [.retrieve_linux_go_tools_deps]
     - dda inv -- -e install-tools --verbose

--- a/.gitlab/.pre/common/macos.yml
+++ b/.gitlab/.pre/common/macos.yml
@@ -76,7 +76,7 @@
 
 .macos_gitlab:
   extends: [".bazel:defs:cache:macos"]
-  needs: []
+  needs: ["setup_agent_version"]
   id_tokens:
     CI_IDENTITIES_GITLAB_ID_TOKEN:
       aud: ci-identities

--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -1,6 +1,3 @@
-include:
-  - .gitlab/.pre/common/macos.yml
-
 .bazel:test:
   stage: source_test
   needs:
@@ -98,7 +95,6 @@ bazel:test:windows-amd64:
   extends: .bazel:test:flavor
   script:
     - !reference [.install_python_dependencies]
-    - !reference [.macos_setup_go]
     - !reference [.bazel:test:flavor, script]
   after_script:
     - !reference [.install_python_dependencies]

--- a/.gitlab/build/binary_build/schema_generation.yml
+++ b/.gitlab/build/binary_build/schema_generation.yml
@@ -1,7 +1,4 @@
 ---
-include:
-  - .gitlab/.pre/common/macos.yml
-
 .on_schema_paths_changed:
   - changes:
       paths:
@@ -57,7 +54,7 @@ generate_config_schema-macos:
     KUBERNETES_MEMORY_LIMIT: 16Gi
     TEST_OUTPUT_FILE: test_output
   tags: ["macos:sonoma-amd64", "specific:true"]
-  needs: ["go_deps", "go_tools_deps"]
+  needs: []
   script:
     - dda inv -- -e agent.build
     - dda inv -- schema.generate --agent-bin=./bin/agent/agent

--- a/.gitlab/build/binary_build/schema_generation.yml
+++ b/.gitlab/build/binary_build/schema_generation.yml
@@ -54,7 +54,6 @@ generate_config_schema-macos:
     KUBERNETES_MEMORY_LIMIT: 16Gi
     TEST_OUTPUT_FILE: test_output
   tags: ["macos:sonoma-amd64", "specific:true"]
-  needs: []
   script:
     - dda inv -- -e agent.build
     - dda inv -- schema.generate --agent-bin=./bin/agent/agent

--- a/.gitlab/build/lint/macos.yml
+++ b/.gitlab/build/lint/macos.yml
@@ -1,7 +1,4 @@
 ---
-include:
-  - .gitlab/.pre/common/macos.yml
-
 .lint_macos_gitlab:
   stage: lint
   extends: .macos_gitlab

--- a/.gitlab/build/package_build/dmg.yml
+++ b/.gitlab/build/package_build/dmg.yml
@@ -25,7 +25,7 @@
 .agent_dmg:
   extends: .bazel:defs:cache:macos
   stage: package_build
-  needs: ["go_deps", "go_mod_tidy_check"]
+  needs: ["go_mod_tidy_check"]
   rules:
      - if: $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
        variables:
@@ -71,7 +71,7 @@
     # List Python and Go existing environments and their disk space
     - !reference [.macos_runner_maintenance]
     - !reference [.macos_setup_cache]
-    - !reference [.retrieve_linux_go_deps]
+    - !reference [.sanitize_goproxy]
     - bash .gitlab/build/package_build/build_agent_dmg.sh
     - !reference [.upload_sbom_artifacts]
 

--- a/.gitlab/build/source_test/macos.yml
+++ b/.gitlab/build/source_test/macos.yml
@@ -1,7 +1,4 @@
 ---
-include:
-  - .gitlab/.pre/common/macos.yml
-
 .tests_macos_gitlab:
   stage: source_test
   extends:

--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -4,7 +4,6 @@ import json
 import os
 import platform
 import re
-import subprocess
 import sys
 import tempfile
 import xml.etree.ElementTree as ET
@@ -15,9 +14,9 @@ from invoke import task
 
 from tasks.build_tags import compute_build_tags_for_flavor
 from tasks.flavor import AgentFlavor
+from tasks.libs.build.bazel import bazel
 from tasks.libs.common.gomodules import AGENT_MODULE_PATH_PREFIX
 
-REPO_ROOT = Path(__file__).parent.parent
 # Top-level Test* declarations in Go source files — Go side of the parity comparison.
 _TEST_FUNC_RE = re.compile(r'^func (Test\w*)\(', re.MULTILINE)
 # Matches json.decoder.WHITESPACE, an undocumented/unstubbed cpython internal.
@@ -52,7 +51,7 @@ def _chunk_import_paths(import_paths: list[str]) -> list[list[str]]:
     return chunks
 
 
-def _go_test_packages(tags: list[str], import_paths: set[str]) -> dict[str, set[str]]:
+def _go_test_packages(ctx, tags: list[str], import_paths: set[str]) -> dict[str, set[str]]:
     """Return {import_path: {Test* func names}} for the given import paths
     compiled under the given build tags."""
     if not import_paths:
@@ -60,21 +59,19 @@ def _go_test_packages(tags: list[str], import_paths: set[str]) -> dict[str, set[
     pkgs: dict[str, set[str]] = {}
     decoder = json.JSONDecoder()
     for chunk in _chunk_import_paths(sorted(import_paths)):
-        # shell=False (the default value, which we still pass explicitly) is
-        # required: cmd.exe on Windows has an 8191-char command-line limit.
-        result = subprocess.run(
-            ["go", "list", "-json", "-e", f"-tags={','.join(sorted(tags))}", *chunk],
-            cwd=REPO_ROOT,
+        text = bazel(
+            ctx,
+            "run",
+            "//:go",
+            "--",
+            "list",
+            "-json",
+            "-e",
+            f"-tags={','.join(sorted(tags))}",
+            *chunk,
             capture_output=True,
-            text=True,
-            encoding="utf-8",
-            shell=False,
         )
-        if result.returncode != 0:
-            # -e reports per-package errors inside the JSON output without failing the
-            # command; a non-zero exit means `go list` itself failed to run at all.
-            raise ChildProcessError(f"go list failed with exit code {result.returncode}: {result.stderr}")
-        text, pos = result.stdout, 0
+        pos = 0
         while pos < len(text):
             pos = _JSON_WHITESPACE_RE.match(text, pos).end()
             if pos >= len(text):
@@ -271,7 +268,7 @@ def ensure_test_parity(ctx, bep, flavor_name, verbose=False, emit_metrics=False)
     # by `!race` must be excluded from the expected test set too.
     tags = [*compute_build_tags_for_flavor("unit-tests", None, None, flavor), "race"]
     coverage = _bazel_test_funcs_from_bep(bep_path)
-    test_pkgs = _go_test_packages(tags, set(coverage))
+    test_pkgs = _go_test_packages(ctx, tags, set(coverage))
 
     go_pkgs = set(test_pkgs)
     extra_in_bazel = {p for p, funcs in coverage.items() if funcs} - go_pkgs

--- a/tasks/unit_tests/bazel_tests.py
+++ b/tasks/unit_tests/bazel_tests.py
@@ -1,10 +1,9 @@
 import json
-import subprocess
 import tempfile
 import unittest
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from tasks.bazel import (
     _IMPORT_PREFIX,
@@ -176,16 +175,15 @@ class TestBazelTestFuncsFromBep(unittest.TestCase):
 
 
 class TestGoTestPackages(unittest.TestCase):
-    def test_empty_import_paths_skips_subprocess(self):
-        with patch("tasks.bazel.subprocess.run") as mock_run:
-            self.assertEqual(_go_test_packages(["race"], set()), {})
-            mock_run.assert_not_called()
+    def test_empty_import_paths_skips_bazel(self):
+        with patch("tasks.bazel.bazel") as mock_bazel:
+            self.assertEqual(_go_test_packages(MagicMock(), ["race"], set()), {})
+            mock_bazel.assert_not_called()
 
-    def test_nonzero_returncode_raises(self):
-        with patch("tasks.bazel.subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
-            with self.assertRaises(ChildProcessError):
-                _go_test_packages(["race"], {"example.com/pkg/foo"})
+    def test_bazel_failure_raises(self):
+        with patch("tasks.bazel.bazel", side_effect=RuntimeError("boom")):
+            with self.assertRaises(RuntimeError):
+                _go_test_packages(MagicMock(), ["race"], {"example.com/pkg/foo"})
 
     def test_parses_concatenated_json_and_filters_by_import_path(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -210,9 +208,8 @@ class TestGoTestPackages(unittest.TestCase):
                 ]
             )
 
-            with patch("tasks.bazel.subprocess.run") as mock_run:
-                mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
-                result = _go_test_packages(["race"], {"example.com/pkg/foo"})
+            with patch("tasks.bazel.bazel", return_value=stdout):
+                result = _go_test_packages(MagicMock(), ["race"], {"example.com/pkg/foo"})
 
             # "example.com/pkg/bar" is filtered out: not in import_paths.
             # TestMain is discarded even though it matched the Test* pattern.


### PR DESCRIPTION
### What does this PR do?
Stop macOS CI jobs from extracting Linux-built `go_deps` and `go_tools_deps` cache tarballs.

Drop the now unused `needs` on those jobs (and the `include: .pre/common/macos.yml` blocks, redundant with `.gitlab-ci.yml`'s globbing).

Make `bazel.ensure-test-parity` use Bazel's own Go toolchain instead of a bare `go` on `$PATH`, dropping its last dependency on `.macos_setup_go` for the macOS Bazel flavor jobs.

### Motivation
_tl;dr: By default, Go fetches lazily whenever a cache is incomplete or out-of-sync, e.g. `install-tools` building a tool it doesn't have cached yet at the pinned version.
Removing the eager brute-force prefetch therefore lets Go maintain its caches in an incremental way, while killing a bogus dependency._

macOS GitLab runners have no virtualization and are reused across jobs, so `$GOPATH` (aliased to the `gimme` Go SDK directory in `.macos_gitlab`) **persists on disk** between jobs for a given Go version.
Unpacking `go_tools_bin.tar.zst` planted a **Linux ELF bazelisk binary** next to the macOS toolchain whenever that step ran on a job later **interrupted before `install-tools` could rebuild it natively**.
Any later job scheduled on the same runner then inherited the wrong-OS binary and failed with ["cannot execute binary file"](https://app.datadoghq.com/logs?query=service%3Agitlab-ci%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%22cannot%20execute%20binary%20file%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2Cci.node.name&fromUser=true&index=ci-app-pipeline-logs-gitlab-datadog-agent&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1783353987332&to_ts=1784649987332&live=true) (as well as more spurious symptoms aka "cosmic bit flips"[^1]), including jobs like the DMG build that never run `install-tools` themselves.

This also surfaced that `ensure-test-parity` was shelling out to a bare `go list` and was the only reason the macOS Bazel flavor jobs (`bazel:test:macos-*:base` and `:dogstatsd`) needed `.macos_setup_go` at all: `bazel test` itself is **hermetic**, since `.bazelrc` sets `--experimental_strict_repo_env` and never whitelists `GOPROXY` nor `GOROOT` into repository rules.

Groundwork:
- [Notebook](https://app.datadoghq.com/notebook/15062298/macos-runner-data-corruption-%25E2%2580%2594-node-20862611?bits_chat_id=c856950f-5fdb-49a2-b3fa-cb70c382a512),
- [Slack thread](https://dd.slack.com/archives/C06TGQ49U1Z/p1784651710512939),
- Special thanks to @alee1246's for its finding:
```
For the cannot execute binary file error, it seems to be coming from executing bazelisk compiled for linux.

I see two versions of bazelisk on the runner,

ec2-user@ip-172-28-64-77 bin % file /Users/ec2-user/.gimme/versions/go1.26.5.darwin.amd64/bin/bazelisk
/Users/ec2-user/.gimme/versions/go1.26.5.darwin.amd64/bin/bazelisk: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, Go BuildID=TFvToPIUKhhzT2vDbcWA/JVjKTQQNRRsFwgTVwDyE/9DA638N4KuugEarzfYoE/BW0_hOyiKUYvqZzCXRV5, BuildID[sha1]=80fa8e9688cbddb3ed3bf3cfc9e5862e5ff9934a, with debug_info, not stripped


ec2-user@ip-172-28-64-77 bin % file /usr/local/bin/bazelisk
/usr/local/bin/bazelisk: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
/usr/local/bin/bazelisk (for architecture x86_64):	Mach-O 64-bit executable x86_64
/usr/local/bin/bazelisk (for architecture arm64):	Mach-O 64-bit executable arm64

The job is trying to execute the binary at /Users/ec2-user/.gimme/versions/go1.26.5.darwin.amd64/bin/bazelisk which is not compiled for macos
```

### Describe how you validated your changes
Checked a completed main pipeline's job traces:
- `go_deps`'s own artifact (`modcache.tar.zst`) is ~1.9GB: no longer downloaded and extracted per macOS job that only needed it (`agent_dmg-*`),
- `go_tools_deps`'s ~216MB (`go_tools_bin.tar.zst` + `modcache_tools.tar.zst`): that's ~2.1GB less for jobs pulling both (`generate_config_schema-macos`, `tests_macos_gitlab_*`).

In wall-clock terms (which will vary with network conditions, unlike the size above):
- jobs pulling both cost ~57-65s per job; 38-50s artifact download + 12-20s extraction,
- jobs pulling only `go_deps` cost ~34s: 23s download + 10-11s extraction.

Also verified that, with the present change:
- no further macOS-tagged job depends on `go_deps`/`go_tools_deps` artifacts,
- every consumer of the removed `.macos_setup_go` does not need a system `go` anymore.

### Additional Notes
Linux and Windows jobs are untouched here (one thing at a time), but:
- Linux: same OS, but not necessarily same architecture (`aarch64` vs `x86_64`), mitigated by the fact runners are ephemeral,
- Windows: same architecture (`X64` is Microsoft's rebranding of `x86_64`), but definitely not the same OS, and the mitigation only partially holds true, so the same problem is likely to surface there.

[^1]: "cosmic bit flips":
    - ["FATAL: zip: checksum error"](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1868261957)
    - ["Compressed data is corrupt"](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1868550677)
    - ["The signature of the binary is invalid"](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1873214779)
    - ["Buffer has checksum ... was expected"](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1874179460)
    - ["malformed LC_DYSYMTAB"](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1878315998)
