### PR TITLE
fix(trace/stats): count additional_metric_tags cardinality by tag values, not full aggregation

### DIFF
--- a/pkg/trace/stats/statsraw.go
+++ b/pkg/trace/stats/statsraw.go
@@ -140,7 +140,7 @@ type RawBucket struct {
 
 	// per-field cardinality limits and trackers (nil map = limit disabled)
 	additionalTagsCardinalityLimit int
-	additionalTagsEntries          int
+	distinctAdditionalTagHashes    map[uint64]struct{}
 	resourceCardinalityLimit       int
 	distinctResources              map[string]struct{}
 	httpEndpointCardinalityLimit   int
@@ -189,6 +189,9 @@ func NewRawBucket(ts, d uint64, limits BucketCardinalityLimits) *RawBucket {
 	}
 	if limits.Origin > 0 {
 		rb.distinctOrigins = make(map[string]struct{})
+	}
+	if limits.AdditionalTags > 0 {
+		rb.distinctAdditionalTagHashes = make(map[uint64]struct{})
 	}
 	if limits.WholeKey > 0 {
 		rb.distinctWholeKeys = make(map[BucketsAggregationKey]struct{})
@@ -289,12 +292,17 @@ func (sb *RawBucket) HandleSpan(s *StatSpan, weight float64, origin string, aggK
 		aggr.BucketsAggregationKey.Synthetics = false
 	}
 
-	// --- additional_metric_tags per-bucket cardinality cap (pre-existing logic) ---
+	// --- additional_metric_tags per-bucket cardinality cap ---
+	// The limit caps distinct additional_metric_tags *value combinations*, so
+	// distinctness is keyed on the hash of the tag values alone (like peer_tags),
+	// independent of resource/name/etc. Keying on the full aggregation would let
+	// high resource cardinality inflate this counter and collapse tags that are
+	// not themselves high-cardinality.
 	additionalMetricTags := s.matchingAdditionalMetricTags
 	if len(additionalMetricTags) > 0 && sb.additionalTagsCardinalityLimit > 0 {
-		// Only new tag-bearing aggregations are counted, before they are added below.
-		if _, exists := sb.data[aggr]; !exists {
-			if sb.additionalTagsEntries >= sb.additionalTagsCardinalityLimit {
+		h := tagsFnvHash(additionalMetricTags)
+		if _, exists := sb.distinctAdditionalTagHashes[h]; !exists {
+			if len(sb.distinctAdditionalTagHashes) >= sb.additionalTagsCardinalityLimit {
 				if !sb.warnedThisBucket {
 					log.Debugf("stats cardinality additional_metric_tags limit (%d) reached for this bucket; masking %d tag value(s)", sb.additionalTagsCardinalityLimit, len(additionalMetricTags))
 					sb.warnedThisBucket = true
@@ -307,7 +315,7 @@ func (sb *RawBucket) HandleSpan(s *StatSpan, weight float64, origin string, aggK
 				aggr.BucketsAggregationKey.AdditionalMetricTagsHash = tagsFnvHash(additionalMetricTags)
 				result.AdditionalTagsCapBlock = true
 			} else {
-				sb.additionalTagsEntries++
+				sb.distinctAdditionalTagHashes[h] = struct{}{}
 			}
 		}
 	}

--- a/pkg/trace/stats/statsraw_test.go
+++ b/pkg/trace/stats/statsraw_test.go
@@ -291,7 +291,7 @@ func TestRawBucketAdditionalMetricTagsCardinalityLimit(t *testing.T) {
 	assert.Equal(t, []string{"customer_id:a"}, spanAAgain.matchingAdditionalMetricTags)
 
 	require.Len(t, sb.data, 3)
-	assert.Equal(t, 2, sb.additionalTagsEntries)
+	assert.Len(t, sb.distinctAdditionalTagHashes, 2)
 	assert.True(t, sb.warnedThisBucket)
 
 	spanAAggr := NewAggregationFromSpan(spanA, "", aggKey)
@@ -313,6 +313,39 @@ func TestRawBucketAdditionalMetricTagsCardinalityLimit(t *testing.T) {
 	assert.Equal(t, []string{"customer_id:tracer_blocked_value"}, maskedStats.additionalMetricTags)
 }
 
+// TestRawBucketAdditionalMetricTagsCardinalityLimitIgnoresResourceCardinality
+// is a regression test: the additional_metric_tags limit must count distinct
+// tag-value combinations, not distinct full aggregations. A service with high
+// resource cardinality but a single tag-value combination must never collapse,
+// no matter how far resource count exceeds the limit.
+func TestRawBucketAdditionalMetricTagsCardinalityLimitIgnoresResourceCardinality(t *testing.T) {
+	aggKey := PayloadAggregationKey{Env: "prod", Hostname: "host"}
+	sb := NewRawBucket(0, 1e9, BucketCardinalityLimits{AdditionalTags: 2})
+
+	// 100 spans, each with a distinct resource but the SAME tag value.
+	// Distinct tag combinations = 1, well under the limit of 2.
+	const resourceCount = 100
+	for i := 0; i < resourceCount; i++ {
+		span := &StatSpan{
+			service:                      "checkout-service",
+			name:                         "checkout.process",
+			resource:                     "POST /checkout/" + strconv.Itoa(i),
+			isTopLevel:                   true,
+			duration:                     int64(time.Millisecond),
+			matchingAdditionalMetricTags: []string{"customer_id:same"},
+		}
+		res := sb.HandleSpan(span, 1, "", aggKey)
+		assert.Equal(t, SpanCollapseResult{}, res, "resource %d should not collapse additional_metric_tags", i)
+		assert.Equal(t, []string{"customer_id:same"}, span.matchingAdditionalMetricTags)
+	}
+
+	// One tag combination seen, so exactly one slot consumed and nothing masked.
+	assert.Len(t, sb.distinctAdditionalTagHashes, 1)
+	assert.False(t, sb.warnedThisBucket)
+	// Each distinct resource still produces its own aggregation.
+	require.Len(t, sb.data, resourceCount)
+}
+
 func TestRawBucketAdditionalMetricTagsCardinalityLimitDefaultNoop(t *testing.T) {
 	aggKey := PayloadAggregationKey{Env: "prod", Hostname: "host"}
 	sb := NewRawBucket(0, 1e9, BucketCardinalityLimits{})
@@ -327,7 +360,7 @@ func TestRawBucketAdditionalMetricTagsCardinalityLimitDefaultNoop(t *testing.T) 
 	}
 
 	require.Len(t, sb.data, 3)
-	assert.Zero(t, sb.additionalTagsEntries)
+	assert.Empty(t, sb.distinctAdditionalTagHashes)
 	assert.False(t, sb.warnedThisBucket)
 	assert.Equal(t, []string{"customer_id:c"}, spans[2].matchingAdditionalMetricTags)
 }
@@ -365,9 +398,9 @@ func TestSpanConcentratorAdditionalMetricTagsCardinalityLimitResetsPerBucket(t *
 	secondBucket, ok := sc.buckets[bsize]
 	require.True(t, ok)
 
-	assert.Equal(t, 1, firstBucket.additionalTagsEntries)
+	assert.Len(t, firstBucket.distinctAdditionalTagHashes, 1)
 	assert.True(t, firstBucket.warnedThisBucket)
-	assert.Equal(t, 1, secondBucket.additionalTagsEntries)
+	assert.Len(t, secondBucket.distinctAdditionalTagHashes, 1)
 	assert.True(t, secondBucket.warnedThisBucket)
 	assert.Equal(t, BlockCounts{CapBlocks: 2}, sc.DrainBlockCounts())
 	assert.Equal(t, BlockCounts{}, sc.DrainBlockCounts())


### PR DESCRIPTION
### What does this PR do?

Fixes how the `additional_metric_tags` per-bucket cardinality limit counts entries. It now counts distinct **tag-value combinations** (keyed on the FNV hash of the tag values), instead of distinct **full aggregation keys**.

### Motivation

The `additional_metric_tags` cardinality limit exists to cap how many unique tag-value combinations (e.g. `priority:high,availability:us-east`) can appear in a stats bucket, protecting the backend against high-cardinality *tag values*.

But the counter was incremented once per new full aggregation:

```go
// before — aggr includes resource, name, http_endpoint, ... AND the tag hash
if _, exists := sb.data[aggr]; !exists {
    if sb.additionalTagsEntries >= sb.additionalTagsCardinalityLimit { ...mask... }
    else { sb.additionalTagsEntries++ }
}
```

Because `aggr` (`NewAggregationFromSpan`) includes `Resource`, resource cardinality leaked directly into the tag-value cap. A service with **high resource cardinality** — lots of unique SQL queries, route patterns, etc. — pairs each new resource with even the same tag values and counts it as a new entry.

**Concrete failure:** a service with 1000 unique resources and only 5 distinct `priority` values blows past a 100-entry cap almost immediately. `additional_metric_tags` gets collapsed to `tracer_blocked_value` not because the tags are high-cardinality, but because the *resources* are.

The sibling `peer_tags` limit already does this correctly — it keys distinctness on `tagsFnvHash(tags)` via `distinctPeerTagHashes`. This change makes `additional_metric_tags` follow the same pattern:

```go
// after — keyed on the tag-value hash alone, resource-independent
h := tagsFnvHash(additionalMetricTags)
if _, exists := sb.distinctAdditionalTagHashes[h]; !exists {
    if len(sb.distinctAdditionalTagHashes) >= sb.additionalTagsCardinalityLimit { ...mask... }
    else { sb.distinctAdditionalTagHashes[h] = struct{}{} }
}
```

The masking/collapse behavior and the overflow-bucket semantics are unchanged; only the counting key changes.

### Describe how you validated your changes

- Updated the three existing tests that asserted on the removed `additionalTagsEntries` counter to assert on `len(distinctAdditionalTagHashes)`. They hold resource constant and still pass unchanged, confirming the fix preserves behavior when only tag values vary.
- Added `TestRawBucketAdditionalMetricTagsCardinalityLimitIgnoresResourceCardinality`: feeds 100 spans with 100 distinct resources but a single shared tag value under a limit of 2, and asserts **no collapse** occurs (1 distinct tag hash, 100 aggregations, no warning). This test fails on the old logic and passes on the new.
- Full `pkg/trace/stats` package test suite passes (`GOTOOLCHAIN=local GOWORK=off go test .`).

### Additional Notes

**dd-trace-go impact:** none in terms of code. The counting logic lives entirely in `pkg/trace/stats`; the Go tracer only passes `AdditionalMetricTagKeys` and reads `DrainBlockCounts`. The tracer picks this up via a normal `datadog-agent` dependency bump once released. The existing dd-trace-go test for this limit holds resource constant, so it neither hit the bug nor breaks with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)