### PR TITLE
[ABLD-536] Bazelify `gotestsum` usage across the repo

### DIFF
--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -66,8 +66,6 @@ tests_linux-x64-py3_hybrid:
     - .linux_tests
     - .linux_x64
   after_script:
-    # In the hybrid test, bazel gets run, and that leaves a symlink to junit-out-base.xml. The uploader chokes on symlinks.
-    - find $(bazel info execution_root) -type l -name 'junit-*.xml' -delete
     - !reference [.upload_junit_source]
     # skip coverage upload for several reasons
     # 1. It would conflate with coverate from the regular job

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -2,6 +2,7 @@
 # e2e stage
 # Contains test jobs based on the new-e2e tests framework
 .new_e2e_template:
+  extends: .bazel:defs:cache:progressive
   stage: e2e
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]

--- a/.gitlab/test/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/test/kernel_matrix_testing/security_agent.yml
@@ -50,6 +50,7 @@ kmt_setup_env_secagent_x64:
     TEST_COMPONENT: security-agent
 
 .upload_secagent_tests:
+  extends: .bazel:defs:cache:progressive
   stage: kernel_matrix_testing_prepare
   allow_failure: true
   rules: !reference [.on_security_agent_changes_or_manual]
@@ -59,6 +60,7 @@ kmt_setup_env_secagent_x64:
     - !reference [.write_ssh_key_file]
   script:
     # copy agent tests
+    - bazel --batch run //internal/tools:install_gotestsum_linux_$ARCH -- --destdir=$CI_PROJECT_DIR/kmt-deps/ci/$ARCH/opt/testing-tools/go/bin
     - pushd $CI_PROJECT_DIR/kmt-deps/ci/$ARCH
     - tar czvf $TEST_ARCHIVE_NAME opt
     - popd

--- a/.gitlab/test/kernel_matrix_testing/system_probe.yml
+++ b/.gitlab/test/kernel_matrix_testing/system_probe.yml
@@ -141,6 +141,7 @@ kmt_setup_env_sysprobe_x64:
     TEST_COMPONENT: system-probe
 
 .upload_sysprobe_tests:
+  extends: .bazel:defs:cache:progressive
   stage: kernel_matrix_testing_prepare
   rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   before_script:
@@ -149,6 +150,7 @@ kmt_setup_env_sysprobe_x64:
     - !reference [.write_ssh_key_file]
   script:
     # copy system probe tests
+    - bazel --batch run //internal/tools:install_gotestsum_linux_$ARCH -- --destdir=$CI_PROJECT_DIR/kmt-deps/ci/$ARCH/opt/testing-tools/go/bin
     - pushd $CI_PROJECT_DIR/kmt-deps/ci/$ARCH
     - tar czvf $TEST_ARCHIVE_NAME opt
     - popd

--- a/internal/tools/BUILD.bazel
+++ b/internal/tools/BUILD.bazel
@@ -1,4 +1,60 @@
-# Tools-only module (//go:build tools tracker for `go install` dependencies).
-# No Bazel targets are generated; the empty BUILD.bazel keeps bazelify_go_work
-# happy without compiling anything.
-# gazelle:ignore
+load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@rules_multitool//multitool:cwd.bzl", "cwd")
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
+
+cwd(
+    name = "gotestsum",
+    tool = "@tools_gotest_gotestsum//:gotestsum",
+)
+
+pkg_files(
+    name = "gotestsum_exe",
+    srcs = ["@tools_gotest_gotestsum//:gotestsum"],
+    attributes = pkg_attributes(mode = "0755"),
+)
+
+pkg_install(
+    name = "install_gotestsum",
+    srcs = [":gotestsum_exe"],
+)
+
+platform_transition_filegroup(
+    name = "gotestsum_linux_arm64",
+    srcs = ["@tools_gotest_gotestsum//:gotestsum"],
+    tags = ["manual"],
+    target_platform = "//bazel/platforms:linux_arm64",
+)
+
+pkg_files(
+    name = "gotestsum_linux_arm64_exe",
+    srcs = [":gotestsum_linux_arm64"],
+    attributes = pkg_attributes(mode = "0755"),
+    tags = ["manual"],
+)
+
+pkg_install(
+    name = "install_gotestsum_linux_arm64",
+    srcs = [":gotestsum_linux_arm64_exe"],
+    tags = ["manual"],
+)
+
+platform_transition_filegroup(
+    name = "gotestsum_linux_x86_64",
+    srcs = ["@tools_gotest_gotestsum//:gotestsum"],
+    tags = ["manual"],
+    target_platform = "//bazel/platforms:linux_x86_64",
+)
+
+pkg_files(
+    name = "gotestsum_linux_x86_64_exe",
+    srcs = [":gotestsum_linux_x86_64"],
+    attributes = pkg_attributes(mode = "0755"),
+    tags = ["manual"],
+)
+
+pkg_install(
+    name = "install_gotestsum_linux_x86_64",
+    srcs = [":gotestsum_linux_x86_64_exe"],
+    tags = ["manual"],
+)

