### PR TITLE
Add AIFT auto-label workflow for Network Configuration Management

### DIFF
--- a/.github/workflows/aift-auto-label-network-configuration-management.yml
+++ b/.github/workflows/aift-auto-label-network-configuration-management.yml
@@ -1,0 +1,42 @@
+name: Auto-label PRs for network-configuration-management
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check team membership and label PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const team = 'network-configuration-management';
+            const org = context.repo.owner;
+            const author = context.payload.pull_request.user.login;
+
+            try {
+              const membership = await github.rest.teams.getMembershipForUserInOrg({
+                org,
+                team_slug: team,
+                username: author,
+              });
+
+              if (membership.data.state === 'active') {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  labels: [`team:${team}`],
+                });
+                console.log(`Labeled PR #${context.issue.number} with team:${team}`);
+              }
+            } catch (error) {
+              if (error.status !== 404) {
+                console.error(`Error checking team membership: ${error.message}`);
+              }
+            }


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically labels PRs from members of the `network-configuration-management` GitHub team with `team:network-configuration-management`.

This enables DORA metrics tracking for the Network Configuration Management POD in shared repos.

The workflow triggers on PR open/reopen and checks GitHub team membership.