### PR TITLE
Remove unused :install targets from deps/

### DIFF
--- a/deps/acl/README.md
+++ b/deps/acl/README.md
@@ -14,13 +14,6 @@ then add the new .c files.
 
 We should only have to do this once.
 
-### Make fake attr
-
-Build the deps and put them where we can find them later
-```
-bazel run @attr//:install -- --dest_dir /tmp/attr
-```
-
 ###
 - Download the current libacl sources
 - untar. Leaves the directory acl-2.3.1

--- a/deps/acl/overlay/overlay.BUILD.bazel
+++ b/deps/acl/overlay/overlay.BUILD.bazel
@@ -7,7 +7,6 @@ load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files", "strip_prefix")
 
 package(default_package_metadata = [":package_metadata", ":ship_source_offer"])
@@ -198,11 +197,4 @@ pkg_filegroup(
     ],
     prefix = "embedded",
     visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/attr/attr.BUILD.bazel
+++ b/deps/attr/attr.BUILD.bazel
@@ -5,7 +5,6 @@ load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(default_package_metadata = [":package_metadata", ":ship_source_offer"])
@@ -122,11 +121,4 @@ pkg_filegroup(
     ],
     prefix = "embedded",
     visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/compile_policy/BUILD.bazel
+++ b/deps/compile_policy/BUILD.bazel
@@ -1,6 +1,5 @@
 # dd-compile-policy - make the prebuilt compiler part of the distribution.
 
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files")
 
 package(default_visibility = ["//packages:__subpackages__"])
@@ -52,12 +51,5 @@ pkg_filegroup(
     srcs = [
         ":bin_files",
         ":license_file",
-    ],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
     ],
 )

