### PR TITLE
[WP] Fix rename events when using io-uring

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/rename.h
+++ b/pkg/security/ebpf/c/include/hooks/rename.h
@@ -42,6 +42,15 @@ int hook_do_renameat2(ctx_t *ctx) {
     return 0;
 }
 
+HOOK_ENTRY("filename_renameat2")
+int hook_filename_renameat2(ctx_t *ctx) {
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_RENAME);
+    if (!syscall) {
+        return trace__sys_rename(ctx, ASYNC_SYSCALL, NULL, NULL);
+    }
+    return 0;
+}
+
 HOOK_ENTRY("vfs_rename")
 int hook_vfs_rename(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_RENAME);
@@ -175,6 +184,12 @@ int __attribute__((always_inline)) sys_rename_ret(void *ctx, int retval, enum TA
 
 HOOK_EXIT("do_renameat2")
 int rethook_do_renameat2(ctx_t *ctx) {
+    int retval = CTX_PARMRET(ctx);
+    return sys_rename_ret(ctx, retval, KPROBE_OR_FENTRY_TYPE);
+}
+
+HOOK_EXIT("filename_renameat2")
+int rethook_filename_renameat2(ctx_t *ctx) {
     int retval = CTX_PARMRET(ctx);
     return sys_rename_ret(ctx, retval, KPROBE_OR_FENTRY_TYPE);
 }

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -230,6 +230,22 @@ func GetSelectorsPerEventType(hasFentry, haveIOURing bool) map[eval.EventType][]
 		}
 	}
 
+	renameIOUringProbes := []manager.ProbesSelector{}
+	if haveIOURing {
+		renameIOUringProbes = []manager.ProbesSelector{
+			&manager.AllOf{Selectors: []manager.ProbesSelector{
+				hookFunc("hook_do_renameat2"),
+				hookFunc("rethook_do_renameat2"),
+			}},
+			// Since 7.0, do_renameat2 was removed from the kernel so we need to hook the filename_renameat2 function instead
+			// It is also used by the io_uring code path
+			&manager.AllOf{Selectors: []manager.ProbesSelector{
+				hookFunc("hook_filename_renameat2"),
+				hookFunc("rethook_filename_renameat2"),
+			}},
+		}
+	}
+
 	selectorsPerEventTypeStore := map[eval.EventType][]manager.ProbesSelector{
 		// The following probes will always be activated, regardless of the loaded rules
 		"*": {
@@ -385,12 +401,8 @@ func GetSelectorsPerEventType(hasFentry, haveIOURing bool) map[eval.EventType][]
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "rename", hasFentry, EntryAndExit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "renameat", hasFentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: append(
-				[]manager.ProbesSelector{
-					hookFunc("hook_do_renameat2"),
-					hookFunc("rethook_do_renameat2"),
-				},
-				ExpandSyscallProbesSelector(SecurityAgentUID, "renameat2", hasFentry, EntryAndExit)...)},
+			&manager.BestEffort{Selectors: renameIOUringProbes},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "renameat2", hasFentry, EntryAndExit)},
 
 			// unlink rmdir probes
 			&manager.AllOf{Selectors: []manager.ProbesSelector{

--- a/pkg/security/ebpf/probes/rename.go
+++ b/pkg/security/ebpf/probes/rename.go
@@ -30,6 +30,18 @@ func getRenameProbes(fentry bool) []*manager.Probe {
 				EBPFFuncName: "rethook_do_renameat2",
 			},
 		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_filename_renameat2",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "rethook_filename_renameat2",
+			},
+		},
 	}
 
 	renameProbes = append(renameProbes, ExpandSyscallProbes(&manager.Probe{


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

 Fix rename events when using io-uring

### Motivation

Since 7.0, do_renameat2 was removed from the kernel so we need to hook the filename_renameat2 function instead

### Describe how you validated your changes

### Additional Notes
