### PR TITLE
fix(windows): correct security-agent.exe InternalName version resource

### DIFF
--- a/cmd/security-agent/windows_resources/security-agent.rc
+++ b/cmd/security-agent/windows_resources/security-agent.rc
@@ -30,7 +30,7 @@ BEGIN
             VALUE "CompanyName", "Datadog, Inc."
             VALUE "FileDescription", "Datadog Security Agent"
             VALUE "FileVersion", FILE_VERSION_STRING
-            VALUE "InternalName", "process-agent"
+            VALUE "InternalName", "security-agent"
             VALUE "LegalCopyright", "Copyright (C) 2023"
             VALUE "OriginalFilename", "security-agent.exe"
             VALUE "ProductName", "Datadog Security Agent"


### PR DESCRIPTION
### What does this PR do?

Fixes the InternalName field in security-agent.rc, which was set to "process-agent" instead of "security-agent".

### Motivation

https://datadoghq.atlassian.net/browse/WINA-2976 — copy-paste bug from process-agent.rc.