### PR TITLE
rtloader: Test ignored event_object field

### DIFF
--- a/rtloader/test/aggregator/aggregator_test.go
+++ b/rtloader/test/aggregator/aggregator_test.go
@@ -8,6 +8,7 @@ package testaggregator
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -278,6 +279,45 @@ func TestSubmitEvent(t *testing.T) {
 	}
 	if _event.tags[0] != "foo" || _event.tags[1] != "bar" {
 		t.Fatalf("Unexpected tags: %v", _event.tags)
+	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
+}
+
+func TestSubmitEventIgnoresEventObject(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
+	type callbackOutput struct {
+		checkID string
+		event   event
+	}
+
+	submitEvent := func(eventObject string) callbackOutput {
+		code := fmt.Sprintf(
+			"aggregator.submit_event(None, 'submit_event_id', {'msg_title': 'Event title', 'msg_text': 'Event message', 'aggregation_key': 'supported-sentinel'%s})",
+			eventObject,
+		)
+		out, err := run(code)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out != "" {
+			t.Fatalf("Unexpected printed value: '%s'", out)
+		}
+		if _event == nil {
+			t.Fatal("Event callback was not invoked")
+		}
+
+		return callbackOutput{checkID: checkID, event: *_event}
+	}
+
+	withoutEventObject := submitEvent("")
+	withEventObject := submitEvent(", 'event_object': 'unsupported-sentinel'")
+
+	if !reflect.DeepEqual(withoutEventObject, withEventObject) {
+		t.Fatalf("event_object changed the event callback output: without=%+v, with=%+v", withoutEventObject, withEventObject)
 	}
 
 	// Check for leaks


### PR DESCRIPTION
### What does this PR do?

Adds an explicit rtloader A/B regression test proving that otherwise identical Python events produce identical callback output with and without the unsupported `event_object` dictionary key.

### Motivation

This documents the Agent-side behavior relied on by DataDog/integrations-core#24611, which removes an MD5-derived vSphere `event_object` value. The existing general event test supplied the key but did not explicitly assert that it is ignored.

### Describe how you validated your changes

- `GOPROXY=https://proxy.golang.org,direct dda inv rtloader.test`
- Pre-commit `go-fmt` and repository checks passed.
- Pre-push modified-package `go-test` and `go-linter` checks passed.
- Manual Agent 7.81.2 system proof: `agent check --json` retained an `aggregation_key` sentinel and omitted `event_object`; the decoded raw zstd `/intake/` request captured by fake intake did the same.

### Additional Notes

This is test-only and does not change Agent runtime behavior, so it does not need a Reno release note.
