### PR TITLE
[CONTP-1921] Fix: KSM auto-sharding coexist with cluster_aggregates_only

### DIFF
--- a/pkg/clusteragent/clusterchecks/ksm_sharding.go
+++ b/pkg/clusteragent/clusterchecks/ksm_sharding.go
@@ -61,33 +61,19 @@ func defaultKSMCollectors() []string {
 	return collectors
 }
 
-// analyzeKSMConfig analyzes a KSM configuration and returns collectors grouped by resource type
-// Simple strategy: {pods}, {nodes}, {everything else}
-func (m *ksmShardingManager) analyzeKSMConfig(config integration.Config) ([]resourceGroup, error) {
+// analyzeKSMConfig groups the shardable instance's collectors by resource type.
+// Simple strategy: {pods}, {nodes}, {everything else}. The caller classifies
+// once and passes the shardable instance in, so this doesn't re-parse the config.
+func (m *ksmShardingManager) analyzeKSMConfig(shardable integration.Data) ([]resourceGroup, error) {
 	// Parse the KSM configuration
 	type ksmInstance struct {
 		Collectors []string `yaml:"collectors"`
 	}
 
-	var instances []ksmInstance
-	for _, data := range config.Instances {
-		var instance ksmInstance
-		if err := yaml.Unmarshal(data, &instance); err != nil {
-			log.Warnf("Failed to parse KSM instance config: %v", err)
-			continue
-		}
-		instances = append(instances, instance)
+	var instance ksmInstance
+	if err := yaml.Unmarshal(shardable, &instance); err != nil {
+		return nil, fmt.Errorf("failed to parse shardable KSM instance: %w", err)
 	}
-
-	if len(instances) == 0 {
-		return nil, errors.New("no valid KSM instances found")
-	}
-
-	if len(instances) > 1 {
-		return nil, fmt.Errorf("KSM check has %d instances configured, but sharding only supports single-instance configs", len(instances))
-	}
-
-	instance := instances[0]
 
 	// If no collectors specified, KSM defaults to collecting all resources (options.DefaultResources)
 	// See kubernetes_state.go:Configure for the same fallback logic
@@ -151,6 +137,58 @@ func (m *ksmShardingManager) analyzeKSMConfig(config integration.Config) ([]reso
 	return groups, nil
 }
 
+// pod_collection_mode values. Duplicated as literals to avoid importing the ksm
+// check package, which is not built with the clusterchecks tag.
+const (
+	clusterAggregatesOnlyMode = "cluster_aggregates_only"
+	clusterUnassignedMode     = "cluster_unassigned"
+)
+
+// classifyKSMInstances splits instances into the single shardable one and any
+// cluster_aggregates_only instances, which do a full-pod watch and so are
+// dispatched as-is instead of being sharded.
+func classifyKSMInstances(config integration.Config) (integration.Data, []integration.Data, error) {
+	type modeOnly struct {
+		PodCollectionMode string `yaml:"pod_collection_mode"`
+	}
+
+	var shardables, passthrough []integration.Data
+	for _, data := range config.Instances {
+		var mo modeOnly
+		if err := yaml.Unmarshal(data, &mo); err != nil {
+			log.Warnf("Failed to parse KSM instance config: %v", err)
+			continue
+		}
+		if mo.PodCollectionMode == clusterAggregatesOnlyMode {
+			passthrough = append(passthrough, data)
+			continue
+		}
+		shardables = append(shardables, data)
+	}
+
+	if len(shardables) == 0 {
+		return nil, nil, errors.New("no shardable KSM instance found")
+	}
+	if len(shardables) > 1 {
+		return nil, nil, fmt.Errorf("KSM sharding supports a single shardable instance, got %d (excluding %s)", len(shardables), clusterAggregatesOnlyMode)
+	}
+	return shardables[0], passthrough, nil
+}
+
+// shardableSuppressesTotal reports whether the shardable instance suppresses its
+// own .total family, which it must when a cluster_aggregates_only instance is
+// also configured. The observed values are returned for the diagnostic message;
+// an unparseable instance reports not-suppressing.
+func shardableSuppressesTotal(shardable integration.Data) (mode string, flag bool, ok bool) {
+	var s struct {
+		PodCollectionMode        string `yaml:"pod_collection_mode"`
+		ClusterAggregatesEnabled bool   `yaml:"cluster_aggregates_enabled"`
+	}
+	_ = yaml.Unmarshal(shardable, &s)
+	return s.PodCollectionMode, s.ClusterAggregatesEnabled,
+		s.PodCollectionMode == clusterUnassignedMode && s.ClusterAggregatesEnabled
+}
+
 // shouldShardKSMCheck determines if a KSM check should be sharded
 func (m *ksmShardingManager) shouldShardKSMCheck(config integration.Config) bool {
 	if !m.enabled || !m.isKSMCheck(config) {
@@ -163,7 +201,13 @@ func (m *ksmShardingManager) shouldShardKSMCheck(config integration.Config) bool
 		return false
 	}
 
-	groups, err := m.analyzeKSMConfig(config)
+	shardable, _, err := classifyKSMInstances(config)
+	if err != nil {
+		log.Warnf("KSM sharding disabled: %v", err)
+		return false
+	}
+
+	groups, err := m.analyzeKSMConfig(shardable)
 	if err != nil {
 		log.Warnf("KSM sharding disabled: %v", err)
 		return false
@@ -196,7 +240,12 @@ func (m *ksmShardingManager) createShardedKSMConfigs(
 	baseConfig integration.Config,
 ) ([]integration.Config, error) {
 
-	groups, err := m.analyzeKSMConfig(baseConfig)
+	shardable, passthrough, err := classifyKSMInstances(baseConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	groups, err := m.analyzeKSMConfig(shardable)
 	if err != nil {
 		return nil, err
 	}
@@ -205,14 +254,54 @@ func (m *ksmShardingManager) createShardedKSMConfigs(
 		return nil, errors.New("no resource groups to shard")
 	}
 
+	// Misconfigurations below are still dispatched, so the cluster keeps reporting
+	// inflated .total values until an operator fixes the config: data corruption
+	// rather than a degraded-but-correct fallback, hence ERROR.
+	if len(passthrough) > 0 {
+		if len(passthrough) > 1 {
+			log.Errorf("KSM sharding: %d %s instances configured; each does a full-pod watch and emits the .total family, which double-counts. Configure exactly one.", len(passthrough), clusterAggregatesOnlyMode)
+		}
+		if mode, flag, ok := shardableSuppressesTotal(shardable); !ok {
+			log.Errorf("KSM sharding: a %s instance is configured, but the shardable instance (pod_collection_mode=%q, cluster_aggregates_enabled=%v) will not suppress its own .total — this double-counts the .total family. Set pod_collection_mode: cluster_unassigned and cluster_aggregates_enabled: true on the shardable instance.", clusterAggregatesOnlyMode, mode, flag)
+		}
+	}
+
+	// Force skip_leader_election since these run on a CLC runner, same as the shards.
+	aggregateInstances := make([]integration.Data, 0, len(passthrough))
+	for _, inst := range passthrough {
+		var mm map[string]interface{}
+		if err := yaml.Unmarshal(inst, &mm); err != nil {
+			log.Warnf("Failed to unmarshal %s instance: %v", clusterAggregatesOnlyMode, err)
+			mm = make(map[string]interface{})
+		}
+		mm["skip_leader_election"] = true
+		data, _ := yaml.Marshal(mm)
+		aggregateInstances = append(aggregateInstances, integration.Data(data))
+	}
+
 	// Always create shards (pods, nodes, others) regardless of runner count
 	// Rebalancing will handle optimal distribution as runners scale up/down
 	var shardedConfigs []integration.Config
+	aggregatesAttached := false
 
 	// Create a config for each resource group
 	for _, group := range groups {
-		shardConfig := m.createKSMConfigForResourceGroup(baseConfig, group)
+		shardConfig := m.createKSMConfigForResourceGroup(baseConfig, shardable, group)
+		// Co-locate the aggregates with the pods shard so one runner carries all
+		// pod-related watches, keeping nodes/others free for other runners.
+		if group.Name == "pods" && len(aggregateInstances) > 0 {
+			shardConfig.Instances = append(shardConfig.Instances, aggregateInstances...)
+			aggregatesAttached = true
+		}
 		shardedConfigs = append(shardedConfigs, shardConfig)
+	}
+
+	// No pods group to attach to: dispatch the aggregates standalone so they are
+	// not dropped.
+	if !aggregatesAttached && len(aggregateInstances) > 0 {
+		aggConfig := baseConfig
+		aggConfig.Instances = aggregateInstances
+		shardedConfigs = append(shardedConfigs, aggConfig)
 	}
 
 	log.Infof("Created %d resource-sharded KSM configs", len(shardedConfigs))
@@ -223,6 +312,7 @@ func (m *ksmShardingManager) createShardedKSMConfigs(
 // createKSMConfigForResourceGroup creates a KSM config for a specific resource group
 func (m *ksmShardingManager) createKSMConfigForResourceGroup(
 	baseConfig integration.Config,
+	shardableInstance integration.Data,
 	group resourceGroup,
 ) integration.Config {
 	// Create a new config by copying fields manually
@@ -244,14 +334,10 @@ func (m *ksmShardingManager) createKSMConfigForResourceGroup(
 		LogsExcluded:            baseConfig.LogsExcluded,
 	}
 
-	// Parse existing instance config
+	// Parse the shardable instance config (not necessarily Instances[0])
 	var instance map[string]interface{}
-	if len(baseConfig.Instances) > 0 {
-		if err := yaml.Unmarshal(baseConfig.Instances[0], &instance); err != nil {
-			log.Warnf("Failed to unmarshal KSM instance config: %v", err)
-			instance = make(map[string]interface{})
-		}
-	} else {
+	if err := yaml.Unmarshal(shardableInstance, &instance); err != nil {
+		log.Warnf("Failed to unmarshal shardable KSM instance config: %v", err)
 		instance = make(map[string]interface{})
 	}
 

--- a/pkg/clusteragent/clusterchecks/ksm_sharding.go
+++ b/pkg/clusteragent/clusterchecks/ksm_sharding.go
@@ -189,6 +189,36 @@ func shardableSuppressesTotal(shardable integration.Data) (mode string, flag boo
 		s.PodCollectionMode == clusterUnassignedMode && s.ClusterAggregatesEnabled
 }
 
+// suppressionDiagnostic reports what to log, if anything, about the shardable
+// instance failing to suppress its own .total when a cluster_aggregates_only
+// instance is also configured. ok is true when there's nothing to report
+// (the shardable suppresses fine). Pure and directly testable, so tests don't
+// need to capture actual log output.
+func suppressionDiagnostic(shardable integration.Data, groups []resourceGroup) (message string, isError bool, ok bool) {
+	mode, flag, suppresses := shardableSuppressesTotal(shardable)
+	if suppresses {
+		return "", false, true
+	}
+
+	hasPodsGroup := false
+	for _, group := range groups {
+		if group.Name == "pods" {
+			hasPodsGroup = true
+			break
+		}
+	}
+
+	// Without a pods group, non-suppression isn't a certain double-count — but
+	// it's not certainly safe either. A shard's collectors can be filtered
+	// against what the live API server exposes and fall back to full defaults
+	// (including "pods"; see kubernetes_state.go Configure()), which this
+	// static analysis can't see. ERROR when certain, WARN when not.
+	if hasPodsGroup {
+		return fmt.Sprintf("KSM sharding: a %s instance is configured, but the shardable instance (pod_collection_mode=%q, cluster_aggregates_enabled=%v) will not suppress its own .total — this double-counts the .total family. Set pod_collection_mode: cluster_unassigned and cluster_aggregates_enabled: true on the shardable instance.", clusterAggregatesOnlyMode, mode, flag), true, false
+	}
+	return fmt.Sprintf("KSM sharding: a %s instance is configured, but the shardable instance (pod_collection_mode=%q, cluster_aggregates_enabled=%v) will not suppress its own .total. None of its shards statically include a pods collector, but if any shard's collectors are unavailable on this cluster it falls back to defaults (including pods) and may already be double-counting. Set pod_collection_mode: cluster_unassigned and cluster_aggregates_enabled: true on the shardable instance.", clusterAggregatesOnlyMode, mode, flag), false, false
+}
+
 // shouldShardKSMCheck determines if a KSM check should be sharded
 func (m *ksmShardingManager) shouldShardKSMCheck(config integration.Config) bool {
 	if !m.enabled || !m.isKSMCheck(config) {
@@ -261,8 +291,12 @@ func (m *ksmShardingManager) createShardedKSMConfigs(
 		if len(passthrough) > 1 {
 			log.Errorf("KSM sharding: %d %s instances configured; each does a full-pod watch and emits the .total family, which double-counts. Configure exactly one.", len(passthrough), clusterAggregatesOnlyMode)
 		}
-		if mode, flag, ok := shardableSuppressesTotal(shardable); !ok {
-			log.Errorf("KSM sharding: a %s instance is configured, but the shardable instance (pod_collection_mode=%q, cluster_aggregates_enabled=%v) will not suppress its own .total — this double-counts the .total family. Set pod_collection_mode: cluster_unassigned and cluster_aggregates_enabled: true on the shardable instance.", clusterAggregatesOnlyMode, mode, flag)
+		if message, isError, ok := suppressionDiagnostic(shardable, groups); !ok {
+			if isError {
+				log.Error(message)
+			} else {
+				log.Warn(message)
+			}
 		}
 	}
 
@@ -315,7 +349,12 @@ func (m *ksmShardingManager) createKSMConfigForResourceGroup(
 	shardableInstance integration.Data,
 	group resourceGroup,
 ) integration.Config {
-	// Create a new config by copying fields manually
+	// Deliberately not a full struct copy: CELSelector/Discovery are omitted,
+	// or the shard's IsTemplate() would flip true on the runner and it would
+	// wait to match a service instead of being scheduled directly.
+	//
+	// PodNamespace/ImageName ARE copied: configmgr.go's secret resolution reads
+	// them for its namespace/image ACL checks, which would otherwise fail open.
 	config := integration.Config{
 		Name:                    baseConfig.Name,
 		InitConfig:              baseConfig.InitConfig,
@@ -332,6 +371,8 @@ func (m *ksmShardingManager) createKSMConfigForResourceGroup(
 		IgnoreAutodiscoveryTags: baseConfig.IgnoreAutodiscoveryTags,
 		MetricsExcluded:         baseConfig.MetricsExcluded,
 		LogsExcluded:            baseConfig.LogsExcluded,
+		PodNamespace:            baseConfig.PodNamespace,
+		ImageName:               baseConfig.ImageName,
 	}
 
 	// Parse the shardable instance config (not necessarily Instances[0])

--- a/pkg/clusteragent/clusterchecks/ksm_sharding_test.go
+++ b/pkg/clusteragent/clusterchecks/ksm_sharding_test.go
@@ -358,6 +358,29 @@ func TestCreateShardedKSMConfigs_PreservesTags(t *testing.T) {
 	}
 }
 
+// TestCreateShardedKSMConfigs_PreservesSecretResolutionContext guards against
+// createKSMConfigForResourceGroup silently dropping PodNamespace/ImageName.
+// comp/core/autodiscovery/impl/configmgr.go resolves secrets on a sharded
+// config directly (it's not a template), passing these two fields into
+// secrets.Component.Resolve for its namespace/image ACL checks — dropping
+// them makes that check fail open on the runner instead of enforcing it.
+func TestCreateShardedKSMConfigs_PreservesSecretResolutionContext(t *testing.T) {
+	manager := newKSMShardingManager(true)
+
+	config := createKSMConfig([]string{"pods", "nodes"})
+	config.PodNamespace = "some-namespace"
+	config.ImageName = "some-image"
+
+	configs, err := manager.createShardedKSMConfigs(config)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(configs))
+
+	for _, shardConfig := range configs {
+		assert.Equal(t, "some-namespace", shardConfig.PodNamespace)
+		assert.Equal(t, "some-image", shardConfig.ImageName)
+	}
+}
+
 func TestShouldShardKSMCheck_MultipleInstances(t *testing.T) {
 	manager := newKSMShardingManager(true)
 	config := createKSMConfigWithMultipleInstances()
@@ -468,6 +491,75 @@ func TestCreateShardedKSMConfigs_AggregateFallbackNoPods(t *testing.T) {
 	assert.True(t, standaloneAggregate, "aggregate dispatched standalone when there is no pods shard")
 }
 
+// TestCreateShardedKSMConfigs_PodsGroup_WarnsOnNonSuppression: WITH a pods
+// group, a non-suppressing shardable is a certain .total double-count — ERROR.
+func TestCreateShardedKSMConfigs_PodsGroup_WarnsOnNonSuppression(t *testing.T) {
+	manager := newKSMShardingManager(true)
+	config := createKSMConfigWithAggregateAndSuppression([]string{"pods", "nodes"}, false)
+
+	message, isError, ok := diagnosticFor(t, manager, config)
+	assert.False(t, ok)
+	assert.True(t, isError, "a genuine pods group must be a certain double-count, not downgraded to a warning")
+	assert.Contains(t, message, "will not suppress its own .total")
+
+	_, err := manager.createShardedKSMConfigs(config)
+	require.NoError(t, err)
+}
+
+// TestCreateShardedKSMConfigs_SafeNoPodsCollectors_WarnsNotErrors: with
+// collectors that are always available (nodes, deployments — ordinary
+// built-in resources), no shard will ever build pods_extended, so the
+// standalone aggregate really is the only .total source. A non-suppressing
+// shardable here is a conditional risk, not a certainty — WARN, not ERROR.
+func TestCreateShardedKSMConfigs_SafeNoPodsCollectors_WarnsNotErrors(t *testing.T) {
+	manager := newKSMShardingManager(true)
+	config := createKSMConfigWithAggregateAndSuppression([]string{"nodes", "deployments"}, false)
+
+	message, isError, ok := diagnosticFor(t, manager, config)
+	assert.False(t, ok)
+	assert.False(t, isError, "no pods group and always-available collectors means this isn't a certain double-count")
+	assert.Contains(t, message, "will not suppress its own .total")
+
+	configs, err := manager.createShardedKSMConfigs(config)
+	require.NoError(t, err)
+	require.Len(t, configs, 3, "nodes shard + others shard + standalone aggregate")
+}
+
+// TestCreateShardedKSMConfigs_UnavailableCollectorRisk_WarnsOnNonSuppression:
+// a shardable with no "pods" collector still gets the suppression diagnostic
+// (as a WARN, not silence). kubernetes_state.go's Configure() filters the
+// configured collectors against what the live API server actually exposes and
+// falls back to the full default set (including "pods") if that filtering
+// empties the list — e.g. an "others" shard whose only collector is a CRD
+// resource that isn't installed yet. That collapse happens on the runner,
+// invisible to this static analysis, so the diagnostic can't be silenced just
+// because none of the analyzed groups is named "pods".
+func TestCreateShardedKSMConfigs_UnavailableCollectorRisk_WarnsOnNonSuppression(t *testing.T) {
+	manager := newKSMShardingManager(true)
+	config := createKSMConfigWithAggregateAndSuppression([]string{"nodes", "unavailable-resource"}, false)
+
+	message, _, ok := diagnosticFor(t, manager, config)
+	assert.False(t, ok)
+	assert.Contains(t, message, "will not suppress its own .total",
+		"the 'others' shard's only collector could be filtered out by the runner and fall back to full defaults (including pods) — this risk must still surface")
+
+	configs, err := manager.createShardedKSMConfigs(config)
+	require.NoError(t, err)
+	require.Len(t, configs, 3, "nodes shard + others shard (unavailable-resource) + standalone aggregate")
+}
+
+// diagnosticFor re-derives the shardable+groups from config and calls
+// suppressionDiagnostic directly, so severity/wording can be asserted without
+// capturing actual log output.
+func diagnosticFor(t *testing.T, manager *ksmShardingManager, config integration.Config) (message string, isError bool, ok bool) {
+	t.Helper()
+	shardable, _, err := classifyKSMInstances(config)
+	require.NoError(t, err)
+	groups, err := manager.analyzeKSMConfig(shardable)
+	require.NoError(t, err)
+	return suppressionDiagnostic(shardable, groups)
+}
+
 // TestCreateShardedKSMConfigs_AggregateFirstOrdering guards order-independence:
 // the shardable instance must be used as the shard base even when the
 // cluster_aggregates_only instance is listed first. If the sharder regressed to
@@ -539,10 +631,17 @@ func mustYAML(m map[string]interface{}) integration.Data {
 // cluster_unassigned instance (given collectors) plus a cluster_aggregates_only
 // instance — the "one config, both features" shape.
 func createKSMConfigWithAggregate(shardableCollectors []string) integration.Config {
+	return createKSMConfigWithAggregateAndSuppression(shardableCollectors, true)
+}
+
+// createKSMConfigWithAggregateAndSuppression is like createKSMConfigWithAggregate
+// but lets the caller control whether the shardable instance suppresses .total,
+// to exercise the non-suppressing (misconfigured) case.
+func createKSMConfigWithAggregateAndSuppression(shardableCollectors []string, suppress bool) integration.Config {
 	shardable := map[string]interface{}{
 		"collectors":                 shardableCollectors,
 		"pod_collection_mode":        "cluster_unassigned",
-		"cluster_aggregates_enabled": true,
+		"cluster_aggregates_enabled": suppress,
 	}
 	aggregate := map[string]interface{}{
 		"pod_collection_mode": "cluster_aggregates_only",

--- a/pkg/clusteragent/clusterchecks/ksm_sharding_test.go
+++ b/pkg/clusteragent/clusterchecks/ksm_sharding_test.go
@@ -110,14 +110,6 @@ func TestAnalyzeKSMConfig(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "not a KSM check",
-			config: integration.Config{
-				Name: "prometheus",
-			},
-			expectedGroups: nil,
-			expectError:    true,
-		},
-		{
 			name: "cluster_check is false - analyzeKSMConfig doesn't validate ClusterCheck",
 			config: integration.Config{
 				Name:         "kubernetes_state_core",
@@ -130,17 +122,14 @@ func TestAnalyzeKSMConfig(t *testing.T) {
 			},
 			expectError: false,
 		},
-		{
-			name:           "multiple instances - returns error",
-			config:         createKSMConfigWithMultipleInstances(),
-			expectedGroups: nil,
-			expectError:    true,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			groups, err := manager.analyzeKSMConfig(tt.config)
+			shardable, _, err := classifyKSMInstances(tt.config)
+			require.NoError(t, err)
+
+			groups, err := manager.analyzeKSMConfig(shardable)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -164,9 +153,10 @@ func TestAnalyzeKSMConfig_EmptyCollectors(t *testing.T) {
 	// When collectors is empty, should use options.DefaultResources which includes:
 	// pods, nodes, deployments, services, configmaps, secrets, etc.
 	// Should create 3 groups: pods, nodes, others
-	config := createKSMConfig([]string{})
+	shardable, _, err := classifyKSMInstances(createKSMConfig([]string{}))
+	require.NoError(t, err)
 
-	groups, err := manager.analyzeKSMConfig(config)
+	groups, err := manager.analyzeKSMConfig(shardable)
 	require.NoError(t, err)
 
 	// Should have 3 groups: pods, nodes, others
@@ -372,9 +362,149 @@ func TestShouldShardKSMCheck_MultipleInstances(t *testing.T) {
 	manager := newKSMShardingManager(true)
 	config := createKSMConfigWithMultipleInstances()
 
-	// Should return false and log warning about multiple instances
+	// Two shardable instances is still unsupported -> should not shard
 	result := manager.shouldShardKSMCheck(config)
-	assert.False(t, result, "Should not shard when multiple instances configured")
+	assert.False(t, result, "Should not shard when multiple shardable instances configured")
+}
+
+func TestClassifyKSMInstances(t *testing.T) {
+	t.Run("single shardable, no aggregate", func(t *testing.T) {
+		shardable, passthrough, err := classifyKSMInstances(createKSMConfig([]string{"pods", "nodes"}))
+		require.NoError(t, err)
+		assert.NotNil(t, shardable)
+		assert.Empty(t, passthrough)
+	})
+
+	t.Run("shardable + aggregate", func(t *testing.T) {
+		shardable, passthrough, err := classifyKSMInstances(createKSMConfigWithAggregate([]string{"pods", "nodes", "deployments"}))
+		require.NoError(t, err)
+		assert.NotNil(t, shardable)
+		require.Len(t, passthrough, 1)
+	})
+
+	t.Run("aggregate only -> no shardable instance", func(t *testing.T) {
+		cfg := integration.Config{
+			Name:         "kubernetes_state_core",
+			ClusterCheck: true,
+			Instances:    []integration.Data{mustYAML(map[string]interface{}{"pod_collection_mode": "cluster_aggregates_only"})},
+		}
+		_, _, err := classifyKSMInstances(cfg)
+		assert.Error(t, err)
+	})
+
+	t.Run("two shardable -> error", func(t *testing.T) {
+		_, _, err := classifyKSMInstances(createKSMConfigWithMultipleInstances())
+		assert.Error(t, err)
+	})
+}
+
+func TestShouldShardKSMCheck_WithAggregate(t *testing.T) {
+	manager := newKSMShardingManager(true)
+	cfg := createKSMConfigWithAggregate([]string{"pods", "nodes", "deployments"})
+	assert.True(t, manager.shouldShardKSMCheck(cfg), "combined instance + cluster_aggregates_only should still shard")
+}
+
+// TestCreateShardedKSMConfigs_WithAggregate: a combined cluster_unassigned instance
+// plus a cluster_aggregates_only instance shards into pods/nodes/others (3 configs),
+// with the aggregate instance riding on the pods shard (not a separate 4th config).
+func TestCreateShardedKSMConfigs_WithAggregate(t *testing.T) {
+	manager := newKSMShardingManager(true)
+	cfg := createKSMConfigWithAggregate([]string{"pods", "nodes", "deployments", "services"})
+
+	configs, err := manager.createShardedKSMConfigs(cfg)
+	require.NoError(t, err)
+	require.Len(t, configs, 3, "pods/nodes/others; aggregate rides the pods shard")
+
+	aggregateCount := 0
+	shardCount := 0
+	var podsShard *integration.Config
+	for i := range configs {
+		assert.Equal(t, "kubernetes_state_core", configs[i].Name)
+		for _, raw := range configs[i].Instances {
+			var inst map[string]interface{}
+			require.NoError(t, yaml.Unmarshal(raw, &inst))
+			if inst["pod_collection_mode"] == "cluster_aggregates_only" {
+				aggregateCount++
+				assert.Equal(t, true, inst["skip_leader_election"], "aggregate must skip leader election on a runner")
+				continue
+			}
+			// Shards must keep suppressing their own .total. Unguarded on purpose:
+			// if a regression dropped the instance keys, pod_collection_mode is nil
+			// here and this fails instead of silently skipping.
+			shardCount++
+			assert.Equal(t, "cluster_unassigned", inst["pod_collection_mode"], "shards must preserve pod_collection_mode")
+			assert.Equal(t, true, inst["cluster_aggregates_enabled"], "shards must preserve cluster_aggregates_enabled")
+			if cols, ok := inst["collectors"].([]interface{}); ok && len(cols) == 1 && cols[0] == "pods" {
+				podsShard = &configs[i]
+			}
+		}
+	}
+
+	assert.Equal(t, 1, aggregateCount, "aggregate instance must appear exactly once")
+	assert.Equal(t, 3, shardCount, "pods/nodes/others shards must all derive from the shardable instance")
+	require.NotNil(t, podsShard, "a pods shard must exist")
+	assert.Len(t, podsShard.Instances, 2, "pods shard carries cluster_unassigned pods + cluster_aggregates_only")
+}
+
+// TestCreateShardedKSMConfigs_AggregateFallbackNoPods: if the shardable instance has
+// no pods collector, the aggregate is dispatched as its own config (not dropped).
+func TestCreateShardedKSMConfigs_AggregateFallbackNoPods(t *testing.T) {
+	manager := newKSMShardingManager(true)
+	configs, err := manager.createShardedKSMConfigs(createKSMConfigWithAggregate([]string{"nodes", "deployments"}))
+	require.NoError(t, err)
+	require.Len(t, configs, 3, "nodes shard + others shard + standalone aggregate")
+
+	standaloneAggregate := false
+	for _, c := range configs {
+		if len(c.Instances) == 1 {
+			var inst map[string]interface{}
+			_ = yaml.Unmarshal(c.Instances[0], &inst)
+			if inst["pod_collection_mode"] == "cluster_aggregates_only" {
+				standaloneAggregate = true
+				assert.Equal(t, true, inst["skip_leader_election"], "standalone aggregate must skip leader election on a runner")
+			}
+		}
+	}
+	assert.True(t, standaloneAggregate, "aggregate dispatched standalone when there is no pods shard")
+}
+
+// TestCreateShardedKSMConfigs_AggregateFirstOrdering guards order-independence:
+// the shardable instance must be used as the shard base even when the
+// cluster_aggregates_only instance is listed first. If the sharder regressed to
+// baseConfig.Instances[0], it would shard the aggregate (which has no collectors)
+// and this would fail.
+func TestCreateShardedKSMConfigs_AggregateFirstOrdering(t *testing.T) {
+	manager := newKSMShardingManager(true)
+	aggregate := map[string]interface{}{"pod_collection_mode": "cluster_aggregates_only"}
+	shardable := map[string]interface{}{
+		"collectors":                 []string{"pods", "nodes", "deployments"},
+		"pod_collection_mode":        "cluster_unassigned",
+		"cluster_aggregates_enabled": true,
+	}
+	cfg := integration.Config{
+		Name:         "kubernetes_state_core",
+		ClusterCheck: true,
+		Instances:    []integration.Data{mustYAML(aggregate), mustYAML(shardable)}, // aggregate FIRST
+	}
+
+	configs, err := manager.createShardedKSMConfigs(cfg)
+	require.NoError(t, err)
+	require.Len(t, configs, 3, "must shard the cluster_unassigned instance, not the aggregate")
+
+	// Every shard's shardable instance must carry cluster_unassigned collectors,
+	// proving Instances[0] (the aggregate) was not used as the shard base.
+	sawUnassigned := false
+	for _, c := range configs {
+		for _, raw := range c.Instances {
+			var inst map[string]interface{}
+			require.NoError(t, yaml.Unmarshal(raw, &inst))
+			if inst["pod_collection_mode"] == "cluster_unassigned" {
+				sawUnassigned = true
+				assert.Contains(t, inst, "collectors")
+			}
+		}
+	}
+	assert.True(t, sawUnassigned, "shards must be built from the cluster_unassigned instance")
 }
 
 // Helper functions
@@ -400,6 +530,30 @@ func createKSMConfigWithTags(collectors []string, tags []string) integration.Con
 	}
 }
 
+func mustYAML(m map[string]interface{}) integration.Data {
+	data, _ := yaml.Marshal(m)
+	return integration.Data(data)
+}
+
+// createKSMConfigWithAggregate builds a single config with a shardable
+// cluster_unassigned instance (given collectors) plus a cluster_aggregates_only
+// instance — the "one config, both features" shape.
+func createKSMConfigWithAggregate(shardableCollectors []string) integration.Config {
+	shardable := map[string]interface{}{
+		"collectors":                 shardableCollectors,
+		"pod_collection_mode":        "cluster_unassigned",
+		"cluster_aggregates_enabled": true,
+	}
+	aggregate := map[string]interface{}{
+		"pod_collection_mode": "cluster_aggregates_only",
+	}
+	return integration.Config{
+		Name:         "kubernetes_state_core",
+		ClusterCheck: true,
+		Instances:    []integration.Data{mustYAML(shardable), mustYAML(aggregate)},
+	}
+}
+
 func createKSMConfigWithMultipleInstances() integration.Config {
 	// Create first instance with pods and nodes
 	instance1 := map[string]interface{}{
@@ -418,4 +572,58 @@ func createKSMConfigWithMultipleInstances() integration.Config {
 		Instances:    []integration.Data{integration.Data(data1), integration.Data(data2)},
 		ClusterCheck: true,
 	}
+}
+
+// TestShardableSuppressesTotal covers the predicate behind the double-emit
+// diagnostic: when a cluster_aggregates_only instance is present, the shardable
+// instance must be cluster_unassigned AND have cluster_aggregates_enabled set,
+// otherwise both emit .total and the family is double-counted.
+func TestShardableSuppressesTotal(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		instance map[string]interface{}
+		wantMode string
+		wantFlag bool
+		wantOK   bool
+	}{
+		{
+			name:     "cluster_unassigned with flag suppresses",
+			instance: map[string]interface{}{"pod_collection_mode": "cluster_unassigned", "cluster_aggregates_enabled": true},
+			wantMode: "cluster_unassigned", wantFlag: true, wantOK: true,
+		},
+		{
+			name:     "cluster_unassigned without flag does not suppress",
+			instance: map[string]interface{}{"pod_collection_mode": "cluster_unassigned"},
+			wantMode: "cluster_unassigned", wantFlag: false, wantOK: false,
+		},
+		{
+			name:     "flag set but default mode does not suppress",
+			instance: map[string]interface{}{"cluster_aggregates_enabled": true},
+			wantMode: "", wantFlag: true, wantOK: false,
+		},
+		{
+			name:     "node_kubelet with flag is not a valid shardable and does not suppress here",
+			instance: map[string]interface{}{"pod_collection_mode": "node_kubelet", "cluster_aggregates_enabled": true},
+			wantMode: "node_kubelet", wantFlag: true, wantOK: false,
+		},
+		{
+			name:     "flag explicitly false does not suppress",
+			instance: map[string]interface{}{"pod_collection_mode": "cluster_unassigned", "cluster_aggregates_enabled": false},
+			wantMode: "cluster_unassigned", wantFlag: false, wantOK: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mode, flag, ok := shardableSuppressesTotal(mustYAML(tc.instance))
+			assert.Equal(t, tc.wantMode, mode)
+			assert.Equal(t, tc.wantFlag, flag)
+			assert.Equal(t, tc.wantOK, ok)
+		})
+	}
+}
+
+// TestShardableSuppressesTotal_Unparseable: a malformed instance must report
+// "does not suppress" rather than silently claiming the config is safe.
+func TestShardableSuppressesTotal_Unparseable(t *testing.T) {
+	_, _, ok := shardableSuppressesTotal(integration.Data("pod_collection_mode: [not, a, string]"))
+	assert.False(t, ok, "unparseable instance must conservatively report not-suppressing")
 }

--- a/releasenotes-dca/notes/ksm-sharding-aggregates-coexist-b2c3d4e5f6a70819.yaml
+++ b/releasenotes-dca/notes/ksm-sharding-aggregates-coexist-b2c3d4e5f6a70819.yaml
@@ -1,0 +1,13 @@
+---
+enhancements:
+  - |
+    The cluster-agent KSM auto-sharding dispatcher
+    (``cluster_checks.ksm_sharding_enabled``) now supports a single
+    ``kubernetes_state_core`` config that combines a shardable
+    ``cluster_unassigned`` instance with a ``cluster_aggregates_only`` instance.
+    The ``cluster_unassigned`` instance is sharded by resource type
+    (pods/nodes/others) as before, and the ``cluster_aggregates_only`` instance
+    (which does a full-pod watch and cannot be sharded) is dispatched alongside
+    the pods shard. Previously such a multi-instance config disabled sharding.
+    This lets KSM auto-sharding and the cluster-aggregate ``.total`` fix be
+    enabled together from one config.


### PR DESCRIPTION
### What does this PR do?

Allows KSM auto-sharding to work when a single kubernetes_state_core configuration contains both:

- one shardable cluster_unassigned or default instance; and
- one or more pass-through cluster_aggregates_only instances.

The shardable instance is split into pods, nodes, and other resource groups as before. The aggregate-only instance is co-located with the pods shard so one Cluster Checks Runner handles the pod-related watches. If there is no pods shard, the aggregate instance is dispatched separately.

Generated shards preserve the original instance settings, including pod_collection_mode and cluster_aggregates_enabled. Potential double-emission configurations are dispatched with a warning rather than silently disabling sharding.

### Motivation

Previously, KSM auto-sharding only supported single-instance configurations. Adding the dedicated cluster_aggregates_only instance caused sharding to be silently disabled.

As a result, KSM auto-sharding and authoritative cluster-level .total metrics required separate configuration files. This change allows both features to be enabled from one configuration.

### Describe how you validated your changes

**Unit tests** — `dda inv test --targets=./pkg/clusteragent/clusterchecks` → 136/136 pass. New cases cover: classification, aggregate present/absent, the no-pods standalone fallback, aggregate-listed-first ordering (guards against regressing to `Instances[0]`), and two-shardable-instances rejection.

**e2e** 
Operator (DatadogAgent CR)

```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  features:
    kubeStateMetricsCore:
      enabled: true
      conf:
        configData: |-
          cluster_check: true
          init_config:
          instances:
            - collectors: [pods, nodes, deployments, services, configmaps]
              pod_collection_mode: cluster_unassigned
              cluster_aggregates_enabled: true
              skip_leader_election: true
            - pod_collection_mode: cluster_aggregates_only
              skip_leader_election: true
    clusterChecksRunner:
      enabled: true
  override:
    clusterAgent:
      replicas: 1
      env:
        - name: DD_CLUSTER_CHECKS_KSM_SHARDING_ENABLED
          value: "true"
    clusterChecksRunner:
      replicas: 3
    nodeAgent:
      extraConfd:
        configDataMap:
          kubernetes_state_core.yaml: |-
            init_config:
            instances:
              - collectors: [pods]
                pod_collection_mode: node_kubelet
                cluster_aggregates_enabled: true  

```

Helm
```
datadog:
  clusterName: ksm-sharding-test
  kubeStateMetricsEnabled: false      # disable the legacy python check
  kubeStateMetricsCore:
    enabled: true                     
    useClusterCheckRunners: true
  confd:                                # node agents → node_kubelet
    kubernetes_state_core.yaml: |-
      init_config:
      instances:
        - collectors: [pods]
          pod_collection_mode: node_kubelet
          cluster_aggregates_enabled: true      # node agents suppress .total

clusterAgent:
  replicas: 1
  env:
    - name: DD_CLUSTER_CHECKS_KSM_SHARDING_ENABLED
      value: "true"
  confd:
    kubernetes_state_core.yaml: |-
      cluster_check: true
      init_config:
      instances:
        # sharded into pods / nodes / others
        - collectors: [pods, nodes, deployments, services, configmaps]
          pod_collection_mode: cluster_unassigned
          cluster_aggregates_enabled: true
          skip_leader_election: true
        # never sharded; rides the pods shard
        - pod_collection_mode: cluster_aggregates_only
          skip_leader_election: true
```
Expected result: datadog-cluster-agent clusterchecks shows 3 kubernetes_state_core checks, the pods shard carries both instances.
```
datadog-cluster-agent clusterchecks — one kubernetes_state_core.yaml dispatched as 3 configs. The pods shard carries both instances:

===== Checks on datadog-cluster-checks-runner-5477bf9f8b-xfh6h =====

=== kubernetes_state_core check ===        # SHARD 1 — pods (2 instances)
Configuration source: file:/etc/datadog-agent/conf.d/kubernetes_state_core.yaml
Config for instance ID: kubernetes_state_core:73e6377b251aac2a
cluster_aggregates_enabled: true
collectors:
  - pods
pod_collection_mode: cluster_unassigned
skip_leader_election: true
~
Config for instance ID: kubernetes_state_core:c6d24f7fa4c3408c
collectors:
  - pods
min_collection_interval: 30
pod_collection_mode: cluster_aggregates_only
skip_leader_election: true
telemetry: true
~

=== kubernetes_state_core check ===        # SHARD 2 — nodes
Config for instance ID: kubernetes_state_core:9ff3577386c4cace
cluster_aggregates_enabled: true
collectors:
  - nodes
pod_collection_mode: cluster_unassigned
skip_leader_election: true
~

=== kubernetes_state_core check ===        # SHARD 3 — others (23 collectors)
Config for instance ID: ku1ca23db529
cluster_aggregates_enabled: true
collectors:
  - apiservices
  - configmaps
  - cronjobs
  - customresourcedefiniti
  ... (23 total)
pod_collection_mode: clust
skip_leader_election: true

```
Before: single shard
After this fix    - 3 shards, split pods / nodes / others
