### PR TITLE
[NDINT-677] [Agent] Add support for all error codes / scenarios 

### DIFF
--- a/comp/networkconfigmanagement/def/BUILD.bazel
+++ b/comp/networkconfigmanagement/def/BUILD.bazel
@@ -9,5 +9,6 @@ go_library(
         "//pkg/aggregator/sender",
         "//pkg/networkconfigmanagement/config",
         "//pkg/networkconfigmanagement/remote",
+        "//pkg/networkconfigmanagement/types",
     ],
 )

--- a/comp/networkconfigmanagement/def/BUILD.bazel
+++ b/comp/networkconfigmanagement/def/BUILD.bazel
@@ -8,5 +8,6 @@ go_library(
     deps = [
         "//pkg/aggregator/sender",
         "//pkg/networkconfigmanagement/config",
+        "//pkg/networkconfigmanagement/remote",
     ],
 )

--- a/comp/networkconfigmanagement/def/BUILD.bazel
+++ b/comp/networkconfigmanagement/def/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/aggregator/sender",
         "//pkg/networkconfigmanagement/config",
-        "//pkg/networkconfigmanagement/remote",
         "//pkg/networkconfigmanagement/types",
     ],
 )

--- a/comp/networkconfigmanagement/def/component.go
+++ b/comp/networkconfigmanagement/def/component.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/config"
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/remote"
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 )
 
 // Component is the component type.
@@ -28,7 +29,7 @@ type Component interface {
 	ReportConfig(ctx context.Context, deviceID string, sender sender.Sender) error
 	// RollbackConfig rolls back a device to a previous configuration that's
 	// saved locally on this agent.
-	RollbackConfig(ctx context.Context, deviceID string, configVersion string, hash string) (*remote.PushResult, error)
+	RollbackConfig(ctx context.Context, deviceID string, configVersion string, hash string) (*remote.PushResult, types.RollbackError)
 	// SetMaxReportInterval sets a maximum time to wait between sending
 	// inventory reports.
 	SetMaxReportInterval(interval time.Duration)

--- a/comp/networkconfigmanagement/def/component.go
+++ b/comp/networkconfigmanagement/def/component.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/config"
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/remote"
 )
 
 // Component is the component type.
@@ -27,7 +28,7 @@ type Component interface {
 	ReportConfig(ctx context.Context, deviceID string, sender sender.Sender) error
 	// RollbackConfig rolls back a device to a previous configuration that's
 	// saved locally on this agent.
-	RollbackConfig(ctx context.Context, deviceID string, configVersion string, hash string) error
+	RollbackConfig(ctx context.Context, deviceID string, configVersion string, hash string) (*remote.PushResult, error)
 	// SetMaxReportInterval sets a maximum time to wait between sending
 	// inventory reports.
 	SetMaxReportInterval(interval time.Duration)

--- a/comp/networkconfigmanagement/def/component.go
+++ b/comp/networkconfigmanagement/def/component.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/config"
-	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/remote"
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 )
 
