### PR TITLE
[cisco-sdwan] Submit partial tunnel metrics when app-route pagination fails

### DIFF
--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client.go
@@ -264,11 +264,10 @@ func (client *Client) GetApplicationAwareRoutingMetrics() ([]AppRouteStatistics,
 	}
 
 	appRoutes, err := getAllEntries[AppRouteStatistics](client, "/dataservice/data/device/statistics/approutestatsstatistics", params)
-	if err != nil {
+	if appRoutes == nil {
 		return nil, err
 	}
-
-	return appRoutes.Data, nil
+	return appRoutes.Data, err
 }
 
 // GetControlConnectionsState gets control connection states

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request.go
@@ -15,6 +15,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// errMaxPagesReached is returned when pagination hits the max_pages limit.
+var errMaxPagesReached = errors.New("reached max pagination limit; increase max_pages or max_count")
+
 // newRequest creates a new request for this client.
 func (client *Client) newRequest(method, uri string, body io.Reader) (*http.Request, error) {
 	return http.NewRequest(method, client.endpoint+uri, body)
@@ -107,6 +110,7 @@ func isValidStatusCode(code int) bool {
 }
 
 // getMoreEntries gets all results from paginated endpoints
+// On error, any successfully fetched entries are still returned so callers can submit partial data
 func getMoreEntries[T Content](client *Client, endpoint string, pageInfo PageInfo) ([]T, error) {
 	var responses []T
 	currentPageInfo := pageInfo
@@ -115,7 +119,7 @@ func getMoreEntries[T Content](client *Client, endpoint string, pageInfo PageInf
 	for page := 0; currentPageInfo.MoreEntries || currentPageInfo.HasMoreData; page++ {
 		// Error if max number of pages is reached
 		if page >= client.maxPages {
-			return nil, errors.New("max number of page reached, increase API count or max number of pages")
+			return responses, fmt.Errorf("%w (limit %d)", errMaxPagesReached, client.maxPages)
 		}
 
 		log.Tracef("Getting page %d from endpoint %s", page+1+1, endpoint)
@@ -129,7 +133,7 @@ func getMoreEntries[T Content](client *Client, endpoint string, pageInfo PageInf
 		// Call the endpoint with the new params
 		data, err := get[T](client, endpoint, nextParams)
 		if err != nil {
-			return nil, err
+			return responses, fmt.Errorf("pagination failed at page %d: %w", page, err)
 		}
 
 		responses = append(responses, data.Data...)
@@ -155,7 +159,8 @@ func getNextPaginationParams(info PageInfo, count string) (map[string]string, er
 	return nil, errors.New("could not build next page params")
 }
 
-// getAllEntries gets all entries from paginated endpoints
+// getAllEntries gets all entries from paginated endpoints.
+// On error, entries fetched before the failure are still returned (see getMoreEntries).
 func getAllEntries[T Content](client *Client, endpoint string, params map[string]string) (*Response[T], error) {
 	data, err := get[T](client, endpoint, params)
 	if err != nil {
@@ -164,11 +169,7 @@ func getAllEntries[T Content](client *Client, endpoint string, params map[string
 
 	// If API response is paginated, get the rest
 	entries, err := getMoreEntries[T](client, endpoint, data.PageInfo)
-	if err != nil {
-		return nil, err
-	}
-
 	data.Data = append(data.Data, entries...)
 
-	return data, nil
+	return data, err
 }

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request_test.go
@@ -297,10 +297,113 @@ func TestGetMoreEntriesMaxPages(t *testing.T) {
 	}
 
 	_, err = getMoreEntries[Device](client, "/dataservice/device", pageInfo)
-	require.ErrorContains(t, err, "max number of page reached")
+	require.ErrorIs(t, err, errMaxPagesReached)
 
 	// Ensure endpoint has been called 20 times
 	require.Equal(t, 20, handler.numberOfCalls())
+}
+
+func TestGetMoreEntriesMaxPagesReturnsPartialData(t *testing.T) {
+	mux := setupCommonServerMux()
+
+	handler := newHandler(func(w http.ResponseWriter, _ *http.Request, _ int32) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`
+			{
+				"data": [{"deviceId": "d"}],
+				"pageInfo": {"startId": "1", "endId": "2", "moreEntries": true}
+			}
+		`))
+	})
+	mux.Handle("/dataservice/device", handler.Func)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := testClient(server)
+	require.NoError(t, err)
+	client.maxPages = 3
+
+	entries, err := getMoreEntries[Device](client, "/dataservice/device", PageInfo{MoreEntries: true})
+	require.ErrorIs(t, err, errMaxPagesReached)
+	require.Len(t, entries, 3)
+}
+
+func TestGetMoreEntriesReturnsPartialDataOnError(t *testing.T) {
+	mux := setupCommonServerMux()
+
+	handler := newHandler(func(w http.ResponseWriter, _ *http.Request, calls int32) {
+		if calls > 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`
+			{
+				"data": [{"deviceId": "d"}],
+				"pageInfo": {"startId": "1", "endId": "2", "moreEntries": true}
+			}
+		`))
+	})
+	mux.Handle("/dataservice/device", handler.Func)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := testClient(server)
+	require.NoError(t, err)
+
+	entries, err := getMoreEntries[Device](client, "/dataservice/device", PageInfo{MoreEntries: true})
+	require.Error(t, err)
+	require.Len(t, entries, 2)
+}
+
+func TestGetAllEntriesReturnsFirstPageOnPaginationError(t *testing.T) {
+	mux := setupCommonServerMux()
+
+	handler := newHandler(func(w http.ResponseWriter, _ *http.Request, calls int32) {
+		if calls > 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`
+			{
+				"data": [{"deviceId": "d"}],
+				"pageInfo": {"startId": "1", "endId": "2", "moreEntries": true}
+			}
+		`))
+	})
+	mux.Handle("/dataservice/device", handler.Func)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := testClient(server)
+	require.NoError(t, err)
+
+	resp, err := getAllEntries[Device](client, "/dataservice/device", nil)
+	require.Error(t, err)
+	require.Len(t, resp.Data, 1)
+}
+
+func TestGetAllEntriesFirstPageErrorReturnsNil(t *testing.T) {
+	mux := setupCommonServerMux()
+
+	handler := newHandler(func(w http.ResponseWriter, _ *http.Request, _ int32) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+	mux.Handle("/dataservice/device", handler.Func)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := testClient(server)
+	require.NoError(t, err)
+
+	resp, err := getAllEntries[Device](client, "/dataservice/device", nil)
+	require.Error(t, err)
+	require.Nil(t, resp)
 }
 
 func TestGetMoreEntriesIndexPagination(t *testing.T) {

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/test_utils.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/test_utils.go
@@ -112,3 +112,35 @@ func SetupMockAPIServer() *httptest.Server {
 
 	return httptest.NewServer(mux)
 }
+
+// SetupMockAPIServerWithAppRoutePaginationError is like SetupMockAPIServer, but the
+// application-aware routing endpoint serves a first page indicating more pages exist and then
+// fails every pagination follow-up with a 429. Used to verify partial tunnel metrics are still submitted.
+func SetupMockAPIServerWithAppRoutePaginationError() *httptest.Server {
+	mux := setupCommonServerMux()
+
+	mux.HandleFunc("/dataservice/device", fixtureHandler(fixtures.GetDevices))
+	mux.HandleFunc("/dataservice/device/counters", fixtureHandler(fixtures.GetDevicesCounters))
+	mux.HandleFunc("/dataservice/data/device/state/Interface", fixtureHandler(fixtures.GetVEdgeInterfaces))
+	mux.HandleFunc("/dataservice/data/device/state/CEdgeInterface", fixtureHandler(fixtures.GetCEdgeInterfaces))
+	mux.HandleFunc("/dataservice/data/device/statistics/interfacestatistics", fixtureHandler(fixtures.GetInterfacesMetrics))
+	mux.HandleFunc("/dataservice/data/device/statistics/devicesystemstatusstatistics", fixtureHandler(fixtures.GetDeviceHardwareStatistics))
+	mux.HandleFunc("/dataservice/data/device/state/ControlConnection", fixtureHandler(fixtures.GetControlConnectionsState))
+	mux.HandleFunc("/dataservice/data/device/state/OMPPeer", fixtureHandler(fixtures.GetOMPPeersState))
+	mux.HandleFunc("/dataservice/data/device/state/BFDSessions", fixtureHandler(fixtures.GetBFDSessionsState))
+	mux.HandleFunc("/dataservice/data/device/state/HardwareEnvironment", fixtureHandler(fixtures.GetHardwareStates))
+	mux.HandleFunc("/dataservice/data/device/statistics/cloudxstatistics", fixtureHandler(fixtures.GetCloudExpressMetrics))
+	mux.HandleFunc("/dataservice/data/device/state/BGPNeighbor", fixtureHandler(fixtures.GetBGPNeighbors))
+
+	appRouteCalls := atomic.NewInt32(0)
+	mux.HandleFunc("/dataservice/data/device/statistics/approutestatsstatistics", func(w http.ResponseWriter, _ *http.Request) {
+		if appRouteCalls.Inc() > 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data": ` + fixtures.GetApplicationAwareRoutingMetrics + `, "pageInfo": {"moreEntries": true, "startId": "1", "endId": "2"}}`))
+	})
+
+	return httptest.NewServer(mux)
+}

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan_test.go
@@ -440,3 +440,52 @@ collect_cloud_applications_metrics: false
 
 	sender.AssertNotCalled(t, "EventPlatformEvent", mock.Anything, mock.Anything)
 }
+
+func TestCiscoSDWANCheckSubmitsPartialTunnelMetricsOnPaginationError(t *testing.T) {
+	payload.TimeNow = mockTimeNow
+	report.TimeNow = mockTimeNow
+
+	// App-route endpoint serves page 1 then 429s on pagination
+	apiMockServer := client.SetupMockAPIServerWithAppRoutePaginationError()
+	defer apiMockServer.Close()
+
+	deps := createDeps(t)
+	chk := newCheck()
+	senderManager := deps.Demultiplexer
+
+	url := strings.TrimPrefix(apiMockServer.URL, "http://")
+
+	rawInstanceConfig := []byte(`
+vmanage_endpoint: ` + url + `
+username: admin
+password: 'test-password'
+use_http: true
+namespace: test
+`)
+
+	id := checkid.BuildID(CheckName, integration.FakeConfigHash, rawInstanceConfig, []byte(``))
+	sender := mocksender.NewMockSenderWithSenderManager(id, senderManager)
+	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("GaugeWithTimestamp", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("CountWithTimestamp", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
+	sender.On("Commit").Return()
+
+	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test", "provider")
+	require.NoError(t, err)
+
+	err = chk.Run()
+	require.NoError(t, err)
+
+	// Despite the pagination 429, the first page of tunnel metrics is still submitted
+	ts := float64(1709050725125) / 1000
+	tags := []string{
+		"system_ip:10.10.1.13",
+		"remote_system_ip:10.10.1.11",
+		"local_color:mpls",
+		"remote_color:public-internet",
+		"state:Up",
+	}
+	sender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", "cisco_sdwan.tunnel.status", 1, "", tags, ts)
+}

--- a/releasenotes/notes/cisco-sdwan-partial-tunnel-metrics-bc9b67995437b29d.yaml
+++ b/releasenotes/notes/cisco-sdwan-partial-tunnel-metrics-bc9b67995437b29d.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Cisco SD-WAN: application-aware routing (tunnel) metrics fetched before a
+    paginated API request fails are now submitted, instead of the whole
+    collection cycle being dropped. Previously a single ``429 Too Many Requests``
+    response or reaching the ``max_pages`` limit while paginating discarded all
+    data already retrieved, causing ``cisco_sdwan.tunnel.*`` metrics to be
+    missing for that cycle.


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Fixes the Cisco SD-WAN check discarding an entire collection cycle's application-aware routing (tunnel) metrics when a paginated Statistics API request fails partway through.

### Motivation

When paginating the vManage app-route stats API fails partway through — a `429` from the rate limit, or hitting `max_pages` , the client threw away every page it had already fetched and returned nothing. So a single failed page dropped all `cisco_sdwan.tunnel.*` metrics for that cycle. This keeps the pages that did succeed.

### Describe how you validated your changes

- Unit tests covering the partial-return paths (`max_pages` and a mid-pagination `429`).
- A test that runs the check against a mock vManage which fails app-route pagination, and confirms tunnel metrics are still submitted

### Additional Notes
Only the tunnel path uses this. The shared pagination helpers return partial data for all endpoints, but the other collection paths (devices, interfaces, control connections, etc.) still drop it on error and are unchanged here. Extending them is a follow-up, and the device/interface metadata paths are left out, since partial inventory snapshots behave differently. Customers may still need to make config changes to max_pages and max_count to collect all data.