### PR TITLE
fix(serverless-init): tag active_instances heartbeat with lambda_microvm_id

### DIFF
--- a/cmd/serverless-init/lifecycle/heartbeat.go
+++ b/cmd/serverless-init/lifecycle/heartbeat.go
@@ -61,7 +61,7 @@ type Heartbeat struct {
 	// construction. Supplied by cloudservice.MicroVM.Init, which currently
 	// passes a single entry: "microvm_image_arn:<arn>" (the raw image ARN from
 	// AWS_LAMBDA_MICROVM_IMAGE_ARN, or "unknown" when the env var is unset). The
-	// per-emit "microvm_id:<id>" tag is appended separately in tagsForEmit.
+	// per-emit "lambda_microvm_id:<id>" tag is appended separately in tagsForEmit.
 	baseTags []string
 
 	mu          sync.Mutex
@@ -74,7 +74,7 @@ type Heartbeat struct {
 // NewHeartbeat constructs a Heartbeat. Non-positive interval falls back to
 // DefaultHeartbeatInterval. baseTags are tags known at construction time
 // (typically derived from env vars, e.g., microvm_image_arn); the
-// microvm_id tag is appended at emit time and is set at runtime via
+// lambda_microvm_id tag is appended at emit time and is set at runtime via
 // SetMicroVMID from the /run request.
 func NewHeartbeat(interval time.Duration, emitter MetricEmitter, source metrics.MetricSource, baseTags []string) *Heartbeat {
 	if interval <= 0 {
@@ -220,13 +220,13 @@ func (h *Heartbeat) emit() {
 }
 
 // tagsForEmit returns a fresh tag slice combining the immutable base tags
-// (set at construction) with the current microvm_id (set at /run).
+// (set at construction) with the current lambda_microvm_id (set at /run).
 func (h *Heartbeat) tagsForEmit() []string {
 	h.mu.Lock()
 	id := h.microVMID
 	h.mu.Unlock()
 	tags := make([]string, 0, len(h.baseTags)+1)
 	tags = append(tags, h.baseTags...)
-	tags = append(tags, "microvm_id:"+id)
+	tags = append(tags, lambdaMicroVMID+id)
 	return tags
 }

--- a/cmd/serverless-init/lifecycle/heartbeat_test.go
+++ b/cmd/serverless-init/lifecycle/heartbeat_test.go
@@ -275,15 +275,15 @@ func TestHeartbeat_ResumeDuringStuckStopRestartsHeartbeat(t *testing.T) {
 	hb.Stop() // clean up the relaunched goroutine
 }
 
-// Until SetMicroVMID is called, the heartbeat tags microvm_id with the
-// placeholder "unknown". Production wiring sets the ID at /run before
+// Until SetMicroVMID is called, the heartbeat tags lambda_microvm_id with
+// the placeholder "unknown". Production wiring sets the ID at /run before
 // Start, so this state should never reach an emitted metric in practice;
 // the test pins the contract anyway in case wiring changes.
 func TestHeartbeat_TagsForEmit_DefaultsMicroVMIDToUnknown(t *testing.T) {
 	hb := NewHeartbeat(time.Hour, &mockMetricEmitter{}, metrics.MetricSourceAWSMicroVMEnhanced, []string{"microvm_image_arn:test-arn"})
 	tags := hb.tagsForEmit()
 	assert.Contains(t, tags, "microvm_image_arn:test-arn")
-	assert.Contains(t, tags, "microvm_id:unknown")
+	assert.Contains(t, tags, "lambda_microvm_id:unknown")
 }
 
 // When resourceName is empty the microvm_image_arn tag must be absent — an
@@ -301,7 +301,7 @@ func TestHeartbeat_SetMicroVMID_ReflectsOnEmittedTags(t *testing.T) {
 	hb.SetMicroVMID("mvm-abc123")
 	tags := hb.tagsForEmit()
 	assert.Contains(t, tags, "microvm_image_arn:test-arn")
-	assert.Contains(t, tags, "microvm_id:mvm-abc123")
+	assert.Contains(t, tags, "lambda_microvm_id:mvm-abc123")
 }
 
 // TestHeartbeat_EmittedMetric_CarriesARNTag verifies end-to-end that the
@@ -340,7 +340,7 @@ func TestHeartbeat_SetMicroVMID_EmptyIsIgnored(t *testing.T) {
 	hb.SetMicroVMID("first-id")
 	hb.SetMicroVMID("")
 	tags := hb.tagsForEmit()
-	assert.Contains(t, tags, "microvm_id:first-id", "empty ID must not clobber the existing value")
+	assert.Contains(t, tags, "lambda_microvm_id:first-id", "empty ID must not clobber the existing value")
 }
 
 func TestHeartbeat_SetMicroVMID_OnNilReceiverIsSafe(t *testing.T) {
@@ -371,7 +371,7 @@ func TestHeartbeat_SetMicroVMID_VisibleOnNextTick(t *testing.T) {
 	// The most recent emission must carry the updated ID.
 	last := emitter.lastTags()
 	require.NotNil(t, last)
-	assert.Contains(t, last, "microvm_id:mvm-after-start")
+	assert.Contains(t, last, "lambda_microvm_id:mvm-after-start")
 }
 
 // TestHeartbeat_EmittedMetricsCarryCurrentTimestamp verifies that heartbeat

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -569,7 +569,7 @@ func (s *Server) aliveCheckReady(w http.ResponseWriter) {
 // (when a forwarder is configured) mirrors the user app's response.
 // handleRun is the only hook that reads r.Body and is therefore not
 // collapsed into dispatchHook directly. The ID is captured before Start
-// so the first heartbeat emission already carries the correct microvm_id tag.
+// so the first heartbeat emission already carries the correct lambda_microvm_id tag.
 func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {
 	// Read the body once so we can parse the instance ID AND still forward the
 	// original payload to the user app. Without this, the forwarder path would

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -1441,7 +1441,7 @@ func TestHandleRun_StartsHeartbeat(t *testing.T) {
 
 // /run must extract the MicroVM ID from the JSON body and apply it to the
 // heartbeat before Start so the very first emission carries the correct
-// microvm_id. The test calls handleRun then inspects the tags that the
+// lambda_microvm_id. The test calls handleRun then inspects the tags that the
 // heartbeat would emit on its next tick.
 func TestHandleRun_AppliesMicroVMIDFromBody(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
@@ -1451,7 +1451,7 @@ func TestHandleRun_AppliesMicroVMIDFromBody(t *testing.T) {
 	body := strings.NewReader(`{"microvmId":"vm-from-body"}`)
 	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
 
-	assert.Contains(t, srv.heartbeat.tagsForEmit(), "microvm_id:vm-from-body")
+	assert.Contains(t, srv.heartbeat.tagsForEmit(), "lambda_microvm_id:vm-from-body")
 	id := srv.instanceID.Load()
 	assert.Equal(t, "vm-from-body", id)
 }
@@ -1465,7 +1465,7 @@ func TestHandleRun_MissingBodyIDUsesUnknown(t *testing.T) {
 
 	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, nil))
 
-	assert.Contains(t, srv.heartbeat.tagsForEmit(), "microvm_id:unknown")
+	assert.Contains(t, srv.heartbeat.tagsForEmit(), "lambda_microvm_id:unknown")
 }
 
 // traced_invocations is emitted by the Heartbeat on each tick, not directly by


### PR DESCRIPTION
## Summary
- `active_instances` was the only MicroVM metric tagged with `microvm_id`; every other MicroVM signal — the `run`/`resume`/`suspend`/`terminate`/`validate` metrics, plus MicroVM logs and traces — tags the instance as `lambda_microvm_id`. That inconsistency makes it easy to write a query/dashboard/join that silently works for one signal and returns nothing for `active_instances`, which is exactly what came up while investigating why this metric looked "missing."
- Renaming the tag closes that gap so all MicroVM telemetry can be filtered and joined on one consistent instance-identifier key, instead of requiring anyone touching this metric to remember it's the odd one out.

## Note
This is a tag-key rename on a live metric — any existing dashboard/monitor/notebook filtering `active_instances` `by {microvm_id}` will need to switch to `lambda_microvm_id` to keep matching new data points going forward.

## Test plan
- [x] Updated the 6 existing unit tests in `heartbeat_test.go`/`server_test.go` that asserted the old `microvm_id:` tag literal to expect `lambda_microvm_id:` instead.
- [x] `dda inv test --targets=./cmd/serverless-init/...` — 337 tests, 333 passed, 4 skipped (platform-specific), 0 failed.
- [x] [Integration test](https://ddserverless.datadoghq.com/metric/explorer?fromUser=true&graph_layout=stacked&start=1784914680438&end=1784917762409&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVCCc21XkyXkNkHYdOMy0zqwAGED5be0dMHzNtLDIggF0qX119V1AoDAQMAH0NfG0AYyVkEHUEXTzLKhEMdQi-QITImiKNPFVkDDANADpMVQAjNK64EUYMEQKoLtUIPO0cADdVLow8iXm4TNENDPHNYGnZhdVNqGQDucWAWjIAVgA2ACY+gA4AdlfLgE4AFjy+y4AzHkHoJLm87mQvhhvlBXg8yBg7t8MIIeEEKKl0lkcnh8oViogyhUQFUakVEtEDCAKcoWm0Ot1egMMEMRmMJlMZhclis1hstjsChpgEy0plzkcTmcuUdLlAyN9nsjnhgwX1-HdAXlHl9Pv5VYIBjcyG9PjcMH07miePEQEYNPIpFpMh5VOllGpNDo9MTtlg0IVQPIMAGEAh8VAcDBMnlnBoZlS0KINnJFLScEmoInk5l6ExlCJQiH0SAoBAHZgsJlU-ikyIlDaeHwQBXxABhKTCGAoERONA8IA) shows the change before and after the change
<img width="3706" height="1394" alt="image" src="https://github.com/user-attachments/assets/1fa457ef-c809-426d-a688-df4218c9323a" />
