### PR TITLE
fix: add `workflows: write` permission to chainguard policies

### DIFF
--- a/.github/chainguard/self.buildimages-update.create-pr.sts.yaml
+++ b/.github/chainguard/self.buildimages-update.create-pr.sts.yaml
@@ -12,3 +12,6 @@ claim_pattern:
 permissions:
   contents: write
   pull_requests: write
+  # Required when targeting a non-main branch: the new PR branch lags main under
+  # .github/workflows, which GitHub refuses to create without this
+  workflows: write

--- a/.github/chainguard/self.gitlab.write.sts.yaml
+++ b/.github/chainguard/self.gitlab.write.sts.yaml
@@ -6,6 +6,7 @@ claim_pattern:
   project_path: "DataDog/datadog-agent"
   project_id: "4670"
   ref: ".+"
-  
+
 permissions:
   contents: write
+  workflows: write


### PR DESCRIPTION
### What does this PR do?

Add `workflows: write` permission to `self.buildimages-update.create-pr.sts.yaml`, as well as `self.gitlab.write.sts.yaml`

### Motivation

This is a tentative fix for failures we've been seeing when running the `Update Buildimages` workflow from non-main branches (ex: https://github.com/DataDog/datadog-agent/actions/runs/30081976132). The error is a nondescript:
```
Branch maxime.chambre/update-builimages-workflow-test does not exist; Creating ref
Error: Resource not accessible by integration - https://docs.github.com/rest/git/refs#create-a-reference
```

The fact that this only occurs on non-main branches, with no changes to the workflow file itself, leads me to believe this could be the same "trying to push a branch that has diffs w.r.t main in `.github/workflows` that's bitten us before.

There is also a fix for failures we've been seeing on the `test_gitlab_compare_to` CI job on release branches, where the test tries to push a branch for test purposes, but gets blocked by GitHub if the release branch happens to have diffs in `.github/workflows` w.r.t. main (which happens quite often)

### Describe how you validated your changes

N/A, can't validate chainguard without merging by design unfortunately

### Additional Notes

See https://dd.slack.com/archives/C06PBHLD4DQ/p1784885515384939 and https://dd.slack.com/archives/C06PBHLD4DQ/p1785138679116059
