### PR TITLE
fix(e2e): wait for an idle macOS pool instance before taking the Pulu…

### DIFF
--- a/test/e2e-framework/resources/aws/ec2/pool/pool.go
+++ b/test/e2e-framework/resources/aws/ec2/pool/pool.go
@@ -166,16 +166,18 @@ func ReleaseInstance(ctx context.Context, region, profile string, instanceID str
 	}
 
 	key := leasePrefix + instanceID
-	var imageID string
-	if getOut, getErr := client.GetObject(ctx, &s3.GetObjectInput{Bucket: aws.String(leaseBucket), Key: aws.String(key)}); getErr == nil {
-		var current leaseRecord
-		if json.NewDecoder(getOut.Body).Decode(&current) == nil {
-			imageID = current.ImageID
-		}
-		getOut.Body.Close()
+	getOut, err := client.GetObject(ctx, &s3.GetObjectInput{Bucket: aws.String(leaseBucket), Key: aws.String(key)})
+	if err != nil {
+		return fmt.Errorf("failed to read lease record for instance %s: %w", instanceID, err)
+	}
+	var current leaseRecord
+	decodeErr := json.NewDecoder(getOut.Body).Decode(&current)
+	getOut.Body.Close()
+	if decodeErr != nil {
+		return fmt.Errorf("failed to decode lease record for instance %s: %w", instanceID, decodeErr)
 	}
 
-	body, err := json.Marshal(leaseRecord{Status: "idle", ImageID: imageID})
+	body, err := json.Marshal(leaseRecord{Status: "idle", ImageID: current.ImageID})
 	if err != nil {
 		return fmt.Errorf("failed to marshal lease record for instance %s: %w", instanceID, err)
 	}
@@ -246,8 +248,9 @@ func NewEC2Client(ctx context.Context, region, profile string) (*awsec2.Client, 
 
 // BuildReleaseScript returns a shell script that reverts instanceID's root volume to
 // imageID's snapshot, then releases the lease at leasePrefix+instanceID conditioned on
-// leaseToken. If imageID is empty, the root-volume replacement is skipped and the
-// lease is released directly.
+// leaseToken. If imageID is empty, or no longer resolves to an existing AMI/snapshot,
+// the root-volume replacement is skipped, IMAGE_ID is cleared to "" before it's written
+// back to the lease, and the lease is released directly.
 //
 // This runs as a Pulumi local.Command's Delete handler, since `pulumi destroy` never
 // re-invokes the Go provisioner program.
@@ -262,22 +265,28 @@ LEASE_KEY=%q
 if [ -z "$IMAGE_ID" ] || [ "$IMAGE_ID" = "None" ]; then
   echo "no baseline image published for instance ${INSTANCE_ID}, skipping root volume replacement" >&2
 else
-  SNAPSHOT_ID=$(aws ec2 describe-images --image-ids "$IMAGE_ID" \
-    --query 'Images[0].BlockDeviceMappings[0].Ebs.SnapshotId' --output text)
+  if ! SNAPSHOT_ID=$(aws ec2 describe-images --image-ids "$IMAGE_ID" \
+    --query 'Images[0].BlockDeviceMappings[0].Ebs.SnapshotId' --output text 2>&1); then
+    echo "error: baseline image ${IMAGE_ID} for instance ${INSTANCE_ID} could not be described (${SNAPSHOT_ID}), skipping root volume replacement" >&2
+    IMAGE_ID=""
+  elif [ -z "$SNAPSHOT_ID" ] || [ "$SNAPSHOT_ID" = "None" ]; then
+    echo "error: baseline image ${IMAGE_ID} for instance ${INSTANCE_ID} has no snapshot, skipping root volume replacement" >&2
+    IMAGE_ID=""
+  else
+    TASK_ID=$(aws ec2 create-replace-root-volume-task \
+      --instance-id "$INSTANCE_ID" --snapshot-id "$SNAPSHOT_ID" \
+      --query 'ReplaceRootVolumeTask.ReplaceRootVolumeTaskId' --output text)
 
-  TASK_ID=$(aws ec2 create-replace-root-volume-task \
-    --instance-id "$INSTANCE_ID" --snapshot-id "$SNAPSHOT_ID" \
-    --query 'ReplaceRootVolumeTask.ReplaceRootVolumeTaskId' --output text)
-
-  for i in $(seq 1 60); do
-    STATE=$(aws ec2 describe-replace-root-volume-tasks --replace-root-volume-task-ids "$TASK_ID" \
-      --query 'ReplaceRootVolumeTasks[0].TaskState' --output text)
-    case "$STATE" in
-      succeeded) break ;;
-      failed|failing) echo "replace-root-volume-task ${TASK_ID} ended in state ${STATE}" >&2; exit 1 ;;
-      *) sleep 10 ;;
-    esac
-  done
+    for i in $(seq 1 60); do
+      STATE=$(aws ec2 describe-replace-root-volume-tasks --replace-root-volume-task-ids "$TASK_ID" \
+        --query 'ReplaceRootVolumeTasks[0].TaskState' --output text)
+      case "$STATE" in
+        succeeded) break ;;
+        failed|failing) echo "replace-root-volume-task ${TASK_ID} ended in state ${STATE}" >&2; exit 1 ;;
+        *) sleep 10 ;;
+      esac
+    done
+  fi
 fi
 
 BODY=$(printf '{"status":"idle","imageId":"%%s"}' "$IMAGE_ID")

