### PR TITLE
Exclude doxygen.nl from link checks

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -5,6 +5,9 @@ include_fragments = "full"
 # This is necessary because the deployed site uses directory URLs.
 index_files = ["index.html"]
 
+# doxygen.nl returns 403/415 responses to automated link checks.
+exclude = ['^https://www\.doxygen\.nl(/|$)']
+
 # Zensical's 404 page uses root-relative URLs because it can be served at any
 # missing path. Exclude that generated page because its links cannot be resolved
 # against the local site directory without special root mapping.

--- a/.markdown-link-check
+++ b/.markdown-link-check
@@ -7,7 +7,10 @@
       "pattern": "^https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/"
     },
     {
-      "pattern": "^https://github.com/DataDog/single-machine-performance":
+      "pattern": "^https://github.com/DataDog/single-machine-performance"
+    },
+    {
+      "pattern": "^https://www\\.doxygen\\.nl(/|$)"
     },
     {
       "pattern": "^/security/threats/"

--- a/docs/public/setup/manual.md
+++ b/docs/public/setup/manual.md
@@ -112,9 +112,9 @@ sudo yum install systemd-devel
 
 ## Doxygen
 
-We use [Doxygen](http://www.doxygen.nl) to generate the documentation for the `rtloader` part of the Agent.
+We use [Doxygen](https://www.doxygen.nl) to generate the documentation for the `rtloader` part of the Agent.
 
-To generate it (using the `dda inv rtloader.generate-doc` command), you'll need to have Doxygen installed on your system and available in your `$PATH`. You can compile and install Doxygen from source with the instructions available [here](http://www.doxygen.nl/manual/install.html). Alternatively, you can use already-compiled Doxygen binaries from [here](http://www.doxygen.nl/download.html).
+To generate it (using the `dda inv rtloader.generate-doc` command), you'll need to have Doxygen installed on your system and available in your `$PATH`. You can compile and install Doxygen from source with the instructions available [here](https://www.doxygen.nl/manual/install.html). Alternatively, you can use already-compiled Doxygen binaries from [here](https://www.doxygen.nl/download.html).
 
 To get the dependency graphs, you may also need to install the `dot` executable from [graphviz](http://www.graphviz.org/) and add it to your `$PATH`.
 


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Doxygen returns 403 when crawled, so I suggest to skip the URL check for this domain.

Sample failures:
- https://github.com/DataDog/datadog-agent/actions/runs/30019854760/job/89249431262
- https://github.com/DataDog/datadog-agent/actions/runs/30090074418/job/89471274727