@@ -29,7 +28,7 @@ type Component interface {
 	ReportConfig(ctx context.Context, deviceID string, sender sender.Sender) error
 	// RollbackConfig rolls back a device to a previous configuration that's
 	// saved locally on this agent.
-	RollbackConfig(ctx context.Context, deviceID string, configVersion string, hash string) (*remote.PushResult, types.RollbackError)
+	RollbackConfig(ctx context.Context, deviceID string, configVersion string, hash string) (*types.PushResult, types.RollbackError)
 	// SetMaxReportInterval sets a maximum time to wait between sending
 	// inventory reports.
 	SetMaxReportInterval(interval time.Duration)

--- a/comp/networkconfigmanagement/impl/BUILD.bazel
+++ b/comp/networkconfigmanagement/impl/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "networkdeviceconfig.go",
         "newcomponent.go",
         "newcomponent_stub.go",
+        "rollback.go",
         "rollback_endpoint.go",
         "store_endpoint.go",
         "types.go",

--- a/comp/networkconfigmanagement/impl/BUILD.bazel
+++ b/comp/networkconfigmanagement/impl/BUILD.bazel
@@ -61,6 +61,7 @@ dd_agent_go_test(
         "//pkg/networkconfigmanagement/remote",
         "//pkg/networkconfigmanagement/report",
         "//pkg/networkconfigmanagement/store",
+        "//pkg/networkconfigmanagement/types",
         "//pkg/networkdevice/integrations",
         "//pkg/networkdevice/metadata",
         "//pkg/util/cache",

--- a/comp/networkconfigmanagement/impl/devicemap.go
+++ b/comp/networkconfigmanagement/impl/devicemap.go
@@ -12,15 +12,23 @@ import (
 
 	ncmconfig "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/config"
 	ncmprofile "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/profile"
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 )
 
 type UnknownDeviceError struct {
 	deviceID string
 }
 
+// Type implements [types.RollbackError].
+func (u *UnknownDeviceError) Type() types.ErrorType {
+	return types.ErrNoSuchDevice
+}
+
 func (u *UnknownDeviceError) Error() string {
 	return fmt.Sprintf("unknown device: %q", u.deviceID)
 }
+
+var _ types.RollbackError = (*UnknownDeviceError)(nil)
 
 // DeviceMap wraps a sync.Map of DeviceContexts to streamline the process of
 // fetching and locking them.

--- a/comp/networkconfigmanagement/impl/devicemap.go
+++ b/comp/networkconfigmanagement/impl/devicemap.go
@@ -14,6 +14,14 @@ import (
 	ncmprofile "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/profile"
 )
 
+type UnknownDeviceError struct {
+	deviceID string
+}
+
+func (u *UnknownDeviceError) Error() string {
+	return fmt.Sprintf("unknown device: %q", u.deviceID)
+}
+
 // DeviceMap wraps a sync.Map of DeviceContexts to streamline the process of
 // fetching and locking them.
 type DeviceMap struct {
@@ -47,14 +55,19 @@ func (d *DeviceMap) RegisterDevice(ctx context.Context, device *ncmconfig.Device
 	return dc.Unlock()
 }
 
+// Get fetches a DeviceContext, or returns an UnknownDeviceError.
 func (d *DeviceMap) Get(deviceID string) (*DeviceContext, error) {
 	dc, ok := d.devices.Load(deviceID)
 	if !ok {
-		return nil, fmt.Errorf("unknown device: %q", deviceID)
+		return nil, &UnknownDeviceError{deviceID}
 	}
 	return dc, nil
 }
 
+// GetAndLock fetches a DeviceContext and locks it. It can return
+// UnknownDeviceError, if the deviceID isn't recognized, or
+// DeadlineExceeded/Canceled if the context terminatesj while waiting for the
+// lock.
 func (d *DeviceMap) GetAndLock(ctx context.Context, deviceID string) (*DeviceContext, error) {
 	dc, err := d.Get(deviceID)
 	if err != nil {

--- a/comp/networkconfigmanagement/impl/devicemap_test.go
+++ b/comp/networkconfigmanagement/impl/devicemap_test.go
@@ -41,14 +41,14 @@ func TestDeviceMap_Get_Unknown(t *testing.T) {
 	dm := NewDeviceMap(time.Millisecond)
 
 	_, err := dm.Get("nonexistent")
-	assert.ErrorContains(t, err, "unknown device")
+	assert.ErrorIs(t, err, &UnknownDeviceError{})
 }
 
 func TestDeviceMap_GetAndLock_Unknown(t *testing.T) {
 	dm := NewDeviceMap(time.Millisecond)
 
 	_, err := dm.GetAndLock(t.Context(), "nonexistent")
-	assert.ErrorContains(t, err, "unknown device")
+	assert.ErrorIs(t, err, &UnknownDeviceError{})
 }
 
 func TestDeviceMap_GetAndLock_LocksDevice(t *testing.T) {

--- a/comp/networkconfigmanagement/impl/devicemap_test.go
+++ b/comp/networkconfigmanagement/impl/devicemap_test.go
@@ -41,14 +41,14 @@ func TestDeviceMap_Get_Unknown(t *testing.T) {
 	dm := NewDeviceMap(time.Millisecond)
 
 	_, err := dm.Get("nonexistent")
-	assert.ErrorIs(t, err, &UnknownDeviceError{})
+	assert.ErrorAs(t, err, &UnknownDeviceError{})
 }
 
 func TestDeviceMap_GetAndLock_Unknown(t *testing.T) {
 	dm := NewDeviceMap(time.Millisecond)
 
 	_, err := dm.GetAndLock(t.Context(), "nonexistent")
-	assert.ErrorIs(t, err, &UnknownDeviceError{})
+	assert.ErrorAs(t, err, &UnknownDeviceError{})
 }
 
 func TestDeviceMap_GetAndLock_LocksDevice(t *testing.T) {

--- a/comp/networkconfigmanagement/impl/devicemap_test.go
+++ b/comp/networkconfigmanagement/impl/devicemap_test.go
@@ -7,6 +7,7 @@ package networkconfigmanagementimpl
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -15,6 +16,12 @@ import (
 
 	ncmprofile "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/profile"
 )
+
+func assertErrorAsType[T error](t testing.TB, err error) bool {
+	_, ok := errors.AsType[T](err)
+	var someT T
+	return assert.True(t, ok, "expected %v to have type %T", err, someT)
+}
 
 func TestDeviceMap(t *testing.T) {
 	dm := NewDeviceMap(time.Millisecond)
@@ -41,14 +48,14 @@ func TestDeviceMap_Get_Unknown(t *testing.T) {
 	dm := NewDeviceMap(time.Millisecond)
 
 	_, err := dm.Get("nonexistent")
-	assert.ErrorAs(t, err, &UnknownDeviceError{})
+	assertErrorAsType[*UnknownDeviceError](t, err)
 }
 
 func TestDeviceMap_GetAndLock_Unknown(t *testing.T) {
 	dm := NewDeviceMap(time.Millisecond)
 
 	_, err := dm.GetAndLock(t.Context(), "nonexistent")
-	assert.ErrorAs(t, err, &UnknownDeviceError{})
+	assertErrorAsType[*UnknownDeviceError](t, err)
 }
 
 func TestDeviceMap_GetAndLock_LocksDevice(t *testing.T) {

--- a/comp/networkconfigmanagement/impl/getconfigs.go
+++ b/comp/networkconfigmanagement/impl/getconfigs.go
@@ -36,7 +36,7 @@ func retrieveAndStoreConfig(ctx context.Context, dc *DeviceContext, conn ncmremo
 	}
 
 	deviceID := dc.device.DeviceID()
-	result, err := dc.profile.ProcessConfig(rawConfig)
+	result, err := dc.profile.ProcessConfig([]byte(rawConfig.Output))
 	if err != nil {
 		return nil, false, fmt.Errorf("unable to process rules for %s config for device %s: %s", mode, deviceID, err)
 	}

--- a/comp/networkconfigmanagement/impl/networkdeviceconfig.go
+++ b/comp/networkconfigmanagement/impl/networkdeviceconfig.go
@@ -195,54 +195,6 @@ func (n *networkDeviceConfigImpl) buildInventoryReport() ([]ncmreport.InventoryE
 	return entries, nil
 }
 
-// RollbackConfig rolls back a device to a previous configuration that's
-// saved locally on this agent.
-func (n *networkDeviceConfigImpl) RollbackConfig(ctx context.Context, deviceID string, configVersion string, hash string) error {
-	if n.store == nil {
-		return errors.New("rollback is disabled")
-	}
-	var log log.Component = NewLogWrapper(n.log, fmt.Sprintf("ncm[%s]: ", deviceID))
-	log.Infof("Rollback requested: Device %q to version %q", deviceID, configVersion)
-	ctx = WithLogger(ctx, log)
-	dc, err := n.devices.GetAndLock(ctx, deviceID)
-	if err != nil {
-		return err
-	}
-	defer dc.UnlockOrLog(log)
-
-	rawConfig, metadata, err := n.store.GetConfig(configVersion)
-	if err != nil {
-		return err
-	}
-	if metadata.DeviceID != deviceID {
-		return fmt.Errorf("input mismatch: config %q is not for device %q", configVersion, deviceID)
-	}
-
-	expectedHash := ncmstore.HashConfig(rawConfig)
-	if expectedHash != hash {
-		return fmt.Errorf("hash mismatch for config %q", configVersion)
-	}
-
-	conn, err := n.connectAndEnsureProfile(ctx, dc)
-	if err != nil {
-		return fmt.Errorf("%v: %w", deviceID, err)
-	}
-	defer conn.Close()
-
-	_, err = conn.PushConfig(ctx, rawConfig)
-	if err != nil {
-		return fmt.Errorf("cannot push config to device %q: %w", deviceID, err)
-	}
-
-	// TODO if this fails we should still return success so that the user knows
-	// the rollback itself happened.
-	reportErr := n.reportConfig(ctx, dc, n.sender)
-	if reportErr != nil {
-		log.Errorf("Rollback succeeded, but reportConfig failed: %v", reportErr)
-	}
-	return nil
-}
-
 // connectAndEnsureProfile connects to dc.device and sets the profile on the connection, calling findMatchingProfile if dc.profile is not yet set.
 func (n *networkDeviceConfigImpl) connectAndEnsureProfile(ctx context.Context, dc *DeviceContext) (ncmremote.Connection, error) {
 	log := LoggerFromContext(ctx)

--- a/comp/networkconfigmanagement/impl/networkdeviceconfig.go
+++ b/comp/networkconfigmanagement/impl/networkdeviceconfig.go
@@ -23,6 +23,7 @@ import (
 	ncmreport "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/report"
 	ncmsender "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/sender"
 	ncmstore "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/store"
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 )
 
 func newNetworkDeviceConfigImpl(log log.Component, store ncmstore.ConfigStore, sender sender.Sender, hostname string, profiles ncmprofile.Map, connectFn func(*ncmconfig.DeviceInstance) (ncmremote.Connection, error), clock clock.Clock) *networkDeviceConfigImpl {
@@ -115,6 +116,7 @@ func (n *networkDeviceConfigImpl) reportConfig(ctx context.Context, dc *DeviceCo
 	device := dc.device
 	sender := ncmsender.NewNCMSender(baseSender, device.Namespace, n.clock, n.hostname)
 
+	var err error
 	conn, err := n.connectAndEnsureProfile(ctx, dc)
 	if err != nil {
 		return err
@@ -196,12 +198,12 @@ func (n *networkDeviceConfigImpl) buildInventoryReport() ([]ncmreport.InventoryE
 }
 
 // connectAndEnsureProfile connects to dc.device and sets the profile on the connection, calling findMatchingProfile if dc.profile is not yet set.
-func (n *networkDeviceConfigImpl) connectAndEnsureProfile(ctx context.Context, dc *DeviceContext) (ncmremote.Connection, error) {
+func (n *networkDeviceConfigImpl) connectAndEnsureProfile(ctx context.Context, dc *DeviceContext) (ncmremote.Connection, types.RollbackError) {
 	log := LoggerFromContext(ctx)
 	conn, err := n.connect(dc.device)
 	if err != nil {
 		log.Errorf("unable to connect to device: %s", err)
-		return nil, err
+		return nil, types.WrapErrorf(types.ErrCannotConnect, "unable to connect to %s: %w", dc.device.DeviceID(), err)
 	}
 	if dc.profile == nil {
 		log.Debug("No profile specified, testing known profiles")
@@ -209,7 +211,7 @@ func (n *networkDeviceConfigImpl) connectAndEnsureProfile(ctx context.Context, d
 		if !ok {
 			dc.noMatchingProfile = true
 			_ = conn.Close()
-			return nil, fmt.Errorf("no matching NCM profile for device %s", dc.device.DeviceID())
+			return nil, types.WrapErrorf(types.ErrNoProfile, "no matching NCM profile for device %s", dc.device.DeviceID())
 		}
 		dc.profile = prof
 	}

--- a/comp/networkconfigmanagement/impl/networkdeviceconfig.go
+++ b/comp/networkconfigmanagement/impl/networkdeviceconfig.go
@@ -229,7 +229,7 @@ func (n *networkDeviceConfigImpl) RollbackConfig(ctx context.Context, deviceID s
 	}
 	defer conn.Close()
 
-	err = conn.PushConfig(ctx, rawConfig)
+	_, err = conn.PushConfig(ctx, rawConfig)
 	if err != nil {
 		return fmt.Errorf("cannot push config to device %q: %w", deviceID, err)
 	}

--- a/comp/networkconfigmanagement/impl/networkdeviceconfig_test.go
+++ b/comp/networkconfigmanagement/impl/networkdeviceconfig_test.go
@@ -111,7 +111,7 @@ func (m *MockConnection) Verify(_ context.Context) error {
 	return err
 }
 
-func (m *MockConnection) PushConfig(_ context.Context, _ string) ([]*ncmremote.CommandResult, error) {
+func (m *MockConnection) PushConfig(_ context.Context, _ string) (*ncmremote.PushResult, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/comp/networkconfigmanagement/impl/networkdeviceconfig_test.go
+++ b/comp/networkconfigmanagement/impl/networkdeviceconfig_test.go
@@ -49,10 +49,20 @@ ip address 192.168.1.1 255.255.255.0`
 	versionOutput = `Cisco Device Version 1.0`
 )
 
+type result = ncmremote.CommandResult
+
+func ok(msg string) *result {
+	return &result{Output: msg}
+}
+
+func fail(err error) *result {
+	return &result{Error: err}
+}
+
 func newMockConnection() *MockConnection {
 	// Set up mock remote client
 	return &MockConnection{
-		OutputMap: map[string]result{
+		OutputMap: map[string]*result{
 			"show running-config": ok(runningOutput),
 			"show startup-config": ok(startupOutput),
 			"show version":        ok(versionOutput),
@@ -61,22 +71,9 @@ func newMockConnection() *MockConnection {
 	}
 }
 
-type result struct {
-	response string
-	err      error
-}
-
-func ok(msg string) result {
-	return result{response: msg}
-}
-
-func fail(err error) result {
-	return result{err: err}
-}
-
 // MockConnection simulates a Connection
 type MockConnection struct {
-	OutputMap map[string]result // cmd -> output
+	OutputMap map[string]*result // cmd -> output
 	Opened    bool
 	Closed    bool
 	Calls     []string
@@ -85,7 +82,7 @@ type MockConnection struct {
 
 var _ ncmremote.Connection = (*MockConnection)(nil)
 
-func (m *MockConnection) execute(cmd *profile.PlainCommand) ([]byte, error) {
+func (m *MockConnection) execute(cmd *profile.PlainCommand) (*ncmremote.CommandResult, error) {
 	r := fail(errors.New("unsupported command"))
 	if cmd != nil {
 		var ok bool
@@ -93,18 +90,19 @@ func (m *MockConnection) execute(cmd *profile.PlainCommand) ([]byte, error) {
 		if !ok {
 			r = fail(fmt.Errorf("unknown command %q", cmd.Command))
 		}
-		if r.err == nil {
-			r.err = cmd.Validator.Validate(r.response)
+		r.CommandStr = cmd.Command
+		if r.Error == nil {
+			r.ValidationError = cmd.Validator.Validate(r.Output)
 		}
 	}
-	return []byte(r.response), r.err
+	return r, r.AnyError()
 }
 
-func (m *MockConnection) RetrieveRunningConfig(_ context.Context) ([]byte, error) {
+func (m *MockConnection) RetrieveRunningConfig(_ context.Context) (*result, error) {
 	return m.execute(m.Profile.Commands.GetRunning)
 }
 
-func (m *MockConnection) RetrieveStartupConfig(_ context.Context) ([]byte, error) {
+func (m *MockConnection) RetrieveStartupConfig(_ context.Context) (*result, error) {
 	return m.execute(m.Profile.Commands.GetStartup)
 }
 
@@ -113,8 +111,8 @@ func (m *MockConnection) Verify(_ context.Context) error {
 	return err
 }
 
-func (m *MockConnection) PushConfig(_ context.Context, _ string) error {
-	return errors.New("not implemented")
+func (m *MockConnection) PushConfig(_ context.Context, _ string) ([]*ncmremote.CommandResult, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (m *MockConnection) SetProfile(np *profile.NCMProfile) {

--- a/comp/networkconfigmanagement/impl/networkdeviceconfig_test.go
+++ b/comp/networkconfigmanagement/impl/networkdeviceconfig_test.go
@@ -95,7 +95,7 @@ func (m *MockConnection) execute(cmd *profile.PlainCommand) (*ncmremote.CommandR
 			r.ValidationError = cmd.Validator.Validate(r.Output)
 		}
 	}
-	return r, r.AnyError()
+	return r, r.FormattedError()
 }
 
 func (m *MockConnection) RetrieveRunningConfig(_ context.Context) (*result, error) {

--- a/comp/networkconfigmanagement/impl/networkdeviceconfig_test.go
+++ b/comp/networkconfigmanagement/impl/networkdeviceconfig_test.go
@@ -92,7 +92,7 @@ func (m *MockConnection) execute(cmd *profile.PlainCommand) (*ncmremote.CommandR
 		}
 		r.CommandStr = cmd.Command
 		if r.Error == nil {
-			r.ValidationError = cmd.Validator.Validate(r.Output)
+			r.Error = cmd.Validator.Validate(r.Output)
 		}
 	}
 	return r, r.FormattedError()

--- a/comp/networkconfigmanagement/impl/networkdeviceconfig_test.go
+++ b/comp/networkconfigmanagement/impl/networkdeviceconfig_test.go
@@ -56,8 +56,8 @@ func ok(msg string) *result {
 	return &result{Output: msg}
 }
 
-func fail(err error) *result {
-	return &result{Error: err}
+func fail(errMsg string) *result {
+	return &result{Error: errMsg}
 }
 
 func newMockConnection() *MockConnection {
@@ -84,17 +84,15 @@ type MockConnection struct {
 var _ ncmremote.Connection = (*MockConnection)(nil)
 
 func (m *MockConnection) execute(cmd *profile.PlainCommand) (*ncmremote.CommandResult, error) {
-	r := fail(errors.New("unsupported command"))
+	r := fail("unsupported command")
 	if cmd != nil {
 		var ok bool
 		r, ok = m.OutputMap[cmd.Command]
 		if !ok {
-			r = fail(fmt.Errorf("unknown command %q", cmd.Command))
+			r = fail(fmt.Sprintf("unknown command %q", cmd.Command))
 		}
 		r.CommandStr = cmd.Command
-		if r.Error == nil {
-			r.Error = cmd.Validator.Validate(r.Output)
-		}
+		r.ApplyValidator(cmd.Validator)
 	}
 	return r, r.FormattedError()
 }
@@ -454,7 +452,7 @@ func TestCheck_FindMatchingProfile(t *testing.T) {
 
 func TestCheck_FindMatchingProfile_Failure(t *testing.T) {
 	comp, reqs := createTestComponent(t)
-	reqs.connFactory.conn.OutputMap["show running-config"] = fail(errors.New("command execution failed"))
+	reqs.connFactory.conn.OutputMap["show running-config"] = fail("command execution failed")
 	device := createTestDevice()
 	err := comp.RegisterDevice(device)
 	assert.NoError(t, err)

--- a/comp/networkconfigmanagement/impl/networkdeviceconfig_test.go
+++ b/comp/networkconfigmanagement/impl/networkdeviceconfig_test.go
@@ -31,6 +31,7 @@ import (
 	ncmremote "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/remote"
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/report"
 	ncmstore "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/store"
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/integrations"
 	devicemetadata "github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
 
@@ -111,8 +112,8 @@ func (m *MockConnection) Verify(_ context.Context) error {
 	return err
 }
 
-func (m *MockConnection) PushConfig(_ context.Context, _ string) (*ncmremote.PushResult, error) {
-	return nil, errors.New("not implemented")
+func (m *MockConnection) PushConfig(_ context.Context, _ string) (*ncmremote.PushResult, types.RollbackError) {
+	return nil, types.InternalError(errors.New("not implemented"))
 }
 
 func (m *MockConnection) SetProfile(np *profile.NCMProfile) {

--- a/comp/networkconfigmanagement/impl/networkdeviceconfig_test.go
+++ b/comp/networkconfigmanagement/impl/networkdeviceconfig_test.go
@@ -50,7 +50,7 @@ ip address 192.168.1.1 255.255.255.0`
 	versionOutput = `Cisco Device Version 1.0`
 )
 
-type result = ncmremote.CommandResult
+type result = types.CommandResult
 
 func ok(msg string) *result {
 	return &result{Output: msg}
@@ -83,7 +83,7 @@ type MockConnection struct {
 
 var _ ncmremote.Connection = (*MockConnection)(nil)
 
-func (m *MockConnection) execute(cmd *profile.PlainCommand) (*ncmremote.CommandResult, error) {
+func (m *MockConnection) execute(cmd *profile.PlainCommand) (*types.CommandResult, error) {
 	r := fail("unsupported command")
 	if cmd != nil {
 		var ok bool
@@ -92,7 +92,7 @@ func (m *MockConnection) execute(cmd *profile.PlainCommand) (*ncmremote.CommandR
 			r = fail(fmt.Sprintf("unknown command %q", cmd.Command))
 		}
 		r.CommandStr = cmd.Command
-		r.ApplyValidator(cmd.Validator)
+		cmd.Validator.ValidateResult(r)
 	}
 	return r, r.FormattedError()
 }
@@ -110,7 +110,7 @@ func (m *MockConnection) Verify(_ context.Context) error {
 	return err
 }
 
-func (m *MockConnection) PushConfig(_ context.Context, _ string) (*ncmremote.PushResult, types.RollbackError) {
+func (m *MockConnection) PushConfig(_ context.Context, _ string) (*types.PushResult, types.RollbackError) {
 	return nil, types.InternalError(errors.New("not implemented"))
 }
 

--- a/comp/networkconfigmanagement/impl/rollback.go
+++ b/comp/networkconfigmanagement/impl/rollback.go
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package networkconfigmanagementimpl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	ncmremote "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/remote"
+	ncmstore "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/store"
+)
+
+type RollbackDisabled struct{}
+
+func (r *RollbackDisabled) Error() string {
+	return "rollback is disabled"
+}
+
+type ArgumentError struct {
+	wrapped error
+}
+
+func (a *ArgumentError) Error() string {
+	return a.wrapped.Error()
+}
+
+func (a *ArgumentError) Unwrap() error {
+	return a.wrapped
+}
+
+// RollbackConfig rolls back a device to a previous configuration that's saved
+// locally on this agent. If any commands are sent to the device, the returned
+// PushResult will document them and their results. NOTE: the returned error
+// will be non-nil if ANYTHING went wrong, including the later stages of the
+// config push or checks performed after the push completed. This means that
+// even if this func returns an error, the config may still have been
+// successfully rolled back, or partially rolled back - check the returned
+// PushResult to see what commands were actually run on the device.
+func (n *networkDeviceConfigImpl) RollbackConfig(ctx context.Context, deviceID string, configVersion string, hash string) (*ncmremote.PushResult, error) {
+	if n.store == nil {
+		return nil, &RollbackDisabled{}
+	}
+	var log log.Component = NewLogWrapper(n.log, fmt.Sprintf("ncm[%s]: ", deviceID))
+	log.Infof("Rollback requested: Device %q to version %q", deviceID, configVersion)
+	ctx = WithLogger(ctx, log)
+	dc, err := n.devices.GetAndLock(ctx, deviceID)
+	if err != nil {
+		// UnknownDeviceError -> the deviceID is bad.
+		if errors.Is(err, &UnknownDeviceError{}) {
+			return nil, &ArgumentError{err}
+		}
+		return nil, err
+	}
+	defer dc.UnlockOrLog(log)
+
+	rawConfig, metadata, err := n.store.GetConfig(configVersion)
+	if err != nil {
+		// Can be [UnknownUUIDError] or various internal errors
+		// UnknownUUIDError -> the deviceID is bad.
+		if errors.Is(err, &ncmstore.UnknownUUIDError{}) {
+			return nil, &ArgumentError{err}
+		}
+		return nil, err
+	}
+	if metadata.DeviceID != deviceID {
+		return nil, &ArgumentError{fmt.Errorf("input mismatch: config %q is not for device %q", configVersion, deviceID)}
+	}
+
+	expectedHash := ncmstore.HashConfig(rawConfig)
+	if expectedHash != hash {
+		return nil, &ArgumentError{fmt.Errorf("hash mismatch for config %q", configVersion)}
+	}
+
+	conn, err := n.connectAndEnsureProfile(ctx, dc)
+	if err != nil {
+		return nil, fmt.Errorf("%v: %w", deviceID, err)
+	}
+	defer conn.Close()
+
+	result, err := conn.PushConfig(ctx, rawConfig)
+	if err != nil {
+		return result, err
+	}
+
+	if err := n.reportConfig(ctx, dc, n.sender); err != nil {
+		return result, err
+	}
+	return result, nil
+}

--- a/comp/networkconfigmanagement/impl/rollback.go
+++ b/comp/networkconfigmanagement/impl/rollback.go
@@ -7,31 +7,13 @@ package networkconfigmanagementimpl
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	ncmremote "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/remote"
 	ncmstore "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/store"
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 )
-
-type RollbackDisabled struct{}
-
-func (r *RollbackDisabled) Error() string {
-	return "rollback is disabled"
-}
-
-type ArgumentError struct {
-	wrapped error
-}
-
-func (a *ArgumentError) Error() string {
-	return a.wrapped.Error()
-}
-
-func (a *ArgumentError) Unwrap() error {
-	return a.wrapped
-}
 
 // RollbackConfig rolls back a device to a previous configuration that's saved
 // locally on this agent. If any commands are sent to the device, the returned
@@ -41,54 +23,45 @@ func (a *ArgumentError) Unwrap() error {
 // even if this func returns an error, the config may still have been
 // successfully rolled back, or partially rolled back - check the returned
 // PushResult to see what commands were actually run on the device.
-func (n *networkDeviceConfigImpl) RollbackConfig(ctx context.Context, deviceID string, configVersion string, hash string) (*ncmremote.PushResult, error) {
+func (n *networkDeviceConfigImpl) RollbackConfig(ctx context.Context, deviceID string, configVersion string, hash string) (result *ncmremote.PushResult, rberr types.RollbackError) {
 	if n.store == nil {
-		return nil, &RollbackDisabled{}
+		return nil, types.RollbackDisabled
 	}
 	var log log.Component = NewLogWrapper(n.log, fmt.Sprintf("ncm[%s]: ", deviceID))
 	log.Infof("Rollback requested: Device %q to version %q", deviceID, configVersion)
 	ctx = WithLogger(ctx, log)
 	dc, err := n.devices.GetAndLock(ctx, deviceID)
 	if err != nil {
-		// UnknownDeviceError -> the deviceID is bad.
-		if errors.Is(err, &UnknownDeviceError{}) {
-			return nil, &ArgumentError{err}
-		}
-		return nil, err
+		return nil, types.AsRollbackError(err)
 	}
 	defer dc.UnlockOrLog(log)
 
 	rawConfig, metadata, err := n.store.GetConfig(configVersion)
 	if err != nil {
-		// Can be [UnknownUUIDError] or various internal errors
-		// UnknownUUIDError -> the deviceID is bad.
-		if errors.Is(err, &ncmstore.UnknownUUIDError{}) {
-			return nil, &ArgumentError{err}
-		}
-		return nil, err
+		return nil, types.AsRollbackError(err)
 	}
 	if metadata.DeviceID != deviceID {
-		return nil, &ArgumentError{fmt.Errorf("input mismatch: config %q is not for device %q", configVersion, deviceID)}
+		return nil, types.WrapErrorf(types.ErrWrongDeviceID, "input mismatch: config %q is not for device %q", configVersion, deviceID)
 	}
 
 	expectedHash := ncmstore.HashConfig(rawConfig)
 	if expectedHash != hash {
-		return nil, &ArgumentError{fmt.Errorf("hash mismatch for config %q", configVersion)}
+		return nil, types.WrapErrorf(types.ErrWrongHash, "hash mismatch for config %q", configVersion)
 	}
 
-	conn, err := n.connectAndEnsureProfile(ctx, dc)
-	if err != nil {
-		return nil, fmt.Errorf("%v: %w", deviceID, err)
+	conn, rberr := n.connectAndEnsureProfile(ctx, dc)
+	if rberr != nil {
+		return nil, rberr
 	}
 	defer conn.Close()
 
-	result, err := conn.PushConfig(ctx, rawConfig)
+	result, err = conn.PushConfig(ctx, rawConfig)
 	if err != nil {
-		return result, err
+		return result, types.AsRollbackError(err)
 	}
 
 	if err := n.reportConfig(ctx, dc, n.sender); err != nil {
-		return result, err
+		return result, types.AsRollbackError(err)
 	}
 	return result, nil
 }

--- a/comp/networkconfigmanagement/impl/rollback.go
+++ b/comp/networkconfigmanagement/impl/rollback.go
@@ -61,7 +61,7 @@ func (n *networkDeviceConfigImpl) RollbackConfig(ctx context.Context, deviceID s
 
 	if err := n.reportConfig(ctx, dc, n.sender); err != nil {
 		log.Warnf("Error reporting config after rollback: %v", err)
-		result.CheckConfigError = err.Error()
+		return result, types.WrapError(types.ErrReportConfigFailed, err)
 	}
 	return result, nil
 }

--- a/comp/networkconfigmanagement/impl/rollback.go
+++ b/comp/networkconfigmanagement/impl/rollback.go
@@ -60,7 +60,8 @@ func (n *networkDeviceConfigImpl) RollbackConfig(ctx context.Context, deviceID s
 	}
 
 	if err := n.reportConfig(ctx, dc, n.sender); err != nil {
-		return result, types.AsRollbackError(err)
+		log.Warnf("Error reporting config after rollback: %v", err)
+		result.CheckConfigError = err.Error()
 	}
 	return result, nil
 }

--- a/comp/networkconfigmanagement/impl/rollback.go
+++ b/comp/networkconfigmanagement/impl/rollback.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	ncmremote "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/remote"
 	ncmstore "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/store"
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 )
@@ -23,7 +22,7 @@ import (
 // even if this func returns an error, the config may still have been
 // successfully rolled back, or partially rolled back - check the returned
 // PushResult to see what commands were actually run on the device.
-func (n *networkDeviceConfigImpl) RollbackConfig(ctx context.Context, deviceID string, configVersion string, hash string) (result *ncmremote.PushResult, rberr types.RollbackError) {
+func (n *networkDeviceConfigImpl) RollbackConfig(ctx context.Context, deviceID string, configVersion string, hash string) (result *types.PushResult, rberr types.RollbackError) {
 	if n.store == nil {
 		return nil, types.RollbackDisabled
 	}

--- a/comp/networkconfigmanagement/impl/rollback_endpoint.go
+++ b/comp/networkconfigmanagement/impl/rollback_endpoint.go
@@ -51,6 +51,7 @@ func (n *networkDeviceConfigImpl) RollbackEndpointHandler() http.HandlerFunc {
 		body, err := json.Marshal(response)
 		if err != nil {
 			httputils.SetJSONError(w, fmt.Errorf("error marshaling response: %w", err), http.StatusInternalServerError)
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("X-Content-Type-Options", "nosniff")

--- a/comp/networkconfigmanagement/impl/rollback_endpoint.go
+++ b/comp/networkconfigmanagement/impl/rollback_endpoint.go
@@ -27,7 +27,7 @@ func (n *networkDeviceConfigImpl) RollbackEndpointHandler() http.HandlerFunc {
 			httputils.SetJSONError(w, err, http.StatusBadRequest)
 			return
 		}
-		if err := n.RollbackConfig(r.Context(), req.DeviceID, req.ConfigVersion, req.Hash); err != nil {
+		if _, err := n.RollbackConfig(r.Context(), req.DeviceID, req.ConfigVersion, req.Hash); err != nil {
 			// TODO set error code to distinguish between bad requests (e.g.
 			// unrecognized device id or hash mismatch) and actual internal
 			// errors

--- a/comp/networkconfigmanagement/impl/rollback_endpoint.go
+++ b/comp/networkconfigmanagement/impl/rollback_endpoint.go
@@ -7,6 +7,7 @@ package networkconfigmanagementimpl
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
@@ -19,6 +20,9 @@ type RollbackRequest struct {
 	Hash          string `json:"hash"`
 }
 
+type RollbackResponse struct {
+}
+
 // RollbackEndpointHandler returns an http.HandlerFunc for POST /agent/ncm/rollback
 func (n *networkDeviceConfigImpl) RollbackEndpointHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -27,7 +31,28 @@ func (n *networkDeviceConfigImpl) RollbackEndpointHandler() http.HandlerFunc {
 			httputils.SetJSONError(w, err, http.StatusBadRequest)
 			return
 		}
-		if _, err := n.RollbackConfig(r.Context(), req.DeviceID, req.ConfigVersion, req.Hash); err != nil {
+		result, err := n.RollbackConfig(r.Context(), req.DeviceID, req.ConfigVersion, req.Hash)
+		if result == nil && err == nil {
+			// this shouldn't be possible.
+			httputils.SetJSONError(w, errors.New("no response from RollbackConfig; this should be impossible"), http.StatusInternalServerError)
+			return
+		}
+		if result == nil {
+			// we failed before sending anything to the device (bad arguments, or couldn't connect, etc.)
+			if errors.Is(err, &ArgumentError{}) {
+				httputils.SetJSONError(w, err, http.StatusBadRequest)
+			} else {
+				httputils.SetJSONError(w, err, http.StatusInternalServerError)
+			}
+			return
+		}
+		// result is not nil -> we sent commands to the device, so we need to
+		// return information about what we did and what happened.
+		if err := result.CopyConfig.AnyError(); err != nil {
+
+		}
+
+		if err != nil {
 			// TODO set error code to distinguish between bad requests (e.g.
 			// unrecognized device id or hash mismatch) and actual internal
 			// errors

--- a/comp/networkconfigmanagement/impl/rollback_endpoint.go
+++ b/comp/networkconfigmanagement/impl/rollback_endpoint.go
@@ -8,8 +8,10 @@ package networkconfigmanagementimpl
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/remote"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 )
 
@@ -21,6 +23,9 @@ type RollbackRequest struct {
 }
 
 type RollbackResponse struct {
+	CommandResults *remote.PushResult `json:"command_results"`
+	ErrorCode      string             `json:"error_code"`
+	ErrorMsg       string             `json:"error_msg"`
 }
 
 // RollbackEndpointHandler returns an http.HandlerFunc for POST /agent/ncm/rollback
@@ -31,34 +36,25 @@ func (n *networkDeviceConfigImpl) RollbackEndpointHandler() http.HandlerFunc {
 			httputils.SetJSONError(w, err, http.StatusBadRequest)
 			return
 		}
-		result, err := n.RollbackConfig(r.Context(), req.DeviceID, req.ConfigVersion, req.Hash)
-		if result == nil && err == nil {
+		var response RollbackResponse
+		result, rberr := n.RollbackConfig(r.Context(), req.DeviceID, req.ConfigVersion, req.Hash)
+		if result == nil && rberr == nil {
 			// this shouldn't be possible.
 			httputils.SetJSONError(w, errors.New("no response from RollbackConfig; this should be impossible"), http.StatusInternalServerError)
 			return
 		}
-		if result == nil {
-			// we failed before sending anything to the device (bad arguments, or couldn't connect, etc.)
-			if errors.Is(err, &ArgumentError{}) {
-				httputils.SetJSONError(w, err, http.StatusBadRequest)
-			} else {
-				httputils.SetJSONError(w, err, http.StatusInternalServerError)
-			}
-			return
+		response.CommandResults = result
+		if rberr != nil {
+			response.ErrorCode = string(rberr.Type())
+			response.ErrorMsg = rberr.Error()
 		}
-		// result is not nil -> we sent commands to the device, so we need to
-		// return information about what we did and what happened.
-		if err := result.CopyConfig.AnyError(); err != nil {
-
-		}
-
+		body, err := json.Marshal(response)
 		if err != nil {
-			// TODO set error code to distinguish between bad requests (e.g.
-			// unrecognized device id or hash mismatch) and actual internal
-			// errors
-			httputils.SetJSONError(w, err, http.StatusInternalServerError)
-			return
+			httputils.SetJSONError(w, fmt.Errorf("error marshaling response: %w", err), http.StatusInternalServerError)
 		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, string(body))
 	}
 }

--- a/comp/networkconfigmanagement/impl/rollback_endpoint.go
+++ b/comp/networkconfigmanagement/impl/rollback_endpoint.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/remote"
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 )
 
@@ -22,12 +22,6 @@ type RollbackRequest struct {
 	Hash          string `json:"hash"`
 }
 
-type RollbackResponse struct {
-	CommandResults *remote.PushResult `json:"command_results"`
-	ErrorCode      string             `json:"error_code"`
-	ErrorMsg       string             `json:"error_msg"`
-}
-
 // RollbackEndpointHandler returns an http.HandlerFunc for POST /agent/ncm/rollback
 func (n *networkDeviceConfigImpl) RollbackEndpointHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -36,7 +30,7 @@ func (n *networkDeviceConfigImpl) RollbackEndpointHandler() http.HandlerFunc {
 			httputils.SetJSONError(w, err, http.StatusBadRequest)
 			return
 		}
-		var response RollbackResponse
+		var response types.RollbackResponse
 		result, rberr := n.RollbackConfig(r.Context(), req.DeviceID, req.ConfigVersion, req.Hash)
 		if result == nil && rberr == nil {
 			// this shouldn't be possible.

--- a/comp/networkconfigmanagement/mock/BUILD.bazel
+++ b/comp/networkconfigmanagement/mock/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//comp/networkconfigmanagement/def",
         "//pkg/aggregator/sender",
         "//pkg/networkconfigmanagement/config",
+        "//pkg/networkconfigmanagement/remote",
         "//pkg/networkconfigmanagement/store",
     ],
 )

--- a/comp/networkconfigmanagement/mock/BUILD.bazel
+++ b/comp/networkconfigmanagement/mock/BUILD.bazel
@@ -11,5 +11,6 @@ go_library(
         "//pkg/networkconfigmanagement/config",
         "//pkg/networkconfigmanagement/remote",
         "//pkg/networkconfigmanagement/store",
+        "//pkg/networkconfigmanagement/types",
     ],
 )

--- a/comp/networkconfigmanagement/mock/BUILD.bazel
+++ b/comp/networkconfigmanagement/mock/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
         "//comp/networkconfigmanagement/def",
         "//pkg/aggregator/sender",
         "//pkg/networkconfigmanagement/config",
-        "//pkg/networkconfigmanagement/remote",
         "//pkg/networkconfigmanagement/store",
         "//pkg/networkconfigmanagement/types",
     ],

--- a/comp/networkconfigmanagement/mock/mock.go
+++ b/comp/networkconfigmanagement/mock/mock.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/config"
 	ncmremote "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/remote"
 	ncmstore "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/store"
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 )
 
 type mockNetworkConfigManagement struct {
@@ -51,8 +52,8 @@ func (m *mockNetworkConfigManagement) RegisterDevice(device *config.DeviceInstan
 }
 
 // RollbackConfig implements [networkconfigmanagement.Component].
-func (m *mockNetworkConfigManagement) RollbackConfig(_ context.Context, _, _, _ string) (*ncmremote.PushResult, error) {
-	return nil, errors.New("TODO unimplemented")
+func (m *mockNetworkConfigManagement) RollbackConfig(_ context.Context, _, _, _ string) (*ncmremote.PushResult, types.RollbackError) {
+	return nil, types.InternalError(errors.New("unimplemented"))
 }
 
 // SetMaxReportInterval implements [networkconfigmanagement.Component].

--- a/comp/networkconfigmanagement/mock/mock.go
+++ b/comp/networkconfigmanagement/mock/mock.go
@@ -17,6 +17,7 @@ import (
 	networkconfigmanagement "github.com/DataDog/datadog-agent/comp/networkconfigmanagement/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/config"
+	ncmremote "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/remote"
 	ncmstore "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/store"
 )
 
@@ -50,8 +51,8 @@ func (m *mockNetworkConfigManagement) RegisterDevice(device *config.DeviceInstan
 }
 
 // RollbackConfig implements [networkconfigmanagement.Component].
-func (m *mockNetworkConfigManagement) RollbackConfig(_ context.Context, _, _, _ string) error {
-	return errors.New("TODO unimplemented")
+func (m *mockNetworkConfigManagement) RollbackConfig(_ context.Context, _, _, _ string) (*ncmremote.PushResult, error) {
+	return nil, errors.New("TODO unimplemented")
 }
 
 // SetMaxReportInterval implements [networkconfigmanagement.Component].

--- a/comp/networkconfigmanagement/mock/mock.go
+++ b/comp/networkconfigmanagement/mock/mock.go
@@ -17,7 +17,6 @@ import (
 	networkconfigmanagement "github.com/DataDog/datadog-agent/comp/networkconfigmanagement/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/config"
-	ncmremote "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/remote"
 	ncmstore "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/store"
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 )
@@ -52,7 +51,7 @@ func (m *mockNetworkConfigManagement) RegisterDevice(device *config.DeviceInstan
 }
 
 // RollbackConfig implements [networkconfigmanagement.Component].
-func (m *mockNetworkConfigManagement) RollbackConfig(_ context.Context, _, _, _ string) (*ncmremote.PushResult, types.RollbackError) {
+func (m *mockNetworkConfigManagement) RollbackConfig(_ context.Context, _, _, _ string) (*types.PushResult, types.RollbackError) {
 	return nil, types.InternalError(errors.New("unimplemented"))
 }
 

--- a/comp/networkconfigmanagement/stub/BUILD.bazel
+++ b/comp/networkconfigmanagement/stub/BUILD.bazel
@@ -10,5 +10,6 @@ go_library(
         "//pkg/aggregator/sender",
         "//pkg/networkconfigmanagement/config",
         "//pkg/networkconfigmanagement/remote",
+        "//pkg/networkconfigmanagement/types",
     ],
 )

--- a/comp/networkconfigmanagement/stub/BUILD.bazel
+++ b/comp/networkconfigmanagement/stub/BUILD.bazel
@@ -9,5 +9,6 @@ go_library(
         "//comp/networkconfigmanagement/def",
         "//pkg/aggregator/sender",
         "//pkg/networkconfigmanagement/config",
+        "//pkg/networkconfigmanagement/remote",
     ],
 )

--- a/comp/networkconfigmanagement/stub/BUILD.bazel
+++ b/comp/networkconfigmanagement/stub/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
         "//comp/networkconfigmanagement/def",
         "//pkg/aggregator/sender",
         "//pkg/networkconfigmanagement/config",
-        "//pkg/networkconfigmanagement/remote",
         "//pkg/networkconfigmanagement/types",
     ],
 )

--- a/comp/networkconfigmanagement/stub/stub.go
+++ b/comp/networkconfigmanagement/stub/stub.go
@@ -17,6 +17,7 @@ import (
 	networkconfigmanagement "github.com/DataDog/datadog-agent/comp/networkconfigmanagement/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/config"
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/remote"
 )
 
 var errNoNCM = errors.New("NCM not available")
@@ -50,8 +51,10 @@ func (s *NCMStub) RegisterDevice(_ *config.DeviceInstance) error { return s.GetE
 func (s *NCMStub) ReportConfig(_ context.Context, _ string, _ sender.Sender) error {
 	return s.GetError()
 }
-func (s *NCMStub) RollbackConfig(_ context.Context, _, _, _ string) error { return s.GetError() }
-func (s *NCMStub) SetMaxReportInterval(_ time.Duration)                   {}
+func (s *NCMStub) RollbackConfig(_ context.Context, _, _, _ string) (*remote.PushResult, error) {
+	return nil, s.GetError()
+}
+func (s *NCMStub) SetMaxReportInterval(_ time.Duration) {}
 
 // GetConfigEndpointHandler implements [networkconfigmanagement.Component].
 func (s *NCMStub) GetConfigEndpointHandler() http.HandlerFunc {

--- a/comp/networkconfigmanagement/stub/stub.go
+++ b/comp/networkconfigmanagement/stub/stub.go
@@ -18,25 +18,26 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/config"
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/remote"
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 )
 
-var errNoNCM = errors.New("NCM not available")
+var errNoNCM = types.WrapErrorf(types.ErrDisabled, "NCM not available")
 
 // NCMStub is an NCM implementation that returns "not available" for every
 // operation.
 type NCMStub struct {
-	err error
+	err types.RollbackError
 }
 
 func NewStub(msg string) *NCMStub {
 	return &NCMStub{
-		err: errors.New(msg),
+		err: types.InternalError(errors.New(msg)),
 	}
 }
 
 var _ networkconfigmanagement.Component = (*NCMStub)(nil)
 
-func (s *NCMStub) GetError() error {
+func (s *NCMStub) GetError() types.RollbackError {
 	if s.err != nil {
 		return s.err
 	}
@@ -51,7 +52,7 @@ func (s *NCMStub) RegisterDevice(_ *config.DeviceInstance) error { return s.GetE
 func (s *NCMStub) ReportConfig(_ context.Context, _ string, _ sender.Sender) error {
 	return s.GetError()
 }
-func (s *NCMStub) RollbackConfig(_ context.Context, _, _, _ string) (*remote.PushResult, error) {
+func (s *NCMStub) RollbackConfig(_ context.Context, _, _, _ string) (*remote.PushResult, types.RollbackError) {
 	return nil, s.GetError()
 }
 func (s *NCMStub) SetMaxReportInterval(_ time.Duration) {}

--- a/comp/networkconfigmanagement/stub/stub.go
+++ b/comp/networkconfigmanagement/stub/stub.go
@@ -17,7 +17,6 @@ import (
 	networkconfigmanagement "github.com/DataDog/datadog-agent/comp/networkconfigmanagement/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/config"
-	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/remote"
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 )
 
@@ -52,7 +51,7 @@ func (s *NCMStub) RegisterDevice(_ *config.DeviceInstance) error { return s.GetE
 func (s *NCMStub) ReportConfig(_ context.Context, _ string, _ sender.Sender) error {
 	return s.GetError()
 }
-func (s *NCMStub) RollbackConfig(_ context.Context, _, _, _ string) (*remote.PushResult, types.RollbackError) {
+func (s *NCMStub) RollbackConfig(_ context.Context, _, _, _ string) (*types.PushResult, types.RollbackError) {
 	return nil, s.GetError()
 }
 func (s *NCMStub) SetMaxReportInterval(_ time.Duration) {}

--- a/pkg/networkconfigmanagement/profile/BUILD.bazel
+++ b/pkg/networkconfigmanagement/profile/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/profile",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/networkconfigmanagement/types",
         "//pkg/util/log",
         "//pkg/util/scrubber",
     ],

--- a/pkg/networkconfigmanagement/profile/command.go
+++ b/pkg/networkconfigmanagement/profile/command.go
@@ -9,6 +9,8 @@ package profile
 import (
 	"fmt"
 	"regexp"
+
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 )
 
 // Validator contains rules for validating the output of a command - requiring
@@ -30,6 +32,17 @@ func (v *Validator) Validate(text string) error {
 		}
 	}
 	return nil
+}
+
+// ValidateResult is a no-op if c.Error is already set, otherwise it runs v on
+// c.Output and saves the result in c.Error.
+func (v *Validator) ValidateResult(c *types.CommandResult) {
+	if c.Error != "" {
+		return
+	}
+	if err := v.Validate(c.Output); err != nil {
+		c.Error = err.Error()
+	}
 }
 
 type Command interface {

--- a/pkg/networkconfigmanagement/profile/default_profiles.go
+++ b/pkg/networkconfigmanagement/profile/default_profiles.go
@@ -167,13 +167,13 @@ var DefaultProfiles = Map{
 			GetRunning: MkCommand("show running-config", Expect(`Building configuration...`), Expect(`Current configuration :`)),
 			GetStartup: MkCommand("show startup-config", Expect(`Using (.*?) out of (.*?) bytes`)),
 			GetVersion: MkCommand("show version"),
-			PushConfig: []Command{
-				&SCPCommand{
+			PushConfig: &PushConfig{
+				Copy: &SCPCommand{
 					RemoteCommand: "scp",
 					Filepath:      "flash:/dd-rollback-config",
 				},
-				MkCommand("configure replace flash:/dd-rollback-config force", Expect("Rollback Done")),
-				MkCommand("write", Expect("[OK]")),
+				SetRunning: MkCommand("configure replace flash:/dd-rollback-config force", Expect("Rollback Done")),
+				SetStartup: MkCommand("write", Expect("[OK]")),
 			},
 		},
 		Preprocessing: []RedactionRule{
@@ -256,13 +256,13 @@ var DefaultProfiles = Map{
 			Verify:     MkCommand("show version", Expect(`Arista .*`)),
 			GetRunning: MkCommand("show running-config | no-more | exclude ! Time:", Expect(`! Command: show running-config`)),
 			GetStartup: MkCommand("show startup-config | no-more | exclude ! Time:", Expect(`! Command: show startup-config`)),
-			PushConfig: []Command{
-				&SCPCommand{
+			PushConfig: &PushConfig{
+				Copy: &SCPCommand{
 					RemoteCommand: "scp",
 					Filepath:      "/tmp/dd-rollback-config",
 				},
-				MkCommand("configure replace file:/tmp/dd-rollback-config", ExpectNot("%")),
-				MkCommand("write", Expect(`Copy completed successfully`)),
+				SetRunning: MkCommand("configure replace file:/tmp/dd-rollback-config", ExpectNot("%")),
+				SetStartup: MkCommand("write", Expect(`Copy completed successfully`)),
 				// TODO should we be deleting the file after?
 				// MkCommand("delete file:/tmp/dd-rollback-config"),
 			},
@@ -321,6 +321,14 @@ var DefaultProfiles = Map{
 			Verify:     MkCommand("show version", Expect(`Junos:`)),
 			GetRunning: MkCommand("show configuration | display omit", Expect(`version \d+\.\d+[^;]*;`)),
 			GetVersion: MkCommand("show version"),
+			// untested
+			// PushConfig: &PushConfig{
+			// 	Copy: &SCPCommand{
+			// 		RemoteCommand: "scp",
+			// 		Filepath:      "/tmp/dd-rollback-config",
+			// 	},
+			// 	SetRunning: MkCommand("configure\nload override /tmp/dd-rollback-config\ncommit\nexit", Expect(`commit complete`)),
+			// },
 		},
 		Redactions: []RedactionRule{
 			MkRedaction(`(?m)^(\s*community) (\S+) (\{)`, WithReplacement("$1 <secret hidden> {")),

--- a/pkg/networkconfigmanagement/profile/profile.go
+++ b/pkg/networkconfigmanagement/profile/profile.go
@@ -29,6 +29,21 @@ type NCMProfile struct {
 	MetadataRules []MetadataRule
 }
 
+type PushConfig struct {
+	Copy       *SCPCommand
+	SetRunning *PlainCommand
+	SetStartup *PlainCommand
+}
+
+// CanPush returns whether or not this PushConfig can be used - mainly it is
+// used for detecting zero values.
+func (pc *PushConfig) CanPush() bool {
+	if pc == nil {
+		return false
+	}
+	return pc.Copy != nil && pc.SetRunning != nil
+}
+
 type CommandSet struct {
 	Verify     *PlainCommand
 	GetVersion *PlainCommand `json:"get_version,omitempty"`
@@ -36,7 +51,12 @@ type CommandSet struct {
 	GetRunning *PlainCommand `json:"get_running,omitempty"`
 	GetStartup *PlainCommand `json:"get_startup,omitempty"`
 	// Config pushing
-	PushConfig []Command
+	PushConfig *PushConfig
+}
+
+// CanPush returns whether or not this CommandSet includes a valid Push command.
+func (cs *CommandSet) CanPush() bool {
+	return cs.PushConfig.CanPush()
 }
 
 // GetProfile retrieves the profile from the profile map (by name)

--- a/pkg/networkconfigmanagement/remote/BUILD.bazel
+++ b/pkg/networkconfigmanagement/remote/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//pkg/networkconfigmanagement/config",
         "//pkg/networkconfigmanagement/profile",
+        "//pkg/networkconfigmanagement/types",
         "//pkg/util/log",
         "@org_golang_x_crypto//ssh",
         "@org_golang_x_crypto//ssh/knownhosts",

--- a/pkg/networkconfigmanagement/remote/cmd.go
+++ b/pkg/networkconfigmanagement/remote/cmd.go
@@ -31,6 +31,16 @@ func (c *CommandResult) AnyError() error {
 	if err == nil {
 		err = c.ValidationError
 	}
+	return err
+}
+
+// FormattedError returns nil if there was no error, and otherwise wraps
+// .AnyError to append any captured output to the error message.
+func (c *CommandResult) FormattedError() error {
+	err := c.Error
+	if err == nil {
+		err = c.ValidationError
+	}
 	if err == nil {
 		return nil
 	}
@@ -38,6 +48,17 @@ func (c *CommandResult) AnyError() error {
 		return fmt.Errorf("%w: %q", err, c.Output)
 	}
 	return err
+}
+
+type ResultList []*CommandResult
+
+func (rl ResultList) AnyError() error {
+	for _, result := range rl {
+		if err := result.AnyError(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // sshClient is a common interface between ssh.Client and RetryingSSHClient
@@ -67,7 +88,7 @@ func ExecuteCommand(ctx context.Context, client sshClient, cmd *profile.PlainCom
 		if r.Error == nil {
 			r.ValidationError = cmd.Validator.Validate(r.Output)
 		}
-		err := r.AnyError()
+		err := r.FormattedError()
 		if err != nil {
 			if r.Output != "" {
 				return r, fmt.Errorf("%w: %q", err, r.Output)
@@ -116,7 +137,7 @@ func ExecuteSCP(ctx context.Context, client sshClient, cmd *profile.SCPCommand, 
 	if r.Error == nil {
 		r.ValidationError = cmd.Validator.Validate(r.Output)
 	}
-	err = r.AnyError()
+	err = r.FormattedError()
 	if err != nil {
 		if r.Output != "" {
 			return r, fmt.Errorf("%w: %q", err, r.Output)

--- a/pkg/networkconfigmanagement/remote/cmd.go
+++ b/pkg/networkconfigmanagement/remote/cmd.go
@@ -18,44 +18,29 @@ import (
 
 // CommandResult records a command that was run and the resulting output.
 type CommandResult struct {
-	CommandStr      string
-	Output          string
-	Error           error
-	ValidationError error
-}
-
-// AnyError returns .Error or .ValidationError, whichever is not nil, or nil if
-// both are nil.
-func (c *CommandResult) AnyError() error {
-	err := c.Error
-	if err == nil {
-		err = c.ValidationError
-	}
-	return err
+	CommandStr string
+	Output     string
+	Error      error
 }
 
 // FormattedError returns nil if there was no error, and otherwise wraps
 // .AnyError to append any captured output to the error message.
 func (c *CommandResult) FormattedError() error {
-	err := c.Error
-	if err == nil {
-		err = c.ValidationError
-	}
-	if err == nil {
+	if c.Error == nil {
 		return nil
 	}
 	if c.Output != "" {
-		return fmt.Errorf("%w: %q", err, c.Output)
+		return fmt.Errorf("%w: %q", c.Error, c.Output)
 	}
-	return err
+	return c.Error
 }
 
 type ResultList []*CommandResult
 
 func (rl ResultList) AnyError() error {
 	for _, result := range rl {
-		if err := result.AnyError(); err != nil {
-			return err
+		if result.Error != nil {
+			return result.Error
 		}
 	}
 	return nil
@@ -86,7 +71,7 @@ func ExecuteCommand(ctx context.Context, client sshClient, cmd *profile.PlainCom
 	select {
 	case r := <-ch:
 		if r.Error == nil {
-			r.ValidationError = cmd.Validator.Validate(r.Output)
+			r.Error = cmd.Validator.Validate(r.Output)
 		}
 		err := r.FormattedError()
 		if err != nil {
@@ -135,7 +120,7 @@ func ExecuteSCP(ctx context.Context, client sshClient, cmd *profile.SCPCommand, 
 	}
 
 	if r.Error == nil {
-		r.ValidationError = cmd.Validator.Validate(r.Output)
+		r.Error = cmd.Validator.Validate(r.Output)
 	}
 	err = r.FormattedError()
 	if err != nil {

--- a/pkg/networkconfigmanagement/remote/cmd.go
+++ b/pkg/networkconfigmanagement/remote/cmd.go
@@ -16,9 +16,28 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/profile"
 )
 
-type result struct {
-	message string
-	err     error
+// CommandResult records a command that was run and the resulting output.
+type CommandResult struct {
+	CommandStr      string
+	Output          string
+	Error           error
+	ValidationError error
+}
+
+// AnyError returns .Error or .ValidationError, whichever is not nil, or nil if
+// both are nil.
+func (c *CommandResult) AnyError() error {
+	err := c.Error
+	if err == nil {
+		err = c.ValidationError
+	}
+	if err == nil {
+		return nil
+	}
+	if c.Output != "" {
+		return fmt.Errorf("%w: %q", err, c.Output)
+	}
+	return err
 }
 
 // sshClient is a common interface between ssh.Client and RetryingSSHClient
@@ -28,28 +47,36 @@ type sshClient interface {
 
 // Execute runs a command and validates the output with its validation rules.
 // The validation runs on the combined stdout and stderr of the command.
-func ExecuteCommand(ctx context.Context, client sshClient, cmd *profile.PlainCommand) (string, error) {
+func ExecuteCommand(ctx context.Context, client sshClient, cmd *profile.PlainCommand) (*CommandResult, error) {
 	session, err := client.NewSession()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer session.Close()
-	ch := make(chan result, 1)
+	ch := make(chan *CommandResult, 1)
 	go func() {
 		output, err := session.CombinedOutput(cmd.Command)
-		ch <- result{string(output), err}
+		ch <- &CommandResult{
+			CommandStr: cmd.Command,
+			Output:     string(output),
+			Error:      err,
+		}
 	}()
 	select {
 	case r := <-ch:
-		if r.err != nil {
-			if r.message != "" {
-				return "", fmt.Errorf("%w: %q", r.err, r.message)
-			}
-			return "", r.err
+		if r.Error == nil {
+			r.ValidationError = cmd.Validator.Validate(r.Output)
 		}
-		return r.message, cmd.Validator.Validate(r.message)
+		err := r.AnyError()
+		if err != nil {
+			if r.Output != "" {
+				return r, fmt.Errorf("%w: %q", err, r.Output)
+			}
+			return r, err
+		}
+		return r, nil
 	case <-ctx.Done():
-		return "", ctx.Err()
+		return nil, ctx.Err()
 	}
 }
 
@@ -59,34 +86,43 @@ func ExecuteCommand(ctx context.Context, client sshClient, cmd *profile.PlainCom
 var filenameRE = regexp.MustCompile("^[a-zA-Z0-9_:./-]*$")
 
 // ExecuteSCP executes an SCP command, sending the given data over SSH.
-func ExecuteSCP(ctx context.Context, client sshClient, cmd *profile.SCPCommand, data string) (string, error) {
+func ExecuteSCP(ctx context.Context, client sshClient, cmd *profile.SCPCommand, data string) (*CommandResult, error) {
 	if !filenameRE.MatchString(cmd.Filepath) {
-		return "", fmt.Errorf("bad filename for scp: %q", cmd.Filepath)
+		return nil, fmt.Errorf("bad filename for scp: %q", cmd.Filepath)
 	}
 	session, err := client.NewSession()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer session.Close()
 	cmdStr := fmt.Sprintf("%s -t %s", cmd.RemoteCommand, cmd.Filepath)
-	ch := make(chan result)
+	ch := make(chan *CommandResult)
 	go func() {
 		response, err := executeSCP(session, cmdStr, filepath.Base(cmd.Filepath), data)
-		ch <- result{response, err}
+		ch <- &CommandResult{
+			CommandStr: cmdStr,
+			Output:     response,
+			Error:      err,
+		}
 	}()
-	var response string
+	var r *CommandResult
 	select {
-	case result := <-ch:
-		response = result.message
-		err = result.err
+	case r = <-ch:
+		// got a result, continue
 	case <-ctx.Done():
-		err = ctx.Err()
+		return nil, fmt.Errorf("scp command %q failed: %w", cmdStr, ctx.Err())
 	}
+
+	if r.Error == nil {
+		r.ValidationError = cmd.Validator.Validate(r.Output)
+	}
+	err = r.AnyError()
 	if err != nil {
-		return "", fmt.Errorf("scp command %q failed: %w", cmdStr, err)
+		if r.Output != "" {
+			return r, fmt.Errorf("%w: %q", err, r.Output)
+		}
+		return r, err
 	}
-	if err := cmd.Validator.Validate(response); err != nil {
-		return response, fmt.Errorf("scp command %q bad output: %w", cmdStr, err)
-	}
-	return response, nil
+
+	return r, nil
 }

--- a/pkg/networkconfigmanagement/remote/cmd.go
+++ b/pkg/networkconfigmanagement/remote/cmd.go
@@ -18,9 +18,9 @@ import (
 
 // CommandResult records a command that was run and the resulting output.
 type CommandResult struct {
-	CommandStr string
-	Output     string
-	Error      error
+	CommandStr string `json:"command_str"`
+	Output     string `json:"output"`
+	Error      error  `json:"error"`
 }
 
 // FormattedError returns nil if there was no error, and otherwise wraps

--- a/pkg/networkconfigmanagement/remote/cmd.go
+++ b/pkg/networkconfigmanagement/remote/cmd.go
@@ -7,6 +7,7 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -20,35 +21,43 @@ import (
 type CommandResult struct {
 	CommandStr string `json:"command_str"`
 	Output     string `json:"output"`
-	Error      error  `json:"error"`
+	Error      string `json:"error"`
 }
 
-// FormattedError returns nil if there was no error, and otherwise wraps
-// .AnyError to append any captured output to the error message.
+// FormattedError returns nil if there was no error, and otherwise returns an
+// error containing .Error and, if it was nonempty, .Output.
 func (c *CommandResult) FormattedError() error {
-	if c.Error == nil {
+	if c.Error == "" {
 		return nil
 	}
 	if c.Output != "" {
-		return fmt.Errorf("%w: %q", c.Error, c.Output)
+		return fmt.Errorf("%v: %q", c.Error, c.Output)
 	}
-	return c.Error
+	return errors.New(c.Error)
 }
 
 type ResultList []*CommandResult
 
-func (rl ResultList) AnyError() error {
-	for _, result := range rl {
-		if result.Error != nil {
-			return result.Error
-		}
-	}
-	return nil
-}
-
 // sshClient is a common interface between ssh.Client and RetryingSSHClient
 type sshClient interface {
 	NewSession() (*ssh.Session, error)
+}
+
+// errorStr converts an error to a string. It's just like e.Error() except that
+// nil maps to "" instead of panicking.
+func errorStr(e error) string {
+	if e == nil {
+		return ""
+	}
+	return e.Error()
+}
+
+// ApplyValidator is a no-op if .Error is already set, otherwise it runs vd on .Output and saves the result in .Error
+func (c *CommandResult) ApplyValidator(vd profile.Validator) {
+	if c.Error != "" {
+		return
+	}
+	c.Error = errorStr(vd.Validate(c.Output))
 }
 
 // Execute runs a command and validates the output with its validation rules.
@@ -65,22 +74,13 @@ func ExecuteCommand(ctx context.Context, client sshClient, cmd *profile.PlainCom
 		ch <- &CommandResult{
 			CommandStr: cmd.Command,
 			Output:     string(output),
-			Error:      err,
+			Error:      errorStr(err),
 		}
 	}()
 	select {
 	case r := <-ch:
-		if r.Error == nil {
-			r.Error = cmd.Validator.Validate(r.Output)
-		}
-		err := r.FormattedError()
-		if err != nil {
-			if r.Output != "" {
-				return r, fmt.Errorf("%w: %q", err, r.Output)
-			}
-			return r, err
-		}
-		return r, nil
+		r.ApplyValidator(cmd.Validator)
+		return r, r.FormattedError()
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
@@ -108,7 +108,7 @@ func ExecuteSCP(ctx context.Context, client sshClient, cmd *profile.SCPCommand, 
 		ch <- &CommandResult{
 			CommandStr: cmdStr,
 			Output:     response,
-			Error:      err,
+			Error:      errorStr(err),
 		}
 	}()
 	var r *CommandResult
@@ -118,17 +118,6 @@ func ExecuteSCP(ctx context.Context, client sshClient, cmd *profile.SCPCommand, 
 	case <-ctx.Done():
 		return nil, fmt.Errorf("scp command %q failed: %w", cmdStr, ctx.Err())
 	}
-
-	if r.Error == nil {
-		r.Error = cmd.Validator.Validate(r.Output)
-	}
-	err = r.FormattedError()
-	if err != nil {
-		if r.Output != "" {
-			return r, fmt.Errorf("%w: %q", err, r.Output)
-		}
-		return r, err
-	}
-
-	return r, nil
+	r.ApplyValidator(cmd.Validator)
+	return r, r.FormattedError()
 }

--- a/pkg/networkconfigmanagement/remote/cmd.go
+++ b/pkg/networkconfigmanagement/remote/cmd.go
@@ -7,7 +7,6 @@ package remote
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -15,28 +14,8 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/profile"
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 )
-
-// CommandResult records a command that was run and the resulting output.
-type CommandResult struct {
-	CommandStr string `json:"command_str"`
-	Output     string `json:"output"`
-	Error      string `json:"error"`
-}
-
-// FormattedError returns nil if there was no error, and otherwise returns an
-// error containing .Error and, if it was nonempty, .Output.
-func (c *CommandResult) FormattedError() error {
-	if c.Error == "" {
-		return nil
-	}
-	if c.Output != "" {
-		return fmt.Errorf("%v: %q", c.Error, c.Output)
-	}
-	return errors.New(c.Error)
-}
-
-type ResultList []*CommandResult
 
 // sshClient is a common interface between ssh.Client and RetryingSSHClient
 type sshClient interface {
@@ -52,26 +31,18 @@ func errorStr(e error) string {
 	return e.Error()
 }
 
-// ApplyValidator is a no-op if .Error is already set, otherwise it runs vd on .Output and saves the result in .Error
-func (c *CommandResult) ApplyValidator(vd profile.Validator) {
-	if c.Error != "" {
-		return
-	}
-	c.Error = errorStr(vd.Validate(c.Output))
-}
-
 // Execute runs a command and validates the output with its validation rules.
 // The validation runs on the combined stdout and stderr of the command.
-func ExecuteCommand(ctx context.Context, client sshClient, cmd *profile.PlainCommand) (*CommandResult, error) {
+func ExecuteCommand(ctx context.Context, client sshClient, cmd *profile.PlainCommand) (*types.CommandResult, error) {
 	session, err := client.NewSession()
 	if err != nil {
 		return nil, err
 	}
 	defer session.Close()
-	ch := make(chan *CommandResult, 1)
+	ch := make(chan *types.CommandResult, 1)
 	go func() {
 		output, err := session.CombinedOutput(cmd.Command)
-		ch <- &CommandResult{
+		ch <- &types.CommandResult{
 			CommandStr: cmd.Command,
 			Output:     string(output),
 			Error:      errorStr(err),
@@ -79,7 +50,7 @@ func ExecuteCommand(ctx context.Context, client sshClient, cmd *profile.PlainCom
 	}()
 	select {
 	case r := <-ch:
-		r.ApplyValidator(cmd.Validator)
+		cmd.Validator.ValidateResult(r)
 		return r, r.FormattedError()
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -92,7 +63,7 @@ func ExecuteCommand(ctx context.Context, client sshClient, cmd *profile.PlainCom
 var filenameRE = regexp.MustCompile("^[a-zA-Z0-9_:./-]*$")
 
 // ExecuteSCP executes an SCP command, sending the given data over SSH.
-func ExecuteSCP(ctx context.Context, client sshClient, cmd *profile.SCPCommand, data string) (*CommandResult, error) {
+func ExecuteSCP(ctx context.Context, client sshClient, cmd *profile.SCPCommand, data string) (*types.CommandResult, error) {
 	if !filenameRE.MatchString(cmd.Filepath) {
 		return nil, fmt.Errorf("bad filename for scp: %q", cmd.Filepath)
 	}
@@ -102,22 +73,22 @@ func ExecuteSCP(ctx context.Context, client sshClient, cmd *profile.SCPCommand, 
 	}
 	defer session.Close()
 	cmdStr := fmt.Sprintf("%s -t %s", cmd.RemoteCommand, cmd.Filepath)
-	ch := make(chan *CommandResult)
+	ch := make(chan *types.CommandResult)
 	go func() {
 		response, err := executeSCP(session, cmdStr, filepath.Base(cmd.Filepath), data)
-		ch <- &CommandResult{
+		ch <- &types.CommandResult{
 			CommandStr: cmdStr,
 			Output:     response,
 			Error:      errorStr(err),
 		}
 	}()
-	var r *CommandResult
+	var r *types.CommandResult
 	select {
 	case r = <-ch:
 		// got a result, continue
 	case <-ctx.Done():
 		return nil, fmt.Errorf("scp command %q failed: %w", cmdStr, ctx.Err())
 	}
-	r.ApplyValidator(cmd.Validator)
+	cmd.Validator.ValidateResult(r)
 	return r, r.FormattedError()
 }

--- a/pkg/networkconfigmanagement/remote/cmd_test.go
+++ b/pkg/networkconfigmanagement/remote/cmd_test.go
@@ -31,7 +31,7 @@ func TestCommand(t *testing.T) {
 		name      string
 		cmd       *profile.PlainCommand
 		expected  string
-		expectErr bool
+		expectErr string
 	}{{
 		name: "unchecked_command",
 		cmd: &profile.PlainCommand{
@@ -56,7 +56,7 @@ func TestCommand(t *testing.T) {
 				Require: []*regexp.Regexp{regexp.MustCompile("Realco")},
 			},
 		},
-		expectErr: true,
+		expectErr: "does not match required regex",
 	}, {
 		name: "has_rejection",
 		cmd: &profile.PlainCommand{
@@ -65,7 +65,7 @@ func TestCommand(t *testing.T) {
 				Reject: []*regexp.Regexp{regexp.MustCompile("Fakesco")},
 			},
 		},
-		expectErr: true,
+		expectErr: "matches failure regex",
 	}, {
 		name: "command_fails",
 		cmd: &profile.PlainCommand{
@@ -75,15 +75,16 @@ func TestCommand(t *testing.T) {
 				Reject:  []*regexp.Regexp{regexp.MustCompile("Realco")},
 			},
 		},
-		expectErr: true,
+		expectErr: `Process exited with status 1: "bad command"`,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := ExecuteCommand(context.Background(), client, tc.cmd)
-			if tc.expectErr {
+			if tc.expectErr != "" {
 				assert.Error(t, err)
-				assert.Error(t, result.Error)
+				assert.ErrorContains(t, result.FormattedError(), tc.expectErr)
 			} else {
 				require.NoError(t, err)
+				assert.Empty(t, result.Error)
 				assert.Equal(t, tc.expected, result.Output)
 			}
 		})

--- a/pkg/networkconfigmanagement/remote/cmd_test.go
+++ b/pkg/networkconfigmanagement/remote/cmd_test.go
@@ -28,10 +28,11 @@ func TestCommand(t *testing.T) {
 	client := MustConnect(t, srv)
 
 	for _, tc := range []struct {
-		name      string
-		cmd       *profile.PlainCommand
-		expected  string
-		expectErr bool
+		name         string
+		cmd          *profile.PlainCommand
+		expected     string
+		expectCmdErr bool
+		expectVdErr  bool
 	}{{
 		name: "unchecked_command",
 		cmd: &profile.PlainCommand{
@@ -56,7 +57,7 @@ func TestCommand(t *testing.T) {
 				Require: []*regexp.Regexp{regexp.MustCompile("Realco")},
 			},
 		},
-		expectErr: true,
+		expectVdErr: true,
 	}, {
 		name: "has_rejection",
 		cmd: &profile.PlainCommand{
@@ -65,7 +66,7 @@ func TestCommand(t *testing.T) {
 				Reject: []*regexp.Regexp{regexp.MustCompile("Fakesco")},
 			},
 		},
-		expectErr: true,
+		expectVdErr: true,
 	}, {
 		name: "command_fails",
 		cmd: &profile.PlainCommand{
@@ -75,15 +76,20 @@ func TestCommand(t *testing.T) {
 				Reject:  []*regexp.Regexp{regexp.MustCompile("Realco")},
 			},
 		},
-		expectErr: true,
+		expectCmdErr: true,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := ExecuteCommand(context.Background(), client, tc.cmd)
-			if tc.expectErr {
+			if tc.expectCmdErr || tc.expectVdErr {
 				assert.Error(t, err)
+				if tc.expectCmdErr {
+					assert.Error(t, result.Error)
+				} else {
+					assert.Error(t, result.ValidationError)
+				}
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, tc.expected, string(result))
+				assert.Equal(t, tc.expected, result.Output)
 			}
 		})
 	}
@@ -168,7 +174,7 @@ func TestSCPCommand(t *testing.T) {
 				assert.ErrorContains(t, err, tc.expectErr)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, tc.expected, response)
+				assert.Equal(t, tc.expected, response.Output)
 			}
 		})
 	}

--- a/pkg/networkconfigmanagement/remote/cmd_test.go
+++ b/pkg/networkconfigmanagement/remote/cmd_test.go
@@ -28,11 +28,10 @@ func TestCommand(t *testing.T) {
 	client := MustConnect(t, srv)
 
 	for _, tc := range []struct {
-		name         string
-		cmd          *profile.PlainCommand
-		expected     string
-		expectCmdErr bool
-		expectVdErr  bool
+		name      string
+		cmd       *profile.PlainCommand
+		expected  string
+		expectErr bool
 	}{{
 		name: "unchecked_command",
 		cmd: &profile.PlainCommand{
@@ -57,7 +56,7 @@ func TestCommand(t *testing.T) {
 				Require: []*regexp.Regexp{regexp.MustCompile("Realco")},
 			},
 		},
-		expectVdErr: true,
+		expectErr: true,
 	}, {
 		name: "has_rejection",
 		cmd: &profile.PlainCommand{
@@ -66,7 +65,7 @@ func TestCommand(t *testing.T) {
 				Reject: []*regexp.Regexp{regexp.MustCompile("Fakesco")},
 			},
 		},
-		expectVdErr: true,
+		expectErr: true,
 	}, {
 		name: "command_fails",
 		cmd: &profile.PlainCommand{
@@ -76,17 +75,13 @@ func TestCommand(t *testing.T) {
 				Reject:  []*regexp.Regexp{regexp.MustCompile("Realco")},
 			},
 		},
-		expectCmdErr: true,
+		expectErr: true,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := ExecuteCommand(context.Background(), client, tc.cmd)
-			if tc.expectCmdErr || tc.expectVdErr {
+			if tc.expectErr {
 				assert.Error(t, err)
-				if tc.expectCmdErr {
-					assert.Error(t, result.Error)
-				} else {
-					assert.Error(t, result.ValidationError)
-				}
+				assert.Error(t, result.Error)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tc.expected, result.Output)

--- a/pkg/networkconfigmanagement/remote/interfaces.go
+++ b/pkg/networkconfigmanagement/remote/interfaces.go
@@ -27,15 +27,15 @@ type Connector interface {
 type PushResult struct {
 	// CopyConfig holds the CommandResults of copying the configuration to the
 	// device (generally via SCP)
-	CopyConfig []*CommandResult
+	CopyConfig ResultList
 	// SetRunning holds the results of attempting to set the device's running
 	// config to the copied configuration.
-	SetRunning []*CommandResult
+	SetRunning ResultList
 	// SetStartup holds the results of attempting to set the device's startup
 	// config to the copied configuration. In most profiles this is done by
 	// copying the running config to the startup config, so this will be empty
 	// if SetRunning contains errors
-	SetStartup []*CommandResult
+	SetStartup ResultList
 }
 
 // Connection is an active connection that can fetch data from a device

--- a/pkg/networkconfigmanagement/remote/interfaces.go
+++ b/pkg/networkconfigmanagement/remote/interfaces.go
@@ -10,6 +10,7 @@ import (
 	"context"
 
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/profile"
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 )
 
 // Connector is an interface that can connect to a device execute commands on a device
@@ -49,6 +50,6 @@ type Connection interface {
 	// commands fail, PushConfig returns an error but ALSO returns a PushResult
 	// with more details - calling code should not assume that the PushResult is
 	// nil just because there was an error.
-	PushConfig(ctx context.Context, config string) (*PushResult, error)
+	PushConfig(ctx context.Context, config string) (*PushResult, types.RollbackError)
 	Close() error
 }

--- a/pkg/networkconfigmanagement/remote/interfaces.go
+++ b/pkg/networkconfigmanagement/remote/interfaces.go
@@ -17,12 +17,38 @@ type Connector interface {
 	Connect() (Connection, error)
 }
 
+// PushResult captures the possible outcomes of executing a PushConfig. We need
+// a more complex structure than just a simple error because we want to track
+// what commands were executed and which ones completed successfully - if, for
+// example, a config push succesfully copies the configuration to the device and
+// sets the running config but fails to set the startup config, it's important
+// that the calling code know that the running configuration has been changed
+// even though the full config replace operation failed.
+type PushResult struct {
+	// CopyConfig holds the CommandResults of copying the configuration to the
+	// device (generally via SCP)
+	CopyConfig []*CommandResult
+	// SetRunning holds the results of attempting to set the device's running
+	// config to the copied configuration.
+	SetRunning []*CommandResult
+	// SetStartup holds the results of attempting to set the device's startup
+	// config to the copied configuration. In most profiles this is done by
+	// copying the running config to the startup config, so this will be empty
+	// if SetRunning contains errors
+	SetStartup []*CommandResult
+}
+
 // Connection is an active connection that can fetch data from a device
 type Connection interface {
 	SetProfile(p *profile.NCMProfile)
 	RetrieveRunningConfig(ctx context.Context) (*CommandResult, error)
 	RetrieveStartupConfig(ctx context.Context) (*CommandResult, error)
 	Verify(ctx context.Context) error
-	PushConfig(ctx context.Context, config string) ([]*CommandResult, error)
+	// PushConfig pushes a new config to the device, returning a PushResult that
+	// documents what commands were executed and their outputs. Note: If any
+	// commands fail, PushConfig returns an error but ALSO returns a PushResult
+	// with more details - calling code should not assume that the PushResult is
+	// nil just because there was an error.
+	PushConfig(ctx context.Context, config string) (*PushResult, error)
 	Close() error
 }

--- a/pkg/networkconfigmanagement/remote/interfaces.go
+++ b/pkg/networkconfigmanagement/remote/interfaces.go
@@ -28,15 +28,15 @@ type Connector interface {
 type PushResult struct {
 	// CopyConfig holds the CommandResults of copying the configuration to the
 	// device (generally via SCP)
-	CopyConfig ResultList
+	CopyConfig ResultList `json:"copy_config"`
 	// SetRunning holds the results of attempting to set the device's running
 	// config to the copied configuration.
-	SetRunning ResultList
+	SetRunning ResultList `json:"set_running"`
 	// SetStartup holds the results of attempting to set the device's startup
 	// config to the copied configuration. In most profiles this is done by
 	// copying the running config to the startup config, so this will be empty
 	// if SetRunning contains errors
-	SetStartup ResultList
+	SetStartup ResultList `json:"set_startup"`
 }
 
 // Connection is an active connection that can fetch data from a device

--- a/pkg/networkconfigmanagement/remote/interfaces.go
+++ b/pkg/networkconfigmanagement/remote/interfaces.go
@@ -20,9 +20,9 @@ type Connector interface {
 // Connection is an active connection that can fetch data from a device
 type Connection interface {
 	SetProfile(p *profile.NCMProfile)
-	RetrieveRunningConfig(ctx context.Context) ([]byte, error)
-	RetrieveStartupConfig(ctx context.Context) ([]byte, error)
+	RetrieveRunningConfig(ctx context.Context) (*CommandResult, error)
+	RetrieveStartupConfig(ctx context.Context) (*CommandResult, error)
 	Verify(ctx context.Context) error
-	PushConfig(ctx context.Context, config string) error
+	PushConfig(ctx context.Context, config string) ([]*CommandResult, error)
 	Close() error
 }

--- a/pkg/networkconfigmanagement/remote/interfaces.go
+++ b/pkg/networkconfigmanagement/remote/interfaces.go
@@ -20,10 +20,10 @@ type Connector interface {
 // PushResult captures the possible outcomes of executing a PushConfig. We need
 // a more complex structure than just a simple error because we want to track
 // what commands were executed and which ones completed successfully - if, for
-// example, a config push succesfully copies the configuration to the device and
-// sets the running config but fails to set the startup config, it's important
-// that the calling code know that the running configuration has been changed
-// even though the full config replace operation failed.
+// example, a config push successfully copies the configuration to the device
+// and sets the running config but fails to set the startup config, it's
+// important that the calling code know that the running configuration has been
+// changed even though the full config replace operation failed.
 type PushResult struct {
 	// CopyConfig holds the CommandResults of copying the configuration to the
 	// device (generally via SCP)

--- a/pkg/networkconfigmanagement/remote/interfaces.go
+++ b/pkg/networkconfigmanagement/remote/interfaces.go
@@ -18,38 +18,17 @@ type Connector interface {
 	Connect() (Connection, error)
 }
 
-// PushResult captures the possible outcomes of executing a PushConfig. We need
-// a more complex structure than just a simple error because we want to track
-// what commands were executed and which ones completed successfully - if, for
-// example, a config push successfully copies the configuration to the device
-// and sets the running config but fails to set the startup config, it's
-// important that the calling code know that the running configuration has been
-// changed even though the full config replace operation failed.
-type PushResult struct {
-	// CopyConfig holds the CommandResults of copying the configuration to the
-	// device (generally via SCP)
-	CopyConfig ResultList `json:"copy_config"`
-	// SetRunning holds the results of attempting to set the device's running
-	// config to the copied configuration.
-	SetRunning ResultList `json:"set_running"`
-	// SetStartup holds the results of attempting to set the device's startup
-	// config to the copied configuration. In most profiles this is done by
-	// copying the running config to the startup config, so this will be empty
-	// if SetRunning contains errors
-	SetStartup ResultList `json:"set_startup"`
-}
-
 // Connection is an active connection that can fetch data from a device
 type Connection interface {
 	SetProfile(p *profile.NCMProfile)
-	RetrieveRunningConfig(ctx context.Context) (*CommandResult, error)
-	RetrieveStartupConfig(ctx context.Context) (*CommandResult, error)
+	RetrieveRunningConfig(ctx context.Context) (*types.CommandResult, error)
+	RetrieveStartupConfig(ctx context.Context) (*types.CommandResult, error)
 	Verify(ctx context.Context) error
 	// PushConfig pushes a new config to the device, returning a PushResult that
 	// documents what commands were executed and their outputs. Note: If any
 	// commands fail, PushConfig returns an error but ALSO returns a PushResult
 	// with more details - calling code should not assume that the PushResult is
 	// nil just because there was an error.
-	PushConfig(ctx context.Context, config string) (*PushResult, types.RollbackError)
+	PushConfig(ctx context.Context, config string) (*types.PushResult, types.RollbackError)
 	Close() error
 }

--- a/pkg/networkconfigmanagement/remote/ssh.go
+++ b/pkg/networkconfigmanagement/remote/ssh.go
@@ -183,33 +183,38 @@ func (c *SSHConnector) Connect() (Connection, error) {
 	}, nil
 }
 
-func (c *SSHConnection) PushConfig(ctx context.Context, rawConfig string) ([]*CommandResult, error) {
+func (c *SSHConnection) PushConfig(ctx context.Context, rawConfig string) (*PushResult, error) {
 	if c.prof == nil {
 		return nil, fmt.Errorf("no device type provided for %q", c.device.IPAddress)
 	}
-	if len(c.prof.Commands.PushConfig) == 0 {
+	pc := c.prof.Commands.PushConfig
+	if !pc.CanPush() {
 		return nil, fmt.Errorf("no push commands for profile %q", c.prof.Name)
 	}
-	var results []*CommandResult
-	for _, untypedCmd := range c.prof.Commands.PushConfig {
-		switch cmd := untypedCmd.(type) {
-		case *profile.SCPCommand:
-			result, err := ExecuteSCP(ctx, c.client, cmd, rawConfig)
-			if result != nil {
-				results = append(results, result)
-			}
-			if err != nil {
-				return results, fmt.Errorf("unable to copy config to device %q: %w", c.device.IPAddress, err)
-			}
-		case *profile.PlainCommand:
-			result, err := ExecuteCommand(ctx, c.client, cmd)
-			if result != nil {
-				results = append(results, result)
-			}
-			if err != nil {
-				return results, fmt.Errorf("error while pushing config to device %q: %w", c.device.IPAddress, err)
-			}
-		}
+	results := &PushResult{}
+	// Copy the raw configuration to the device
+	result, err := ExecuteSCP(ctx, c.client, pc.Copy, rawConfig)
+	if result != nil {
+		results.CopyConfig = append(results.CopyConfig, result)
+	}
+	if err != nil {
+		return results, fmt.Errorf("unable to copy config to device %q: %w", c.device.IPAddress, err)
+	}
+	// Set the running configuration from the file
+	result, err = ExecuteCommand(ctx, c.client, pc.SetRunning)
+	if result != nil {
+		results.SetRunning = append(results.SetRunning, result)
+	}
+	if err != nil {
+		return results, fmt.Errorf("error while pushing config to device %q: %w", c.device.IPAddress, err)
+	}
+	// Set the startup configuration from the running config
+	result, err = ExecuteCommand(ctx, c.client, pc.SetStartup)
+	if result != nil {
+		results.SetStartup = append(results.SetStartup, result)
+	}
+	if err != nil {
+		return results, fmt.Errorf("error while pushing config to device %q: %w", c.device.IPAddress, err)
 	}
 	return results, nil
 }

--- a/pkg/networkconfigmanagement/remote/ssh.go
+++ b/pkg/networkconfigmanagement/remote/ssh.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/crypto/ssh/knownhosts"
 
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/profile"
+	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 
 	ncmconfig "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -184,12 +185,13 @@ func (c *SSHConnector) Connect() (Connection, error) {
 }
 
 func (c *SSHConnection) PushConfig(ctx context.Context, rawConfig string) (*PushResult, error) {
+
 	if c.prof == nil {
-		return nil, fmt.Errorf("no device type provided for %q", c.device.IPAddress)
+		return nil, types.WrapErrorf(types.ErrNoProfile, "no device type provided for %q", c.device.IPAddress)
 	}
 	pc := c.prof.Commands.PushConfig
 	if !pc.CanPush() {
-		return nil, fmt.Errorf("no push commands for profile %q", c.prof.Name)
+		return nil, types.WrapErrorf(types.ErrPushUnsupported, "no push commands for profile %q", c.prof.Name)
 	}
 	results := &PushResult{}
 	// Copy the raw configuration to the device
@@ -198,7 +200,7 @@ func (c *SSHConnection) PushConfig(ctx context.Context, rawConfig string) (*Push
 		results.CopyConfig = append(results.CopyConfig, result)
 	}
 	if err != nil {
-		return results, fmt.Errorf("unable to copy config to device %q: %w", c.device.IPAddress, err)
+		return results, types.WrapErrorf(types.ErrCopyFailed, "unable to copy config to device %q: %w", c.device.IPAddress, err)
 	}
 	// Set the running configuration from the file
 	result, err = ExecuteCommand(ctx, c.client, pc.SetRunning)
@@ -206,7 +208,7 @@ func (c *SSHConnection) PushConfig(ctx context.Context, rawConfig string) (*Push
 		results.SetRunning = append(results.SetRunning, result)
 	}
 	if err != nil {
-		return results, fmt.Errorf("error while pushing config to device %q: %w", c.device.IPAddress, err)
+		return results, types.WrapErrorf(types.ErrSetRunningFailed, "error while pushing config to device %q: %w", c.device.IPAddress, err)
 	}
 	// Set the startup configuration from the running config
 	result, err = ExecuteCommand(ctx, c.client, pc.SetStartup)
@@ -214,7 +216,7 @@ func (c *SSHConnection) PushConfig(ctx context.Context, rawConfig string) (*Push
 		results.SetStartup = append(results.SetStartup, result)
 	}
 	if err != nil {
-		return results, fmt.Errorf("error while pushing config to device %q: %w", c.device.IPAddress, err)
+		return results, types.WrapErrorf(types.ErrSetStartupFailed, "error while pushing config to device %q: %w", c.device.IPAddress, err)
 	}
 	return results, nil
 }

--- a/pkg/networkconfigmanagement/remote/ssh.go
+++ b/pkg/networkconfigmanagement/remote/ssh.go
@@ -183,26 +183,35 @@ func (c *SSHConnector) Connect() (Connection, error) {
 	}, nil
 }
 
-func (c *SSHConnection) PushConfig(ctx context.Context, rawConfig string) error {
+func (c *SSHConnection) PushConfig(ctx context.Context, rawConfig string) ([]*CommandResult, error) {
 	if c.prof == nil {
-		return fmt.Errorf("no device type provided for %q", c.device.IPAddress)
+		return nil, fmt.Errorf("no device type provided for %q", c.device.IPAddress)
 	}
 	if len(c.prof.Commands.PushConfig) == 0 {
-		return fmt.Errorf("no push commands for profile %q", c.prof.Name)
+		return nil, fmt.Errorf("no push commands for profile %q", c.prof.Name)
 	}
+	var results []*CommandResult
 	for _, untypedCmd := range c.prof.Commands.PushConfig {
 		switch cmd := untypedCmd.(type) {
 		case *profile.SCPCommand:
-			if _, err := ExecuteSCP(ctx, c.client, cmd, rawConfig); err != nil {
-				return fmt.Errorf("unable to copy config to device %q: %w", c.device.IPAddress, err)
+			result, err := ExecuteSCP(ctx, c.client, cmd, rawConfig)
+			if result != nil {
+				results = append(results, result)
+			}
+			if err != nil {
+				return results, fmt.Errorf("unable to copy config to device %q: %w", c.device.IPAddress, err)
 			}
 		case *profile.PlainCommand:
-			if _, err := ExecuteCommand(ctx, c.client, cmd); err != nil {
-				return fmt.Errorf("error while pushing config to device %q: %w", c.device.IPAddress, err)
+			result, err := ExecuteCommand(ctx, c.client, cmd)
+			if result != nil {
+				results = append(results, result)
+			}
+			if err != nil {
+				return results, fmt.Errorf("error while pushing config to device %q: %w", c.device.IPAddress, err)
 			}
 		}
 	}
-	return nil
+	return results, nil
 }
 
 // Verify validates that the profile works as we expect it to
@@ -219,7 +228,7 @@ func (c *SSHConnection) Verify(ctx context.Context) error {
 }
 
 // RetrieveRunningConfig retrieves the running configuration for the device connected via SSH
-func (c *SSHConnection) RetrieveRunningConfig(ctx context.Context) ([]byte, error) {
+func (c *SSHConnection) RetrieveRunningConfig(ctx context.Context) (*CommandResult, error) {
 	if c.prof == nil {
 		return nil, fmt.Errorf("no device type provided for %q", c.device.IPAddress)
 	}
@@ -231,7 +240,7 @@ func (c *SSHConnection) RetrieveRunningConfig(ctx context.Context) ([]byte, erro
 }
 
 // RetrieveStartupConfig retrieves the startup configuration for the device connected via SSH
-func (c *SSHConnection) RetrieveStartupConfig(ctx context.Context) ([]byte, error) {
+func (c *SSHConnection) RetrieveStartupConfig(ctx context.Context) (*CommandResult, error) {
 	if c.prof == nil {
 		return nil, fmt.Errorf("no device type provided for %q", c.device.IPAddress)
 	}
@@ -242,12 +251,8 @@ func (c *SSHConnection) RetrieveStartupConfig(ctx context.Context) ([]byte, erro
 	return c.execute(ctx, cmd)
 }
 
-func (c *SSHConnection) execute(ctx context.Context, cmd *profile.PlainCommand) ([]byte, error) {
-	result, err := ExecuteCommand(ctx, c.client, cmd)
-	if err != nil {
-		return nil, err
-	}
-	return []byte(result), nil
+func (c *SSHConnection) execute(ctx context.Context, cmd *profile.PlainCommand) (*CommandResult, error) {
+	return ExecuteCommand(ctx, c.client, cmd)
 }
 
 // Close closes the SSH client connection

--- a/pkg/networkconfigmanagement/remote/ssh.go
+++ b/pkg/networkconfigmanagement/remote/ssh.go
@@ -184,7 +184,7 @@ func (c *SSHConnector) Connect() (Connection, error) {
 	}, nil
 }
 
-func (c *SSHConnection) PushConfig(ctx context.Context, rawConfig string) (*PushResult, error) {
+func (c *SSHConnection) PushConfig(ctx context.Context, rawConfig string) (*PushResult, types.RollbackError) {
 
 	if c.prof == nil {
 		return nil, types.WrapErrorf(types.ErrNoProfile, "no device type provided for %q", c.device.IPAddress)

--- a/pkg/networkconfigmanagement/remote/ssh.go
+++ b/pkg/networkconfigmanagement/remote/ssh.go
@@ -210,13 +210,15 @@ func (c *SSHConnection) PushConfig(ctx context.Context, rawConfig string) (*type
 	if err != nil {
 		return results, types.WrapErrorf(types.ErrSetRunningFailed, "error while pushing config to device %q: %w", c.device.IPAddress, err)
 	}
-	// Set the startup configuration from the running config
-	result, err = ExecuteCommand(ctx, c.client, pc.SetStartup)
-	if result != nil {
-		results.SetStartup = append(results.SetStartup, result)
-	}
-	if err != nil {
-		return results, types.WrapErrorf(types.ErrSetStartupFailed, "error while pushing config to device %q: %w", c.device.IPAddress, err)
+	if pc.SetStartup != nil {
+		// Set the startup configuration from the running config
+		result, err = ExecuteCommand(ctx, c.client, pc.SetStartup)
+		if result != nil {
+			results.SetStartup = append(results.SetStartup, result)
+		}
+		if err != nil {
+			return results, types.WrapErrorf(types.ErrSetStartupFailed, "error while pushing config to device %q: %w", c.device.IPAddress, err)
+		}
 	}
 	return results, nil
 }

--- a/pkg/networkconfigmanagement/remote/ssh.go
+++ b/pkg/networkconfigmanagement/remote/ssh.go
@@ -184,7 +184,7 @@ func (c *SSHConnector) Connect() (Connection, error) {
 	}, nil
 }
 
-func (c *SSHConnection) PushConfig(ctx context.Context, rawConfig string) (*PushResult, types.RollbackError) {
+func (c *SSHConnection) PushConfig(ctx context.Context, rawConfig string) (*types.PushResult, types.RollbackError) {
 
 	if c.prof == nil {
 		return nil, types.WrapErrorf(types.ErrNoProfile, "no device type provided for %q", c.device.IPAddress)
@@ -193,7 +193,7 @@ func (c *SSHConnection) PushConfig(ctx context.Context, rawConfig string) (*Push
 	if !pc.CanPush() {
 		return nil, types.WrapErrorf(types.ErrPushUnsupported, "no push commands for profile %q", c.prof.Name)
 	}
-	results := &PushResult{}
+	results := &types.PushResult{}
 	// Copy the raw configuration to the device
 	result, err := ExecuteSCP(ctx, c.client, pc.Copy, rawConfig)
 	if result != nil {
@@ -235,7 +235,7 @@ func (c *SSHConnection) Verify(ctx context.Context) error {
 }
 
 // RetrieveRunningConfig retrieves the running configuration for the device connected via SSH
-func (c *SSHConnection) RetrieveRunningConfig(ctx context.Context) (*CommandResult, error) {
+func (c *SSHConnection) RetrieveRunningConfig(ctx context.Context) (*types.CommandResult, error) {
 	if c.prof == nil {
 		return nil, fmt.Errorf("no device type provided for %q", c.device.IPAddress)
 	}
@@ -247,7 +247,7 @@ func (c *SSHConnection) RetrieveRunningConfig(ctx context.Context) (*CommandResu
 }
 
 // RetrieveStartupConfig retrieves the startup configuration for the device connected via SSH
-func (c *SSHConnection) RetrieveStartupConfig(ctx context.Context) (*CommandResult, error) {
+func (c *SSHConnection) RetrieveStartupConfig(ctx context.Context) (*types.CommandResult, error) {
 	if c.prof == nil {
 		return nil, fmt.Errorf("no device type provided for %q", c.device.IPAddress)
 	}
@@ -258,7 +258,7 @@ func (c *SSHConnection) RetrieveStartupConfig(ctx context.Context) (*CommandResu
 	return c.execute(ctx, cmd)
 }
 
-func (c *SSHConnection) execute(ctx context.Context, cmd *profile.PlainCommand) (*CommandResult, error) {
+func (c *SSHConnection) execute(ctx context.Context, cmd *profile.PlainCommand) (*types.CommandResult, error) {
 	return ExecuteCommand(ctx, c.client, cmd)
 }
 

--- a/pkg/networkconfigmanagement/remote/ssh_test.go
+++ b/pkg/networkconfigmanagement/remote/ssh_test.go
@@ -92,15 +92,15 @@ interface GigabitEthernet0/1
 		},
 	})
 	t.Run("running_config", func(t *testing.T) {
-		config, err := conn.RetrieveRunningConfig(context.Background())
+		result, err := conn.RetrieveRunningConfig(context.Background())
 		if assert.NoError(t, err) {
-			assert.Equal(t, expectedConfig, string(config))
+			assert.Equal(t, expectedConfig, string(result.Output))
 		}
 	})
 	t.Run("startup_config", func(t *testing.T) {
-		config, err := conn.RetrieveStartupConfig(context.Background())
+		result, err := conn.RetrieveStartupConfig(context.Background())
 		if assert.NoError(t, err) {
-			assert.Equal(t, expectedConfig, string(config))
+			assert.Equal(t, expectedConfig, string(result.Output))
 		}
 	})
 }

--- a/pkg/networkconfigmanagement/store/mem_store.go
+++ b/pkg/networkconfigmanagement/store/mem_store.go
@@ -128,7 +128,7 @@ func (m *memConfigStore) GetConfig(configUUID string) (string, *types.ConfigMeta
 
 	rawConfig, ok := m.rawConfigs[configUUID]
 	if !ok {
-		return "", nil, &UnknownUUIDError{configUUID}
+		return "", nil, &ConfigNotFoundError{configUUID}
 	}
 
 	meta := m.metadata[configUUID]

--- a/pkg/networkconfigmanagement/store/mem_store.go
+++ b/pkg/networkconfigmanagement/store/mem_store.go
@@ -7,7 +7,6 @@ package store
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"sync"
 
@@ -129,7 +128,7 @@ func (m *memConfigStore) GetConfig(configUUID string) (string, *types.ConfigMeta
 
 	rawConfig, ok := m.rawConfigs[configUUID]
 	if !ok {
-		return "", nil, fmt.Errorf("raw config not found for UUID: %s", configUUID)
+		return "", nil, &UnknownUUIDError{configUUID}
 	}
 
 	meta := m.metadata[configUUID]

--- a/pkg/networkconfigmanagement/store/store.go
+++ b/pkg/networkconfigmanagement/store/store.go
@@ -242,7 +242,7 @@ func (cs *configStore) GetConfig(configUUID string) (string, *types.ConfigMetada
 		// Unmarshal raw config
 		rawConfigBytes := tx.Bucket([]byte(rawConfigBucket)).Get(key)
 		if rawConfigBytes == nil {
-			return &UnknownUUIDError{configUUID}
+			return &ConfigNotFoundError{configUUID}
 		}
 		decompressedRawConfig, err := cs.compressor.Decompress(rawConfigBytes)
 		if err != nil {

--- a/pkg/networkconfigmanagement/store/store.go
+++ b/pkg/networkconfigmanagement/store/store.go
@@ -228,8 +228,10 @@ func (cs *configStore) CheckDuplicate(deviceID string, configType types.ConfigTy
 	return existing.ConfigUUID, nil
 }
 
-// GetConfig retrieves all the data associated with a config given its UUID, and refreshes
-// its LastAccessedAt so actively-retrieved configs aren't treated as stale by LRU eviction.
+// GetConfig retrieves the data for a config by UUID, and refreshes its
+// LastAccessedAt so actively-retrieved configs aren't treated as stale by LRU
+// eviction. It will return an UnknownUUIDError if the UUID isn't recognized;
+// any other returned error indicates a problem with the database.
 func (cs *configStore) GetConfig(configUUID string) (string, *types.ConfigMetadata, error) {
 	var rawConfig string
 	var metadata types.ConfigMetadata
@@ -240,7 +242,7 @@ func (cs *configStore) GetConfig(configUUID string) (string, *types.ConfigMetada
 		// Unmarshal raw config
 		rawConfigBytes := tx.Bucket([]byte(rawConfigBucket)).Get(key)
 		if rawConfigBytes == nil {
-			return fmt.Errorf("raw config not found for UUID: %s", configUUID)
+			return &UnknownUUIDError{configUUID}
 		}
 		decompressedRawConfig, err := cs.compressor.Decompress(rawConfigBytes)
 		if err != nil {

--- a/pkg/networkconfigmanagement/store/types.go
+++ b/pkg/networkconfigmanagement/store/types.go
@@ -13,14 +13,21 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 )
 
-// UnknownUUIDError indicates that the given UUID wasn't present in the store.
-type UnknownUUIDError struct {
+// ConfigNotFoundError indicates that the given UUID wasn't present in the store.
+type ConfigNotFoundError struct {
 	UUID string
 }
 
-func (u *UnknownUUIDError) Error() string {
+// Type implements [types.RollbackError].
+func (u *ConfigNotFoundError) Type() types.ErrorType {
+	return types.ErrConfigNotPresent
+}
+
+func (u *ConfigNotFoundError) Error() string {
 	return "raw config not found for UUID: " + u.UUID
 }
+
+var _ types.RollbackError = (*ConfigNotFoundError)(nil)
 
 // ConfigStore implements persistent KV store for configurations for rollbacks
 // whenever a config is retrieved, we will store agent-side along with the payload sent

--- a/pkg/networkconfigmanagement/store/types.go
+++ b/pkg/networkconfigmanagement/store/types.go
@@ -13,12 +13,24 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 )
 
+// UnknownUUIDError indicates that the given UUID wasn't present in the store.
+type UnknownUUIDError struct {
+	UUID string
+}
+
+func (u *UnknownUUIDError) Error() string {
+	return "raw config not found for UUID: " + u.UUID
+}
+
 // ConfigStore implements persistent KV store for configurations for rollbacks
 // whenever a config is retrieved, we will store agent-side along with the payload sent
 // to intake to enable "rollbacks" without sending sensitive data (in configs) back and forth
 type ConfigStore interface {
 	Close(context.Context) error
 	StoreConfig(deviceID string, configType types.ConfigType, rawConfig string) (configUUID string, configHash string, stored bool, err error)
+	// GetConfig fetches data for a given UUID. It should return an
+	// UnknownUUIDError if the UUID isn't present in the store (any other error
+	// type indicates a problem with the store itself, such as data corruption)
 	GetConfig(configUUID string) (string, *types.ConfigMetadata, error)
 	CheckDuplicate(deviceID string, configType types.ConfigType, rawHash string) (string, error)
 	GetAllConfigMetadata() ([]*types.ConfigMetadata, error)

--- a/pkg/networkconfigmanagement/types/BUILD.bazel
+++ b/pkg/networkconfigmanagement/types/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "types",
-    srcs = ["types.go"],
+    srcs = [
+        "errors.go",
+        "types.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types",
     visibility = ["//visibility:public"],
 )

--- a/pkg/networkconfigmanagement/types/BUILD.bazel
+++ b/pkg/networkconfigmanagement/types/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "types",
     srcs = [
         "errors.go",
+        "results.go",
         "types.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types",

--- a/pkg/networkconfigmanagement/types/errors.go
+++ b/pkg/networkconfigmanagement/types/errors.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package types
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrorType indicates what type of error happened
+type ErrorType string
+
+const (
+	ErrUnknown  ErrorType = ""
+	ErrInternal ErrorType = "internal_error"
+	ErrDisabled ErrorType = "rollback_disabled"
+	// Argument errors
+	ErrNoSuchDevice     ErrorType = "unknown_device"     // the DeviceID isn't recognized
+	ErrConfigNotPresent ErrorType = "unknown_config"     // the configID isn't in the local store
+	ErrWrongDeviceID    ErrorType = "device_id_mismatch" // the config in the local store isn't for this deviceID
+	ErrWrongHash        ErrorType = "hash_mismatch"      // the config has doesn't match what's in the store
+	// Connection/profile errors
+	ErrCannotConnect ErrorType = "cannot_connect" // failed to connect to the device
+	ErrNoProfile     ErrorType = "no_profile"     // the device doesn't have a configured profile and no candidate matched
+	// ErrProfileNotMatched // the device DOES have an explicitly-configured profile but it doesn't agree with the Verify() method
+	ErrPushUnsupported ErrorType = "rollback_not_implemented" // the device's profile doesn't support pushing config
+	// Failures during the actual rollback
+	ErrCopyFailed       ErrorType = "copy_failed"        // we couldn't copy the configuration to the device
+	ErrSetRunningFailed ErrorType = "set_running_failed" // we couldn't set the running config
+	ErrSetStartupFailed ErrorType = "set_startup_failed" // we couldn't set the startup config
+	// Trailing errors (rollback succeeds but something else goes wrong)
+	ErrReportConfigFailed ErrorType = "report_config_failed" // rollback succeeded but something went wrong trying to fetch the configuration afterwards
+)
+
+// RollbackError is an error that exposes an ErrorType
+type RollbackError interface {
+	error
+	Type() ErrorType
+}
+
+// rollbackWrapper wraps an existing error with an ErrorType
+type rollbackWrapper struct {
+	errType ErrorType
+	wrapped error
+}
+
+func (re *rollbackWrapper) Type() ErrorType {
+	return re.errType
+}
+
+func (re *rollbackWrapper) Error() string {
+	return re.wrapped.Error()
+}
+
+func (re *rollbackWrapper) Unwrap() error {
+	return re.wrapped
+}
+
+// WrapError wraps an error in a RollbackError
+func WrapError(etype ErrorType, err error) RollbackError {
+	return &rollbackWrapper{
+		errType: etype,
+		wrapped: err,
+	}
+}
+
+// WrapErrorf is shorthand for WrapError(etype, fmt.Errorf(...))
+func WrapErrorf(etype ErrorType, msg string, args ...any) RollbackError {
+	return WrapError(etype, fmt.Errorf(msg, args...))
+}
+
+var RollbackDisabled = WrapErrorf(ErrDisabled, "rollback is disabled")
+
+// InternalError is a shorthand for wrapping an error with ErrInternal
+func InternalError(err error) RollbackError {
+	return WrapError(ErrInternal, err)
+}
+
+// AsRollbackError is a no-op if error is nil or already a RollbackError,
+// otherwise it wraps it with ErrInternal.
+func AsRollbackError(err error) RollbackError {
+	// no error -> ok
+	if err == nil {
+		return nil
+	}
+	// already a rollback error -> nothing to do
+	if rberr, ok := errors.AsType[RollbackError](err); ok {
+		return rberr
+	}
+	// not a RollbackError -> wrap with InternalError
+	return InternalError(err)
+
+}

--- a/pkg/networkconfigmanagement/types/errors.go
+++ b/pkg/networkconfigmanagement/types/errors.go
@@ -23,10 +23,10 @@ const (
 	ErrWrongDeviceID    ErrorType = "device_id_mismatch" // the config in the local store isn't for this deviceID
 	ErrWrongHash        ErrorType = "hash_mismatch"      // the config has doesn't match what's in the store
 	// Connection/profile errors
-	ErrCannotConnect ErrorType = "cannot_connect" // failed to connect to the device
-	ErrNoProfile     ErrorType = "no_profile"     // the device doesn't have a configured profile and no candidate matched
+	ErrCannotConnect ErrorType = "device_unreachable" // failed to connect to the device
+	ErrNoProfile     ErrorType = "no_profile"         // the device doesn't have a configured profile and no candidate matched
 	// ErrProfileNotMatched // the device DOES have an explicitly-configured profile but it doesn't agree with the Verify() method
-	ErrPushUnsupported ErrorType = "rollback_not_implemented" // the device's profile doesn't support pushing config
+	ErrPushUnsupported ErrorType = "rollback_not_supported" // the device's profile doesn't support pushing config
 	// Failures during the actual rollback
 	ErrCopyFailed       ErrorType = "copy_failed"        // we couldn't copy the configuration to the device
 	ErrSetRunningFailed ErrorType = "set_running_failed" // we couldn't set the running config

--- a/pkg/networkconfigmanagement/types/results.go
+++ b/pkg/networkconfigmanagement/types/results.go
@@ -51,9 +51,6 @@ type PushResult struct {
 	// copying the running config to the startup config, so this will be empty
 	// if SetRunning contains errors
 	SetStartup ResultList `json:"set_startup"`
-	// CheckConfigError holds any error that came up trying to fetch the config
-	// after successfully executing the push.
-	CheckConfigError string `json:"check_config_error"`
 }
 
 // RollbackResponse is the JSON body returned by the /agent/ncm/rollback endpoint.

--- a/pkg/networkconfigmanagement/types/results.go
+++ b/pkg/networkconfigmanagement/types/results.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package types
+
+import (
+	"errors"
+	"fmt"
+)
+
+// CommandResult records a command that was run and the resulting output.
+type CommandResult struct {
+	CommandStr string `json:"command_str"`
+	Output     string `json:"output"`
+	Error      string `json:"error"`
+}
+
+// FormattedError returns nil if there was no error, and otherwise returns an
+// error containing .Error and, if it was nonempty, .Output.
+func (c *CommandResult) FormattedError() error {
+	if c.Error == "" {
+		return nil
+	}
+	if c.Output != "" {
+		return fmt.Errorf("%v: %q", c.Error, c.Output)
+	}
+	return errors.New(c.Error)
+}
+
+// ResultList is a list of CommandResults
+type ResultList []*CommandResult
+
+// PushResult captures the possible outcomes of executing a PushConfig. We need
+// a more complex structure than just a simple error because we want to track
+// what commands were executed and which ones completed successfully - if, for
+// example, a config push successfully copies the configuration to the device
+// and sets the running config but fails to set the startup config, it's
+// important that the calling code know that the running configuration has been
+// changed even though the full config replace operation failed.
+type PushResult struct {
+	// CopyConfig holds the CommandResults of copying the configuration to the
+	// device (generally via SCP)
+	CopyConfig ResultList `json:"copy_config"`
+	// SetRunning holds the results of attempting to set the device's running
+	// config to the copied configuration.
+	SetRunning ResultList `json:"set_running"`
+	// SetStartup holds the results of attempting to set the device's startup
+	// config to the copied configuration. In most profiles this is done by
+	// copying the running config to the startup config, so this will be empty
+	// if SetRunning contains errors
+	SetStartup ResultList `json:"set_startup"`
+}
+
+// RollbackResponse is the JSON body returned by the /agent/ncm/rollback endpoint.
+type RollbackResponse struct {
+	CommandResults *PushResult `json:"command_results"`
+	ErrorCode      string      `json:"error_code"`
+	ErrorMsg       string      `json:"error_msg"`
+}

--- a/pkg/networkconfigmanagement/types/results.go
+++ b/pkg/networkconfigmanagement/types/results.go
@@ -51,6 +51,9 @@ type PushResult struct {
 	// copying the running config to the startup config, so this will be empty
 	// if SetRunning contains errors
 	SetStartup ResultList `json:"set_startup"`
+	// CheckConfigError holds any error that came up trying to fetch the config
+	// after successfully executing the push.
+	CheckConfigError string `json:"check_config_error"`
 }
 
 // RollbackResponse is the JSON body returned by the /agent/ncm/rollback endpoint.

--- a/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement/BUILD.bazel
+++ b/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement/BUILD.bazel
@@ -10,10 +10,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/ipc/def",
-        "//comp/networkconfigmanagement/impl",
         "//pkg/config/helper",
         "//pkg/config/setup",
-        "//pkg/networkconfigmanagement/remote",
+        "//pkg/networkconfigmanagement/types",
         "//pkg/privateactionrunner/libs/privateconnection",
         "//pkg/privateactionrunner/types",
         "@com_github_benbjohnson_clock//:clock",

--- a/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement/BUILD.bazel
+++ b/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement/BUILD.bazel
@@ -10,8 +10,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/ipc/def",
+        "//comp/networkconfigmanagement/impl",
         "//pkg/config/helper",
         "//pkg/config/setup",
+        "//pkg/networkconfigmanagement/remote",
         "//pkg/privateactionrunner/libs/privateconnection",
         "//pkg/privateactionrunner/types",
         "@com_github_benbjohnson_clock//:clock",

--- a/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement/rollback_config.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement/rollback_config.go
@@ -19,10 +19,9 @@ import (
 	"github.com/benbjohnson/clock"
 
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
-	networkconfigmanagementimpl "github.com/DataDog/datadog-agent/comp/networkconfigmanagement/impl"
 	pkgconfighelper "github.com/DataDog/datadog-agent/pkg/config/helper"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-	ncmremote "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/remote"
+	ncmtypes "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/types"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
 )
@@ -54,11 +53,11 @@ type RollbackConfigInputs struct {
 
 // RollbackConfigOutputs is the output of a rollbackConfig action.
 type RollbackConfigOutputs struct {
-	Success        bool                  `json:"success,omitempty"`
-	CommandResults *ncmremote.PushResult `json:"command_results"`
-	Error          string                `json:"error,omitempty"`
-	ErrorCode      string                `json:"error_code"`
-	FinishedAt     *time.Time            `json:"finished_at,omitempty"`
+	Success        bool                 `json:"success,omitempty"`
+	CommandResults *ncmtypes.PushResult `json:"command_results"`
+	Error          string               `json:"error,omitempty"`
+	ErrorCode      string               `json:"error_code"`
+	FinishedAt     *time.Time           `json:"finished_at,omitempty"`
 }
 
 // Run executes the rollbackConfig action
@@ -106,7 +105,7 @@ func (h *RollbackConfigHandler) Run(
 		}
 		return RollbackConfigOutputs{Error: errMsg}, err
 	}
-	var response *networkconfigmanagementimpl.RollbackResponse
+	var response *ncmtypes.RollbackResponse
 	if err := json.Unmarshal(resp, &response); err != nil {
 		return RollbackConfigOutputs{Error: err.Error()}, fmt.Errorf("unable to unmarshal rollback response: %w", err)
 	}

--- a/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement/rollback_config.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement/rollback_config.go
@@ -54,11 +54,11 @@ type RollbackConfigInputs struct {
 
 // RollbackConfigOutputs is the output of a rollbackConfig action.
 type RollbackConfigOutputs struct {
-	Success        bool `json:"success,omitempty"`
-	CommandResults *ncmremote.PushResult
-	Error          string `json:"error,omitempty"`
-	ErrorCode      string
-	FinishedAt     *time.Time `json:"finished_at,omitempty"`
+	Success        bool                  `json:"success,omitempty"`
+	CommandResults *ncmremote.PushResult `json:"command_results"`
+	Error          string                `json:"error,omitempty"`
+	ErrorCode      string                `json:"error_code"`
+	FinishedAt     *time.Time            `json:"finished_at,omitempty"`
 }
 
 // Run executes the rollbackConfig action

--- a/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement/rollback_config.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement/rollback_config.go
@@ -19,8 +19,10 @@ import (
 	"github.com/benbjohnson/clock"
 
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	networkconfigmanagementimpl "github.com/DataDog/datadog-agent/comp/networkconfigmanagement/impl"
 	pkgconfighelper "github.com/DataDog/datadog-agent/pkg/config/helper"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	ncmremote "github.com/DataDog/datadog-agent/pkg/networkconfigmanagement/remote"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
 )
@@ -52,9 +54,11 @@ type RollbackConfigInputs struct {
 
 // RollbackConfigOutputs is the output of a rollbackConfig action.
 type RollbackConfigOutputs struct {
-	Success    bool       `json:"success,omitempty"`
-	Error      string     `json:"error,omitempty"`
-	FinishedAt *time.Time `json:"finished_at,omitempty"`
+	Success        bool `json:"success,omitempty"`
+	CommandResults *ncmremote.PushResult
+	Error          string `json:"error,omitempty"`
+	ErrorCode      string
+	FinishedAt     *time.Time `json:"finished_at,omitempty"`
 }
 
 // Run executes the rollbackConfig action
@@ -93,13 +97,25 @@ func (h *RollbackConfigHandler) Run(
 
 	resp, err := h.ipcClient.Post(url, "application/json", bytes.NewBuffer(body))
 	if err != nil {
+		// This case only happens when there's an internal error - errors during
+		// the rollback itself are returned in the RollbackResult. The response
+		// here should be a struct like `{"error":"<error message>"}`
 		errMsg := strings.TrimSpace(string(resp))
 		if errMsg == "" {
 			errMsg = err.Error()
 		}
 		return RollbackConfigOutputs{Error: errMsg}, err
 	}
-
+	var response *networkconfigmanagementimpl.RollbackResponse
+	if err := json.Unmarshal(resp, &response); err != nil {
+		return RollbackConfigOutputs{Error: err.Error()}, fmt.Errorf("unable to unmarshal rollback response: %w", err)
+	}
 	t := h.clock.Now()
-	return RollbackConfigOutputs{Success: true, FinishedAt: &t}, nil
+	var result RollbackConfigOutputs
+	result.Success = response.ErrorCode == ""
+	result.FinishedAt = &t
+	result.Error = response.ErrorMsg
+	result.ErrorCode = response.ErrorCode
+	result.CommandResults = response.CommandResults
+	return result, nil
 }


### PR DESCRIPTION
### What does this PR do?

This PR captures the outputs of the commands run during a rollback attempt and returns them as part of the rollback action response. It also returns one of a fixed list of error codes for different error cases, so that the results can be handled sensibly.

### Motivation

https://datadoghq.atlassian.net/browse/NDINT-677
https://datadoghq.atlassian.net/browse/NDINT-676

There are two goals here:
1. We want to provide more accurate error messages in the frontend, so that we can distinguish between e.g. "a rollback failed because there's a bug in datadog code" and "a rollback failed because the device isn't configured properly".
2. We want to record the device outputs even in success cases, so that we can expose it in cases where a device's OS prints something more useful than just "Write successful."

### Describe how you validated your changes

I ran this locally against an Arista cEOS device, testing both normal successful rollbacks and modifying the profile locally to cause various failures deliberately.
