### PR TITLE
comp/core/agenttelemetry: harden metric aggregation

### DIFF
--- a/comp/core/agenttelemetry/impl/BUILD.bazel
+++ b/comp/core/agenttelemetry/impl/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "@com_github_prometheus_client_model//go",
         "@com_github_robfig_cron_v3//:cron",
         "@in_yaml_go_yaml_v2//:yaml",
+        "@org_golang_google_protobuf//proto",
         "@org_uber_go_atomic//:atomic",
     ],
 )
@@ -45,6 +46,7 @@ dd_agent_go_test(
     srcs = [
         "agenttelemetry_test.go",
         "errortracking_sender_test.go",
+        "utils_test.go",
     ],
     embed = [":impl"],
     deps = [
@@ -63,6 +65,8 @@ dd_agent_go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//mock",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//types/known/timestamppb",
         "@org_uber_go_atomic//:atomic",
     ],
 )

--- a/comp/core/agenttelemetry/impl/agenttelemetry.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry.go
@@ -336,7 +336,7 @@ func (a *atel) aggregateMetricTags(mCfg *MetricConfig, mt dto.MetricType, ms []*
 					specTags = append(specTags, t)
 				}
 			}
-			tagsKey = convertLabelsToKey(specTags)
+			tagsKey = encodeSortedLabels(specTags)
 
 			if mCfg.AggregateTotal {
 				aggregateMetric(mt, totalm, m)
@@ -395,7 +395,8 @@ func buildKeysForMetricsPreviousValues(mt dto.MetricType, metricName string, met
 			// Each timeseries or "m" on each iteration in this code, will contain a set of unique
 			// tagset (as m.GetLabel()). Accordingly, each timeseries should be represented by a unique
 			// and stable (reproducible) key formed by tagset key names and values.
-			keyName = fmt.Sprintf("%s%s:", metricName, convertLabelsToKey(tags))
+			sortedTags := cloneLabelsSorted(tags)
+			keyName = fmt.Sprintf("%s%s:", metricName, encodeSortedLabels(sortedTags))
 		}
 
 		if mt == dto.MetricType_HISTOGRAM {

--- a/comp/core/agenttelemetry/impl/agenttelemetry.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry.go
@@ -292,8 +292,9 @@ func NewComponent(deps Requires) Provides {
 	}
 }
 
-// Prometheus preserves ':' in label values, so delimiter-only concatenation can encode distinct sorted label sets identically.
-// Length prefixes make each name/value boundary unambiguous.
+// Prometheus preserves ':' in label values, so delimiter-only concatenation
+// can encode distinct sorted label sets identically. Length prefixes make each
+// name/value boundary unambiguous.
 func encodeSortedAggregationLabels(labels []*dto.LabelPair) string {
 	var key strings.Builder
 	for _, label := range labels {

--- a/comp/core/agenttelemetry/impl/agenttelemetry.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry.go
@@ -292,7 +292,8 @@ func NewComponent(deps Requires) Provides {
 	}
 }
 
-// encodeSortedAggregationLabels returns an unambiguous length-prefixed encoding for aggregation keys.
+// Prometheus preserves ':' in label values, so delimiter-only concatenation can encode distinct sorted label sets identically.
+// Length prefixes make each name/value boundary unambiguous.
 func encodeSortedAggregationLabels(labels []*dto.LabelPair) string {
 	var key strings.Builder
 	for _, label := range labels {

--- a/comp/core/agenttelemetry/impl/agenttelemetry.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry.go
@@ -292,6 +292,22 @@ func NewComponent(deps Requires) Provides {
 	}
 }
 
+// encodeSortedAggregationLabels returns an unambiguous length-prefixed encoding for aggregation keys.
+func encodeSortedAggregationLabels(labels []*dto.LabelPair) string {
+	var key strings.Builder
+	for _, label := range labels {
+		name := label.GetName()
+		value := label.GetValue()
+		key.WriteString(strconv.Itoa(len(name)))
+		key.WriteByte(':')
+		key.WriteString(name)
+		key.WriteString(strconv.Itoa(len(value)))
+		key.WriteByte(':')
+		key.WriteString(value)
+	}
+	return key.String()
+}
+
 func (a *atel) aggregateMetricTags(mCfg *MetricConfig, mt dto.MetricType, ms []*dto.Metric) []*dto.Metric {
 	// Nothing to aggregate?
 	if len(ms) == 0 {
@@ -331,14 +347,12 @@ func (a *atel) aggregateMetricTags(mCfg *MetricConfig, mt dto.MetricType, ms []*
 
 			// create a key from the tags (and drop not specified in the configuration tags)
 			var specTags = make([]*dto.LabelPair, 0, len(origTags))
-			var sb strings.Builder
 			for _, t := range tags {
 				if _, ok := mCfg.preserveTagsMap[t.GetName()]; ok {
 					specTags = append(specTags, t)
-					sb.WriteString(makeLabelPairKey(t))
 				}
 			}
-			tagsKey = sb.String()
+			tagsKey = encodeSortedAggregationLabels(specTags)
 
 			if mCfg.AggregateTotal {
 				aggregateMetric(mt, totalm, m)

--- a/comp/core/agenttelemetry/impl/agenttelemetry.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry.go
@@ -292,24 +292,6 @@ func NewComponent(deps Requires) Provides {
 	}
 }
 
-// Prometheus preserves ':' in label values, so delimiter-only concatenation
-// can encode distinct sorted label sets identically. Length prefixes make each
-// name/value boundary unambiguous.
-func encodeSortedAggregationLabels(labels []*dto.LabelPair) string {
-	var key strings.Builder
-	for _, label := range labels {
-		name := label.GetName()
-		value := label.GetValue()
-		key.WriteString(strconv.Itoa(len(name)))
-		key.WriteByte(':')
-		key.WriteString(name)
-		key.WriteString(strconv.Itoa(len(value)))
-		key.WriteByte(':')
-		key.WriteString(value)
-	}
-	return key.String()
-}
-
 func (a *atel) aggregateMetricTags(mCfg *MetricConfig, mt dto.MetricType, ms []*dto.Metric) []*dto.Metric {
 	// Nothing to aggregate?
 	if len(ms) == 0 {
@@ -354,7 +336,7 @@ func (a *atel) aggregateMetricTags(mCfg *MetricConfig, mt dto.MetricType, ms []*
 					specTags = append(specTags, t)
 				}
 			}
-			tagsKey = encodeSortedAggregationLabels(specTags)
+			tagsKey = convertLabelsToKey(specTags)
 
 			if mCfg.AggregateTotal {
 				aggregateMetric(mt, totalm, m)

--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -975,6 +975,91 @@ func TestTagAggregateTotalCounter(t *testing.T) {
 	assert.Equal(t, float64(210), m4.Counter.GetValue())
 }
 
+func TestAggregateTotalRejectsReservedTotalPreserveTag(t *testing.T) {
+	const wantErr = "profile 'foo' metric 'bar.zoo' cannot preserve reserved tag 'total' when aggregate_total is enabled"
+
+	for _, tt := range []struct {
+		name                string
+		aggregateTotal      bool
+		tags                string
+		wantErr             bool
+		wantPreservedTags   []string
+		wantUnpreservedTags []string
+	}{
+		{
+			name:           "preserve_tags with aggregate total enabled",
+			aggregateTotal: true,
+			tags: `
+            preserve_tags:
+              - total`,
+			wantErr: true,
+		},
+		{
+			name: "preserve_tags with aggregate total disabled",
+			tags: `
+            preserve_tags:
+              - total`,
+			wantPreservedTags: []string{"total"},
+		},
+		{
+			name:           "deprecated aggregate_tags with aggregate total enabled",
+			aggregateTotal: true,
+			tags: `
+            aggregate_tags:
+              - total`,
+			wantErr: true,
+		},
+		{
+			name:           "preserve_tags takes precedence over deprecated alias",
+			aggregateTotal: true,
+			tags: `
+            preserve_tags:
+              - tag1
+            aggregate_tags:
+              - total`,
+			wantPreservedTags:   []string{"tag1"},
+			wantUnpreservedTags: []string{"total"},
+		},
+		{
+			name:           "empty preserve_tags falls back to deprecated alias",
+			aggregateTotal: true,
+			tags: `
+            preserve_tags: []
+            aggregate_tags:
+              - total`,
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := configmock.NewFromYAML(t, fmt.Sprintf(`
+agent_telemetry:
+  enabled: true
+  profiles:
+    - name: foo
+      metric:
+        metrics:
+          - name: bar.zoo
+            aggregate_total: %t%s
+`, tt.aggregateTotal, tt.tags))
+
+			atelCfg, err := parseConfig(cfg)
+			if tt.wantErr {
+				require.EqualError(t, err, wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			mCfg := &atelCfg.Profiles[0].Metric.Metrics[0]
+			for _, tag := range tt.wantPreservedTags {
+				require.Contains(t, mCfg.preserveTagsMap, tag)
+			}
+			for _, tag := range tt.wantUnpreservedTags {
+				require.NotContains(t, mCfg.preserveTagsMap, tag)
+			}
+		})
+	}
+}
+
 // TestAggregateTotalDeltaStabilityOnTimeseriesCountChange verifies that the
 // aggregate_total counter delta remains correct when the number of timeseries
 // changes between collection cycles. This is a regression test for a bug where

--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -154,8 +154,11 @@ func makeStableMetricMap(metrics []*dto.Metric) map[string]*dto.Metric {
 		// sort by names and values before insertion
 		origTags := m.GetLabel()
 		if len(origTags) > 0 {
-			for _, t := range cloneLabelsSorted(origTags) {
-				tagsKeyBuilder.WriteString(makeLabelPairKey(t))
+			for _, tag := range cloneLabelsSorted(origTags) {
+				tagsKeyBuilder.WriteString(tag.GetName())
+				tagsKeyBuilder.WriteByte(':')
+				tagsKeyBuilder.WriteString(tag.GetValue())
+				tagsKeyBuilder.WriteByte(':')
 			}
 		}
 
@@ -914,6 +917,124 @@ func TestAggregationPreservedTagKeyDoesNotCollideOnDelimiters(t *testing.T) {
 	}
 	require.Equal(t, []string{"a=b:c", "d=e"}, labelsByValue[10])
 	require.Equal(t, []string{"a=b", "c=d:e"}, labelsByValue[20])
+}
+
+func TestCounterDeltaCacheLabelKeyDoesNotCollideOnDelimiters(t *testing.T) {
+	const config = `
+    agent_telemetry:
+      enabled: true
+      profiles:
+        - name: xxx
+          metric:
+            metrics:
+              - name: foo.counter
+                preserve_tags:
+                  - a
+                  - c
+    `
+
+	tel := makeTelMock(t)
+	a := getTestAtel(t, tel, config, makeSenderImpl(t, nil, config), nil, newRunnerMock())
+	require.True(t, a.enabled)
+
+	counter := tel.NewCounter("foo", "counter", []string{"a", "c"}, "")
+	firstTags := map[string]string{"a": "x:c:y", "c": "z"}
+	secondTags := map[string]string{"a": "x", "c": "y:c:z"}
+	firstPayloadTags := map[string]interface{}{"a": "x:c:y", "c": "z"}
+	secondPayloadTags := map[string]interface{}{"a": "x", "c": "y:c:z"}
+
+	assertDeltas := func(firstExpected, secondExpected float64) {
+		metrics, ok := getPayloadFilteredMetricList(a, "foo.counter")
+		require.True(t, ok)
+		require.Len(t, metrics, 2)
+
+		first, ok := getPayloadMetricByTagValues(metrics, firstPayloadTags)
+		require.True(t, ok)
+		second, ok := getPayloadMetricByTagValues(metrics, secondPayloadTags)
+		require.True(t, ok)
+		assert.Equal(t, firstExpected, first.Value)
+		assert.Equal(t, secondExpected, second.Value)
+	}
+
+	counter.AddWithTags(10, firstTags)
+	counter.AddWithTags(100, secondTags)
+	assertDeltas(10, 100)
+
+	counter.AddWithTags(3, firstTags)
+	counter.AddWithTags(7, secondTags)
+	assertDeltas(3, 7)
+}
+
+func TestHistogramDeltaCacheLabelKeyDoesNotCollideOnDelimiters(t *testing.T) {
+	const config = `
+    agent_telemetry:
+      enabled: true
+      profiles:
+        - name: xxx
+          metric:
+            metrics:
+              - name: foo.histogram
+                preserve_tags:
+                  - a
+                  - c
+    `
+
+	tel := makeTelMock(t)
+	a := getTestAtel(t, tel, config, makeSenderImpl(t, nil, config), nil, newRunnerMock())
+	require.True(t, a.enabled)
+
+	histogram := tel.NewHistogram("foo", "histogram", []string{"a", "c"}, "", []float64{1})
+	firstTags := map[string]string{"a": "x:c:y", "c": "z"}
+	secondTags := map[string]string{"a": "x", "c": "y:c:z"}
+	firstPayloadTags := map[string]interface{}{"a": "x:c:y", "c": "z"}
+	secondPayloadTags := map[string]interface{}{"a": "x", "c": "y:c:z"}
+
+	observe := func(tags map[string]string, explicitBucketCount, infBucketCount int) {
+		for range explicitBucketCount {
+			histogram.WithTags(tags).Observe(0.5)
+		}
+		for range infBucketCount {
+			histogram.WithTags(tags).Observe(2)
+		}
+	}
+	assertDeltas := func(firstExpected, secondExpected map[string]uint64) {
+		payload, err := getPayload(a)
+		require.NoError(t, err)
+		payloads, ok := payload.Payload.([]Payload)
+		require.True(t, ok)
+		metrics := make([]*MetricPayload, 0, len(payloads))
+		for _, payload := range payloads {
+			agentMetrics, ok := payload.Payload.(AgentMetricsPayload)
+			require.True(t, ok)
+			metricValue, ok := agentMetrics.Metrics["foo.histogram"]
+			require.True(t, ok)
+			metric, ok := metricValue.(MetricPayload)
+			require.True(t, ok)
+			metrics = append(metrics, &metric)
+		}
+		require.Len(t, metrics, 2)
+
+		first, ok := getPayloadMetricByTagValues(metrics, firstPayloadTags)
+		require.True(t, ok)
+		second, ok := getPayloadMetricByTagValues(metrics, secondPayloadTags)
+		require.True(t, ok)
+		assert.Equal(t, firstExpected, first.Buckets)
+		assert.Equal(t, secondExpected, second.Buckets)
+	}
+
+	observe(firstTags, 1, 1)
+	observe(secondTags, 4, 2)
+	assertDeltas(
+		map[string]uint64{"1": 1, "+Inf": 1},
+		map[string]uint64{"1": 4, "+Inf": 2},
+	)
+
+	observe(firstTags, 2, 1)
+	observe(secondTags, 3, 2)
+	assertDeltas(
+		map[string]uint64{"1": 2, "+Inf": 1},
+		map[string]uint64{"1": 3, "+Inf": 2},
+	)
 }
 
 func TestTagAggregateTotalCounter(t *testing.T) {

--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -881,6 +881,41 @@ func TestTagSpecifiedAggregationCounter(t *testing.T) {
 	assert.Equal(t, float64(30), m2.Counter.GetValue())
 }
 
+func TestAggregationPreservedTagKeyDoesNotCollideOnDelimiters(t *testing.T) {
+	labelPair := func(name, value string) *dto.LabelPair {
+		return &dto.LabelPair{Name: &name, Value: &value}
+	}
+	gaugeMetric := func(value float64, labels ...*dto.LabelPair) *dto.Metric {
+		return &dto.Metric{Label: labels, Gauge: &dto.Gauge{Value: &value}}
+	}
+	mCfg := &MetricConfig{
+		preserveTagsExists: true,
+		preserveTagsMap: map[string]any{
+			"a": struct{}{},
+			"c": struct{}{},
+			"d": struct{}{},
+		},
+	}
+	metrics := []*dto.Metric{
+		gaugeMetric(10, labelPair("a", "b:c"), labelPair("d", "e")),
+		gaugeMetric(20, labelPair("a", "b"), labelPair("c", "d:e")),
+	}
+
+	results := (&atel{}).aggregateMetricTags(mCfg, dto.MetricType_GAUGE, metrics)
+
+	require.Len(t, results, 2)
+	labelsByValue := make(map[float64][]string, len(results))
+	for _, result := range results {
+		labels := make([]string, len(result.GetLabel()))
+		for i, label := range result.GetLabel() {
+			labels[i] = label.GetName() + "=" + label.GetValue()
+		}
+		labelsByValue[result.Gauge.GetValue()] = labels
+	}
+	require.Equal(t, []string{"a=b:c", "d=e"}, labelsByValue[10])
+	require.Equal(t, []string{"a=b", "c=d:e"}, labelsByValue[20])
+}
+
 func TestTagAggregateTotalCounter(t *testing.T) {
 	var c = `
     agent_telemetry:

--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -256,7 +256,8 @@ func compileMetric(p *Profile, m *MetricConfig) error {
 	if len(tags) == 0 {
 		tags = m.AggregateTags
 	}
-	// AggregateTotal synthesizes total=<timeseries count>; preserving a source total tag could emit two series with the same metric name and tags.
+	// AggregateTotal synthesizes total=<timeseries count>; preserving a source
+	// total tag could emit two series with the same metric name and tags.
 	if m.AggregateTotal {
 		for _, tag := range tags {
 			if tag == "total" {

--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -256,6 +256,13 @@ func compileMetric(p *Profile, m *MetricConfig) error {
 	if len(tags) == 0 {
 		tags = m.AggregateTags
 	}
+	if m.AggregateTotal {
+		for _, tag := range tags {
+			if tag == "total" {
+				return fmt.Errorf("profile '%s' metric '%s' cannot preserve reserved tag 'total' when aggregate_total is enabled", p.Name, m.Name)
+			}
+		}
+	}
 	if len(tags) == 0 {
 		m.preserveTagsExists = false
 	} else {

--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -256,6 +256,7 @@ func compileMetric(p *Profile, m *MetricConfig) error {
 	if len(tags) == 0 {
 		tags = m.AggregateTags
 	}
+	// AggregateTotal synthesizes total=<timeseries count>; preserving a source total tag could emit two series with the same metric name and tags.
 	if m.AggregateTotal {
 		for _, tag := range tags {
 			if tag == "total" {

--- a/comp/core/agenttelemetry/impl/go.mod
+++ b/comp/core/agenttelemetry/impl/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/atomic v1.11.0
 	go.yaml.in/yaml/v2 v2.4.4
+	google.golang.org/protobuf v1.36.12-0.20260116114154-8c4c4ae446ca
 )
 
 require (
@@ -104,7 +105,6 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
-	google.golang.org/protobuf v1.36.12-0.20260116114154-8c4c4ae446ca // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/comp/core/agenttelemetry/impl/utils.go
+++ b/comp/core/agenttelemetry/impl/utils.go
@@ -126,10 +126,9 @@ func cloneLabelsSorted(labels []*dto.LabelPair) []*dto.LabelPair {
 // Prometheus preserves ':' in label values, so delimiter-only concatenation
 // can encode distinct sorted label sets identically. Length prefixes make each
 // name/value boundary unambiguous.
-func convertLabelsToKey(labels []*dto.LabelPair) string {
-	sortedLabels := cloneLabelsSorted(labels)
+func encodeSortedLabels(labels []*dto.LabelPair) string {
 	var key strings.Builder
-	for _, label := range sortedLabels {
+	for _, label := range labels {
 		name := label.GetName()
 		value := label.GetValue()
 		key.WriteString(strconv.Itoa(len(name)))

--- a/comp/core/agenttelemetry/impl/utils.go
+++ b/comp/core/agenttelemetry/impl/utils.go
@@ -6,8 +6,8 @@
 package agenttelemetryimpl
 
 import (
-	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	dto "github.com/prometheus/client_model/go"
@@ -123,17 +123,21 @@ func cloneLabelsSorted(labels []*dto.LabelPair) []*dto.LabelPair {
 	return sorted
 }
 
-// Make string key from LabelPair
-func makeLabelPairKey(l *dto.LabelPair) string {
-	return fmt.Sprintf("%s:%s:", l.GetName(), l.GetValue())
-}
-
-// Sort and serialize labels into a string
+// Prometheus preserves ':' in label values, so delimiter-only concatenation
+// can encode distinct sorted label sets identically. Length prefixes make each
+// name/value boundary unambiguous.
 func convertLabelsToKey(labels []*dto.LabelPair) string {
 	sortedLabels := cloneLabelsSorted(labels)
-	var sb strings.Builder
-	for _, tag := range sortedLabels {
-		sb.WriteString(makeLabelPairKey(tag))
+	var key strings.Builder
+	for _, label := range sortedLabels {
+		name := label.GetName()
+		value := label.GetValue()
+		key.WriteString(strconv.Itoa(len(name)))
+		key.WriteByte(':')
+		key.WriteString(name)
+		key.WriteString(strconv.Itoa(len(value)))
+		key.WriteByte(':')
+		key.WriteString(value)
 	}
-	return sb.String()
+	return key.String()
 }

--- a/comp/core/agenttelemetry/impl/utils.go
+++ b/comp/core/agenttelemetry/impl/utils.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/protobuf/proto"
 )
 
 // select only supported metric types
@@ -87,21 +88,18 @@ func aggregateMetric(mt dto.MetricType, aggm *dto.Metric, srcm *dto.Metric) {
 		*aggm.Gauge.Value += srcm.Gauge.GetValue()
 	case dto.MetricType_HISTOGRAM:
 		if aggm.Histogram == nil {
-			// Histogram is a complex structure and hard to initialize completlty and properly
-			// howwever we are using and interested only in its buckets but in future additional fields
-			// may be used and should be initialized properly
-			aggm.Histogram = &dto.Histogram{}
-			// just copy the buckets from the source metric on first iteration
-			aggm.Histogram.Bucket = append(aggm.Histogram.Bucket, srcm.Histogram.Bucket...)
-			// reset buckets specific Label (just in case - it is not used in the current code or Agent)
-			for _, aggmb := range aggm.Histogram.Bucket {
+			sampleCount := srcm.Histogram.GetSampleCount()
+			aggm.Histogram = &dto.Histogram{
+				SampleCount: &sampleCount,
+				Bucket:      make([]*dto.Bucket, len(srcm.Histogram.Bucket)),
+			}
+			for i, srcb := range srcm.Histogram.Bucket {
+				aggmb := proto.Clone(srcb).(*dto.Bucket)
 				if aggmb.Exemplar != nil {
 					aggmb.Exemplar.Label = nil
 				}
+				aggm.Histogram.Bucket[i] = aggmb
 			}
-
-			// copy the sample count (it is implicit "+Inf" bucket)
-			aggm.Histogram.SampleCount = srcm.Histogram.SampleCount
 		} else {
 			// for the same metric family bucket structure is the same
 			for i, srcb := range srcm.Histogram.Bucket {

--- a/comp/core/agenttelemetry/impl/utils_test.go
+++ b/comp/core/agenttelemetry/impl/utils_test.go
@@ -16,13 +16,25 @@ import (
 
 func TestAggregateMetricHistogramDoesNotAliasSources(t *testing.T) {
 	newHistogramMetric := func(sampleCount, cumulativeCount uint64, exemplarValue float64, timestampSeconds int64) *dto.Metric {
+		sampleCountFloat := float64(sampleCount) + 0.5
+		sampleSum := float64(sampleCount * 2)
+		schema := int32(1)
+		spanOffset := int32(0)
+		spanLength := uint32(1)
 		upperBound := 10.0
 		labelName := "trace_id"
 		labelValue := "abc123"
 
 		return &dto.Metric{
 			Histogram: &dto.Histogram{
-				SampleCount: &sampleCount,
+				SampleCount:      &sampleCount,
+				SampleCountFloat: &sampleCountFloat,
+				SampleSum:        &sampleSum,
+				Schema:           &schema,
+				PositiveSpan: []*dto.BucketSpan{
+					{Offset: &spanOffset, Length: &spanLength},
+				},
+				PositiveDelta: []int64{int64(cumulativeCount)},
 				Bucket: []*dto.Bucket{
 					{
 						CumulativeCount: &cumulativeCount,
@@ -59,6 +71,8 @@ func TestAggregateMetricHistogramDoesNotAliasSources(t *testing.T) {
 	require.Empty(t, group.GetHistogram().GetBucket()[0].GetExemplar().GetLabel())
 	require.Equal(t, 1.5, total.GetHistogram().GetBucket()[0].GetExemplar().GetValue())
 	require.Equal(t, int64(100), total.GetHistogram().GetBucket()[0].GetExemplar().GetTimestamp().GetSeconds())
+	requireUnsupportedHistogramFieldsAbsent(t, total.GetHistogram())
+	requireUnsupportedHistogramFieldsAbsent(t, group.GetHistogram())
 	require.True(t, proto.Equal(src1Snapshot, src1), "first source histogram was mutated")
 	require.True(t, proto.Equal(src2Snapshot, src2), "second source histogram was mutated")
 
@@ -77,6 +91,15 @@ func TestAggregateMetricHistogramDoesNotAliasSources(t *testing.T) {
 	require.True(t, proto.Equal(src1Snapshot, src1), "mutating aggregate changed first source histogram")
 	require.True(t, proto.Equal(src2Snapshot, src2), "mutating aggregate changed second source histogram")
 	require.True(t, proto.Equal(groupSnapshot, group), "mutating total aggregate changed group aggregate")
+}
+
+func requireUnsupportedHistogramFieldsAbsent(t *testing.T, histogram *dto.Histogram) {
+	t.Helper()
+	require.Nil(t, histogram.SampleCountFloat)
+	require.Nil(t, histogram.SampleSum)
+	require.Nil(t, histogram.Schema)
+	require.Nil(t, histogram.PositiveSpan)
+	require.Nil(t, histogram.PositiveDelta)
 }
 
 func requireHistogramPointersIndependent(t *testing.T, left, right *dto.Histogram) {

--- a/comp/core/agenttelemetry/impl/utils_test.go
+++ b/comp/core/agenttelemetry/impl/utils_test.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package agenttelemetryimpl
+
+import (
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestAggregateMetricHistogramDoesNotAliasSources(t *testing.T) {
+	newHistogramMetric := func(sampleCount, cumulativeCount uint64, exemplarValue float64, timestampSeconds int64) *dto.Metric {
+		upperBound := 10.0
+		labelName := "trace_id"
+		labelValue := "abc123"
+
+		return &dto.Metric{
+			Histogram: &dto.Histogram{
+				SampleCount: &sampleCount,
+				Bucket: []*dto.Bucket{
+					{
+						CumulativeCount: &cumulativeCount,
+						UpperBound:      &upperBound,
+						Exemplar: &dto.Exemplar{
+							Label: []*dto.LabelPair{
+								{Name: &labelName, Value: &labelValue},
+							},
+							Value:     &exemplarValue,
+							Timestamp: &timestamppb.Timestamp{Seconds: timestampSeconds, Nanos: 123},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	src1 := newHistogramMetric(3, 2, 1.5, 100)
+	src2 := newHistogramMetric(5, 4, 2.5, 200)
+	src1Snapshot := proto.Clone(src1).(*dto.Metric)
+	src2Snapshot := proto.Clone(src2).(*dto.Metric)
+
+	total := &dto.Metric{}
+	group := &dto.Metric{}
+	aggregateMetric(dto.MetricType_HISTOGRAM, total, src1)
+	aggregateMetric(dto.MetricType_HISTOGRAM, group, src1)
+	aggregateMetric(dto.MetricType_HISTOGRAM, total, src2)
+
+	require.Equal(t, uint64(8), total.GetHistogram().GetSampleCount())
+	require.Equal(t, uint64(6), total.GetHistogram().GetBucket()[0].GetCumulativeCount())
+	require.Equal(t, uint64(3), group.GetHistogram().GetSampleCount())
+	require.Equal(t, uint64(2), group.GetHistogram().GetBucket()[0].GetCumulativeCount())
+	require.Empty(t, total.GetHistogram().GetBucket()[0].GetExemplar().GetLabel())
+	require.Empty(t, group.GetHistogram().GetBucket()[0].GetExemplar().GetLabel())
+	require.Equal(t, 1.5, total.GetHistogram().GetBucket()[0].GetExemplar().GetValue())
+	require.Equal(t, int64(100), total.GetHistogram().GetBucket()[0].GetExemplar().GetTimestamp().GetSeconds())
+	require.True(t, proto.Equal(src1Snapshot, src1), "first source histogram was mutated")
+	require.True(t, proto.Equal(src2Snapshot, src2), "second source histogram was mutated")
+
+	requireHistogramPointersIndependent(t, total.GetHistogram(), src1.GetHistogram())
+	requireHistogramPointersIndependent(t, total.GetHistogram(), src2.GetHistogram())
+	requireHistogramPointersIndependent(t, group.GetHistogram(), src1.GetHistogram())
+	requireHistogramPointersIndependent(t, total.GetHistogram(), group.GetHistogram())
+
+	groupSnapshot := proto.Clone(group).(*dto.Metric)
+	*total.Histogram.SampleCount = 80
+	*total.Histogram.Bucket[0].CumulativeCount = 60
+	*total.Histogram.Bucket[0].UpperBound = 20
+	*total.Histogram.Bucket[0].Exemplar.Value = 3.5
+	total.Histogram.Bucket[0].Exemplar.Timestamp.Seconds = 300
+
+	require.True(t, proto.Equal(src1Snapshot, src1), "mutating aggregate changed first source histogram")
+	require.True(t, proto.Equal(src2Snapshot, src2), "mutating aggregate changed second source histogram")
+	require.True(t, proto.Equal(groupSnapshot, group), "mutating total aggregate changed group aggregate")
+}
+
+func requireHistogramPointersIndependent(t *testing.T, left, right *dto.Histogram) {
+	t.Helper()
+	require.NotNil(t, left)
+	require.NotNil(t, right)
+	require.NotSame(t, left.SampleCount, right.SampleCount)
+	require.Len(t, left.Bucket, 1)
+	require.Len(t, right.Bucket, 1)
+	require.NotSame(t, left.Bucket[0], right.Bucket[0])
+	require.NotSame(t, left.Bucket[0].CumulativeCount, right.Bucket[0].CumulativeCount)
+	require.NotSame(t, left.Bucket[0].UpperBound, right.Bucket[0].UpperBound)
+	require.NotNil(t, left.Bucket[0].Exemplar)
+	require.NotNil(t, right.Bucket[0].Exemplar)
+	require.NotSame(t, left.Bucket[0].Exemplar, right.Bucket[0].Exemplar)
+	require.NotSame(t, left.Bucket[0].Exemplar.Value, right.Bucket[0].Exemplar.Value)
+	require.NotNil(t, left.Bucket[0].Exemplar.Timestamp)
+	require.NotNil(t, right.Bucket[0].Exemplar.Timestamp)
+	require.NotSame(t, left.Bucket[0].Exemplar.Timestamp, right.Bucket[0].Exemplar.Timestamp)
+}


### PR DESCRIPTION
### What does this PR do?

This PR extracts three aggregation correctness fixes that were discovered while developing the mandatory-emitter work in the now-closed draft #50648. They are independent of emitter behavior and are easier to reason about and review separately.

#### 1. Give histogram aggregates independent ownership

The previous histogram aggregation path copied bucket and sample-count pointers from the first source metric into the destination aggregate. That meant the source DTO, a grouped aggregate, and an `aggregate_total` result could share mutable protobuf state. Adding another sample to one aggregate could therefore mutate another aggregate or the registry-owned source metric.

The new path:

- allocates an independent integer sample count;
- deep-clones each conventional histogram bucket before using it in an aggregate;
- removes exemplar labels only from the cloned bucket, leaving the source exemplar untouched;
- retains the existing aggregation contract: conventional cumulative buckets and integer sample count only. It does not introduce `SampleSum` or native-histogram aggregation.

The regression test creates two aggregates from the same sources, verifies all relevant pointers are independent, and then mutates one aggregate to prove neither the other aggregate nor either source changes.

#### 2. Make preserved-tag aggregation keys collision-safe

Preserved labels were previously serialized by concatenating delimiter-separated names and values. Delimiters are valid label content, so distinct tagsets could produce the same map key. For example:

```text
[a="b:c", d="e"]
[a="b", c="d:e"]
```

Both could collapse into one aggregate, combining values from unrelated timeseries and emitting the wrong labels/value.

The shared label serializer now length-prefixes each sorted label name and value. This makes component boundaries unambiguous while retaining deterministic grouping, and protects both preserved-tag aggregation keys and the raw counter and histogram delta-cache keys used before aggregation.

#### 3. Reject an ambiguous `aggregate_total` configuration

When `aggregate_total` is enabled, agenttelemetry emits a synthetic series with a `total` label containing the number of source timeseries. Allowing `total` in `preserve_tags` can also produce an ordinary grouped series with the same metric identity as that generated total series.

Configuration compilation now rejects the exact preserved tag `total` when `aggregate_total: true`. Validation happens after resolving the deprecated `aggregate_tags` alias, so both configuration forms behave consistently. Preserving `total` remains accepted when `aggregate_total` is disabled for backward compatibility.

### Motivation

These issues can produce incorrect telemetry without an obvious local failure:

- shared histogram state can make aggregation order affect sources and other outputs;
- ambiguous string keys can silently merge distinct valid timeseries;
- an ambiguous total configuration can create ordinary and generated series with the same identity.

Keeping these fixes in a prerequisite PR gives them one focused narrative—aggregation correctness—and keeps the follow-up mandatory-emitter PR substantially smaller. This PR does **not** intentionally change emitter defaults, emitter filtering, default profiles, or total partitioning.

### Describe how you validated your changes

Each regression was developed test-first and observed failing for the intended pre-fix behavior:

- histogram ownership: a second aggregation mutated the first source-backed aggregate;
- delimiter collision: two distinct tagsets became one gauge with their values summed;
- reserved `total`: invalid enabled configurations parsed successfully.

Final validation:

- `dda inv test --targets=./comp/core/agenttelemetry/impl` — passed (`72/72` in the unified report)
- `bazel test //comp/core/agenttelemetry/impl:impl_test_base` — passed
- `bazel run //bazel/buildifier` — passed
- `git diff --check` — passed

The complete branch also received separate specification and code-quality review passes.

### Additional Notes

Implementation and regression coverage were extracted and adapted from #50648. This PR is intentionally opened as a draft and is a prerequisite for a new, smaller mandatory-emitter feature PR.
