### PR TITLE
[DSEC-170] notify data-security-dev for datadog agent reviews

### DIFF
--- a/tasks/libs/pipeline/github_slack_map.yaml
+++ b/tasks/libs/pipeline/github_slack_map.yaml
@@ -386,11 +386,11 @@
     id: 'C027P1CK07N'
 '@datadog/sensitive-data-scanner':
   notification:
-    name: '#sensitive-data-scanner'
-    id: 'C035A167T0S'
+    name: '#data-security-dev'
+    id: 'C0B1T21VBM1'
   review:
-    name: '#sensitive-data-scanner'
-    id: 'C035A167T0S'
+    name: '#data-security-dev'
+    id: 'C0B1T21VBM1'
 '@datadog/serverless':
   notification:
     name: '#serverless-agent'


### PR DESCRIPTION
### What does this PR do?
Routes GitHub review and notification pings for `@datadog/sensitive-data-scanner` to the `#data-security-dev` Slack channel.

### Motivation
The sensitive-data-scanner team updating the agent monitor this channel `#data-security-dev`, so agent reviews for that team should land there instead of `#sensitive-data-scanner` channel.
