### PR TITLE
deps: bump ebpf-manager to release kernel BTF after program load

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -205,7 +205,7 @@ require (
 	github.com/DataDog/datadog-traceroute v1.0.19
 	github.com/DataDog/dd-trace-go/v2 v2.9.0
 	github.com/DataDog/ddtrivy v0.0.0-20260519164847-bf6bcaf2f9b7
-	github.com/DataDog/ebpf-manager v0.8.0
+	github.com/DataDog/ebpf-manager v0.8.1-0.20260723114030-df952c39a4e3
 	github.com/DataDog/go-acl v1.0.1
 	github.com/DataDog/go-sqllexer v0.2.4
 	github.com/DataDog/jsonapi v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -2549,8 +2549,8 @@ github.com/DataDog/dd-trace-go/v2 v2.9.0 h1:J/EsZ7nPqkf3Pa56AAre306ylYMhtzz6oylm
 github.com/DataDog/dd-trace-go/v2 v2.9.0/go.mod h1:SdMkCESSBc2knx56Xol2pO7jhMDPi7MxyNj6vRYMW48=
 github.com/DataDog/ddtrivy v0.0.0-20260519164847-bf6bcaf2f9b7 h1:N9Ufc+tRU6BaVpxw0D60bvhqwsJ90r5ygXNIbx/kucg=
 github.com/DataDog/ddtrivy v0.0.0-20260519164847-bf6bcaf2f9b7/go.mod h1:cy6fMTy/g9yD4GxWUXTTDzKKJE9ZbONxcwiQfpPrv/M=
-github.com/DataDog/ebpf-manager v0.8.0 h1:4L0PqS63shWA/WtSW+ShFthlnOJBuWgWNsLVezHYM6I=
-github.com/DataDog/ebpf-manager v0.8.0/go.mod h1:RiD34iatXndGN5PVbDuG8NuGdzlRjqSxXPvAeX9gyh8=
+github.com/DataDog/ebpf-manager v0.8.1-0.20260723114030-df952c39a4e3 h1:pwNwwUS6pnk73IiEv99zTdtBFUIP+lqpdEtG0EFGgEE=
+github.com/DataDog/ebpf-manager v0.8.1-0.20260723114030-df952c39a4e3/go.mod h1:zlmQH/xpl87sWLv2k0ek5Nw1PsAOEfDYc8+AYd7lYxw=
 github.com/DataDog/go-acl v1.0.1 h1:uRbp98YmlVZYqNNyTBFNI3Y6bnziBLyCIR4nRu0bIpU=
 github.com/DataDog/go-acl v1.0.1/go.mod h1:YJx333qSb3GUqCLIbqKeGaZS2pUYh2IYGI7+FsX18CU=
 github.com/DataDog/go-cmp v0.0.0-20250605161605-8f326bf2ab9d h1:ErpIQikDqtpE21afk2ExlJn0wg7gGWyUVu/RY4rBlMI=


### PR DESCRIPTION
### What does this PR do?

Bumps `github.com/DataDog/ebpf-manager` to the commit that releases kernel BTF once eBPF program loading finishes. `Manager.Start()` now clears both `VerifierOptions.Programs.KernelTypes` and the shared `VerifierOptions.Cache` after the collection is loaded (unless the caller opts out via `KeepKernelBTF`).

Pinned as a temporary pseudo-version (`v0.8.1-0.20260723114030-df952c39a4e3`) pending the `v0.8.1` tag — see DataDog/ebpf-manager#283.

### Motivation

A long-lived `system-probe` kept the parsed kernel vmlinux BTF pinned in the shared verifier cache for the entire process lifetime, even though it is only needed while loading programs. This regressed idle heap/RSS. Releasing the cache after load lets that memory be reclaimed.

### Describe how you validated your changes

- Upstream change carries a unit test (`TestReleaseKernelBTF`) covering both the default-release and `KeepKernelBTF`-retain paths.
- Built `system-probe` against the pinned version and confirmed it compiles and loads eBPF programs (NPM + USM + CWS) without errors.

### Additional Notes

Follow-up: once DataDog/ebpf-manager#283 merges and `v0.8.1` is tagged, swap the pseudo-version for the tag and re-run `dda inv tidy`.
