### PR TITLE
Fix non-hermetic env var leaks in serverless-init and otel-agent tests

### DIFF
--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -33,6 +33,20 @@ func (suite *ConfigTestSuite) SetupTest() {
 	configmock.New(suite.T())
 	suite.T().Setenv("DD_API_KEY", "")
 	suite.T().Setenv("DD_SITE", "")
+	// LoadProxyFromEnv treats a present-but-empty var as set, so these must be
+	// unset rather than set to "" - otherwise DD_PROXY_* short-circuits the
+	// HTTP_PROXY/HTTPS_PROXY/NO_PROXY fallback even when a test sets those.
+	// The lowercase variants are cleared too since LoadProxyFromEnv falls
+	// back to them when the uppercase ones aren't set.
+	os.Unsetenv("HTTP_PROXY")
+	os.Unsetenv("http_proxy")
+	os.Unsetenv("HTTPS_PROXY")
+	os.Unsetenv("https_proxy")
+	os.Unsetenv("NO_PROXY")
+	os.Unsetenv("no_proxy")
+	os.Unsetenv("DD_PROXY_HTTP")
+	os.Unsetenv("DD_PROXY_HTTPS")
+	os.Unsetenv("DD_PROXY_NO_PROXY")
 }
 
 func TestNoURIsProvided(t *testing.T) {

--- a/cmd/serverless-init/mode/initcontainer_mode_test.go
+++ b/cmd/serverless-init/mode/initcontainer_mode_test.go
@@ -136,6 +136,8 @@ func TestJavaTracerIsAutoInstrumented(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	fs.Create("/dd_tracer/java/")
 
+	t.Setenv("JAVA_TOOL_OPTIONS", "")
+
 	autoInstrumentTracer(fs)
 
 	assert.Equal(t, "-javaagent:/dd_tracer/java/dd-java-agent.jar", os.Getenv("JAVA_TOOL_OPTIONS"))


### PR DESCRIPTION
### What does this PR do?

Fixes two non-hermetic tests that leak ambient environment variables from the CI runner into their assertions:

- `cmd/serverless-init/mode`: `TestJavaTracerIsAutoInstrumented` didn't reset `JAVA_TOOL_OPTIONS` before running.
- `cmd/otel-agent/config`: several `ConfigTestSuite` proxy tests didn't reset `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` (and their `DD_PROXY_*`/lowercase equivalents) before running.

### Motivation

Both tests reliably fail on runners where these variables are pre-populated (e.g. with proxy settings), unrelated to any code change. Found while investigating unrelated CI failures on another PR:
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1889811399
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1890231814

### Describe how you validated your changes

- Ran unit tests locally

### Additional Notes

Split out of https://github.com/DataDog/datadog-agent/pull/53847