--- a/test/e2e-framework/resources/aws/ec2/pool/pool.go
+++ b/test/e2e-framework/resources/aws/ec2/pool/pool.go
@@ -247,20 +247,27 @@ func NewEC2Client(ctx context.Context, region, profile string) (*awsec2.Client, 
 }
 
 // BuildReleaseScript returns a shell script that reverts instanceID's root volume to
-// imageID's snapshot, then releases the lease at leasePrefix+instanceID conditioned on
-// leaseToken. If imageID is empty, or no longer resolves to an existing AMI/snapshot,
-// the root-volume replacement is skipped, IMAGE_ID is cleared to "" before it's written
-// back to the lease, and the lease is released directly.
+// the lease's current baseline imageId (read fresh from S3 at release time, not the
+// value baked in at acquire time, so a baseline rotated mid-checkout is still
+// honored), then releases the lease at leasePrefix+instanceID conditioned on
+// leaseToken. If the current imageId is empty, or no longer resolves to an existing
+// AMI/snapshot, the root-volume replacement is skipped, IMAGE_ID is cleared to ""
+// before it's written back to the lease, and the lease is released directly.
 //
 // This runs as a Pulumi local.Command's Delete handler, since `pulumi destroy` never
 // re-invokes the Go provisioner program.
-func BuildReleaseScript(instanceID, leaseToken, imageID string) string {
+func BuildReleaseScript(instanceID, leaseToken string) string {
 	return fmt.Sprintf(`set -e
 INSTANCE_ID=%q
-IMAGE_ID=%q
 LEASE_TOKEN=%q
 LEASE_BUCKET=%q
 LEASE_KEY=%q
+
+LEASE_FILE=$(mktemp)
+BODY_FILE=$(mktemp)
+trap 'rm -f "$LEASE_FILE" "$BODY_FILE"' EXIT
+aws s3api get-object --bucket "$LEASE_BUCKET" --key "$LEASE_KEY" "$LEASE_FILE" >/dev/null
+IMAGE_ID=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("imageId") or "")' "$LEASE_FILE")
 
 if [ -z "$IMAGE_ID" ] || [ "$IMAGE_ID" = "None" ]; then
   echo "no baseline image published for instance ${INSTANCE_ID}, skipping root volume replacement" >&2
@@ -290,9 +297,10 @@ else
 fi
 
 BODY=$(printf '{"status":"idle","imageId":"%%s"}' "$IMAGE_ID")
+printf '%%s' "$BODY" > "$BODY_FILE"
 aws s3api put-object --bucket "$LEASE_BUCKET" --key "$LEASE_KEY" \
-  --body <(printf '%%s' "$BODY") --if-match "$LEASE_TOKEN"
-`, instanceID, imageID, leaseToken, leaseBucket, leasePrefix+instanceID)
+  --body "$BODY_FILE" --if-match "$LEASE_TOKEN"
+`, instanceID, leaseToken, leaseBucket, leasePrefix+instanceID)
 }
 
 func newS3Client(ctx context.Context, region, profile string) (*s3.Client, error) {

--- a/test/e2e-framework/resources/aws/ec2/pool_release.go
+++ b/test/e2e-framework/resources/aws/ec2/pool_release.go
@@ -15,13 +15,14 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-// ScheduleReleaseOnDestroy attaches instanceID/leaseToken/imageID's release-and-revert
-// logic to opts' owning stack via a local.Command whose Delete handler runs
+// ScheduleReleaseOnDestroy attaches instanceID/leaseToken's release-and-revert logic
+// to opts' owning stack via a local.Command whose Delete handler runs
 // pool.BuildReleaseScript. Create is a no-op; the resource exists to carry a Delete
-// action. imageID may be empty, in which case the Delete handler skips the
-// root-volume replacement but still releases the lease. leaseToken is passed via
-// Triggers so a new lease on the same instance produces a fresh trigger value.
-func ScheduleReleaseOnDestroy(e aws.Environment, name string, instanceID string, leaseToken string, imageID string, opts ...pulumi.ResourceOption) (*local.Command, error) {
+// action. The Delete handler reads the lease's current imageId from S3 at release
+// time and skips the root-volume replacement if none is published. leaseToken is
+// passed via Triggers so a new lease on the same instance produces a fresh trigger
+// value.
+func ScheduleReleaseOnDestroy(e aws.Environment, name string, instanceID string, leaseToken string, opts ...pulumi.ResourceOption) (*local.Command, error) {
 	if instanceID == "" {
 		return nil, fmt.Errorf("instanceID is required to schedule a pool release")
 	}
@@ -31,7 +32,7 @@ func ScheduleReleaseOnDestroy(e aws.Environment, name string, instanceID string,
 
 	return local.NewCommand(e.Ctx(), e.Namer.ResourceName(name), &local.CommandArgs{
 		Create:      pulumi.String("true"),
-		Delete:      pulumi.String(pool.BuildReleaseScript(instanceID, leaseToken, imageID)),
+		Delete:      pulumi.String(pool.BuildReleaseScript(instanceID, leaseToken)),
 		Environment: awsCommandEnvironment(e),
 		Triggers:    pulumi.Array{pulumi.String(leaseToken)},
 	}, opts...)

--- a/test/e2e-framework/scenarios/aws/ec2/run_args.go
+++ b/test/e2e-framework/scenarios/aws/ec2/run_args.go
@@ -120,6 +120,14 @@ func WithEC2InstanceOptions(opts ...VMOption) Option {
 	}
 }
 
+// IsMacOSPoolCandidate reports whether p's instance options describe a macOS
+// pool member -- see the package-level IsMacOSPoolCandidate for the underlying
+// check. Lets callers outside this package (e.g. awshost.Provisioner's pre-Up
+// hook) peek at the unexported instanceOptions field.
+func (p *Params) IsMacOSPoolCandidate() (bool, error) {
+	return IsMacOSPoolCandidate(p.instanceOptions...)
+}
+
 // WithAgentOptions adds options to the Agent.
 func WithAgentOptions(opts ...agentparams.Option) Option {
 	return func(params *Params) error {

--- a/test/e2e-framework/scenarios/aws/ec2/vm.go
+++ b/test/e2e-framework/scenarios/aws/ec2/vm.go
@@ -68,13 +68,19 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 		var poolAcquired pool.AcquireResult
 
 		if isMacOSPoolMember {
-			poolClient, err := pool.NewEC2Client(e.Ctx().Context(), e.Region(), e.Profile())
-			if err != nil {
-				return err
-			}
-			poolAcquired, err = pool.Acquire(e.Ctx().Context(), e.Region(), e.Profile(), poolClient, e.PipelineID())
-			if err != nil {
-				return err
+			if vmArgs.preAcquiredPool != nil {
+				// Already claimed by the caller (e.g. awshost.Provisioner's pre-Up
+				// hook) before this Pulumi program ran, ahead of the stack lock.
+				poolAcquired = vmArgs.preAcquiredPool.Result
+			} else {
+				poolClient, err := pool.NewEC2Client(e.Ctx().Context(), e.Region(), e.Profile())
+				if err != nil {
+					return err
+				}
+				poolAcquired, err = pool.Acquire(e.Ctx().Context(), e.Region(), e.Profile(), poolClient, e.PipelineID())
+				if err != nil {
+					return err
+				}
 			}
 
 			// Deleting a Dedicated Host requires it to have lived for at least 24
@@ -115,6 +121,13 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 
 			if _, err := ec2.ScheduleReleaseOnDestroy(e, name, poolAcquired.InstanceID, poolAcquired.LeaseToken, poolAcquired.ImageID, releaseOpts...); err != nil {
 				return err
+			}
+
+			// Ownership of releasing the lease is now transferred to the
+			// scheduled release-on-destroy script. Tell the caller that claimed
+			// it (if any) so its own cleanup doesn't also try to release it.
+			if vmArgs.preAcquiredPool != nil && vmArgs.preAcquiredPool.Claimed != nil {
+				*vmArgs.preAcquiredPool.Claimed = true
 			}
 		}
 

--- a/test/e2e-framework/scenarios/aws/ec2/vm.go
+++ b/test/e2e-framework/scenarios/aws/ec2/vm.go
@@ -119,7 +119,7 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 		if isMacOSPoolMember {
 			releaseOpts := []pulumi.ResourceOption{pulumi.Parent(c), pulumi.DependsOn([]pulumi.Resource{instance}), e.WithProviders(config.ProviderCommand)}
 
-			if _, err := ec2.ScheduleReleaseOnDestroy(e, name, poolAcquired.InstanceID, poolAcquired.LeaseToken, poolAcquired.ImageID, releaseOpts...); err != nil {
+			if _, err := ec2.ScheduleReleaseOnDestroy(e, name, poolAcquired.InstanceID, poolAcquired.LeaseToken, releaseOpts...); err != nil {
 				return err
 			}
 

--- a/test/e2e-framework/scenarios/aws/ec2/vmargs.go
+++ b/test/e2e-framework/scenarios/aws/ec2/vmargs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws/ec2/pool"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -43,6 +44,12 @@ type vmArgs struct {
 	httpTokensRequired    bool
 	volumeThroughput      int // GP3 volume throughput in MiB/s (125-1000, default 125)
 	pulumiResourceOptions []pulumi.ResourceOption
+
+	// preAcquiredPool, when set, is a pool.AcquireResult already claimed by the
+	// caller (see WithPreAcquiredPoolResult) before NewVM ran -- e.g. by
+	// awshost.Provisioner's pre-Up hook, ahead of the Pulumi stack lock. NewVM
+	// then skips its own pool.NewEC2Client/pool.Acquire call and reuses this one.
+	preAcquiredPool *PreAcquiredPoolResult
 }
 
 type VMOption = func(*vmArgs) error
@@ -146,4 +153,40 @@ func WithVolumeThroughput(throughput int) VMOption {
 		p.volumeThroughput = throughput
 		return nil
 	}
+}
+
+// PreAcquiredPoolResult carries a pool.AcquireResult claimed by a caller ahead
+// of NewVM -- e.g. by awshost.Provisioner's pre-Up hook, before the Pulumi
+// stack lock is taken -- together with a flag NewVM flips to true right after
+// it successfully hands ownership of releasing the lease over to
+// ec2.ScheduleReleaseOnDestroy. The caller's own cleanup (e.g. releasing the
+// lease if Up never got that far) must check this flag to avoid double-release.
+type PreAcquiredPoolResult struct {
+	Result  pool.AcquireResult
+	Claimed *bool
+}
+
+// WithPreAcquiredPoolResult supplies a pool.AcquireResult already claimed by
+// the caller, so NewVM reuses it instead of calling pool.NewEC2Client/pool.Acquire
+// itself. Only meaningful for macOS pool members (see IsMacOSPoolCandidate);
+// ignored otherwise.
+func WithPreAcquiredPoolResult(r *PreAcquiredPoolResult) VMOption {
+	return func(p *vmArgs) error {
+		p.preAcquiredPool = r
+		return nil
+	}
+}
+
+// IsMacOSPoolCandidate reports whether the given VM options describe a macOS
+// pool member (a macOS VM with no explicit dedicated HostID), the same
+// condition NewVM uses to decide whether to draw from the pool. It only
+// inspects pure option state via buildArgs -- no AMI-resolution network calls
+// -- so it's safe to call before a *pulumi.Context exists, e.g. from a
+// provisioner's pre-Up hook.
+func IsMacOSPoolCandidate(opts ...VMOption) (bool, error) {
+	vmArgs, err := buildArgs(opts...)
+	if err != nil {
+		return false, err
+	}
+	return vmArgs.osInfo != nil && vmArgs.osInfo.Family() == os.MacOSFamily && vmArgs.hostID == "", nil
 }

--- a/test/e2e-framework/testing/provisioners/aws/host/host.go
+++ b/test/e2e-framework/testing/provisioners/aws/host/host.go
@@ -7,17 +7,29 @@
 package awshost
 
 import (
+	"context"
 	"fmt"
+	"os"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws/ec2/pool"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/infra"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/optional"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
+
+// defaultPoolRegion is the fallback region used by the pool pre-Up hook when
+// the stack's "aws:region" config isn't set explicitly. Every environmentDefault
+// entry in resources/aws currently defaults to this region, but that mapping
+// is duplicated here rather than read from aws.Environment.Region() because
+// the hook runs before a *pulumi.Context (and therefore an aws.Environment)
+// exists -- see Provisioner's pre-Up hook for the full gap this leaves.
+const defaultPoolRegion = "us-east-1"
 
 const provisionerBaseID = "aws-ec2vm-"
 
@@ -71,11 +83,22 @@ func Provisioner(opts ...ProvisionerOption) provisioners.TypedProvisioner[enviro
 	params := getProvisionerParams(opts...)
 	runParams := ec2.GetParams(params.runOptions...)
 
+	// preAcquired is set by the pre-Up hook below (run by getStack before
+	// stack.Up, i.e. before the Pulumi stack lock is taken) and read by the
+	// RunFunc closure (run during stack.Up, strictly after the hook returns).
+	// Scoped to this Provisioner() call, so it's not shared across unrelated
+	// provisioners/stacks.
+	var preAcquired *ec2.PreAcquiredPoolResult
+
 	provisioner := provisioners.NewTypedPulumiProvisioner(provisionerBaseID+runParams.Name, func(ctx *pulumi.Context, env *environments.Host) error {
 		// We ALWAYS need to make a deep copy of `params`, as the provisioner can be called multiple times.
 		// and it's easy to forget about it, leading to hard to debug issues.
 		params := getProvisionerParams(opts...)
-		runParams := ec2.GetParams(params.runOptions...)
+		runOptions := params.runOptions
+		if preAcquired != nil {
+			runOptions = append(runOptions, ec2.WithEC2InstanceOptions(ec2.WithPreAcquiredPoolResult(preAcquired)))
+		}
+		runParams := ec2.GetParams(runOptions...)
 
 		var awsEnv aws.Environment
 		var err error
@@ -92,7 +115,68 @@ func Provisioner(opts ...ProvisionerOption) provisioners.TypedProvisioner[enviro
 		return ec2.Run(ctx, awsEnv, env, runParams)
 	}, params.extraConfigParams)
 
+	provisioner.SetGetStackOptions(infra.WithPreUpHook(newMacOSPoolPreUpHook(params.runOptions, &preAcquired)))
+
 	return provisioner
+}
+
+// newMacOSPoolPreUpHook returns an infra.PreUpHookFunc that claims a macOS
+// pool member -- via pool.Acquire -- before stack.Up runs, i.e. before the
+// Pulumi stack lock is taken. It's a no-op (nil cleanup, nil error) for any
+// VM that isn't a macOS pool candidate, so non-macOS/non-pool provisioning is
+// unaffected. On success, *preAcquired is set so the RunFunc closure in
+// Provisioner reuses this claim instead of calling pool.Acquire itself.
+//
+// region/profile come from the persisted "aws:region"/"aws:profile" stack
+// config (read back by getStack). Most scenarios never set those explicitly --
+// they rely on aws.Environment.Region()/Profile()'s per-environment defaults,
+// resolved from a *pulumi.Context that doesn't exist yet at this point -- so
+// this hook falls back to defaultPoolRegion and $AWS_PROFILE respectively.
+// That matches Environment.Region()'s current defaults (every environmentDefault
+// entry defaults to defaultPoolRegion) and the first part of Environment.Profile()'s
+// precedence, but NOT its final fallback to a per-environment default profile
+// when neither $AWS_PROFILE nor static AWS credentials are set: in that one
+// case this hook and aws.Environment could resolve to different profiles.
+func newMacOSPoolPreUpHook(runOptions []ec2.Option, preAcquired **ec2.PreAcquiredPoolResult) infra.PreUpHookFunc {
+	return func(ctx context.Context, region, profile, pipelineID string) (func(error), error) {
+		isPoolCandidate, err := ec2.GetParams(runOptions...).IsMacOSPoolCandidate()
+		if err != nil {
+			return nil, err
+		}
+		if !isPoolCandidate {
+			return nil, nil
+		}
+
+		if region == "" {
+			region = defaultPoolRegion
+		}
+		if profile == "" {
+			profile = os.Getenv("AWS_PROFILE")
+		}
+
+		poolClient, err := pool.NewEC2Client(ctx, region, profile)
+		if err != nil {
+			return nil, err
+		}
+		result, err := pool.Acquire(ctx, region, profile, poolClient, pipelineID)
+		if err != nil {
+			return nil, err
+		}
+
+		claimed := false
+		*preAcquired = &ec2.PreAcquiredPoolResult{Result: result, Claimed: &claimed}
+
+		return func(_ error) {
+			// If NewVM never got as far as scheduling the release-on-destroy
+			// command (e.g. Up failed before then), ownership of the lease
+			// was never transferred to it, so release it here instead.
+			if !claimed {
+				if releaseErr := pool.ReleaseInstance(context.Background(), region, profile, result.InstanceID, result.LeaseToken); releaseErr != nil {
+					fmt.Printf("Failed to release pre-acquired macOS pool instance %s: %v\n", result.InstanceID, releaseErr)
+				}
+			}
+		}, nil
+	}
 }
 
 func ProvisionerNoFakeIntake(opts ...ProvisionerOption) provisioners.TypedProvisioner[environments.Host] {

--- a/test/e2e-framework/testing/provisioners/pulumi_provisioner.go
+++ b/test/e2e-framework/testing/provisioners/pulumi_provisioner.go
@@ -28,10 +28,11 @@ type PulumiEnvRunFunc[Env any] func(ctx *pulumi.Context, env *Env) error
 
 // PulumiProvisioner is a provisioner based on Pulumi with binding to an environment.
 type PulumiProvisioner[Env any] struct {
-	id           string
-	runFunc      PulumiEnvRunFunc[Env]
-	configMap    runner.ConfigMap
-	diagnoseFunc func(ctx context.Context, stackName string) (string, error)
+	id              string
+	runFunc         PulumiEnvRunFunc[Env]
+	configMap       runner.ConfigMap
+	diagnoseFunc    func(ctx context.Context, stackName string) (string, error)
+	getStackOptions []infra.GetStackOption
 }
 
 var (
@@ -64,6 +65,14 @@ func (pp *PulumiProvisioner[Env]) ID() string {
 	return pp.id
 }
 
+// SetGetStackOptions registers additional infra.GetStackOption values applied
+// on every ProvisionEnv/Provision call by this provisioner -- e.g. a pool-agnostic
+// infra.WithPreUpHook. Optional; unset by default, so provisioners that never
+// call this see no behavior change.
+func (pp *PulumiProvisioner[Env]) SetGetStackOptions(opts ...infra.GetStackOption) {
+	pp.getStackOptions = opts
+}
+
 // Provision runs the Pulumi program and returns the raw resources.
 func (pp *PulumiProvisioner[Env]) Provision(ctx context.Context, stackName string, logger io.Writer) (RawResources, error) {
 	return pp.ProvisionEnv(ctx, stackName, logger, nil)
@@ -71,14 +80,18 @@ func (pp *PulumiProvisioner[Env]) Provision(ctx context.Context, stackName strin
 
 // ProvisionEnv runs the Pulumi program with a given environment and returns the raw resources.
 func (pp *PulumiProvisioner[Env]) ProvisionEnv(ctx context.Context, stackName string, logger io.Writer, env *Env) (RawResources, error) {
+	getStackOptions := append([]infra.GetStackOption{
+		infra.WithConfigMap(pp.configMap),
+		infra.WithLogWriter(logger),
+	}, pp.getStackOptions...)
+
 	_, stackOutput, err := infra.GetStackManager().GetStackNoDeleteOnFailure(
 		ctx,
 		stackName,
 		func(ctx *pulumi.Context) error {
 			return pp.runFunc(ctx, env)
 		},
-		infra.WithConfigMap(pp.configMap),
-		infra.WithLogWriter(logger),
+		getStackOptions...,
 	)
 
 	if err != nil {

--- a/test/e2e-framework/testing/utils/infra/stack_manager.go
+++ b/test/e2e-framework/testing/utils/infra/stack_manager.go
@@ -159,10 +159,31 @@ type getStackParams struct {
 	UpTimeout          time.Duration
 	DestroyTimeout     time.Duration
 	CancelTimeout      time.Duration
+	PreUpHook          PreUpHookFunc
 }
 
 // GetStackOption is a function that sets a parameter for GetStack function
 type GetStackOption func(*getStackParams)
+
+// PreUpHookFunc runs once per getStack call, after the stack's config has been
+// set and before the first stack.Up attempt -- i.e. before the Pulumi stack
+// lock is taken, unlike anything done from inside deployFunc. It receives
+// region/profile/pipelineID as plain strings (no *pulumi.Context is available
+// yet at this point in getStack). The returned cleanup func, if non-nil, is
+// invoked exactly once after the whole Up-retry loop finishes (success or
+// giving up), with the final error. getStack has no knowledge of what the hook
+// or its cleanup actually do -- e.g. claiming/releasing a resource pool lease
+// lives entirely in the caller (see awshost.Provisioner).
+type PreUpHookFunc func(ctx context.Context, region, profile, pipelineID string) (cleanup func(err error), err error)
+
+// WithPreUpHook registers a PreUpHookFunc for this GetStack/GetStackNoDeleteOnFailure
+// call. Leave unset for pool-agnostic/non-macOS provisioners: behavior is
+// unchanged when no hook is registered.
+func WithPreUpHook(hook PreUpHookFunc) GetStackOption {
+	return func(p *getStackParams) {
+		p.PreUpHook = hook
+	}
+}
 
 // WithConfigMap sets the configuration map for the stack
 func WithConfigMap(config runner.ConfigMap) GetStackOption {
@@ -485,6 +506,38 @@ func (sm *StackManager) getStack(ctx context.Context, name string, deployFunc pu
 		return nil, auto.UpResult{}, err
 	}
 
+	// Run the pool-agnostic pre-Up hook (if any) exactly once per getStack call,
+	// after config is set and before the first stack.Up attempt below -- not
+	// re-invoked by the Up-retry loop inside runUpLoop. region/profile are read
+	// back from the persisted stack config as plain strings; if a scenario never
+	// sets "aws:region"/"aws:profile" explicitly (relying instead on in-program
+	// defaults resolved from a *pulumi.Context, e.g. aws.Environment.Region()),
+	// GetConfig returns them empty and it's up to the hook to apply its own
+	// fallback -- see awshost.Provisioner's hook for the documented gap.
+	var preUpCleanup func(error)
+	if params.PreUpHook != nil {
+		region, _ := stack.GetConfig(ctx, "aws:region")
+		awsProfile, _ := stack.GetConfig(ctx, "aws:profile")
+		pipelineID, _ := profile.ParamStore().Get(parameters.PipelineID)
+
+		preUpCleanup, err = params.PreUpHook(ctx, region.Value, awsProfile.Value, pipelineID)
+		if err != nil {
+			return nil, auto.UpResult{}, err
+		}
+	}
+
+	retStack, retUpResult, retErr := sm.runUpLoop(ctx, stack, name, profile, cm, &params)
+	if preUpCleanup != nil {
+		preUpCleanup(retErr)
+	}
+	return retStack, retUpResult, retErr
+}
+
+// runUpLoop runs stack.Up, retrying per sm.GetRetryStrategyFrom, until success or
+// a non-retryable outcome. Extracted from getStack so the pre-Up hook's cleanup
+// (see getStack) can wrap the whole retry loop and fire exactly once regardless
+// of which of the loop's several return paths is taken.
+func (sm *StackManager) runUpLoop(ctx context.Context, stack *auto.Stack, name string, profile runner.Profile, cm runner.ConfigMap, params *getStackParams) (*auto.Stack, auto.UpResult, error) {
 	loggingOptions, err := sm.getLoggingOptions()
 	if err != nil {
 		return nil, auto.UpResult{}, err
@@ -547,7 +600,7 @@ func (sm *StackManager) getStack(ctx context.Context, name string, deployFunc pu
 		if len(changedOpts) > 0 {
 			// apply changed options from retry strategy
 			for _, opt := range changedOpts {
-				opt(&params)
+				opt(params)
 			}
 
 			cm, err = runner.BuildStackParameters(profile, params.Config)


### PR DESCRIPTION
…mi stack lock

pool.Acquire's blocking wait for pool capacity (up to 10 retries x 1 minute) used to run inside NewVM, i.e. inside the Pulumi program that only executes while stack.Up() already holds the stack lock. A second invocation targeting the same stack would get rejected with a lock-contention error for the whole wait, even though no real provisioning work had started.

Add a pool-agnostic PreUpHookFunc/WithPreUpHook to StackManager.getStack, invoked once after SetAllConfig and before the first Up attempt, with region/profile/pipelineID as plain strings (no *pulumi.Context exists yet at that point). awshost.Provisioner registers a hook that claims a pool instance there, ahead of the lock, and hands the claimed result to NewVM via a new PreAcquiredPoolResult so it skips its own pool.Acquire call. If Up fails before NewVM transfers release ownership to ScheduleReleaseOnDestroy, the hook's cleanup releases the lease itself.

<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
