### PR TITLE
fix(aix): read AGENT_DATA_PLANE_VERSION from deps/adp.json

### DIFF
--- a/packaging/aix/stages/00-checkout.sh
+++ b/packaging/aix/stages/00-checkout.sh
@@ -84,12 +84,17 @@ fi
 
 log "INTEGRATIONS_CORE_VERSION = $INTEGRATIONS_CORE_VERSION"
 
+ADP_JSON="$AGENT_SRC/deps/adp.json"
 if [ -z "${AGENT_DATA_PLANE_VERSION:-}" ]; then
+    if [ ! -f "$ADP_JSON" ]; then
+        log "ERROR: $ADP_JSON not found — is the source tree complete?"
+        exit 1
+    fi
     AGENT_DATA_PLANE_VERSION=$(python3.12 -c \
-        "import json; print(json.load(open('$RELEASE_JSON'))['dependencies']['AGENT_DATA_PLANE_VERSION'])")
+        "import json; print(json.load(open('$ADP_JSON'))['version'])")
 fi
 if [ -z "$AGENT_DATA_PLANE_VERSION" ]; then
-    log "ERROR: Could not read AGENT_DATA_PLANE_VERSION from $RELEASE_JSON"
+    log "ERROR: Could not read AGENT_DATA_PLANE_VERSION from $ADP_JSON"
     exit 1
 fi
 log "AGENT_DATA_PLANE_VERSION = $AGENT_DATA_PLANE_VERSION"


### PR DESCRIPTION
### What does this PR do?

Fixes `packaging/aix/stages/00-checkout.sh` to read `AGENT_DATA_PLANE_VERSION` from `deps/adp.json['version']` instead of the outdated `release.json['dependencies']['AGENT_DATA_PLANE_VERSION']`.

### Motivation

The AIX build pipeline's checkout stage crashed immediately with a `KeyError` since that key doesn't exist anymore.

### Describe how you validated your changes

Ran the fixed script on the AIX build host; `00-checkout` now completes and correctly checks out saluki at the pinned ADP version (`1.4.0`).

### Additional Notes