### PR TITLE
removed user_id from ai-usage event

### DIFF
--- a/cmd/ai_prompt_logger/README.md
+++ b/cmd/ai_prompt_logger/README.md
@@ -71,7 +71,7 @@ Relevant config keys under `desktop_monitoring`:
 
 Broad runtime names such as `node.exe`/`node`, `python.exe`/`python`, and `conhost.exe` are not direct AI-tool matches by default because they need command-line or path inspection to avoid false positives.
 
-Desktop events use the extension-compatible field semantics: tool display name, provider, user ID, and approved flag. The event source is `desktop_app`.
+Desktop events use the extension-compatible field semantics: tool display name, provider, and approved flag. The event source is `desktop_app`.
 
 On Windows, `--desktop-monitor` detaches from the scheduler-created console after startup. When file logging is enabled for diagnostics or startup config errors need to be reported, logs are written to `C:\ProgramData\Datadog\logs\ai-usage-desktop-monitor.log`, falling back to `%LOCALAPPDATA%\Datadog\logs\ai-usage-desktop-monitor.log` if the ProgramData log path is unavailable. Each record includes the process ID and user. The log rotates at 10 MB with one `.1` backup.
 
@@ -104,7 +104,6 @@ Request (shape used by the AI usage extension):
 {
   "type": "SEND_USAGE_EVENT",
   "tool": "example",
-  "user_id": "user-1",
   "approved": true
 }
 ```

--- a/cmd/ai_prompt_logger/scripts/test_host.py
+++ b/cmd/ai_prompt_logger/scripts/test_host.py
@@ -54,7 +54,6 @@ def test_send_usage_event(proc):
         {
             'type': 'SEND_USAGE_EVENT',
             'tool': 'test-tool',
-            'user_id': 'test-user',
             'approved': True,
         },
     )

--- a/cmd/ai_prompt_logger/src/datadog.rs
+++ b/cmd/ai_prompt_logger/src/datadog.rs
@@ -248,7 +248,6 @@ pub struct AiUsageEvent {
     pub detection_type: String,
     pub source: String,
     pub tool: String,
-    pub user_id: String,
     pub hostname: String,
     pub approved: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -257,18 +256,11 @@ pub struct AiUsageEvent {
 
 impl AiUsageEvent {
     /// Create a new event with the fixed fields pre-populated.
-    pub fn new(
-        detection_type: &str,
-        tool: String,
-        user_id: String,
-        hostname: String,
-        approved: bool,
-    ) -> Self {
+    pub fn new(detection_type: &str, tool: String, hostname: String, approved: bool) -> Self {
         Self::new_with_source(
             detection_type,
             "browser_extension",
             tool,
-            user_id,
             hostname,
             approved,
         )
@@ -278,7 +270,6 @@ impl AiUsageEvent {
         detection_type: &str,
         source: &str,
         tool: String,
-        user_id: String,
         hostname: String,
         approved: bool,
     ) -> Self {
@@ -288,7 +279,6 @@ impl AiUsageEvent {
             detection_type: detection_type.to_string(),
             source: source.to_string(),
             tool,
-            user_id,
             hostname,
             approved,
             provider: None,
@@ -310,13 +300,8 @@ mod tests {
 
     #[test]
     fn ai_usage_body_keeps_event_fields_at_top_level() {
-        let mut event = AiUsageEvent::new(
-            "observed",
-            "gemini".to_string(),
-            "user@example.com".to_string(),
-            "host-1".to_string(),
-            true,
-        );
+        let mut event =
+            AiUsageEvent::new("observed", "gemini".to_string(), "host-1".to_string(), true);
         event.provider = Some("Google".to_string());
 
         let body = DatadogClient::ai_usage_body(&event).expect("AI usage body should serialize");
@@ -334,6 +319,7 @@ mod tests {
             Some(&Value::String("Google".to_string()))
         );
         assert_eq!(body.get("approved"), Some(&Value::Bool(true)));
+        assert!(!body.contains_key("user_id"));
         assert!(!body.contains_key("message"));
         assert!(!body.contains_key("ddsource"));
         assert!(!body.contains_key("service"));

--- a/cmd/ai_prompt_logger/src/desktop/mod.rs
+++ b/cmd/ai_prompt_logger/src/desktop/mod.rs
@@ -185,7 +185,6 @@ fn poll_once(
         return;
     }
 
-    let user_id = resolve_user_id();
     let hostname = resolve_hostname();
     for detection in detections {
         logger.info(format!(
@@ -202,7 +201,6 @@ fn poll_once(
             "observed",
             "desktop_app",
             detection.tool,
-            user_id.clone(),
             hostname.clone(),
             detection.approved,
         );
@@ -329,15 +327,6 @@ fn read_write_activity_observed(delta: &ProcessActivityDelta) -> bool {
     .into_iter()
     .flatten()
     .any(|delta| delta > 0)
-}
-
-/// Resolve the user identifier attached to observed desktop usage events.
-fn resolve_user_id() -> String {
-    std::env::var("USERNAME")
-        .or_else(|_| std::env::var("USER"))
-        .ok()
-        .filter(|user| !user.is_empty())
-        .unwrap_or_else(|| "unknown".to_string())
 }
 
 /// Emit debug details about hosted AI candidates and their foreground process ancestry.
@@ -583,6 +572,7 @@ fn descendant_pids_of(
 mod tests {
     use super::*;
     use crate::datadog::DesktopMonitoringConfig;
+    use crate::desktop::matcher::ProcessEdge;
 
     fn config() -> DesktopMonitoringConfig {
         DesktopMonitoringConfig {

--- a/cmd/ai_prompt_logger/src/main.rs
+++ b/cmd/ai_prompt_logger/src/main.rs
@@ -36,7 +36,6 @@ enum Request {
         tool: String,
         #[serde(default)]
         provider: Option<String>,
-        user_id: String,
         #[serde(default)]
         approved: bool,
     },
@@ -107,11 +106,10 @@ fn handle_message(dd_client: &DatadogClient, request: Request) -> Response {
         Request::SendUsageEvent {
             tool,
             provider,
-            user_id,
             approved,
         } => {
             let resolved_host = resolve_hostname();
-            let mut event = AiUsageEvent::new("observed", tool, user_id, resolved_host, approved);
+            let mut event = AiUsageEvent::new("observed", tool, resolved_host, approved);
             let prov = provider
                 .as_deref()
                 .filter(|s| !s.is_empty())

--- a/releasenotes/notes/ai-usage-user-id-removal-5f91fc4d363df733.yaml
+++ b/releasenotes/notes/ai-usage-user-id-removal-5f91fc4d363df733.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Removed ``user_id`` field from AI usage event to avoid inconsistency
+    between Chrome extension mode and desktop-monitor mode.  ``user_id``
+    is taken care of by Datadog backend.


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
This PR removes `user_id` field from AI-usage event. `user_id `is taken care of by the backend, ensuring consistent attribution across browser-extension and desktop-monitor modes.

### Motivation
[WINA-2958](https://datadoghq.atlassian.net/browse/WINA-2958)

### Describe how you validated your changes
Validation is done through end-to-end testing.

### Additional Notes


[WINA-2958]: https://datadoghq.atlassian.net/browse/WINA-2958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