### PR TITLE
cmd/system-probe/modules: run its tests in CI, fix swapped assert

### DIFF
--- a/cmd/system-probe/modules/network_tracer_test.go
+++ b/cmd/system-probe/modules/network_tracer_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestNetworkModuleOrder(t *testing.T) {
 	allModules := All()
-	assert.Less(t, slices.Index(allModules, EventMonitor), slices.Index(allModules, NetworkTracer))
+	assert.Less(t, slices.Index(allModules, NetworkTracer), slices.Index(allModules, EventMonitor))
 }
 
 func TestDecode(t *testing.T) {

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -48,6 +48,7 @@ NPM_TAG = "npm"
 TEST_DIR = os.getenv('DD_AGENT_TESTING_DIR') or os.path.normpath(os.path.join(os.getcwd(), "test", "new-e2e", "tests"))
 E2E_ARTIFACT_DIR = os.path.join(TEST_DIR, "sysprobe-functional/artifacts")
 TEST_PACKAGES_LIST = [
+    "./cmd/system-probe/modules/...",
     "./pkg/ebpf/...",
     "./pkg/network/...",
     "./pkg/collector/corechecks/ebpf/...",


### PR DESCRIPTION
### What does this PR do?

- Adds `cmd/system-probe/modules` to the system-probe test package list so its `linux_bpf`-gated tests actually get built and run.
- Fixes a swapped assertion in `TestNetworkModuleOrder`.

### Motivation

`network_tracer_test.go`'s `TestNetworkModuleOrder` asserted the opposite of the documented module order (`moduleOrder` in `modules.go` places `NetworkTracer` before `EventMonitor`, since `EventMonitor` depends on it).
This went unnoticed because `cmd/system-probe/modules` was never in `TEST_PACKAGES_LIST`, so the `linux_bpf`-gated test files in that package were never compiled or run by any CI job.

### Describe how you validated your changes

- Traced the CI package list through `tasks/kmt.py` to confirm `cmd/system-probe/modules` will now be built and tested by the existing `kmt_run_sysprobe_tests_*` jobs.
- Verified the corrected assertion matches `moduleOrder`'s documented ordering.

### Additional Notes
