### PR TITLE
[DRAFT] Add infrastructure_mode=heroku (PoC)

### DIFF
--- a/comp/metadata/inventoryagent/impl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/impl/inventoryagent.go
@@ -175,7 +175,7 @@ func (ia *inventoryagent) initData() {
 
 	infraMode := scrub(ia.conf.GetString("infrastructure_mode"))
 	// fleet-automation: This validation should be done by the Config once we have such mechanism
-	if !slices.Contains([]string{"full", "end_user_device", "basic", "cloud_cost_only", "none"}, infraMode) {
+	if !slices.Contains([]string{"full", "end_user_device", "basic", "cloud_cost_only", "heroku", "none"}, infraMode) {
 		ia.log.Warnf("invalid value for 'infrastructure_mode': '%s' (defaulting to 'full')", infraMode)
 		infraMode = "full"
 	}

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1236,7 +1236,7 @@ func agent(config pkgconfigmodel.Setup) {
 
 	// Infrastructure mode
 	// The infrastructure mode is used to determine the features that are available to the agent.
-	// The possible values are: full, basic, end_user_device, cloud_cost_only, none.
+	// The possible values are: full, basic, end_user_device, cloud_cost_only, heroku, none.
 	config.BindEnvAndSetDefault("infrastructure_mode", "full")
 
 	// Infrastructure full mode section (default mode, allows all checks)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1401,6 +1401,28 @@ func applyInfrastructureModeOverrides(config pkgconfigmodel.Config) {
 		config.Set("integration.enabled", false, pkgconfigmodel.SourceInfraMode)
 		// Avoid detailed ECS task metadata collection when not collecting infrastructure.
 		config.Set("ecs_task_collection_enabled", false, pkgconfigmodel.SourceInfraMode)
+	} else if infraMode == "heroku" {
+		// Mirror the Heroku Agent build flavor's runtime behavior on the regular
+		// Agent. The heroku build drops container runtimes, Kubernetes, cloud-provider
+		// (ec2/fargate), orchestration, and SBOM, but keeps APM (trace-agent),
+		// integrations, and DogStatsD. This disables the corresponding subsystems at
+		// runtime and routes DogStatsD through ADP so the Go DogStatsD server is not
+		// needed. It does NOT reproduce the smaller heroku *package* (that is a build
+		// difference, not a runtime one) — see the "Freezing the Heroku Agent" proposal.
+		//
+		// As with the other modes these use SourceInfraMode, so an explicit user
+		// config file or environment variable still takes precedence.
+		config.Set("process_config.process_collection.enabled", false, pkgconfigmodel.SourceInfraMode)
+		config.Set("process_config.container_collection.enabled", false, pkgconfigmodel.SourceInfraMode)
+		config.Set("container_image.enabled", false, pkgconfigmodel.SourceInfraMode)
+		config.Set("container_lifecycle.enabled", false, pkgconfigmodel.SourceInfraMode)
+		config.Set("orchestrator_explorer.enabled", false, pkgconfigmodel.SourceInfraMode)
+		config.Set("sbom.enabled", false, pkgconfigmodel.SourceInfraMode)
+		config.Set("ecs_task_collection_enabled", false, pkgconfigmodel.SourceInfraMode)
+		// Serve DogStatsD via ADP rather than the Go DogStatsD server. APM and
+		// host integrations are intentionally left enabled (the heroku flavor ships them).
+		config.Set("data_plane.enabled", true, pkgconfigmodel.SourceInfraMode)
+		config.Set("data_plane.dogstatsd.enabled", true, pkgconfigmodel.SourceInfraMode)
 	}
 }
 

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -783,6 +783,29 @@ infrastructure_mode: none
 	assert.False(t, config.GetBool("integration.enabled"))
 }
 
+func TestInfrastructureModeHeroku(t *testing.T) {
+	datadogYaml := `
+infrastructure_mode: heroku
+`
+	config := confFromYAML(t, datadogYaml)
+	applyInfrastructureModeOverrides(config)
+
+	// Container / orchestration / cloud-provider subsystems the heroku build omits are disabled.
+	assert.False(t, config.GetBool("process_config.process_collection.enabled"))
+	assert.False(t, config.GetBool("process_config.container_collection.enabled"))
+	assert.False(t, config.GetBool("orchestrator_explorer.enabled"))
+	assert.False(t, config.GetBool("sbom.enabled"))
+	assert.False(t, config.GetBool("ecs_task_collection_enabled"))
+
+	// APM and integrations are kept (the heroku flavor ships them).
+	assert.True(t, config.GetBool("apm_config.enabled"))
+	assert.True(t, config.GetBool("integration.enabled"))
+
+	// DogStatsD is served by ADP.
+	assert.True(t, config.GetBool("data_plane.enabled"))
+	assert.True(t, config.GetBool("data_plane.dogstatsd.enabled"))
+}
+
 func TestInfrastructureModeLegacyAliases(t *testing.T) {
 	// Test that legacy allowed_additional_checks is aliased to mode-specific
 	// key via applyInfrastructureModeOverrides

--- a/releasenotes/notes/add-infrastructure-mode-heroku-jszwedko.yaml
+++ b/releasenotes/notes/add-infrastructure-mode-heroku-jszwedko.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not differ between releases and is easy to understand.
+---
+features:
+  - |
+    Added a new ``infrastructure_mode`` value, ``heroku``, which constrains the
+    regular Agent to the Heroku Agent flavor's runtime feature set (no container,
+    Kubernetes, cloud-provider, orchestration, or SBOM collection; APM and
+    integrations kept) with DogStatsD served by Agent Data Plane. Proof-of-concept
+    migration target for the Heroku Agent distribution.


### PR DESCRIPTION
## Summary

Proof-of-concept for one of the alternatives in the "Freezing the Heroku Agent" proposal: a runtime `infrastructure_mode: heroku` on the regular Agent as a possible migration target for the Heroku distribution. It mirrors the Heroku build flavor's runtime feature set — disables container, Kubernetes, cloud-provider (ecs/fargate), orchestration, and SBOM collection while keeping APM and integrations, and routes DogStatsD through Agent Data Plane so the Go DogStatsD server isn't needed.

Included for completeness. It is the *weaker* alternative in the proposal: a runtime mode runs on the full Agent binary and so cannot reproduce Heroku's smaller build-flavor package (~307 MiB vs ~750 MiB) — Heroku's main benefit. Draft; not intended to merge.

## Test plan

- New unit test covers the `heroku` overrides and that APM/integrations remain enabled (`pkg/config/setup/config_test.go`).
