### PR TITLE
feat(serverless-init): add per-hook forward enable/disable config for MicroVM lifecycle

### DIFF
--- a/cmd/serverless-init/cloudservice/microvm.go
+++ b/cmd/serverless-init/cloudservice/microvm.go
@@ -183,6 +183,7 @@ func (m *MicroVM) Init(ctx *TracingContext) error {
 		lc.FlushTimeout,
 		components.Handle,
 		components.Forwarder,
+		components.EnabledHooks,
 		heartbeat,
 	)
 	if lc.LogsTagSetter != nil {

--- a/cmd/serverless-init/cloudservice/microvm.go
+++ b/cmd/serverless-init/cloudservice/microvm.go
@@ -237,9 +237,6 @@ func (m *MicroVM) Shutdown(_ *serverlessMetrics.ServerlessMetricAgent, _ bool, _
 // metric when the /run hook fires; emitting it here would double-count.
 func (m *MicroVM) AddStartMetric(_ *serverlessMetrics.ServerlessMetricAgent) {}
 
-// ShouldForceFlushAllOnForceFlushToSerializer returns false for MicroVM.
-func (m *MicroVM) ShouldForceFlushAllOnForceFlushToSerializer() bool { return false }
-
 // isMicroVM returns true when running inside an AWS Lambda MicroVM.
 func isMicroVM() bool {
 	_, exists := os.LookupEnv(serverlessenv.MicroVMImageARNEnvVar)

--- a/cmd/serverless-init/cloudservice/microvm_test.go
+++ b/cmd/serverless-init/cloudservice/microvm_test.go
@@ -167,8 +167,9 @@ func TestMicroVM_CurrentUsageMetricTags_BeforeRun_ReturnsNil(t *testing.T) {
 		(&MicroVM{}).GetSource(),
 		time.Second,
 		lifecycle.NewNoopChildHandle(),
-		nil, // no forwarder
-		nil, // no heartbeat
+		nil,                     // no forwarder
+		lifecycle.HookToggles{}, // no hooks enabled
+		nil,                     // no heartbeat
 	)
 	m := &MicroVM{server: srv}
 	assert.Nil(t, m.CurrentUsageMetricTags())
@@ -187,8 +188,9 @@ func TestMicroVM_CurrentUsageMetricTags_AfterRun_ReturnsInstanceTag(t *testing.T
 		(&MicroVM{}).GetSource(),
 		time.Second,
 		lifecycle.NewNoopChildHandle(),
-		nil, // no forwarder
-		nil, // no heartbeat
+		nil,                     // no forwarder
+		lifecycle.HookToggles{}, // no hooks enabled
+		nil,                     // no heartbeat
 	)
 	l, err := srv.Listen()
 	require.NoError(t, err)
@@ -309,8 +311,9 @@ func TestMicroVM_LogsTagSetter_InvokedOnRun(t *testing.T) {
 		(&MicroVM{}).GetSource(),
 		time.Second,
 		lifecycle.NewNoopChildHandle(),
-		nil, // no forwarder
-		nil, // no heartbeat
+		nil,                     // no forwarder
+		lifecycle.HookToggles{}, // no hooks enabled
+		nil,                     // no heartbeat
 	)
 	// This is the call Init makes when lc.LogsTagSetter != nil.
 	srv.SetLogsTagSetter(setter, baseTags)
@@ -371,8 +374,9 @@ func TestMicroVM_TraceTagSetter_InvokedOnRun(t *testing.T) {
 		(&MicroVM{}).GetSource(),
 		time.Second,
 		lifecycle.NewNoopChildHandle(),
-		nil, // no forwarder
-		nil, // no heartbeat
+		nil,                     // no forwarder
+		lifecycle.HookToggles{}, // no hooks enabled
+		nil,                     // no heartbeat
 	)
 	// This is the call Init makes when lc.TraceTagSetter != nil.
 	srv.SetTraceTagSetter(setter, baseTraceTags)
@@ -450,8 +454,9 @@ func TestMicroVMShutdown_LiveServer_StopsCleanly(t *testing.T) {
 		(&MicroVM{}).GetSource(),
 		time.Second,
 		lifecycle.NewNoopChildHandle(),
-		nil, // no forwarder
-		nil, // no heartbeat
+		nil,                     // no forwarder
+		lifecycle.HookToggles{}, // no hooks enabled
+		nil,                     // no heartbeat
 	)
 	l, err := srv.Listen()
 	require.NoError(t, err)

--- a/cmd/serverless-init/cloudservice/microvm_test.go
+++ b/cmd/serverless-init/cloudservice/microvm_test.go
@@ -167,8 +167,9 @@ func TestMicroVM_CurrentUsageMetricTags_BeforeRun_ReturnsNil(t *testing.T) {
 		(&MicroVM{}).GetSource(),
 		time.Second,
 		lifecycle.NewNoopChildHandle(),
-		nil, // no forwarder
-		nil, // no heartbeat
+		nil,                     // no forwarder
+		lifecycle.HookToggles{}, // no hooks enabled
+		nil,                     // no heartbeat
 	)
 	m := &MicroVM{server: srv}
 	assert.Nil(t, m.CurrentUsageMetricTags())
@@ -187,8 +188,9 @@ func TestMicroVM_CurrentUsageMetricTags_AfterRun_ReturnsInstanceTag(t *testing.T
 		(&MicroVM{}).GetSource(),
 		time.Second,
 		lifecycle.NewNoopChildHandle(),
-		nil, // no forwarder
-		nil, // no heartbeat
+		nil,                     // no forwarder
+		lifecycle.HookToggles{}, // no hooks enabled
+		nil,                     // no heartbeat
 	)
 	require.NoError(t, srv.ListenAndServe(nil))
 	t.Cleanup(func() {
@@ -308,8 +310,9 @@ func TestMicroVM_LogsTagSetter_InvokedOnRun(t *testing.T) {
 		(&MicroVM{}).GetSource(),
 		time.Second,
 		lifecycle.NewNoopChildHandle(),
-		nil, // no forwarder
-		nil, // no heartbeat
+		nil,                     // no forwarder
+		lifecycle.HookToggles{}, // no hooks enabled
+		nil,                     // no heartbeat
 	)
 	// This is the call Init makes when lc.LogsTagSetter != nil.
 	srv.SetLogsTagSetter(setter, baseTags)
@@ -368,8 +371,9 @@ func TestMicroVM_TraceTagSetter_InvokedOnRun(t *testing.T) {
 		(&MicroVM{}).GetSource(),
 		time.Second,
 		lifecycle.NewNoopChildHandle(),
-		nil, // no forwarder
-		nil, // no heartbeat
+		nil,                     // no forwarder
+		lifecycle.HookToggles{}, // no hooks enabled
+		nil,                     // no heartbeat
 	)
 	// This is the call Init makes when lc.TraceTagSetter != nil.
 	srv.SetTraceTagSetter(setter, baseTraceTags)
@@ -445,8 +449,9 @@ func TestMicroVMShutdown_LiveServer_StopsCleanly(t *testing.T) {
 		(&MicroVM{}).GetSource(),
 		time.Second,
 		lifecycle.NewNoopChildHandle(),
-		nil, // no forwarder
-		nil, // no heartbeat
+		nil,                     // no forwarder
+		lifecycle.HookToggles{}, // no hooks enabled
+		nil,                     // no heartbeat
 	)
 	require.NoError(t, srv.ListenAndServe(nil))
 

--- a/cmd/serverless-init/lifecycle/config.go
+++ b/cmd/serverless-init/lifecycle/config.go
@@ -11,6 +11,8 @@ import (
 	"math"
 	"strconv"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // DefaultPort is the port the MicroVM platform expects the lifecycle hook server on.
@@ -30,6 +32,38 @@ const ReadyTimeoutMsEnvVar = "DD_AWS_MICROVM_READY_TIMEOUT_MS"
 
 // ValidateTimeoutMsEnvVar overrides the timeout (ms) for /validate.
 const ValidateTimeoutMsEnvVar = "DD_AWS_MICROVM_VALIDATE_TIMEOUT_MS"
+
+// EnableReadyEnvVar opts the /ready hook into forwarding. Requires UserAppPortEnvVar too; defaults to false.
+const EnableReadyEnvVar = "DD_AWS_MICROVM_ENABLE_READY"
+
+// EnableValidateEnvVar opts the /validate hook into forwarding. Requires UserAppPortEnvVar too; defaults to false.
+const EnableValidateEnvVar = "DD_AWS_MICROVM_ENABLE_VALIDATE"
+
+// EnableRunEnvVar opts the /run hook into forwarding. Requires UserAppPortEnvVar too; defaults to false.
+const EnableRunEnvVar = "DD_AWS_MICROVM_ENABLE_RUN"
+
+// EnableResumeEnvVar opts the /resume hook into forwarding. Requires UserAppPortEnvVar too; defaults to false.
+const EnableResumeEnvVar = "DD_AWS_MICROVM_ENABLE_RESUME"
+
+// EnableSuspendEnvVar opts the /suspend hook into forwarding. Requires UserAppPortEnvVar too; defaults to false.
+const EnableSuspendEnvVar = "DD_AWS_MICROVM_ENABLE_SUSPEND"
+
+// EnableTerminateEnvVar opts the /terminate hook into forwarding. Requires UserAppPortEnvVar too; defaults to false.
+const EnableTerminateEnvVar = "DD_AWS_MICROVM_ENABLE_TERMINATE"
+
+// HookToggles controls, per lifecycle hook, whether the hook is forwarded to
+// the user app (true) or handled by the agent itself (false, the default).
+// A hook is only actually forwarded when both its toggle is true AND a
+// Forwarder is configured (UserAppPortEnvVar set); a toggle set to true with
+// no Forwarder configured has no effect (see setupComponents in wire.go).
+type HookToggles struct {
+	Ready     bool
+	Validate  bool
+	Run       bool
+	Resume    bool
+	Suspend   bool
+	Terminate bool
+}
 
 // parsePort parses a port number from a raw env-var string.
 // Returns defaultVal when raw is empty. Parsed port must not equal any value in forbidden.
@@ -68,4 +102,20 @@ func parseDurationMs(envVar, raw string, defaultVal time.Duration) (time.Duratio
 		return 0, fmt.Errorf("%s: too large to represent as a duration (got %d ms)", envVar, ms)
 	}
 	return time.Duration(ms) * time.Millisecond, nil
+}
+
+// parseBoolFlag parses a boolean env var. Returns defaultVal when raw is
+// empty. Unlike parsePort/parseDurationMs, a malformed (non-empty, non-bool)
+// value does not fail setup — it logs a warning and falls back to defaultVal,
+// so a typo in one hook's toggle cannot take down the others.
+func parseBoolFlag(envVar, raw string, defaultVal bool) bool {
+	if raw == "" {
+		return defaultVal
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		log.Warnf("%s: invalid boolean value %q; using default %t", envVar, raw, defaultVal)
+		return defaultVal
+	}
+	return v
 }

--- a/cmd/serverless-init/lifecycle/config_test.go
+++ b/cmd/serverless-init/lifecycle/config_test.go
@@ -151,3 +151,29 @@ func TestParseDurationMs_RejectsOverflow(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, ForwardTimeoutMsEnvVar)
 }
+
+// --- parseBoolFlag ---
+
+func TestParseBoolFlag_UnsetReturnsDefault(t *testing.T) {
+	assert.False(t, parseBoolFlag(EnableRunEnvVar, "", false))
+	assert.True(t, parseBoolFlag(EnableRunEnvVar, "", true))
+}
+
+func TestParseBoolFlag_ValidTrue(t *testing.T) {
+	assert.True(t, parseBoolFlag(EnableRunEnvVar, "true", false))
+}
+
+func TestParseBoolFlag_ValidFalse(t *testing.T) {
+	assert.False(t, parseBoolFlag(EnableRunEnvVar, "false", true))
+}
+
+// TestParseBoolFlag_Malformed_FallsBackToDefault verifies that a malformed
+// (non-empty, non-bool) value does not error — it logs a warning and falls
+// back to defaultVal, so a typo in one hook's toggle cannot fail the whole
+// lifecycle setup the way an invalid port or timeout does.
+func TestParseBoolFlag_Malformed_FallsBackToDefault(t *testing.T) {
+	for _, raw := range []string{"yes", "on", "enabled", "2"} {
+		assert.False(t, parseBoolFlag(EnableRunEnvVar, raw, false), "raw=%q should fall back to default", raw)
+		assert.True(t, parseBoolFlag(EnableRunEnvVar, raw, true), "raw=%q should fall back to default", raw)
+	}
+}

--- a/cmd/serverless-init/lifecycle/heartbeat.go
+++ b/cmd/serverless-init/lifecycle/heartbeat.go
@@ -61,7 +61,7 @@ type Heartbeat struct {
 	// construction. Supplied by cloudservice.MicroVM.Init, which currently
 	// passes a single entry: "microvm_image_arn:<arn>" (the raw image ARN from
 	// AWS_LAMBDA_MICROVM_IMAGE_ARN, or "unknown" when the env var is unset). The
-	// per-emit "microvm_id:<id>" tag is appended separately in tagsForEmit.
+	// per-emit "lambda_microvm_id:<id>" tag is appended separately in tagsForEmit.
 	baseTags []string
 
 	mu          sync.Mutex
@@ -74,7 +74,7 @@ type Heartbeat struct {
 // NewHeartbeat constructs a Heartbeat. Non-positive interval falls back to
 // DefaultHeartbeatInterval. baseTags are tags known at construction time
 // (typically derived from env vars, e.g., microvm_image_arn); the
-// microvm_id tag is appended at emit time and is set at runtime via
+// lambda_microvm_id tag is appended at emit time and is set at runtime via
 // SetMicroVMID from the /run request.
 func NewHeartbeat(interval time.Duration, emitter MetricEmitter, source metrics.MetricSource, baseTags []string) *Heartbeat {
 	if interval <= 0 {
@@ -220,13 +220,13 @@ func (h *Heartbeat) emit() {
 }
 
 // tagsForEmit returns a fresh tag slice combining the immutable base tags
-// (set at construction) with the current microvm_id (set at /run).
+// (set at construction) with the current lambda_microvm_id (set at /run).
 func (h *Heartbeat) tagsForEmit() []string {
 	h.mu.Lock()
 	id := h.microVMID
 	h.mu.Unlock()
 	tags := make([]string, 0, len(h.baseTags)+1)
 	tags = append(tags, h.baseTags...)
-	tags = append(tags, "microvm_id:"+id)
+	tags = append(tags, lambdaMicroVMIDPrefix+id)
 	return tags
 }

--- a/cmd/serverless-init/lifecycle/heartbeat_test.go
+++ b/cmd/serverless-init/lifecycle/heartbeat_test.go
@@ -275,15 +275,15 @@ func TestHeartbeat_ResumeDuringStuckStopRestartsHeartbeat(t *testing.T) {
 	hb.Stop() // clean up the relaunched goroutine
 }
 
-// Until SetMicroVMID is called, the heartbeat tags microvm_id with the
-// placeholder "unknown". Production wiring sets the ID at /run before
+// Until SetMicroVMID is called, the heartbeat tags lambda_microvm_id with
+// the placeholder "unknown". Production wiring sets the ID at /run before
 // Start, so this state should never reach an emitted metric in practice;
 // the test pins the contract anyway in case wiring changes.
 func TestHeartbeat_TagsForEmit_DefaultsMicroVMIDToUnknown(t *testing.T) {
 	hb := NewHeartbeat(time.Hour, &mockMetricEmitter{}, metrics.MetricSourceAWSMicroVMEnhanced, []string{"microvm_image_arn:test-arn"})
 	tags := hb.tagsForEmit()
 	assert.Contains(t, tags, "microvm_image_arn:test-arn")
-	assert.Contains(t, tags, "microvm_id:unknown")
+	assert.Contains(t, tags, "lambda_microvm_id:unknown")
 }
 
 // When resourceName is empty the microvm_image_arn tag must be absent — an
@@ -301,7 +301,7 @@ func TestHeartbeat_SetMicroVMID_ReflectsOnEmittedTags(t *testing.T) {
 	hb.SetMicroVMID("mvm-abc123")
 	tags := hb.tagsForEmit()
 	assert.Contains(t, tags, "microvm_image_arn:test-arn")
-	assert.Contains(t, tags, "microvm_id:mvm-abc123")
+	assert.Contains(t, tags, "lambda_microvm_id:mvm-abc123")
 }
 
 // TestHeartbeat_EmittedMetric_CarriesARNTag verifies end-to-end that the
@@ -340,7 +340,7 @@ func TestHeartbeat_SetMicroVMID_EmptyIsIgnored(t *testing.T) {
 	hb.SetMicroVMID("first-id")
 	hb.SetMicroVMID("")
 	tags := hb.tagsForEmit()
-	assert.Contains(t, tags, "microvm_id:first-id", "empty ID must not clobber the existing value")
+	assert.Contains(t, tags, "lambda_microvm_id:first-id", "empty ID must not clobber the existing value")
 }
 
 func TestHeartbeat_SetMicroVMID_OnNilReceiverIsSafe(t *testing.T) {
@@ -371,7 +371,7 @@ func TestHeartbeat_SetMicroVMID_VisibleOnNextTick(t *testing.T) {
 	// The most recent emission must carry the updated ID.
 	last := emitter.lastTags()
 	require.NotNil(t, last)
-	assert.Contains(t, last, "microvm_id:mvm-after-start")
+	assert.Contains(t, last, "lambda_microvm_id:mvm-after-start")
 }
 
 // TestHeartbeat_EmittedMetricsCarryCurrentTimestamp verifies that heartbeat

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -21,23 +21,27 @@
 //   - /suspend  — VM is about to be snapshotted/frozen.
 //   - /terminate — VM is being torn down permanently.
 //
-// This server handles those hooks in two modes:
+// Each hook is forwarded independently based on a pair of conditions:
 //
-//   - When DD_AWS_MICROVM_USER_APP_PORT is unset: the agent responds
-//     to each hook itself. /ready checks child-process liveness; /validate
-//     returns 200 directly; /run, /resume, /suspend, and /terminate emit
-//     an enhanced metric and, for /suspend and /terminate, flush telemetry
-//     before responding.
+//   - DD_AWS_MICROVM_USER_APP_PORT must be set (a Forwarder is configured).
+//   - That hook's own DD_AWS_MICROVM_ENABLE_{READY,VALIDATE,RUN,RESUME,
+//     SUSPEND,TERMINATE} toggle must be true (defaults to false).
 //
-//   - When the env var is set: the agent forwards each hook to
-//     127.0.0.1:<user-app-port> on the same path and mirrors the user app's
-//     response (status, body, Content-Type) back to the platform. /ready and
-//     /validate check TCP reachability with a single fast dial before
-//     forwarding, answering 503 immediately if the app isn't up yet rather
-//     than blocking — the platform owns the retry loop for those two hooks.
-//     For /run, /resume, /suspend, and /terminate the agent's own work —
-//     metric emission, /suspend and /terminate telemetry flush — runs in a
-//     goroutine in parallel with the pass-through.
+// When both are true for a given hook, the agent forwards it to
+// 127.0.0.1:<user-app-port> on the same path and mirrors the user app's
+// response (status, body, Content-Type) back to the platform. /ready and
+// /validate check TCP reachability with a single fast dial before
+// forwarding, answering 503 immediately if the app isn't up yet rather than
+// blocking — the platform owns the retry loop for those two hooks. For
+// /run, /resume, /suspend, and /terminate the agent's own work — metric
+// emission, /suspend and /terminate telemetry flush — runs in a goroutine in
+// parallel with the pass-through.
+//
+// Otherwise (no Forwarder, or the hook's own toggle is false) the agent
+// responds to that hook itself: /ready checks child-process liveness;
+// /validate returns 200 directly; /run, /resume, /suspend, and /terminate
+// emit an enhanced metric and, for /suspend and /terminate, flush telemetry
+// before responding.
 //
 // /terminate does NOT synthesize SIGTERM. The platform owns process
 // termination via OS signals delivered independently of this HTTP event.
@@ -169,10 +173,11 @@ type Server struct {
 	metricSource  metrics.MetricSource
 	flushTimeout  time.Duration
 
-	childHandle ChildHandle // production: *Child (init) or NewNoopChildHandle() (sidecar); always non-nil after lifecycle.SetupFromEnv. nil only in legacy unit tests; logs WARN if hit.
-	child       *Child      // non-nil only in init-container mode; nil in sidecar and unit tests. Derived from childHandle when it is a *Child.
-	fwd         *Forwarder  // nil = no opt-in; today's behavior preserved
-	heartbeat   *Heartbeat  // nil-safe; nil disables periodic heartbeat emission
+	childHandle  ChildHandle // production: *Child (init) or NewNoopChildHandle() (sidecar); always non-nil after lifecycle.SetupFromEnv. nil only in legacy unit tests; logs WARN if hit.
+	child        *Child      // non-nil only in init-container mode; nil in sidecar and unit tests. Derived from childHandle when it is a *Child.
+	fwd          *Forwarder  // nil = no forwarder configured; forwarding also requires the hook's own enabledHooks.* toggle
+	enabledHooks HookToggles // per-hook forwarding opt-in; only meaningful when fwd != nil
+	heartbeat    *Heartbeat  // nil-safe; nil disables periodic heartbeat emission
 
 	logsTagSetter  LogsTagSetter     // nil-safe; set via SetLogsTagSetter after construction
 	baseLogTags    []string          // startup log tag snapshot; lambda_microvm_id is appended at /run
@@ -214,6 +219,7 @@ func NewServer(
 	flushTimeout time.Duration,
 	childHandle ChildHandle, // may be nil
 	fwd *Forwarder, // may be nil
+	enabledHooks HookToggles, // only meaningful when fwd != nil
 	heartbeat *Heartbeat, // may be nil
 ) *Server {
 	s := &Server{
@@ -226,6 +232,7 @@ func NewServer(
 		flushTimeout:  flushTimeout,
 		childHandle:   childHandle,
 		fwd:           fwd,
+		enabledHooks:  enabledHooks,
 		instanceID:    atomic.NewString(""),
 		heartbeat:     heartbeat,
 	}
@@ -348,9 +355,9 @@ func (s *Server) handler() http.Handler {
 // causes a retry (the platform does not treat /ready failures as fatal).
 //
 // Dispatcher:
-//   - If a Forwarder is configured (env-var opt-in), pass-through to the user
-//     app with a fast reachability check: dial errors and deadline exceeded
-//     both map to 503.
+//   - If a Forwarder is configured AND the /ready hook is enabled
+//     (DD_AWS_MICROVM_ENABLE_READY), pass-through to the user app with a fast
+//     reachability check: dial errors and deadline exceeded both map to 503.
 //   - Otherwise, alive-check via ChildHandle: child alive → 200, anything
 //     else (not yet started, already exited, or nil handle) → 503. The
 //     pre-spawn race is absorbed by the platform's /ready retry behavior;
@@ -358,7 +365,7 @@ func (s *Server) handler() http.Handler {
 //     call site in mode.RunInit, where the actual error value is available.
 func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: ready")
-	if s.fwd != nil {
+	if s.fwd != nil && s.enabledHooks.Ready {
 		s.passThroughReady(w, r)
 		return
 	}
@@ -377,13 +384,13 @@ func (s *Server) passThroughReady(w http.ResponseWriter, r *http.Request) {
 // retry until validateTimeout. It is NOT sent during the normal run/resume
 // lifecycle of a production MicroVM.
 //
-// When a Forwarder is configured (DD_AWS_MICROVM_USER_APP_PORT set):
-// pass-through to the user app with a fast reachability check, mirroring the
-// response, so the user app's own smoke test drives the build's validity
-// decision. A 503 while the app isn't yet reachable on the test run relies on
-// the platform's own /validate retry to absorb the window. Without a
-// forwarder the agent returns 200 directly; the user app is not required to
-// implement /validate in that mode.
+// When a Forwarder is configured (DD_AWS_MICROVM_USER_APP_PORT set) AND the
+// /validate hook is enabled (DD_AWS_MICROVM_ENABLE_VALIDATE): pass-through to
+// the user app with a fast reachability check, mirroring the response, so the
+// user app's own smoke test drives the build's validity decision. A 503
+// while the app isn't yet reachable on the test run relies on the platform's
+// own /validate retry to absorb the window. Otherwise the agent returns 200
+// directly; the user app is not required to implement /validate in that mode.
 func (s *Server) handleValidate(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: validate")
 	// TODO(microvm-validate-metric): /validate is a build-time hook that only
@@ -393,7 +400,7 @@ func (s *Server) handleValidate(w http.ResponseWriter, r *http.Request) {
 	// may not reliably flush before the test VM is torn down. Revisit whether it
 	// carries enough value to keep alongside the genuine runtime lifecycle metrics.
 	s.emitLifecycleMetric(validateMetricName)
-	if s.fwd != nil {
+	if s.fwd != nil && s.enabledHooks.Validate {
 		s.passThroughValidate(w, r)
 		return
 	}
@@ -612,15 +619,16 @@ func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {
 	// forwarded /run request carries a fixed Content-Length rather than
 	// chunked encoding (which some user-app HTTP servers reject).
 	r.Header.Set("Content-Length", strconv.Itoa(len(bodyBytes)))
-	s.dispatchHook(runMetricName, pathRun, noFlush, w, r)
+	s.dispatchHook(runMetricName, pathRun, noFlush, s.enabledHooks.Run, w, r)
 }
 
 // handleResume emits the resume metric, restarts the heartbeat (stopped at
-// /suspend), and (when a forwarder is configured) mirrors the user app's response.
+// /suspend), and (when a forwarder is configured and enabled) mirrors the
+// user app's response.
 func (s *Server) handleResume(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: resume")
 	s.heartbeat.Start()
-	s.dispatchHook(resumeMetricName, pathResume, noFlush, w, r)
+	s.dispatchHook(resumeMetricName, pathResume, noFlush, s.enabledHooks.Resume, w, r)
 }
 
 // handleSuspend stops the heartbeat, flushes telemetry, and (when a forwarder
@@ -658,7 +666,7 @@ func (s *Server) handleResume(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleSuspend(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: suspend — flushing telemetry")
 	s.heartbeat.Stop()
-	s.dispatchHook(suspendMetricName, pathSuspend, flushParallel, w, r)
+	s.dispatchHook(suspendMetricName, pathSuspend, flushParallel, s.enabledHooks.Suspend, w, r)
 }
 
 // handleTerminate flushes all telemetry and, when a forwarder is configured,
@@ -675,17 +683,18 @@ func (s *Server) handleSuspend(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleTerminate(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: terminate — flushing telemetry")
 	s.heartbeat.Stop()
-	s.dispatchHook(terminateMetricName, pathTerminate, flushSequential, w, r)
+	s.dispatchHook(terminateMetricName, pathTerminate, flushSequential, s.enabledHooks.Terminate, w, r)
 }
 
 // dispatchHook is the shared dispatch path for run, resume, suspend, and
 // terminate. When a forwarder is configured (DD_AWS_MICROVM_USER_APP_PORT
-// set): delegates to handleWithForwarder which mirrors the user app's response.
-// When no forwarder is configured: emit metric, optionally flush, return 200.
-// In standalone mode the parallel/sequential distinction does not apply, so
-// both flush modes result in a single flushAll call.
-func (s *Server) dispatchHook(metricName, path string, mode flushMode, w http.ResponseWriter, r *http.Request) {
-	if s.fwd != nil {
+// set) AND enabled is true (the hook's own DD_AWS_MICROVM_ENABLE_* toggle):
+// delegates to handleWithForwarder which mirrors the user app's response.
+// Otherwise: emit metric, optionally flush, return 200. In standalone mode
+// the parallel/sequential distinction does not apply, so both flush modes
+// result in a single flushAll call.
+func (s *Server) dispatchHook(metricName, path string, mode flushMode, enabled bool, w http.ResponseWriter, r *http.Request) {
+	if s.fwd != nil && enabled {
 		s.handleWithForwarder(metricName, path, mode, w, r)
 		return
 	}

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -120,6 +120,15 @@ type Flusher interface {
 	Flush()
 }
 
+// ForceFlusher is optionally satisfied by metricFlusher (ServerlessMetricAgent
+// does; the trace flusher doesn't). flushAll calls it only for /terminate,
+// never /suspend: /suspend can resume, and forcing the open bucket there would
+// let a later flush send a second, partial point for that bucket — overwriting
+// the pre-suspend data in the backend instead of merging with it.
+type ForceFlusher interface {
+	FlushAll()
+}
+
 // LogsFlusher is satisfied by logsAgent.ServerlessLogsAgent.
 type LogsFlusher interface {
 	Flush(ctx context.Context)
@@ -478,7 +487,8 @@ func mirrorResponse(w http.ResponseWriter, resp *http.Response) {
 // and by handleSuspend / handleTerminate for the env-var-unset path.
 // It first drains any pending metric samples so that lifecycle metrics
 // emitted immediately before this call are included in the flush.
-func (s *Server) flushAll(flushCtx context.Context) {
+// forceFlushAll is true only for /terminate (see ForceFlusher).
+func (s *Server) flushAll(flushCtx context.Context, forceFlushAll bool) {
 	if s.sampleDrainer != nil {
 		drained := make(chan struct{})
 		go func() {
@@ -492,7 +502,13 @@ func (s *Server) flushAll(flushCtx context.Context) {
 		}
 	}
 	var wg sync.WaitGroup
-	wg.Go(s.metricFlusher.Flush)
+	wg.Go(func() {
+		if ff, ok := s.metricFlusher.(ForceFlusher); ok && forceFlushAll {
+			ff.FlushAll()
+		} else {
+			s.metricFlusher.Flush()
+		}
+	})
 	wg.Go(s.traceFlusher.Flush)
 	wg.Go(func() {
 		if s.logsFlusher != nil {
@@ -558,7 +574,7 @@ func (s *Server) handleWithForwarder(metricName, path string, mode flushMode, w 
 		defer close(sideDone)
 		s.emitLifecycleMetric(metricName)
 		if mode == flushParallel {
-			s.flushAll(parallelCtx)
+			s.flushAll(parallelCtx, false)
 		}
 	}()
 
@@ -586,7 +602,7 @@ func (s *Server) handleWithForwarder(metricName, path string, mode flushMode, w 
 	if mode == flushSequential {
 		seqCtx, cancel := context.WithTimeout(context.Background(), s.flushTimeout)
 		defer cancel()
-		s.flushAll(seqCtx)
+		s.flushAll(seqCtx, true)
 	}
 
 	mirrorResponse(w, resp)
@@ -617,7 +633,7 @@ func (s *Server) aliveCheckReady(w http.ResponseWriter) {
 // (when a forwarder is configured) mirrors the user app's response.
 // handleRun is the only hook that reads r.Body and is therefore not
 // collapsed into dispatchHook directly. The ID is captured before Start
-// so the first heartbeat emission already carries the correct microvm_id tag.
+// so the first heartbeat emission already carries the correct lambda_microvm_id tag.
 func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {
 	// Read the body once so we can parse the instance ID AND still forward the
 	// original payload to the user app. Without this, the forwarder path would
@@ -749,7 +765,7 @@ func (s *Server) dispatchHook(metricName, path string, mode flushMode, forwardEn
 	if mode != noFlush {
 		flushCtx, cancel := context.WithTimeout(context.Background(), s.flushTimeout)
 		defer cancel()
-		s.flushAll(flushCtx)
+		s.flushAll(flushCtx, mode == flushSequential)
 	}
 	w.WriteHeader(http.StatusOK)
 }

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -21,23 +21,27 @@
 //   - /suspend  — VM is about to be snapshotted/frozen.
 //   - /terminate — VM is being torn down permanently.
 //
-// This server handles those hooks in two modes:
+// Each hook is forwarded independently based on a pair of conditions:
 //
-//   - When DD_AWS_MICROVM_USER_APP_PORT is unset: the agent responds
-//     to each hook itself. /ready checks child-process liveness; /validate
-//     returns 200 directly; /run, /resume, /suspend, and /terminate emit
-//     an enhanced metric and, for /suspend and /terminate, flush telemetry
-//     before responding.
+//   - DD_AWS_MICROVM_USER_APP_PORT must be set (a Forwarder is configured).
+//   - That hook's own DD_AWS_MICROVM_ENABLE_{READY,VALIDATE,RUN,RESUME,
+//     SUSPEND,TERMINATE} toggle must be true (defaults to false).
 //
-//   - When the env var is set: the agent forwards each hook to
-//     127.0.0.1:<user-app-port> on the same path and mirrors the user app's
-//     response (status, body, Content-Type) back to the platform. /ready and
-//     /validate check TCP reachability with a single fast dial before
-//     forwarding, answering 503 immediately if the app isn't up yet rather
-//     than blocking — the platform owns the retry loop for those two hooks.
-//     For /run, /resume, /suspend, and /terminate the agent's own work —
-//     metric emission, /suspend and /terminate telemetry flush — runs in a
-//     goroutine in parallel with the pass-through.
+// When both are true for a given hook, the agent forwards it to
+// 127.0.0.1:<user-app-port> on the same path and mirrors the user app's
+// response (status, body, Content-Type) back to the platform. /ready and
+// /validate check TCP reachability with a single fast dial before
+// forwarding, answering 503 immediately if the app isn't up yet rather than
+// blocking — the platform owns the retry loop for those two hooks. For
+// /run, /resume, /suspend, and /terminate the agent's own work — metric
+// emission, /suspend and /terminate telemetry flush — runs in a goroutine in
+// parallel with the pass-through.
+//
+// Otherwise (no Forwarder, or the hook's own toggle is false) the agent
+// responds to that hook itself: /ready checks child-process liveness;
+// /validate returns 200 directly; /run, /resume, /suspend, and /terminate
+// emit an enhanced metric and, for /suspend and /terminate, flush telemetry
+// before responding.
 //
 // /terminate does NOT synthesize SIGTERM. The platform owns process
 // termination via OS signals delivered independently of this HTTP event.
@@ -169,10 +173,11 @@ type Server struct {
 	metricSource  metrics.MetricSource
 	flushTimeout  time.Duration
 
-	childHandle ChildHandle // production: *Child (init) or NewNoopChildHandle() (sidecar); always non-nil after lifecycle.SetupFromEnv. nil only in legacy unit tests; logs WARN if hit.
-	child       *Child      // non-nil only in init-container mode; nil in sidecar and unit tests. Derived from childHandle when it is a *Child.
-	fwd         *Forwarder  // nil = no opt-in; today's behavior preserved
-	heartbeat   *Heartbeat  // nil-safe; nil disables periodic heartbeat emission
+	childHandle  ChildHandle // production: *Child (init) or NewNoopChildHandle() (sidecar); always non-nil after lifecycle.SetupFromEnv. nil only in legacy unit tests; logs WARN if hit.
+	child        *Child      // non-nil only in init-container mode; nil in sidecar and unit tests. Derived from childHandle when it is a *Child.
+	fwd          *Forwarder  // nil = no forwarder configured; forwarding also requires the hook's own enabledHooks.* toggle
+	enabledHooks HookToggles // per-hook forwarding opt-in; only meaningful when fwd != nil
+	heartbeat    *Heartbeat  // nil-safe; nil disables periodic heartbeat emission
 
 	logsTagSetter  LogsTagSetter     // nil-safe; set via SetLogsTagSetter after construction
 	baseLogTags    []string          // startup log tag snapshot; lambda_microvm_id is appended at /run
@@ -215,6 +220,7 @@ func NewServer(
 	flushTimeout time.Duration,
 	childHandle ChildHandle, // may be nil
 	fwd *Forwarder, // may be nil
+	enabledHooks HookToggles, // only meaningful when fwd != nil
 	heartbeat *Heartbeat, // may be nil
 ) *Server {
 	s := &Server{
@@ -227,6 +233,7 @@ func NewServer(
 		flushTimeout:  flushTimeout,
 		childHandle:   childHandle,
 		fwd:           fwd,
+		enabledHooks:  enabledHooks,
 		instanceID:    atomic.NewString(""),
 		heartbeat:     heartbeat,
 	}
@@ -380,9 +387,9 @@ func (s *Server) handler() http.Handler {
 // causes a retry (the platform does not treat /ready failures as fatal).
 //
 // Dispatcher:
-//   - If a Forwarder is configured (env-var opt-in), pass-through to the user
-//     app with a fast reachability check: dial errors and deadline exceeded
-//     both map to 503.
+//   - If a Forwarder is configured AND the /ready hook is enabled
+//     (DD_AWS_MICROVM_ENABLE_READY), pass-through to the user app with a fast
+//     reachability check: dial errors and deadline exceeded both map to 503.
 //   - Otherwise, alive-check via ChildHandle: child alive → 200, anything
 //     else (not yet started, already exited, or nil handle) → 503. The
 //     pre-spawn race is absorbed by the platform's /ready retry behavior;
@@ -390,7 +397,7 @@ func (s *Server) handler() http.Handler {
 //     call site in mode.RunInit, where the actual error value is available.
 func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: ready")
-	if s.fwd != nil {
+	if s.fwd != nil && s.enabledHooks.Ready {
 		s.passThroughReady(w, r)
 		return
 	}
@@ -409,13 +416,13 @@ func (s *Server) passThroughReady(w http.ResponseWriter, r *http.Request) {
 // retry until validateTimeout. It is NOT sent during the normal run/resume
 // lifecycle of a production MicroVM.
 //
-// When a Forwarder is configured (DD_AWS_MICROVM_USER_APP_PORT set):
-// pass-through to the user app with a fast reachability check, mirroring the
-// response, so the user app's own smoke test drives the build's validity
-// decision. A 503 while the app isn't yet reachable on the test run relies on
-// the platform's own /validate retry to absorb the window. Without a
-// forwarder the agent returns 200 directly; the user app is not required to
-// implement /validate in that mode.
+// When a Forwarder is configured (DD_AWS_MICROVM_USER_APP_PORT set) AND the
+// /validate hook is enabled (DD_AWS_MICROVM_ENABLE_VALIDATE): pass-through to
+// the user app with a fast reachability check, mirroring the response, so the
+// user app's own smoke test drives the build's validity decision. A 503
+// while the app isn't yet reachable on the test run relies on the platform's
+// own /validate retry to absorb the window. Otherwise the agent returns 200
+// directly; the user app is not required to implement /validate in that mode.
 func (s *Server) handleValidate(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: validate")
 	// TODO(microvm-validate-metric): /validate is a build-time hook that only
@@ -425,7 +432,7 @@ func (s *Server) handleValidate(w http.ResponseWriter, r *http.Request) {
 	// may not reliably flush before the test VM is torn down. Revisit whether it
 	// carries enough value to keep alongside the genuine runtime lifecycle metrics.
 	s.emitLifecycleMetric(validateMetricName)
-	if s.fwd != nil {
+	if s.fwd != nil && s.enabledHooks.Validate {
 		s.passThroughValidate(w, r)
 		return
 	}
@@ -659,15 +666,16 @@ func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {
 	// forwarded /run request carries a fixed Content-Length rather than
 	// chunked encoding (which some user-app HTTP servers reject).
 	r.Header.Set("Content-Length", strconv.Itoa(len(bodyBytes)))
-	s.dispatchHook(runMetricName, pathRun, noFlush, w, r)
+	s.dispatchHook(runMetricName, pathRun, noFlush, s.enabledHooks.Run, w, r)
 }
 
 // handleResume emits the resume metric, restarts the heartbeat (stopped at
-// /suspend), and (when a forwarder is configured) mirrors the user app's response.
+// /suspend), and (when a forwarder is configured and enabled) mirrors the
+// user app's response.
 func (s *Server) handleResume(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: resume")
 	s.heartbeat.Start()
-	s.dispatchHook(resumeMetricName, pathResume, noFlush, w, r)
+	s.dispatchHook(resumeMetricName, pathResume, noFlush, s.enabledHooks.Resume, w, r)
 }
 
 // handleSuspend stops the heartbeat, flushes telemetry, and (when a forwarder
@@ -705,7 +713,7 @@ func (s *Server) handleResume(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleSuspend(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: suspend — flushing telemetry")
 	s.heartbeat.Stop()
-	s.dispatchHook(suspendMetricName, pathSuspend, flushParallel, w, r)
+	s.dispatchHook(suspendMetricName, pathSuspend, flushParallel, s.enabledHooks.Suspend, w, r)
 }
 
 // handleTerminate flushes all telemetry and, when a forwarder is configured,
@@ -722,17 +730,18 @@ func (s *Server) handleSuspend(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleTerminate(w http.ResponseWriter, r *http.Request) {
 	log.Info("MicroVM lifecycle: terminate — flushing telemetry")
 	s.heartbeat.Stop()
-	s.dispatchHook(terminateMetricName, pathTerminate, flushSequential, w, r)
+	s.dispatchHook(terminateMetricName, pathTerminate, flushSequential, s.enabledHooks.Terminate, w, r)
 }
 
 // dispatchHook is the shared dispatch path for run, resume, suspend, and
 // terminate. When a forwarder is configured (DD_AWS_MICROVM_USER_APP_PORT
-// set): delegates to handleWithForwarder which mirrors the user app's response.
-// When no forwarder is configured: emit metric, optionally flush, return 200.
-// In standalone mode the parallel/sequential distinction does not apply, so
+// set) AND forwardEnabled is true (the hook's own DD_AWS_MICROVM_ENABLE_*
+// toggle): delegates to handleWithForwarder which mirrors the user app's
+// response. Otherwise: emit metric, optionally flush, return 200. In
+// standalone mode the parallel/sequential distinction does not apply, so
 // both flush modes result in a single flushAll call.
-func (s *Server) dispatchHook(metricName, path string, mode flushMode, w http.ResponseWriter, r *http.Request) {
-	if s.fwd != nil {
+func (s *Server) dispatchHook(metricName, path string, mode flushMode, forwardEnabled bool, w http.ResponseWriter, r *http.Request) {
+	if s.fwd != nil && forwardEnabled {
 		s.handleWithForwarder(metricName, path, mode, w, r)
 		return
 	}

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -85,9 +85,9 @@ func newTestServer() (*Server, *mockFlusher, *mockFlusher, *mockLogsAgent, *mock
 	emitter := &mockMetricEmitter{}
 	drainer := &mockSampleDrainer{}
 	// port 0 — handler-level tests don't bind. Tests that need a childHandle,
-	// forwarder, or heartbeat assign srv.childHandle / srv.fwd / srv.heartbeat
-	// after construction.
-	srv := NewServer(0, metric, trace, logs, emitter, drainer, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, nil)
+	// forwarder, enabled hooks, or heartbeat assign srv.childHandle / srv.fwd /
+	// srv.enabledHooks / srv.heartbeat after construction.
+	srv := NewServer(0, metric, trace, logs, emitter, drainer, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, HookToggles{}, nil)
 	return srv, metric, trace, logs, emitter, drainer
 }
 
@@ -200,6 +200,7 @@ func TestHandleRunWithForwarderParsesInstanceID(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 
 	body := strings.NewReader(`{"microvmId":"vm-fwd123"}`)
 	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
@@ -247,6 +248,7 @@ func TestHandleRunWithForwarderBodyReadErrorDoesNotForward(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 
 	req := httptest.NewRequest(http.MethodPost, pathRun, serverErrReader{})
 	rec := httptest.NewRecorder()
@@ -356,6 +358,7 @@ func TestEmittedMetricsCarryCurrentTimestamp_ForwarderPath(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 
 	before := float64(time.Now().UnixNano()) / float64(time.Second)
 	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, nil))
@@ -442,6 +445,7 @@ func TestHandleReady_WithForwarder_PassesThrough(t *testing.T) {
 		readyTimeout:         200 * time.Millisecond,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Ready = true
 	rec := httptest.NewRecorder()
 	srv.handleReady(rec, httptest.NewRequest(http.MethodPost, pathReady, nil))
 	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
@@ -451,6 +455,38 @@ func TestHandleReady_WithForwarder_PassesThrough(t *testing.T) {
 	// hide that.
 	assert.Equal(t, "application/x-ready", rec.Header().Get("Content-Type"))
 	assert.Equal(t, `{"ready":false,"reason":"warming"}`, rec.Body.String())
+}
+
+// TestHandleReady_WithForwarderButHookDisabled_UsesBuiltInAliveCheck verifies
+// that a configured Forwarder alone is not enough to forward /ready — the
+// hook's own enabledHooks.Ready toggle (default false) must also be set.
+// With the toggle left false, /ready must use the built-in alive-check
+// instead of contacting the upstream user app.
+func TestHandleReady_WithForwarderButHookDisabled_UsesBuiltInAliveCheck(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		readyTimeout:         200 * time.Millisecond,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Ready left false (the default).
+	h := newFakeChildHandle()
+	h.alive.Store(true)
+	srv.childHandle = h
+
+	rec := httptest.NewRecorder()
+	srv.handleReady(rec, httptest.NewRequest(http.MethodPost, pathReady, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must use the built-in alive-check result")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /ready toggle is disabled")
 }
 
 // /validate shares passThroughReady's PassThroughWaiting code path (same
@@ -472,11 +508,40 @@ func TestHandleValidate_WithForwarder_PassesThrough(t *testing.T) {
 		validateTimeout:      200 * time.Millisecond,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Validate = true
 	rec := httptest.NewRecorder()
 	srv.handleValidate(rec, httptest.NewRequest(http.MethodPost, pathValidate, nil))
 	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
 	assert.Equal(t, "application/x-validate", rec.Header().Get("Content-Type"))
 	assert.Equal(t, `{"valid":false,"reason":"warming"}`, rec.Body.String())
+}
+
+// TestHandleValidate_WithForwarderButHookDisabled_ReturnsBuiltIn200 mirrors
+// TestHandleReady_WithForwarderButHookDisabled_UsesBuiltInAliveCheck for
+// /validate: a configured Forwarder alone does not forward /validate without
+// enabledHooks.Validate also being true.
+func TestHandleValidate_WithForwarderButHookDisabled_ReturnsBuiltIn200(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		validateTimeout:      200 * time.Millisecond,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Validate left false (the default).
+
+	rec := httptest.NewRecorder()
+	srv.handleValidate(rec, httptest.NewRequest(http.MethodPost, pathValidate, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must return the built-in 200, not the upstream's 503")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /validate toggle is disabled")
 }
 
 // /run with a forwarder configured mirrors the user-app's status code,
@@ -497,6 +562,7 @@ func TestHandleRun_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 
 	rec := httptest.NewRecorder()
 	srv.handleRun(rec, httptest.NewRequest(http.MethodPost, pathRun, nil))
@@ -509,6 +575,36 @@ func TestHandleRun_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 	assert.Equal(t, int32(0), metric.count.Load(), "run must not flush")
 	assert.Equal(t, int32(0), trace.count.Load())
 	assert.Equal(t, int32(0), logs.count.Load())
+}
+
+// TestHandleRun_WithForwarderButHookDisabled_DoesNotForward verifies dispatchHook's
+// enabled gate for the run/resume/suspend/terminate group: a configured
+// Forwarder alone is not enough to forward /run — enabledHooks.Run (default
+// false) must also be true. With it left false, /run must take the built-in
+// metric-only path and never contact the upstream user app.
+func TestHandleRun_WithForwarderButHookDisabled_DoesNotForward(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Run left false (the default).
+
+	rec := httptest.NewRecorder()
+	srv.handleRun(rec, httptest.NewRequest(http.MethodPost, pathRun, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must return the built-in 200")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /run toggle is disabled")
+	assert.Contains(t, emitter.getEmitted(), runMetricName, "the run metric must still be emitted")
 }
 
 // /resume with a forwarder configured mirrors the user-app's response and
@@ -526,6 +622,7 @@ func TestHandleResume_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Resume = true
 
 	rec := httptest.NewRecorder()
 	srv.handleResume(rec, httptest.NewRequest(http.MethodPost, pathResume, nil))
@@ -535,6 +632,38 @@ func TestHandleResume_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 	assert.Equal(t, int32(0), metric.count.Load(), "resume must not flush")
 	assert.Equal(t, int32(0), trace.count.Load())
 	assert.Equal(t, int32(0), logs.count.Load())
+}
+
+// TestHandleResume_WithForwarderButHookDisabled_DoesNotForward mirrors
+// TestHandleRun_WithForwarderButHookDisabled_DoesNotForward for /resume: a
+// configured Forwarder alone does not forward /resume without
+// enabledHooks.Resume also being true. Also guards against a hardcoded
+// enabled=true regression in handleResume's dispatchHook call, which the
+// WithForwarder_MirrorsUserAppResponse test above would not catch since it
+// sets the toggle true anyway.
+func TestHandleResume_WithForwarderButHookDisabled_DoesNotForward(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Resume left false (the default).
+
+	rec := httptest.NewRecorder()
+	srv.handleResume(rec, httptest.NewRequest(http.MethodPost, pathResume, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must return the built-in 200")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /resume toggle is disabled")
+	assert.Contains(t, emitter.getEmitted(), resumeMetricName, "the resume metric must still be emitted")
 }
 
 // /terminate with a forwarder configured mirrors the user-app's response,
@@ -553,6 +682,7 @@ func TestHandleTerminate_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Terminate = true
 
 	rec := httptest.NewRecorder()
 	srv.handleTerminate(rec, httptest.NewRequest(http.MethodPost, pathTerminate, nil))
@@ -560,6 +690,39 @@ func TestHandleTerminate_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 	assert.Equal(t, 503, rec.Code, "must mirror user-app status, not hardcoded 200")
 	assert.Contains(t, emitter.getEmitted(), terminateMetricName)
 	assert.Equal(t, int32(1), metric.count.Load(), "terminate must flush")
+	assert.Equal(t, int32(1), trace.count.Load())
+	assert.Equal(t, int32(1), logs.count.Load())
+}
+
+// TestHandleTerminate_WithForwarderButHookDisabled_DoesNotForward mirrors
+// TestHandleRun_WithForwarderButHookDisabled_DoesNotForward for /terminate: a
+// configured Forwarder alone does not forward /terminate without
+// enabledHooks.Terminate also being true. The built-in path still flushes
+// telemetry — only the pass-through to the user app is skipped.
+func TestHandleTerminate_WithForwarderButHookDisabled_DoesNotForward(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, metric, trace, logs, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Terminate left false (the default).
+
+	rec := httptest.NewRecorder()
+	srv.handleTerminate(rec, httptest.NewRequest(http.MethodPost, pathTerminate, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must return the built-in 200")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /terminate toggle is disabled")
+	assert.Contains(t, emitter.getEmitted(), terminateMetricName, "the terminate metric must still be emitted")
+	assert.Equal(t, int32(1), metric.count.Load(), "the built-in path must still flush")
 	assert.Equal(t, int32(1), trace.count.Load())
 	assert.Equal(t, int32(1), logs.count.Load())
 }
@@ -583,6 +746,7 @@ func TestHandleSuspend_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Suspend = true
 
 	rec := httptest.NewRecorder()
 	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
@@ -596,6 +760,39 @@ func TestHandleSuspend_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 	assert.Equal(t, int32(1), trace.count.Load(), "trace flush must still run")
 	assert.Equal(t, int32(1), logs.count.Load(), "logs flush must still run")
 	assert.Contains(t, emitter.getEmitted(), suspendMetricName, "metric must still be emitted")
+}
+
+// TestHandleSuspend_WithForwarderButHookDisabled_DoesNotForward mirrors
+// TestHandleRun_WithForwarderButHookDisabled_DoesNotForward for /suspend: a
+// configured Forwarder alone does not forward /suspend without
+// enabledHooks.Suspend also being true. The built-in path still flushes
+// telemetry — only the pass-through to the user app is skipped.
+func TestHandleSuspend_WithForwarderButHookDisabled_DoesNotForward(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, metric, trace, logs, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Suspend left false (the default).
+
+	rec := httptest.NewRecorder()
+	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must return the built-in 200")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /suspend toggle is disabled")
+	assert.Contains(t, emitter.getEmitted(), suspendMetricName, "the suspend metric must still be emitted")
+	assert.Equal(t, int32(1), metric.count.Load(), "the built-in path must still flush")
+	assert.Equal(t, int32(1), trace.count.Load())
+	assert.Equal(t, int32(1), logs.count.Load())
 }
 
 // Parallelism pin: the upstream handler blocks until all three flush mocks
@@ -634,6 +831,7 @@ func TestHandleSuspend_WithForwarder_FlushCompletesBeforeForwardReturns(t *testi
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Suspend = true
 
 	rec := httptest.NewRecorder()
 	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
@@ -656,6 +854,7 @@ func TestHandleSuspend_WithForwarder_DialErrorStillRunsFlush(t *testing.T) {
 		forwardTimeout:       200 * time.Millisecond,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Suspend = true
 
 	rec := httptest.NewRecorder()
 	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
@@ -678,6 +877,7 @@ func TestHandleSuspend_WithForwarder_WaitsForForwardBeforeResponse(t *testing.T)
 
 	srv, metric, trace, logs, _, _ := newTestServer()
 	srv.fwd = &Forwarder{target: upstream.URL, client: &http.Client{}, forwardTimeout: 5 * time.Second}
+	srv.enabledHooks.Suspend = true
 
 	handlerReturned := make(chan struct{})
 	rec := httptest.NewRecorder()
@@ -759,6 +959,7 @@ func TestHandleSuspend_WithForwarder_FlushTimeout_ReturnsPromptly(t *testing.T) 
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Suspend = true
 
 	start := time.Now()
 	rec := httptest.NewRecorder()
@@ -807,6 +1008,7 @@ func TestHandleSuspend_WithForwarder_BodyBufferedBeforeFlush(t *testing.T) {
 		forwardTimeout:       100 * time.Millisecond,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Suspend = true
 
 	rec := httptest.NewRecorder()
 	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
@@ -833,6 +1035,7 @@ func TestHandleTerminate_WithForwarder_FlushTimeout_ReturnsPromptly(t *testing.T
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Terminate = true
 
 	start := time.Now()
 	rec := httptest.NewRecorder()
@@ -875,6 +1078,7 @@ func TestHandleTerminate_WithForwarder_BodyBufferedBeforeFlush(t *testing.T) {
 		forwardTimeout:       100 * time.Millisecond,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Terminate = true
 
 	rec := httptest.NewRecorder()
 	srv.handleTerminate(rec, httptest.NewRequest(http.MethodPost, pathTerminate, nil))
@@ -905,6 +1109,7 @@ func TestHandleTerminate_WithForwarder_WaitsForSlowForward(t *testing.T) {
 		forwardTimeout:       5 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Terminate = true
 
 	handlerReturned := make(chan struct{})
 	rec := httptest.NewRecorder()
@@ -992,7 +1197,7 @@ func TestServeAndStopGracefulShutdown(t *testing.T) {
 // TestNewServerWithForwarderWriteTimeoutCoversForwardBudget below.
 func TestNewServerConfiguresHTTPTimeouts(t *testing.T) {
 	flushTimeout := 5 * time.Second
-	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, nil, nil)
+	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, nil, HookToggles{}, nil)
 	assert.Equal(t, 30*time.Second, srv.httpServer.ReadTimeout)
 	assert.Equal(t, flushTimeout+writeTimeoutHeadroom, srv.httpServer.WriteTimeout)
 }
@@ -1009,7 +1214,7 @@ func TestNewServerWithForwarderWriteTimeoutCoversForwardBudget(t *testing.T) {
 		client:               &http.Client{},
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
-	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, fwd, nil)
+	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, fwd, HookToggles{}, nil)
 	assert.Equal(t, fwd.forwardTimeout+flushTimeout+writeTimeoutHeadroom, srv.httpServer.WriteTimeout,
 		"WriteTimeout must cover forwardTimeout+flushTimeout (terminate sequential-flush path)")
 }
@@ -1027,7 +1232,7 @@ func TestNewServerWithForwarderWriteTimeoutCoversReadinessBudgets(t *testing.T) 
 		client:               &http.Client{},
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
-	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, fwd, nil)
+	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, fwd, HookToggles{}, nil)
 	assert.Equal(t, dialCheckTimeout+fwd.validateTimeout+writeTimeoutHeadroom, srv.httpServer.WriteTimeout,
 		"WriteTimeout must cover dialCheckTimeout+validateTimeout for /validate")
 }
@@ -1117,7 +1322,7 @@ func TestMirrorResponse_BodyReadError_DoesNotPanic(t *testing.T) {
 func TestDispatchHook_NoForwarder_WithFlushFalse_EmitsMetricReturns200NoFlush(t *testing.T) {
 	srv, metric, trace, logs, emitter, drainer := newTestServer()
 	rec := httptest.NewRecorder()
-	srv.dispatchHook("test.metric", "/test", noFlush, rec, httptest.NewRequest(http.MethodPost, "/test", nil))
+	srv.dispatchHook("test.metric", "/test", noFlush, false, rec, httptest.NewRequest(http.MethodPost, "/test", nil))
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, emitter.getEmitted(), "test.metric")
 	assert.Equal(t, int32(0), metric.count.Load(), "noFlush must not flush")
@@ -1131,7 +1336,7 @@ func TestDispatchHook_NoForwarder_WithFlushFalse_EmitsMetricReturns200NoFlush(t 
 func TestDispatchHook_NoForwarder_WithFlushTrue_EmitsMetricAndFlushes(t *testing.T) {
 	srv, metric, trace, logs, emitter, drainer := newTestServer()
 	rec := httptest.NewRecorder()
-	srv.dispatchHook("test.metric", "/test", flushParallel, rec, httptest.NewRequest(http.MethodPost, "/test", nil))
+	srv.dispatchHook("test.metric", "/test", flushParallel, false, rec, httptest.NewRequest(http.MethodPost, "/test", nil))
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, emitter.getEmitted(), "test.metric")
 	assert.Equal(t, int32(1), metric.count.Load(), "flushParallel must flush metric agent")
@@ -1159,7 +1364,7 @@ func TestDispatchHook_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	srv.dispatchHook("test.metric", pathResume, noFlush, rec, httptest.NewRequest(http.MethodPost, pathResume, nil))
+	srv.dispatchHook("test.metric", pathResume, noFlush, true, rec, httptest.NewRequest(http.MethodPost, pathResume, nil))
 	assert.Equal(t, 418, rec.Code, "must mirror user-app status, not hardcoded 200")
 	assert.Contains(t, emitter.getEmitted(), "test.metric")
 }
@@ -1169,7 +1374,7 @@ func TestDispatchHook_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 // lifecycle server stalling — and blocking the MicroVM platform's suspend/terminate
 // handshake — when the metric aggregator worker is deadlocked or slow.
 func TestFlushAllDrainTimeoutDoesNotBlock(t *testing.T) {
-	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &neverDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 50*time.Millisecond, nil, nil, nil)
+	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &neverDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 50*time.Millisecond, nil, nil, HookToggles{}, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), srv.flushTimeout)
 	defer cancel()
@@ -1193,7 +1398,7 @@ func TestFlushAllNilLogsFlusherDoesNotPanic(t *testing.T) {
 	metric := &mockFlusher{}
 	trace := &mockFlusher{}
 	drainer := &mockSampleDrainer{}
-	srv := NewServer(0, metric, trace, nil, &mockMetricEmitter{}, drainer, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, nil)
+	srv := NewServer(0, metric, trace, nil, &mockMetricEmitter{}, drainer, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, HookToggles{}, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), srv.flushTimeout)
 	defer cancel()
@@ -1499,6 +1704,7 @@ func TestHandleRun_WithForwarder_UpdatesLogTags(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 	setter := &mockLogsTagSetter{}
 	srv.SetLogsTagSetter(setter, []string{"env:staging"})
 
@@ -1660,6 +1866,7 @@ func TestHandleRun_WithForwarder_UpdatesTraceTags(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 	setter := &mockTraceTagSetter{}
 	srv.SetTraceTagSetter(setter, map[string]string{"env": "staging"})
 

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -85,9 +85,9 @@ func newTestServer() (*Server, *mockFlusher, *mockFlusher, *mockLogsAgent, *mock
 	emitter := &mockMetricEmitter{}
 	drainer := &mockSampleDrainer{}
 	// port 0 — handler-level tests don't bind. Tests that need a childHandle,
-	// forwarder, or heartbeat assign srv.childHandle / srv.fwd / srv.heartbeat
-	// after construction.
-	srv := NewServer(0, metric, trace, logs, emitter, drainer, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, nil)
+	// forwarder, enabled hooks, or heartbeat assign srv.childHandle / srv.fwd /
+	// srv.enabledHooks / srv.heartbeat after construction.
+	srv := NewServer(0, metric, trace, logs, emitter, drainer, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, HookToggles{}, nil)
 	return srv, metric, trace, logs, emitter, drainer
 }
 
@@ -200,6 +200,7 @@ func TestHandleRunWithForwarderParsesInstanceID(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 
 	body := strings.NewReader(`{"microvmId":"vm-fwd123"}`)
 	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
@@ -247,6 +248,7 @@ func TestHandleRunWithForwarderBodyReadErrorDoesNotForward(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 
 	req := httptest.NewRequest(http.MethodPost, pathRun, serverErrReader{})
 	rec := httptest.NewRecorder()
@@ -356,6 +358,7 @@ func TestEmittedMetricsCarryCurrentTimestamp_ForwarderPath(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 
 	before := float64(time.Now().UnixNano()) / float64(time.Second)
 	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, nil))
@@ -442,6 +445,7 @@ func TestHandleReady_WithForwarder_PassesThrough(t *testing.T) {
 		readyTimeout:         200 * time.Millisecond,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Ready = true
 	rec := httptest.NewRecorder()
 	srv.handleReady(rec, httptest.NewRequest(http.MethodPost, pathReady, nil))
 	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
@@ -451,6 +455,38 @@ func TestHandleReady_WithForwarder_PassesThrough(t *testing.T) {
 	// hide that.
 	assert.Equal(t, "application/x-ready", rec.Header().Get("Content-Type"))
 	assert.Equal(t, `{"ready":false,"reason":"warming"}`, rec.Body.String())
+}
+
+// TestHandleReady_WithForwarderButHookDisabled_UsesBuiltInAliveCheck verifies
+// that a configured Forwarder alone is not enough to forward /ready — the
+// hook's own enabledHooks.Ready toggle (default false) must also be set.
+// With the toggle left false, /ready must use the built-in alive-check
+// instead of contacting the upstream user app.
+func TestHandleReady_WithForwarderButHookDisabled_UsesBuiltInAliveCheck(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		readyTimeout:         200 * time.Millisecond,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Ready left false (the default).
+	h := newFakeChildHandle()
+	h.alive.Store(true)
+	srv.childHandle = h
+
+	rec := httptest.NewRecorder()
+	srv.handleReady(rec, httptest.NewRequest(http.MethodPost, pathReady, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must use the built-in alive-check result")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /ready toggle is disabled")
 }
 
 // /validate shares passThroughReady's PassThroughWaiting code path (same
@@ -472,11 +508,40 @@ func TestHandleValidate_WithForwarder_PassesThrough(t *testing.T) {
 		validateTimeout:      200 * time.Millisecond,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Validate = true
 	rec := httptest.NewRecorder()
 	srv.handleValidate(rec, httptest.NewRequest(http.MethodPost, pathValidate, nil))
 	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
 	assert.Equal(t, "application/x-validate", rec.Header().Get("Content-Type"))
 	assert.Equal(t, `{"valid":false,"reason":"warming"}`, rec.Body.String())
+}
+
+// TestHandleValidate_WithForwarderButHookDisabled_ReturnsBuiltIn200 mirrors
+// TestHandleReady_WithForwarderButHookDisabled_UsesBuiltInAliveCheck for
+// /validate: a configured Forwarder alone does not forward /validate without
+// enabledHooks.Validate also being true.
+func TestHandleValidate_WithForwarderButHookDisabled_ReturnsBuiltIn200(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, _, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		validateTimeout:      200 * time.Millisecond,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Validate left false (the default).
+
+	rec := httptest.NewRecorder()
+	srv.handleValidate(rec, httptest.NewRequest(http.MethodPost, pathValidate, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must return the built-in 200, not the upstream's 503")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /validate toggle is disabled")
 }
 
 // /run with a forwarder configured mirrors the user-app's status code,
@@ -497,6 +562,7 @@ func TestHandleRun_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 
 	rec := httptest.NewRecorder()
 	srv.handleRun(rec, httptest.NewRequest(http.MethodPost, pathRun, nil))
@@ -509,6 +575,36 @@ func TestHandleRun_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 	assert.Equal(t, int32(0), metric.count.Load(), "run must not flush")
 	assert.Equal(t, int32(0), trace.count.Load())
 	assert.Equal(t, int32(0), logs.count.Load())
+}
+
+// TestHandleRun_WithForwarderButHookDisabled_DoesNotForward verifies dispatchHook's
+// enabled gate for the run/resume/suspend/terminate group: a configured
+// Forwarder alone is not enough to forward /run — enabledHooks.Run (default
+// false) must also be true. With it left false, /run must take the built-in
+// metric-only path and never contact the upstream user app.
+func TestHandleRun_WithForwarderButHookDisabled_DoesNotForward(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Run left false (the default).
+
+	rec := httptest.NewRecorder()
+	srv.handleRun(rec, httptest.NewRequest(http.MethodPost, pathRun, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must return the built-in 200")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /run toggle is disabled")
+	assert.Contains(t, emitter.getEmitted(), runMetricName, "the run metric must still be emitted")
 }
 
 // /resume with a forwarder configured mirrors the user-app's response and
@@ -526,6 +622,7 @@ func TestHandleResume_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Resume = true
 
 	rec := httptest.NewRecorder()
 	srv.handleResume(rec, httptest.NewRequest(http.MethodPost, pathResume, nil))
@@ -535,6 +632,38 @@ func TestHandleResume_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 	assert.Equal(t, int32(0), metric.count.Load(), "resume must not flush")
 	assert.Equal(t, int32(0), trace.count.Load())
 	assert.Equal(t, int32(0), logs.count.Load())
+}
+
+// TestHandleResume_WithForwarderButHookDisabled_DoesNotForward mirrors
+// TestHandleRun_WithForwarderButHookDisabled_DoesNotForward for /resume: a
+// configured Forwarder alone does not forward /resume without
+// enabledHooks.Resume also being true. Also guards against a hardcoded
+// enabled=true regression in handleResume's dispatchHook call, which the
+// WithForwarder_MirrorsUserAppResponse test above would not catch since it
+// sets the toggle true anyway.
+func TestHandleResume_WithForwarderButHookDisabled_DoesNotForward(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, _, _, _, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Resume left false (the default).
+
+	rec := httptest.NewRecorder()
+	srv.handleResume(rec, httptest.NewRequest(http.MethodPost, pathResume, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must return the built-in 200")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /resume toggle is disabled")
+	assert.Contains(t, emitter.getEmitted(), resumeMetricName, "the resume metric must still be emitted")
 }
 
 // /terminate with a forwarder configured mirrors the user-app's response,
@@ -553,6 +682,7 @@ func TestHandleTerminate_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Terminate = true
 
 	rec := httptest.NewRecorder()
 	srv.handleTerminate(rec, httptest.NewRequest(http.MethodPost, pathTerminate, nil))
@@ -560,6 +690,39 @@ func TestHandleTerminate_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 	assert.Equal(t, 503, rec.Code, "must mirror user-app status, not hardcoded 200")
 	assert.Contains(t, emitter.getEmitted(), terminateMetricName)
 	assert.Equal(t, int32(1), metric.count.Load(), "terminate must flush")
+	assert.Equal(t, int32(1), trace.count.Load())
+	assert.Equal(t, int32(1), logs.count.Load())
+}
+
+// TestHandleTerminate_WithForwarderButHookDisabled_DoesNotForward mirrors
+// TestHandleRun_WithForwarderButHookDisabled_DoesNotForward for /terminate: a
+// configured Forwarder alone does not forward /terminate without
+// enabledHooks.Terminate also being true. The built-in path still flushes
+// telemetry — only the pass-through to the user app is skipped.
+func TestHandleTerminate_WithForwarderButHookDisabled_DoesNotForward(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, metric, trace, logs, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Terminate left false (the default).
+
+	rec := httptest.NewRecorder()
+	srv.handleTerminate(rec, httptest.NewRequest(http.MethodPost, pathTerminate, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must return the built-in 200")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /terminate toggle is disabled")
+	assert.Contains(t, emitter.getEmitted(), terminateMetricName, "the terminate metric must still be emitted")
+	assert.Equal(t, int32(1), metric.count.Load(), "the built-in path must still flush")
 	assert.Equal(t, int32(1), trace.count.Load())
 	assert.Equal(t, int32(1), logs.count.Load())
 }
@@ -583,6 +746,7 @@ func TestHandleSuspend_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Suspend = true
 
 	rec := httptest.NewRecorder()
 	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
@@ -596,6 +760,39 @@ func TestHandleSuspend_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 	assert.Equal(t, int32(1), trace.count.Load(), "trace flush must still run")
 	assert.Equal(t, int32(1), logs.count.Load(), "logs flush must still run")
 	assert.Contains(t, emitter.getEmitted(), suspendMetricName, "metric must still be emitted")
+}
+
+// TestHandleSuspend_WithForwarderButHookDisabled_DoesNotForward mirrors
+// TestHandleRun_WithForwarderButHookDisabled_DoesNotForward for /suspend: a
+// configured Forwarder alone does not forward /suspend without
+// enabledHooks.Suspend also being true. The built-in path still flushes
+// telemetry — only the pass-through to the user app is skipped.
+func TestHandleSuspend_WithForwarderButHookDisabled_DoesNotForward(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	srv, metric, trace, logs, emitter, _ := newTestServer()
+	srv.fwd = &Forwarder{
+		target:               upstream.URL,
+		client:               &http.Client{},
+		forwardTimeout:       2 * time.Second,
+		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
+	}
+	// srv.enabledHooks.Suspend left false (the default).
+
+	rec := httptest.NewRecorder()
+	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code, "must return the built-in 200")
+	assert.Equal(t, int32(0), reached.Load(), "user app must not be contacted when the /suspend toggle is disabled")
+	assert.Contains(t, emitter.getEmitted(), suspendMetricName, "the suspend metric must still be emitted")
+	assert.Equal(t, int32(1), metric.count.Load(), "the built-in path must still flush")
+	assert.Equal(t, int32(1), trace.count.Load())
+	assert.Equal(t, int32(1), logs.count.Load())
 }
 
 // Parallelism pin: the upstream handler blocks until all three flush mocks
@@ -634,6 +831,7 @@ func TestHandleSuspend_WithForwarder_FlushCompletesBeforeForwardReturns(t *testi
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Suspend = true
 
 	rec := httptest.NewRecorder()
 	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
@@ -656,6 +854,7 @@ func TestHandleSuspend_WithForwarder_DialErrorStillRunsFlush(t *testing.T) {
 		forwardTimeout:       200 * time.Millisecond,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Suspend = true
 
 	rec := httptest.NewRecorder()
 	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
@@ -678,6 +877,7 @@ func TestHandleSuspend_WithForwarder_WaitsForForwardBeforeResponse(t *testing.T)
 
 	srv, metric, trace, logs, _, _ := newTestServer()
 	srv.fwd = &Forwarder{target: upstream.URL, client: &http.Client{}, forwardTimeout: 5 * time.Second}
+	srv.enabledHooks.Suspend = true
 
 	handlerReturned := make(chan struct{})
 	rec := httptest.NewRecorder()
@@ -759,6 +959,7 @@ func TestHandleSuspend_WithForwarder_FlushTimeout_ReturnsPromptly(t *testing.T) 
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Suspend = true
 
 	start := time.Now()
 	rec := httptest.NewRecorder()
@@ -807,6 +1008,7 @@ func TestHandleSuspend_WithForwarder_BodyBufferedBeforeFlush(t *testing.T) {
 		forwardTimeout:       100 * time.Millisecond,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Suspend = true
 
 	rec := httptest.NewRecorder()
 	srv.handleSuspend(rec, httptest.NewRequest(http.MethodPost, pathSuspend, nil))
@@ -833,6 +1035,7 @@ func TestHandleTerminate_WithForwarder_FlushTimeout_ReturnsPromptly(t *testing.T
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Terminate = true
 
 	start := time.Now()
 	rec := httptest.NewRecorder()
@@ -875,6 +1078,7 @@ func TestHandleTerminate_WithForwarder_BodyBufferedBeforeFlush(t *testing.T) {
 		forwardTimeout:       100 * time.Millisecond,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Terminate = true
 
 	rec := httptest.NewRecorder()
 	srv.handleTerminate(rec, httptest.NewRequest(http.MethodPost, pathTerminate, nil))
@@ -905,6 +1109,7 @@ func TestHandleTerminate_WithForwarder_WaitsForSlowForward(t *testing.T) {
 		forwardTimeout:       5 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Terminate = true
 
 	handlerReturned := make(chan struct{})
 	rec := httptest.NewRecorder()
@@ -1016,7 +1221,7 @@ func TestListenAndServe_BindFailureReturnsErrorDirectly(t *testing.T) {
 	defer occupied.Close()
 	port := occupied.Addr().(*net.TCPAddr).Port
 
-	srv := NewServer(port, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, nil)
+	srv := NewServer(port, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, HookToggles{}, nil)
 
 	called := false
 	err = srv.ListenAndServe(func(error) { called = true })
@@ -1075,7 +1280,7 @@ func TestListenAndServe_StopDoesNotInvokeOnServeError(t *testing.T) {
 // TestNewServerWithForwarderWriteTimeoutCoversForwardBudget below.
 func TestNewServerConfiguresHTTPTimeouts(t *testing.T) {
 	flushTimeout := 5 * time.Second
-	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, nil, nil)
+	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, nil, HookToggles{}, nil)
 	assert.Equal(t, 30*time.Second, srv.httpServer.ReadTimeout)
 	assert.Equal(t, flushTimeout+writeTimeoutHeadroom, srv.httpServer.WriteTimeout)
 }
@@ -1092,7 +1297,7 @@ func TestNewServerWithForwarderWriteTimeoutCoversForwardBudget(t *testing.T) {
 		client:               &http.Client{},
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
-	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, fwd, nil)
+	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, fwd, HookToggles{}, nil)
 	assert.Equal(t, fwd.forwardTimeout+flushTimeout+writeTimeoutHeadroom, srv.httpServer.WriteTimeout,
 		"WriteTimeout must cover forwardTimeout+flushTimeout (terminate sequential-flush path)")
 }
@@ -1110,7 +1315,7 @@ func TestNewServerWithForwarderWriteTimeoutCoversReadinessBudgets(t *testing.T) 
 		client:               &http.Client{},
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
-	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, fwd, nil)
+	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, flushTimeout, nil, fwd, HookToggles{}, nil)
 	assert.Equal(t, dialCheckTimeout+fwd.validateTimeout+writeTimeoutHeadroom, srv.httpServer.WriteTimeout,
 		"WriteTimeout must cover dialCheckTimeout+validateTimeout for /validate")
 }
@@ -1200,7 +1405,7 @@ func TestMirrorResponse_BodyReadError_DoesNotPanic(t *testing.T) {
 func TestDispatchHook_NoForwarder_WithFlushFalse_EmitsMetricReturns200NoFlush(t *testing.T) {
 	srv, metric, trace, logs, emitter, drainer := newTestServer()
 	rec := httptest.NewRecorder()
-	srv.dispatchHook("test.metric", "/test", noFlush, rec, httptest.NewRequest(http.MethodPost, "/test", nil))
+	srv.dispatchHook("test.metric", "/test", noFlush, false, rec, httptest.NewRequest(http.MethodPost, "/test", nil))
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, emitter.getEmitted(), "test.metric")
 	assert.Equal(t, int32(0), metric.count.Load(), "noFlush must not flush")
@@ -1214,7 +1419,7 @@ func TestDispatchHook_NoForwarder_WithFlushFalse_EmitsMetricReturns200NoFlush(t 
 func TestDispatchHook_NoForwarder_WithFlushTrue_EmitsMetricAndFlushes(t *testing.T) {
 	srv, metric, trace, logs, emitter, drainer := newTestServer()
 	rec := httptest.NewRecorder()
-	srv.dispatchHook("test.metric", "/test", flushParallel, rec, httptest.NewRequest(http.MethodPost, "/test", nil))
+	srv.dispatchHook("test.metric", "/test", flushParallel, false, rec, httptest.NewRequest(http.MethodPost, "/test", nil))
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, emitter.getEmitted(), "test.metric")
 	assert.Equal(t, int32(1), metric.count.Load(), "flushParallel must flush metric agent")
@@ -1242,7 +1447,7 @@ func TestDispatchHook_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	srv.dispatchHook("test.metric", pathResume, noFlush, rec, httptest.NewRequest(http.MethodPost, pathResume, nil))
+	srv.dispatchHook("test.metric", pathResume, noFlush, true, rec, httptest.NewRequest(http.MethodPost, pathResume, nil))
 	assert.Equal(t, 418, rec.Code, "must mirror user-app status, not hardcoded 200")
 	assert.Contains(t, emitter.getEmitted(), "test.metric")
 }
@@ -1252,7 +1457,7 @@ func TestDispatchHook_WithForwarder_MirrorsUserAppResponse(t *testing.T) {
 // lifecycle server stalling — and blocking the MicroVM platform's suspend/terminate
 // handshake — when the metric aggregator worker is deadlocked or slow.
 func TestFlushAllDrainTimeoutDoesNotBlock(t *testing.T) {
-	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &neverDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 50*time.Millisecond, nil, nil, nil)
+	srv := NewServer(0, &mockFlusher{}, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &neverDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 50*time.Millisecond, nil, nil, HookToggles{}, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), srv.flushTimeout)
 	defer cancel()
@@ -1276,7 +1481,7 @@ func TestFlushAllNilLogsFlusherDoesNotPanic(t *testing.T) {
 	metric := &mockFlusher{}
 	trace := &mockFlusher{}
 	drainer := &mockSampleDrainer{}
-	srv := NewServer(0, metric, trace, nil, &mockMetricEmitter{}, drainer, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, nil)
+	srv := NewServer(0, metric, trace, nil, &mockMetricEmitter{}, drainer, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, HookToggles{}, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), srv.flushTimeout)
 	defer cancel()
@@ -1582,6 +1787,7 @@ func TestHandleRun_WithForwarder_UpdatesLogTags(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 	setter := &mockLogsTagSetter{}
 	srv.SetLogsTagSetter(setter, []string{"env:staging"})
 
@@ -1743,6 +1949,7 @@ func TestHandleRun_WithForwarder_UpdatesTraceTags(t *testing.T) {
 		forwardTimeout:       2 * time.Second,
 		maxResponseBodyBytes: defaultMaxResponseBodyBytes,
 	}
+	srv.enabledHooks.Run = true
 	setter := &mockTraceTagSetter{}
 	srv.SetTraceTagSetter(setter, map[string]string{"env": "staging"})
 

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -46,6 +46,16 @@ func (m *mockFlusher) Flush() {
 	}
 }
 
+// mockForceFlusher tracks Flush and FlushAll calls separately; it satisfies
+// both Flusher and ForceFlusher.
+type mockForceFlusher struct {
+	flushCount    atomic.Int32
+	flushAllCount atomic.Int32
+}
+
+func (m *mockForceFlusher) Flush()    { m.flushCount.Add(1) }
+func (m *mockForceFlusher) FlushAll() { m.flushAllCount.Add(1) }
+
 // mockLogsAgent counts how many times Flush was called and records when each
 // call returned. onFlush, if set, is invoked after each Flush.
 type mockLogsAgent struct {
@@ -319,6 +329,30 @@ func TestHandleTerminate_NoForwarder_FlushesAndEmitsMetric_NoSigterm(t *testing.
 	case <-time.After(100 * time.Millisecond):
 		// Pass — no synthetic signal observed.
 	}
+}
+
+// TestHandleSuspend_UsesFlushNotFlushAll pins that /suspend calls Flush, not
+// FlushAll (see ForceFlusher for why).
+func TestHandleSuspend_UsesFlushNotFlushAll(t *testing.T) {
+	metric := &mockForceFlusher{}
+	srv := NewServer(0, metric, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, HookToggles{}, nil)
+
+	srv.handleSuspend(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathSuspend, nil))
+
+	assert.Equal(t, int32(1), metric.flushCount.Load(), "/suspend must call Flush")
+	assert.Equal(t, int32(0), metric.flushAllCount.Load(), "/suspend must not call FlushAll")
+}
+
+// TestHandleTerminate_UsesFlushAllNotFlush pins that /terminate calls
+// FlushAll, not Flush (see ForceFlusher for why).
+func TestHandleTerminate_UsesFlushAllNotFlush(t *testing.T) {
+	metric := &mockForceFlusher{}
+	srv := NewServer(0, metric, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, HookToggles{}, nil)
+
+	srv.handleTerminate(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathTerminate, nil))
+
+	assert.Equal(t, int32(1), metric.flushAllCount.Load(), "/terminate must call FlushAll")
+	assert.Equal(t, int32(0), metric.flushCount.Load(), "/terminate must not call Flush")
 }
 
 // TestEmittedMetricsCarryCurrentTimestamp verifies the lifecycle handlers pass
@@ -1462,7 +1496,7 @@ func TestFlushAllDrainTimeoutDoesNotBlock(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), srv.flushTimeout)
 	defer cancel()
 	start := time.Now()
-	srv.flushAll(ctx)
+	srv.flushAll(ctx, false)
 	assert.Less(t, time.Since(start), 500*time.Millisecond, "flushAll must return within flushTimeout even when drainer blocks")
 }
 
@@ -1486,7 +1520,7 @@ func TestFlushAllNilLogsFlusherDoesNotPanic(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), srv.flushTimeout)
 	defer cancel()
 	start := time.Now()
-	assert.NotPanics(t, func() { srv.flushAll(ctx) })
+	assert.NotPanics(t, func() { srv.flushAll(ctx, false) })
 	assert.Less(t, time.Since(start), 500*time.Millisecond, "flushAll must not fall back to the flushTimeout path when logsFlusher is nil")
 	assert.Equal(t, int32(1), metric.count.Load())
 	assert.Equal(t, int32(1), trace.count.Load())
@@ -1525,7 +1559,7 @@ func TestHandleRun_StartsHeartbeat(t *testing.T) {
 
 // /run must extract the MicroVM ID from the JSON body and apply it to the
 // heartbeat before Start so the very first emission carries the correct
-// microvm_id. The test calls handleRun then inspects the tags that the
+// lambda_microvm_id. The test calls handleRun then inspects the tags that the
 // heartbeat would emit on its next tick.
 func TestHandleRun_AppliesMicroVMIDFromBody(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
@@ -1535,7 +1569,7 @@ func TestHandleRun_AppliesMicroVMIDFromBody(t *testing.T) {
 	body := strings.NewReader(`{"microvmId":"vm-from-body"}`)
 	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
 
-	assert.Contains(t, srv.heartbeat.tagsForEmit(), "microvm_id:vm-from-body")
+	assert.Contains(t, srv.heartbeat.tagsForEmit(), "lambda_microvm_id:vm-from-body")
 	id := srv.instanceID.Load()
 	assert.Equal(t, "vm-from-body", id)
 }
@@ -1549,7 +1583,7 @@ func TestHandleRun_MissingBodyIDUsesUnknown(t *testing.T) {
 
 	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, nil))
 
-	assert.Contains(t, srv.heartbeat.tagsForEmit(), "microvm_id:unknown")
+	assert.Contains(t, srv.heartbeat.tagsForEmit(), "lambda_microvm_id:unknown")
 }
 
 // traced_invocations is emitted by the Heartbeat on each tick, not directly by

--- a/cmd/serverless-init/lifecycle/wire.go
+++ b/cmd/serverless-init/lifecycle/wire.go
@@ -15,33 +15,46 @@ import (
 // SetupComponents holds the lifecycle dependencies that setup() threads
 // into the lifecycle server and into mode.RunInit.
 type SetupComponents struct {
-	Port      int         // lifecycle hook server port; always set (defaults to DefaultPort)
-	Handle    ChildHandle // always non-nil; noop in sidecar mode
-	Child     *Child      // non-nil only in init-container mode (used by mode.RunInit)
-	Forwarder *Forwarder  // non-nil only when env var is valid AND init-container mode
+	Port         int         // lifecycle hook server port; always set (defaults to DefaultPort)
+	Handle       ChildHandle // always non-nil; noop in sidecar mode
+	Child        *Child      // non-nil only in init-container mode (used by mode.RunInit)
+	Forwarder    *Forwarder  // non-nil only when env var is valid AND init-container mode
+	EnabledHooks HookToggles // per-hook forwarding opt-in; only meaningful when Forwarder != nil
 }
 
 // setupInput holds the raw string values for setupComponents. Empty string means
 // "unset / use default" for each field, matching env-var semantics.
 type setupInput struct {
-	userAppPort   string
-	lifecyclePort string
-	forwardMs     string
-	readyMs       string
-	validateMs    string
-	sidecarMode   bool
+	userAppPort     string
+	lifecyclePort   string
+	forwardMs       string
+	readyMs         string
+	validateMs      string
+	enableReady     string
+	enableValidate  string
+	enableRun       string
+	enableResume    string
+	enableSuspend   string
+	enableTerminate string
+	sidecarMode     bool
 }
 
 // SetupFromEnv reads lifecycle configuration from environment variables and
 // delegates to setupComponents.
 func SetupFromEnv(sidecarMode bool) (SetupComponents, error) {
 	return setupComponents(setupInput{
-		userAppPort:   os.Getenv(UserAppPortEnvVar),
-		lifecyclePort: os.Getenv(LifecyclePortEnvVar),
-		forwardMs:     os.Getenv(ForwardTimeoutMsEnvVar),
-		readyMs:       os.Getenv(ReadyTimeoutMsEnvVar),
-		validateMs:    os.Getenv(ValidateTimeoutMsEnvVar),
-		sidecarMode:   sidecarMode,
+		userAppPort:     os.Getenv(UserAppPortEnvVar),
+		lifecyclePort:   os.Getenv(LifecyclePortEnvVar),
+		forwardMs:       os.Getenv(ForwardTimeoutMsEnvVar),
+		readyMs:         os.Getenv(ReadyTimeoutMsEnvVar),
+		validateMs:      os.Getenv(ValidateTimeoutMsEnvVar),
+		enableReady:     os.Getenv(EnableReadyEnvVar),
+		enableValidate:  os.Getenv(EnableValidateEnvVar),
+		enableRun:       os.Getenv(EnableRunEnvVar),
+		enableResume:    os.Getenv(EnableResumeEnvVar),
+		enableSuspend:   os.Getenv(EnableSuspendEnvVar),
+		enableTerminate: os.Getenv(EnableTerminateEnvVar),
+		sidecarMode:     sidecarMode,
 	})
 }
 
@@ -97,11 +110,60 @@ func setupComponents(in setupInput) (SetupComponents, error) {
 		return SetupComponents{}, err
 	}
 
-	c := SetupComponents{Port: lifecyclePort}
+	enabled := HookToggles{
+		Ready:     parseBoolFlag(EnableReadyEnvVar, in.enableReady, false),
+		Validate:  parseBoolFlag(EnableValidateEnvVar, in.enableValidate, false),
+		Run:       parseBoolFlag(EnableRunEnvVar, in.enableRun, false),
+		Resume:    parseBoolFlag(EnableResumeEnvVar, in.enableResume, false),
+		Suspend:   parseBoolFlag(EnableSuspendEnvVar, in.enableSuspend, false),
+		Terminate: parseBoolFlag(EnableTerminateEnvVar, in.enableTerminate, false),
+	}
+	warnHookTogglesMismatch(userAppPort != 0, enabled)
+
+	c := SetupComponents{Port: lifecyclePort, EnabledHooks: enabled}
 	c.Child = NewChild()
 	c.Handle = c.Child
 	if userAppPort != 0 {
 		c.Forwarder = NewForwarder(userAppPort, forwardTimeout, readyTimeout, validateTimeout)
 	}
 	return c, nil
+}
+
+// warnHookTogglesMismatch logs when the forwarder and the per-hook toggles
+// disagree in a way the user likely did not intend:
+//   - a forwarder is configured but no hook opted in (forwarding is fully
+//     off, a change from the previous all-hooks-forward behavior), or
+//   - a hook opted in but there is no forwarder to forward to.
+func warnHookTogglesMismatch(hasForwarder bool, enabled HookToggles) {
+	names := enabledHookNames(enabled)
+	switch {
+	case hasForwarder && len(names) == 0:
+		log.Warnf("MicroVM lifecycle: %s is set but no hooks are enabled via DD_AWS_MICROVM_ENABLE_*; all hooks will use built-in handling instead of forwarding", UserAppPortEnvVar)
+	case !hasForwarder && len(names) > 0:
+		log.Warnf("MicroVM lifecycle: hook(s) %v enabled via DD_AWS_MICROVM_ENABLE_* but %s is not set; those hooks will use built-in handling", names, UserAppPortEnvVar)
+	}
+}
+
+// enabledHookNames returns the lowercase hook names with their toggle set to true.
+func enabledHookNames(t HookToggles) []string {
+	var names []string
+	if t.Ready {
+		names = append(names, "ready")
+	}
+	if t.Validate {
+		names = append(names, "validate")
+	}
+	if t.Run {
+		names = append(names, "run")
+	}
+	if t.Resume {
+		names = append(names, "resume")
+	}
+	if t.Suspend {
+		names = append(names, "suspend")
+	}
+	if t.Terminate {
+		names = append(names, "terminate")
+	}
+	return names
 }

--- a/cmd/serverless-init/lifecycle/wire_test.go
+++ b/cmd/serverless-init/lifecycle/wire_test.go
@@ -129,6 +129,76 @@ func TestSetupComponents_SidecarMode_InvalidTimeoutMs_NoError(t *testing.T) {
 	}
 }
 
+// --- HookToggles (DD_AWS_MICROVM_ENABLE_*) ---
+
+// Every hook toggle defaults to false — a hook is not forwarded unless
+// explicitly enabled, even when a Forwarder is configured.
+func TestSetupComponents_EnabledHooks_DefaultFalse(t *testing.T) {
+	got, err := setupComponents(setupInput{userAppPort: "8080"})
+	require.NoError(t, err)
+	require.NotNil(t, got.Forwarder)
+	assert.Equal(t, HookToggles{}, got.EnabledHooks)
+}
+
+// TestSetupComponents_EnabledHooks_ParsedFromEnv enables exactly one hook per
+// case and asserts that ONLY that hook ends up true. Setting all six at once
+// would not catch a field-swap bug (e.g. Resume accidentally wired to
+// in.enableSuspend) since both inputs would be "true" either way; isolating
+// each hook makes such a swap show up as an unexpected field being set.
+func TestSetupComponents_EnabledHooks_ParsedFromEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input setupInput
+		want  HookToggles
+	}{
+		{"ready", setupInput{enableReady: "true"}, HookToggles{Ready: true}},
+		{"validate", setupInput{enableValidate: "true"}, HookToggles{Validate: true}},
+		{"run", setupInput{enableRun: "true"}, HookToggles{Run: true}},
+		{"resume", setupInput{enableResume: "true"}, HookToggles{Resume: true}},
+		{"suspend", setupInput{enableSuspend: "true"}, HookToggles{Suspend: true}},
+		{"terminate", setupInput{enableTerminate: "true"}, HookToggles{Terminate: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			in := tc.input
+			in.userAppPort = "8080"
+			got, err := setupComponents(in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got.EnabledHooks)
+		})
+	}
+}
+
+// A hook enabled without a Forwarder configured (no USER_APP_PORT) has no
+// effect on the Forwarder — the toggle is still recorded on EnabledHooks —
+// but there's nothing to forward to, so server.go's fwd!=nil check keeps it
+// on the built-in path.
+func TestSetupComponents_EnabledHooks_TrueWithoutUserAppPort_NoForwarder(t *testing.T) {
+	got, err := setupComponents(setupInput{enableRun: "true"})
+	require.NoError(t, err)
+	assert.Nil(t, got.Forwarder)
+	assert.True(t, got.EnabledHooks.Run)
+}
+
+// A malformed toggle value falls back to false for that hook only — it does
+// not fail setup or affect the Forwarder or the other hooks' toggles.
+func TestSetupComponents_EnabledHooks_MalformedValue_ScopedToThatHook(t *testing.T) {
+	got, err := setupComponents(setupInput{userAppPort: "8080", enableRun: "not-a-bool", enableSuspend: "true"})
+	require.NoError(t, err)
+	require.NotNil(t, got.Forwarder)
+	assert.False(t, got.EnabledHooks.Run, "malformed value must fall back to false")
+	assert.True(t, got.EnabledHooks.Suspend, "other hooks must be unaffected by a malformed sibling toggle")
+}
+
+// Sidecar mode returns before the enable-toggle parsing block (the forwarder
+// is never built there), so EnabledHooks stays zero-value regardless of the
+// env vars — mirrors how userAppPort and the timeouts are ignored in sidecar
+// mode.
+func TestSetupComponents_SidecarMode_EnabledHooksIgnored(t *testing.T) {
+	got, err := setupComponents(setupInput{sidecarMode: true, enableRun: "true"})
+	require.NoError(t, err)
+	assert.Equal(t, HookToggles{}, got.EnabledHooks)
+}
+
 // SetupFromEnv must read UserAppPortEnvVar from the process environment
 // and delegate to setupComponents. Pins the env binding so a refactor
 // can't silently swap the env-var name or skip the lookup.
@@ -145,6 +215,34 @@ func TestSetupFromEnv_UnsetEnv_NoForwarder(t *testing.T) {
 	got, err := SetupFromEnv(false)
 	require.NoError(t, err)
 	assert.Nil(t, got.Forwarder)
+}
+
+// SetupFromEnv must read each DD_AWS_MICROVM_ENABLE_* env var from the
+// process environment. Pins the env-var-name binding for all six toggles the
+// same way TestSetupFromEnv_ReadsEnvVar_BuildsForwarder pins UserAppPortEnvVar
+// — setupComponents-level tests alone can't catch a typo'd env var name in
+// SetupFromEnv's os.Getenv calls, since they bypass os.Getenv entirely.
+func TestSetupFromEnv_ReadsEnableEnvVars(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		envVar string
+		want   HookToggles
+	}{
+		{"ready", EnableReadyEnvVar, HookToggles{Ready: true}},
+		{"validate", EnableValidateEnvVar, HookToggles{Validate: true}},
+		{"run", EnableRunEnvVar, HookToggles{Run: true}},
+		{"resume", EnableResumeEnvVar, HookToggles{Resume: true}},
+		{"suspend", EnableSuspendEnvVar, HookToggles{Suspend: true}},
+		{"terminate", EnableTerminateEnvVar, HookToggles{Terminate: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(UserAppPortEnvVar, "8080")
+			t.Setenv(tc.envVar, "true")
+			got, err := SetupFromEnv(false /*sidecar*/)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got.EnabledHooks)
+		})
+	}
 }
 
 func TestSetupFromEnv_PropagatesParseError(t *testing.T) {

--- a/cmd/serverless-init/lifecycle/wire_test.go
+++ b/cmd/serverless-init/lifecycle/wire_test.go
@@ -6,6 +6,7 @@
 package lifecycle
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -129,6 +130,76 @@ func TestSetupComponents_SidecarMode_InvalidTimeoutMs_NoError(t *testing.T) {
 	}
 }
 
+// --- HookToggles (DD_AWS_MICROVM_ENABLE_*) ---
+
+// Every hook toggle defaults to false — a hook is not forwarded unless
+// explicitly enabled, even when a Forwarder is configured.
+func TestSetupComponents_EnabledHooks_DefaultFalse(t *testing.T) {
+	got, err := setupComponents(setupInput{userAppPort: "8080"})
+	require.NoError(t, err)
+	require.NotNil(t, got.Forwarder)
+	assert.Equal(t, HookToggles{}, got.EnabledHooks)
+}
+
+// TestSetupComponents_EnabledHooks_ParsedFromEnv enables exactly one hook per
+// case and asserts that ONLY that hook ends up true. Setting all six at once
+// would not catch a field-swap bug (e.g. Resume accidentally wired to
+// in.enableSuspend) since both inputs would be "true" either way; isolating
+// each hook makes such a swap show up as an unexpected field being set.
+func TestSetupComponents_EnabledHooks_ParsedFromEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input setupInput
+		want  HookToggles
+	}{
+		{"ready", setupInput{enableReady: "true"}, HookToggles{Ready: true}},
+		{"validate", setupInput{enableValidate: "true"}, HookToggles{Validate: true}},
+		{"run", setupInput{enableRun: "true"}, HookToggles{Run: true}},
+		{"resume", setupInput{enableResume: "true"}, HookToggles{Resume: true}},
+		{"suspend", setupInput{enableSuspend: "true"}, HookToggles{Suspend: true}},
+		{"terminate", setupInput{enableTerminate: "true"}, HookToggles{Terminate: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			in := tc.input
+			in.userAppPort = "8080"
+			got, err := setupComponents(in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got.EnabledHooks)
+		})
+	}
+}
+
+// A hook enabled without a Forwarder configured (no USER_APP_PORT) has no
+// effect on the Forwarder — the toggle is still recorded on EnabledHooks —
+// but there's nothing to forward to, so server.go's fwd!=nil check keeps it
+// on the built-in path.
+func TestSetupComponents_EnabledHooks_TrueWithoutUserAppPort_NoForwarder(t *testing.T) {
+	got, err := setupComponents(setupInput{enableRun: "true"})
+	require.NoError(t, err)
+	assert.Nil(t, got.Forwarder)
+	assert.True(t, got.EnabledHooks.Run)
+}
+
+// A malformed toggle value falls back to false for that hook only — it does
+// not fail setup or affect the Forwarder or the other hooks' toggles.
+func TestSetupComponents_EnabledHooks_MalformedValue_ScopedToThatHook(t *testing.T) {
+	got, err := setupComponents(setupInput{userAppPort: "8080", enableRun: "not-a-bool", enableSuspend: "true"})
+	require.NoError(t, err)
+	require.NotNil(t, got.Forwarder)
+	assert.False(t, got.EnabledHooks.Run, "malformed value must fall back to false")
+	assert.True(t, got.EnabledHooks.Suspend, "other hooks must be unaffected by a malformed sibling toggle")
+}
+
+// Sidecar mode returns before the enable-toggle parsing block (the forwarder
+// is never built there), so EnabledHooks stays zero-value regardless of the
+// env vars — mirrors how userAppPort and the timeouts are ignored in sidecar
+// mode.
+func TestSetupComponents_SidecarMode_EnabledHooksIgnored(t *testing.T) {
+	got, err := setupComponents(setupInput{sidecarMode: true, enableRun: "true"})
+	require.NoError(t, err)
+	assert.Equal(t, HookToggles{}, got.EnabledHooks)
+}
+
 // SetupFromEnv must read UserAppPortEnvVar from the process environment
 // and delegate to setupComponents. Pins the env binding so a refactor
 // can't silently swap the env-var name or skip the lookup.
@@ -145,6 +216,52 @@ func TestSetupFromEnv_UnsetEnv_NoForwarder(t *testing.T) {
 	got, err := SetupFromEnv(false)
 	require.NoError(t, err)
 	assert.Nil(t, got.Forwarder)
+}
+
+// SetupFromEnv must read each DD_AWS_MICROVM_ENABLE_* env var from the
+// process environment. Pins the env-var-name binding for all six toggles the
+// same way TestSetupFromEnv_ReadsEnvVar_BuildsForwarder pins UserAppPortEnvVar
+// — setupComponents-level tests alone can't catch a typo'd env var name in
+// SetupFromEnv's os.Getenv calls, since they bypass os.Getenv entirely.
+func TestSetupFromEnv_ReadsEnableEnvVars(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		envVar string
+		want   HookToggles
+	}{
+		{"ready", EnableReadyEnvVar, HookToggles{Ready: true}},
+		{"validate", EnableValidateEnvVar, HookToggles{Validate: true}},
+		{"run", EnableRunEnvVar, HookToggles{Run: true}},
+		{"resume", EnableResumeEnvVar, HookToggles{Resume: true}},
+		{"suspend", EnableSuspendEnvVar, HookToggles{Suspend: true}},
+		{"terminate", EnableTerminateEnvVar, HookToggles{Terminate: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(UserAppPortEnvVar, "8080")
+			t.Setenv(tc.envVar, "true")
+			got, err := SetupFromEnv(false /*sidecar*/)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got.EnabledHooks)
+		})
+	}
+}
+
+// enabledHookNames hand-lists each HookToggles field; nothing forces that
+// list to grow when a field is added. This test fails loudly if HookToggles
+// ever gains a field that enabledHookNames doesn't report, by comparing its
+// output (with every toggle set to true) against the struct's field count.
+func TestEnabledHookNames_CoversAllHookTogglesFields(t *testing.T) {
+	allEnabled := HookToggles{
+		Ready:     true,
+		Validate:  true,
+		Run:       true,
+		Resume:    true,
+		Suspend:   true,
+		Terminate: true,
+	}
+	fieldCount := reflect.TypeOf(allEnabled).NumField()
+	names := enabledHookNames(allEnabled)
+	assert.Len(t, names, fieldCount, "enabledHookNames must report one name per HookToggles field; update it after adding/removing a field")
 }
 
 func TestSetupFromEnv_PropagatesParseError(t *testing.T) {

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -496,6 +496,7 @@ func setup(
 				MetricFlusher: metricAgent,
 				LogsFlusher:   logsAgent,
 				MetricEmitter: metricAgent,
+				SampleDrainer: metricAgent,
 				FlushTimeout:  agentLogConfig.FlushTimeout,
 				SidecarMode:   modeConf.SidecarMode,
 				LogsTagSetter: lifecycle.LogsTagSetterFunc(func(tags []string) {
@@ -532,6 +533,7 @@ func setup(
 			MetricFlusher: metricAgent,
 			LogsFlusher:   logsAgent,
 			MetricEmitter: metricAgent,
+			SampleDrainer: metricAgent,
 			FlushTimeout:  agentLogConfig.FlushTimeout,
 			SidecarMode:   modeConf.SidecarMode,
 			LogsTagSetter: lifecycle.LogsTagSetterFunc(func(tags []string) {

--- a/pkg/aggregator/BUILD.bazel
+++ b/pkg/aggregator/BUILD.bazel
@@ -109,6 +109,7 @@ dd_agent_go_test(
         "tagfilter_cache_test.go",
         "tagset_telem_test.go",
         "time_sampler_test.go",
+        "time_sampler_worker_test.go",
     ],
     embed = [":aggregator"],
     gotags_sets = [[

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -384,7 +384,7 @@ func TestSeriesTooManyTags(t *testing.T) {
 			s.On("SendServiceChecks", mock.Anything).Return(nil)
 			s.On("SendIterableSeries", mock.Anything).Return(nil)
 
-			demux.ForceFlushToSerializer(start, true)
+			demux.ForceFlushToSerializer(start, true, false)
 			s.AssertNotCalled(t, "SendEvents")
 			s.AssertNotCalled(t, "SendSketch")
 
@@ -453,7 +453,7 @@ func TestDistributionsTooManyTags(t *testing.T) {
 			s.On("SendIterableSeries", mock.Anything).Return(nil).Times(1)
 			s.On("SendSketch", mock.Anything).Return(nil).Times(1)
 
-			demux.ForceFlushToSerializer(start, true)
+			demux.ForceFlushToSerializer(start, true, false)
 			s.AssertNotCalled(t, "SendEvents")
 
 			expMap := map[string]uint64{}
@@ -540,7 +540,7 @@ func TestRecurrentSeries(t *testing.T) {
 	})
 
 	s.On("SendServiceChecks", agentUpMatcher).Return(nil).Times(1)
-	demux.ForceFlushToSerializer(start, true)
+	demux.ForceFlushToSerializer(start, true, false)
 	require.EqualValues(t, expectedSeries, s.series)
 	s.series = nil
 
@@ -550,7 +550,7 @@ func TestRecurrentSeries(t *testing.T) {
 	// Assert that recurrentSeries are sent on each flushed
 	// same goes for the service check
 	s.On("SendServiceChecks", agentUpMatcher).Return(nil).Times(1)
-	demux.ForceFlushToSerializer(start, true)
+	demux.ForceFlushToSerializer(start, true, false)
 	require.EqualValues(t, expectedSeries, s.series)
 	s.series = nil
 
@@ -759,7 +759,7 @@ func flushSomeSamples(demux *AgentDemultiplexer) map[string]*metrics.Serie {
 	// sure all samples have been processed by the sampler
 	time.Sleep(1 * time.Second)
 
-	demux.ForceFlushToSerializer(time.Unix(int64(timeSamplerBucketSize)*3, 0), true)
+	demux.ForceFlushToSerializer(time.Unix(int64(timeSamplerBucketSize)*3, 0), true, false)
 	return expectedSeries
 }
 

--- a/pkg/aggregator/demultiplexer.go
+++ b/pkg/aggregator/demultiplexer.go
@@ -46,8 +46,9 @@ type Demultiplexer interface {
 	SendSamplesWithoutAggregation(metrics metrics.MetricSampleBatch)
 
 	// ForceFlushToSerializer flushes all the aggregated data from the different samplers to
-	// the serialization/forwarding parts.
-	ForceFlushToSerializer(start time.Time, waitForSerializer bool)
+	// the serialization/forwarding parts. forceFlushAll additionally includes samples in
+	// the current, not-yet-closed time bucket (otherwise they wait for the next flush).
+	ForceFlushToSerializer(start time.Time, waitForSerializer bool, forceFlushAll bool)
 	// GetMetricSamplePool returns a shared resource used in the whole DogStatsD
 	// pipeline to re-use metric samples slices: the server is getting a slice
 	// and filling it with samples, the rest of the pipeline process them the

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -519,12 +519,12 @@ func (d *AgentDemultiplexer) Stop() {
 // ForceFlushToSerializer triggers the execution of a flush from all data of samplers
 // and the BufferedAggregator to the serializer.
 // Safe to call from multiple threads.
-func (d *AgentDemultiplexer) ForceFlushToSerializer(start time.Time, waitForSerializer bool) {
+func (d *AgentDemultiplexer) ForceFlushToSerializer(start time.Time, waitForSerializer bool, forceFlushAll bool) {
 	trigger := trigger{
 		time:              start,
 		waitForSerializer: waitForSerializer,
 		blockChan:         make(chan struct{}),
-		forceFlushAll:     false,
+		forceFlushAll:     forceFlushAll,
 	}
 	d.flushChan <- trigger
 	<-trigger.blockChan
@@ -690,11 +690,23 @@ func (d *AgentDemultiplexer) AggregateSamples(shard TimeSamplerID, samples metri
 	d.statsd.workers[shard].addSamples(samples)
 }
 
+// singleSampleShard is the time sampler shard used by AggregateSample.
+// WaitForPendingSamples drains this same shard, so the two must stay in sync.
+const singleSampleShard TimeSamplerID = 0
+
 // AggregateSample adds a MetricSample in the first DogStatsD time sampler.
 func (d *AgentDemultiplexer) AggregateSample(sample metrics.MetricSample) {
 	batch := d.GetMetricSamplePool().GetBatch()
 	batch[0] = sample
-	d.statsd.workers[0].addSamples(batch[:1])
+	d.statsd.workers[singleSampleShard].addSamples(batch[:1])
+}
+
+// WaitForPendingSamples blocks until samples enqueued on singleSampleShard
+// before this call have been consumed. Used by serverless-init's on-demand
+// flush, where a sample submitted right before a flush could otherwise race
+// it.
+func (d *AgentDemultiplexer) WaitForPendingSamples() {
+	d.statsd.workers[singleSampleShard].waitForPendingSamples()
 }
 
 // AggregateCheckSample adds check sample sent by a check from one of the collectors into a check sampler pipeline.

--- a/pkg/aggregator/demultiplexer_agent_test.go
+++ b/pkg/aggregator/demultiplexer_agent_test.go
@@ -433,7 +433,7 @@ func TestUpdateTagFilterList(t *testing.T) {
 		require.Eventually(func() bool {
 			return len(demux.statsd.workers[0].samplesChan) == 0
 		}, time.Second, time.Millisecond)
-		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true)
+		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true, false)
 
 		metric := slices.IndexFunc(s.sketches, func(serie metrics.Distribution) bool {
 			return serie.GetName() == "dist.metric"
@@ -561,7 +561,7 @@ func TestUpdateTagFilterListCheckSamplerCacheInvalidation(t *testing.T) {
 		require.Eventually(func() bool {
 			return len(demux.aggregator.checkItems) == 0
 		}, time.Second, time.Millisecond)
-		demux.ForceFlushToSerializer(time.Now(), true)
+		demux.ForceFlushToSerializer(time.Now(), true, false)
 	}
 
 	// First send: tag1 and tag2 are excluded. This is a cache miss so the
@@ -642,7 +642,7 @@ func TestUpdateMetricFilterList(t *testing.T) {
 		require.Eventually(func() bool {
 			return len(demux.statsd.workers[0].samplesChan) == 0
 		}, time.Second, time.Millisecond)
-		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true)
+		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true, false)
 
 		// We should always contain the average of the histogram.
 		require.Equal(blockCount, slices.ContainsFunc(s.series, func(serie *metrics.Serie) bool {

--- a/pkg/aggregator/time_sampler_worker.go
+++ b/pkg/aggregator/time_sampler_worker.go
@@ -49,6 +49,10 @@ type timeSamplerWorker struct {
 	samplesChan chan []metrics.MetricSample
 	// samplesDrained is closed after last sample is read from samplesChan
 	samplesDrained chan struct{}
+	// drainChan requests a synchronous drain of samplesChan. Unlike
+	// shutdown/samplesDrained, it's repeatable and doesn't touch the worker's
+	// lifecycle.
+	drainChan chan chan struct{}
 	// use this chan to trigger a flush of the time sampler
 	flushChan chan flushTrigger
 	// use this chan to trigger a filterList reconfiguration
@@ -83,6 +87,7 @@ func newTimeSamplerWorker(sampler *TimeSampler, flushInterval time.Duration, buf
 
 		samplesChan:          make(chan []metrics.MetricSample, bufferSize),
 		samplesDrained:       make(chan struct{}),
+		drainChan:            make(chan chan struct{}),
 		stopChan:             make(chan struct{}),
 		flushChan:            make(chan flushTrigger),
 		dumpChan:             make(chan dumpTrigger),
@@ -112,15 +117,7 @@ func (w *timeSamplerWorker) run() {
 				close(w.samplesDrained)
 				continue
 			}
-
-			aggregatorDogstatsdMetricSample.Add(int64(len(ms)))
-			tlmProcessed.Add(float64(len(ms)), shard, "dogstatsd_metrics")
-			t := timeNowNano()
-
-			for i := 0; i < len(ms); i++ {
-				w.sampler.sample(&ms[i], t, w.tagFilterList)
-			}
-			w.metricSamplePool.PutBatch(ms)
+			w.processBatch(ms)
 		case matcher := <-w.metricFilterListChan:
 			w.flushFilterList = matcher
 		case matcher := <-w.tagFilterListChan:
@@ -130,8 +127,38 @@ func (w *timeSamplerWorker) run() {
 			w.tagsStore.Shrink()
 		case trigger := <-w.dumpChan:
 			trigger.done <- w.sampler.dumpContexts(trigger.dest)
+		case done := <-w.drainChan:
+			// select doesn't order drainChan against samplesChan, so drain
+			// whatever's already buffered before acking.
+		drainLoop:
+			for {
+				select {
+				case ms := <-w.samplesChan:
+					if ms == nil {
+						close(w.samplesDrained)
+						continue
+					}
+					w.processBatch(ms)
+				default:
+					break drainLoop
+				}
+			}
+			close(done)
 		}
 	}
+}
+
+// processBatch samples ms, called from run()'s normal loop or from a drain.
+func (w *timeSamplerWorker) processBatch(ms []metrics.MetricSample) {
+	shard := w.sampler.idString
+	aggregatorDogstatsdMetricSample.Add(int64(len(ms)))
+	tlmProcessed.Add(float64(len(ms)), shard, "dogstatsd_metrics")
+	t := timeNowNano()
+
+	for i := 0; i < len(ms); i++ {
+		w.sampler.sample(&ms[i], t, w.tagFilterList)
+	}
+	w.metricSamplePool.PutBatch(ms)
 }
 
 // Set a new filterlist, ensuring we also clear the context resolver strip cache
@@ -177,4 +204,12 @@ func (w *timeSamplerWorker) waitForShutdown(ctx context.Context) {
 	case <-w.samplesDrained:
 	case <-ctx.Done():
 	}
+}
+
+// waitForPendingSamples blocks until samples enqueued before this call have
+// been processed. Safe to call repeatedly, unlike shutdown/waitForShutdown.
+func (w *timeSamplerWorker) waitForPendingSamples() {
+	done := make(chan struct{})
+	w.drainChan <- done
+	<-done
 }

--- a/pkg/aggregator/time_sampler_worker_test.go
+++ b/pkg/aggregator/time_sampler_worker_test.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package aggregator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+// A sample sent right before WaitForPendingSamples must be processed by the
+// time the call returns, and the call must be repeatable.
+func TestWaitForPendingSamplesDrainsBeforeReturning(t *testing.T) {
+	require := require.New(t)
+
+	deps := createDemultiplexerAgentTestDeps(t)
+	opts := demuxTestOptions()
+	// InitAndStartAgentDemultiplexer (not initAgentDemultiplexer) is required
+	// here: WaitForPendingSamples needs the worker's run() goroutine actually
+	// running to service drainChan.
+	demux := InitAndStartAgentDemultiplexer(deps.Log, NewForwarderTest(deps.Log), deps.OrchestratorFwd, opts, deps.EventPlatform, deps.HaAgent, deps.Compressor, deps.Tagger, deps.FilterList, "")
+	defer demux.Stop()
+
+	worker := demux.statsd.workers[0]
+	require.Equal(0, worker.sampler.contextResolver.length())
+
+	demux.AggregateSample(metrics.MetricSample{
+		Name:      "test.metric",
+		Value:     1,
+		Mtype:     metrics.GaugeType,
+		Timestamp: 1657099120.0,
+		Tags:      []string{"tag:1"},
+	})
+
+	demux.WaitForPendingSamples()
+
+	require.Len(worker.samplesChan, 0, "the sample must have been drained from samplesChan")
+	require.Equal(1, worker.sampler.contextResolver.length(), "the sample must have been aggregated into a context, not just dequeued")
+
+	// Calling it again with nothing pending must not block or panic.
+	demux.WaitForPendingSamples()
+}

--- a/pkg/clusteragent/admission/validate/kubernetesadmissionevents/kubernetesadmissionevents_test.go
+++ b/pkg/clusteragent/admission/validate/kubernetesadmissionevents/kubernetesadmissionevents_test.go
@@ -262,7 +262,7 @@ func TestKubernetesAdmissionEvents(t *testing.T) {
 			mockSender.On("Event", mock.AnythingOfType("event.Event")).Return().Once()
 			validated, err := kubernetesAuditWebhook.emitEvent(&tt.request, "", nil)
 			// Force flush to serializer to ensure the event is emitted and received.
-			demultiplexerMock.ForceFlushToSerializer(start, true)
+			demultiplexerMock.ForceFlushToSerializer(start, true, false)
 			assert.NoError(t, err)
 			assert.True(t, validated)
 			if tt.expectedEmitted {

--- a/pkg/serverless/metrics/BUILD.bazel
+++ b/pkg/serverless/metrics/BUILD.bazel
@@ -17,6 +17,7 @@ dd_agent_go_test(
     name = "metrics_test",
     srcs = [
         "metric_add_test.go",
+        "metric_drain_test.go",
         "metric_test.go",
     ],
     embed = [":metrics"],
@@ -30,6 +31,7 @@ dd_agent_go_test(
         "//comp/core/log/mock",
         "//comp/core/secrets/def",
         "//comp/core/secrets/mock",
+        "//comp/core/tagger/fx-mock",
         "//comp/core/tagger/impl-noop",
         "//comp/filterlist/fx-mock",
         "//comp/forwarder/defaultforwarder/def",

--- a/pkg/serverless/metrics/metric.go
+++ b/pkg/serverless/metrics/metric.go
@@ -56,15 +56,43 @@ func (c *ServerlessMetricAgent) AddEnhancedUsageMetric(name string, value float6
 	c.sendMetricSample(name, value, metricSource, metrics.GaugeType, timestamp, c.tags.EnhancedUsageMetric, extraTags...)
 }
 
-// Flush forces an immediate flush of aggregated samples to the serializer.
+// Flush forces an immediate flush of already-closed buckets to the serializer.
 // Satisfied interface: cmd/serverless-init/lifecycle.Flusher, used by MicroVM
-// to flush telemetry on-demand before a Firecracker snapshot (/suspend,
-// /terminate), independent of the Fx-managed shutdown flush.
+// to flush telemetry on-demand before a Firecracker snapshot on /suspend,
+// independent of the Fx-managed shutdown flush. /terminate uses FlushAll instead.
 func (c *ServerlessMetricAgent) Flush() {
 	if c.Demux == nil {
 		return
 	}
-	c.Demux.ForceFlushToSerializer(time.Now(), true)
+	c.Demux.ForceFlushToSerializer(time.Now(), true, false)
+}
+
+// FlushAll additionally includes the current, not-yet-closed bucket. Satisfied
+// interface: cmd/serverless-init/lifecycle.ForceFlusher — see that doc for why
+// this must stay off /suspend's path.
+func (c *ServerlessMetricAgent) FlushAll() {
+	if c.Demux == nil {
+		return
+	}
+	c.Demux.ForceFlushToSerializer(time.Now(), true, true)
+}
+
+// pendingSampleDrainer is satisfied by *aggregator.AgentDemultiplexer, and by
+// anything embedding it — notably the Fx demultiplexer component's wrapper
+// struct, which is what c.Demux actually holds in production. Asserting
+// against this interface instead of the concrete *AgentDemultiplexer type
+// lets Go's method promotion see through that wrapper.
+type pendingSampleDrainer interface {
+	WaitForPendingSamples()
+}
+
+// WaitForPendingSamples blocks until samples enqueued before this call have
+// been consumed. Satisfied interface: cmd/serverless-init/lifecycle.SampleDrainer.
+// No-op if the demux doesn't support draining (e.g. unset in tests).
+func (c *ServerlessMetricAgent) WaitForPendingSamples() {
+	if d, ok := c.Demux.(pendingSampleDrainer); ok {
+		d.WaitForPendingSamples()
+	}
 }
 
 // sendMetricSample records a distribution metric sample using the agent's extra tags plus any

--- a/pkg/serverless/metrics/metric_drain_test.go
+++ b/pkg/serverless/metrics/metric_drain_test.go
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
+	secretsmock "github.com/DataDog/datadog-agent/comp/core/secrets/mock"
+	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	filterlistmock "github.com/DataDog/datadog-agent/comp/filterlist/fx-mock"
+	defaultforwarder "github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/def"
+	haagentmock "github.com/DataDog/datadog-agent/comp/haagent/mock"
+	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
+	metricscompression "github.com/DataDog/datadog-agent/comp/serializer/metricscompression/fx-mock"
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	pkgmetrics "github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/serverless/metrics/metricstest"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Same nil-Demux safety already covered for Flush/FlushAll by
+// TestMetricAgentNoOpWithoutDemux in main_test.go.
+func TestWaitForPendingSamplesNoOpWithoutDemux(t *testing.T) {
+	agent := &ServerlessMetricAgent{}
+	assert.NotPanics(t, func() {
+		agent.WaitForPendingSamples()
+	})
+}
+
+// TestWaitForPendingSamplesDrainsRealDemux runs against the actual Fx wiring
+// production code gets. bundle.Demux's dynamic type is the demultiplexerimpl
+// wrapper struct, not a bare *aggregator.AgentDemultiplexer — a concrete-type
+// assertion in WaitForPendingSamples would silently no-op here.
+func TestWaitForPendingSamplesDrainsRealDemux(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	bundle := metricstest.New(t, fakeTagger)
+
+	_, ok := bundle.Demux.(pendingSampleDrainer)
+	require.True(t, ok, "the Fx-provided demux must satisfy pendingSampleDrainer, or WaitForPendingSamples silently no-ops in production")
+
+	agent := New(bundle.Demux, Tags{EnhancedMetric: []string{"tag:1"}})
+	assert.NotPanics(t, func() {
+		agent.AddEnhancedMetric("test.metric", 1.0, pkgmetrics.MetricSourceServerless, 0)
+		agent.WaitForPendingSamples()
+		agent.WaitForPendingSamples()
+	})
+}
+
+// TestWaitForPendingSamplesDrainsThroughWrappedDemux mirrors
+// TestStopDrainsThroughWrappedDemux above (same wrappedDemux type): proves a
+// sample submitted through the wrapped Demux is actually drained, not just
+// that the type assertion succeeds. Without a working drain, AddEnhancedMetric
+// and the worker processing it race FlushAll — same race TestStopDrainsBeforeFlush
+// documents — so a single iteration can pass by luck; 100 iterations make a
+// broken drain reliably show up as a sketchCount short of iterations.
+func TestWaitForPendingSamplesDrainsThroughWrappedDemux(t *testing.T) {
+	mockConfig := configmock.New(t)
+	pkgconfigsetup.LoadDatadog(mockConfig, secretsmock.New(t), delegatedauthmock.New(t), nil)
+
+	cf := newCountingForwarder()
+
+	deps := fxutil.Test[aggregator.TestDeps](t,
+		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
+		fx.Provide(func() defaultforwarder.Component { return cf }),
+		core.MockBundle(),
+		hostnameimpl.MockModule(),
+		haagentmock.Module(),
+		logscompression.MockModule(),
+		metricscompression.MockModule(),
+		filterlistmock.MockModule(),
+	)
+
+	const iterations = 100
+	future := float64(time.Now().Add(time.Hour).UnixNano()) / float64(time.Second)
+	for i := 0; i < iterations; i++ {
+		opts := aggregator.DefaultAgentDemultiplexerOptions()
+		opts.FlushInterval = time.Hour
+		opts.DontStartForwarders = true
+		demux := aggregator.InitAndStartAgentDemultiplexerForTest(deps, opts, "")
+
+		agent := New(wrappedDemux{AgentDemultiplexer: demux}, Tags{})
+		agent.AddEnhancedMetric("test.metric", 1.0, pkgmetrics.MetricSourceServerless, future)
+
+		agent.WaitForPendingSamples()
+		agent.FlushAll()
+
+		demux.Stop()
+	}
+
+	require.Equal(t, int64(iterations), cf.sketchCount.Load(),
+		"WaitForPendingSamples must drain every sample submitted through the wrapped Demux before FlushAll runs")
+}

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -234,3 +234,83 @@ func TestShutdownCascadeFlushesLateSample(t *testing.T) {
 	require.Equal(t, int64(1), cf.sketchCount.Load(),
 		"the OnStop cascade must drain and flush the late sample to the forwarder")
 }
+
+// TestFlushAllDeliversOpenBucketSample proves FlushAll delivers a sample still
+// sitting in the current, open bucket — no periodic flush needed.
+// require.Eventually retries because AddEnhancedMetric and the worker
+// processing it race (the still-open SampleDrainer gap); that's not what this
+// test covers.
+func TestFlushAllDeliversOpenBucketSample(t *testing.T) {
+	mockConfig := configmock.New(t)
+	pkgconfigsetup.LoadDatadog(mockConfig, secretsmock.New(t), delegatedauthmock.New(t), nil)
+
+	cf := newCountingForwarder()
+
+	deps := fxutil.Test[aggregator.TestDeps](t,
+		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
+		fx.Provide(func() defaultforwarder.Component { return cf }),
+		core.MockBundle(),
+		hostnameimpl.MockModule(),
+		haagentmock.Module(),
+		logscompression.MockModule(),
+		metricscompression.MockModule(),
+		filterlistmock.MockModule(),
+	)
+
+	opts := aggregator.DefaultAgentDemultiplexerOptions()
+	opts.FlushInterval = time.Hour // disable automatic flushes
+	opts.DontStartForwarders = true
+	demux := aggregator.InitAndStartAgentDemultiplexerForTest(deps, opts, "")
+	defer demux.Stop()
+
+	agent := New(demux, Tags{})
+	// An hour out so the bucket can never close mid-test, regardless of real
+	// bucket-boundary timing.
+	future := float64(time.Now().Add(time.Hour).UnixNano()) / float64(time.Second)
+	agent.AddEnhancedMetric("test.metric", 1.0, pkgmetrics.MetricSourceServerless, future)
+
+	require.Eventually(t, func() bool {
+		agent.FlushAll()
+		return cf.sketchCount.Load() >= 1
+	}, time.Second, time.Millisecond,
+		"FlushAll must deliver a sample from the still-open bucket")
+}
+
+// TestFlushSkipsOpenBucket is the negative control for
+// TestFlushAllDeliversOpenBucketSample: Flush must never include a sample
+// from the still-open bucket.
+func TestFlushSkipsOpenBucket(t *testing.T) {
+	mockConfig := configmock.New(t)
+	pkgconfigsetup.LoadDatadog(mockConfig, secretsmock.New(t), delegatedauthmock.New(t), nil)
+
+	cf := newCountingForwarder()
+
+	deps := fxutil.Test[aggregator.TestDeps](t,
+		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
+		fx.Provide(func() defaultforwarder.Component { return cf }),
+		core.MockBundle(),
+		hostnameimpl.MockModule(),
+		haagentmock.Module(),
+		logscompression.MockModule(),
+		metricscompression.MockModule(),
+		filterlistmock.MockModule(),
+	)
+
+	opts := aggregator.DefaultAgentDemultiplexerOptions()
+	opts.FlushInterval = time.Hour // disable automatic flushes
+	opts.DontStartForwarders = true
+	demux := aggregator.InitAndStartAgentDemultiplexerForTest(deps, opts, "")
+	defer demux.Stop()
+
+	agent := New(demux, Tags{})
+	future := float64(time.Now().Add(time.Hour).UnixNano()) / float64(time.Second)
+	agent.AddEnhancedMetric("test.metric", 1.0, pkgmetrics.MetricSourceServerless, future)
+
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		agent.Flush()
+		time.Sleep(time.Millisecond)
+	}
+	assert.Equal(t, int64(0), cf.sketchCount.Load(),
+		"Flush must not deliver a sample from the still-open bucket")
+}


### PR DESCRIPTION
DD_AWS_MICROVM_USER_APP_PORT is currently all-or-nothing: set it and every lifecycle hook (ready/validate/run/resume/suspend/terminate) forwards to the user app. Not all apps implement all six — a common case is /run and /suspend but not /ready — and the agent had no way to know that, so it kept forwarding to paths that don't exist and eating the timeout.

This adds a per-hook opt-in (DD_AWS_MICROVM_ENABLE_READY / _VALIDATE / _RUN / _RESUME / _SUSPEND / _TERMINATE, default false) so forwarding requires both the port and that specific hook's flag. Same shape AWS already uses for its own --hooks manifest — each hook there also defaults to DISABLED unless explicitly turned on:

> A hook left at its default `DISABLED` is not called even if the application implements the path.

(from AWS's [lifecycle-model.md](https://github.com/aws/agent-toolkit-for-aws/blob/847f477649252b98f8fb828bbfeaf109b57b8cac/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/lifecycle-model.md))

Heads up: this flips the existing default. USER_APP_PORT alone used to forward everything; now it forwards nothing until you flip the flags on. Fine for now since nobody's depending on the old behavior yet.

Run the tests:

    dda inv test --targets=./cmd/serverless-init/lifecycle/...,./cmd/serverless-init/cloudservice/...

Integration tests [with](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda-microvms$252Fsample-nodejs-app/log-events/16.0$252F8c35c388-7d6a-4760-abe8-651ac1f32bb5$3FfilterPattern$3DLTN) and [without](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda-microvms$252Fsample-nodejs-app/log-events/15.0$252F3bbabbd3-c025-4b8b-899a-0ed851ef412c$3FfilterPattern$3DLTN) flags show the expected output.