### PR TITLE
Temporarily raise idle_all_features memory quality gate to 512 MiB

### DIFF
--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -10,7 +10,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 30% higher than the memory_usage check value
-  memory_allotment: 644 MiB
+  memory_allotment: 666 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -64,7 +64,7 @@ checks:
       #
       # When updating this, update the memory_allotment in the target section to
       # 30% higher
-      upper_bound: "495 MiB"
+      upper_bound: "512 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."


### PR DESCRIPTION
The `quality_gate_idle_all_features` memory bound is set to 495 MiB, but last night's run used 505.83 MiB. Without headroom, this will incorrectly flag unrelated PRs as regressions.

This increase is a temporary workaround. We will follow up with optimizations and fixes to reduce it or document it as a known and necessary increase.

## Change

- `upper_bound`: 495 MiB -> 512 MiB (1% + 1 MiB headroom over 505.83 MiB, rounded up)
- `memory_allotment`: 644 MiB -> 666 MiB (30% above the new bound)