### PR TITLE
[FA] - Fix flake for stat and file exists check on Window's flare

### DIFF
--- a/comp/core/flare/helpers/builder_test.go
+++ b/comp/core/flare/helpers/builder_test.go
@@ -70,12 +70,10 @@ func TestNewFlareBuilder(t *testing.T) {
 	archive, err := fb.Save()
 	require.NoError(t, err)
 
-	// On Windows CI runners the file can be briefly invisible right after a successful os.Rename
-	// (e.g. antivirus/real-time-scan locking), so poll before doing the real assertion below.
 	assert.Eventually(t, func() bool {
 		info, err := os.Lstat(archive)
 		return err == nil && !info.IsDir()
-	}, time.Second, 10*time.Millisecond, "unable to find file %q", archive)
+	}, 3*time.Second, 10*time.Millisecond, "unable to find file %q", archive)
 	assert.FileExists(t, archive)
 	os.RemoveAll(archive)
 
@@ -94,12 +92,10 @@ func TestSave(t *testing.T) {
 	require.NoError(t, err)
 	assert.NoDirExists(t, fb.tmpDir)
 
-	// On Windows CI runners the file can be briefly invisible right after a successful os.Rename
-	// (e.g. antivirus/real-time-scan locking), so poll before doing the real assertion below.
 	require.Eventually(t, func() bool {
 		info, err := os.Lstat(archivePath)
 		return err == nil && !info.IsDir()
-	}, time.Second, 10*time.Millisecond, "unable to find file %q", archivePath)
+	}, 3*time.Second, 10*time.Millisecond, "unable to find file %q", archivePath)
 	require.FileExists(t, archivePath)
 
 	defer os.RemoveAll(archivePath)

--- a/comp/core/flare/helpers/builder_test.go
+++ b/comp/core/flare/helpers/builder_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,7 +68,14 @@ func TestNewFlareBuilder(t *testing.T) {
 	require.FileExists(t, filepath.Join(fb.flareDir, "flare_creation.log"))
 
 	archive, err := fb.Save()
-	assert.NoError(t, err)
+	require.NoError(t, err)
+
+	// On Windows CI runners the file can be briefly invisible right after a successful os.Rename
+	// (e.g. antivirus/real-time-scan locking), so poll before doing the real assertion below.
+	assert.Eventually(t, func() bool {
+		info, err := os.Lstat(archive)
+		return err == nil && !info.IsDir()
+	}, time.Second, 10*time.Millisecond, "unable to find file %q", archive)
 	assert.FileExists(t, archive)
 	os.RemoveAll(archive)
 
@@ -85,6 +93,13 @@ func TestSave(t *testing.T) {
 	archivePath, err := fb.Save()
 	require.NoError(t, err)
 	assert.NoDirExists(t, fb.tmpDir)
+
+	// On Windows CI runners the file can be briefly invisible right after a successful os.Rename
+	// (e.g. antivirus/real-time-scan locking), so poll before doing the real assertion below.
+	require.Eventually(t, func() bool {
+		info, err := os.Lstat(archivePath)
+		return err == nil && !info.IsDir()
+	}, time.Second, 10*time.Millisecond, "unable to find file %q", archivePath)
 	require.FileExists(t, archivePath)
 
 	defer os.RemoveAll(archivePath)


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Fix a flake happening on Windows where the `FileExists` check is done while the file is still not fully acknowledged as moved after the archive

### Describe how you validated your changes

### Additional Notes
