### PR TITLE
Update renovate config to try to enforce minimulReleaseAge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,8 @@
     "updateNotScheduled": false,
     "ignorePaths": [],
     "minimumReleaseAge": "7 days",
+    "internalChecksFilter": "strict",
+    "prCreation": "not-pending",
     "prConcurrentLimit": 20,
     "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
     "stopUpdatingLabel": "stop-updating",


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

After https://github.com/DataDog/datadog-agent/pull/53959 updating a dependency that was less than 7 days old we want to be more explicit in Renovate config:
```
    "internalChecksFilter": "strict",
```
should already be the default but better make it explicit.
```
    "prCreation": "not-pending",
```
that one could solve the issue we observed, by making sure the PR pending because not passing the minimulReleaseAge are not opened. Opening those PRs is likely to lead them to being merged because we rely on another tool than renovate to auto-merge PR.

Those settings are recommended here: https://docs.renovatebot.com/configuration-options/#await-x-time-duration-before-automerging

### Motivation

### Describe how you validated your changes

### Additional Notes
