### PR TITLE
packaging/aix: set NLSPATH so the IBM MQ client can find its message catalogs

### DIFF
--- a/CHANGELOG-AIX.md
+++ b/CHANGELOG-AIX.md
@@ -10,6 +10,7 @@
 
 <!-- Add entries here for changes not yet in a release. -->
 
+- Set `NLSPATH` in the agent wrapper so the IBM MQ client library can locate its own message catalogs. Previously, `ibm_mq` check errors and other MQ client errors rendered as unreadable generic text (e.g. `AMQ9211E: Failed to find error message id`) instead of the real message, because the agent process only had AIX's default `NLSPATH` (`/usr/lib/nls/msg/...`), which doesn't include MQ's catalog directory.
 - Bump the embedded Python from 3.13.12 to 3.13.14, matching the version used by the Linux omnibus/bazel build
 - Build embedded OpenSSL with the same hardening flags as the Linux omnibus/bazel build (`no-idea no-mdc2 no-rc5 no-ssl3 no-gost no-filenames`, dynamic zlib loading) — the AIX build previously shipped OpenSSL with default settings, retaining legacy/weak algorithms and the GOST engine that Linux deliberately strips
 - Add a `/usr/bin/datadog-agent` convenience symlink to the agent wrapper on install, matching the Linux packages

--- a/packaging/aix/agent-wrapper.sh
+++ b/packaging/aix/agent-wrapper.sh
@@ -6,5 +6,9 @@
 # (a Go/ld limitation on AIX); this wrapper sets the correct installed paths
 # so the binary works when invoked directly, not just via SRC.
 export LIBPATH=/opt/datadog-agent/rtloader:/opt/datadog-agent/embedded/lib:/opt/mqm/lib64:/opt/mqm/lib:/usr/mqm/lib64:/usr/mqm/lib:/opt/ibm/db2/clidriver/lib:/opt/datadog-agent/embedded/lib/python3.13/site-packages/clidriver/lib:/opt/freeware/lib64:/opt/freeware/lib${LIBPATH:+:$LIBPATH}
+# The IBM MQ client library looks up its own message catalogs via NLSPATH;
+# without this, MQ errors render as unreadable generic text (e.g. AMQ9211E
+# "Failed to find error message id") instead of the real message.
+export NLSPATH=/opt/mqm/msg/%L/%N:/opt/mqm/msg/%L/%N.cat:/usr/mqm/msg/%L/%N:/usr/mqm/msg/%L/%N.cat${NLSPATH:+:$NLSPATH}
 export PATH=/opt/datadog-agent/embedded/bin:/opt/freeware/bin:/usr/sbin:/usr/bin:/bin:"${PATH}"
 exec /opt/datadog-agent/bin/agent/agent-bin "$@"


### PR DESCRIPTION
### What does this PR do?

Adds `NLSPATH` to the `agent-wrapper.sh`, pointing at IBM MQ's message catalog directories for both common install locations (`/opt/mqm`, `/usr/mqm`), ahead of whatever `NLSPATH` is already set.

### Motivation

MQ client errors path was missing for the default, so MQ check errors showed `AMQ9211E: Failed to find error message id ...`.

### Describe how you validated your changes
n/a

### Additional Notes
