### PR TITLE
fix(e2e-framework): pass --keep-archive when generating diagnose flares

### DIFF
--- a/test/e2e-framework/testing/environments/dockerhost.go
+++ b/test/e2e-framework/testing/environments/dockerhost.go
@@ -211,7 +211,9 @@ func (e *DockerHost) generateAndDownloadAgentFlare(outputDir string) (string, er
 	}
 	// generate a flare, it will fallback to local flare generation if the running agent cannot be reached
 	// discard error, flare command might return error if there is no intake, but the archive is still generated
-	flareCommandOutput, err := e.Agent.Client.FlareWithError(agentclient.WithArgs([]string{"--email", "e2e-tests@datadog-agent", "--send"}))
+	// --keep-archive prevents the agent from deleting the local archive after a successful upload,
+	// since we need it to still be on disk afterwards to download it below.
+	flareCommandOutput, err := e.Agent.Client.FlareWithError(agentclient.WithArgs([]string{"--email", "e2e-tests@datadog-agent", "--send", "--keep-archive"}))
 
 	lines := []string{flareCommandOutput}
 	if err != nil {

--- a/test/e2e-framework/testing/environments/host.go
+++ b/test/e2e-framework/testing/environments/host.go
@@ -127,7 +127,9 @@ func generateAndDownloadAgentFlare(agent *components.RemoteHostAgent, host *comp
 	// to redirect stdin to null, on linux adding `</dev/null`
 	// on windows prepending command with `@() |`, pre-piping with an empty array
 	// discard error, flare command might return error if there is no intake, but it the archive is still generated
-	flareCommandOutput, err := agent.Client.FlareWithError(agentclient.WithArgs([]string{"--email", "e2e-tests@datadog-agent", "--send"}))
+	// --keep-archive prevents the agent from deleting the local archive after a successful upload,
+	// since we need it to still be on disk afterwards to download it below.
+	flareCommandOutput, err := agent.Client.FlareWithError(agentclient.WithArgs([]string{"--email", "e2e-tests@datadog-agent", "--send", "--keep-archive"}))
 
 	lines := []string{flareCommandOutput}
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Adds `--keep-archive` to the `agent flare --send` invocation used by the e2e framework's `Diagnose()` helpers (`Host`, `WindowsHost` via shared `host.go`, and `DockerHost`).

### Motivation

Since #47418, `agent flare` deletes the local archive after a successful upload unless `--keep-archive` is passed. Add `--keep-archive` argument to ensure the flare is still available on the host when we try to use it after the command returns.

### Describe how you validated your changes
CI

### Additional Notes

Found while investigating a Windows e2e job failure where the test itself failed and the framework's automatic flare-based diagnostics also failed because of this, making the original failure harder to debug.