### PR TITLE
[DSEC-140] Wire the sds-result event platform track gated behind data_security.enabled

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -162,6 +162,7 @@ linters:
             - "!**/comp/forwarder/eventplatform/impl/epforwarder.go"
             - "!**/comp/forwarder/eventplatform/impl/pipelines_container.go"
             - "!**/comp/forwarder/eventplatform/impl/pipelines_dataobservability.go"
+            - "!**/comp/forwarder/eventplatform/impl/pipelines_datasecurity.go"
             - "!**/comp/forwarder/eventplatform/impl/pipelines_datastreams.go"
             - "!**/comp/forwarder/eventplatform/impl/pipelines_dbm.go"
             - "!**/comp/forwarder/eventplatform/impl/pipelines_eventmanagement.go"

--- a/comp/forwarder/eventplatform/def/component.go
+++ b/comp/forwarder/eventplatform/def/component.go
@@ -47,6 +47,8 @@ const (
 	EventTypeKubeActions = "kube-actions"
 	// EventTypeAgentDiscovery represents an Agent Discovery configuration files event
 	EventTypeAgentDiscovery = "agentdiscovery"
+	// EventTypeSDSResult represents a sensitive-data-scanner result event
+	EventTypeSDSResult = "sds-result"
 )
 
 // Component is the interface of the event platform forwarder component.

--- a/comp/forwarder/eventplatform/impl/BUILD.bazel
+++ b/comp/forwarder/eventplatform/impl/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "pipelines_agentdiscovery.go",
         "pipelines_container.go",
         "pipelines_dataobservability.go",
+        "pipelines_datasecurity.go",
         "pipelines_datastreams.go",
         "pipelines_dbm.go",
         "pipelines_eventmanagement.go",

