### PR TITLE
test(e2e): provision FakeIntake and Agent Pulumi-free for macOS pool …

### DIFF
--- a/test/e2e-framework/resources/aws/ec2/pool/macos_host.go
+++ b/test/e2e-framework/resources/aws/ec2/pool/macos_host.go
@@ -21,14 +21,20 @@ import (
 type LaunchConfig struct {
 	Region  string
 	Profile string
+	// EnvName is the short aws.Environment name (e.g. "agent-sandbox") whose hardcoded
+	// ECS/network defaults (resources/aws/environmentDefaults.go) the FakeIntake ECS
+	// provisioner falls back to, since it has no live *pulumi.Context to read stack
+	// config overrides from.
+	EnvName string
 }
 
 // LoadLaunchConfigFromEnv reads LaunchConfig from E2E_MACOS_POOL_* env vars, defaulting
-// the region to us-east-1 if unset.
+// the region to us-east-1 and the environment name to agent-sandbox if unset.
 func LoadLaunchConfigFromEnv() (*LaunchConfig, error) {
 	return &LaunchConfig{
 		Region:  getEnvDefault("E2E_MACOS_POOL_REGION", "us-east-1"),
 		Profile: os.Getenv("E2E_MACOS_POOL_PROFILE"),
+		EnvName: getEnvDefault("E2E_MACOS_POOL_AWS_ENV", "agent-sandbox"),
 	}, nil
 }
 

--- a/test/e2e-framework/resources/aws/ecs/client.go
+++ b/test/e2e-framework/resources/aws/ecs/client.go
@@ -33,6 +33,19 @@ func NewECSClient(ctx context.Context, e aws.Environment) (*Client, error) {
 	return &Client{Client: awsECS.NewFromConfig(cfg), ctx: ctx}, nil
 }
 
+// NewRawClient returns a Client built from a plain region/profile pair, for
+// Pulumi-free callers (the macOS pool provisioner) that have no aws.Environment.
+func NewRawClient(ctx context.Context, region, profile string) (*Client, error) {
+	cfg, err := awsConfig.LoadDefaultConfig(ctx,
+		awsConfig.WithRegion(region),
+		awsConfig.WithSharedConfigProfile(profile),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{Client: awsECS.NewFromConfig(cfg), ctx: ctx}, nil
+}
+
 func (c *Client) GetTaskPrivateIP(clusterArn, serviceName string) (string, error) {
 	taskArn, err := c.getTaskArn(clusterArn, serviceName)
 	if err != nil {

--- a/test/e2e-framework/resources/aws/environmentDefaults.go
+++ b/test/e2e-framework/resources/aws/environmentDefaults.go
@@ -90,6 +90,27 @@ type DDInfraEKSPodSubnets struct {
 	SubnetID string `json:"subnet"`
 }
 
+// ECSFakeintakeNetworkDefaults resolves the ECS Fargate cluster ARN, IAM task-exec/task
+// role ARNs, VPC/subnet/security-group defaults, and the service-public-IP default for
+// the given short environment name (e.g. "sandbox", "agent-sandbox"), for callers that
+// have no *pulumi.Context to pull live stack-config overrides from — namely the
+// Pulumi-free macOS pool FakeIntake provisioner. It returns the same hardcoded defaults
+// aws.Environment falls back to when no live Pulumi config override is present; the
+// override path itself (e.InfraConfig, bound to a live pulumi.Context) is unavailable
+// here by construction.
+func ECSFakeintakeNetworkDefaults(envName string) (clusterArn, taskExecutionRole, taskRole, vpcID string, subnets, securityGroups []string, serviceAllocatePublicIP bool) {
+	d := getEnvironmentDefault("aws/" + envName)
+	if len(d.ddInfra.ecs.fargateFakeintakeClusterArn) > 0 {
+		clusterArn = d.ddInfra.ecs.fargateFakeintakeClusterArn[0]
+	}
+	for _, s := range d.ddInfra.defaultSubnets {
+		if !d.ddInfra.useMacosCompatibleSubnets || s.MacOSCompatible {
+			subnets = append(subnets, s.ID)
+		}
+	}
+	return clusterArn, d.ddInfra.ecs.taskExecutionRole, d.ddInfra.ecs.taskRole, d.ddInfra.defaultVPCID, subnets, d.ddInfra.defaultSecurityGroups, d.ddInfra.ecs.serviceAllocatePublicIP
+}
+
 func getEnvironmentDefault(envName string) environmentDefault {
 	switch envName {
 	case sandboxEnv:

--- a/test/e2e-framework/scenarios/aws/ec2/run_args.go
+++ b/test/e2e-framework/scenarios/aws/ec2/run_args.go
@@ -55,9 +55,30 @@ func (p *Params) HasAgent() bool {
 	return p.agentOptions != nil
 }
 
+// AgentOptions returns the agentparams.Options accumulated via WithAgentOptions, for
+// callers outside this package (the macOS pool provisioner) that need to resolve them
+// without going through NewVM/aws.Environment.
+func (p *Params) AgentOptions() []agentparams.Option {
+	return p.agentOptions
+}
+
+// AgentClientOptions returns the agentclientparams.Options accumulated via
+// WithAgentClientOptions, for callers outside this package (the macOS pool provisioner)
+// that need to resolve them without going through NewVM/aws.Environment.
+func (p *Params) AgentClientOptions() []agentclientparams.Option {
+	return p.agentClientOptions
+}
+
 // HasFakeIntake reports whether a FakeIntake was requested (i.e. WithoutFakeIntake was not used).
 func (p *Params) HasFakeIntake() bool {
 	return p.fakeintakeOptions != nil
+}
+
+// FakeIntakeOptions returns the fakeintake.Options accumulated via WithFakeIntakeOptions,
+// for callers outside this package (the macOS pool provisioner) that need to resolve them
+// without going through NewVM/aws.Environment.
+func (p *Params) FakeIntakeOptions() []fakeintake.Option {
+	return p.fakeintakeOptions
 }
 
 // InstallsUpdater reports whether the Datadog Updater was requested via WithUpdater.

--- a/test/e2e-framework/scenarios/aws/fakeintake/fakeintake.go
+++ b/test/e2e-framework/scenarios/aws/fakeintake/fakeintake.go
@@ -129,7 +129,7 @@ func fargateSvcNoLB(e aws.Environment, namer namer.Namer, taskDef *awsxEcs.Farga
 
 		// fail the deployment if the fakeintake is not healthy
 		e.Ctx().Log.Info(fmt.Sprintf("waiting for fakeintake at %s to be healthy", ipAddress), nil)
-		healthURL := buildFakeIntakeURL("http", ipAddress, "/fakeintake/health", httpPort)
+		healthURL := BuildFakeIntakeURL("http", ipAddress, "/fakeintake/health", httpPort)
 		_, err = backoff.Retry(ctx, func() (any, error) {
 			e.Ctx().Log.Debug(fmt.Sprintf("getting fakeintake health at %s", healthURL), nil)
 			resp, err := http.Get(healthURL)
@@ -149,7 +149,7 @@ func fargateSvcNoLB(e aws.Environment, namer namer.Namer, taskDef *awsxEcs.Farga
 		}
 		e.Ctx().Log.Info(fmt.Sprintf("fakeintake healthy at %s", ipAddress), nil)
 
-		return []string{ipAddress, buildFakeIntakeURL("http", ipAddress, "", httpPort)}, nil
+		return []string{ipAddress, BuildFakeIntakeURL("http", ipAddress, "", httpPort)}, nil
 	}).(pulumi.StringArrayOutput)
 
 	fi.Scheme = pulumi.Sprintf("%s", "http")
@@ -219,7 +219,10 @@ func fargateSvcLB(e aws.Environment, namer namer.Namer, taskDef *awsxEcs.Fargate
 	return nil
 }
 
-func fargateLinuxContainerDefinition(apiKeySSMParamName pulumi.StringInput, params *Params) *awsxEcs.TaskDefinitionContainerDefinitionArgs {
+// FakeIntakeContainerCommand returns the fakeintake container's command-line
+// arguments. Shared with the Pulumi-free macOS pool provisioner
+// (testing/provisioners/aws/host/macos_pool_fakeintake.go) so the two never drift apart.
+func FakeIntakeContainerCommand(params *Params) []string {
 	command := []string{}
 	if params.DDDevForwarding {
 		command = append(command, "--dddev-forward")
@@ -233,22 +236,49 @@ func fargateLinuxContainerDefinition(apiKeySSMParamName pulumi.StringInput, para
 	// deterministic and matches what the agent is configured with at provision time.
 	command = append(command, "--rc-key-data="+fakeintake.DefaultRCSigningKeySeed)
 
+	return command
+}
+
+// FakeIntakeContainerEnv returns the fakeintake container's environment variables as
+// ordered name/value pairs. Shared with the Pulumi-free macOS pool provisioner
+// (testing/provisioners/aws/host/macos_pool_fakeintake.go) so the two never drift apart.
+func FakeIntakeContainerEnv(params *Params) [][2]string {
+	return [][2]string{
+		{"GOMEMLIMIT", fmt.Sprintf("%dMiB", params.Memory)},
+		{"STORAGE_DRIVER", "memory"},
+	}
+}
+
+// FakeIntakeHealthCheckCommand, FakeIntakeHealthCheckIntervalSeconds,
+// FakeIntakeHealthCheckRetries and FakeIntakeHealthCheckTimeoutSeconds pin the
+// fakeintake container health check to fixed values (rather than left to defaults) so
+// `pulumi up` doesn't want to recreate the task definition when nothing changed. Shared
+// with the Pulumi-free macOS pool provisioner
+// (testing/provisioners/aws/host/macos_pool_fakeintake.go) so the two never drift apart.
+const (
+	FakeIntakeHealthCheckCommand         = "curl --fail http://localhost/fakeintake/health"
+	FakeIntakeHealthCheckIntervalSeconds = 30
+	FakeIntakeHealthCheckRetries         = 3
+	FakeIntakeHealthCheckTimeoutSeconds  = 5
+)
+
+func fargateLinuxContainerDefinition(apiKeySSMParamName pulumi.StringInput, params *Params) *awsxEcs.TaskDefinitionContainerDefinitionArgs {
+	envPairs := FakeIntakeContainerEnv(params)
+	environment := make(awsxEcs.TaskDefinitionKeyValuePairArray, 0, len(envPairs))
+	for _, pair := range envPairs {
+		environment = append(environment, awsxEcs.TaskDefinitionKeyValuePairArgs{
+			Name:  pulumi.StringPtr(pair[0]),
+			Value: pulumi.StringPtr(pair[1]),
+		})
+	}
+
 	return &awsxEcs.TaskDefinitionContainerDefinitionArgs{
 		Name:        pulumi.String(containerName),
 		Image:       pulumi.String(params.ImageURL),
 		Essential:   pulumi.BoolPtr(true),
-		Command:     pulumi.ToStringArray(command),
+		Command:     pulumi.ToStringArray(FakeIntakeContainerCommand(params)),
 		MountPoints: awsxEcs.TaskDefinitionMountPointArray{},
-		Environment: awsxEcs.TaskDefinitionKeyValuePairArray{
-			awsxEcs.TaskDefinitionKeyValuePairArgs{
-				Name:  pulumi.StringPtr("GOMEMLIMIT"),
-				Value: pulumi.StringPtr(fmt.Sprintf("%dMiB", params.Memory)),
-			},
-			awsxEcs.TaskDefinitionKeyValuePairArgs{
-				Name:  pulumi.StringPtr("STORAGE_DRIVER"),
-				Value: pulumi.StringPtr("memory"),
-			},
-		},
+		Environment: environment,
 		Secrets: awsxEcs.TaskDefinitionSecretArray{
 			awsxEcs.TaskDefinitionSecretArgs{
 				Name:      pulumi.String("DD_API_KEY"),
@@ -263,12 +293,10 @@ func fargateLinuxContainerDefinition(apiKeySSMParamName pulumi.StringInput, para
 			},
 		},
 		HealthCheck: &awsxEcs.TaskDefinitionHealthCheckArgs{
-			Command: pulumi.ToStringArray([]string{"CMD-SHELL", "curl --fail http://localhost/fakeintake/health"}),
-			// Explicitly set the following 3 parameters to their default values.
-			// Because otherwise, `pulumi up` wants to recreate the task definition even when it is not needed.
-			Interval: pulumi.IntPtr(30),
-			Retries:  pulumi.IntPtr(3),
-			Timeout:  pulumi.IntPtr(5),
+			Command:  pulumi.ToStringArray([]string{"CMD-SHELL", FakeIntakeHealthCheckCommand}),
+			Interval: pulumi.IntPtr(FakeIntakeHealthCheckIntervalSeconds),
+			Retries:  pulumi.IntPtr(FakeIntakeHealthCheckRetries),
+			Timeout:  pulumi.IntPtr(FakeIntakeHealthCheckTimeoutSeconds),
 		},
 		DockerLabels: pulumi.StringMap{
 			"com.datadoghq.ad.checks": pulumi.String(utils.JSONMustMarshal(
@@ -309,7 +337,10 @@ func fargateLinuxContainerDefinition(apiKeySSMParamName pulumi.StringInput, para
 	}
 }
 
-func buildFakeIntakeURL(scheme, host, path string, port int) string {
+// BuildFakeIntakeURL builds a fakeintake URL from its component parts. Shared with the
+// Pulumi-free macOS pool provisioner (testing/provisioners/aws/host/macos_pool_fakeintake.go)
+// so the two never drift apart.
+func BuildFakeIntakeURL(scheme, host, path string, port int) string {
 	url := &url.URL{
 		Scheme: scheme,
 		Host:   net.JoinHostPort(host, strconv.Itoa(port)),

--- a/test/e2e-framework/testing/provisioners/aws/host/host.go
+++ b/test/e2e-framework/testing/provisioners/aws/host/host.go
@@ -73,7 +73,7 @@ func Provisioner(opts ...ProvisionerOption) provisioners.TypedProvisioner[enviro
 	runParams := ec2.GetParams(params.runOptions...)
 
 	if usesMacOSPool(runParams) {
-		return NewMacOSPoolProvisioner(runParams.Name, runParams.InstanceOptions()...)
+		return NewMacOSPoolProvisioner(runParams.Name, runParams)
 	}
 
 	provisioner := provisioners.NewTypedPulumiProvisioner(provisionerBaseID+runParams.Name, func(ctx *pulumi.Context, env *environments.Host) error {
@@ -100,13 +100,13 @@ func Provisioner(opts ...ProvisionerOption) provisioners.TypedProvisioner[enviro
 	return provisioner
 }
 
-// usesMacOSPool reports whether runParams describes a bare macOS host (no Agent,
-// FakeIntake, or Updater requested) that the non-Pulumi macOS pool provisioner can serve
-// directly. Any other combination (non-macOS OS, or a macOS host that also wants an
-// Agent/FakeIntake/Updater deployed) falls back to the existing Pulumi path, since the
-// pool provisioner only ever imports a bare RemoteHost.
+// usesMacOSPool reports whether runParams describes a macOS host that the non-Pulumi
+// macOS pool provisioner can serve directly. Agent and FakeIntake are provisioned
+// Pulumi-free by macOSPoolProvisioner itself, so requesting them does not fall back to
+// the Pulumi path. The Updater is not supported Pulumi-free, so requesting it (or any
+// non-macOS OS) falls back to the existing Pulumi path.
 func usesMacOSPool(runParams *ec2.Params) bool {
-	if runParams.HasAgent() || runParams.HasFakeIntake() || runParams.InstallsUpdater() {
+	if runParams.InstallsUpdater() {
 		return false
 	}
 

--- a/test/e2e-framework/testing/provisioners/aws/host/macos_pool_agent.go
+++ b/test/e2e-framework/testing/provisioners/aws/host/macos_pool_agent.go
@@ -1,0 +1,261 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package awshost
+
+import (
+	"encoding/base64"
+	"fmt"
+	"path"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agent"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/fakeintake"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/remote"
+	e2eclient "github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/e2e/client"
+)
+
+// macOSAgentConfigFolder mirrors agentMacOSManager.getAgentConfigFolder
+// (components/datadog/agent/host_macos.go).
+const macOSAgentConfigFolder = "/opt/datadog-agent/etc"
+
+// provisionMacOSPoolAgent installs the Agent on host over SSH, sequentially, mirroring
+// agentMacOSManager's install-script flow (components/datadog/agent/host_macos.go and
+// components/datadog/agent/host.go) but without a *pulumi.Context: commands run directly
+// through host.Execute/WriteFile instead of being scheduled as Pulumi command.Command
+// resources. Only the install-script path is supported; a local .dmg/.pkg (LocalPath) is
+// not, matching the framework-wide constraint of this Pulumi-free pool provisioner.
+func provisionMacOSPoolAgent(host *e2eclient.Host, hostOutput remote.HostOutput, apiKey string, agentOptions []agentparams.Option, fakeIntakeExtraConfig string) (*agent.HostAgentOutput, error) {
+	params, err := resolveMacOSPoolAgentParams(agentOptions)
+	if err != nil {
+		return nil, err
+	}
+	if params.Version.LocalPath != "" {
+		return nil, fmt.Errorf("installing the macOS pool agent from a local package is not supported")
+	}
+
+	if _, err := host.Execute(macOSInstallScriptCommand(params.Version, apiKey)); err != nil {
+		return nil, fmt.Errorf("failed to run macOS agent install script: %w", err)
+	}
+
+	if err := writeMacOSAgentConfig(host, "datadog.yaml", params.AgentConfig, params.ExtraAgentConfig, fakeIntakeExtraConfig, apiKey, params.SkipAPIKeyInConfig); err != nil {
+		return nil, err
+	}
+	for _, cfg := range []struct{ path, content string }{
+		{"system-probe.yaml", params.SystemProbeConfig},
+		{"security-agent.yaml", params.SecurityAgentConfig},
+	} {
+		if cfg.content == "" {
+			continue
+		}
+		if err := writeMacOSAgentConfig(host, cfg.path, cfg.content, nil, "", "", true); err != nil {
+			return nil, err
+		}
+	}
+
+	for confPath, def := range params.Integrations {
+		if err := writeMacOSAgentFile(host, path.Join(macOSAgentConfigFolder, confPath), def); err != nil {
+			return nil, fmt.Errorf("failed to write integration config %s: %w", confPath, err)
+		}
+	}
+	for absPath, def := range params.Files {
+		if err := writeMacOSAgentFile(host, absPath, def); err != nil {
+			return nil, fmt.Errorf("failed to write file %s: %w", absPath, err)
+		}
+	}
+
+	if _, err := host.Execute("sudo launchctl kickstart -k system/com.datadoghq.agent"); err != nil {
+		return nil, fmt.Errorf("failed to restart macOS agent service: %w", err)
+	}
+
+	return &agent.HostAgentOutput{
+		Host:        hostOutput,
+		FIPSEnabled: params.Version.Flavor == agentparams.FIPSFlavor,
+	}, nil
+}
+
+// resolveMacOSPoolAgentParams applies agentOptions over sane, Pulumi-free defaults
+// mirroring agentparams.NewParams' defaults (WithLatestNightly, DefaultFlavor,
+// DefaultMajorVersion) — NewParams itself cannot be used here since it requires a
+// config.Env, whose PipelineID/AgentAPIKey/etc. accessors read live Pulumi stack config.
+func resolveMacOSPoolAgentParams(agentOptions []agentparams.Option) (*agentparams.Params, error) {
+	params := &agentparams.Params{
+		Integrations: make(map[string]*agentparams.FileDefinition),
+		Files:        make(map[string]*agentparams.FileDefinition),
+	}
+	defaults := []agentparams.Option{
+		agentparams.WithLatestNightly(),
+		agentparams.WithMajorVersion(config.DefaultMajorVersion),
+		agentparams.WithFlavor(agentparams.DefaultFlavor),
+	}
+	return common.ApplyOption(params, append(defaults, agentOptions...))
+}
+
+// macOSInstallScriptCommand replicates agentMacOSManager.getInstallCommand
+// (components/datadog/agent/host_macos.go) with a plain apiKey string in place of a
+// pulumi.StringInput.
+func macOSInstallScriptCommand(version agentparams.PackageVersion, apiKey string) string {
+	exports := []string{}
+	if version.Major != "" {
+		exports = append(exports, fmt.Sprintf("DD_AGENT_MAJOR_VERSION=%s", version.Major))
+	}
+	if version.Minor != "" {
+		exports = append(exports, fmt.Sprintf("DD_AGENT_MINOR_VERSION=%s", version.Minor))
+	}
+	if version.PipelineID != "" {
+		exports = append(exports, fmt.Sprintf("DD_REPO_URL=https://dd-agent-macostesting.s3.amazonaws.com/ci/datadog-agent/pipeline-%s", version.PipelineID))
+	}
+
+	env := ""
+	for _, e := range exports {
+		env += e + " "
+	}
+
+	return fmt.Sprintf(`for i in 1 2 3 4 5; do curl -fsSL https://install.datadoghq.com/scripts/install_mac_os.sh -o install-script.sh && break || sleep $((2**$i)); done && for i in 1 2 3; do DD_API_KEY=%s %sDD_INSTALL_ONLY=true bash install-script.sh && exit 0 || sleep $((2**$i)); done; exit 1`, apiKey, env)
+}
+
+// writeMacOSAgentConfig merges baseConfig with extraAgentConfig (converted from
+// pulumi.StringInput, which must resolve to a plain pulumi.String literal since there is
+// no pulumi engine here to evaluate Outputs), fakeIntakeExtraConfig, and an api_key line
+// (unless skipAPIKey), then writes the result to configPath under the Agent's config
+// folder.
+func writeMacOSAgentConfig(host *e2eclient.Host, configPath, baseConfig string, extraAgentConfig []pulumi.StringInput, fakeIntakeExtraConfig, apiKey string, skipAPIKey bool) error {
+	merged := baseConfig
+	for _, extra := range extraAgentConfig {
+		str, ok := extra.(pulumi.String)
+		if !ok {
+			return fmt.Errorf("extra agent config for %s must be a plain pulumi.String literal in the Pulumi-free macOS pool path, got %T", configPath, extra)
+		}
+		var err error
+		merged, err = utils.MergeYAMLWithSlices(merged, string(str))
+		if err != nil {
+			return fmt.Errorf("failed to merge extra agent config into %s: %w", configPath, err)
+		}
+	}
+
+	var err error
+	if fakeIntakeExtraConfig != "" {
+		merged, err = utils.MergeYAMLWithSlices(merged, fakeIntakeExtraConfig)
+		if err != nil {
+			return fmt.Errorf("failed to merge fakeintake config into %s: %w", configPath, err)
+		}
+	}
+	if !skipAPIKey {
+		merged, err = utils.MergeYAMLWithSlices(merged, fmt.Sprintf("api_key: %s", apiKey))
+		if err != nil {
+			return fmt.Errorf("failed to merge api_key into %s: %w", configPath, err)
+		}
+	}
+
+	fullPath := path.Join(macOSAgentConfigFolder, configPath)
+	if _, err := host.Execute(fmt.Sprintf("mkdir -p %s", macOSAgentConfigFolder)); err != nil {
+		return fmt.Errorf("failed to create agent config folder: %w", err)
+	}
+	return writeMacOSFileWithSudo(host, fullPath, merged)
+}
+
+// writeMacOSAgentFile writes def to fullPath, creating parent directories and applying
+// permissions as agentMacOSManager.writeFileDefinition
+// (components/datadog/agent/host.go) does through Pulumi commands.
+func writeMacOSAgentFile(host *e2eclient.Host, fullPath string, def *agentparams.FileDefinition) error {
+	if _, err := host.Execute(fmt.Sprintf("mkdir -p %s", path.Dir(fullPath))); err != nil {
+		return fmt.Errorf("failed to create parent directory for %s: %w", fullPath, err)
+	}
+
+	if err := writeMacOSFileWithSudo(host, fullPath, def.Content); err != nil {
+		return err
+	}
+
+	if permsValue, found := def.Permissions.Get(); found {
+		if cmd := permsValue.SetupPermissionsCommand(fullPath); cmd != "" {
+			if _, err := host.Execute(cmd); err != nil {
+				return fmt.Errorf("failed to set permissions on %s: %w", fullPath, err)
+			}
+		}
+	}
+	return nil
+}
+
+// macOSFakeIntakeExtraConfig renders the same intake-hostname and Remote Config settings
+// as agentparams.WithFakeintake (components/datadog/agentparams/params.go), using plain
+// strings from fi instead of pulumi.StringOutput/ApplyT, since there is no pulumi engine
+// here to evaluate Outputs.
+func macOSFakeIntakeExtraConfig(fi *fakeintake.FakeintakeOutput) (string, error) {
+	rootJSON, err := fakeintake.RCRootJSON()
+	if err != nil {
+		return "", fmt.Errorf("build fakeintake rc root json: %w", err)
+	}
+
+	return fmt.Sprintf(`dd_url: %[3]s://%[1]s:%[2]d
+logs_config.logs_dd_url: %[1]s:%[2]d
+logs_config.logs_no_ssl: true
+logs_config.force_use_http: true
+process_config.process_dd_url: %[3]s://%[1]s:%[2]d
+apm_config.apm_dd_url: %[3]s://%[1]s:%[2]d
+database_monitoring.metrics.logs_dd_url: %[1]s:%[2]d
+database_monitoring.metrics.logs_no_ssl: true
+database_monitoring.activity.logs_dd_url: %[1]s:%[2]d
+database_monitoring.activity.logs_no_ssl: true
+database_monitoring.samples.logs_dd_url: %[1]s:%[2]d
+database_monitoring.samples.logs_no_ssl: true
+network_devices.metadata.logs_dd_url: %[1]s:%[2]d
+network_devices.metadata.logs_no_ssl: true
+network_devices.snmp_traps.forwarder.logs_dd_url: %[1]s:%[2]d
+network_devices.snmp_traps.forwarder.logs_no_ssl: true
+network_devices.netflow.forwarder.logs_dd_url: %[1]s:%[2]d
+network_devices.netflow.forwarder.logs_no_ssl: true
+network_path.forwarder.logs_dd_url: %[1]s:%[2]d
+network_path.forwarder.logs_no_ssl: true
+network_devices.config_management.forwarder.logs_dd_url: %[1]s:%[2]d
+network_devices.config_management.forwarder.logs_no_ssl: true
+synthetics.forwarder.logs_dd_url: %[1]s:%[2]d
+synthetics.forwarder.logs_no_ssl: true
+container_lifecycle.logs_dd_url: %[1]s:%[2]d
+container_lifecycle.logs_no_ssl: true
+container_image.logs_dd_url: %[1]s:%[2]d
+container_image.logs_no_ssl: true
+sbom.logs_dd_url: %[1]s:%[2]d
+sbom.logs_no_ssl: true
+service_discovery.forwarder.logs_dd_url: %[1]s:%[2]d
+service_discovery.forwarder.logs_no_ssl: true
+config_files_discovery.forwarder.logs_dd_url: %[1]s:%[2]d
+config_files_discovery.forwarder.logs_no_ssl: true
+software_inventory.forwarder.logs_dd_url: %[1]s:%[2]d
+software_inventory.forwarder.logs_no_ssl: true
+data_streams.forwarder.logs_dd_url: %[1]s:%[2]d
+data_streams.forwarder.logs_no_ssl: true
+event_management.forwarder.logs_dd_url: %[1]s:%[2]d
+event_management.forwarder.logs_no_ssl: true
+agent_telemetry.logs_dd_url: %[1]s:%[2]d
+agent_telemetry.logs_no_ssl: true
+agent_telemetry.use_compression: false
+compliance_config.endpoints.logs_dd_url: %[1]s:%[2]d
+compliance_config.endpoints.logs_no_ssl: true
+compliance_config.endpoints.force_use_http: true
+remote_configuration.enabled: true
+remote_configuration.rc_dd_url: %[4]s
+remote_configuration.no_tls: true
+remote_configuration.refresh_interval: 5s
+remote_configuration.config_root: '%[5]s'
+remote_configuration.director_root: '%[5]s'
+`, fi.Host, fi.Port, fi.Scheme, fi.URL, rootJSON), nil
+}
+
+// writeMacOSFileWithSudo writes content to fullPath via a base64-encoded sudo tee, since
+// the SSH login user (ec2-user) does not own /opt/datadog-agent and host.WriteFile's sftp
+// client is unprivileged.
+func writeMacOSFileWithSudo(host *e2eclient.Host, fullPath, content string) error {
+	encoded := base64.StdEncoding.EncodeToString([]byte(content))
+	cmd := fmt.Sprintf("echo %s | base64 --decode | sudo tee %s > /dev/null", encoded, fullPath)
+	if _, err := host.Execute(cmd); err != nil {
+		return fmt.Errorf("failed to write file %s: %w", fullPath, err)
+	}
+	return nil
+}

--- a/test/e2e-framework/testing/provisioners/aws/host/macos_pool_fakeintake.go
+++ b/test/e2e-framework/testing/provisioners/aws/host/macos_pool_fakeintake.go
@@ -1,0 +1,236 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package awshost
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	awsECS "github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/fakeintake"
+	awsresources "github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws/ecs"
+	fakeintakescenario "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/fakeintake"
+)
+
+// fakeIntakeContainerName is the ECS container name for the single fakeintake
+// container. Unlike the Pulumi ECS path, this Pulumi-free path does not bundle a
+// self-monitoring Agent sidecar or Firelens log router: E2E tests only exercise
+// fakeintake's own HTTP API, so that machinery would be provisioned for no benefit.
+const fakeIntakeContainerName = "fakeintake"
+
+const (
+	fakeIntakeHTTPPort           = 80
+	fakeIntakeTaskCPU            = "512"
+	fakeIntakeTaskMemory         = "1024"
+	fakeIntakeServiceWaitTimeout = 5 * time.Minute
+	fakeIntakeHealthWaitTimeout  = 5 * time.Minute
+	fakeIntakePollInterval       = 5 * time.Second
+)
+
+// macOSPoolFakeIntake tracks the raw ECS resources created for a single macOS pool
+// run's FakeIntake, so Destroy can tear them down without a live *pulumi.Context.
+type macOSPoolFakeIntake struct {
+	region      string
+	profile     string
+	clusterArn  string
+	serviceName string
+	taskDefArn  string
+}
+
+// provisionMacOSPoolFakeIntake registers an ECS Fargate task definition and service
+// running a single fakeintake container, waits for it to become healthy, and returns
+// its output alongside the tracking state Destroy needs.
+func provisionMacOSPoolFakeIntake(ctx context.Context, logger io.Writer, region, profile, envName string, fiOpts []fakeintakescenario.Option) (*macOSPoolFakeIntake, *fakeintake.FakeintakeOutput, error) {
+	params, err := fakeintakescenario.NewParams(fiOpts...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	clusterArn, taskExecutionRole, _, vpcID, subnets, securityGroups, allocatePublicIP := awsresources.ECSFakeintakeNetworkDefaults(envName)
+	if clusterArn == "" || vpcID == "" || len(subnets) == 0 {
+		return nil, nil, fmt.Errorf("no ECS/network defaults found for environment %q", envName)
+	}
+
+	client, err := ecs.NewRawClient(ctx, region, profile)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	family := "fakeintake-ecs-pool-" + macOSPoolOwnerID()
+	registerOut, err := client.RegisterTaskDefinition(ctx, &awsECS.RegisterTaskDefinitionInput{
+		Family:                  &family,
+		NetworkMode:             ecsTypes.NetworkModeAwsvpc,
+		RequiresCompatibilities: []ecsTypes.Compatibility{ecsTypes.CompatibilityFargate},
+		Cpu:                     awssdk.String(fakeIntakeTaskCPU),
+		Memory:                  awssdk.String(fakeIntakeTaskMemory),
+		ExecutionRoleArn:        awssdk.String(taskExecutionRole),
+		ContainerDefinitions:    []ecsTypes.ContainerDefinition{fakeIntakeContainerDefinition(params)},
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to register fakeintake task definition: %w", err)
+	}
+	taskDefArn := *registerOut.TaskDefinition.TaskDefinitionArn
+
+	fi := &macOSPoolFakeIntake{
+		region:     region,
+		profile:    profile,
+		clusterArn: clusterArn,
+		taskDefArn: taskDefArn,
+	}
+
+	assignPublicIP := ecsTypes.AssignPublicIpDisabled
+	if allocatePublicIP {
+		assignPublicIP = ecsTypes.AssignPublicIpEnabled
+	}
+
+	serviceName := family
+	_, err = client.CreateService(ctx, &awsECS.CreateServiceInput{
+		Cluster:        &clusterArn,
+		ServiceName:    &serviceName,
+		TaskDefinition: &taskDefArn,
+		DesiredCount:   awssdk.Int32(1),
+		LaunchType:     ecsTypes.LaunchTypeFargate,
+		NetworkConfiguration: &ecsTypes.NetworkConfiguration{
+			AwsvpcConfiguration: &ecsTypes.AwsVpcConfiguration{
+				Subnets:        subnets,
+				SecurityGroups: securityGroups,
+				AssignPublicIp: assignPublicIP,
+			},
+		},
+	})
+	if err != nil {
+		return fi, nil, fmt.Errorf("failed to create fakeintake ECS service: %w", err)
+	}
+	fi.serviceName = serviceName
+
+	fmt.Fprintf(logger, "waiting for fakeintake ECS task private ip on cluster %s, service %s\n", clusterArn, serviceName)
+	ip, err := waitForFakeIntakeTaskIP(client, clusterArn, serviceName, fakeIntakeServiceWaitTimeout)
+	if err != nil {
+		return fi, nil, fmt.Errorf("failed to obtain fakeintake task private ip: %w", err)
+	}
+
+	url := fmt.Sprintf("http://%s:%d", ip, fakeIntakeHTTPPort)
+	fmt.Fprintf(logger, "waiting for fakeintake at %s to be healthy\n", url)
+	if err := waitForFakeIntakeHealth(url, fakeIntakeHealthWaitTimeout); err != nil {
+		return fi, nil, fmt.Errorf("fakeintake at %s never became healthy: %w", url, err)
+	}
+	fmt.Fprintf(logger, "fakeintake healthy at %s\n", url)
+
+	return fi, &fakeintake.FakeintakeOutput{
+		Host:   ip,
+		Scheme: "http",
+		Port:   fakeIntakeHTTPPort,
+		URL:    url,
+	}, nil
+}
+
+// destroy deletes the FakeIntake ECS service and deregisters its task definition. It
+// is a no-op if provisionMacOSPoolFakeIntake never successfully created a service.
+func (fi *macOSPoolFakeIntake) destroy(ctx context.Context) error {
+	if fi == nil || fi.serviceName == "" {
+		return nil
+	}
+
+	client, err := ecs.NewRawClient(ctx, fi.region, fi.profile)
+	if err != nil {
+		return err
+	}
+
+	force := true
+	if _, err := client.DeleteService(ctx, &awsECS.DeleteServiceInput{
+		Cluster: &fi.clusterArn,
+		Service: &fi.serviceName,
+		Force:   &force,
+	}); err != nil {
+		return fmt.Errorf("failed to delete fakeintake ECS service %s: %w", fi.serviceName, err)
+	}
+
+	if fi.taskDefArn != "" {
+		if _, err := client.DeregisterTaskDefinition(ctx, &awsECS.DeregisterTaskDefinitionInput{
+			TaskDefinition: &fi.taskDefArn,
+		}); err != nil {
+			return fmt.Errorf("failed to deregister fakeintake task definition %s: %w", fi.taskDefArn, err)
+		}
+	}
+
+	return nil
+}
+
+func fakeIntakeContainerDefinition(params *fakeintakescenario.Params) ecsTypes.ContainerDefinition {
+	command := []string{}
+	if params.DDDevForwarding {
+		command = append(command, "--dddev-forward")
+	}
+	if params.RetentionPeriod != "" {
+		command = append(command, "-retention-period="+params.RetentionPeriod)
+	}
+	command = append(command, "--rc-key-data="+fakeintake.DefaultRCSigningKeySeed)
+
+	return ecsTypes.ContainerDefinition{
+		Name:      awssdk.String(fakeIntakeContainerName),
+		Image:     awssdk.String(params.ImageURL),
+		Essential: awssdk.Bool(true),
+		Command:   command,
+		Environment: []ecsTypes.KeyValuePair{
+			{Name: awssdk.String("GOMEMLIMIT"), Value: awssdk.String(fmt.Sprintf("%dMiB", params.Memory))},
+			{Name: awssdk.String("STORAGE_DRIVER"), Value: awssdk.String("memory")},
+		},
+		PortMappings: []ecsTypes.PortMapping{
+			{ContainerPort: awssdk.Int32(fakeIntakeHTTPPort), HostPort: awssdk.Int32(fakeIntakeHTTPPort), Protocol: ecsTypes.TransportProtocolTcp},
+		},
+		HealthCheck: &ecsTypes.HealthCheck{
+			Command:  []string{"CMD-SHELL", "curl --fail http://localhost/fakeintake/health"},
+			Interval: awssdk.Int32(30),
+			Retries:  awssdk.Int32(3),
+			Timeout:  awssdk.Int32(5),
+		},
+	}
+}
+
+// waitForFakeIntakeTaskIP polls the ECS service until a running task with a private
+// IP appears, or timeout elapses.
+func waitForFakeIntakeTaskIP(client *ecs.Client, clusterArn, serviceName string, timeout time.Duration) (string, error) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		ip, err := client.GetTaskPrivateIP(clusterArn, serviceName)
+		if err == nil {
+			return ip, nil
+		}
+		lastErr = err
+		time.Sleep(fakeIntakePollInterval)
+	}
+	return "", fmt.Errorf("timed out waiting for fakeintake task private ip: %w", lastErr)
+}
+
+// waitForFakeIntakeHealth polls fakeintake's health endpoint until it returns 200, or
+// timeout elapses.
+func waitForFakeIntakeHealth(url string, timeout time.Duration) error {
+	healthURL := url + "/fakeintake/health"
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(healthURL) //nolint:gosec // healthURL is built from our own ECS task's private IP, not user input.
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+			lastErr = fmt.Errorf("unexpected status %d from %s", resp.StatusCode, healthURL)
+		} else {
+			lastErr = err
+		}
+		time.Sleep(fakeIntakePollInterval)
+	}
+	return lastErr
+}

--- a/test/e2e-framework/testing/provisioners/aws/host/macos_pool_fakeintake.go
+++ b/test/e2e-framework/testing/provisioners/aws/host/macos_pool_fakeintake.go
@@ -119,7 +119,7 @@ func provisionMacOSPoolFakeIntake(ctx context.Context, logger io.Writer, region,
 		return fi, nil, fmt.Errorf("failed to obtain fakeintake task private ip: %w", err)
 	}
 
-	url := fmt.Sprintf("http://%s:%d", ip, fakeIntakeHTTPPort)
+	url := fakeintakescenario.BuildFakeIntakeURL("http", ip, "", fakeIntakeHTTPPort)
 	fmt.Fprintf(logger, "waiting for fakeintake at %s to be healthy\n", url)
 	if err := waitForFakeIntakeHealth(url, fakeIntakeHealthWaitTimeout); err != nil {
 		return fi, nil, fmt.Errorf("fakeintake at %s never became healthy: %w", url, err)
@@ -167,32 +167,26 @@ func (fi *macOSPoolFakeIntake) destroy(ctx context.Context) error {
 }
 
 func fakeIntakeContainerDefinition(params *fakeintakescenario.Params) ecsTypes.ContainerDefinition {
-	command := []string{}
-	if params.DDDevForwarding {
-		command = append(command, "--dddev-forward")
+	envPairs := fakeintakescenario.FakeIntakeContainerEnv(params)
+	environment := make([]ecsTypes.KeyValuePair, 0, len(envPairs))
+	for _, pair := range envPairs {
+		environment = append(environment, ecsTypes.KeyValuePair{Name: awssdk.String(pair[0]), Value: awssdk.String(pair[1])})
 	}
-	if params.RetentionPeriod != "" {
-		command = append(command, "-retention-period="+params.RetentionPeriod)
-	}
-	command = append(command, "--rc-key-data="+fakeintake.DefaultRCSigningKeySeed)
 
 	return ecsTypes.ContainerDefinition{
-		Name:      awssdk.String(fakeIntakeContainerName),
-		Image:     awssdk.String(params.ImageURL),
-		Essential: awssdk.Bool(true),
-		Command:   command,
-		Environment: []ecsTypes.KeyValuePair{
-			{Name: awssdk.String("GOMEMLIMIT"), Value: awssdk.String(fmt.Sprintf("%dMiB", params.Memory))},
-			{Name: awssdk.String("STORAGE_DRIVER"), Value: awssdk.String("memory")},
-		},
+		Name:        awssdk.String(fakeIntakeContainerName),
+		Image:       awssdk.String(params.ImageURL),
+		Essential:   awssdk.Bool(true),
+		Command:     fakeintakescenario.FakeIntakeContainerCommand(params),
+		Environment: environment,
 		PortMappings: []ecsTypes.PortMapping{
 			{ContainerPort: awssdk.Int32(fakeIntakeHTTPPort), HostPort: awssdk.Int32(fakeIntakeHTTPPort), Protocol: ecsTypes.TransportProtocolTcp},
 		},
 		HealthCheck: &ecsTypes.HealthCheck{
-			Command:  []string{"CMD-SHELL", "curl --fail http://localhost/fakeintake/health"},
-			Interval: awssdk.Int32(30),
-			Retries:  awssdk.Int32(3),
-			Timeout:  awssdk.Int32(5),
+			Command:  []string{"CMD-SHELL", fakeintakescenario.FakeIntakeHealthCheckCommand},
+			Interval: awssdk.Int32(fakeintakescenario.FakeIntakeHealthCheckIntervalSeconds),
+			Retries:  awssdk.Int32(fakeintakescenario.FakeIntakeHealthCheckRetries),
+			Timeout:  awssdk.Int32(fakeintakescenario.FakeIntakeHealthCheckTimeoutSeconds),
 		},
 	}
 }

--- a/test/e2e-framework/testing/provisioners/aws/host/macos_pool_provisioner.go
+++ b/test/e2e-framework/testing/provisioners/aws/host/macos_pool_provisioner.go
@@ -14,12 +14,15 @@ import (
 	"time"
 
 	rootcomponents "github.com/DataDog/datadog-agent/test/e2e-framework/components"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/fakeintake"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/remote"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws/ec2/pool"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/components"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner/parameters"
 	e2eclient "github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/e2e/client"
 )
 
@@ -38,26 +41,30 @@ const (
 // macOSPoolProvisioner provisions a macOS environments.Host directly through the AWS
 // SDK and the resources/aws/ec2/pool package, bypassing Pulumi: it acquires a member of
 // the shared macOS EC2 pool and waits for it to become SSH-reachable, instead of
-// relying on a Pulumi remote.Host resource.
+// relying on a Pulumi remote.Host resource. FakeIntake and Agent, if requested, are
+// likewise provisioned Pulumi-free (raw ECS Fargate calls and sequential SSH commands,
+// respectively).
 type macOSPoolProvisioner struct {
-	id   string
-	opts []ec2.VMOption
+	id        string
+	runParams *ec2.Params
 
 	region     string
 	profile    string
 	instanceID string
 	leaseToken string
+	fakeIntake *macOSPoolFakeIntake
 }
 
 var _ provisioners.TypedProvisioner[environments.Host] = &macOSPoolProvisioner{}
 
 // NewMacOSPoolProvisioner returns a Pulumi-free provisioner for a macOS
-// environments.Host, drawing from the shared EC2 pool. opts are the same VMOptions
-// passed to ec2.WithEC2InstanceOptions.
-func NewMacOSPoolProvisioner(name string, opts ...ec2.VMOption) provisioners.TypedProvisioner[environments.Host] {
+// environments.Host, drawing from the shared EC2 pool. runParams carries the resolved
+// ec2.Params (instance options plus any requested Agent/FakeIntake configuration) for
+// the caller's run.
+func NewMacOSPoolProvisioner(name string, runParams *ec2.Params) provisioners.TypedProvisioner[environments.Host] {
 	return &macOSPoolProvisioner{
-		id:   macOSPoolProvisionerBaseID + name,
-		opts: opts,
+		id:        macOSPoolProvisionerBaseID + name,
+		runParams: runParams,
 	}
 }
 
@@ -66,15 +73,19 @@ func (p *macOSPoolProvisioner) ID() string {
 	return p.id
 }
 
-// ProvisionEnv acquires an existing macOS pool instance and imports it into env.RemoteHost.
+// ProvisionEnv acquires an existing macOS pool instance and imports it into env.RemoteHost,
+// then provisions FakeIntake and the Agent Pulumi-free if requested by p.runParams.
 func (p *macOSPoolProvisioner) ProvisionEnv(ctx context.Context, _ string, logger io.Writer, env *environments.Host) (provisioners.RawResources, error) {
-	// This provisioner only ever imports RemoteHost, so Agent/FakeIntake/Updater must
-	// be explicitly disabled.
-	env.DisableAgent()
-	env.DisableFakeIntake()
+	// The Updater is never supported Pulumi-free.
 	env.DisableUpdater()
+	if !p.runParams.HasFakeIntake() {
+		env.DisableFakeIntake()
+	}
+	if !p.runParams.HasAgent() {
+		env.DisableAgent()
+	}
 
-	vmArgs, err := ec2.ResolveMacOSPoolArgs(p.opts...)
+	vmArgs, err := ec2.ResolveMacOSPoolArgs(p.runParams.InstanceOptions()...)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +129,8 @@ func (p *macOSPoolProvisioner) ProvisionEnv(ctx context.Context, _ string, logge
 		Architecture:  vmArgs.OSInfo.Architecture,
 	}
 
-	if err := waitForSSH(ctx, logger, hostOutput); err != nil {
+	sshHost, err := waitForSSH(ctx, logger, hostOutput)
+	if err != nil {
 		return nil, fmt.Errorf("macOS pool instance %s never became SSH-reachable: %w", p.instanceID, err)
 	}
 
@@ -127,31 +139,85 @@ func (p *macOSPoolProvisioner) ProvisionEnv(ctx context.Context, _ string, logge
 	}
 	env.RemoteHost.SetKey(p.id)
 
-	marshalled, err := json.Marshal(hostOutput)
+	marshalledHost, err := json.Marshal(hostOutput)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal macOS pool host output: %w", err)
 	}
+	resources := provisioners.RawResources{p.id: marshalledHost}
 
-	return provisioners.RawResources{p.id: marshalled}, nil
+	var fiOutput *fakeintake.FakeintakeOutput
+	if p.runParams.HasFakeIntake() {
+		fiKey := p.id + "-fakeintake"
+
+		var fiState *macOSPoolFakeIntake
+		fiState, fiOutput, err = provisionMacOSPoolFakeIntake(ctx, logger, cfg.Region, cfg.Profile, cfg.EnvName, p.runParams.FakeIntakeOptions())
+		p.fakeIntake = fiState
+		if err != nil {
+			return nil, fmt.Errorf("failed to provision macOS pool FakeIntake: %w", err)
+		}
+
+		marshalledFI, err := json.Marshal(fiOutput)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal macOS pool FakeIntake output: %w", err)
+		}
+		env.FakeIntakeOutput() // ensures env.FakeIntake is non-nil
+		env.FakeIntake.SetKey(fiKey)
+		resources[fiKey] = marshalledFI
+	}
+
+	if p.runParams.HasAgent() {
+		agentKey := p.id + "-agent"
+
+		apiKey, err := runner.GetProfile().SecretStore().Get(parameters.APIKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve Agent API key for macOS pool provisioner: %w", err)
+		}
+
+		var fakeIntakeExtraConfig string
+		if fiOutput != nil {
+			fakeIntakeExtraConfig, err = macOSFakeIntakeExtraConfig(fiOutput)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build FakeIntake agent config: %w", err)
+			}
+		}
+
+		agentOutput, err := provisionMacOSPoolAgent(sshHost, hostOutput, apiKey, p.runParams.AgentOptions(), fakeIntakeExtraConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to provision macOS pool Agent: %w", err)
+		}
+
+		marshalledAgent, err := json.Marshal(agentOutput)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal macOS pool Agent output: %w", err)
+		}
+		env.AgentOutput() // ensures env.Agent is non-nil
+		env.Agent.SetKey(agentKey)
+		env.Agent.ClientOptions = p.runParams.AgentClientOptions()
+		resources[agentKey] = marshalledAgent
+	}
+
+	return resources, nil
 }
 
-// waitForSSH polls client.NewHost until it succeeds or sshWaitTimeout elapses.
-func waitForSSH(ctx context.Context, logger io.Writer, hostOutput remote.HostOutput) error {
+// waitForSSH polls client.NewHost until it succeeds or sshWaitTimeout elapses, returning
+// the connected client so callers don't have to reconnect for follow-up work (e.g. the
+// Agent install).
+func waitForSSH(ctx context.Context, logger io.Writer, hostOutput remote.HostOutput) (*e2eclient.Host, error) {
 	deadline := time.Now().Add(sshWaitTimeout)
 	sshCtx := &sshWaitContext{logger: logger}
 
 	for {
-		_, err := e2eclient.NewHost(sshCtx, hostOutput)
+		host, err := e2eclient.NewHost(sshCtx, hostOutput)
 		if err == nil {
-			return nil
+			return host, nil
 		}
 		if time.Now().After(deadline) {
-			return err
+			return nil, err
 		}
 		select {
 		case <-time.After(sshWaitRetryInterval):
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil, ctx.Err()
 		}
 	}
 }
@@ -183,9 +249,18 @@ func macOSPoolOwnerID() string {
 	return "local"
 }
 
-// Destroy resets the pool instance's root volume to its launch state and releases its
-// lease. It is a no-op if ProvisionEnv never successfully claimed an instance.
+// Destroy tears down the FakeIntake ECS resources (if any were provisioned), resets the
+// pool instance's root volume to its launch state, and releases its lease. It is a no-op
+// on the pool instance if ProvisionEnv never successfully claimed one.
 func (p *macOSPoolProvisioner) Destroy(ctx context.Context, _ string, logger io.Writer) error {
+	if p.fakeIntake != nil {
+		fmt.Fprintf(logger, "tearing down macOS pool FakeIntake ECS resources\n")
+		if err := p.fakeIntake.destroy(ctx); err != nil {
+			return fmt.Errorf("failed to destroy macOS pool FakeIntake: %w", err)
+		}
+		p.fakeIntake = nil
+	}
+
 	if p.instanceID == "" {
 		return nil
 	}


### PR DESCRIPTION
…hosts

Wire the macOS EC2 pool provisioner to provision FakeIntake (raw ECS Fargate calls) and the Agent (sequential SSH commands) without a live Pulumi context, alongside the already Pulumi-free pool instance acquisition. Non-macOS provisioning paths are unchanged.

<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
