### PR TITLE
Support negative time and nanoseconds

### DIFF
--- a/tasks/schema/codegen_init_settings.py
+++ b/tasks/schema/codegen_init_settings.py
@@ -278,14 +278,16 @@ def output_func_footer(_, sourcecode):
 def try_parse_duration(text):
     if not isinstance(text, str):
         return None
-    m = re.fullmatch(r'(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?(?:(\d+)ms)?(?:(\d+)µs)?', text)
+    m = re.fullmatch(r'(-)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?(?:(\d+)ms)?(?:(\d+)µs)?(?:(\d+)ns)?', text)
     if not m or not any(m.groups()):
         return None
-    hours = int(m.group(1) or 0)
-    minutes = int(m.group(2) or 0)
-    seconds = int(m.group(3) or 0)
-    millis = int(m.group(4) or 0)
-    micros = int(m.group(5) or 0)
+    minus = m.group(1) or False
+    hours = int(m.group(2) or 0)
+    minutes = int(m.group(3) or 0)
+    seconds = int(m.group(4) or 0)
+    millis = int(m.group(5) or 0)
+    micros = int(m.group(6) or 0)
+    nanos = int(m.group(7) or 0)
     parts = []
     if hours:
         parts.append('%d*time.Hour' % hours)
@@ -297,8 +299,14 @@ def try_parse_duration(text):
         parts.append('%d*time.Millisecond' % millis)
     if micros:
         parts.append('%d*time.Microsecond' % micros)
+    if nanos:
+        parts.append('%d*time.Nanosecond' % nanos)
     if not parts:
         return 'time.Duration(0)'
+    if minus and len(parts) == 1:
+        return f"-{parts[0]}"
+    elif minus:
+        return f"-({' + '.join(parts)})"
     return ' + '.join(parts)
 
 

--- a/tasks/unit_tests/schema_codegen_tests.py
+++ b/tasks/unit_tests/schema_codegen_tests.py
@@ -129,6 +129,5 @@ class TestCodegenInitSettings(unittest.TestCase):
                 self.assertEqual(c['expect'], actual, c['describe'])
 
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/tasks/unit_tests/schema_codegen_tests.py
+++ b/tasks/unit_tests/schema_codegen_tests.py
@@ -7,7 +7,7 @@ import unittest
 import yaml
 
 import tasks.schema.codegen_init_settings as codegen
-from tasks.schema.codegen_init_settings import as_go_value
+from tasks.schema.codegen_init_settings import as_go_value, try_parse_duration
 
 TESTDATA = os.path.join(os.path.dirname(__file__), "testdata", "schema_codegen")
 
@@ -89,6 +89,45 @@ class TestCodegenInitSettings(unittest.TestCase):
             with self.subTest(service=c['describe']):
                 actual = as_go_value(c['input'], split_lines=c['split_lines'])
                 self.assertEqual(c['expect'], actual, c['describe'])
+
+    def test_try_parse_duration(self):
+        cases = [
+            {
+                "describe": "10 seconds",
+                "input": "10s",
+                "expect": "10*time.Second",
+            },
+            {
+                "describe": "4 minutes, 30 seconds",
+                "input": "4m30s",
+                "expect": "4*time.Minute + 30*time.Second",
+            },
+            {
+                "describe": "100 microseconds",
+                "input": "100µs",
+                "expect": "100*time.Microsecond",
+            },
+            {
+                "describe": "4 nanoseconds",
+                "input": "4ns",
+                "expect": "4*time.Nanosecond",
+            },
+            {
+                "describe": "-1 nanoseconds",
+                "input": "-1ns",
+                "expect": "-1*time.Nanosecond",
+            },
+            {
+                "describe": "-2 hours and 400 milliseconds",
+                "input": "-2h400ms",
+                "expect": "-(2*time.Hour + 400*time.Millisecond)",
+            },
+        ]
+        for c in cases:
+            with self.subTest(service=c['describe']):
+                actual = try_parse_duration(c['input'])
+                self.assertEqual(c['expect'], actual, c['describe'])
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What does this PR do?

Support negative time durations like "-1ns" in the codegen.

### Motivation

Easier to read codegen

### Describe how you validated your changes

Added unit tests to cover this case and more of the time.Duration codegen functionality.

### Additional Notes
