### PR TITLE
fix(snmp-status): fix `expvar` leaks and subnet index collisions

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/discovery/discovery.go
+++ b/pkg/collector/corechecks/snmp/internal/discovery/discovery.go
@@ -13,6 +13,7 @@ import (
 	"expvar"
 	"fmt"
 	"net"
+	"strconv"
 	"sync"
 	"time"
 
@@ -38,6 +39,7 @@ var (
 // Discovery handles snmp discovery states
 type Discovery struct {
 	config    *checkconfig.CheckConfig
+	index     int
 	stop      chan struct{}
 	discDevMu sync.RWMutex
 
@@ -89,6 +91,8 @@ func (d *Discovery) Start() {
 func (d *Discovery) Stop() {
 	log.Debugf("subnet %s: Stop discovery", d.config.Network)
 	close(d.stop)
+	// A changed-credentials reload gets a new index, so delete the old key explicitly.
+	discoveryVar.Delete(listeners.GetSubnetVarKey(d.config.Network, d.index))
 }
 
 // GetDiscoveredDeviceConfigs returns discovered device configs
@@ -157,7 +161,7 @@ func (d *Discovery) discoverDevices() {
 	discoveryTicker := time.NewTicker(time.Duration(d.config.DiscoveryInterval) * time.Second)
 	defer discoveryTicker.Stop()
 	for {
-		discoveryVar.Set(listeners.GetSubnetVarKey(d.config.Network, 0), &expvar.String{})
+		discoveryVar.Set(listeners.GetSubnetVarKey(d.config.Network, d.index), &expvar.String{})
 		subnet.devicesScannedCounter.Store(uint32(len(subnet.config.IgnoredIPAddresses)))
 		log.Debugf("subnet %s: Run discovery", d.config.Network)
 		startingIP := make(net.IP, len(subnet.startingIP))
@@ -226,7 +230,7 @@ func (d *Discovery) checkDevice(job checkDeviceJob) error {
 	}
 
 	discoveryStatus := listeners.AutodiscoveryStatus{DevicesFoundList: d.getDevicesFound(), CurrentDevice: job.currentIP.String(), DevicesScannedCount: int(job.subnet.devicesScannedCounter.Inc())}
-	discoveryVar.Set(listeners.GetSubnetVarKey(job.subnet.config.Network, 0), &discoveryStatus)
+	discoveryVar.Set(listeners.GetSubnetVarKey(job.subnet.config.Network, d.index), &discoveryStatus)
 
 	return nil
 }
@@ -352,8 +356,12 @@ func (d *Discovery) writeCache(subnet *snmpSubnet) {
 
 // NewDiscovery return a new Discovery instance
 func NewDiscovery(config *checkconfig.CheckConfig, sessionFactory session.Factory, agentConfig config.Component, scanManager snmpscanmanager.Component) *Discovery {
+	// Derived from the config digest, not a counter, so reconfiguring the same instance
+	// (Cancel then Configure) reuses its snmpDiscovery expvar key instead of leaking a new one.
+	digest, _ := strconv.ParseUint(string(config.DeviceDigest(config.Network)), 16, 64)
 	return &Discovery{
 		discoveredDevices: make(map[checkconfig.DeviceDigest]Device),
+		index:             int(digest),
 		stop:              make(chan struct{}),
 		config:            config,
 		sessionFactory:    sessionFactory,

--- a/pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go
+++ b/pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go
@@ -7,11 +7,14 @@ package discovery
 
 import (
 	"errors"
+	"expvar"
 	"fmt"
 	"net"
 	"testing"
+	"testing/synctest"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/listeners"
 	agentconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
 	snmpscanmanagermock "github.com/DataDog/datadog-agent/comp/snmpscanmanager/mock"
@@ -33,6 +36,16 @@ func waitForDiscoveredDevices(discovery *Discovery, expectedDeviceCount int, tim
 		time.Sleep(100 * time.Millisecond)
 	}
 	return fmt.Errorf("timeout after waiting for %v, expected at least %d devices but %d has been discovered", timeout, expectedDeviceCount, deviceCount)
+}
+
+func discoveryVarHasKey(key string) bool {
+	found := false
+	discoveryVar.Do(func(kv expvar.KeyValue) {
+		if kv.Key == key {
+			found = true
+		}
+	})
+	return found
 }
 
 func TestDiscovery(t *testing.T) {
@@ -159,6 +172,56 @@ func TestDiscoveryCache(t *testing.T) {
 		actualDiscoveredIpsFromCache = append(actualDiscoveredIpsFromCache, deviceCk.GetIPAddress())
 	}
 	assert.ElementsMatch(t, expectedDiscoveredIps, actualDiscoveredIpsFromCache)
+}
+
+func TestNewDiscoveryIndex(t *testing.T) {
+	config1 := &checkconfig.CheckConfig{
+		Network:         "127.0.10.1/30",
+		CommunityString: "public",
+	}
+	config2 := &checkconfig.CheckConfig{
+		Network:         "127.0.10.1/30",
+		CommunityString: "cisco",
+	}
+
+	original := NewDiscovery(config1, nil, nil, nil)
+	reconfigured := NewDiscovery(config1, nil, nil, nil)
+	assert.Equal(t, original.index, reconfigured.index, "reconfiguring the same config must reuse its index")
+
+	differentCreds := NewDiscovery(config2, nil, nil, nil)
+	assert.NotEqual(t, original.index, differentCreds.index, "configs with different credentials must not collide")
+}
+
+func TestDiscoveryStopDeletesExpvarKey(t *testing.T) {
+	synctest.Test(t, syncTestDiscoveryStopDeletesExpvarKey)
+}
+
+func syncTestDiscoveryStopDeletesExpvarKey(t *testing.T) {
+	config := agentconfig.NewMock(t)
+	config.SetInTest("run_path", t.TempDir())
+
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
+		return nil, nil
+	}
+
+	checkConfig := &checkconfig.CheckConfig{
+		Network:            "192.168.1.0/32",
+		CommunityString:    "public",
+		DiscoveryInterval:  3600,
+		DiscoveryWorkers:   1,
+		IgnoredIPAddresses: map[string]bool{"192.168.1.0": true},
+		ProfileProvider:    profile.StaticProvider(nil),
+	}
+	discovery := NewDiscovery(checkConfig, sessionFactory, config, nil)
+	key := listeners.GetSubnetVarKey(checkConfig.Network, discovery.index)
+
+	discovery.Start()
+	synctest.Wait()
+	assert.True(t, discoveryVarHasKey(key), "Start must publish the subnet's status")
+
+	discovery.Stop()
+	synctest.Wait()
+	assert.False(t, discoveryVarHasKey(key), "Stop must delete the subnet's status")
 }
 
 func TestDiscoveryTicker(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/status/status_test.go
+++ b/pkg/collector/corechecks/snmp/status/status_test.go
@@ -72,6 +72,7 @@ func TestStatusWithProfileError(t *testing.T) {
 	cfg := configmock.New(t)
 	cfg.SetInTest("snmp_profile_errors", "error")
 	profileExpVar := expvar.Get("snmpProfileErrors").(*expvar.Map)
+	t.Cleanup(func() { profileExpVar.Init() })
 	errors := []string{"error1", "error2"}
 	profileExpVar.Set("foobar", expvar.Func(func() interface{} {
 		return strings.Join(errors, "\n")
@@ -187,6 +188,7 @@ func TestStatusAutodiscoveryMultipleSubnets(t *testing.T) {
 	snmpConfig3 := listenerConfig.Configs[2]
 
 	autodiscoveryExpVar := expvar.Get("snmpAutodiscovery").(*expvar.Map)
+	t.Cleanup(func() { autodiscoveryExpVar.Init() })
 
 	autodiscoveryStatus1 := listeners.AutodiscoveryStatus{DevicesFoundList: []string{}, CurrentDevice: "", DevicesScannedCount: 0}
 	autodiscoveryExpVar.Set(listeners.GetSubnetVarKey(snmpConfig1.Network, 0), &autodiscoveryStatus1)
@@ -288,15 +290,16 @@ func TestStatusLegacyDiscoveryMultipleSubnets(t *testing.T) {
 	}
 
 	autodiscoveryExpVar := expvar.Get("snmpDiscovery").(*expvar.Map)
+	t.Cleanup(func() { autodiscoveryExpVar.Init() })
 
 	autodiscoveryStatus1 := listeners.AutodiscoveryStatus{DevicesFoundList: []string{}, CurrentDevice: "", DevicesScannedCount: 0}
 	autodiscoveryExpVar.Set(listeners.GetSubnetVarKey(snmpConfig1.Network, 0), &autodiscoveryStatus1)
 
 	autodiscoveryStatus2 := listeners.AutodiscoveryStatus{DevicesFoundList: []string{"127.0.10.1", "127.0.10.2"}, CurrentDevice: "127.0.10.2", DevicesScannedCount: 3}
-	autodiscoveryExpVar.Set(listeners.GetSubnetVarKey(snmpConfig2.Network, 0), &autodiscoveryStatus2)
+	autodiscoveryExpVar.Set(listeners.GetSubnetVarKey(snmpConfig2.Network, 1), &autodiscoveryStatus2)
 
 	autodiscoveryStatus3 := listeners.AutodiscoveryStatus{DevicesFoundList: []string{}, CurrentDevice: "127.0.10.3", DevicesScannedCount: 4}
-	autodiscoveryExpVar.Set(listeners.GetSubnetVarKey(snmpConfig3.Network, 0), &autodiscoveryStatus3)
+	autodiscoveryExpVar.Set(listeners.GetSubnetVarKey(snmpConfig3.Network, 2), &autodiscoveryStatus3)
 
 	provider := Provider{}
 	tests := []struct {


### PR DESCRIPTION
### What does this PR do?
Reset the shared `expvar` maps (`snmpProfileErrors`, `snmpAutodiscovery`, `snmpDiscovery`) each test writes to, via `t.Cleanup(...Init())`, so entries from one test never **leak** into another test or into a later `-count` iteration of the same test.

Give each `Discovery` instance a unique subnet index, instead of hardcoding index `0`, so 2+ `snmp.d` configs scanning the same network with different credentials no longer **overwrite** the same `snmpDiscovery` expvar key.

### Motivation
Found while investigating unrelated flaky tests in the sibling `discovery` package (#54036).

To confirm that flakiness had nothing to do with this package, running `-race -count=5` against `./pkg/collector/corechecks/snmp/status` alone (no `discovery` package in the target list) already failed on the `main` branch.

Isolating `TestStatusLegacyDiscoveryMultipleSubnets` with `-run` and `-count=1` showed it was already failing on its own, on unmodified `main`: it hardcoded subnet index `0` for both of its `127.0.10.1/30` configs, so the second `.Set()` silently overwrote the first, and its assertions only appeared to pass, in a full suite run, by **coincidentally** matching leftover `snmpAutodiscovery` content from an earlier test.

The fix was to give `TestStatusLegacyDiscoveryMultipleSubnets` distinct indices (`1`, `2`), matching what `TestStatusAutodiscoveryMultipleSubnets` already does for the same two configs.

On top of that, a Codex [review](https://github.com/DataDog/datadog-agent/pull/54116#discussion_r3647602777) surfaced another bug: `pkg/collector/corechecks/snmp/internal/discovery/discovery.go` had always been writing index `0`, so the test scenario was showing distinct keys while production was lagging behind by still producing overlapping ones.

That collision isn't as old as it looks: before #39459, both call sites used `GetSubnetVarKey(network, subnet.cacheKey)`, and `cacheKey` came from `CheckConfig.DeviceDigest`, which hashes in `CommunityString`/`User`/`AuthKey`/etc., so two configs sharing a network with different credentials never collided.
#39459 swapped `GetSubnetVarKey`'s second parameter for a plain `int`, to stop the modern listener's status from depending on the `Digest` function it was reworking.
The modern listener got a real per-subnet index, but the legacy call sites were just given `0` to satisfy the new signature, introducing the collision as a side effect.

The fix needs `index` to be both distinct per config and stable across reconfiguration. Mirroring the modern listener's process-global counter would only satisfy the first: `Configure()` builds a new `Discovery` (and a fresh counter value) on every check reconfiguration, while `Cancel()`'s `Stop()` never deletes the old `snmpDiscovery` entry, so every reload would leak a stale, duplicate key into the map. A second Codex [review](https://github.com/DataDog/datadog-agent/pull/54116#discussion_r3648457928) confirmed exactly that gap.

Deriving `index` from `CheckConfig.DeviceDigest(Network)` satisfies both: it restores the pre-#39459 property where reconfiguring the same instance reuses the same digest and overwrites its own key, while two configs with different credentials for the same subnet still hash to different keys.

A third Codex [review](https://github.com/DataDog/datadog-agent/pull/54116#discussion_r3648816033) found the remaining gap: a reload that changes credentials or ignored IPs changes the digest too, so the new instance's key differs from the old one, and nothing ever deletes the old one. `Stop()` now deletes its own `snmpDiscovery` key, so a changed-credentials reload cleans up after itself instead of leaving a stale entry indefinitely.

=> added `TestNewDiscoveryIndex` and `TestDiscoveryStopDeletesExpvarKey` to lock in these properties.

### Describe how you validated your changes
- `TestStatusLegacyDiscoveryMultipleSubnets` alone, `-run` plus `-count=1`, failed on unmodified `main`, passes after this fix,
- 50 repeated `-race` runs of `./pkg/collector/corechecks/snmp/status`, 12 tests each run, 0 failures and 0 retries needed,
- `dda inv test --targets=./pkg/collector/corechecks/snmp/...`, with and without `--race`: 552 tests, 551 passed, 1 pre-existing, unrelated skip,
- `dda inv linter.go --targets=./pkg/collector/corechecks/snmp/...`: 0 issues.

### Additional Notes
- the two SNMP status templates render `.autodiscoverySubnets` and `.discoverySubnets` back to back with identical text, inside the same `<div>`: that's how `TestStatusLegacyDiscoveryMultipleSubnets` could pass while asserting on data never in `snmpDiscovery`,
- `t.Cleanup(...Init())` targets the process-global `*expvar.Map` returned by `expvar.Get`, not a package-local copy, so it also protects any other test file in this package that reads the same 3 vars.