### PR TITLE
[DRAFT] Package Agent Data Plane with the IoT Agent (size probe)

### DIFF
--- a/.gitlab/build/package_build/linux.yml
+++ b/.gitlab/build/package_build/linux.yml
@@ -117,11 +117,17 @@ iot-agent-x64:
   extends: [.iot-agent-common, .toolchain-common-x64]
   rules:
     - when: on_success
+  variables:
+    # Size-probe: bundle Agent Data Plane into the amd64 IoT build only.
+    IOT_INCLUDE_ADP: "true"
 
 iot-agent-arm64:
   extends: [.iot-agent-common, .toolchain-common-arm64]
   rules:
     - when: on_success
+  variables:
+    # Size-probe: bundle Agent Data Plane into the arm64 IoT build only.
+    IOT_INCLUDE_ADP: "true"
 
 iot-agent-armhf:
   extends: .iot-agent-common

--- a/omnibus/config/projects/iot-agent.rb
+++ b/omnibus/config/projects/iot-agent.rb
@@ -75,7 +75,11 @@ else
   # measure the package-size impact of shipping ADP with the IoT Agent
   # (DogStatsD-on-ADP for the IoT flavor). See the "Freezing the IoT Agent"
   # proposal for context.
-  dependency 'datadog-agent-data-plane' if (linux_target? || osx_target? || windows_target?) && !heroku_target?
+  #
+  # ADP only ships amd64/arm64 artifacts and the recipe maps any arm target to
+  # arm64, so the armhf/armv7l IoT build is explicitly excluded to avoid
+  # packaging an aarch64 binary into a 32-bit ARM package.
+  dependency 'datadog-agent-data-plane' if (linux_target? || osx_target? || windows_target?) && !heroku_target? && !arm7l_target?
 
   if windows_target?
     dependency 'datadog-agent-finalize'

--- a/omnibus/config/projects/iot-agent.rb
+++ b/omnibus/config/projects/iot-agent.rb
@@ -70,6 +70,13 @@ else
   # Datadog agent
   dependency 'datadog-iot-agent'
 
+  # Agent Data Plane (ADP): prebuilt binary, mirrors the guard used in
+  # datadog-agent-dependencies.rb for the regular Agent. Included here to
+  # measure the package-size impact of shipping ADP with the IoT Agent
+  # (DogStatsD-on-ADP for the IoT flavor). See the "Freezing the IoT Agent"
+  # proposal for context.
+  dependency 'datadog-agent-data-plane' if (linux_target? || osx_target? || windows_target?) && !heroku_target?
+
   if windows_target?
     dependency 'datadog-agent-finalize'
   end

--- a/omnibus/config/projects/iot-agent.rb
+++ b/omnibus/config/projects/iot-agent.rb
@@ -73,16 +73,16 @@ else
   # Datadog agent
   dependency 'datadog-iot-agent'
 
-  # Agent Data Plane (ADP): prebuilt binary, mirrors the guard used in
-  # datadog-agent-dependencies.rb for the regular Agent. Included here to
-  # measure the package-size impact of shipping ADP with the IoT Agent
-  # (DogStatsD-on-ADP for the IoT flavor). See the "Freezing the IoT Agent"
-  # proposal for context.
+  # Agent Data Plane (ADP): prebuilt binary, included to measure the
+  # package-size impact of shipping ADP with the IoT Agent (DogStatsD-on-ADP
+  # for the IoT flavor). See the "Freezing the IoT Agent" proposal.
   #
-  # ADP only ships amd64/arm64 artifacts and the recipe maps any arm target to
-  # arm64, so the armhf/armv7l IoT build is explicitly excluded to avoid
-  # packaging an aarch64 binary into a 32-bit ARM package.
-  dependency 'datadog-agent-data-plane' if (linux_target? || osx_target? || windows_target?) && !heroku_target? && !arm7l_target?
+  # Gated behind an explicit IOT_INCLUDE_ADP env flag rather than arch helpers:
+  # ADP only ships amd64/arm64 artifacts, and the armhf IoT build cross-compiles
+  # on an arm64 host with an LD_PRELOAD armv7l shim that does not reach ohai, so
+  # arm7l_target?/arm_target? are unreliable here. The flag is set only on the
+  # amd64/arm64 IoT build jobs, so the armhf build never pulls ADP.
+  dependency 'datadog-agent-data-plane' if ENV['IOT_INCLUDE_ADP'] == 'true' && (linux_target? || osx_target? || windows_target?) && !heroku_target?
 
   if windows_target?
     dependency 'datadog-agent-finalize'

--- a/omnibus/config/projects/iot-agent.rb
+++ b/omnibus/config/projects/iot-agent.rb
@@ -4,6 +4,9 @@
 # Copyright 2016-present Datadog, Inc.
 
 require "./lib/ostools.rb"
+# Needed for the do_repackage? helper referenced by the datadog-agent-data-plane
+# software definition (ADP dependency below).
+require "./lib/project_helpers.rb"
 
 name 'iot-agent'
 package_name 'datadog-iot-agent'

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -192,6 +192,13 @@ def get_omnibus_env(
     if kubernetes_cpu_request:
         env['OMNIBUS_WORKERS_OVERRIDE'] = str(int(kubernetes_cpu_request) + 1)
 
+    # Size-probe (IoT + ADP): forward the opt-in flag to the Omnibus process so
+    # the iot-agent project can conditionally bundle Agent Data Plane. Forwarded
+    # explicitly (not via the passthrough allowlist) to avoid a "missing env
+    # var" warning on every build that doesn't set it.
+    if os.environ.get('IOT_INCLUDE_ADP'):
+        env['IOT_INCLUDE_ADP'] = os.environ['IOT_INCLUDE_ADP']
+
     env_to_forward = _passthrough_env_for_os(os.environ, sys.platform)
     env.update(env_to_forward)
 


### PR DESCRIPTION
## Summary

One alternative under evaluation in the "Freezing the IoT Agent" proposal is to keep shipping the IoT Agent but bundle Agent Data Plane (ADP) with it, so the IoT flavor can move to DogStatsD-on-ADP instead of the Go DogStatsD server. The main cost of that option is package size: ADP is an additional prebuilt binary. This draft adds the `agent-data-plane` omnibus dependency to the IoT Agent project purely so CI's static quality gates report the resulting size delta on the `iot_agent_*` artifacts, which we can cite as the artifact for that alternative.

Draft only — not intended to merge. It measures size, not full functionality: ADP service/init-script wiring and Windows signing/stripping for the IoT flavor are intentionally omitted.

## Test plan

- [ ] Read the Static Quality Gates comment on this PR and compare the `iot_agent_deb_amd64` / `iot_agent_rpm_amd64` / `iot_agent_suse_amd64` sizes against the baseline (~46 MB today).
