### PR TITLE
[host profiler] enable ruby skip native resume by default

### DIFF
--- a/comp/host-profiler/collector/impl/receiver/config.go
+++ b/comp/host-profiler/collector/impl/receiver/config.go
@@ -87,7 +87,7 @@ func defaultConfig(profilerName string) component.Config {
 	// Default jitter is 20%, which makes sense for 5s intervals (~1s variation).
 	// With 60s intervals, 20% would mean ~12s variation, so we reduce to 5% (~3s).
 	cfg.ReporterJitter = 0.05
-
+	cfg.Interpreters.Ruby.SkipNativeResume = true
 	symbolUploaderConfig := symboluploader.DefaultSymbolUploaderConfig(profilerName)
 	return Config{
 		EbpfCollectorConfig: cfg,

--- a/comp/host-profiler/collector/impl/receiver/config.go
+++ b/comp/host-profiler/collector/impl/receiver/config.go
@@ -87,10 +87,7 @@ func defaultConfig(profilerName string) component.Config {
 	// Default jitter is 20%, which makes sense for 5s intervals (~1s variation).
 	// With 60s intervals, 20% would mean ~12s variation, so we reduce to 5% (~3s).
 	cfg.ReporterJitter = 0.05
-	// CRuby has lots of Ruby->native->Ruby transitions which runs out of ebpf tail calls very fast
-	// and captures only a small part of the stack. This config fixes this by skipping native frames
-	// (and tail calls) for Ruby methods implemented in C. Leaf native frames are still captured.
-	cfg.Interpreters.Ruby.SkipNativeResume = true
+
 	symbolUploaderConfig := symboluploader.DefaultSymbolUploaderConfig(profilerName)
 	return Config{
 		EbpfCollectorConfig: cfg,
@@ -105,5 +102,10 @@ func defaultInterpretersConfig() interpreterconfig.Config {
 	cfg.Go.Symbolization = interpreter.BaseConfig{Disabled: true}
 	//  Disable Labels by default. It will be enabled if ReporterConfig.CollectContext is true.
 	cfg.Go.Labels = interpreter.BaseConfig{Disabled: true}
+	// CRuby has lots of Ruby->native->Ruby transitions which runs out of ebpf tail calls very fast
+	// and captures only a small part of the stack. This config fixes this by skipping native frames
+	// (and tail calls) for Ruby methods implemented in C. Leaf native frames are still captured.
+	// See https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1335
+	cfg.Ruby.SkipNativeResume = true
 	return cfg
 }

--- a/comp/host-profiler/collector/impl/receiver/config.go
+++ b/comp/host-profiler/collector/impl/receiver/config.go
@@ -87,6 +87,9 @@ func defaultConfig(profilerName string) component.Config {
 	// Default jitter is 20%, which makes sense for 5s intervals (~1s variation).
 	// With 60s intervals, 20% would mean ~12s variation, so we reduce to 5% (~3s).
 	cfg.ReporterJitter = 0.05
+	// CRuby has lots of Ruby->native->Ruby transitions which runs out of ebpf tail calls very fast
+	// and captures only a small part of the stack. This config fixes this by skipping native frames
+	// (and tail calls) for Ruby methods implemented in C. Leaf native frames are still captured.
 	cfg.Interpreters.Ruby.SkipNativeResume = true
 	symbolUploaderConfig := symboluploader.DefaultSymbolUploaderConfig(profilerName)
 	return Config{


### PR DESCRIPTION
### What does this PR do?

leverages [new ruby interpreter option](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1335) to avoid reporting profiles like https://ddstaging.datadoghq.com/profiling/explorer?query=service%3Arp-ruby-gitlab&agg_m=%40prof_ruby_global_lock_wait_time_total&agg_m_source=base&agg_q=service&agg_q_source=base&agg_t=sum&color_by=self&fromUser=true&my_code=enabled&profile_type=ebpf-cpu-time&refresh_mode=paused&top_n=100&top_o=top&viz=flame_graph&x_missing=true&from_ts=1785056135937&to_ts=1785142535937&live=false

### Motivation

### Describe how you validated your changes

### Additional Notes