--- a/comp/forwarder/eventplatform/impl/epforwarder.go
+++ b/comp/forwarder/eventplatform/impl/epforwarder.go
@@ -80,6 +80,7 @@ func getPassthroughPipelines() []passthroughPipelineDesc {
 		getDataObservabilityPipelines,
 		getSoftwareInventoryPipelines,
 		getAgentDiscoveryPipelines,
+		getDataSecurityPipelines,
 	}
 	var descs []passthroughPipelineDesc
 	for _, get := range getters {
@@ -120,6 +121,9 @@ func Diagnose() []diagnose.Diagnosis {
 
 	for _, desc := range getPassthroughPipelines() {
 		if desc.eventType == eventplatform.EventTypeAgentDiscovery && !cfg.GetBool("config_files_discovery.enabled") {
+			continue
+		}
+		if desc.eventType == eventplatform.EventTypeSDSResult && !cfg.GetBool("data_security.enabled") {
 			continue
 		}
 		//nolint:misspell

--- a/comp/forwarder/eventplatform/impl/epforwarder.go
+++ b/comp/forwarder/eventplatform/impl/epforwarder.go
@@ -123,6 +123,7 @@ func Diagnose() []diagnose.Diagnosis {
 		if desc.eventType == eventplatform.EventTypeAgentDiscovery && !cfg.GetBool("config_files_discovery.enabled") {
 			continue
 		}
+		// TODO(dsec): could we diagnose the SDS result pipeline?
 		if desc.eventType == eventplatform.EventTypeSDSResult && !cfg.GetBool("data_security.enabled") {
 			continue
 		}
@@ -462,6 +463,10 @@ func newDefaultEventPlatformForwarder(config model.Reader, eventPlatformReceiver
 	destinationsCtx.Start()
 	pipelines := make(map[string]*passthroughPipeline)
 	for i, desc := range getPassthroughPipelines() {
+		// TODO(dsec): This could be removed if we want to enable the SDS result pipeline by default.
+		if desc.eventType == eventplatform.EventTypeSDSResult && !config.GetBool("data_security.enabled") {
+			continue
+		}
 		p, err := newHTTPPassthroughPipeline(config, eventPlatformReceiver, compression, desc, destinationsCtx, i, hostname, secretsComp)
 		if err != nil {
 			log.Errorf("Failed to initialize event platform forwarder pipeline. eventType=%s, error=%s", desc.eventType, err.Error())

--- a/comp/forwarder/eventplatform/impl/epforwarder.go
+++ b/comp/forwarder/eventplatform/impl/epforwarder.go
@@ -123,7 +123,7 @@ func Diagnose() []diagnose.Diagnosis {
 		if desc.eventType == eventplatform.EventTypeAgentDiscovery && !cfg.GetBool("config_files_discovery.enabled") {
 			continue
 		}
-		// TODO(dsec): could we diagnose the SDS result pipeline?
+		// TODO(dsec-182): could we diagnose the SDS result pipeline?
 		if desc.eventType == eventplatform.EventTypeSDSResult && !cfg.GetBool("data_security.enabled") {
 			continue
 		}
@@ -463,7 +463,7 @@ func newDefaultEventPlatformForwarder(config model.Reader, eventPlatformReceiver
 	destinationsCtx.Start()
 	pipelines := make(map[string]*passthroughPipeline)
 	for i, desc := range getPassthroughPipelines() {
-		// TODO(dsec): This could be removed if we want to enable the SDS result pipeline by default.
+		// TODO(dsec-182): This could be removed if we want to enable the SDS result pipeline by default.
 		if desc.eventType == eventplatform.EventTypeSDSResult && !config.GetBool("data_security.enabled") {
 			continue
 		}

--- a/comp/forwarder/eventplatform/impl/pipelines_datasecurity.go
+++ b/comp/forwarder/eventplatform/impl/pipelines_datasecurity.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package eventplatformimpl
+
+import (
+	eventplatform "github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/def"
+	logshttp "github.com/DataDog/datadog-agent/comp/logs-library/client/http"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+)
+
+func getDataSecurityPipelines() []passthroughPipelineDesc {
+	return []passthroughPipelineDesc{
+		{
+			eventType:                     eventplatform.EventTypeSDSResult,
+			category:                      "Data Security",
+			contentType:                   logshttp.ProtobufContentType,
+			endpointsConfigPrefix:         "sds_result.forwarder.",
+			hostnameEndpointPrefix:        "sds-intake.",
+			intakeTrackType:               "sdsresult",
+			defaultBatchMaxConcurrentSend: 10,
+			defaultBatchMaxContentSize:    pkgconfigsetup.DefaultBatchMaxContentSize,
+			defaultBatchMaxSize:           pkgconfigsetup.DefaultBatchMaxSize,
+			defaultInputChanSize:          pkgconfigsetup.DefaultInputChanSize,
+		},
+	}
+}

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -7308,6 +7308,17 @@ properties:
         default: true
     tags:
     - full-agent-only:true
+  data_security:
+    node_type: section
+    type: object
+    properties:
+      enabled:
+        node_type: setting
+        type: boolean
+        default: false
+        comment: |-
+          Data Security: single enablement flag gating both the autodiscovery provider
+          and the sds-result event platform pipeline.
   data_streams:
     node_type: section
     type: object
@@ -9689,14 +9700,6 @@ properties:
     default: ${run_path}
   runtime_security_config:
     $ref: runtime_security_config.yaml
-  data_security:
-    node_type: section
-    type: object
-    properties:
-      enabled:
-        node_type: setting
-        type: boolean
-        default: false
   sds_result:
     node_type: section
     type: object

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -9689,6 +9689,118 @@ properties:
     default: ${run_path}
   runtime_security_config:
     $ref: runtime_security_config.yaml
+  data_security:
+    node_type: section
+    type: object
+    properties:
+      enabled:
+        node_type: setting
+        type: boolean
+        default: false
+  sds_result:
+    node_type: section
+    type: object
+    properties:
+      forwarder:
+        node_type: section
+        type: object
+        properties:
+          additional_endpoints:
+            node_type: setting
+            type: array
+            default: []
+            items:
+              type: object
+          batch_max_concurrent_send:
+            node_type: setting
+            type: integer
+            default: 0
+          batch_max_content_size:
+            node_type: setting
+            type: integer
+            default: 5000000
+          batch_max_size:
+            node_type: setting
+            type: integer
+            default: 1000
+          batch_wait:
+            node_type: setting
+            type: number
+            default: 5
+            tags:
+            - golang_type:float64
+          compression_kind:
+            node_type: setting
+            type: string
+            default: zstd
+          compression_level:
+            node_type: setting
+            type: integer
+            default: 6
+          connection_reset_interval:
+            node_type: setting
+            type: integer
+            default: 0
+          dd_url:
+            node_type: setting
+            type: string
+            default: ''
+          dev_mode_no_ssl:
+            node_type: setting
+            type: boolean
+            default: false
+            tags:
+            - no-env
+          input_chan_size:
+            node_type: setting
+            type: integer
+            default: 100
+          logs_dd_url:
+            node_type: setting
+            type: string
+            default: ''
+          logs_no_ssl:
+            node_type: setting
+            type: boolean
+            default: false
+          sender_backoff_base:
+            node_type: setting
+            type: number
+            default: 1
+            tags:
+            - golang_type:float64
+          sender_backoff_factor:
+            node_type: setting
+            type: number
+            default: 2
+            tags:
+            - golang_type:float64
+          sender_backoff_max:
+            node_type: setting
+            type: number
+            default: 120
+            tags:
+            - golang_type:float64
+          sender_recovery_interval:
+            node_type: setting
+            type: integer
+            default: 2
+          sender_recovery_reset:
+            node_type: setting
+            type: boolean
+            default: false
+          use_compression:
+            node_type: setting
+            type: boolean
+            default: true
+          use_v2_api:
+            node_type: setting
+            type: boolean
+            default: true
+          zstd_compression_level:
+            node_type: setting
+            type: integer
+            default: 1
   secret_audit_file_max_size:
     node_type: setting
     type: integer

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1334,6 +1334,12 @@ func agent(config pkgconfigmodel.Setup) {
 	// https://docs.datadoghq.com/api/latest/events#post-an-event
 	bindEnvAndSetLogsConfigKeys(config, "event_management.forwarder.")
 
+	// Data Security: single enablement flag gating both the autodiscovery provider
+	// and the sds-result event platform pipeline.
+	config.BindEnvAndSetDefault("data_security.enabled", false)
+	// Data Security (sensitive-data-scanner results) event platform forwarder
+	bindEnvAndSetLogsConfigKeys(config, "sds_result.forwarder.")
+
 	// The cardinality of tags to send for checks.
 	// Choices are: low, orchestrator, high.
 	// Changing this setting may impact your custom metrics billing.

--- a/releasenotes/notes/sds-result-event-platform-a4504e93770bf334.yaml
+++ b/releasenotes/notes/sds-result-event-platform-a4504e93770bf334.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added the ``data_security.enabled`` configuration flag (disabled by
+    default) which enables the ``sds-result`` event platform forwarder used to
+    send sensitive-data-scanner results to Datadog.


### PR DESCRIPTION
### What does this PR do?

Wires the `sds-result` event platform track:
- Registers the **Data Security forwarder** pipeline (`sds-result` event type, `sdsresult` intake track, `sds_result.forwarder.*` config keys + `DD_SDS_RESULT_FORWARDER_*` env vars).
- Adds the **`data_security.enabled`** flag (schema + binding), a single switch gating both this pipeline and the upcoming Data Security autodiscovery provider.

### Motivation

Groundwork to ship sensitive-data-scanner results to the backend. This PR only wires config/plumbing; no producer emits `sds-result` events yet.

### Describe how you validated your changes

End-to-end tests were conducted in a subsequent PR, confirming the backend consumes the `sds-result` payload and handles it properly as expected.

### Additional Notes

`data_security.enabled` defaults to **false**
Made with [Cursor](https://cursor.com)