### PR TITLE
[logs] Retire RTT fairness by default; add logs_config.enable_rtt_fairness

### DIFF
--- a/comp/logs-library/pipeline/provider.go
+++ b/comp/logs-library/pipeline/provider.go
@@ -187,8 +187,11 @@ func httpSender(
 		// worker counts low.
 		queueCount = sender.DefaultQueuesCount
 		workersPerQueue = sender.DefaultWorkersPerQueue
-		minSenderConcurrency = numberOfPipelines
-		maxSenderConcurrency = numberOfPipelines * maxConcurrencyPerPipeline
+		// RTT fairness is retired: run a fixed sender concurrency (min == max, so the worker
+		// pool never scales with latency) instead of dynamically scaling with it. Operators who
+		// need to control the connection count should set the endpoint's batch_max_concurrent_send.
+		minSenderConcurrency = numberOfPipelines * maxConcurrencyPerPipeline
+		maxSenderConcurrency = minSenderConcurrency
 		if endpoints.BatchMaxConcurrentSend != constants.DefaultBatchMaxConcurrentSend {
 			// If the BatchMaxConcurrentSend parameter is set, we use it to control the concurrency of the destination.
 			// Legacy behavior ran numberOfPipelines senders, each with a concurrency of BatchMaxConcurrentSend, so

--- a/comp/logs-library/pipeline/provider_test.go
+++ b/comp/logs-library/pipeline/provider_test.go
@@ -128,6 +128,7 @@ func TestProviderConfigurations(t *testing.T) {
 			batchMaxConcurrentSend: constants.DefaultBatchMaxConcurrentSend,
 		},
 		{
+			// RTT fairness retired by default: concurrency is pinned static at the cap (min == max).
 			name:                   "HTTP sender default",
 			useHTTP:                true,
 			legacyMode:             false,
@@ -135,7 +136,7 @@ func TestProviderConfigurations(t *testing.T) {
 			serverless:             false,
 			expectedQueues:         sender.DefaultQueuesCount,     // 1
 			expectedWorkers:        sender.DefaultWorkersPerQueue, // 1
-			expectedMinConcurrency: 3,
+			expectedMinConcurrency: 30,                            // pinned at pipelines * maxConcurrencyPerPipeline
 			expectedMaxConcurrency: 30,
 			batchMaxConcurrentSend: constants.DefaultBatchMaxConcurrentSend,
 		},

--- a/releasenotes/notes/retire-rtt-fairness-static-sender-concurrency-6d5f2a1c8b3e4f07.yaml
+++ b/releasenotes/notes/retire-rtt-fairness-static-sender-concurrency-6d5f2a1c8b3e4f07.yaml
@@ -1,0 +1,24 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    The logs Agent now sends log payloads at a fixed higher concurrency by default instead
+    of scaling the number of concurrent senders dynamically with intake latency (the
+    previous "RTT fairness" behavior). This improves throughput for high-latency and
+    high-volume workloads without manual tuning.
+
+    The Agent now uses a static send concurrency of ``logs_config.pipelines`` x 10 (for
+    example, 40 concurrent senders on a host with the default 4 pipelines).
+
+    **Connection impact — please review before upgrading:** because the Agent now runs more
+    senders concurrently by default, it may open more simultaneous connections to the logs
+    intake (up to the static concurrency above). If you need to limit connections — for
+    example behind a proxy or on a connection-constrained network — set
+    ``logs_config.batch_max_concurrent_send`` to a lower value (``1`` keeps a single sender
+    per pipeline).

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -43,7 +43,8 @@ checks:
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."
     bounds:
       series: "connection.current"
-      upper_bound: 6
+      # Static sender concurrency cap (pipelines * 10 = 40) after retiring RTT fairness.
+      upper_bound: 40
 
   - name: total_bytes_received
     description: "Bytes received quality gate. This bounds total network egress."

--- a/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
@@ -45,7 +45,8 @@ checks:
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."
     bounds:
       series: "connection.current"
-      upper_bound: 6
+      # Static sender concurrency cap (pipelines * 10 = 40) after retiring RTT fairness.
+      upper_bound: 40
 
   - name: missed_bytes
     description: "Allowable bytes not processed by Agent"


### PR DESCRIPTION
### What does this PR do?

Retires the RTT fairness algorithm (dynamic sender-concurrency scaling) in the logs HTTP
sender and runs a **fixed** concurrency instead: `numberOfPipelines * maxConcurrencyPerPipeline`
(the previous dynamic ceiling — 40 senders on a host with the default 4 pipelines).

Mechanism: RTT fairness only scales when `minWorkers < maxWorkers`; the destination worker
pool short-circuits all latency math when `min == max`. The default path now sets
`min == max`, so the pool runs a static concurrency and never scales with latency. The
worker-pool/algorithm code is **not** removed — it is left dormant (unreachable while
`min == max`) and slated for removal in a later change.

**No new config flag.** Operators who need to control the connection count use the existing
`logs_config.batch_max_concurrent_send` (e.g. `1` keeps one sender per pipeline). This keeps
the escape hatch on a generic, durable setting rather than one tied to the RTT-fairness
implementation — so there is nothing to deprecate when that code is deleted.

### Motivation

Large, high-latency / high-volume workloads suffer backpressure against the intake, and the
only mitigation today is hand-tuning `logs_config.batch_max_concurrent_send`. Running a
higher static send concurrency by default gives those workloads throughput out of the box
and simplifies configuration.


### Describe how you validated your changes

- `dda inv test --targets=./comp/logs-library/pipeline` — passes (the default HTTP case now
  asserts `min == max == pipelines * 10`).
- `dda inv agent.build --build-exclude=systemd` — builds clean.

### Additional Notes (reviewer context)

**Connection impact — this is the main thing to review.** Going from a dynamic floor
(~`pipelines`, i.e. ~4 at low latency) to a static `pipelines * 10` (~40) increases the number of *concurrent* sends, and therefore the number of connections to the intake **when the transport is HTTP/1.1** (one connection per in-flight sender). On HTTP/2 the senders multiplex over ~1–2 connections and the increase is negligible.

Empirically checked the agent's default logs endpoint (`agent-http-intake.logs.<site>`) per
DC via ALPN:

| DC | protocol | connection impact |
|----|----------|-------------------|
| us3, us5, eu1, ap1, ap2, gov | HTTP/2 | negligible (multiplexed) |
| **us1** | **HTTP/1.1** | **real — up to ~40 connections/agent** |

So **us1 is the only DC where this materially increases connections.** Its L4 listener already
speaks h2 (`l4-http-intake.logs.datadoghq.com`), but the agent-facing FQDN hasn't been cut over yet (tracked loosely on the Fabric Gateways "L4 Cloud Load Balancer migration" page;

**SMP `intake_connections` gate:** these experiments run over plaintext HTTP/1.1, so they model the us1 worst case. `connection.current` rises from `<= 6` to ~17–19 under load. The bound is raised `6 -> 40` (the static cap) so the gate passes for the new behavior while still catching anything that exceeds the cap. `quality_gate_logs` and `quality_gate_metrics_logs` updated.

**Bounded blast radius:** `logs_config.pipelines` defaults to `min(GOMAXPROCS, 4)`, so the
static ceiling is `<= 40` senders even on large hosts — the same worst case the dynamic algorithm already produced, now always-on.
