### PR TITLE
allow configmap collection in otel

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
@@ -580,7 +580,7 @@ func buildCommonTags() []string {
 // for security or data sensitivity reasons. This matches the behavior of the orchestrator
 // collector which skips secrets and configmaps as they can contain sensitive data.
 func shouldSkipResourceKind(kind string, group string) bool {
-	if group == "v1" && (strings.ToLower(kind) == "secret" || strings.ToLower(kind) == "configmap") {
+	if group == "v1" && strings.ToLower(kind) == "secret" {
 		return true
 	}
 


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Datadog agent starts to collect configmap in PR https://github.com/DataDog/datadog-agent/pull/52659

In datadog exporter for OTel, we should have the same behavior.

