### PR TITLE
fix(aggregator): honor forceFlushAll on MicroVM's on-demand Flush

### DIFF
--- a/cmd/serverless-init/cloudservice/microvm.go
+++ b/cmd/serverless-init/cloudservice/microvm.go
@@ -237,9 +237,6 @@ func (m *MicroVM) Shutdown(_ *serverlessMetrics.ServerlessMetricAgent, _ bool, _
 // metric when the /run hook fires; emitting it here would double-count.
 func (m *MicroVM) AddStartMetric(_ *serverlessMetrics.ServerlessMetricAgent) {}
 
-// ShouldForceFlushAllOnForceFlushToSerializer returns false for MicroVM.
-func (m *MicroVM) ShouldForceFlushAllOnForceFlushToSerializer() bool { return false }
-
 // isMicroVM returns true when running inside an AWS Lambda MicroVM.
 func isMicroVM() bool {
 	_, exists := os.LookupEnv(serverlessenv.MicroVMImageARNEnvVar)

--- a/cmd/serverless-init/lifecycle/heartbeat.go
+++ b/cmd/serverless-init/lifecycle/heartbeat.go
@@ -227,6 +227,6 @@ func (h *Heartbeat) tagsForEmit() []string {
 	h.mu.Unlock()
 	tags := make([]string, 0, len(h.baseTags)+1)
 	tags = append(tags, h.baseTags...)
-	tags = append(tags, lambdaMicroVMID+id)
+	tags = append(tags, lambdaMicroVMIDPrefix+id)
 	return tags
 }

--- a/cmd/serverless-init/lifecycle/heartbeat.go
+++ b/cmd/serverless-init/lifecycle/heartbeat.go
@@ -61,7 +61,7 @@ type Heartbeat struct {
 	// construction. Supplied by cloudservice.MicroVM.Init, which currently
 	// passes a single entry: "microvm_image_arn:<arn>" (the raw image ARN from
 	// AWS_LAMBDA_MICROVM_IMAGE_ARN, or "unknown" when the env var is unset). The
-	// per-emit "microvm_id:<id>" tag is appended separately in tagsForEmit.
+	// per-emit "lambda_microvm_id:<id>" tag is appended separately in tagsForEmit.
 	baseTags []string
 
 	mu          sync.Mutex
@@ -74,7 +74,7 @@ type Heartbeat struct {
 // NewHeartbeat constructs a Heartbeat. Non-positive interval falls back to
 // DefaultHeartbeatInterval. baseTags are tags known at construction time
 // (typically derived from env vars, e.g., microvm_image_arn); the
-// microvm_id tag is appended at emit time and is set at runtime via
+// lambda_microvm_id tag is appended at emit time and is set at runtime via
 // SetMicroVMID from the /run request.
 func NewHeartbeat(interval time.Duration, emitter MetricEmitter, source metrics.MetricSource, baseTags []string) *Heartbeat {
 	if interval <= 0 {
@@ -220,13 +220,13 @@ func (h *Heartbeat) emit() {
 }
 
 // tagsForEmit returns a fresh tag slice combining the immutable base tags
-// (set at construction) with the current microvm_id (set at /run).
+// (set at construction) with the current lambda_microvm_id (set at /run).
 func (h *Heartbeat) tagsForEmit() []string {
 	h.mu.Lock()
 	id := h.microVMID
 	h.mu.Unlock()
 	tags := make([]string, 0, len(h.baseTags)+1)
 	tags = append(tags, h.baseTags...)
-	tags = append(tags, "microvm_id:"+id)
+	tags = append(tags, lambdaMicroVMID+id)
 	return tags
 }

--- a/cmd/serverless-init/lifecycle/heartbeat_test.go
+++ b/cmd/serverless-init/lifecycle/heartbeat_test.go
@@ -275,15 +275,15 @@ func TestHeartbeat_ResumeDuringStuckStopRestartsHeartbeat(t *testing.T) {
 	hb.Stop() // clean up the relaunched goroutine
 }
 
-// Until SetMicroVMID is called, the heartbeat tags microvm_id with the
-// placeholder "unknown". Production wiring sets the ID at /run before
+// Until SetMicroVMID is called, the heartbeat tags lambda_microvm_id with
+// the placeholder "unknown". Production wiring sets the ID at /run before
 // Start, so this state should never reach an emitted metric in practice;
 // the test pins the contract anyway in case wiring changes.
 func TestHeartbeat_TagsForEmit_DefaultsMicroVMIDToUnknown(t *testing.T) {
 	hb := NewHeartbeat(time.Hour, &mockMetricEmitter{}, metrics.MetricSourceAWSMicroVMEnhanced, []string{"microvm_image_arn:test-arn"})
 	tags := hb.tagsForEmit()
 	assert.Contains(t, tags, "microvm_image_arn:test-arn")
-	assert.Contains(t, tags, "microvm_id:unknown")
+	assert.Contains(t, tags, "lambda_microvm_id:unknown")
 }
 
 // When resourceName is empty the microvm_image_arn tag must be absent — an
@@ -301,7 +301,7 @@ func TestHeartbeat_SetMicroVMID_ReflectsOnEmittedTags(t *testing.T) {
 	hb.SetMicroVMID("mvm-abc123")
 	tags := hb.tagsForEmit()
 	assert.Contains(t, tags, "microvm_image_arn:test-arn")
-	assert.Contains(t, tags, "microvm_id:mvm-abc123")
+	assert.Contains(t, tags, "lambda_microvm_id:mvm-abc123")
 }
 
 // TestHeartbeat_EmittedMetric_CarriesARNTag verifies end-to-end that the
@@ -340,7 +340,7 @@ func TestHeartbeat_SetMicroVMID_EmptyIsIgnored(t *testing.T) {
 	hb.SetMicroVMID("first-id")
 	hb.SetMicroVMID("")
 	tags := hb.tagsForEmit()
-	assert.Contains(t, tags, "microvm_id:first-id", "empty ID must not clobber the existing value")
+	assert.Contains(t, tags, "lambda_microvm_id:first-id", "empty ID must not clobber the existing value")
 }
 
 func TestHeartbeat_SetMicroVMID_OnNilReceiverIsSafe(t *testing.T) {
@@ -371,7 +371,7 @@ func TestHeartbeat_SetMicroVMID_VisibleOnNextTick(t *testing.T) {
 	// The most recent emission must carry the updated ID.
 	last := emitter.lastTags()
 	require.NotNil(t, last)
-	assert.Contains(t, last, "microvm_id:mvm-after-start")
+	assert.Contains(t, last, "lambda_microvm_id:mvm-after-start")
 }
 
 // TestHeartbeat_EmittedMetricsCarryCurrentTimestamp verifies that heartbeat

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -120,6 +120,15 @@ type Flusher interface {
 	Flush()
 }
 
+// ForceFlusher is optionally satisfied by metricFlusher (ServerlessMetricAgent
+// does; the trace flusher doesn't). flushAll calls it only for /terminate,
+// never /suspend: /suspend can resume, and forcing the open bucket there would
+// let a later flush send a second, partial point for that bucket — overwriting
+// the pre-suspend data in the backend instead of merging with it.
+type ForceFlusher interface {
+	FlushAll()
+}
+
 // LogsFlusher is satisfied by logsAgent.ServerlessLogsAgent.
 type LogsFlusher interface {
 	Flush(ctx context.Context)
@@ -446,7 +455,8 @@ func mirrorResponse(w http.ResponseWriter, resp *http.Response) {
 // and by handleSuspend / handleTerminate for the env-var-unset path.
 // It first drains any pending metric samples so that lifecycle metrics
 // emitted immediately before this call are included in the flush.
-func (s *Server) flushAll(flushCtx context.Context) {
+// forceFlushAll is true only for /terminate (see ForceFlusher).
+func (s *Server) flushAll(flushCtx context.Context, forceFlushAll bool) {
 	if s.sampleDrainer != nil {
 		drained := make(chan struct{})
 		go func() {
@@ -464,7 +474,13 @@ func (s *Server) flushAll(flushCtx context.Context) {
 		wg.Add(1)
 		go func() { defer wg.Done(); flush() }()
 	}
-	runFlush(s.metricFlusher.Flush)
+	runFlush(func() {
+		if ff, ok := s.metricFlusher.(ForceFlusher); ok && forceFlushAll {
+			ff.FlushAll()
+		} else {
+			s.metricFlusher.Flush()
+		}
+	})
 	runFlush(s.traceFlusher.Flush)
 	runFlush(func() {
 		if s.logsFlusher != nil {
@@ -511,7 +527,7 @@ func (s *Server) handleWithForwarder(metricName, path string, mode flushMode, w 
 		defer close(sideDone)
 		s.emitLifecycleMetric(metricName)
 		if mode == flushParallel {
-			s.flushAll(parallelCtx)
+			s.flushAll(parallelCtx, false)
 		}
 	}()
 
@@ -539,7 +555,7 @@ func (s *Server) handleWithForwarder(metricName, path string, mode flushMode, w 
 	if mode == flushSequential {
 		seqCtx, cancel := context.WithTimeout(context.Background(), s.flushTimeout)
 		defer cancel()
-		s.flushAll(seqCtx)
+		s.flushAll(seqCtx, true)
 	}
 
 	mirrorResponse(w, resp)
@@ -702,7 +718,7 @@ func (s *Server) dispatchHook(metricName, path string, mode flushMode, enabled b
 	if mode != noFlush {
 		flushCtx, cancel := context.WithTimeout(context.Background(), s.flushTimeout)
 		defer cancel()
-		s.flushAll(flushCtx)
+		s.flushAll(flushCtx, mode == flushSequential)
 	}
 	w.WriteHeader(http.StatusOK)
 }

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -570,7 +570,7 @@ func (s *Server) aliveCheckReady(w http.ResponseWriter) {
 // (when a forwarder is configured) mirrors the user app's response.
 // handleRun is the only hook that reads r.Body and is therefore not
 // collapsed into dispatchHook directly. The ID is captured before Start
-// so the first heartbeat emission already carries the correct microvm_id tag.
+// so the first heartbeat emission already carries the correct lambda_microvm_id tag.
 func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {
 	// Read the body once so we can parse the instance ID AND still forward the
 	// original payload to the user app. Without this, the forwarder path would

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -120,6 +120,15 @@ type Flusher interface {
 	Flush()
 }
 
+// ForceFlusher is optionally satisfied by metricFlusher (ServerlessMetricAgent
+// does; the trace flusher doesn't). flushAll calls it only for /terminate,
+// never /suspend: /suspend can resume, and forcing the open bucket there would
+// let a later flush send a second, partial point for that bucket — overwriting
+// the pre-suspend data in the backend instead of merging with it.
+type ForceFlusher interface {
+	FlushAll()
+}
+
 // LogsFlusher is satisfied by logsAgent.ServerlessLogsAgent.
 type LogsFlusher interface {
 	Flush(ctx context.Context)
@@ -478,7 +487,8 @@ func mirrorResponse(w http.ResponseWriter, resp *http.Response) {
 // and by handleSuspend / handleTerminate for the env-var-unset path.
 // It first drains any pending metric samples so that lifecycle metrics
 // emitted immediately before this call are included in the flush.
-func (s *Server) flushAll(flushCtx context.Context) {
+// forceFlushAll is true only for /terminate (see ForceFlusher).
+func (s *Server) flushAll(flushCtx context.Context, forceFlushAll bool) {
 	if s.sampleDrainer != nil {
 		drained := make(chan struct{})
 		go func() {
@@ -492,7 +502,13 @@ func (s *Server) flushAll(flushCtx context.Context) {
 		}
 	}
 	var wg sync.WaitGroup
-	wg.Go(s.metricFlusher.Flush)
+	wg.Go(func() {
+		if ff, ok := s.metricFlusher.(ForceFlusher); ok && forceFlushAll {
+			ff.FlushAll()
+		} else {
+			s.metricFlusher.Flush()
+		}
+	})
 	wg.Go(s.traceFlusher.Flush)
 	wg.Go(func() {
 		if s.logsFlusher != nil {
@@ -558,7 +574,7 @@ func (s *Server) handleWithForwarder(metricName, path string, mode flushMode, w 
 		defer close(sideDone)
 		s.emitLifecycleMetric(metricName)
 		if mode == flushParallel {
-			s.flushAll(parallelCtx)
+			s.flushAll(parallelCtx, false)
 		}
 	}()
 
@@ -586,7 +602,7 @@ func (s *Server) handleWithForwarder(metricName, path string, mode flushMode, w 
 	if mode == flushSequential {
 		seqCtx, cancel := context.WithTimeout(context.Background(), s.flushTimeout)
 		defer cancel()
-		s.flushAll(seqCtx)
+		s.flushAll(seqCtx, true)
 	}
 
 	mirrorResponse(w, resp)
@@ -749,7 +765,7 @@ func (s *Server) dispatchHook(metricName, path string, mode flushMode, forwardEn
 	if mode != noFlush {
 		flushCtx, cancel := context.WithTimeout(context.Background(), s.flushTimeout)
 		defer cancel()
-		s.flushAll(flushCtx)
+		s.flushAll(flushCtx, mode == flushSequential)
 	}
 	w.WriteHeader(http.StatusOK)
 }

--- a/cmd/serverless-init/lifecycle/server.go
+++ b/cmd/serverless-init/lifecycle/server.go
@@ -617,7 +617,7 @@ func (s *Server) aliveCheckReady(w http.ResponseWriter) {
 // (when a forwarder is configured) mirrors the user app's response.
 // handleRun is the only hook that reads r.Body and is therefore not
 // collapsed into dispatchHook directly. The ID is captured before Start
-// so the first heartbeat emission already carries the correct microvm_id tag.
+// so the first heartbeat emission already carries the correct lambda_microvm_id tag.
 func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {
 	// Read the body once so we can parse the instance ID AND still forward the
 	// original payload to the user app. Without this, the forwarder path would

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -46,6 +46,16 @@ func (m *mockFlusher) Flush() {
 	}
 }
 
+// mockForceFlusher tracks Flush and FlushAll calls separately; it satisfies
+// both Flusher and ForceFlusher.
+type mockForceFlusher struct {
+	flushCount    atomic.Int32
+	flushAllCount atomic.Int32
+}
+
+func (m *mockForceFlusher) Flush()    { m.flushCount.Add(1) }
+func (m *mockForceFlusher) FlushAll() { m.flushAllCount.Add(1) }
+
 // mockLogsAgent counts how many times Flush was called and records when each
 // call returned. onFlush, if set, is invoked after each Flush.
 type mockLogsAgent struct {
@@ -319,6 +329,30 @@ func TestHandleTerminate_NoForwarder_FlushesAndEmitsMetric_NoSigterm(t *testing.
 	case <-time.After(100 * time.Millisecond):
 		// Pass — no synthetic signal observed.
 	}
+}
+
+// TestHandleSuspend_UsesFlushNotFlushAll pins that /suspend calls Flush, not
+// FlushAll (see ForceFlusher for why).
+func TestHandleSuspend_UsesFlushNotFlushAll(t *testing.T) {
+	metric := &mockForceFlusher{}
+	srv := NewServer(0, metric, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, HookToggles{}, nil)
+
+	srv.handleSuspend(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathSuspend, nil))
+
+	assert.Equal(t, int32(1), metric.flushCount.Load(), "/suspend must call Flush")
+	assert.Equal(t, int32(0), metric.flushAllCount.Load(), "/suspend must not call FlushAll")
+}
+
+// TestHandleTerminate_UsesFlushAllNotFlush pins that /terminate calls
+// FlushAll, not Flush (see ForceFlusher for why).
+func TestHandleTerminate_UsesFlushAllNotFlush(t *testing.T) {
+	metric := &mockForceFlusher{}
+	srv := NewServer(0, metric, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, HookToggles{}, nil)
+
+	srv.handleTerminate(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathTerminate, nil))
+
+	assert.Equal(t, int32(1), metric.flushAllCount.Load(), "/terminate must call FlushAll")
+	assert.Equal(t, int32(0), metric.flushCount.Load(), "/terminate must not call Flush")
 }
 
 // TestEmittedMetricsCarryCurrentTimestamp verifies the lifecycle handlers pass
@@ -1379,7 +1413,7 @@ func TestFlushAllDrainTimeoutDoesNotBlock(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), srv.flushTimeout)
 	defer cancel()
 	start := time.Now()
-	srv.flushAll(ctx)
+	srv.flushAll(ctx, false)
 	assert.Less(t, time.Since(start), 500*time.Millisecond, "flushAll must return within flushTimeout even when drainer blocks")
 }
 
@@ -1403,7 +1437,7 @@ func TestFlushAllNilLogsFlusherDoesNotPanic(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), srv.flushTimeout)
 	defer cancel()
 	start := time.Now()
-	assert.NotPanics(t, func() { srv.flushAll(ctx) })
+	assert.NotPanics(t, func() { srv.flushAll(ctx, false) })
 	assert.Less(t, time.Since(start), 500*time.Millisecond, "flushAll must not fall back to the flushTimeout path when logsFlusher is nil")
 	assert.Equal(t, int32(1), metric.count.Load())
 	assert.Equal(t, int32(1), trace.count.Load())

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -1442,7 +1442,7 @@ func TestHandleRun_StartsHeartbeat(t *testing.T) {
 
 // /run must extract the MicroVM ID from the JSON body and apply it to the
 // heartbeat before Start so the very first emission carries the correct
-// microvm_id. The test calls handleRun then inspects the tags that the
+// lambda_microvm_id. The test calls handleRun then inspects the tags that the
 // heartbeat would emit on its next tick.
 func TestHandleRun_AppliesMicroVMIDFromBody(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
@@ -1452,7 +1452,7 @@ func TestHandleRun_AppliesMicroVMIDFromBody(t *testing.T) {
 	body := strings.NewReader(`{"microvmId":"vm-from-body"}`)
 	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
 
-	assert.Contains(t, srv.heartbeat.tagsForEmit(), "microvm_id:vm-from-body")
+	assert.Contains(t, srv.heartbeat.tagsForEmit(), "lambda_microvm_id:vm-from-body")
 	id := srv.instanceID.Load()
 	assert.Equal(t, "vm-from-body", id)
 }
@@ -1466,7 +1466,7 @@ func TestHandleRun_MissingBodyIDUsesUnknown(t *testing.T) {
 
 	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, nil))
 
-	assert.Contains(t, srv.heartbeat.tagsForEmit(), "microvm_id:unknown")
+	assert.Contains(t, srv.heartbeat.tagsForEmit(), "lambda_microvm_id:unknown")
 }
 
 // traced_invocations is emitted by the Heartbeat on each tick, not directly by

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -46,6 +46,16 @@ func (m *mockFlusher) Flush() {
 	}
 }
 
+// mockForceFlusher tracks Flush and FlushAll calls separately; it satisfies
+// both Flusher and ForceFlusher.
+type mockForceFlusher struct {
+	flushCount    atomic.Int32
+	flushAllCount atomic.Int32
+}
+
+func (m *mockForceFlusher) Flush()    { m.flushCount.Add(1) }
+func (m *mockForceFlusher) FlushAll() { m.flushAllCount.Add(1) }
+
 // mockLogsAgent counts how many times Flush was called and records when each
 // call returned. onFlush, if set, is invoked after each Flush.
 type mockLogsAgent struct {
@@ -319,6 +329,30 @@ func TestHandleTerminate_NoForwarder_FlushesAndEmitsMetric_NoSigterm(t *testing.
 	case <-time.After(100 * time.Millisecond):
 		// Pass — no synthetic signal observed.
 	}
+}
+
+// TestHandleSuspend_UsesFlushNotFlushAll pins that /suspend calls Flush, not
+// FlushAll (see ForceFlusher for why).
+func TestHandleSuspend_UsesFlushNotFlushAll(t *testing.T) {
+	metric := &mockForceFlusher{}
+	srv := NewServer(0, metric, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, HookToggles{}, nil)
+
+	srv.handleSuspend(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathSuspend, nil))
+
+	assert.Equal(t, int32(1), metric.flushCount.Load(), "/suspend must call Flush")
+	assert.Equal(t, int32(0), metric.flushAllCount.Load(), "/suspend must not call FlushAll")
+}
+
+// TestHandleTerminate_UsesFlushAllNotFlush pins that /terminate calls
+// FlushAll, not Flush (see ForceFlusher for why).
+func TestHandleTerminate_UsesFlushAllNotFlush(t *testing.T) {
+	metric := &mockForceFlusher{}
+	srv := NewServer(0, metric, &mockFlusher{}, &mockLogsAgent{}, &mockMetricEmitter{}, &mockSampleDrainer{}, metrics.MetricSourceAWSMicroVMEnhanced, 2*time.Second, nil, nil, HookToggles{}, nil)
+
+	srv.handleTerminate(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathTerminate, nil))
+
+	assert.Equal(t, int32(1), metric.flushAllCount.Load(), "/terminate must call FlushAll")
+	assert.Equal(t, int32(0), metric.flushCount.Load(), "/terminate must not call Flush")
 }
 
 // TestEmittedMetricsCarryCurrentTimestamp verifies the lifecycle handlers pass
@@ -1462,7 +1496,7 @@ func TestFlushAllDrainTimeoutDoesNotBlock(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), srv.flushTimeout)
 	defer cancel()
 	start := time.Now()
-	srv.flushAll(ctx)
+	srv.flushAll(ctx, false)
 	assert.Less(t, time.Since(start), 500*time.Millisecond, "flushAll must return within flushTimeout even when drainer blocks")
 }
 
@@ -1486,7 +1520,7 @@ func TestFlushAllNilLogsFlusherDoesNotPanic(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), srv.flushTimeout)
 	defer cancel()
 	start := time.Now()
-	assert.NotPanics(t, func() { srv.flushAll(ctx) })
+	assert.NotPanics(t, func() { srv.flushAll(ctx, false) })
 	assert.Less(t, time.Since(start), 500*time.Millisecond, "flushAll must not fall back to the flushTimeout path when logsFlusher is nil")
 	assert.Equal(t, int32(1), metric.count.Load())
 	assert.Equal(t, int32(1), trace.count.Load())

--- a/cmd/serverless-init/lifecycle/server_test.go
+++ b/cmd/serverless-init/lifecycle/server_test.go
@@ -1525,7 +1525,7 @@ func TestHandleRun_StartsHeartbeat(t *testing.T) {
 
 // /run must extract the MicroVM ID from the JSON body and apply it to the
 // heartbeat before Start so the very first emission carries the correct
-// microvm_id. The test calls handleRun then inspects the tags that the
+// lambda_microvm_id. The test calls handleRun then inspects the tags that the
 // heartbeat would emit on its next tick.
 func TestHandleRun_AppliesMicroVMIDFromBody(t *testing.T) {
 	srv, _, _, _, _, _ := newTestServer()
@@ -1535,7 +1535,7 @@ func TestHandleRun_AppliesMicroVMIDFromBody(t *testing.T) {
 	body := strings.NewReader(`{"microvmId":"vm-from-body"}`)
 	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, body))
 
-	assert.Contains(t, srv.heartbeat.tagsForEmit(), "microvm_id:vm-from-body")
+	assert.Contains(t, srv.heartbeat.tagsForEmit(), "lambda_microvm_id:vm-from-body")
 	id := srv.instanceID.Load()
 	assert.Equal(t, "vm-from-body", id)
 }
@@ -1549,7 +1549,7 @@ func TestHandleRun_MissingBodyIDUsesUnknown(t *testing.T) {
 
 	srv.handleRun(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, pathRun, nil))
 
-	assert.Contains(t, srv.heartbeat.tagsForEmit(), "microvm_id:unknown")
+	assert.Contains(t, srv.heartbeat.tagsForEmit(), "lambda_microvm_id:unknown")
 }
 
 // traced_invocations is emitted by the Heartbeat on each tick, not directly by

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -496,6 +496,7 @@ func setup(
 				MetricFlusher: metricAgent,
 				LogsFlusher:   logsAgent,
 				MetricEmitter: metricAgent,
+				SampleDrainer: metricAgent,
 				FlushTimeout:  agentLogConfig.FlushTimeout,
 				SidecarMode:   modeConf.SidecarMode,
 				LogsTagSetter: lifecycle.LogsTagSetterFunc(func(tags []string) {
@@ -532,6 +533,7 @@ func setup(
 			MetricFlusher: metricAgent,
 			LogsFlusher:   logsAgent,
 			MetricEmitter: metricAgent,
+			SampleDrainer: metricAgent,
 			FlushTimeout:  agentLogConfig.FlushTimeout,
 			SidecarMode:   modeConf.SidecarMode,
 			LogsTagSetter: lifecycle.LogsTagSetterFunc(func(tags []string) {

--- a/pkg/aggregator/BUILD.bazel
+++ b/pkg/aggregator/BUILD.bazel
@@ -109,6 +109,7 @@ dd_agent_go_test(
         "tagfilter_cache_test.go",
         "tagset_telem_test.go",
         "time_sampler_test.go",
+        "time_sampler_worker_test.go",
     ],
     embed = [":aggregator"],
     gotags_sets = [[

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -384,7 +384,7 @@ func TestSeriesTooManyTags(t *testing.T) {
 			s.On("SendServiceChecks", mock.Anything).Return(nil)
 			s.On("SendIterableSeries", mock.Anything).Return(nil)
 
-			demux.ForceFlushToSerializer(start, true)
+			demux.ForceFlushToSerializer(start, true, false)
 			s.AssertNotCalled(t, "SendEvents")
 			s.AssertNotCalled(t, "SendSketch")
 
@@ -453,7 +453,7 @@ func TestDistributionsTooManyTags(t *testing.T) {
 			s.On("SendIterableSeries", mock.Anything).Return(nil).Times(1)
 			s.On("SendSketch", mock.Anything).Return(nil).Times(1)
 
-			demux.ForceFlushToSerializer(start, true)
+			demux.ForceFlushToSerializer(start, true, false)
 			s.AssertNotCalled(t, "SendEvents")
 
 			expMap := map[string]uint64{}
@@ -540,7 +540,7 @@ func TestRecurrentSeries(t *testing.T) {
 	})
 
 	s.On("SendServiceChecks", agentUpMatcher).Return(nil).Times(1)
-	demux.ForceFlushToSerializer(start, true)
+	demux.ForceFlushToSerializer(start, true, false)
 	require.EqualValues(t, expectedSeries, s.series)
 	s.series = nil
 
@@ -550,7 +550,7 @@ func TestRecurrentSeries(t *testing.T) {
 	// Assert that recurrentSeries are sent on each flushed
 	// same goes for the service check
 	s.On("SendServiceChecks", agentUpMatcher).Return(nil).Times(1)
-	demux.ForceFlushToSerializer(start, true)
+	demux.ForceFlushToSerializer(start, true, false)
 	require.EqualValues(t, expectedSeries, s.series)
 	s.series = nil
 
@@ -759,7 +759,7 @@ func flushSomeSamples(demux *AgentDemultiplexer) map[string]*metrics.Serie {
 	// sure all samples have been processed by the sampler
 	time.Sleep(1 * time.Second)
 
-	demux.ForceFlushToSerializer(time.Unix(int64(timeSamplerBucketSize)*3, 0), true)
+	demux.ForceFlushToSerializer(time.Unix(int64(timeSamplerBucketSize)*3, 0), true, false)
 	return expectedSeries
 }
 

--- a/pkg/aggregator/demultiplexer.go
+++ b/pkg/aggregator/demultiplexer.go
@@ -46,8 +46,9 @@ type Demultiplexer interface {
 	SendSamplesWithoutAggregation(metrics metrics.MetricSampleBatch)
 
 	// ForceFlushToSerializer flushes all the aggregated data from the different samplers to
-	// the serialization/forwarding parts.
-	ForceFlushToSerializer(start time.Time, waitForSerializer bool)
+	// the serialization/forwarding parts. forceFlushAll additionally includes samples in
+	// the current, not-yet-closed time bucket (otherwise they wait for the next flush).
+	ForceFlushToSerializer(start time.Time, waitForSerializer bool, forceFlushAll bool)
 	// GetMetricSamplePool returns a shared resource used in the whole DogStatsD
 	// pipeline to re-use metric samples slices: the server is getting a slice
 	// and filling it with samples, the rest of the pipeline process them the

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -516,12 +516,12 @@ func (d *AgentDemultiplexer) Stop() {
 // ForceFlushToSerializer triggers the execution of a flush from all data of samplers
 // and the BufferedAggregator to the serializer.
 // Safe to call from multiple threads.
-func (d *AgentDemultiplexer) ForceFlushToSerializer(start time.Time, waitForSerializer bool) {
+func (d *AgentDemultiplexer) ForceFlushToSerializer(start time.Time, waitForSerializer bool, forceFlushAll bool) {
 	trigger := trigger{
 		time:              start,
 		waitForSerializer: waitForSerializer,
 		blockChan:         make(chan struct{}),
-		forceFlushAll:     false,
+		forceFlushAll:     forceFlushAll,
 	}
 	d.flushChan <- trigger
 	<-trigger.blockChan

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -519,12 +519,12 @@ func (d *AgentDemultiplexer) Stop() {
 // ForceFlushToSerializer triggers the execution of a flush from all data of samplers
 // and the BufferedAggregator to the serializer.
 // Safe to call from multiple threads.
-func (d *AgentDemultiplexer) ForceFlushToSerializer(start time.Time, waitForSerializer bool) {
+func (d *AgentDemultiplexer) ForceFlushToSerializer(start time.Time, waitForSerializer bool, forceFlushAll bool) {
 	trigger := trigger{
 		time:              start,
 		waitForSerializer: waitForSerializer,
 		blockChan:         make(chan struct{}),
-		forceFlushAll:     false,
+		forceFlushAll:     forceFlushAll,
 	}
 	d.flushChan <- trigger
 	<-trigger.blockChan

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -690,11 +690,23 @@ func (d *AgentDemultiplexer) AggregateSamples(shard TimeSamplerID, samples metri
 	d.statsd.workers[shard].addSamples(samples)
 }
 
+// singleSampleShard is the time sampler shard used by AggregateSample.
+// WaitForPendingSamples drains this same shard, so the two must stay in sync.
+const singleSampleShard TimeSamplerID = 0
+
 // AggregateSample adds a MetricSample in the first DogStatsD time sampler.
 func (d *AgentDemultiplexer) AggregateSample(sample metrics.MetricSample) {
 	batch := d.GetMetricSamplePool().GetBatch()
 	batch[0] = sample
-	d.statsd.workers[0].addSamples(batch[:1])
+	d.statsd.workers[singleSampleShard].addSamples(batch[:1])
+}
+
+// WaitForPendingSamples blocks until samples enqueued on singleSampleShard
+// before this call have been consumed. Used by serverless-init's on-demand
+// flush, where a sample submitted right before a flush could otherwise race
+// it.
+func (d *AgentDemultiplexer) WaitForPendingSamples() {
+	d.statsd.workers[singleSampleShard].waitForPendingSamples()
 }
 
 // AggregateCheckSample adds check sample sent by a check from one of the collectors into a check sampler pipeline.

--- a/pkg/aggregator/demultiplexer_agent_test.go
+++ b/pkg/aggregator/demultiplexer_agent_test.go
@@ -435,7 +435,7 @@ func TestUpdateTagFilterList(t *testing.T) {
 		require.Eventually(func() bool {
 			return len(demux.statsd.workers[0].samplesChan) == 0
 		}, time.Second, time.Millisecond)
-		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true)
+		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true, false)
 
 		metric := slices.IndexFunc(s.sketches, func(serie metrics.Distribution) bool {
 			return serie.GetName() == "dist.metric"
@@ -563,7 +563,7 @@ func TestUpdateTagFilterListCheckSamplerCacheInvalidation(t *testing.T) {
 		require.Eventually(func() bool {
 			return len(demux.aggregator.checkItems) == 0
 		}, time.Second, time.Millisecond)
-		demux.ForceFlushToSerializer(time.Now(), true)
+		demux.ForceFlushToSerializer(time.Now(), true, false)
 	}
 
 	// First send: tag1 and tag2 are excluded. This is a cache miss so the
@@ -644,7 +644,7 @@ func TestUpdateMetricFilterList(t *testing.T) {
 		require.Eventually(func() bool {
 			return len(demux.statsd.workers[0].samplesChan) == 0
 		}, time.Second, time.Millisecond)
-		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true)
+		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true, false)
 
 		// We should always contain the average of the histogram.
 		require.Equal(blockCount, slices.ContainsFunc(s.series, func(serie *metrics.Serie) bool {

--- a/pkg/aggregator/demultiplexer_agent_test.go
+++ b/pkg/aggregator/demultiplexer_agent_test.go
@@ -433,7 +433,7 @@ func TestUpdateTagFilterList(t *testing.T) {
 		require.Eventually(func() bool {
 			return len(demux.statsd.workers[0].samplesChan) == 0
 		}, time.Second, time.Millisecond)
-		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true)
+		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true, false)
 
 		metric := slices.IndexFunc(s.sketches, func(serie metrics.Distribution) bool {
 			return serie.GetName() == "dist.metric"
@@ -561,7 +561,7 @@ func TestUpdateTagFilterListCheckSamplerCacheInvalidation(t *testing.T) {
 		require.Eventually(func() bool {
 			return len(demux.aggregator.checkItems) == 0
 		}, time.Second, time.Millisecond)
-		demux.ForceFlushToSerializer(time.Now(), true)
+		demux.ForceFlushToSerializer(time.Now(), true, false)
 	}
 
 	// First send: tag1 and tag2 are excluded. This is a cache miss so the
@@ -642,7 +642,7 @@ func TestUpdateMetricFilterList(t *testing.T) {
 		require.Eventually(func() bool {
 			return len(demux.statsd.workers[0].samplesChan) == 0
 		}, time.Second, time.Millisecond)
-		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true)
+		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true, false)
 
 		// We should always contain the average of the histogram.
 		require.Equal(blockCount, slices.ContainsFunc(s.series, func(serie *metrics.Serie) bool {

--- a/pkg/aggregator/time_sampler_worker.go
+++ b/pkg/aggregator/time_sampler_worker.go
@@ -49,6 +49,10 @@ type timeSamplerWorker struct {
 	samplesChan chan []metrics.MetricSample
 	// samplesDrained is closed after last sample is read from samplesChan
 	samplesDrained chan struct{}
+	// drainChan requests a synchronous drain of samplesChan. Unlike
+	// shutdown/samplesDrained, it's repeatable and doesn't touch the worker's
+	// lifecycle.
+	drainChan chan chan struct{}
 	// use this chan to trigger a flush of the time sampler
 	flushChan chan flushTrigger
 	// use this chan to trigger a filterList reconfiguration
@@ -83,6 +87,7 @@ func newTimeSamplerWorker(sampler *TimeSampler, flushInterval time.Duration, buf
 
 		samplesChan:          make(chan []metrics.MetricSample, bufferSize),
 		samplesDrained:       make(chan struct{}),
+		drainChan:            make(chan chan struct{}),
 		stopChan:             make(chan struct{}),
 		flushChan:            make(chan flushTrigger),
 		dumpChan:             make(chan dumpTrigger),
@@ -112,15 +117,7 @@ func (w *timeSamplerWorker) run() {
 				close(w.samplesDrained)
 				continue
 			}
-
-			aggregatorDogstatsdMetricSample.Add(int64(len(ms)))
-			tlmProcessed.Add(float64(len(ms)), shard, "dogstatsd_metrics")
-			t := timeNowNano()
-
-			for i := 0; i < len(ms); i++ {
-				w.sampler.sample(&ms[i], t, w.tagFilterList)
-			}
-			w.metricSamplePool.PutBatch(ms)
+			w.processBatch(ms)
 		case matcher := <-w.metricFilterListChan:
 			w.flushFilterList = matcher
 		case matcher := <-w.tagFilterListChan:
@@ -130,8 +127,38 @@ func (w *timeSamplerWorker) run() {
 			w.tagsStore.Shrink()
 		case trigger := <-w.dumpChan:
 			trigger.done <- w.sampler.dumpContexts(trigger.dest)
+		case done := <-w.drainChan:
+			// select doesn't order drainChan against samplesChan, so drain
+			// whatever's already buffered before acking.
+		drainLoop:
+			for {
+				select {
+				case ms := <-w.samplesChan:
+					if ms == nil {
+						close(w.samplesDrained)
+						continue
+					}
+					w.processBatch(ms)
+				default:
+					break drainLoop
+				}
+			}
+			close(done)
 		}
 	}
+}
+
+// processBatch samples ms, called from run()'s normal loop or from a drain.
+func (w *timeSamplerWorker) processBatch(ms []metrics.MetricSample) {
+	shard := w.sampler.idString
+	aggregatorDogstatsdMetricSample.Add(int64(len(ms)))
+	tlmProcessed.Add(float64(len(ms)), shard, "dogstatsd_metrics")
+	t := timeNowNano()
+
+	for i := 0; i < len(ms); i++ {
+		w.sampler.sample(&ms[i], t, w.tagFilterList)
+	}
+	w.metricSamplePool.PutBatch(ms)
 }
 
 // Set a new filterlist, ensuring we also clear the context resolver strip cache
@@ -177,4 +204,12 @@ func (w *timeSamplerWorker) waitForShutdown(ctx context.Context) {
 	case <-w.samplesDrained:
 	case <-ctx.Done():
 	}
+}
+
+// waitForPendingSamples blocks until samples enqueued before this call have
+// been processed. Safe to call repeatedly, unlike shutdown/waitForShutdown.
+func (w *timeSamplerWorker) waitForPendingSamples() {
+	done := make(chan struct{})
+	w.drainChan <- done
+	<-done
 }

--- a/pkg/aggregator/time_sampler_worker_test.go
+++ b/pkg/aggregator/time_sampler_worker_test.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package aggregator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+// A sample sent right before WaitForPendingSamples must be processed by the
+// time the call returns, and the call must be repeatable.
+func TestWaitForPendingSamplesDrainsBeforeReturning(t *testing.T) {
+	require := require.New(t)
+
+	deps := createDemultiplexerAgentTestDeps(t)
+	opts := demuxTestOptions()
+	// InitAndStartAgentDemultiplexer (not initAgentDemultiplexer) is required
+	// here: WaitForPendingSamples needs the worker's run() goroutine actually
+	// running to service drainChan.
+	demux := InitAndStartAgentDemultiplexer(deps.Log, NewForwarderTest(deps.Log), deps.OrchestratorFwd, opts, deps.EventPlatform, deps.HaAgent, deps.Compressor, deps.Tagger, deps.FilterList, "")
+	defer demux.Stop()
+
+	worker := demux.statsd.workers[0]
+	require.Equal(0, worker.sampler.contextResolver.length())
+
+	demux.AggregateSample(metrics.MetricSample{
+		Name:      "test.metric",
+		Value:     1,
+		Mtype:     metrics.GaugeType,
+		Timestamp: 1657099120.0,
+		Tags:      []string{"tag:1"},
+	})
+
+	demux.WaitForPendingSamples()
+
+	require.Len(worker.samplesChan, 0, "the sample must have been drained from samplesChan")
+	require.Equal(1, worker.sampler.contextResolver.length(), "the sample must have been aggregated into a context, not just dequeued")
+
+	// Calling it again with nothing pending must not block or panic.
+	demux.WaitForPendingSamples()
+}

--- a/pkg/clusteragent/admission/validate/kubernetesadmissionevents/kubernetesadmissionevents_test.go
+++ b/pkg/clusteragent/admission/validate/kubernetesadmissionevents/kubernetesadmissionevents_test.go
@@ -262,7 +262,7 @@ func TestKubernetesAdmissionEvents(t *testing.T) {
 			mockSender.On("Event", mock.AnythingOfType("event.Event")).Return().Once()
 			validated, err := kubernetesAuditWebhook.emitEvent(&tt.request, "", nil)
 			// Force flush to serializer to ensure the event is emitted and received.
-			demultiplexerMock.ForceFlushToSerializer(start, true)
+			demultiplexerMock.ForceFlushToSerializer(start, true, false)
 			assert.NoError(t, err)
 			assert.True(t, validated)
 			if tt.expectedEmitted {

--- a/pkg/serverless/metrics/BUILD.bazel
+++ b/pkg/serverless/metrics/BUILD.bazel
@@ -17,6 +17,7 @@ dd_agent_go_test(
     name = "metrics_test",
     srcs = [
         "metric_add_test.go",
+        "metric_drain_test.go",
         "metric_test.go",
     ],
     embed = [":metrics"],
@@ -30,6 +31,7 @@ dd_agent_go_test(
         "//comp/core/log/mock",
         "//comp/core/secrets/def",
         "//comp/core/secrets/mock",
+        "//comp/core/tagger/fx-mock",
         "//comp/core/tagger/impl-noop",
         "//comp/filterlist/fx-mock",
         "//comp/forwarder/defaultforwarder/def",

--- a/pkg/serverless/metrics/metric.go
+++ b/pkg/serverless/metrics/metric.go
@@ -77,6 +77,24 @@ func (c *ServerlessMetricAgent) FlushAll() {
 	c.Demux.ForceFlushToSerializer(time.Now(), true, true)
 }
 
+// pendingSampleDrainer is satisfied by *aggregator.AgentDemultiplexer, and by
+// anything embedding it — notably the Fx demultiplexer component's wrapper
+// struct, which is what c.Demux actually holds in production. Asserting
+// against this interface instead of the concrete *AgentDemultiplexer type
+// lets Go's method promotion see through that wrapper.
+type pendingSampleDrainer interface {
+	WaitForPendingSamples()
+}
+
+// WaitForPendingSamples blocks until samples enqueued before this call have
+// been consumed. Satisfied interface: cmd/serverless-init/lifecycle.SampleDrainer.
+// No-op if the demux doesn't support draining (e.g. unset in tests).
+func (c *ServerlessMetricAgent) WaitForPendingSamples() {
+	if d, ok := c.Demux.(pendingSampleDrainer); ok {
+		d.WaitForPendingSamples()
+	}
+}
+
 // sendMetricSample records a distribution metric sample using the agent's extra tags plus any
 // optional tags supplied as `key:value` strings through extraTags.
 func (c *ServerlessMetricAgent) sendMetricSample(name string, value float64, metricSource metrics.MetricSource, metricsType metrics.MetricType, timestamp float64, tags []string, extraTags ...string) {

--- a/pkg/serverless/metrics/metric.go
+++ b/pkg/serverless/metrics/metric.go
@@ -56,15 +56,25 @@ func (c *ServerlessMetricAgent) AddEnhancedUsageMetric(name string, value float6
 	c.sendMetricSample(name, value, metricSource, metrics.GaugeType, timestamp, c.tags.EnhancedUsageMetric, extraTags...)
 }
 
-// Flush forces an immediate flush of aggregated samples to the serializer.
+// Flush forces an immediate flush of already-closed buckets to the serializer.
 // Satisfied interface: cmd/serverless-init/lifecycle.Flusher, used by MicroVM
-// to flush telemetry on-demand before a Firecracker snapshot (/suspend,
-// /terminate), independent of the Fx-managed shutdown flush.
+// to flush telemetry on-demand before a Firecracker snapshot on /suspend,
+// independent of the Fx-managed shutdown flush. /terminate uses FlushAll instead.
 func (c *ServerlessMetricAgent) Flush() {
 	if c.Demux == nil {
 		return
 	}
-	c.Demux.ForceFlushToSerializer(time.Now(), true)
+	c.Demux.ForceFlushToSerializer(time.Now(), true, false)
+}
+
+// FlushAll additionally includes the current, not-yet-closed bucket. Satisfied
+// interface: cmd/serverless-init/lifecycle.ForceFlusher — see that doc for why
+// this must stay off /suspend's path.
+func (c *ServerlessMetricAgent) FlushAll() {
+	if c.Demux == nil {
+		return
+	}
+	c.Demux.ForceFlushToSerializer(time.Now(), true, true)
 }
 
 // sendMetricSample records a distribution metric sample using the agent's extra tags plus any

--- a/pkg/serverless/metrics/metric_drain_test.go
+++ b/pkg/serverless/metrics/metric_drain_test.go
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
+	secretsmock "github.com/DataDog/datadog-agent/comp/core/secrets/mock"
+	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	filterlistmock "github.com/DataDog/datadog-agent/comp/filterlist/fx-mock"
+	defaultforwarder "github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/def"
+	haagentmock "github.com/DataDog/datadog-agent/comp/haagent/mock"
+	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
+	metricscompression "github.com/DataDog/datadog-agent/comp/serializer/metricscompression/fx-mock"
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	pkgmetrics "github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/serverless/metrics/metricstest"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Same nil-Demux safety already covered for Flush/FlushAll by
+// TestMetricAgentNoOpWithoutDemux in main_test.go.
+func TestWaitForPendingSamplesNoOpWithoutDemux(t *testing.T) {
+	agent := &ServerlessMetricAgent{}
+	assert.NotPanics(t, func() {
+		agent.WaitForPendingSamples()
+	})
+}
+
+// TestWaitForPendingSamplesDrainsRealDemux runs against the actual Fx wiring
+// production code gets. bundle.Demux's dynamic type is the demultiplexerimpl
+// wrapper struct, not a bare *aggregator.AgentDemultiplexer — a concrete-type
+// assertion in WaitForPendingSamples would silently no-op here.
+func TestWaitForPendingSamplesDrainsRealDemux(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	bundle := metricstest.New(t, fakeTagger)
+
+	_, ok := bundle.Demux.(pendingSampleDrainer)
+	require.True(t, ok, "the Fx-provided demux must satisfy pendingSampleDrainer, or WaitForPendingSamples silently no-ops in production")
+
+	agent := New(bundle.Demux, Tags{EnhancedMetric: []string{"tag:1"}})
+	assert.NotPanics(t, func() {
+		agent.AddEnhancedMetric("test.metric", 1.0, pkgmetrics.MetricSourceServerless, 0)
+		agent.WaitForPendingSamples()
+		agent.WaitForPendingSamples()
+	})
+}
+
+// TestWaitForPendingSamplesDrainsThroughWrappedDemux mirrors
+// TestStopDrainsThroughWrappedDemux above (same wrappedDemux type): proves a
+// sample submitted through the wrapped Demux is actually drained, not just
+// that the type assertion succeeds. Without a working drain, AddEnhancedMetric
+// and the worker processing it race FlushAll — same race TestStopDrainsBeforeFlush
+// documents — so a single iteration can pass by luck; 100 iterations make a
+// broken drain reliably show up as a sketchCount short of iterations.
+func TestWaitForPendingSamplesDrainsThroughWrappedDemux(t *testing.T) {
+	mockConfig := configmock.New(t)
+	pkgconfigsetup.LoadDatadog(mockConfig, secretsmock.New(t), delegatedauthmock.New(t), nil)
+
+	cf := newCountingForwarder()
+
+	deps := fxutil.Test[aggregator.TestDeps](t,
+		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
+		fx.Provide(func() defaultforwarder.Component { return cf }),
+		core.MockBundle(),
+		hostnameimpl.MockModule(),
+		haagentmock.Module(),
+		logscompression.MockModule(),
+		metricscompression.MockModule(),
+		filterlistmock.MockModule(),
+	)
+
+	const iterations = 100
+	future := float64(time.Now().Add(time.Hour).UnixNano()) / float64(time.Second)
+	for i := 0; i < iterations; i++ {
+		opts := aggregator.DefaultAgentDemultiplexerOptions()
+		opts.FlushInterval = time.Hour
+		opts.DontStartForwarders = true
+		demux := aggregator.InitAndStartAgentDemultiplexerForTest(deps, opts, "")
+
+		agent := New(wrappedDemux{AgentDemultiplexer: demux}, Tags{})
+		agent.AddEnhancedMetric("test.metric", 1.0, pkgmetrics.MetricSourceServerless, future)
+
+		agent.WaitForPendingSamples()
+		agent.FlushAll()
+
+		demux.Stop()
+	}
+
+	require.Equal(t, int64(iterations), cf.sketchCount.Load(),
+		"WaitForPendingSamples must drain every sample submitted through the wrapped Demux before FlushAll runs")
+}

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -234,3 +234,83 @@ func TestShutdownCascadeFlushesLateSample(t *testing.T) {
 	require.Equal(t, int64(1), cf.sketchCount.Load(),
 		"the OnStop cascade must drain and flush the late sample to the forwarder")
 }
+
+// TestFlushAllDeliversOpenBucketSample proves FlushAll delivers a sample still
+// sitting in the current, open bucket — no periodic flush needed.
+// require.Eventually retries because AddEnhancedMetric and the worker
+// processing it race (the still-open SampleDrainer gap); that's not what this
+// test covers.
+func TestFlushAllDeliversOpenBucketSample(t *testing.T) {
+	mockConfig := configmock.New(t)
+	pkgconfigsetup.LoadDatadog(mockConfig, secretsmock.New(t), delegatedauthmock.New(t), nil)
+
+	cf := newCountingForwarder()
+
+	deps := fxutil.Test[aggregator.TestDeps](t,
+		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
+		fx.Provide(func() defaultforwarder.Component { return cf }),
+		core.MockBundle(),
+		hostnameimpl.MockModule(),
+		haagentmock.Module(),
+		logscompression.MockModule(),
+		metricscompression.MockModule(),
+		filterlistmock.MockModule(),
+	)
+
+	opts := aggregator.DefaultAgentDemultiplexerOptions()
+	opts.FlushInterval = time.Hour // disable automatic flushes
+	opts.DontStartForwarders = true
+	demux := aggregator.InitAndStartAgentDemultiplexerForTest(deps, opts, "")
+	defer demux.Stop()
+
+	agent := New(demux, Tags{})
+	// An hour out so the bucket can never close mid-test, regardless of real
+	// bucket-boundary timing.
+	future := float64(time.Now().Add(time.Hour).UnixNano()) / float64(time.Second)
+	agent.AddEnhancedMetric("test.metric", 1.0, pkgmetrics.MetricSourceServerless, future)
+
+	require.Eventually(t, func() bool {
+		agent.FlushAll()
+		return cf.sketchCount.Load() >= 1
+	}, time.Second, time.Millisecond,
+		"FlushAll must deliver a sample from the still-open bucket")
+}
+
+// TestFlushSkipsOpenBucket is the negative control for
+// TestFlushAllDeliversOpenBucketSample: Flush must never include a sample
+// from the still-open bucket.
+func TestFlushSkipsOpenBucket(t *testing.T) {
+	mockConfig := configmock.New(t)
+	pkgconfigsetup.LoadDatadog(mockConfig, secretsmock.New(t), delegatedauthmock.New(t), nil)
+
+	cf := newCountingForwarder()
+
+	deps := fxutil.Test[aggregator.TestDeps](t,
+		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
+		fx.Provide(func() defaultforwarder.Component { return cf }),
+		core.MockBundle(),
+		hostnameimpl.MockModule(),
+		haagentmock.Module(),
+		logscompression.MockModule(),
+		metricscompression.MockModule(),
+		filterlistmock.MockModule(),
+	)
+
+	opts := aggregator.DefaultAgentDemultiplexerOptions()
+	opts.FlushInterval = time.Hour // disable automatic flushes
+	opts.DontStartForwarders = true
+	demux := aggregator.InitAndStartAgentDemultiplexerForTest(deps, opts, "")
+	defer demux.Stop()
+
+	agent := New(demux, Tags{})
+	future := float64(time.Now().Add(time.Hour).UnixNano()) / float64(time.Second)
+	agent.AddEnhancedMetric("test.metric", 1.0, pkgmetrics.MetricSourceServerless, future)
+
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		agent.Flush()
+		time.Sleep(time.Millisecond)
+	}
+	assert.Equal(t, int64(0), cf.sketchCount.Load(),
+		"Flush must not deliver a sample from the still-open bucket")
+}

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -229,3 +229,83 @@ func TestShutdownCascadeFlushesLateSample(t *testing.T) {
 	require.Equal(t, int64(1), cf.sketchCount.Load(),
 		"the OnStop cascade must drain and flush the late sample to the forwarder")
 }
+
+// TestFlushAllDeliversOpenBucketSample proves FlushAll delivers a sample still
+// sitting in the current, open bucket — no periodic flush needed.
+// require.Eventually retries because AddEnhancedMetric and the worker
+// processing it race (the still-open SampleDrainer gap); that's not what this
+// test covers.
+func TestFlushAllDeliversOpenBucketSample(t *testing.T) {
+	mockConfig := configmock.New(t)
+	pkgconfigsetup.LoadDatadog(mockConfig, secretsmock.New(t), delegatedauthmock.New(t), nil)
+
+	cf := newCountingForwarder()
+
+	deps := fxutil.Test[aggregator.TestDeps](t,
+		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
+		fx.Provide(func() defaultforwarder.Component { return cf }),
+		core.MockBundle(),
+		hostnameimpl.MockModule(),
+		haagentmock.Module(),
+		logscompression.MockModule(),
+		metricscompression.MockModule(),
+		filterlistmock.MockModule(),
+	)
+
+	opts := aggregator.DefaultAgentDemultiplexerOptions()
+	opts.FlushInterval = time.Hour // disable automatic flushes
+	opts.DontStartForwarders = true
+	demux := aggregator.InitAndStartAgentDemultiplexerForTest(deps, opts, "")
+	defer demux.Stop()
+
+	agent := New(demux, Tags{})
+	// An hour out so the bucket can never close mid-test, regardless of real
+	// bucket-boundary timing.
+	future := float64(time.Now().Add(time.Hour).UnixNano()) / float64(time.Second)
+	agent.AddEnhancedMetric("test.metric", 1.0, pkgmetrics.MetricSourceServerless, future)
+
+	require.Eventually(t, func() bool {
+		agent.FlushAll()
+		return cf.sketchCount.Load() >= 1
+	}, time.Second, time.Millisecond,
+		"FlushAll must deliver a sample from the still-open bucket")
+}
+
+// TestFlushSkipsOpenBucket is the negative control for
+// TestFlushAllDeliversOpenBucketSample: Flush must never include a sample
+// from the still-open bucket.
+func TestFlushSkipsOpenBucket(t *testing.T) {
+	mockConfig := configmock.New(t)
+	pkgconfigsetup.LoadDatadog(mockConfig, secretsmock.New(t), delegatedauthmock.New(t), nil)
+
+	cf := newCountingForwarder()
+
+	deps := fxutil.Test[aggregator.TestDeps](t,
+		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
+		fx.Provide(func() defaultforwarder.Component { return cf }),
+		core.MockBundle(),
+		hostnameimpl.MockModule(),
+		haagentmock.Module(),
+		logscompression.MockModule(),
+		metricscompression.MockModule(),
+		filterlistmock.MockModule(),
+	)
+
+	opts := aggregator.DefaultAgentDemultiplexerOptions()
+	opts.FlushInterval = time.Hour // disable automatic flushes
+	opts.DontStartForwarders = true
+	demux := aggregator.InitAndStartAgentDemultiplexerForTest(deps, opts, "")
+	defer demux.Stop()
+
+	agent := New(demux, Tags{})
+	future := float64(time.Now().Add(time.Hour).UnixNano()) / float64(time.Second)
+	agent.AddEnhancedMetric("test.metric", 1.0, pkgmetrics.MetricSourceServerless, future)
+
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		agent.Flush()
+		time.Sleep(time.Millisecond)
+	}
+	assert.Equal(t, int64(0), cf.sketchCount.Load(),
+		"Flush must not deliver a sample from the still-open bucket")
+}


### PR DESCRIPTION
Driven by Codex's comment on #54111: https://github.com/DataDog/datadog-agent/pull/54111#issuecomment-5073315536

`/suspend` and `/terminate` call `Flush()` to make MicroVM telemetry durable before the VM is snapshotted or torn down. `ForceFlushToSerializer` ignored that intent and always skipped the current, still-open time bucket — a metric emitted right before the call, including the `/terminate` metric itself, could get dropped with nothing to retry once the VM is gone. That lines up with `aws.lambda.enhanced.microvm.terminate` having zero data points anywhere in the org for the last 30 days.

This threads a real `forceFlushAll` flag from MicroVM down through `ServerlessMetricAgent.Flush()` into `Demultiplexer.ForceFlushToSerializer`. Every other cloud service opts out — none of them call `Flush()` outside the normal periodic/shutdown cycle, so nothing else changes.

The other issue from that comment — `SampleDrainer` never being wired up — needs new drain plumbing in `pkg/aggregator`'s `timeSamplerWorker`; the existing `shutdown()`/`waitForShutdown()` is one-shot and would panic on a second `/suspend`. That's a separate PR.

## Test plan
- [x] New tests prove the fix directly: a sample in the current open bucket is delivered when `forceFlushAll` is true, never delivered when false.
- [x] `dda inv test` on every touched package (`pkg/aggregator`, `pkg/serverless`, `cmd/serverless-init`, `pkg/clusteragent/.../kubernetesadmissionevents`) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
