### PR TITLE
enhancement(rar): add support for subscribing to Remote Agent events

### DIFF
--- a/comp/core/remoteagentregistry/def/BUILD.bazel
+++ b/comp/core/remoteagentregistry/def/BUILD.bazel
@@ -4,8 +4,10 @@ go_library(
     name = "def",
     srcs = [
         "component.go",
+        "subscriber.go",
         "types.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/def",
     visibility = ["//visibility:public"],
+    deps = ["@org_uber_go_fx//:fx"],
 )

--- a/comp/core/remoteagentregistry/def/subscriber.go
+++ b/comp/core/remoteagentregistry/def/subscriber.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package remoteagentregistry
+
+import "go.uber.org/fx"
+
+// EventCallback is registered by a component to receive Remote Agent events.
+//
+// It is invoked synchronously on the event-reporting path, once per report, with the events reported
+// together by a single remote agent. Implementations MUST return quickly and MUST NOT block: offload
+// any slow work (network calls, refreshes, etc.) to their own goroutine.
+type EventCallback func(agent RegisteredAgent, events []RemoteAgentEvent)
+
+// EventSubscriber wraps an EventCallback for registration via an fx value group. It is a struct rather
+// than a bare func so that fields can be added later without breaking existing subscribers.
+type EventSubscriber struct {
+	// Name identifies the subscriber in logs (for example, if its callback panics). Optional.
+	Name string
+	// Callback receives the reported events. Required.
+	Callback EventCallback
+}
+
+// EventSubscriberProvider is provided by components to register themselves as a subscriber of Remote
+// Agent events. The Remote Agent Registry collects every provided subscriber through the
+// "remoteAgentEventSubscriber" fx value group and invokes them whenever a remote agent reports events.
+type EventSubscriberProvider struct {
+	fx.Out
+
+	Subscriber *EventSubscriber `group:"remoteAgentEventSubscriber"`
+}
+
+// NewEventSubscriber returns an EventSubscriberProvider wrapping the given callback.
+func NewEventSubscriber(name string, callback EventCallback) EventSubscriberProvider {
+	return EventSubscriberProvider{
+		Subscriber: &EventSubscriber{
+			Name:     name,
+			Callback: callback,
+		},
+	}
+}

--- a/comp/core/remoteagentregistry/impl/registry.go
+++ b/comp/core/remoteagentregistry/impl/registry.go
@@ -252,7 +252,7 @@ func (ra *remoteAgentRegistry) ReportRemoteAgentEvent(sessionID string, events [
 		log.Debugf("Remote agent '%s' reported event (type: %s): %s", agent.DisplayName, eventType, event.Message)
 	}
 
-	// For each subscriber, dispatch the events through `dispatchEvent` which provides panic recovery behavior so
+	// For each subscriber, dispatch the events through `dispatchEvents` which provides panic recovery behavior so
 	// that we don't bork the entire gRPC handler.
 	for _, subscriber := range ra.eventSubscribers {
 		if subscriber == nil || subscriber.Callback == nil {

--- a/comp/core/remoteagentregistry/impl/registry.go
+++ b/comp/core/remoteagentregistry/impl/registry.go
@@ -29,10 +29,10 @@ import (
 
 // Requires defines the dependencies for the remoteagentregistry component
 type Requires struct {
-	Config    config.Component
-	Ipc       ipc.Component
-	Lifecycle compdef.Lifecycle
-	Telemetry telemetry.Component
+	Config           config.Component
+	Ipc              ipc.Component
+	Lifecycle        compdef.Lifecycle
+	Telemetry        telemetry.Component
 	EventSubscribers []*remoteagentregistry.EventSubscriber `group:"remoteAgentEventSubscriber"`
 }
 

--- a/comp/core/remoteagentregistry/impl/registry.go
+++ b/comp/core/remoteagentregistry/impl/registry.go
@@ -33,6 +33,7 @@ type Requires struct {
 	Ipc       ipc.Component
 	Lifecycle compdef.Lifecycle
 	Telemetry telemetry.Component
+	EventSubscribers []*remoteagentregistry.EventSubscriber `group:"remoteAgentEventSubscriber"`
 }
 
 // Provides defines the output of the remoteagentregistry component
@@ -73,6 +74,7 @@ func newRegistry(reqs Requires) *remoteAgentRegistry {
 			FlareServiceName:     {},
 			TelemetryServiceName: {},
 		},
+		eventSubscribers: reqs.EventSubscribers,
 	}
 
 	reqs.Lifecycle.Append(compdef.Hook{
@@ -180,6 +182,10 @@ type remoteAgentRegistry struct {
 
 	// Define the services that the remote agent supports
 	remoteAgentServices map[remoteAgentServiceName]struct{}
+
+	// eventSubscribers receive Remote Agent events reported via ReportRemoteAgentEvent. The slice is
+	// set once at construction and is immutable afterwards, so it needs no lock.
+	eventSubscribers []*remoteagentregistry.EventSubscriber
 }
 
 // RegisterRemoteAgent registers a remote agent with the registry.
@@ -221,30 +227,54 @@ func (ra *remoteAgentRegistry) RefreshRemoteAgent(sessionID string) bool {
 	return ok
 }
 
-// ReportRemoteAgentEvent records one or more events reported by a remote agent.
+// ReportRemoteAgentEvent records one or more events reported by a remote agent and broadcasts them to
+// every registered event subscriber.
 //
 // It returns an error if no remote agent is registered with the given session ID.
-//
-// NOTE: This is currently a stub that only logs the reported events. Routing them to telemetry/alerting is future work.
 func (ra *remoteAgentRegistry) ReportRemoteAgentEvent(sessionID string, events []remoteagentregistry.RemoteAgentEvent) error {
 	ra.agentMapMu.Lock()
 	agentClient, ok := ra.agentMap[sessionID]
+	var agent remoteagentregistry.RegisteredAgent
+	if ok {
+		agent = agentClient.RegisteredAgent
+	}
 	ra.agentMapMu.Unlock()
 
 	if !ok {
 		return fmt.Errorf("no remote agent found with session ID %q", sessionID)
 	}
 
-	displayName := agentClient.RegisteredAgent.DisplayName
 	for _, event := range events {
 		eventType := "unknown"
 		if event.Details != nil {
 			eventType = event.Details.EventType()
 		}
-		log.Debugf("Remote agent '%s' reported event (type: %s): %s", displayName, eventType, event.Message)
+		log.Debugf("Remote agent '%s' reported event (type: %s): %s", agent.DisplayName, eventType, event.Message)
+	}
+
+	// For each subscriber, dispatch the events through `dispatchEvent` which provides panic recovery behavior so
+	// that we don't bork the entire gRPC handler.
+	for _, subscriber := range ra.eventSubscribers {
+		if subscriber == nil || subscriber.Callback == nil {
+			continue
+		}
+		ra.dispatchEvents(subscriber, agent, events)
 	}
 
 	return nil
+}
+
+// dispatchEvents invokes a single subscriber's callback, recovering from any panic so that a
+// misbehaving subscriber can neither fail the reporting RPC nor prevent the remaining subscribers from
+// being notified.
+func (ra *remoteAgentRegistry) dispatchEvents(subscriber *remoteagentregistry.EventSubscriber, agent remoteagentregistry.RegisteredAgent, events []remoteagentregistry.RemoteAgentEvent) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorf("Remote Agent event subscriber %q panicked while handling events: %v", subscriber.Name, r)
+		}
+	}()
+
+	subscriber.Callback(agent, events)
 }
 
 // Start starts the remote agent registry, which periodically checks for idle remote agents and deregisters them.

--- a/comp/core/remoteagentregistry/impl/registry_test.go
+++ b/comp/core/remoteagentregistry/impl/registry_test.go
@@ -120,10 +120,10 @@ func TestReportRemoteAgentEventBroadcast(t *testing.T) {
 	}
 
 	reqs := Requires{
-		Config:      cfg,
-		Ipc:         ipcComp,
-		Lifecycle:   lc,
-		Telemetry:   tel,
+		Config:           cfg,
+		Ipc:              ipcComp,
+		Lifecycle:        lc,
+		Telemetry:        tel,
 		EventSubscribers: []*remoteagent.EventSubscriber{panicker, nil, recorder},
 	}
 	component := NewComponent(reqs).Comp.(*remoteAgentRegistry)

--- a/comp/core/remoteagentregistry/impl/registry_test.go
+++ b/comp/core/remoteagentregistry/impl/registry_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -86,6 +87,62 @@ func TestReportRemoteAgentEvent(t *testing.T) {
 
 	// An unknown session returns an error.
 	require.Error(t, component.ReportRemoteAgentEvent("does-not-exist", events))
+}
+
+func TestReportRemoteAgentEventBroadcast(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.SetInTest("remote_agent.registry.enabled", true)
+
+	lc := compdef.NewTestLifecycle(t)
+	tel := telemetryimpl.NewMock(t)
+	ipcComp := ipcmock.New(t)
+
+	var mu sync.Mutex
+	var gotAgent remoteagent.RegisteredAgent
+	var gotEvents []remoteagent.RemoteAgentEvent
+	recorderCalls := 0
+
+	// A panicking subscriber must not fail the RPC or starve the recorder, and a nil entry must be
+	// skipped, so the recorder (registered last) still receives the events exactly once.
+	panicker := &remoteagent.EventSubscriber{
+		Name:     "panicker",
+		Callback: func(remoteagent.RegisteredAgent, []remoteagent.RemoteAgentEvent) { panic("boom") },
+	}
+	recorder := &remoteagent.EventSubscriber{
+		Name: "recorder",
+		Callback: func(agent remoteagent.RegisteredAgent, events []remoteagent.RemoteAgentEvent) {
+			mu.Lock()
+			defer mu.Unlock()
+			recorderCalls++
+			gotAgent = agent
+			gotEvents = events
+		},
+	}
+
+	reqs := Requires{
+		Config:      cfg,
+		Ipc:         ipcComp,
+		Lifecycle:   lc,
+		Telemetry:   tel,
+		EventSubscribers: []*remoteagent.EventSubscriber{panicker, nil, recorder},
+	}
+	component := NewComponent(reqs).Comp.(*remoteAgentRegistry)
+
+	remoteAgent := buildAndRegisterRemoteAgent(t, ipcComp, component, "test-agent", "Test Agent", "1234")
+
+	events := []remoteagent.RemoteAgentEvent{
+		{Message: "invalid API key detected", Details: &remoteagent.InvalidAPIKey{}},
+	}
+
+	// The panicking subscriber is recovered and the nil subscriber skipped, so the call still succeeds.
+	require.NoError(t, component.ReportRemoteAgentEvent(remoteAgent.registeredSessionID, events))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, 1, recorderCalls)
+	require.Equal(t, "Test Agent", gotAgent.DisplayName)
+	require.Len(t, gotEvents, 1)
+	require.Equal(t, "invalid_api_key", gotEvents[0].Details.EventType())
 }
 
 func TestGetRegisteredAgentsIdleTimeout(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

This PR adds support for subscribing to Remote Agent events through an `fx` value groups/provider-based approach.

### Motivation

In #51749, we added general support for Remote Agent "events": generalized events with minimal typing, suitable for remote agents to signal back when things happen, such as encountering invalid API keys. The idea here was that there will inevitably be a need for remote agents to signal things to the control plane (Core Agent) that only the control plane can do something about, whether it's trying to remediate the issue or simply surface it in the Datadog UI.

However, part of this design hinged on being able to write code to listen for these events to then actually execute some logic in response to them. We didn't include them in the initial PR, so we're including it now. :D

This PR introduces a design that is based on fx value groups (the "provider" pattern), which we already use for things like exposing flare providers. Interested parties can implement a callback that is invoked with the remote agent name and the list of events, and then provide that callback during fx initialization of their own component. These providers are grouped together and dispatched to whenever any Remote Agent events are received.

Not unlike the initial PR, we're deferring the actual implementation of these providers and focusing solely on the API surface for now.

### Describe how you validated your changes

New and existing unit tests. 

### Additional Notes
