### PR TITLE
test(windows): add missing binaries to E2E code-signing check list

### DIFF
--- a/test/new-e2e/tests/windows/install-test/assert.go
+++ b/test/new-e2e/tests/windows/install-test/assert.go
@@ -158,6 +158,7 @@ func getExpectedBinFilesForAgentMajorVersion(majorVersion string) []string {
 		// user binaries
 		`bin\agent.exe`,
 		`bin\secret-generic-connector.exe`,
+		`bin\dd-compile-policy.exe`,
 		`bin\agent\ddtray.exe`,
 		`bin\agent\trace-agent.exe`,
 		`bin\agent\process-agent.exe`,
@@ -167,7 +168,6 @@ func getExpectedBinFilesForAgentMajorVersion(majorVersion string) []string {
 		`bin\agent\dd-procmgr.exe`,
 		`bin\agent\dd-procmgrd.exe`,
 		`bin\agent\agent-data-plane.exe`,
-		`bin\agent\dd-compile-policy.exe`,
 		// drivers
 		`bin\agent\driver\ddnpm.sys`,
 		`bin\agent\driver\ddnpm.inf`,

--- a/test/new-e2e/tests/windows/install-test/assert.go
+++ b/test/new-e2e/tests/windows/install-test/assert.go
@@ -163,6 +163,11 @@ func getExpectedBinFilesForAgentMajorVersion(majorVersion string) []string {
 		`bin\agent\process-agent.exe`,
 		`bin\agent\security-agent.exe`,
 		`bin\agent\system-probe.exe`,
+		`bin\agent\privateactionrunner.exe`,
+		`bin\agent\dd-procmgr.exe`,
+		`bin\agent\dd-procmgrd.exe`,
+		`bin\agent\agent-data-plane.exe`,
+		`bin\agent\dd-compile-policy.exe`,
 		// drivers
 		`bin\agent\driver\ddnpm.sys`,
 		`bin\agent\driver\ddnpm.inf`,


### PR DESCRIPTION
### What does this PR do?

Adds privateactionrunner.exe, dd-procmgr.exe, dd-procmgrd.exe, agent-data-plane.exe, and dd-compile-policy.exe to the E2E code-signing check list.

### Motivation

https://datadoghq.atlassian.net/browse/WINA-2975 — these binaries are signed and shipped but weren't verified by the install-test suite.