### PR TITLE
fix(gpu): disable deprecated eBPF probes by default

### DIFF
--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -1308,7 +1308,7 @@ properties:
       enable_ebpf_probes:
         node_type: setting
         type: boolean
-        default: true
+        default: false
       enable_fatbin_parsing:
         node_type: setting
         type: boolean

--- a/pkg/config/setup/system_probe_settings.go
+++ b/pkg/config/setup/system_probe_settings.go
@@ -314,7 +314,7 @@ func initMainSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logon_duration.enabled", false)
 	config.BindEnvAndSetDefault("fleet_policies_dir", "")
 	config.BindEnvAndSetDefault("gpu_monitoring.enabled", false)
-	config.BindEnvAndSetDefault("gpu_monitoring.enable_ebpf_probes", true)
+	config.BindEnvAndSetDefault("gpu_monitoring.enable_ebpf_probes", false)
 	config.BindEnvAndSetDefault("gpu_monitoring.nvml_lib_path", "")
 	config.BindEnvAndSetDefault("gpu_monitoring.process_scan_interval_seconds", 5)
 	config.BindEnvAndSetDefault("gpu_monitoring.initial_process_sync", true)

--- a/releasenotes/notes/disable-gpu-ebpf-probes-by-default-52386987e7f3edee.yaml
+++ b/releasenotes/notes/disable-gpu-ebpf-probes-by-default-52386987e7f3edee.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    The eBPF probes for GPU Monitoring are deprecated and are now disabled by
+    default. 


### PR DESCRIPTION
### What does this PR do?
This commit disables the eBPF probes by default. We still need to have privileged mode so that customers can set cgroup permissions in some environments.

### Motivation
The eBPF probes for GPU Monitoring are deprecated. Some customers still have the previously recommended setting  `gpu.privilegedMode` enabled. These probes have caused crashes on  NVIDIA GB300 Grace Blackwell Ultra machines. We want to disable the probes by default moving forward given they are deprecated