### PR TITLE
fix(aix): wrap agent-data-plane with a LIBPATH-setting launcher

### DIFF
--- a/packaging/aix/agent-data-plane-wrapper.sh
+++ b/packaging/aix/agent-data-plane-wrapper.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Agent Data Plane (ADP) entry point wrapper.
+#
+# AIX's dynamic loader uses LIBPATH (not RPATH) for library resolution.
+# The SRC subsystem invokes this binary directly (no shell), so without this
+# wrapper LIBPATH is never set and the loader cannot find bundled libraries
+# such as libunwind, causing an immediate "Cannot load program" failure.
+export LIBPATH=/opt/datadog-agent/rtloader:/opt/datadog-agent/embedded/lib:/opt/freeware/lib64:/opt/freeware/lib${LIBPATH:+:$LIBPATH}
+export PATH=/opt/datadog-agent/embedded/bin:/opt/freeware/bin:/usr/sbin:/usr/bin:/bin:"${PATH}"
+exec /opt/datadog-agent/embedded/bin/agent-data-plane-bin "$@"

--- a/packaging/aix/stages/05-agent-data-plane.sh
+++ b/packaging/aix/stages/05-agent-data-plane.sh
@@ -191,7 +191,6 @@ log "ADP license artifacts staged under $ADP_LICENSES_DEST"
 
 log "Verifying agent-data-plane binary is XCOFF64"
 MAGIC=$(od -A x -t x1 "$ADP_BIN_DEST" | head -1 | awk '{print $2 $3}')
-# ($ADP_BIN_DEST is the real binary; $ADP_WRAPPER_DEST is a shell wrapper script.)
 if [ "$MAGIC" != "01f7" ]; then
     log "ERROR: agent-data-plane binary is not XCOFF64 (got: $MAGIC)"
     log "       Expected magic bytes: 01 f7"

--- a/packaging/aix/stages/05-agent-data-plane.sh
+++ b/packaging/aix/stages/05-agent-data-plane.sh
@@ -39,7 +39,8 @@ ADP_SPDX_LICENSES_ARCHIVE="$BUILD_DIR/agent-data-plane-spdx-licenses.tar.gz"
 ADP_SPDX_LICENSES_EXTRACT_DIR="$BUILD_DIR/agent-data-plane-spdx-licenses-extract"
 ADP_SPDX_LICENSES_DIR="$BUILD_DIR/agent-data-plane-spdx-licenses"
 ADP_THIRD_PARTY_GENERATED_DIR="$BUILD_DIR/agent-data-plane-third-party-licenses"
-ADP_BIN_DEST="$STAGING/opt/datadog-agent/embedded/bin/agent-data-plane"
+ADP_BIN_DEST="$STAGING/opt/datadog-agent/embedded/bin/agent-data-plane-bin"
+ADP_WRAPPER_DEST="$STAGING/opt/datadog-agent/embedded/bin/agent-data-plane"
 ADP_LICENSES_DEST="$STAGING/opt/datadog-agent/LICENSES"
 
 # --- Pre-flight ---
@@ -55,7 +56,7 @@ log "Building Agent Data Plane from saluki commit $(git -C "$SALUKI_SRC" rev-par
 cleanup() {
     if [ $? -ne 0 ]; then
         log "ERROR: $STAGE_NAME failed. Removing partial outputs."
-        rm -f "$ADP_BIN_DEST"
+        rm -f "$ADP_BIN_DEST" "$ADP_WRAPPER_DEST"
         rm -f "$ADP_LICENSES_DEST/LICENSE-agent-data-plane-3rdparty.csv"
         rm -f "$ADP_SPDX_LICENSES_ARCHIVE"
         rm -rf "$ADP_LICENSES_DEST"/THIRD-PARTY-*
@@ -122,6 +123,13 @@ strip -X64 "$ADP_BIN_DEST"
 chmod 755 "$ADP_BIN_DEST"
 log "agent-data-plane binary staged at $ADP_BIN_DEST"
 
+# The SRC subsystem execs the installed path directly (no shell involved), so
+# without this wrapper LIBPATH is never set and the AIX loader cannot find
+# bundled libraries (e.g. libunwind), causing an immediate load failure.
+cp "$SCRIPT_DIR/../agent-data-plane-wrapper.sh" "$ADP_WRAPPER_DEST"
+chmod 755 "$ADP_WRAPPER_DEST"
+log "agent-data-plane wrapper staged at $ADP_WRAPPER_DEST"
+
 # ─── Step 3: Stage license artifacts ──────────────────────────────────────────
 
 ADP_LICENSE_3RDPARTY=${ADP_LICENSE_3RDPARTY:-}
@@ -183,6 +191,7 @@ log "ADP license artifacts staged under $ADP_LICENSES_DEST"
 
 log "Verifying agent-data-plane binary is XCOFF64"
 MAGIC=$(od -A x -t x1 "$ADP_BIN_DEST" | head -1 | awk '{print $2 $3}')
+# ($ADP_BIN_DEST is the real binary; $ADP_WRAPPER_DEST is a shell wrapper script.)
 if [ "$MAGIC" != "01f7" ]; then
     log "ERROR: agent-data-plane binary is not XCOFF64 (got: $MAGIC)"
     log "       Expected magic bytes: 01 f7"


### PR DESCRIPTION
### What does this PR do?

Adds a shell wrapper for `agent-data-plane` on AIX, matching the existing `agent`/`trace-agent` wrapper pattern.

### Motivation

The SRC subsystem execs the installed `agent-data-plane` binary directly (no shell), so `LIBPATH` was never set and the AIX loader could not find bundled libraries (e.g. `libunwind`), causing an immediate load failure on `startsrc`.

### Describe how you validated your changes

Validated on an AIX host.

### Additional Notes