### PR TITLE
fix(dataobs): exclude sap_hana DO-targeted instance from remainder

### DIFF
--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -265,9 +265,16 @@ func (c *component) reconcileBases(changes *integration.ConfigChanges) {
 	}
 }
 
-// buildRemainder returns a copy of base containing only the instances whose host is NOT in
+// buildRemainder returns a copy of base containing only the instances NOT targeted by any host in
 // matchedHosts. Returns nil when no instances remain (every instance is DO-managed). Instances
 // whose YAML cannot be parsed are kept, so a config we cannot classify is never silently dropped.
+//
+// Matching uses instanceMatchesHost — the same logic that selected the instance for scheduling —
+// so an instance is excluded from the remainder exactly when a DO query action runs it as its own
+// check. matchedHosts holds DBIdentifier.Host values verbatim, which for sap_hana are the
+// "host:port" form (e.g. "172.17.128.2:39041") while the instance keys host under "server" with a
+// separate "port"; comparing the raw "host" key alone would never match and would duplicate the
+// instance.
 func buildRemainder(base *integration.Config, matchedHosts map[string]bool) *integration.Config {
 	kept := make([]integration.Data, 0, len(base.Instances))
 	for _, instanceData := range base.Instances {
@@ -276,8 +283,7 @@ func buildRemainder(base *integration.Config, matchedHosts map[string]bool) *int
 			kept = append(kept, instanceData)
 			continue
 		}
-		host, _ := instance["host"].(string)
-		if matchedHosts[host] {
+		if instanceTargeted(instance, matchedHosts) {
 			continue
 		}
 		kept = append(kept, instanceData)
@@ -288,6 +294,17 @@ func buildRemainder(base *integration.Config, matchedHosts map[string]bool) *int
 	remainder := *base
 	remainder.Instances = kept
 	return &remainder
+}
+
+// instanceTargeted reports whether any host in matchedHosts targets this instance, using the same
+// host-matching semantics as scheduling.
+func instanceTargeted(instance map[string]any, matchedHosts map[string]bool) bool {
+	for host := range matchedHosts {
+		if instanceMatchesHost(instance, host) {
+			return true
+		}
+	}
+	return false
 }
 
 // sameConfig reports whether two optional configs are equivalent by autodiscovery digest.
@@ -335,17 +352,25 @@ func (c *component) findMatchingConfig(dbID *DBIdentifier) (*integration.Config,
 
 // matchesIdentifier checks if an instance matches the given DB identifier.
 // Matching is by host — per-query dbname fields handle database routing.
-// sap_hana uses "server" as the host key; postgres uses "host".
-// dbID.Host may be "host:port" (as sent by sap_hana backends) or bare "host".
-// We match against both the bare host and the "host:port" form built from the instance.
 func matchesIdentifier(instance map[string]any, dbID *DBIdentifier) bool {
+	return instanceMatchesHost(instance, dbID.Host)
+}
+
+// instanceMatchesHost reports whether an integration instance targets the given host.
+// sap_hana uses "server" as the host key; postgres uses "host". The target host may be
+// "host:port" (as sent by sap_hana backends) or bare "host", so we match against both the
+// bare host and the "host:port" form built from the instance. This is the single source of
+// truth for host matching, shared by matchesIdentifier (which decides what to schedule) and
+// buildRemainder (which decides what to keep), so the two can never disagree about whether an
+// instance is targeted by a DO query action.
+func instanceMatchesHost(instance map[string]any, targetHost string) bool {
 	host := instanceHost(instance)
-	if host == dbID.Host {
+	if host == targetHost {
 		return true
 	}
 	// Try matching "host:port" form — sap_hana backends include the port in the identifier.
 	if port, ok := instancePort(instance); ok {
-		return fmt.Sprintf("%s:%d", host, port) == dbID.Host
+		return fmt.Sprintf("%s:%d", host, port) == targetHost
 	}
 	return false
 }

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -7,6 +7,7 @@ package queryactionsimpl
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	autodiscovery "github.com/DataDog/datadog-agent/comp/core/autodiscovery/def"
@@ -589,6 +590,113 @@ func TestOnRCUpdate_PreservesUnrelatedInstances(t *testing.T) {
 	assert.Equal(t, rdsHost, rdsInstance["host"])
 	_, rdsHasQueries := rdsInstance["data_observability"].(map[string]any)["queries"]
 	assert.False(t, rdsHasQueries, "RDS instance must remain a plain DBM instance with no DO queries")
+}
+
+// TestBuildRemainder_SapHanaServerKey is a focused regression test for buildRemainder using the
+// "server" key and the "host:port" identifier form sap_hana backends actually send. sap_hana
+// instances key the host under "server" (not "host") with a separate "port", while the RC
+// identifier arrives as "server:port" (e.g. "172.17.128.2:39041"). buildRemainder must recognize
+// the targeted server as DO-managed and drop it from the remainder. Before the fix it compared the
+// absent "host" key against the "host:port" identifier, so no sap_hana instance ever matched and
+// the targeted one was wrongly kept, duplicating collection.
+func TestBuildRemainder_SapHanaServerKey(t *testing.T) {
+	const targetedServer = "172.17.128.2"
+	const siblingServer = "172.17.128.3"
+	const port = 39041
+	base := &integration.Config{
+		Name:     "sap_hana",
+		Provider: "file",
+		Instances: []integration.Data{
+			integration.Data(fmt.Sprintf("server: %s\nport: %d\n", targetedServer, port)),
+			integration.Data(fmt.Sprintf("server: %s\nport: %d\n", siblingServer, port)),
+		},
+	}
+	// matchedHosts holds DBIdentifier.Host verbatim: the "host:port" form for sap_hana.
+	targetedHostPort := fmt.Sprintf("%s:%d", targetedServer, port)
+	siblingHostPort := fmt.Sprintf("%s:%d", siblingServer, port)
+
+	t.Run("targeted server excluded, sibling kept", func(t *testing.T) {
+		remainder := buildRemainder(base, map[string]bool{targetedHostPort: true})
+		require.NotNil(t, remainder, "sibling instance must keep the remainder alive")
+		require.Len(t, remainder.Instances, 1, "targeted server must be excluded from the remainder")
+		var instance map[string]any
+		require.NoError(t, yaml.Unmarshal(remainder.Instances[0], &instance))
+		assert.Equal(t, siblingServer, instance["server"], "remainder should hold only the untargeted sibling")
+	})
+
+	t.Run("all servers targeted yields nil remainder", func(t *testing.T) {
+		remainder := buildRemainder(base, map[string]bool{targetedHostPort: true, siblingHostPort: true})
+		assert.Nil(t, remainder, "no instances should remain when every sap_hana server is DO-managed")
+	})
+}
+
+// TestOnRCUpdate_SapHana_ExcludesTargetedInstanceFromRemainder is the end-to-end regression test
+// for the "3 parallel sap_hana check instances" bug, using the real "host:port" identifier form.
+// A base config bundles two sap_hana instances (keyed by "server"); a DO config targets only the
+// first via a "server:port" identifier. The targeted server must run solely as the DO check while
+// the sibling stays in the remainder. Before the fix the remainder wrongly kept the targeted
+// server too, so it ran both as the DO check and in the remainder alongside the original
+// file-provider config.
+func TestOnRCUpdate_SapHana_ExcludesTargetedInstanceFromRemainder(t *testing.T) {
+	const targetedServer = "172.17.128.2"
+	const siblingServer = "172.17.128.3"
+	const port = 39041
+	sapHanaCfg := integration.Config{
+		Name:     "sap_hana",
+		Provider: "file",
+		Instances: []integration.Data{
+			integration.Data(fmt.Sprintf("server: %s\nport: %d\ndata_observability:\n  enabled: true\n", targetedServer, port)),
+			integration.Data(fmt.Sprintf("server: %s\nport: %d\ndata_observability:\n  enabled: true\n", siblingServer, port)),
+		},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{sapHanaCfg})
+
+	payload := DOQueryPayload{
+		ConfigID:     "cfg-saphana",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: fmt.Sprintf("%s:%d", targetedServer, port)},
+		Queries:      []QuerySpec{{Type: "run_query", Query: "SELECT 1", IntervalSeconds: 60, TimeoutSeconds: 10}},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-saphana": {Config: payloadJSON},
+	})
+
+	require.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-saphana"].State)
+
+	// The original two-instance base config is unscheduled.
+	require.Len(t, changes.Unschedule, 1)
+
+	// Exactly two configs scheduled: the DO check for the targeted server and the remainder holding
+	// only the untargeted sibling. A third scheduled instance would be the regression.
+	require.Len(t, changes.Schedule, 2)
+
+	serversOf := func(cfg integration.Config) []string {
+		servers := make([]string, 0, len(cfg.Instances))
+		for _, instanceData := range cfg.Instances {
+			var instance map[string]any
+			require.NoError(t, yaml.Unmarshal(instanceData, &instance))
+			servers = append(servers, instance["server"].(string))
+		}
+		return servers
+	}
+
+	var doCfg, remainder *integration.Config
+	for i := range changes.Schedule {
+		var instance map[string]any
+		require.NoError(t, yaml.Unmarshal(changes.Schedule[i].Instances[0], &instance))
+		if _, hasQueries := instance["data_observability"].(map[string]any)["queries"]; hasQueries {
+			doCfg = &changes.Schedule[i]
+		} else {
+			remainder = &changes.Schedule[i]
+		}
+	}
+	require.NotNil(t, doCfg, "a DO check config should be scheduled")
+	require.NotNil(t, remainder, "a remainder config should be scheduled")
+
+	assert.Equal(t, []string{targetedServer}, serversOf(*doCfg), "DO check should carry only the targeted sap_hana server")
+	assert.Equal(t, []string{siblingServer}, serversOf(*remainder), "remainder must exclude the targeted server and keep only the sibling")
 }
 
 // TestOnRCUpdate_MultipleDOConfigsSameBase verifies that two DO configs targeting two different

--- a/releasenotes/notes/fix-saphana-do-query-actions-duplicate-d2b76d4d25fb0c61.yaml
+++ b/releasenotes/notes/fix-saphana-do-query-actions-duplicate-d2b76d4d25fb0c61.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix a bug where a SAP HANA instance targeted by a Data Observability query
+    action could run as multiple duplicate check instances at once, causing
+    duplicate database monitoring collection. The targeted instance is now
+    correctly excluded from the remaining file-provider configuration.


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the Data Observability query-actions component where a sap_hana instance targeted by a `DO_QUERY_ACTIONS` remote-config was scheduled **three times** in parallel: once as the DO check, once in the "remainder" config, and once as the original file-provider config.

`buildRemainder` had its own host lookup (`instance["host"]`) that bypassed `matchesIdentifier`. For sap_hana the host is keyed under `server` (not `host`), and the RC identifier arrives in `host:port` form (e.g. `172.17.128.2:39041`), so the raw `host` comparison never matched — the targeted instance was never recognized as DO-managed and stayed in the remainder.

The fix extracts host matching into a single `instanceMatchesHost` helper (handles the `server`/`host` key difference and both bare-`host` and `host:port` forms) and routes **both** `matchesIdentifier` (schedule decision) and `buildRemainder` (keep decision) through it, so the two can never disagree about whether an instance is targeted.

### Motivation

Observed 3 parallel sap_hana check instances when a `DO_QUERY_ACTIONS` config was active, causing duplicate DBM collection.

### Describe how you validated your changes

- Added a focused unit test (`TestBuildRemainder_SapHanaServerKey`) and an end-to-end regression test (`TestOnRCUpdate_SapHana_ExcludesTargetedInstanceFromRemainder`), both using the real `host:port` identifier form so they fail against the previous behavior.
- `dda inv test --targets=./comp/dataobs/queryactions/impl` → 36/36 tests pass.

### Additional Notes

The `matchesIdentifier` refactor is behavior-preserving — it now delegates to `instanceMatchesHost`. Note that matching is done against `GetUnresolvedConfigs()`, so DB integrations configured via autodiscovery templates (unresolved `%%host%%`/`%%port%%`) would not match a concrete RC identifier; this is a pre-existing limitation and does not affect self-hosted (file-based) configs like the sap_hana case here.
