### PR TITLE
[FA-1327] Run feature detection on the config-stream fast path in comp/core/config

### DIFF
--- a/comp/core/config/BUILD.bazel
+++ b/comp/core/config/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//comp/core/flare/types",
         "//comp/core/secrets/def",
         "//comp/core/secrets/noop-impl/types",
+        "//pkg/config/env",
         "//pkg/config/mock",
         "//pkg/config/model",
         "//pkg/config/setup",

--- a/comp/core/config/config.go
+++ b/comp/core/config/config.go
@@ -20,6 +20,7 @@ import (
 	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	secretnooptypes "github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl/types"
+	pkgconfigenv "github.com/DataDog/datadog-agent/pkg/config/env"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
@@ -87,6 +88,9 @@ func newConfig(deps dependencies) (*cfg, error) {
 	if deps.Cfgstream != nil && deps.Cfgstream.IsActive() {
 		// Snapshot already in the global builder; skip disk load to avoid
 		// clobbering streamed values via same-source last-write-wins.
+		// Feature detection still needs to run here since LoadDatadog (which
+		// normally triggers it) is skipped on this path.
+		pkgconfigenv.DetectFeatures(config)
 		return &cfg{Config: config, warnings: warnings}, nil
 	}
 

--- a/comp/core/config/go.mod
+++ b/comp/core/config/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.72.0-rc.1
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.72.0-rc.1
 	github.com/DataDog/datadog-agent/comp/core/secrets/noop-impl v0.77.0-devel.0.20260211235139-a5361978c2b6
+	github.com/DataDog/datadog-agent/pkg/config/env v0.61.0
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.70.0
 	github.com/DataDog/datadog-agent/pkg/config/model v0.77.2
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.61.0
@@ -26,7 +27,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/basic v0.0.0-20260211235139-a5361978c2b6 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/buildschema v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/create v0.70.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/config/env v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/helper v0.73.0-devel.0.20251030121902-cd89eab046d6 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect


### PR DESCRIPTION
## What does this PR do?

Fixes a `CrashLoopBackOff` seen on trace-agent (and other remote agents) when config streaming is active:

```
panic: Trying to access features before detection has run
pkg/config/env.IsFeaturePresent
pkg/util/fargate.GetOrchestrator()
comp/trace/config/impl.prepareConfig
```

`env.IsFeaturePresent`/`GetDetectedFeatures` panic if `env.DetectFeatures` hasn't run yet. That call normally happens inside `pkgconfigsetup.LoadDatadog`. But when a remote agent (trace-agent, process-agent, security-agent) receives its config via a streamed snapshot from the core agent's Remote Agent Registry instead of loading `datadog.yaml` itself, `comp/core/config` takes a fast path that returns early and skips `setupConfig`/`LoadDatadog` entirely — so feature detection never runs, and `detectedFeatures` stays `nil`. Any later call into `env.IsFeaturePresent` (e.g. trace-agent's `prepareConfig` via `fargate.GetOrchestrator()`) panics.

Fix: call `pkgconfigenv.DetectFeatures(config)` on the config-stream fast path before returning.

## Test plan

Ran core agent with config streaming enabled + attached trace-agent, process-agent, security-agent; all three now log `"N Features detected from environment"` and register with the Remote Agent Registry without panicking