### PR TITLE
Run e2e install-script test on installer package changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -772,6 +772,17 @@ workflow:
   - <<: *if_installer_tests
   - <<: *on_build_changes
 
+.on_linux_installer_package_changes:
+  - !reference [.except_mergequeue]
+  - <<: *if_disable_e2e_tests
+    when: never
+  - changes:
+      paths:
+        - pkg/fleet/installer/packages/**/*
+        - omnibus/package-scripts/agent-*/**/*
+      compare_to: $COMPARE_TO_BRANCH
+    when: on_success
+
 # Specific rules for each e2e test type
 .on_install_script_tests:
   - !reference [.except_mergequeue]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -771,11 +771,6 @@ workflow:
     when: never
   - <<: *if_installer_tests
   - <<: *on_build_changes
-
-.on_linux_installer_package_changes:
-  - !reference [.except_mergequeue]
-  - <<: *if_disable_e2e_tests
-    when: never
   - changes:
       paths:
         - pkg/fleet/installer/packages/**/*

--- a/.gitlab/test/e2e_install_packages/ubuntu.yml
+++ b/.gitlab/test/e2e_install_packages/ubuntu.yml
@@ -34,8 +34,7 @@ new-e2e-agent-platform-install-script-ubuntu-a7-arm64:
     - .new-e2e_ubuntu_a7_arm64
     - .new-e2e_agent_a7
   rules:
-    - !reference [.on_linux_installer_package_changes]
-    - !reference [.on_all_install_script_tests]
+    !reference [.on_all_install_script_tests]
   variables:
     FLAVOR: datadog-agent
 

--- a/.gitlab/test/e2e_install_packages/ubuntu.yml
+++ b/.gitlab/test/e2e_install_packages/ubuntu.yml
@@ -34,7 +34,8 @@ new-e2e-agent-platform-install-script-ubuntu-a7-arm64:
     - .new-e2e_ubuntu_a7_arm64
     - .new-e2e_agent_a7
   rules:
-    !reference [.on_all_install_script_tests]
+    - !reference [.on_linux_installer_package_changes]
+    - !reference [.on_all_install_script_tests]
   variables:
     FLAVOR: datadog-agent
 


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

 ### What does this PR do?

  Runs the [Agent install-script](https://github.com/DataDog/datadog-agent/blob/main/test/new-e2e/tests/agent-platform/tests/install_script_test.go) e2e job when Linux installer package hooks or Agent package scripts change.

  ### Motivation

  Catches uninstall/package-ownership regressions like generated files left under `/opt/datadog-agent` before they reach main.

  ### Describe how you validated your changes

  ### Additional Notes


#incident-58217