--- a/deps/curl/overlay/overlay.BUILD.bazel
+++ b/deps/curl/overlay/overlay.BUILD.bazel
@@ -5,7 +5,6 @@ load("@@//bazel/rules/dd_packaging:dd_collect_dependencies.bzl", "dd_collect_dep
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 load(
     "lib_contents.bzl",
@@ -275,12 +274,4 @@ pkg_filegroup(
     name = "installed_libs",
     srcs = [":_installed_libs"],
     prefix = "embedded",
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-        ":installed_libs",
-    ],
 )

--- a/deps/dbus/dbus.BUILD.bazel
+++ b/deps/dbus/dbus.BUILD.bazel
@@ -2,7 +2,6 @@ load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(default_package_metadata = [":license"])
@@ -167,11 +166,4 @@ pkg_filegroup(
     ],
     prefix = "embedded",
     visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/gcrypt/gcrypt.BUILD.bazel
+++ b/deps/gcrypt/gcrypt.BUILD.bazel
@@ -6,7 +6,6 @@ load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(
@@ -787,12 +786,5 @@ pkg_filegroup(
     visibility = [
         "@@//deps/openscap:__pkg__",
         "@@//packages:__subpackages__",
-    ],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
     ],
 )

--- a/deps/gpg-error/gpg-error.BUILD.bazel
+++ b/deps/gpg-error/gpg-error.BUILD.bazel
@@ -6,7 +6,6 @@ load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(
@@ -298,11 +297,4 @@ pkg_filegroup(
         ":hdr_files",
     ],
     prefix = "embedded",
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/gstatus/BUILD.bazel
+++ b/deps/gstatus/BUILD.bazel
@@ -1,7 +1,6 @@
 # dd-compile-policy - make the prebuilt compiler part of the distribution.
 
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files")
 
 package(
@@ -54,12 +53,5 @@ pkg_filegroup(
     srcs = [
         ":bin_files",
         ":license_file",
-    ],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
     ],
 )

--- a/deps/jmxfetch/BUILD.bazel
+++ b/deps/jmxfetch/BUILD.bazel
@@ -1,7 +1,6 @@
 # jmxfetch JAR file.
 
 load("@agent_volatile//:env_vars.bzl", "env_vars")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files")
 load("//bazel/rules/macos/codesign:code_sign_jar_macos.bzl", "code_sign_jar_macos")
 load(":module_utils_test.bzl", "jmxfetch_module_utils_test_suite")
@@ -50,14 +49,6 @@ pkg_filegroup(
     name = "all_files",
     srcs = [
         ":jar_file",
-    ],
-    tags = ["manual"],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
     ],
     tags = ["manual"],
 )

--- a/deps/libselinux.BUILD.bazel
+++ b/deps/libselinux.BUILD.bazel
@@ -3,7 +3,6 @@ load("@@//compliance/rules:purl.bzl", "purl_for_generic")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(
@@ -100,11 +99,4 @@ pkg_filegroup(
     ],
     prefix = "embedded",
     visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/libsepol.BUILD.bazel
+++ b/deps/libsepol.BUILD.bazel
@@ -4,7 +4,6 @@ load("@@//compliance/rules:ship_source_offer.bzl", "ship_source_offer")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(default_package_metadata = [":package_metadata", ":ship_source_offer"])
@@ -112,11 +111,4 @@ pkg_filegroup(
     ],
     prefix = "embedded",
     visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/libxml2/overlay.BUILD.bazel
+++ b/deps/libxml2/overlay.BUILD.bazel
@@ -3,7 +3,6 @@ load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 VERSION = "2.15.3"
@@ -174,11 +173,4 @@ pkg_filegroup(
         ":headers",
     ],
     prefix = "embedded",
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/libxslt/overlay.BUILD.bazel
+++ b/deps/libxslt/overlay.BUILD.bazel
@@ -3,7 +3,6 @@ load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 XSLT_VERSION = "1.1.45"
@@ -215,11 +214,4 @@ pkg_filegroup(
     ],
     prefix = "embedded",
     visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/libyaml.BUILD.bazel
+++ b/deps/libyaml.BUILD.bazel
@@ -3,7 +3,6 @@
 load("@@//bazel/rules/dd_packaging:dd_cc_packaged.bzl", "dd_cc_packaged")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 VERSION = "0.2.5"
@@ -71,11 +70,4 @@ pkg_filegroup(
     ],
     prefix = "embedded",
     visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/nfsiostat/BUILD.bazel
+++ b/deps/nfsiostat/BUILD.bazel
@@ -1,6 +1,5 @@
 """nfsiostat"""
 
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files")
 
 package(default_visibility = [
@@ -28,11 +27,4 @@ pkg_filegroup(
         ":bin_files",
     ],
     prefix = "embedded",
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/nghttp2/nghttp2.BUILD.bazel
+++ b/deps/nghttp2/nghttp2.BUILD.bazel
@@ -1,7 +1,6 @@
 load("@@//bazel/rules/dd_packaging:dd_cc_packaged.bzl", "dd_cc_packaged")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(
@@ -134,12 +133,4 @@ pkg_filegroup(
     ],
     prefix = "embedded",
     visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
-)
-
-#  This is generally installed with destdir={install_dir}
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/openscap/openscap.BUILD.bazel
+++ b/deps/openscap/openscap.BUILD.bazel
@@ -8,7 +8,6 @@ load("@@//compliance/rules:ship_source_offer.bzl", "ship_source_offer")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files")
 
 package(
@@ -676,11 +675,4 @@ pkg_filegroup(
         ":_dep_libs",
     ],
     prefix = "embedded",
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/pcre2.BUILD.bazel
+++ b/deps/pcre2.BUILD.bazel
@@ -5,7 +5,6 @@ load("@bazel_skylib//rules:native_binary.bzl", "native_test")
 load("@package_metadata//licenses/rules:license.bzl", "license")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_shared_library")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(
@@ -248,11 +247,4 @@ pkg_filegroup(
     ],
     prefix = "embedded",
     visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/popt.BUILD.bazel
+++ b/deps/popt.BUILD.bazel
@@ -1,7 +1,6 @@
 load("@@//bazel/rules/dd_packaging:dd_cc_packaged.bzl", "dd_cc_packaged")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(default_package_metadata = [":license"])
@@ -96,11 +95,4 @@ pkg_filegroup(
     ],
     prefix = "embedded",
     visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -130,7 +130,7 @@ http_archive(
 http_archive(
     name = "pcre2",
     files = {
-        # We still need to vendor the build file as long as we need .pc files & the :install rule
+        # We still need to vendor the build file as long as we need .pc files
         "BUILD.bazel": "//deps:pcre2.BUILD.bazel",
     },
     sha256 = "15fbc5aba6beee0b17aecb04602ae39432393aba1ebd8e39b7cabf7db883299f",

--- a/deps/rpm/rpm.BUILD.bazel
+++ b/deps/rpm/rpm.BUILD.bazel
@@ -3,7 +3,6 @@ load("@@//bazel/rules/dd_packaging:dd_cc_packaged.bzl", "dd_cc_packaged")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(default_package_metadata = [":license"])
@@ -326,11 +325,4 @@ pkg_filegroup(
     ],
     prefix = "embedded",
     visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/security_agent_policies/BUILD.bazel
+++ b/deps/security_agent_policies/BUILD.bazel
@@ -1,6 +1,5 @@
 # security-agent-policies - policy files for the security agent.
 
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
 
 package(default_visibility = ["//packages:__subpackages__"])
@@ -8,9 +7,4 @@ package(default_visibility = ["//packages:__subpackages__"])
 pkg_filegroup(
     name = "all_files",
     srcs = ["@security_agent_policies//:all_files"],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [":all_files"],
 )

--- a/deps/security_agent_policies/security_agent_policies.BUILD.bazel
+++ b/deps/security_agent_policies/security_agent_policies.BUILD.bazel
@@ -4,7 +4,6 @@
 load("@@//compliance/rules:purl.bzl", "purl_for_generic")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 load(":version.bzl", "DOWNLOAD_URL", "VERSION")
 
@@ -63,9 +62,4 @@ pkg_filegroup(
         "@@//deps/security_agent_policies:__pkg__",
         "@@//packages:__subpackages__",
     ],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [":all_files"],
 )

--- a/deps/snmp_traps/BUILD.bazel
+++ b/deps/snmp_traps/BUILD.bazel
@@ -1,6 +1,5 @@
 # dd-compile-policy - make the prebuilt compiler part of the distribution.
 
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 
 package(default_visibility = ["//packages:__subpackages__"])
@@ -24,11 +23,4 @@ pkg_files(
     renames = {
         "@snmp_traps//file": "dd_traps_db.json.gz",
     },
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/systemd/systemd.BUILD.bazel
+++ b/deps/systemd/systemd.BUILD.bazel
@@ -3,7 +3,6 @@ load("@@//compliance/rules:ship_source_offer.bzl", "ship_source_offer")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(default_package_metadata = [":package_metadata", ":ship_source_offer"])
@@ -52,9 +51,4 @@ pkg_filegroup(
     srcs = [":hdr_files"],
     prefix = "embedded",
     visibility = ["@@//packages:__subpackages__"],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [":all_files"],
 )

--- a/deps/windows/BUILD.bazel
+++ b/deps/windows/BUILD.bazel
@@ -1,6 +1,5 @@
 # Windows drivers.
 
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 package(default_visibility = ["//packages:__subpackages__"])
@@ -12,11 +11,4 @@ pkg_files(
         "@windows_procmon_driver//:DDPROCMON.msm",
     ],
     prefix = "bin/agent",
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/xmlsec/xmlsec.BUILD.bazel
+++ b/deps/xmlsec/xmlsec.BUILD.bazel
@@ -2,7 +2,6 @@ load("@@//bazel/rules/dd_packaging:dd_cc_packaged.bzl", "dd_cc_packaged")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(default_package_metadata = [":license"])
@@ -219,11 +218,4 @@ pkg_filegroup(
     ],
     prefix = "embedded",
     visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )

--- a/deps/zlib.BUILD.bazel
+++ b/deps/zlib.BUILD.bazel
@@ -38,7 +38,6 @@
 load("@@//bazel/rules/dd_packaging:dd_cc_packaged.bzl", "dd_cc_packaged")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(
@@ -146,13 +145,6 @@ pkg_filegroup(
     ],
     prefix = "embedded",
     visibility = ["//visibility:public"],
-)
-
-pkg_install(
-    name = "install",
-    srcs = [
-        ":all_files",
-    ],
 )
 
 # buildifier: disable=no-effect


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Removes unused `pkg_install(name = "install", ...)` targets.

### Motivation

These `:install` targets have no references anywhere in the repo anymore. The files are automatically collected through `dd_cc_packaged`.

### Describe how you validated your changes

- `bazel build --config=cache //deps/... //packages/agent/dependencies:all_files`

### Additional Notes
