### PR TITLE
[DSEC-140] rustchecks: support sending event platform events as bytes

### DIFF
--- a/pkg/collector/sharedlibrary/rustchecks/core/src/agent_check.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/agent_check.rs
@@ -247,4 +247,18 @@ impl AgentCheck {
             event_track_type,
         )
     }
+
+    // TODO(dsec-157): make event_platform_event delegate to this.
+    pub fn event_platform_event_bytes(
+        &self,
+        raw_event: &[u8],
+        event_track_type: &str,
+    ) -> Result<()> {
+        self.aggregator.submit_event_platform_event_bytes(
+            &self.check_id,
+            raw_event,
+            raw_event.len() as c_int,
+            event_track_type,
+        )
+    }
 }

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/aggregator.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/aggregator.rs
@@ -286,4 +286,32 @@ impl Aggregator {
 
         Ok(())
     }
+
+    // TODO(dsec-157): refactor so submit_event_platform_event depends on
+    // submit_event_platform_event_bytes.
+    pub fn submit_event_platform_event_bytes(
+        &self,
+        check_id: &str,
+        raw_event: &[u8],
+        raw_event_size: c_int,
+        event_type: &str,
+    ) -> Result<()> {
+        // create C strings guards to automatically free the underlying C strings
+        let cstr_check_id = CStringGuard::new(check_id)?;
+        let cstr_event_type = CStringGuard::new(event_type)?;
+
+        // `raw_event` needs no guard: it is borrowed (not allocated here) and the
+        // Go callback copies it synchronously via `C.GoBytes`, so there is nothing
+        // to free. A `CString` wouldn't work, as protobuf bytes may contain NULs.
+        let raw_event_ptr = raw_event.as_ptr() as *mut c_char;
+
+        (self.cb_submit_event_platform_event)(
+            cstr_check_id.as_ptr(),
+            raw_event_ptr,
+            raw_event_size,
+            cstr_event_type.as_ptr(),
+        );
+
+        Ok(())
+    }
 }

--- a/releasenotes/notes/rustchecks-event-platform-bytes-cf70bf7626f0ee70.yaml
+++ b/releasenotes/notes/rustchecks-event-platform-bytes-cf70bf7626f0ee70.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    Shared-library (Rust) checks can now submit event platform events as raw
+    bytes, in addition to strings, allowing binary payloads such as protobuf.


### PR DESCRIPTION
### What does this PR do?

Adds `event_platform_event_bytes` (and the underlying `submit_event_platform_event_bytes`) to the shared-library (Rust) check core, so checks can submit event platform events as **raw bytes** — not just UTF-8 strings.

### Motivation

The `datasecurity` check will emit its `sds-result` payload as protobuf; the existing string-based API cannot carry binary data (protobuf bytes may contain interior NULs).

### Guard / memory safety

The bytes path intentionally does **not** wrap `raw_event` in a `CStringGuard`:
- it is a borrowed slice (nothing is allocated here), and the Go callback copies it synchronously via `C.GoBytes`, so there is nothing to free;
- a `CString` could not hold it, since protobuf bytes may contain interior NULs.

### Describe how you validated your changes
That the bytes are transmitted correctly and received/handled properly by the Datadog platform is validated end-to-end in a subsequent PR.

Made with [Cursor](https://cursor.com)