--- a/internal/tools/BUILD.bazel
+++ b/internal/tools/BUILD.bazel
@@ -1,0 +1,60 @@
+load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@rules_multitool//multitool:cwd.bzl", "cwd")
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
+
+cwd(
+    name = "gotestsum",
+    tool = "@tools_gotest_gotestsum//:gotestsum",
+)
+
+pkg_files(
+    name = "gotestsum_exe",
+    srcs = ["@tools_gotest_gotestsum//:gotestsum"],
+    attributes = pkg_attributes(mode = "0755"),
+)
+
+pkg_install(
+    name = "install_gotestsum",
+    srcs = [":gotestsum_exe"],
+)
+
+platform_transition_filegroup(
+    name = "gotestsum_linux_arm64",
+    srcs = ["@tools_gotest_gotestsum//:gotestsum"],
+    tags = ["manual"],
+    target_platform = "//bazel/platforms:linux_arm64",
+)
+
+pkg_files(
+    name = "gotestsum_linux_arm64_exe",
+    srcs = [":gotestsum_linux_arm64"],
+    attributes = pkg_attributes(mode = "0755"),
+    tags = ["manual"],
+)
+
+pkg_install(
+    name = "install_gotestsum_linux_arm64",
+    srcs = [":gotestsum_linux_arm64_exe"],
+    tags = ["manual"],
+)
+
+platform_transition_filegroup(
+    name = "gotestsum_linux_x86_64",
+    srcs = ["@tools_gotest_gotestsum//:gotestsum"],
+    tags = ["manual"],
+    target_platform = "//bazel/platforms:linux_x86_64",
+)
+
+pkg_files(
+    name = "gotestsum_linux_x86_64_exe",
+    srcs = [":gotestsum_linux_x86_64"],
+    attributes = pkg_attributes(mode = "0755"),
+    tags = ["manual"],
+)
+
+pkg_install(
+    name = "install_gotestsum_linux_x86_64",
+    srcs = [":gotestsum_linux_x86_64_exe"],
+    tags = ["manual"],
+)

--- a/pkg/collector/corechecks/oracle/test-utils/run-tests.sh
+++ b/pkg/collector/corechecks/oracle/test-utils/run-tests.sh
@@ -38,5 +38,5 @@ do
   go clean -testcache
 
   # Tests are running sequentially for the predictability of the memory leak test
-  gotestsum --jsonfile module_test_output.json --format pkgname --packages=./pkg/collector/corechecks/oracle/... -- -mod=readonly -vet=off --tags=oracle_test,oracle,test 
+  bazel run //internal/tools:gotestsum -- --jsonfile module_test_output.json --format pkgname --packages=./pkg/collector/corechecks/oracle/... -- -mod=readonly -vet=off --tags=oracle_test,oracle,test
 done

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -10,6 +10,7 @@ import glob
 import operator
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -29,6 +30,7 @@ from tasks.collector import OTEL_CONTRIB_VERSION
 from tasks.coverage import PROFILE_COV, CodecovWorkaround
 from tasks.devcontainer import run_on_devcontainer
 from tasks.flavor import AgentFlavor
+from tasks.libs.build.bazel import bazel
 from tasks.libs.common.bazel_query import bazel_query
 from tasks.libs.common.color import color_message
 from tasks.libs.common.datadog_api import create_count, send_metrics
