### PR TITLE
[DRAFT] Package Agent Data Plane with the Heroku Agent (size probe)

### DIFF
--- a/.gitlab/build/package_build/heroku.yml
+++ b/.gitlab/build/package_build/heroku.yml
@@ -33,3 +33,6 @@ agent_heroku_deb-x64-a7:
   extends: .heroku_build_base
   variables:
     DESTINATION_DBG_DEB: "datadog-heroku-agent-dbg_7_amd64.deb"
+    # Size-probe: bundle Agent Data Plane into the Heroku build to measure the
+    # "package ADP alongside the Heroku Agent" alternative.
+    HEROKU_INCLUDE_ADP: "true"

--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -2,7 +2,10 @@ name 'datadog-agent-dependencies'
 
 description "Enforce building dependencies as soon as possible so they can be cached"
 
-dependency 'datadog-agent-data-plane' if (linux_target? || osx_target? || windows_target?) && !heroku_target?
+# ADP is normally excluded from the Heroku build. Size-probe: allow bundling it
+# into Heroku when HEROKU_INCLUDE_ADP=true, to measure the "package ADP alongside
+# the Heroku Agent" alternative in the "Freezing the Heroku Agent" proposal.
+dependency 'datadog-agent-data-plane' if (linux_target? || osx_target? || windows_target?) && (!heroku_target? || ENV['HEROKU_INCLUDE_ADP'] == 'true')
 
 dependency 'datadog-agent-integrations-py3'
 

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -196,6 +196,13 @@ def get_omnibus_env(
     if kubernetes_cpu_request:
         env['OMNIBUS_WORKERS_OVERRIDE'] = str(int(kubernetes_cpu_request) + 1)
 
+    # Size-probe (Heroku + ADP): forward the opt-in flag to the Omnibus process
+    # so datadog-agent-dependencies can conditionally bundle ADP into the Heroku
+    # build. Forwarded explicitly (not via the passthrough allowlist) to avoid a
+    # "missing env var" warning on every build that doesn't set it.
+    if os.environ.get('HEROKU_INCLUDE_ADP'):
+        env['HEROKU_INCLUDE_ADP'] = os.environ['HEROKU_INCLUDE_ADP']
+
     env_to_forward = _passthrough_env_for_os(os.environ, sys.platform)
     env.update(env_to_forward)
 


### PR DESCRIPTION
## Summary

The Heroku Agent embeds the Go DogStatsD server, so it blocks deleting that server as part of the DogStatsD Succession. One alternative in the "Freezing the Heroku Agent" proposal is to keep the Heroku distribution but bundle Agent Data Plane (ADP) with it (so DogStatsD moves to ADP and the Go server can be deleted). ADP is excluded from the Heroku build today by a one-line omnibus guard; this draft allows bundling it behind a `HEROKU_INCLUDE_ADP` flag (set only on the Heroku build job) purely to measure the resulting `agent_heroku_amd64` package-size delta.

Draft only — measures size, not full functionality (the buildpack's process supervision would still need to start ADP).

## Test plan

- [ ] Read the Static Quality Gates comment and compare `agent_heroku_amd64` against the ~307.5 MiB baseline.
