### PR TITLE
Set CGO_ENABLED=1 in env in go-deps.graph

### DIFF
--- a/tasks/go_deps.py
+++ b/tasks/go_deps.py
@@ -535,7 +535,7 @@ def graph(
 
     cmd = f"goda graph {stdarg} {clusterarg} \"{expr}\""
 
-    env = {"GOOS": os, "GOARCH": arch}
+    env = {"GOOS": os, "GOARCH": arch, "CGO_ENABLED": "1"}
     res = ctx.run(cmd, env=env, hide='out')
     assert res
 


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Set CGO_ENABLED=1 in env in `go-deps.graph`.

### Motivation
CGO_ENABLED impacts the dependencies resolved by the task, giving different results.
`go-deps.show` sets CGO_ENABLED=1 for example, which results in discrepancies.
Almost all of our binary builds use CGO so that's more correct.

### Describe how you validated your changes
Local validation.

### Additional Notes
The impact can be seen when running the following
```
dda inv -e go-deps.graph -b agent -o linux -t github.com/DataDog/zstd_0
```