### PR TITLE
[DRAFT] Add infrastructure_mode=dogstatsd (DogStatsD-only mode)

### DIFF
--- a/comp/metadata/inventoryagent/impl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/impl/inventoryagent.go
@@ -175,7 +175,7 @@ func (ia *inventoryagent) initData() {
 
 	infraMode := scrub(ia.conf.GetString("infrastructure_mode"))
 	// fleet-automation: This validation should be done by the Config once we have such mechanism
-	if !slices.Contains([]string{"full", "end_user_device", "basic", "cloud_cost_only", "none"}, infraMode) {
+	if !slices.Contains([]string{"full", "end_user_device", "basic", "cloud_cost_only", "dogstatsd", "none"}, infraMode) {
 		ia.log.Warnf("invalid value for 'infrastructure_mode': '%s' (defaulting to 'full')", infraMode)
 		infraMode = "full"
 	}

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1236,7 +1236,7 @@ func agent(config pkgconfigmodel.Setup) {
 
 	// Infrastructure mode
 	// The infrastructure mode is used to determine the features that are available to the agent.
-	// The possible values are: full, basic, end_user_device, cloud_cost_only, none.
+	// The possible values are: full, basic, end_user_device, cloud_cost_only, dogstatsd, none.
 	config.BindEnvAndSetDefault("infrastructure_mode", "full")
 
 	// Infrastructure full mode section (default mode, allows all checks)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1401,6 +1401,27 @@ func applyInfrastructureModeOverrides(config pkgconfigmodel.Config) {
 		config.Set("integration.enabled", false, pkgconfigmodel.SourceInfraMode)
 		// Avoid detailed ECS task metadata collection when not collecting infrastructure.
 		config.Set("ecs_task_collection_enabled", false, pkgconfigmodel.SourceInfraMode)
+	} else if infraMode == "dogstatsd" {
+		// Mirror the standalone DogStatsD flavor: run only the DogStatsD intake
+		// pipeline, nothing else. Disable all checks/integrations and every
+		// subsystem the standalone dogstatsd build omits, and route DogStatsD
+		// through Agent Data Plane (ADP) so the Go DogStatsD server is not needed.
+		//
+		// As with the other modes these use SourceInfraMode, so an explicit user
+		// config file or environment variable still takes precedence.
+		config.Set("integration.enabled", false, pkgconfigmodel.SourceInfraMode)
+		config.Set("ecs_task_collection_enabled", false, pkgconfigmodel.SourceInfraMode)
+		config.Set("apm_config.enabled", false, pkgconfigmodel.SourceInfraMode)
+		config.Set("logs_enabled", false, pkgconfigmodel.SourceInfraMode)
+		config.Set("process_config.process_collection.enabled", false, pkgconfigmodel.SourceInfraMode)
+		config.Set("process_config.container_collection.enabled", false, pkgconfigmodel.SourceInfraMode)
+		config.Set("container_image.enabled", false, pkgconfigmodel.SourceInfraMode)
+		config.Set("container_lifecycle.enabled", false, pkgconfigmodel.SourceInfraMode)
+		config.Set("orchestrator_explorer.enabled", false, pkgconfigmodel.SourceInfraMode)
+		config.Set("sbom.enabled", false, pkgconfigmodel.SourceInfraMode)
+		// Serve DogStatsD via ADP rather than the Go DogStatsD server.
+		config.Set("data_plane.enabled", true, pkgconfigmodel.SourceInfraMode)
+		config.Set("data_plane.dogstatsd.enabled", true, pkgconfigmodel.SourceInfraMode)
 	}
 }
 

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -783,6 +783,41 @@ infrastructure_mode: none
 	assert.False(t, config.GetBool("integration.enabled"))
 }
 
+func TestInfrastructureModeDogstatsd(t *testing.T) {
+	datadogYaml := `
+infrastructure_mode: dogstatsd
+`
+	config := confFromYAML(t, datadogYaml)
+	applyInfrastructureModeOverrides(config)
+
+	// Everything except the DogStatsD intake is disabled.
+	assert.False(t, config.GetBool("integration.enabled"))
+	assert.False(t, config.GetBool("apm_config.enabled"))
+	assert.False(t, config.GetBool("logs_enabled"))
+	assert.False(t, config.GetBool("process_config.process_collection.enabled"))
+	assert.False(t, config.GetBool("process_config.container_collection.enabled"))
+	assert.False(t, config.GetBool("orchestrator_explorer.enabled"))
+	assert.False(t, config.GetBool("sbom.enabled"))
+	assert.False(t, config.GetBool("ecs_task_collection_enabled"))
+
+	// DogStatsD is served by ADP.
+	assert.True(t, config.GetBool("data_plane.enabled"))
+	assert.True(t, config.GetBool("data_plane.dogstatsd.enabled"))
+}
+
+func TestInfrastructureModeDogstatsdRespectsUserOverride(t *testing.T) {
+	// SourceInfraMode must lose to an explicit user setting.
+	datadogYaml := `
+infrastructure_mode: dogstatsd
+apm_config:
+  enabled: true
+`
+	config := confFromYAML(t, datadogYaml)
+	applyInfrastructureModeOverrides(config)
+
+	assert.True(t, config.GetBool("apm_config.enabled"))
+}
+
 func TestInfrastructureModeLegacyAliases(t *testing.T) {
 	// Test that legacy allowed_additional_checks is aliased to mode-specific
 	// key via applyInfrastructureModeOverrides

--- a/releasenotes/notes/add-infrastructure-mode-dogstatsd-jszwedko.yaml
+++ b/releasenotes/notes/add-infrastructure-mode-dogstatsd-jszwedko.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not differ between releases and is easy to understand.
+---
+features:
+  - |
+    Added a new ``infrastructure_mode`` value, ``dogstatsd``, which constrains
+    the regular Agent to run only the DogStatsD intake pipeline (served by Agent
+    Data Plane) with all checks/integrations and other subsystems disabled. This
+    provides an in-place migration target for users of the standalone DogStatsD
+    Agent flavor.


### PR DESCRIPTION
## Summary

Standalone DogStatsD is a separate Agent flavor that runs only the Go DogStatsD server — one of the artifacts blocking deletion of that server as part of the DogStatsD Succession. This adds an `infrastructure_mode: dogstatsd` so the regular Agent can reproduce the standalone flavor's behavior at runtime (DogStatsD intake only, served by Agent Data Plane), giving standalone-DogStatsD users an in-place migration target so the flavor can be frozen. The mode disables all checks/integrations, APM, logs, process/container collection, orchestration, and SBOM, and enables `data_plane.enabled` so DogStatsD is served by ADP rather than the Go server.

PoC for the "Freezing Standalone DogStatsD" proposal; mirrors the `infrastructure_mode: iot` pattern (#54020).

## Test plan

- New unit tests cover the `dogstatsd` overrides and that an explicit user setting still wins over `SourceInfraMode` (`pkg/config/setup/config_test.go`).
- [ ] Validate on a host that a regular Agent with `infrastructure_mode: dogstatsd` accepts DogStatsD traffic (via ADP) and runs no checks — matching the standalone DogStatsD flavor.
