### PR TITLE
fix(serverless-init): drain pending samples before MicroVM flush

### DIFF
--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -496,6 +496,7 @@ func setup(
 				MetricFlusher: metricAgent,
 				LogsFlusher:   logsAgent,
 				MetricEmitter: metricAgent,
+				SampleDrainer: metricAgent,
 				FlushTimeout:  agentLogConfig.FlushTimeout,
 				SidecarMode:   modeConf.SidecarMode,
 				LogsTagSetter: lifecycle.LogsTagSetterFunc(func(tags []string) {
@@ -532,6 +533,7 @@ func setup(
 			MetricFlusher: metricAgent,
 			LogsFlusher:   logsAgent,
 			MetricEmitter: metricAgent,
+			SampleDrainer: metricAgent,
 			FlushTimeout:  agentLogConfig.FlushTimeout,
 			SidecarMode:   modeConf.SidecarMode,
 			LogsTagSetter: lifecycle.LogsTagSetterFunc(func(tags []string) {

--- a/pkg/aggregator/BUILD.bazel
+++ b/pkg/aggregator/BUILD.bazel
@@ -108,6 +108,7 @@ go_test(
         "tagfilter_cache_test.go",
         "tagset_telem_test.go",
         "time_sampler_test.go",
+        "time_sampler_worker_test.go",
     ],
     embed = [":aggregator"],
     gotags = ["test"],

--- a/pkg/aggregator/BUILD.bazel
+++ b/pkg/aggregator/BUILD.bazel
@@ -109,6 +109,7 @@ dd_agent_go_test(
         "tagfilter_cache_test.go",
         "tagset_telem_test.go",
         "time_sampler_test.go",
+        "time_sampler_worker_test.go",
     ],
     embed = [":aggregator"],
     gotags_sets = [[

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -694,6 +694,14 @@ func (d *AgentDemultiplexer) AggregateSample(sample metrics.MetricSample) {
 	d.statsd.workers[0].addSamples(batch[:1])
 }
 
+// WaitForPendingSamples blocks until samples enqueued on shard 0 before this
+// call have been consumed. Used by serverless-init's on-demand flush, where a
+// sample submitted right before a flush could otherwise race it. Only shard 0
+// is drained since AggregateSample always targets it.
+func (d *AgentDemultiplexer) WaitForPendingSamples() {
+	d.statsd.workers[0].waitForPendingSamples()
+}
+
 // AggregateCheckSample adds check sample sent by a check from one of the collectors into a check sampler pipeline.
 func (d *AgentDemultiplexer) AggregateCheckSample(_ metrics.MetricSample) {
 	panic("not implemented yet.")

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -690,11 +690,23 @@ func (d *AgentDemultiplexer) AggregateSamples(shard TimeSamplerID, samples metri
 	d.statsd.workers[shard].addSamples(samples)
 }
 
+// singleSampleShard is the time sampler shard used by AggregateSample.
+// WaitForPendingSamples drains this same shard, so the two must stay in sync.
+const singleSampleShard TimeSamplerID = 0
+
 // AggregateSample adds a MetricSample in the first DogStatsD time sampler.
 func (d *AgentDemultiplexer) AggregateSample(sample metrics.MetricSample) {
 	batch := d.GetMetricSamplePool().GetBatch()
 	batch[0] = sample
-	d.statsd.workers[0].addSamples(batch[:1])
+	d.statsd.workers[singleSampleShard].addSamples(batch[:1])
+}
+
+// WaitForPendingSamples blocks until samples enqueued on singleSampleShard
+// before this call have been consumed. Used by serverless-init's on-demand
+// flush, where a sample submitted right before a flush could otherwise race
+// it.
+func (d *AgentDemultiplexer) WaitForPendingSamples() {
+	d.statsd.workers[singleSampleShard].waitForPendingSamples()
 }
 
 // AggregateCheckSample adds check sample sent by a check from one of the collectors into a check sampler pipeline.

--- a/pkg/aggregator/time_sampler_worker.go
+++ b/pkg/aggregator/time_sampler_worker.go
@@ -49,6 +49,10 @@ type timeSamplerWorker struct {
 	samplesChan chan []metrics.MetricSample
 	// samplesDrained is closed after last sample is read from samplesChan
 	samplesDrained chan struct{}
+	// drainChan requests a synchronous drain of samplesChan. Unlike
+	// shutdown/samplesDrained, it's repeatable and doesn't touch the worker's
+	// lifecycle.
+	drainChan chan chan struct{}
 	// use this chan to trigger a flush of the time sampler
 	flushChan chan flushTrigger
 	// use this chan to trigger a filterList reconfiguration
@@ -83,6 +87,7 @@ func newTimeSamplerWorker(sampler *TimeSampler, flushInterval time.Duration, buf
 
 		samplesChan:          make(chan []metrics.MetricSample, bufferSize),
 		samplesDrained:       make(chan struct{}),
+		drainChan:            make(chan chan struct{}),
 		stopChan:             make(chan struct{}),
 		flushChan:            make(chan flushTrigger),
 		dumpChan:             make(chan dumpTrigger),
@@ -112,15 +117,7 @@ func (w *timeSamplerWorker) run() {
 				close(w.samplesDrained)
 				continue
 			}
-
-			aggregatorDogstatsdMetricSample.Add(int64(len(ms)))
-			tlmProcessed.Add(float64(len(ms)), shard, "dogstatsd_metrics")
-			t := timeNowNano()
-
-			for i := 0; i < len(ms); i++ {
-				w.sampler.sample(&ms[i], t, w.tagFilterList)
-			}
-			w.metricSamplePool.PutBatch(ms)
+			w.processBatch(ms)
 		case matcher := <-w.metricFilterListChan:
 			w.flushFilterList = matcher
 		case matcher := <-w.tagFilterListChan:
@@ -130,8 +127,38 @@ func (w *timeSamplerWorker) run() {
 			w.tagsStore.Shrink()
 		case trigger := <-w.dumpChan:
 			trigger.done <- w.sampler.dumpContexts(trigger.dest)
+		case done := <-w.drainChan:
+			// select doesn't order drainChan against samplesChan, so drain
+			// whatever's already buffered before acking.
+		drainLoop:
+			for {
+				select {
+				case ms := <-w.samplesChan:
+					if ms == nil {
+						close(w.samplesDrained)
+						continue
+					}
+					w.processBatch(ms)
+				default:
+					break drainLoop
+				}
+			}
+			close(done)
 		}
 	}
+}
+
+// processBatch samples ms, called from run()'s normal loop or from a drain.
+func (w *timeSamplerWorker) processBatch(ms []metrics.MetricSample) {
+	shard := w.sampler.idString
+	aggregatorDogstatsdMetricSample.Add(int64(len(ms)))
+	tlmProcessed.Add(float64(len(ms)), shard, "dogstatsd_metrics")
+	t := timeNowNano()
+
+	for i := 0; i < len(ms); i++ {
+		w.sampler.sample(&ms[i], t, w.tagFilterList)
+	}
+	w.metricSamplePool.PutBatch(ms)
 }
 
 // Set a new filterlist, ensuring we also clear the context resolver strip cache
@@ -177,4 +204,12 @@ func (w *timeSamplerWorker) waitForShutdown(ctx context.Context) {
 	case <-w.samplesDrained:
 	case <-ctx.Done():
 	}
+}
+
+// waitForPendingSamples blocks until samples enqueued before this call have
+// been processed. Safe to call repeatedly, unlike shutdown/waitForShutdown.
+func (w *timeSamplerWorker) waitForPendingSamples() {
+	done := make(chan struct{})
+	w.drainChan <- done
+	<-done
 }

--- a/pkg/aggregator/time_sampler_worker_test.go
+++ b/pkg/aggregator/time_sampler_worker_test.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package aggregator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+// A sample sent right before WaitForPendingSamples must be processed by the
+// time the call returns, and the call must be repeatable.
+func TestWaitForPendingSamplesDrainsBeforeReturning(t *testing.T) {
+	require := require.New(t)
+
+	deps := createDemultiplexerAgentTestDeps(t)
+	opts := demuxTestOptions()
+	// InitAndStartAgentDemultiplexer (not initAgentDemultiplexer) is required
+	// here: WaitForPendingSamples needs the worker's run() goroutine actually
+	// running to service drainChan.
+	demux := InitAndStartAgentDemultiplexer(deps.Log, NewForwarderTest(deps.Log), deps.OrchestratorFwd, opts, deps.EventPlatform, deps.HaAgent, deps.Compressor, deps.Tagger, deps.FilterList, "")
+	defer demux.Stop()
+
+	worker := demux.statsd.workers[0]
+	require.Equal(0, worker.sampler.contextResolver.length())
+
+	demux.AggregateSample(metrics.MetricSample{
+		Name:      "test.metric",
+		Value:     1,
+		Mtype:     metrics.GaugeType,
+		Timestamp: 1657099120.0,
+		Tags:      []string{"tag:1"},
+	})
+
+	demux.WaitForPendingSamples()
+
+	require.Len(worker.samplesChan, 0, "the sample must have been drained from samplesChan")
+	require.Equal(1, worker.sampler.contextResolver.length(), "the sample must have been aggregated into a context, not just dequeued")
+
+	// Calling it again with nothing pending must not block or panic.
+	demux.WaitForPendingSamples()
+}

--- a/pkg/serverless/metrics/BUILD.bazel
+++ b/pkg/serverless/metrics/BUILD.bazel
@@ -16,6 +16,7 @@ go_test(
     name = "metrics_test",
     srcs = [
         "metric_add_test.go",
+        "metric_drain_test.go",
         "metric_test.go",
     ],
     embed = [":metrics"],
@@ -30,6 +31,7 @@ go_test(
         "//comp/core/log/mock",
         "//comp/core/secrets/def",
         "//comp/core/secrets/mock",
+        "//comp/core/tagger/fx-mock",
         "//comp/core/tagger/impl-noop",
         "//comp/filterlist/fx-mock",
         "//comp/forwarder/defaultforwarder/def",

--- a/pkg/serverless/metrics/BUILD.bazel
+++ b/pkg/serverless/metrics/BUILD.bazel
@@ -17,6 +17,7 @@ dd_agent_go_test(
     name = "metrics_test",
     srcs = [
         "metric_add_test.go",
+        "metric_drain_test.go",
         "metric_test.go",
     ],
     embed = [":metrics"],
@@ -30,6 +31,7 @@ dd_agent_go_test(
         "//comp/core/log/mock",
         "//comp/core/secrets/def",
         "//comp/core/secrets/mock",
+        "//comp/core/tagger/fx-mock",
         "//comp/core/tagger/impl-noop",
         "//comp/filterlist/fx-mock",
         "//comp/forwarder/defaultforwarder/def",

--- a/pkg/serverless/metrics/metric.go
+++ b/pkg/serverless/metrics/metric.go
@@ -77,6 +77,24 @@ func (c *ServerlessMetricAgent) FlushAll() {
 	c.Demux.ForceFlushToSerializer(time.Now(), true, true)
 }
 
+// pendingSampleDrainer is satisfied by *aggregator.AgentDemultiplexer, and by
+// anything embedding it — notably the Fx demultiplexer component's wrapper
+// struct, which is what c.Demux actually holds in production. Asserting
+// against this interface instead of the concrete *AgentDemultiplexer type
+// lets Go's method promotion see through that wrapper.
+type pendingSampleDrainer interface {
+	WaitForPendingSamples()
+}
+
+// WaitForPendingSamples blocks until samples enqueued before this call have
+// been consumed. Satisfied interface: cmd/serverless-init/lifecycle.SampleDrainer.
+// No-op if the demux doesn't support draining (e.g. unset in tests).
+func (c *ServerlessMetricAgent) WaitForPendingSamples() {
+	if d, ok := c.Demux.(pendingSampleDrainer); ok {
+		d.WaitForPendingSamples()
+	}
+}
+
 // sendMetricSample records a distribution metric sample using the agent's extra tags plus any
 // optional tags supplied as `key:value` strings through extraTags.
 func (c *ServerlessMetricAgent) sendMetricSample(name string, value float64, metricSource metrics.MetricSource, metricsType metrics.MetricType, timestamp float64, tags []string, extraTags ...string) {

--- a/pkg/serverless/metrics/metric_drain_test.go
+++ b/pkg/serverless/metrics/metric_drain_test.go
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
+	secretsmock "github.com/DataDog/datadog-agent/comp/core/secrets/mock"
+	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	filterlistmock "github.com/DataDog/datadog-agent/comp/filterlist/fx-mock"
+	defaultforwarder "github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/def"
+	haagentmock "github.com/DataDog/datadog-agent/comp/haagent/mock"
+	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
+	metricscompression "github.com/DataDog/datadog-agent/comp/serializer/metricscompression/fx-mock"
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	pkgmetrics "github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/serverless/metrics/metricstest"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Same nil-Demux safety already covered for Flush/FlushAll by
+// TestMetricAgentNoOpWithoutDemux in main_test.go.
+func TestWaitForPendingSamplesNoOpWithoutDemux(t *testing.T) {
+	agent := &ServerlessMetricAgent{}
+	assert.NotPanics(t, func() {
+		agent.WaitForPendingSamples()
+	})
+}
+
+// TestWaitForPendingSamplesDrainsRealDemux runs against the actual Fx wiring
+// production code gets. bundle.Demux's dynamic type is the demultiplexerimpl
+// wrapper struct, not a bare *aggregator.AgentDemultiplexer — a concrete-type
+// assertion in WaitForPendingSamples would silently no-op here.
+func TestWaitForPendingSamplesDrainsRealDemux(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	bundle := metricstest.New(t, fakeTagger)
+
+	_, ok := bundle.Demux.(pendingSampleDrainer)
+	require.True(t, ok, "the Fx-provided demux must satisfy pendingSampleDrainer, or WaitForPendingSamples silently no-ops in production")
+
+	agent := New(bundle.Demux, Tags{EnhancedMetric: []string{"tag:1"}})
+	assert.NotPanics(t, func() {
+		agent.AddEnhancedMetric("test.metric", 1.0, pkgmetrics.MetricSourceServerless, 0)
+		agent.WaitForPendingSamples()
+		agent.WaitForPendingSamples()
+	})
+}
+
+// TestWaitForPendingSamplesDrainsThroughWrappedDemux mirrors
+// TestStopDrainsThroughWrappedDemux above (same wrappedDemux type): proves a
+// sample submitted through the wrapped Demux is actually drained, not just
+// that the type assertion succeeds. Without a working drain, AddEnhancedMetric
+// and the worker processing it race FlushAll — same race TestStopDrainsBeforeFlush
+// documents — so a single iteration can pass by luck; 100 iterations make a
+// broken drain reliably show up as a sketchCount short of iterations.
+func TestWaitForPendingSamplesDrainsThroughWrappedDemux(t *testing.T) {
+	mockConfig := configmock.New(t)
+	pkgconfigsetup.LoadDatadog(mockConfig, secretsmock.New(t), delegatedauthmock.New(t), nil)
+
+	cf := newCountingForwarder()
+
+	deps := fxutil.Test[aggregator.TestDeps](t,
+		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
+		fx.Provide(func() defaultforwarder.Component { return cf }),
+		core.MockBundle(),
+		hostnameimpl.MockModule(),
+		haagentmock.Module(),
+		logscompression.MockModule(),
+		metricscompression.MockModule(),
+		filterlistmock.MockModule(),
+	)
+
+	const iterations = 100
+	future := float64(time.Now().Add(time.Hour).UnixNano()) / float64(time.Second)
+	for i := 0; i < iterations; i++ {
+		opts := aggregator.DefaultAgentDemultiplexerOptions()
+		opts.FlushInterval = time.Hour
+		opts.DontStartForwarders = true
+		demux := aggregator.InitAndStartAgentDemultiplexerForTest(deps, opts, "")
+
+		agent := New(wrappedDemux{AgentDemultiplexer: demux}, Tags{})
+		agent.AddEnhancedMetric("test.metric", 1.0, pkgmetrics.MetricSourceServerless, future)
+
+		agent.WaitForPendingSamples()
+		agent.FlushAll()
+
+		demux.Stop()
+	}
+
+	require.Equal(t, int64(iterations), cf.sketchCount.Load(),
+		"WaitForPendingSamples must drain every sample submitted through the wrapped Demux before FlushAll runs")
+}


### PR DESCRIPTION
## Why

MicroVM's `/suspend` and `/terminate` hooks flush telemetry on demand, without the process exiting — every other cloud service only flushes at shutdown. That on-demand flush races the aggregator's async sample pipeline: a metric emitted right before the flush (the heartbeat's last tick, say) can still be sitting unprocessed in an internal channel when the flush fires, and gets silently dropped.

`SampleDrainer` was scaffolded to prevent exactly this, but nothing ever implemented it, so the drain step in `flushAll` was a no-op. Traced this while looking into Codex's review comment on #54111: https://github.com/DataDog/datadog-agent/pull/54111#issuecomment-5073315536

Fix: generalize the one-shot drain the aggregator already uses at process shutdown into a repeatable version, implement it on `ServerlessMetricAgent`, and wire it into MicroVM's lifecycle context.

Codex's review on this PR caught a follow-up bug in that fix: the type assertion in `WaitForPendingSamples` only matched a bare `*AgentDemultiplexer`, but production's Fx-provided demux is a wrapper struct that embeds one instead, so the drain would've stayed a no-op even after this change. Now asserts against a small interface so the wrapper is handled too, with a test that reproduces the exact failure mode to guard against a regression.

## Test plan

- [x] `dda inv test --targets=./pkg/aggregator,./pkg/serverless/metrics,./cmd/serverless-init`
- [x] `dda inv linter.go` on the same targets
- [x] Manual QA on a real MicroVM instance: metric emitted right before `/suspend` shows up in the flush, across `/resume`/`/suspend`/`/terminate` cycles. ([metric manifests](https://ddserverless.datadoghq.com/metric/explorer?fromUser=false&graph_layout=multi&start=1785264445753&end=1785268800000&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYAKwGIFCeGE4a+NoAxkrIIOoIulmWgWZxyhp4qsgYYBoAdJiqAEYp9XAijBgiOVD1qhBZ2jgAbqr12ngiwABUPPUYGk5Z+CIIABQAlCB8oJHRebFYACxJKQhpGXjZufmIRSUgRxVVNXWNUa0Y7Z3dvf2DYZjeqVewdKCzeaLZarDbbXYRKK3I4ANjOqXSmRyygKDySzzylWqtQaTS+Py6PTgfQGQ1G4zsVTgkIWSxWUzhOwoeyRMTKWAA7OiLpjrti8rjBo8CSAiW9SZ82h1Kf9aUDxggdANIpqWdD2WstjsALpUVzuPCYULhc2qS0YPk6BJc0C2+2OuKnBFuzAerBo71uO2+w78oU8U2yuRoXKgeQYGMITXKKA4GDLK0aQZJNwCbROZo0PIjBNmR5oURwJxyRQVHAVqBJCsiKv0JjKERBhNc5IQeyYLDVhS3ZoYbSWCM8Piy+QVhAAYSkwhgKBElrQPCAA))

<img width="2636" height="1388" alt="image" src="https://github.com/user-attachments/assets/de609f93-1c5a-45e2-a14a-1ea746544f94" />