@@ -436,12 +438,12 @@ def test_flavor(
     # Produce the result json file, which is used to show the failures at the end of the test run
     if result_json:
         result.result_json_path = os.path.join(result.path, result_json)
-        args["json_flag"] = "--jsonfile " + result.result_json_path
+        args["json_flag"] = f'--jsonfile "{result.result_json_path}"'
 
     # Produce the junit file if needed
     if result_junit:
         result_junit_path = os.path.join(result.path, result_junit)
-        args["junit_file_flag"] = "--junitfile " + result_junit_path
+        args["junit_file_flag"] = f'--junitfile "{result_junit_path}"'
 
     # Compute full list of targets to run tests against
     module_list = list(modules)
@@ -482,15 +484,15 @@ def test_flavor(
     for batch in batches:
         batch_packages = ' '.join(batch)
         with CodecovWorkaround(ctx, result.path, coverage, batch_packages, args) as cov_test_path:
-            res = ctx.run(
-                command=cmd.format(
-                    packages=batch_packages,
-                    cov_test_path=cov_test_path,
-                    **args,
-                ),
-                env=env,
-                out_stream=test_profiler,
-                warn=True,
+            res = bazel(
+                ctx,
+                "run",
+                "//internal/tools:gotestsum",
+                "--",
+                *shlex.split(cmd.format(packages=batch_packages, cov_test_path=cov_test_path, **args)),
+                env=env,  # contains secrets, so passing each variable through `--run_env=` would print their values
+                ignore_errors=True,
+                output_stream=test_profiler,
             )
             # early stop on SIGINT: exit code is 128 + signal number, SIGINT is 2, so 130
             if res is not None and res.exited == 130:
@@ -723,7 +725,7 @@ def test(
     gobuild_flags = '-mod={go_mod} -tags "{go_build_tags}" -gcflags="{gcflags}" -ldflags="{ldflags}" {build_cpus} {race_opt} {trimpath_opt}'
 
     stdlib_build_cmd = f'go build {{verbose}} {gobuild_flags} std cmd'
-    rerun_coverage_fix = '--raw-command {cov_test_path}' if coverage else ""
+    rerun_coverage_fix = '--raw-command "{cov_test_path}"' if coverage else ""
     gotestsum_flags = (
         '{junit_file_flag} {json_flag} --format {gotestsum_format} {rerun_fails} --packages="{packages}" '
         + rerun_coverage_fix
@@ -732,7 +734,7 @@ def test(
     gotest_flags = (
         '{verbose} {test_cpus} -timeout {timeout}s -short {covermode_opt} {test_run_arg} {nocache} {extra_args}'
     )
-    cmd = f'gotestsum {gotestsum_flags} -- {gobuild_flags} {govet_flags} {gotest_flags}'
+    cmd = f'{gotestsum_flags} -- {gobuild_flags} {govet_flags} {gotest_flags}'
     args = {
         "go_mod": go_mod,
         "gcflags": gcflags,

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -9,6 +9,7 @@ import fnmatch
 import glob
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -28,6 +29,7 @@ from tasks.collector import OTEL_CONTRIB_VERSION
 from tasks.coverage import PROFILE_COV, CodecovWorkaround
 from tasks.devcontainer import run_on_devcontainer
 from tasks.flavor import AgentFlavor
+from tasks.libs.build.bazel import bazel
 from tasks.libs.common.bazel_query import bazel_query
 from tasks.libs.common.color import color_message
 from tasks.libs.common.datadog_api import create_count, send_metrics
@@ -402,12 +404,12 @@ def test_flavor(
     # Produce the result json file, which is used to show the failures at the end of the test run
     if result_json:
         result.result_json_path = os.path.join(result.path, result_json)
-        args["json_flag"] = "--jsonfile " + result.result_json_path
+        args["json_flag"] = f'--jsonfile "{result.result_json_path}"'
 
     # Produce the junit file if needed
     if result_junit:
         result_junit_path = os.path.join(result.path, result_junit)
-        args["junit_file_flag"] = "--junitfile " + result_junit_path
+        args["junit_file_flag"] = f'--junitfile "{result_junit_path}"'
 
     # Compute full list of targets to run tests against
     module_list = list(modules)
@@ -448,14 +450,14 @@ def test_flavor(
     for batch in batches:
         batch_packages = ' '.join(batch)
         with CodecovWorkaround(ctx, result.path, coverage, batch_packages, args) as cov_test_path:
-            res = ctx.run(
-                command=cmd.format(
-                    packages=batch_packages,
-                    cov_test_path=cov_test_path,
-                    **args,
-                ),
-                env=env,
-                warn=True,
+            res = bazel(
+                ctx,
+                "run",
+                "//internal/tools:gotestsum",
+                "--",
+                *shlex.split(cmd.format(packages=batch_packages, cov_test_path=cov_test_path, **args)),
+                env=env,  # contains secrets, so passing each variable through `--run_env=` would print their values
+                ignore_errors=True,
             )
             # early stop on SIGINT: exit code is 128 + signal number, SIGINT is 2, so 130
             if res is not None and res.exited == 130:
@@ -687,7 +689,7 @@ def test(
     gobuild_flags = '-mod={go_mod} -tags "{go_build_tags}" -gcflags="{gcflags}" -ldflags="{ldflags}" {build_cpus} {race_opt} {trimpath_opt}'
 
     stdlib_build_cmd = f'go build {{verbose}} {gobuild_flags} std cmd'
-    rerun_coverage_fix = '--raw-command {cov_test_path}' if coverage else ""
+    rerun_coverage_fix = '--raw-command "{cov_test_path}"' if coverage else ""
     gotestsum_flags = (
         '{junit_file_flag} {json_flag} --format {gotestsum_format} {rerun_fails} --packages="{packages}" '
         + rerun_coverage_fix
@@ -696,7 +698,7 @@ def test(
     gotest_flags = (
         '{verbose} {test_cpus} -timeout {timeout}s -short {covermode_opt} {test_run_arg} {nocache} {extra_args}'
     )
-    cmd = f'gotestsum {gotestsum_flags} -- {gobuild_flags} {govet_flags} {gotest_flags}'
+    cmd = f'{gotestsum_flags} -- {gobuild_flags} {govet_flags} {gotest_flags}'
     args = {
         "go_mod": go_mod,
         "gcflags": gcflags,

--- a/tasks/install_tasks.py
+++ b/tasks/install_tasks.py
@@ -17,7 +17,6 @@ TOOL_LIST = [
     'github.com/go-enry/go-license-detector/v4/cmd/license-detector',
     'github.com/golangci/golangci-lint/v2/cmd/golangci-lint',
     'github.com/goware/modvendor',
-    'gotest.tools/gotestsum',
     'github.com/vektra/mockery/v3',
     'github.com/wadey/gocovmerge',
     'github.com/uber-go/gopatch',

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -49,7 +49,7 @@ from tasks.kernel_matrix_testing.kmt_os import get_kmt_os
 from tasks.kernel_matrix_testing.platforms import get_platforms, platforms_file
 from tasks.kernel_matrix_testing.setup import check_requirements, get_requirements
 from tasks.kernel_matrix_testing.stacks import check_and_get_stack, check_and_get_stack_or_exit, ec2_instance_ids
-from tasks.kernel_matrix_testing.tool import Exit, ask, error, get_binary_target_arch, info, warn
+from tasks.kernel_matrix_testing.tool import Exit, ask, error, info, warn
 from tasks.kernel_matrix_testing.types import PlatformInfo, component_from_str
 from tasks.kernel_matrix_testing.vars import KMT_SUPPORTED_ARCHS, KMTPaths
 from tasks.libs.build.bazel import bazel
@@ -62,7 +62,7 @@ from tasks.libs.ciproviders.gitlab_api import (
 )
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.git import get_current_branch
-from tasks.libs.common.utils import get_build_flags, get_gobin
+from tasks.libs.common.utils import get_build_flags
 from tasks.libs.pipeline.tools import GitlabJobStatus, loop_status
 from tasks.libs.releasing.json import load_release_json
 from tasks.libs.releasing.version import VERSION_RE, check_version
@@ -94,7 +94,6 @@ if TYPE_CHECKING:
         Component,  # noqa: F401
         DependenciesLayout,
         KMTArchNameOrLocal,
-        PathOrStr,
         SSHKey,
     )
 
@@ -649,35 +648,6 @@ def get_archs_in_domains(domains: Iterable[LibvirtDomain]) -> set[Arch]:
     return archs
 
 
-TOOLS_PATH = f"{CONTAINER_AGENT_PATH}/internal/tools"
-GOTESTSUM = "gotest.tools/gotestsum"
-
-
-def download_gotestsum(ctx: Context, arch: Arch, fgotestsum: PathOrStr):
-    if os.path.isfile(fgotestsum):
-        file_arch = get_binary_target_arch(ctx, fgotestsum)
-        if file_arch == arch:
-            return
-
-    paths = KMTPaths(None, arch)
-    paths.tools.mkdir(parents=True, exist_ok=True)
-
-    cc = get_compiler(ctx)
-    target_path = CONTAINER_AGENT_PATH / paths.tools.relative_to(paths.repo_root) / "gotestsum"
-    env = {
-        "GOARCH": arch.go_arch,
-        "CC": "\\$DD_CC_CROSS" if arch.is_cross_compiling() else "\\$DD_CC",
-        "CXX": "\\$DD_CXX_CROSS" if arch.is_cross_compiling() else "\\$DD_CXX",
-    }
-
-    env_str = " ".join(f"{key}={value}" for key, value in env.items())
-    cc.exec(
-        f"cd {TOOLS_PATH} && {env_str} go build -o {target_path} {GOTESTSUM}",
-    )
-
-    ctx.run(f"cp {paths.tools}/gotestsum {fgotestsum}")
-
-
 def is_root():
     return os.getuid() == 0
 
@@ -954,12 +924,10 @@ def _prepare(
         # In CI, these binaries are always present
         llc_path = LLC_PATH_CI
         clang_path = CLANG_PATH_CI
-        gotestsum_path = Path(get_gobin(ctx)) / "gotestsum"
 
         # Copy the binaries to the target directory, CI will take them from those
         # paths as artifacts
         copy_static_files = {
-            gotestsum_path: paths.dependencies / "go/bin/gotestsum",
             clang_path: paths.arch_dir / "opt/datadog-agent/embedded/bin/clang-bpf",
             llc_path: paths.arch_dir / "opt/datadog-agent/embedded/bin/llc-bpf",
             "flakes.yaml": paths.dependencies / "flakes.yaml",
@@ -969,8 +937,13 @@ def _prepare(
         for src, dst in copy_static_files.items():
             ctx.run(f"install -D {src} {dst}")
     else:
-        gotestsum_path = paths.dependencies / "go/bin/gotestsum"
-        download_gotestsum(ctx, arch_obj, gotestsum_path)
+        bazel(
+            ctx,
+            "run",
+            f"//internal/tools:install_gotestsum_linux_{arch_obj.kmt_arch}",
+            "--",
+            f"--destdir={paths.dependencies / "go/bin"}",
+        )
 
         # We cannot use the pre-built local clang and llc-bpf binaries, as they
         # might not be built for the target architecture.

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -49,7 +49,7 @@ from tasks.kernel_matrix_testing.kmt_os import get_kmt_os
 from tasks.kernel_matrix_testing.platforms import get_platforms, platforms_file
 from tasks.kernel_matrix_testing.setup import check_requirements, get_requirements
 from tasks.kernel_matrix_testing.stacks import check_and_get_stack, check_and_get_stack_or_exit, ec2_instance_ids
-from tasks.kernel_matrix_testing.tool import Exit, ask, error, get_binary_target_arch, info, warn
+from tasks.kernel_matrix_testing.tool import Exit, ask, error, info, warn
 from tasks.kernel_matrix_testing.types import PlatformInfo, component_from_str
 from tasks.kernel_matrix_testing.vars import KMT_SUPPORTED_ARCHS, KMTPaths
 from tasks.libs.build.bazel import bazel
@@ -62,7 +62,7 @@ from tasks.libs.ciproviders.gitlab_api import (
 )
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.git import get_current_branch
-from tasks.libs.common.utils import get_build_flags, get_gobin
+from tasks.libs.common.utils import get_build_flags
 from tasks.libs.pipeline.tools import GitlabJobStatus, loop_status
 from tasks.libs.releasing.json import load_release_json
 from tasks.libs.releasing.version import VERSION_RE, check_version
@@ -95,7 +95,6 @@ if TYPE_CHECKING:
         Component,  # noqa: F401
         DependenciesLayout,
         KMTArchNameOrLocal,
-        PathOrStr,
         SSHKey,
     )
 
@@ -650,35 +649,6 @@ def get_archs_in_domains(domains: Iterable[LibvirtDomain]) -> set[Arch]:
     return archs
 
 
-TOOLS_PATH = f"{CONTAINER_AGENT_PATH}/internal/tools"
-GOTESTSUM = "gotest.tools/gotestsum"
-
-
-def download_gotestsum(ctx: Context, arch: Arch, fgotestsum: PathOrStr):
-    if os.path.isfile(fgotestsum):
-        file_arch = get_binary_target_arch(ctx, fgotestsum)
-        if file_arch == arch:
-            return
-
-    paths = KMTPaths(None, arch)
-    paths.tools.mkdir(parents=True, exist_ok=True)
-
-    cc = get_compiler(ctx)
-    target_path = CONTAINER_AGENT_PATH / paths.tools.relative_to(paths.repo_root) / "gotestsum"
-    env = {
-        "GOARCH": arch.go_arch,
-        "CC": "\\$DD_CC_CROSS" if arch.is_cross_compiling() else "\\$DD_CC",
-        "CXX": "\\$DD_CXX_CROSS" if arch.is_cross_compiling() else "\\$DD_CXX",
-    }
-
-    env_str = " ".join(f"{key}={value}" for key, value in env.items())
-    cc.exec(
-        f"cd {TOOLS_PATH} && {env_str} go build -o {target_path} {GOTESTSUM}",
-    )
-
-    ctx.run(f"cp {paths.tools}/gotestsum {fgotestsum}")
-
-
 def is_root():
     return os.getuid() == 0
 
@@ -958,12 +928,10 @@ def _prepare(
         # In CI, these binaries are always present
         llc_path = LLC_PATH_CI
         clang_path = CLANG_PATH_CI
-        gotestsum_path = Path(get_gobin(ctx)) / "gotestsum"
 
         # Copy the binaries to the target directory, CI will take them from those
         # paths as artifacts
         copy_static_files = {
-            gotestsum_path: paths.dependencies / "go/bin/gotestsum",
             clang_path: paths.arch_dir / "opt/datadog-agent/embedded/bin/clang-bpf",
             llc_path: paths.arch_dir / "opt/datadog-agent/embedded/bin/llc-bpf",
             "flakes.yaml": paths.dependencies / "flakes.yaml",
@@ -973,8 +941,13 @@ def _prepare(
         for src, dst in copy_static_files.items():
             ctx.run(f"install -D {src} {dst}")
     else:
-        gotestsum_path = paths.dependencies / "go/bin/gotestsum"
-        download_gotestsum(ctx, arch_obj, gotestsum_path)
+        bazel(
+            ctx,
+            "run",
+            f"//internal/tools:install_gotestsum_linux_{arch_obj.kmt_arch}",
+            "--",
+            f"--destdir={paths.dependencies / "go/bin"}",
+        )
 
         # We cannot use the pre-built local clang and llc-bpf binaries, as they
         # might not be built for the target architecture.

--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -12,6 +12,7 @@ from typing import IO, NamedTuple
 
 from invoke import Exit
 from invoke.context import Context
+from invoke.runners import Result
 
 from tasks.libs.common.color import color_message
 from tasks.libs.common.utils import get_repo_root
@@ -97,17 +98,16 @@ def bazel(
     ctx: Context,
     *args: str,
     capture_output: bool = False,
-    capture_stderr: bool = False,
+    env: dict[str, str] | None = None,
     ignore_errors: bool = False,
     input_stream: IO[str] | bool = False,
+    output_stream: IO[str] | None = None,
     sudo: bool = False,
-) -> str:
+) -> str | Result:
     """Execute a bazel command.
 
-    capture_output: capture stdout.
-    capture_stderr: also capture stderr and append it to the returned string.
-        Use this when Bazel writes important output (e.g.  test results) to stderr
-        and the caller needs to process it.
+    env: environment variables that would expose secrets if passed through the corresponding Bazel `--*_env=` flags.
+    ignore_errors: do not fail fast, but instead return the raw `Result`, whether the Bazel command succeeded or not.
     """
 
     if not (bazelisk := shutil.which("bazelisk")):  # `/usr/bin/bazel` may otherwise take precedence in DD Workspaces
@@ -120,21 +120,16 @@ def bazel(
     # In every other libray, that would be called capture, and the
     # act of capturing it would hide it from the user.
     # https://docs.pyinvoke.org/en/stable/api/runners.html#invoke.runners.Runner.run
-    if capture_output and capture_stderr:
-        kwargs["hide"] = "both"
-    elif capture_output:
+    if capture_output:
         kwargs["hide"] = "out"
-    elif capture_stderr:
-        kwargs["hide"] = "err"
     elif not sudo and sys.stdout.isatty() and sys.platform != "win32":
         kwargs["pty"] = True
-    result = ctx.run(cmdline, echo=False, in_stream=input_stream, warn=ignore_errors, **kwargs)
-    captured = []
-    if capture_output and result.ok:
-        captured.append(result.stdout)
-    if capture_stderr:
-        captured.append(result.stderr)
-    return "".join(captured)
+    result = ctx.run(
+        cmdline, echo=False, env=env, in_stream=input_stream, out_stream=output_stream, warn=ignore_errors, **kwargs
+    )
+    if ignore_errors:
+        return result
+    return result.stdout if capture_output else ""
 
 
 def _insert_omnibazel_flags(args: tuple[str, ...]) -> tuple[str, ...]:

--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -12,6 +12,7 @@ from typing import IO, NamedTuple
 
 from invoke import Exit
 from invoke.context import Context
+from invoke.runners import Result
 
 from tasks.libs.common.color import color_message
 from tasks.libs.common.utils import get_repo_root
@@ -97,17 +98,15 @@ def bazel(
     ctx: Context,
     *args: str,
     capture_output: bool = False,
-    capture_stderr: bool = False,
+    env: dict[str, str] | None = None,
     ignore_errors: bool = False,
     input_stream: IO[str] | bool = False,
     sudo: bool = False,
-) -> str:
+) -> str | Result:
     """Execute a bazel command.
 
-    capture_output: capture stdout.
-    capture_stderr: also capture stderr and append it to the returned string.
-        Use this when Bazel writes important output (e.g.  test results) to stderr
-        and the caller needs to process it.
+    env: environment variables that would expose secrets if passed through the corresponding Bazel `--*_env=` flags.
+    ignore_errors: do not fail fast, but instead return the raw `Result`, whether the Bazel command succeeded or not.
     """
 
     if not (bazelisk := shutil.which("bazelisk")):  # `/usr/bin/bazel` may otherwise take precedence in DD Workspaces
@@ -120,21 +119,14 @@ def bazel(
     # In every other libray, that would be called capture, and the
     # act of capturing it would hide it from the user.
     # https://docs.pyinvoke.org/en/stable/api/runners.html#invoke.runners.Runner.run
-    if capture_output and capture_stderr:
-        kwargs["hide"] = "both"
-    elif capture_output:
+    if capture_output:
         kwargs["hide"] = "out"
-    elif capture_stderr:
-        kwargs["hide"] = "err"
     elif not sudo and sys.stdout.isatty() and sys.platform != "win32":
         kwargs["pty"] = True
-    result = ctx.run(cmdline, echo=False, in_stream=input_stream, warn=ignore_errors, **kwargs)
-    captured = []
-    if capture_output and result.ok:
-        captured.append(result.stdout)
-    if capture_stderr:
-        captured.append(result.stderr)
-    return "".join(captured)
+    result = ctx.run(cmdline, echo=False, env=env, in_stream=input_stream, warn=ignore_errors, **kwargs)
+    if ignore_errors:
+        return result
+    return result.stdout if capture_output else ""
 
 
 def _insert_omnibazel_flags(args: tuple[str, ...]) -> tuple[str, ...]:

--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -105,7 +105,7 @@ def bazel(
 ) -> str | Result:
     """Execute a bazel command.
 
-    env: environment variables that would expose secrets if passed through the corresponding Bazel `--*_env=` flags.
+    env: environment variables when passing them through the corresponding Bazel `--*_env=` flags is not suitable.
     ignore_errors: do not fail fast, but instead return the raw `Result`, whether the Bazel command succeeded or not.
     """
 

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -760,7 +760,7 @@ def run(
         with open(os.environ.get("FLAKY_PATTERNS_CONFIG"), 'a') as f:
             f.write("{}")
 
-    cmd = f"gotestsum --format {gotestsum_format} "
+    cmd = f"--format {gotestsum_format} "
     raw_command = ""
     # Scrub the test output to avoid leaking API or APP keys when running in the CI
 

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -767,7 +767,7 @@ def run(
     # TODO: remove once Bazel is used to build the Agent
     schema_codegen(ctx)
 
-    cmd = f"gotestsum --format {gotestsum_format} "
+    cmd = f"--format {gotestsum_format} "
     raw_command = ""
     # Scrub the test output to avoid leaking API or APP keys when running in the CI
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -591,11 +591,9 @@ def e2e_prepare(ctx, ci=False, packages=""):
                 binary = Path(target_path) / cbin
                 ctx.run(f"clang -static -o {binary} {source}")
 
-    gopath = os.getenv("GOPATH")
     copy_files = [
         "/opt/datadog-agent/embedded/bin/clang-bpf",
         "/opt/datadog-agent/embedded/bin/llc-bpf",
-        f"{gopath}/bin/gotestsum",
     ]
 
     files_dir = os.path.join(E2E_ARTIFACT_DIR, "..")
@@ -603,6 +601,7 @@ def e2e_prepare(ctx, ci=False, packages=""):
         if os.path.exists(cf):
             shutil.copy(cf, files_dir)
 
+    bazel(ctx, "run", "//internal/tools:install_gotestsum", "--", f"--destdir={files_dir}")
     go_build(ctx, "cmd/test2json", ldflags="-s -w", bin_path=f"{files_dir}/test2json", env={"CGO_ENABLED": "0"})
     ctx.run(f"echo {get_commit_sha(ctx)} > {BUILD_COMMIT}")
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -595,11 +595,9 @@ def e2e_prepare(ctx, ci=False, packages=""):
                 binary = Path(target_path) / cbin
                 ctx.run(f"clang -static -o {binary} {source}")
 
-    gopath = os.getenv("GOPATH")
     copy_files = [
         "/opt/datadog-agent/embedded/bin/clang-bpf",
         "/opt/datadog-agent/embedded/bin/llc-bpf",
-        f"{gopath}/bin/gotestsum",
     ]
 
     files_dir = os.path.join(E2E_ARTIFACT_DIR, "..")
@@ -607,6 +605,7 @@ def e2e_prepare(ctx, ci=False, packages=""):
         if os.path.exists(cf):
             shutil.copy(cf, files_dir)
 
+    bazel(ctx, "run", "//internal/tools:install_gotestsum", "--", f"--destdir={files_dir}")
     go_build(ctx, "cmd/test2json", ldflags="-s -w", bin_path=f"{files_dir}/test2json", env={"CGO_ENABLED": "0"})
     ctx.run(f"echo {get_commit_sha(ctx)} > {BUILD_COMMIT}")
 

--- a/tasks/unit_tests/libs/build/bazel_tests.py
+++ b/tasks/unit_tests/libs/build/bazel_tests.py
@@ -29,22 +29,11 @@ class TestBazel(unittest.TestCase):
         self.assertEqual(bazel(self._ctx(), "info", capture_output=True), "out\n")
 
     @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
-    def test_capture_stderr(self, _):
-        self.assertEqual(bazel(self._ctx(), "info", capture_stderr=True), "err\n")
-
-    @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
-    def test_capture_both(self, _):
-        self.assertEqual(bazel(self._ctx(), "info", capture_output=True, capture_stderr=True), "out\nerr\n")
-
-    @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
-    def test_ignore_errors_captures_output_on_success(self, _):
-        self.assertEqual(bazel(self._ctx(), "info", ignore_errors=True, capture_output=True), "out\n")
-
-    @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
-    def test_ignore_errors_only_captures_stderr_on_failure(self, _):
-        self.assertEqual(
-            bazel(self._ctx(exit=1), "info", ignore_errors=True, capture_output=True, capture_stderr=True), "err\n"
-        )
+    def test_ignore_errors_returns_raw_result(self, _):
+        res = bazel(self._ctx(exit=1), "info", ignore_errors=True, capture_output=True)
+        self.assertFalse(res.ok)
+        self.assertEqual(res.stdout, "out\n")
+        self.assertEqual(res.stderr, "err\n")
 
     @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
     def test_input_stream_disabled_by_default(self, _):

--- a/tools/ci/junit_upload.sh
+++ b/tools/ci/junit_upload.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 # shellcheck source=/dev/null
+
+# Drop Bazel-generated symlinks to actual JUnit reports to prevent the same report from being processed twice and to
+# avoid GitLab failing on `ERROR: Uploading artifacts as "junit" [...] error [...] "junit.xml" is not a regular file`.
+[ -d .cache ] && find .cache -type l -name 'junit-*.xml' -delete
+
 # junit file name can differ in kitchen or macos context
 junit_files="junit-*.tgz"
 if [[ -n "$1" ]]; then


### PR DESCRIPTION
### What does this PR do?
Route `gotestsum` through Bazel wherever it was invoked via `go install`, `$GOBIN`, or `$GOPATH`, and drop it from `install-tools`' `TOOL_LIST`.

Replace every direct `gotestsum` invocation with `bazel run *:gotestsum` whenever possible.

Otherwise install it by leveraging:
1. `platform_transition_filegroup` to cross-compile it without incurring the overhead of a full platform transition (for which some Bazel rules are not suited[^1]),
2. `pkg_install` for copying it out of the sandbox.

Together, both of the above provide a flawless[^2] alternative in runtime environments where Bazel is not (yet) available.

### Initial Motivation
`gotestsum`'s version and toolchain provenance were at best tracked by a runtime version check, and `go install` left it exposed to the "gotestsum not found" and wrong-arch incident class, leading us to land urgent PRs (e.g., #53993):
- [#incident-56214](https://app.datadoghq.com/incidents/56214),
- [#incident-56215](https://app.datadoghq.com/incidents/56215),
- [#incident-56553](https://app.datadoghq.com/incidents/56553),
- etc.

=> Bazel's hermetic build and efficient caching remove the failure mode at the source instead of patching around it again.

### Additional Motivation
It introduces `platform_transition_filegroup` as a first working case that cross-compiles without having to globally alter `bazel --platforms` flags that would invalidate the action cache[^1][^2].

By adding the necessary GitLab `extends` as well as tweaking adhoc scripts, this also prepare jobs for:
- switching from `bazel run *:gotestsum` to `bazel test`,
- moving more non-hermetic tool invocations to `bazel run`, towards [ABLD-536](https://datadoghq.atlassian.net/browse/ABLD-536).

### Describe how you validated your changes
`dda inv test` ran end to end through the new `bazel run` path: 18 tests passed with correct output and exit code.

`kmt.py` and `system_probe.py`'s install paths were exercised directly, producing correct-arch binaries, verified via `file(1)`, for host, `arm64`, and `x86_64` targets, including the KMT cross-compile case.

Existing unit test suites, `bazel_tests.py`, `e2e_testing_tests.py`, `setup_env_tests.py`, and `go_tests.py`, pass unchanged.

### Additional Notes
[^1]: a bare `--platforms=` flag on the whole `bazel run` invocation doesn't just cost more, it breaks `pkg_install`'s own launcher outright (hit this directly: a garbled venv/Python launcher, `Syntax error: ')' unexpected`, zero output).

[^2]: a naive `bazel build` followed by a copy of the resulting binary by gardening into Bazel's output is flawed: not only is the operation not atomic, but output paths collide across `--platforms` invocations. Also, build artifacts would get thrashed over `--platforms` switches.

[ABLD-536]: https://datadoghq.atlassian.net/browse/ABLD-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