### PR TITLE
debugger: drain req body when logs are disabled

### DIFF
--- a/pkg/trace/api/debugger.go
+++ b/pkg/trace/api/debugger.go
@@ -7,6 +7,7 @@ package api
 
 import (
 	"fmt"
+	"io"
 	stdlog "log"
 	"net/http"
 	"net/http/httputil"
@@ -14,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/api/apiutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/google/uuid"
@@ -36,7 +38,7 @@ const (
 // to the logs intake.
 func (r *HTTPReceiver) debuggerLogsProxyHandler() http.Handler {
 	if !r.conf.DebuggerLogsEnabled {
-		return debuggerLogsDisabledHandler()
+		return debuggerLogsDisabledHandler(r.conf.MaxRequestBytes)
 	}
 	return r.debuggerProxyHandler(logsIntakeURLTemplate, r.conf.DebuggerProxy)
 }
@@ -53,7 +55,7 @@ func (r *HTTPReceiver) debuggerDiagnosticsProxyHandler() http.Handler {
 // tracers).
 func (r *HTTPReceiver) debuggerV2IntakeProxyHandler() http.Handler {
 	if !r.conf.DebuggerLogsEnabled {
-		return debuggerLogsDisabledHandler()
+		return debuggerLogsDisabledHandler(r.conf.MaxRequestBytes)
 	}
 	return r.debuggerProxyHandler(debuggerIntakeURLTemplate, r.conf.DebuggerIntakeProxy)
 }
@@ -61,9 +63,12 @@ func (r *HTTPReceiver) debuggerV2IntakeProxyHandler() http.Handler {
 // debuggerLogsDisabledHandler returns an http.Handler that silently drops
 // debugger data when logs are disabled at the agent level (logs_enabled: false).
 // It returns 200 OK so tracers do not retry or log errors.
-func debuggerLogsDisabledHandler() http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+func debuggerLogsDisabledHandler(maxBytes int64) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		log.Debug("Debugger proxy: dropping request because logs are disabled (logs_enabled: false)")
+		// Drain up to maxBytes so normal uploads get a clean 200 instead of a connection reset,
+		// without waiting on an unbounded body before acknowledging.
+		_, _ = io.Copy(io.Discard, apiutil.NewLimitedReader(req.Body, maxBytes))
 		w.WriteHeader(http.StatusOK)
 	})
 }

--- a/pkg/trace/api/debugger_test.go
+++ b/pkg/trace/api/debugger_test.go
@@ -329,6 +329,37 @@ func TestDebuggerProxyLogsDisabled(t *testing.T) {
 		assert.False(t, called, "request should not be proxied when logs are disabled")
 		assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
 	})
+
+	t.Run("drains_body_when_disabled", func(t *testing.T) {
+		req, err := http.NewRequest("POST", "/some/path", strings.NewReader(strings.Repeat("x", 1024)))
+		assert.NoError(t, err)
+		conf := getConf()
+		conf.DebuggerLogsEnabled = false
+		receiver := newTestReceiverFromConfig(conf)
+		rec := httptest.NewRecorder()
+		receiver.debuggerV2IntakeProxyHandler().ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+		// Body must be fully consumed so large uploads get a clean 200 instead of a connection reset.
+		remaining, err := io.ReadAll(req.Body)
+		assert.NoError(t, err)
+		assert.Empty(t, remaining, "handler must drain the request body")
+	})
+
+	t.Run("bounds_body_drain_when_disabled", func(t *testing.T) {
+		req, err := http.NewRequest("POST", "/some/path", strings.NewReader(strings.Repeat("x", 1024)))
+		assert.NoError(t, err)
+		conf := getConf()
+		conf.DebuggerLogsEnabled = false
+		conf.MaxRequestBytes = 10
+		receiver := newTestReceiverFromConfig(conf)
+		rec := httptest.NewRecorder()
+		receiver.debuggerV2IntakeProxyHandler().ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+		// The drain must stop at MaxRequestBytes so we never wait on an unbounded body.
+		remaining, err := io.ReadAll(req.Body)
+		assert.NoError(t, err)
+		assert.Len(t, remaining, 1024-10, "handler must bound the drain to MaxRequestBytes")
+	})
 }
 
 func getConf() *traceconfig.AgentConfig {

--- a/releasenotes/notes/debugger-drain-body-when-logs-disabled-8d41c6e2f5a90b73.yaml
+++ b/releasenotes/notes/debugger-drain-body-when-logs-disabled-8d41c6e2f5a90b73.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    APM: Fixed Dynamic Instrumentation snapshot and log-probe uploads failing
+    with a connection reset when the Logs product is disabled
+    (``logs_enabled: false``). The debugger proxy now drains the request body
+    before responding, so these uploads are dropped cleanly instead of
+    resetting the tracer's connection.


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where request bodies coming from the tracers weren't being properly drained.

### Motivation

Customer reported an issue with downstream `Connection reset` errors.