### PR TITLE
Reduce SNMP discovery load with batch writes and `synctest`

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/discovery/discovery.go
+++ b/pkg/collector/corechecks/snmp/internal/discovery/discovery.go
@@ -39,6 +39,7 @@ var (
 type Discovery struct {
 	config    *checkconfig.CheckConfig
 	stop      chan struct{}
+	done      chan struct{}
 	discDevMu sync.RWMutex
 
 	// TODO: use a new type for device deviceDigest
@@ -62,7 +63,8 @@ type snmpSubnet struct {
 	startingIP net.IP
 	network    net.IPNet
 
-	cacheKey string
+	cacheKey   string
+	cacheDirty bool
 
 	// discoveredDevices contains devices ip with device deviceDigest as map key
 	// see also CheckConfig.DeviceDigest()
@@ -77,18 +79,24 @@ type snmpSubnet struct {
 type checkDeviceJob struct {
 	subnet    *snmpSubnet
 	currentIP net.IP
+	wg        *sync.WaitGroup
 }
 
 // Start discovery
 func (d *Discovery) Start() {
 	log.Debugf("subnet %s: Start discovery", d.config.Network)
-	go d.discoverDevices()
+	go func() {
+		d.discoverDevices()
+		close(d.done)
+	}()
 }
 
-// Stop signal discovery to shut down
+// Stop signals discovery to shut down and waits for any in-flight pass,
+// including its trailing cache write, to actually finish before returning.
 func (d *Discovery) Stop() {
 	log.Debugf("subnet %s: Stop discovery", d.config.Network)
 	close(d.stop)
+	<-d.done
 }
 
 // GetDiscoveredDeviceConfigs returns discovered device configs
@@ -118,6 +126,7 @@ func (d *Discovery) runWorker(w int, jobs <-chan checkDeviceJob) {
 			if err != nil {
 				log.Errorf("%s", err.Error())
 			}
+			job.wg.Done()
 		}
 	}
 }
@@ -149,6 +158,11 @@ func (d *Discovery) discoverDevices() {
 
 	d.loadCache(&subnet)
 
+	if d.config.DiscoveryWorkers <= 0 {
+		<-d.stop // without workers to consume them, scheduling devices would block forever on the jobs channel
+		return
+	}
+
 	jobs := make(chan checkDeviceJob)
 	for w := 0; w < d.config.DiscoveryWorkers; w++ {
 		go d.runWorker(w, jobs)
@@ -162,6 +176,7 @@ func (d *Discovery) discoverDevices() {
 		log.Debugf("subnet %s: Run discovery", d.config.Network)
 		startingIP := make(net.IP, len(subnet.startingIP))
 		copy(startingIP, subnet.startingIP)
+		var wg sync.WaitGroup
 		for currentIP := startingIP; subnet.network.Contains(currentIP); incrementIP(currentIP) {
 
 			if ignored := subnet.config.IsIPIgnored(currentIP); ignored {
@@ -170,19 +185,26 @@ func (d *Discovery) discoverDevices() {
 
 			jobIP := make(net.IP, len(currentIP))
 			copy(jobIP, currentIP)
+			wg.Add(1)
 			job := checkDeviceJob{
 				subnet:    &subnet,
 				currentIP: jobIP,
+				wg:        &wg,
 			}
-			jobs <- job
 
 			select {
+			case jobs <- job:
 			case <-d.stop:
 				log.Debugf("subnet %s: Stop scheduling devices", d.config.Network)
+				wg.Done() // this job was never picked up by a worker
+				wg.Wait()
+				d.writeCache(&subnet) // persist what the partial pass found
 				return
-			default:
 			}
 		}
+
+		wg.Wait()
+		d.writeCache(&subnet) // persist what the completed pass found
 
 		select {
 		case <-d.stop:
@@ -242,7 +264,7 @@ func (d *Discovery) getDevicesFound() []string {
 	return ipsFound
 }
 
-func (d *Discovery) createDevice(deviceDigest checkconfig.DeviceDigest, subnet *snmpSubnet, deviceIP string, writeCache bool) {
+func (d *Discovery) createDevice(deviceDigest checkconfig.DeviceDigest, subnet *snmpSubnet, deviceIP string, justProbed bool) {
 	deviceConfig := subnet.config.CopyWithNewIP(deviceIP)
 	connMgr := devicecheck.NewConnectionManager(deviceConfig, d.sessionFactory)
 	deviceCk, err := devicecheck.NewDeviceCheck(deviceConfig, connMgr, d.agentConfig)
@@ -268,8 +290,8 @@ func (d *Discovery) createDevice(deviceDigest checkconfig.DeviceDigest, subnet *
 	subnet.devices[deviceDigest] = deviceIP
 	subnet.deviceFailures[deviceDigest] = 0
 
-	if writeCache {
-		d.writeCache(subnet)
+	if justProbed {
+		subnet.cacheDirty = true
 	}
 
 	if d.scanManager == nil {
@@ -300,7 +322,7 @@ func (d *Discovery) deleteDevice(deviceDigest checkconfig.DeviceDigest, subnet *
 			delete(d.discoveredDevices, deviceDigest)
 			delete(subnet.devices, deviceDigest)
 			delete(subnet.deviceFailures, deviceDigest)
-			d.writeCache(subnet)
+			subnet.cacheDirty = true
 		}
 	}
 }
@@ -332,8 +354,17 @@ func (d *Discovery) loadCache(subnet *snmpSubnet) {
 	}
 }
 
+// writeCache writes the subnet's cache to disk if it changed since the last write.
+// Use once per pass, not per device, to avoid serializing the pass behind repeated
+// disk I/O for no correctness benefit.
 func (d *Discovery) writeCache(subnet *snmpSubnet) {
-	// We don't lock the subnet for now, because the discovery ought to be already locked
+	d.discDevMu.Lock()
+	defer d.discDevMu.Unlock()
+	if !subnet.cacheDirty {
+		return
+	}
+	subnet.cacheDirty = false
+
 	devices := make([]string, 0, len(subnet.devices))
 	for _, v := range subnet.devices {
 		devices = append(devices, v)
@@ -355,6 +386,7 @@ func NewDiscovery(config *checkconfig.CheckConfig, sessionFactory session.Factor
 	return &Discovery{
 		discoveredDevices: make(map[checkconfig.DeviceDigest]Device),
 		stop:              make(chan struct{}),
+		done:              make(chan struct{}),
 		config:            config,
 		sessionFactory:    sessionFactory,
 		agentConfig:       agentConfig,

--- a/pkg/collector/corechecks/snmp/internal/discovery/discovery.go
+++ b/pkg/collector/corechecks/snmp/internal/discovery/discovery.go
@@ -363,7 +363,6 @@ func (d *Discovery) writeCache(subnet *snmpSubnet) {
 	if !subnet.cacheDirty {
 		return
 	}
-	subnet.cacheDirty = false
 
 	devices := make([]string, 0, len(subnet.devices))
 	for _, v := range subnet.devices {
@@ -378,7 +377,10 @@ func (d *Discovery) writeCache(subnet *snmpSubnet) {
 
 	if err = persistentcache.Write(subnet.cacheKey, string(cacheValue)); err != nil {
 		log.Errorf("subnet %s: Couldn't write cache: %s", d.config.Network, err)
+		return
 	}
+
+	subnet.cacheDirty = false
 }
 
 // NewDiscovery return a new Discovery instance

--- a/pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go
+++ b/pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go
@@ -9,7 +9,9 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	agentconfig "github.com/DataDog/datadog-agent/comp/core/config"
@@ -23,19 +25,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func waitForDiscoveredDevices(discovery *Discovery, expectedDeviceCount int, timeout time.Duration) error {
-	var deviceCount int
-	for start := time.Now(); time.Since(start) < timeout; {
-		deviceCount = len(discovery.GetDiscoveredDeviceConfigs())
-		if deviceCount >= expectedDeviceCount {
-			return nil
-		}
-		time.Sleep(100 * time.Millisecond)
+func waitForDiscoveredDevices(discovery *Discovery, expectedDeviceCount int) error {
+	synctest.Wait()
+	deviceCount := len(discovery.GetDiscoveredDeviceConfigs())
+	if deviceCount == expectedDeviceCount {
+		return nil
 	}
-	return fmt.Errorf("timeout after waiting for %v, expected at least %d devices but %d has been discovered", timeout, expectedDeviceCount, deviceCount)
+	return fmt.Errorf("expected exactly %d devices but %d has been discovered", expectedDeviceCount, deviceCount)
+}
+
+func cacheKey(checkConfig *checkconfig.CheckConfig) string {
+	return fmt.Sprintf("%s:%s", cacheKeyPrefix, checkConfig.DeviceDigest(checkConfig.Network))
+}
+
+func readCachedIPs(t *testing.T, discovery *Discovery, cacheKey string) []string {
+	t.Helper()
+	ips, err := discovery.readCache(&snmpSubnet{cacheKey: cacheKey})
+	assert.NoError(t, err)
+	var ipStrings []string
+	for _, ip := range ips {
+		ipStrings = append(ipStrings, ip.String())
+	}
+	return ipStrings
 }
 
 func TestDiscovery(t *testing.T) {
+	synctest.Test(t, syncTestDiscovery)
+}
+
+func syncTestDiscovery(t *testing.T) {
 	config := agentconfig.NewMock(t)
 	config.SetInTest("run_path", t.TempDir())
 
@@ -65,7 +83,7 @@ func TestDiscovery(t *testing.T) {
 	}
 	discovery := NewDiscovery(checkConfig, sessionFactory, config, nil)
 	discovery.Start()
-	assert.NoError(t, waitForDiscoveredDevices(discovery, 7, 2*time.Second))
+	assert.NoError(t, waitForDiscoveredDevices(discovery, 7))
 	discovery.Stop()
 
 	deviceConfigs := discovery.GetDiscoveredDeviceConfigs()
@@ -88,6 +106,10 @@ func TestDiscovery(t *testing.T) {
 }
 
 func TestDiscoveryCache(t *testing.T) {
+	synctest.Test(t, syncTestDiscoveryCache)
+}
+
+func syncTestDiscoveryCache(t *testing.T) {
 	config := agentconfig.NewMock(t)
 	config.SetInTest("run_path", t.TempDir())
 
@@ -116,7 +138,7 @@ func TestDiscoveryCache(t *testing.T) {
 	}
 	discovery := NewDiscovery(checkConfig, sessionFactory, config, nil)
 	discovery.Start()
-	assert.NoError(t, waitForDiscoveredDevices(discovery, 4, 2*time.Second))
+	assert.NoError(t, waitForDiscoveredDevices(discovery, 4))
 	discovery.Stop()
 
 	deviceConfigs := discovery.GetDiscoveredDeviceConfigs()
@@ -149,7 +171,7 @@ func TestDiscoveryCache(t *testing.T) {
 	}
 	discovery2 := NewDiscovery(checkConfig, sessionFactory, config, nil)
 	discovery2.Start()
-	assert.NoError(t, waitForDiscoveredDevices(discovery2, 4, 2*time.Second))
+	assert.NoError(t, waitForDiscoveredDevices(discovery2, 4))
 	discovery2.Stop()
 
 	deviceConfigsFromCache := discovery2.GetDiscoveredDeviceConfigs()
@@ -159,11 +181,16 @@ func TestDiscoveryCache(t *testing.T) {
 		actualDiscoveredIpsFromCache = append(actualDiscoveredIpsFromCache, deviceCk.GetIPAddress())
 	}
 	assert.ElementsMatch(t, expectedDiscoveredIps, actualDiscoveredIpsFromCache)
+
+	// test readCache directly against what discovery's pass persisted to disk
+	assert.ElementsMatch(t, expectedDiscoveredIps, readCachedIPs(t, discovery2, cacheKey(checkConfig)))
 }
 
 func TestDiscoveryTicker(t *testing.T) {
-	t.Skip() // TODO: FIX ME, currently this test is leading to data race when ran with other tests
+	synctest.Test(t, syncTestDiscoveryTicker)
+}
 
+func syncTestDiscoveryTicker(t *testing.T) {
 	config := agentconfig.NewMock(t)
 	config.SetInTest("run_path", t.TempDir())
 
@@ -347,9 +374,27 @@ func TestDiscovery_createDevice(t *testing.T) {
 	device1Digest := subnet.config.DeviceDigest("192.168.0.1")
 	device2Digest := subnet.config.DeviceDigest("192.168.0.2")
 	device3Digest := subnet.config.DeviceDigest("192.168.0.3")
-	discovery.createDevice(device1Digest, subnet, "192.168.0.1", true)
+
+	// loading device1 at startup should not mark the cache dirty
+	assert.False(t, subnet.cacheDirty)
+	discovery.createDevice(device1Digest, subnet, "192.168.0.1", false)
+	assert.False(t, subnet.cacheDirty)
+	discovery.writeCache(subnet)
+	assert.Empty(t, readCachedIPs(t, discovery, subnet.cacheKey))
+
+	// discovering device2 should mark the cache dirty, and writing encompass device1
 	discovery.createDevice(device2Digest, subnet, "192.168.0.2", true)
-	discovery.createDevice(device3Digest, subnet, "192.168.0.3", false)
+	assert.True(t, subnet.cacheDirty)
+	discovery.writeCache(subnet)
+	assert.False(t, subnet.cacheDirty)
+	assert.ElementsMatch(t, []string{"192.168.0.1", "192.168.0.2"}, readCachedIPs(t, discovery, subnet.cacheKey))
+
+	// discovering device3 should also mark the cache dirty, and writing encompass all 3
+	discovery.createDevice(device3Digest, subnet, "192.168.0.3", true)
+	assert.True(t, subnet.cacheDirty)
+	discovery.writeCache(subnet)
+	assert.False(t, subnet.cacheDirty)
+	assert.ElementsMatch(t, []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"}, readCachedIPs(t, discovery, subnet.cacheKey))
 
 	assert.Equal(t, 3, len(discovery.discoveredDevices))
 
@@ -360,11 +405,6 @@ func TestDiscovery_createDevice(t *testing.T) {
 
 	assert.Equal(t, device2Digest, discovery.discoveredDevices[device2Digest].deviceDigest)
 	assert.Equal(t, "192.168.0.2", discovery.discoveredDevices[device2Digest].deviceIP)
-
-	// test that only createDevice with writeCache:true are written to cache
-	ips, err := discovery.readCache(subnet)
-	assert.Nil(t, err)
-	assert.Equal(t, 2, len(ips))
 
 	// test deleteDevice
 	assert.Equal(t, 0, subnet.deviceFailures[device1Digest])
@@ -379,9 +419,16 @@ func TestDiscovery_createDevice(t *testing.T) {
 	assert.Equal(t, true, present)
 	discovery.deleteDevice(device1Digest, subnet) // really deletes the device
 	assert.Equal(t, 2, len(discovery.discoveredDevices))
+	discovery.writeCache(subnet)
+	assert.False(t, subnet.cacheDirty)
+	assert.ElementsMatch(t, []string{"192.168.0.2", "192.168.0.3"}, readCachedIPs(t, discovery, subnet.cacheKey))
 }
 
 func TestDeviceScansAreRequested(t *testing.T) {
+	synctest.Test(t, syncTestDeviceScansAreRequested)
+}
+
+func syncTestDeviceScansAreRequested(t *testing.T) {
 	config := agentconfig.NewMock(t)
 	config.SetInTest("run_path", t.TempDir())
 
@@ -428,8 +475,206 @@ func TestDeviceScansAreRequested(t *testing.T) {
 
 	discovery := NewDiscovery(checkConfig, sessionFactory, config, scanManager)
 	discovery.Start()
-	assert.NoError(t, waitForDiscoveredDevices(discovery, 4, 2*time.Second))
+	assert.NoError(t, waitForDiscoveredDevices(discovery, 4))
 	discovery.Stop()
 
 	mockScanManager.AssertExpectations(t)
+}
+
+func TestDiscoveryWritesCacheOnceAfterTheWholePass(t *testing.T) {
+	synctest.Test(t, syncTestDiscoveryWritesCacheOnceAfterTheWholePass)
+}
+
+func syncTestDiscoveryWritesCacheOnceAfterTheWholePass(t *testing.T) {
+	config := agentconfig.NewMock(t)
+	config.SetInTest("run_path", t.TempDir())
+
+	sess := session.CreateMockSession()
+	packet := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.3.6.1.2.1.1.2.0",
+				Type:  gosnmp.ObjectIdentifier,
+				Value: "1.3.6.1.4.1.3375.2.1.3.4.1",
+			},
+		},
+	}
+	device1Chan := make(chan time.Time)
+	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).WaitUntil(device1Chan).Return(&packet, nil).Once()
+	device2Chan := make(chan time.Time)
+	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).WaitUntil(device2Chan).Return(&packet, nil).Once()
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
+		return sess, nil
+	}
+
+	checkConfig := &checkconfig.CheckConfig{
+		Network:            "192.168.0.0/30",
+		CommunityString:    "public",
+		DiscoveryInterval:  3600,
+		DiscoveryWorkers:   1,
+		IgnoredIPAddresses: map[string]bool{"192.168.0.2": true, "192.168.0.3": true},
+		ProfileProvider:    profile.StaticProvider(nil),
+	}
+	discovery := NewDiscovery(checkConfig, sessionFactory, config, nil)
+
+	returnDevice1 := sync.OnceFunc(func() { close(device1Chan) })
+	returnDevice2 := sync.OnceFunc(func() { close(device2Chan) })
+	discovery.Start()
+	t.Cleanup(func() {
+		// never leave a worker goroutine blocked, even if an assertion fails
+		returnDevice1()
+		returnDevice2()
+		discovery.Stop()
+	})
+
+	// the worker is now durably blocked inside device1's Get
+	synctest.Wait()
+
+	// let device1's check complete: the worker moves on to device2's Get
+	returnDevice1()
+	synctest.Wait()
+
+	// nothing should be written yet: device1 succeeded, but the pass isn't done
+	assert.Empty(t, readCachedIPs(t, discovery, cacheKey(checkConfig)))
+
+	// let device2's check complete: this finishes the pass
+	returnDevice2()
+	synctest.Wait()
+
+	// the completed pass writes the cache once, covering both devices
+	assert.ElementsMatch(t, []string{"192.168.0.0", "192.168.0.1"}, readCachedIPs(t, discovery, cacheKey(checkConfig)))
+}
+
+func TestDiscoveryStopWaitsForInFlightCheck(t *testing.T) {
+	synctest.Test(t, syncTestDiscoveryStopWaitsForInFlightCheck)
+}
+
+func syncTestDiscoveryStopWaitsForInFlightCheck(t *testing.T) {
+	config := agentconfig.NewMock(t)
+	config.SetInTest("run_path", t.TempDir())
+
+	sess := session.CreateMockSession()
+	packet := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.3.6.1.2.1.1.2.0",
+				Type:  gosnmp.ObjectIdentifier,
+				Value: "1.3.6.1.4.1.3375.2.1.3.4.1",
+			},
+		},
+	}
+	deviceChan := make(chan time.Time)
+	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).WaitUntil(deviceChan).Return(&packet, nil)
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
+		return sess, nil
+	}
+
+	checkConfig := &checkconfig.CheckConfig{
+		Network:           "192.168.0.0/32",
+		CommunityString:   "public",
+		DiscoveryInterval: 3600,
+		DiscoveryWorkers:  1,
+		ProfileProvider:   profile.StaticProvider(nil),
+	}
+	discovery := NewDiscovery(checkConfig, sessionFactory, config, nil)
+	discovery.Start()
+
+	returnDevice := sync.OnceFunc(func() { close(deviceChan) })
+	t.Cleanup(returnDevice) // never leave the worker goroutine blocked, even if an assertion fails
+
+	// the worker is now durably blocked inside Get, mid-pass
+	synctest.Wait()
+
+	// Stop is now durably blocked on <-d.done, waiting on the check above
+	stopped := make(chan struct{})
+	go func() {
+		discovery.Stop()
+		close(stopped)
+	}()
+	synctest.Wait()
+	select {
+	case <-stopped:
+		t.Fatal("Stop returned before the in-flight device check completed")
+	default:
+	}
+
+	// releasing the blocked check lets the pass, and Stop, run to completion
+	returnDevice()
+	synctest.Wait()
+	select {
+	case <-stopped:
+	default:
+		t.Fatal("Stop did not return after the in-flight device check completed")
+	}
+
+	// by the time Stop returned, the pass's trailing cache write must already be on disk
+	assert.ElementsMatch(t, []string{"192.168.0.0"}, readCachedIPs(t, discovery, cacheKey(checkConfig)))
+}
+
+func TestDiscoveryStopCancelsPendingSchedule(t *testing.T) {
+	synctest.Test(t, syncTestDiscoveryStopCancelsPendingSchedule)
+}
+
+func syncTestDiscoveryStopCancelsPendingSchedule(t *testing.T) {
+	config := agentconfig.NewMock(t)
+	config.SetInTest("run_path", t.TempDir())
+
+	sess := session.CreateMockSession()
+	packet := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.3.6.1.2.1.1.2.0",
+				Type:  gosnmp.ObjectIdentifier,
+				Value: "1.3.6.1.4.1.3375.2.1.3.4.1",
+			},
+		},
+	}
+	deviceChan := make(chan time.Time)
+	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).WaitUntil(deviceChan).Return(&packet, nil)
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
+		return sess, nil
+	}
+
+	checkConfig := &checkconfig.CheckConfig{
+		Network:            "192.168.0.0/30",
+		CommunityString:    "public",
+		DiscoveryInterval:  3600,
+		DiscoveryWorkers:   1,
+		IgnoredIPAddresses: map[string]bool{"192.168.0.2": true, "192.168.0.3": true},
+		ProfileProvider:    profile.StaticProvider(nil),
+	}
+	discovery := NewDiscovery(checkConfig, sessionFactory, config, nil)
+	discovery.Start()
+
+	returnDevice := sync.OnceFunc(func() { close(deviceChan) })
+	t.Cleanup(returnDevice) // never leave the worker goroutine blocked, even if an assertion fails
+
+	// the single worker is now durably blocked checking 192.168.0.0; with no
+	// worker free, scheduling 192.168.0.1 is durably blocked too
+	synctest.Wait()
+
+	// Stop must not wait for a job that was never picked up by a worker
+	stopped := make(chan struct{})
+	go func() {
+		discovery.Stop()
+		close(stopped)
+	}()
+	synctest.Wait()
+	select {
+	case <-stopped:
+		t.Fatal("Stop returned before the in-flight device check completed")
+	default:
+	}
+
+	// releasing the blocked check lets the pass, and Stop, run to completion
+	returnDevice()
+	synctest.Wait()
+	select {
+	case <-stopped:
+	default:
+		t.Fatal("Stop did not return: it hung waiting on the abandoned job")
+	}
+
+	// only the device that was actually checked made it into the cache
+	assert.ElementsMatch(t, []string{"192.168.0.0"}, readCachedIPs(t, discovery, cacheKey(checkConfig)))
 }


### PR DESCRIPTION
### What does this PR do?
Batch the subnet cache write so it happens once per completed discovery pass instead of once per discovered device: `snmpSubnet` gets a `cacheDirty` flag, and `writeCache` now writes only when dirty, guarded by a `WaitGroup` that tracks in-flight jobs.
=> `TestDiscoveryWritesCacheOnceAfterTheWholePass` verifies the cache is written once after a full pass rather than once per device.

Make `Discovery.Stop()` wait for the in-flight pass, including any trailing write, before returning (previously "fire and forget").
=> `TestDiscoveryStopWaitsForInFlightCheck` verifies `Stop` actually waits for an in-flight check to finish.

Waiting on `Stop()` also surfaced two dormant bugs, previously unnoticed because nothing waited on the goroutine they blocked:
1. `DiscoveryWorkers: 0` scheduled jobs into an unconsumed channel and blocked forever: it now returns immediately after loading from cache instead of leaking a goroutine,
2. an unconditional `jobs <- job` could block forever once every worker was busy and `Stop()` fired, since nothing was left to receive it: scheduling a job now also selects on `d.stop`.
=> `TestDiscoveryStopCancelsPendingSchedule` verifies `Stop` no longer hangs on a job that was never picked up by a worker.

Deflake formerly wallclock-sensitive tests thanks to `synctest`.

The determinism and fixes let us **un-skip** `TestDiscoveryTicker`: the data race it used to hit running alongside other tests no longer reproduces.

### Motivation
Initially motivated by tests exhibiting flakiness:
- in CI ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1877754078/viewer#L552)):
```
Error Trace:	pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go:431
Error:      	Received unexpected error:
            	timeout after waiting for 2s, expected at least 4 devices but 3 has been discovered
Test:       	TestDeviceScansAreRequested
```
- on my machine:
```
Error Trace:    pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go:68
Error:          Received unexpected error:
                timeout after waiting for 2s, expected at least 7 devices but 4 has been discovered
Test:           TestDiscovery
```

Profiling with `go tool trace -pprof=syscall` over 200 runs showed `syscall.openat` alone accounted for the large majority of all blocking-syscall time, entirely inside `checkDevice`/`createDevice`: every discovered device triggered a full synchronous rewrite of the whole cache file.

Batching the writes cut total blocking-syscall time about 30x and `openat` specifically about 330x in a clean 200-run before/after comparison.

### Describe how you validated your changes
- 553/553 tests pass across the `snmp` package tree in a single `-race` pass, with 0 skips (previously 1, see above),
- 100 repeated `-race` runs of the discovery package alone,
- `go tool trace -pprof=syscall` before/after, 200 runs of `TestDiscovery`:
  - total blocking time: **4.5s to 150ms**,
  - `syscall.openat`: **4.3s to 13ms**.

### Additional Notes
- `writeCache` taking its own lock (previously it relied on a comment saying the caller must already hold it) is safe here: its only 2 call sites, both in `discoverDevices`, never hold `discDevMu` beforehand,
- out of scope: a pre-existing, unrelated flakiness source in `pkg/collector/corechecks/snmp/status` (global `expvar` state leaking across repeated `-count=N` runs of the same test binary) is deferred to a follow-up PR.