### PR TITLE
Remove CODEOWNERS for fakeintake VERSION

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -911,6 +911,7 @@
 /test/e2e-framework/components/datadog/otel-standalone/ @DataDog/opentelemetry-agent
 /test/e2e-framework/components/windows/                @DataDog/windows-products
 /test/fakeintake/                              @DataDog/agent-devx
+/test/fakeintake/version/VERSION               # do not notify anyone
 /test/fakeintake/aggregator/ndmAggregator.go @DataDog/network-device-monitoring-core
 /test/fakeintake/aggregator/ndmAggregator_test.go @DataDog/network-device-monitoring-core
 /test/fakeintake/aggregator/ndmflowAggregator.go @DataDog/ndm-integrations


### PR DESCRIPTION
<!-- dd-meta {"pullId":"c81a1c5d-07ac-48c8-8f0d-9619c4513a54","source":"chat","resourceId":"8d310701-e667-4374-ab35-de2d1ed8417c","workflowId":"66abc566-f8e2-4093-ab34-038bf246a928","codeChangeId":"66abc566-f8e2-4093-ab34-038bf246a928","sourceType":"slack"} -->
### What does this PR do?

Removes ownership of `test/fakeintake/version/VERSION` in CODEOWNERS so that bumping this file no longer triggers a review request from `@DataDog/agent-devx`.

### Motivation

The fakeintake is now versioned, and the `dd-gitlab/fakeintake_check_version_bump` CI job enforces that `test/fakeintake/version/VERSION` is updated when the fakeintake `go.mod` changes. However, since `/test/fakeintake/` is owned by `@DataDog/agent-devx`, every PR that bumps agent-payload or other dependencies touching fakeintake's `go.mod` also requests a review from `agent-devx` just for the VERSION file bump — adding unnecessary review overhead.

This follows the same pattern used for `go.mod` files, which are explicitly unowned with `# do not notify anyone` to avoid pulling teams into every dependency update. The CI job remains in place to enforce correctness.

### Describe how you validated your changes

CODEOWNERS syntax verified — the more specific path `/test/fakeintake/version/VERSION` overrides the parent `/test/fakeintake/` rule, matching GitHub's last-matching-pattern semantics.

### Additional Notes

Context: https://github.com/DataDog/datadog-agent/pull/54002 and related Slack discussion.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/8d310701-e667-4374-ab35-de2d1ed8417c)

Comment @datadog to request changes