### PR TITLE
Try to prevent macos jobs from leaving unwritable files behind

### DIFF
--- a/.gitlab/.pre/common/macos.yml
+++ b/.gitlab/.pre/common/macos.yml
@@ -96,3 +96,12 @@
     - !reference [.macos_runner_maintenance]
     - export GOCACHE="$TMPDIR/go-build"
     - dda inv -- -e install-tools --verbose
+
+.macos_runner_make_workspace_writable:
+  - |
+    # GitLab Runner 18 fails the next job during clear_worktree when the
+    # previous job leaves read-only files in the persistent macOS workspace.
+    # Best-effort only: do not mask the job's real result if cleanup fails.
+    if [ -n "$CI_PROJECT_DIR" ] && [ -d "$CI_PROJECT_DIR" ]; then
+      chmod -R u+w "$CI_PROJECT_DIR" 2>/dev/null || true
+    fi

--- a/.gitlab/build/binary_build/schema_generation.yml
+++ b/.gitlab/build/binary_build/schema_generation.yml
@@ -58,6 +58,8 @@ generate_config_schema-macos:
     - dda inv -- -e agent.build
     - dda inv -- schema.generate --agent-bin=./bin/agent/agent
     - bash $CI_PROJECT_DIR/tasks/schema/check_config_templates.sh $CI_PROJECT_DIR
+  after_script:
+    - !reference [.macos_runner_make_workspace_writable]
   artifacts:
     when: always
     expire_in: 2 weeks

--- a/.gitlab/build/source_test/macos.yml
+++ b/.gitlab/build/source_test/macos.yml
@@ -17,6 +17,7 @@
     - dda inv -- -e agent.build
     - dda inv -- -e test --rerun-fails=2 --race --profile --cpus 12 --result-json ${TEST_OUTPUT_FILE}.json --junit-tar "junit-${CI_JOB_NAME}.tgz" $FAST_TESTS_FLAG --test-washer --coverage
   after_script:
+    - !reference [.macos_runner_make_workspace_writable]
     - !reference [.vault_login]
     - !reference [.install_python_dependencies]
     - !reference [.upload_junit_source]


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

It adds a step in the `after_script` of select macos jobs which are known to potentially leave files with read-only permission so that a best-effort attempt is done at making them writable, to make cleanup possible.

### Motivation

#incident-57903

Jobs where we install rtloader and its deps onto the `CI_PROJECT_DIR` rely on a pkg_install rule, which first copies the files out of bazel's output root to the destination and only after that does it change the permissions ([source](https://github.com/bazelbuild/rules_pkg/blob/22b54a36730453bf03de28ec4ad4bf15eed3fb59/pkg/private/install.py.tpl#L141-L153)). If the job gets interrupted between those two steps, as it did for this incident, those files could remain with the existing read-only permissions. Given that macos runners are persistent, the checkout step needs to first cleanup any existing checkout first, and this step fails if there are non-writable files, such that we were seeing errors such as:

```
warning: failed to remove dev/embedded/lib/python3.13/lib-dynload/termios.cpython-313-darwin.so: Permission denied
```

### Describe how you validated your changes

### Additional Notes
