### PR TITLE
[DADP-159] Track Agent Data Plane in the procmgr COAT catalog

### DIFF
--- a/pkg/procmgr/coat/BUILD.bazel
+++ b/pkg/procmgr/coat/BUILD.bazel
@@ -133,6 +133,11 @@ go_test(
             "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
         ],
+        "@rules_go//go/platform:windows": [
+            "//pkg/proto/pbgo/procmgr",
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
         "@rules_go//go/platform:linux": [
             "//pkg/proto/pbgo/procmgr",
             "@com_github_stretchr_testify//assert",

--- a/pkg/procmgr/coat/BUILD.bazel
+++ b/pkg/procmgr/coat/BUILD.bazel
@@ -123,6 +123,11 @@ go_test(
             "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
         ],
+        "@rules_go//go/platform:darwin": [
+            "//pkg/proto/pbgo/procmgr",
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
         "@rules_go//go/platform:linux": [
             "//pkg/proto/pbgo/procmgr",
             "@com_github_stretchr_testify//assert",

--- a/pkg/procmgr/coat/BUILD.bazel
+++ b/pkg/procmgr/coat/BUILD.bazel
@@ -117,32 +117,9 @@ go_test(
     srcs = ["collector_test.go"],
     embed = [":coat"],
     gotags = ["test"],
-    deps = select({
-        "@rules_go//go/platform:android": [
-            "//pkg/proto/pbgo/procmgr",
-            "@com_github_stretchr_testify//assert",
-            "@com_github_stretchr_testify//require",
-        ],
-        "@rules_go//go/platform:darwin": [
-            "//pkg/proto/pbgo/procmgr",
-            "@com_github_stretchr_testify//assert",
-            "@com_github_stretchr_testify//require",
-        ],
-        "@rules_go//go/platform:osx": [
-            "//pkg/proto/pbgo/procmgr",
-            "@com_github_stretchr_testify//assert",
-            "@com_github_stretchr_testify//require",
-        ],
-        "@rules_go//go/platform:windows": [
-            "//pkg/proto/pbgo/procmgr",
-            "@com_github_stretchr_testify//assert",
-            "@com_github_stretchr_testify//require",
-        ],
-        "@rules_go//go/platform:linux": [
-            "//pkg/proto/pbgo/procmgr",
-            "@com_github_stretchr_testify//assert",
-            "@com_github_stretchr_testify//require",
-        ],
-        "//conditions:default": [],
-    }),
+    deps = [
+        "//pkg/proto/pbgo/procmgr",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/procmgr/coat/BUILD.bazel
+++ b/pkg/procmgr/coat/BUILD.bazel
@@ -128,6 +128,11 @@ go_test(
             "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
         ],
+        "@rules_go//go/platform:osx": [
+            "//pkg/proto/pbgo/procmgr",
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
         "@rules_go//go/platform:linux": [
             "//pkg/proto/pbgo/procmgr",
             "@com_github_stretchr_testify//assert",

--- a/pkg/procmgr/coat/collector_test.go
+++ b/pkg/procmgr/coat/collector_test.go
@@ -146,16 +146,6 @@ func TestCollectServiceProcmgrRunning(t *testing.T) {
 func TestCollectADPProcmgrRunning(t *testing.T) {
 	adp, ok := serviceByID("agent-data-plane")
 	require.True(t, ok)
-	assert.Equal(t, "datadog-agent-data-plane", adp.ProcmgrProcessName)
-	assert.Equal(t, "datadog-agent-data-plane.yaml", adp.ProcmgrConfigFile)
-	assert.Equal(t, []string{
-		"embedded/bin/agent-data-plane",
-		"bin/agent/agent-data-plane",
-	}, adp.InstallMarkerRels)
-	assert.Equal(t, []string{
-		"datadog-agent-data-plane.service",
-		"datadog-agent-data-plane-exp.service",
-	}, adp.LegacySystemdUnits)
 
 	root := t.TempDir()
 	marker := installMarkerForTest(t, root, adp, 0)

--- a/pkg/procmgr/coat/collector_test.go
+++ b/pkg/procmgr/coat/collector_test.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
-//go:build linux || darwin
-
 package coat
 
 import (
@@ -73,6 +71,14 @@ func serviceSnapshotByID(t *testing.T, snapshot Snapshot, id string) ServiceSnap
 	return ServiceSnapshot{}
 }
 
+func installMarkerForTest(t *testing.T, root string, service MigratableService, index int) string {
+	t.Helper()
+
+	markers := installMarkerPaths(root, service)
+	require.Greater(t, len(markers), index)
+	return markers[index]
+}
+
 func setupDDOTInstallFixture(t *testing.T) string {
 	t.Helper()
 
@@ -80,7 +86,7 @@ func setupDDOTInstallFixture(t *testing.T) string {
 	require.True(t, ok)
 
 	root := t.TempDir()
-	marker := filepath.Join(root, ddot.InstallMarkerRels[0])
+	marker := installMarkerForTest(t, root, ddot, 0)
 	require.NoError(t, os.MkdirAll(filepath.Dir(marker), 0o755))
 	require.NoError(t, os.WriteFile(marker, []byte("bin"), 0o644))
 	require.NoError(t, os.MkdirAll(filepath.Join(root, processesDirRel), 0o755))
@@ -97,7 +103,7 @@ func TestCollectInstalledViaStandaloneMarkerOnly(t *testing.T) {
 	require.True(t, ok)
 
 	root := t.TempDir()
-	standalone := filepath.Join(root, ddot.InstallMarkerRels[1])
+	standalone := installMarkerForTest(t, root, ddot, 1)
 	require.NoError(t, os.MkdirAll(filepath.Dir(standalone), 0o755))
 	require.NoError(t, os.WriteFile(standalone, []byte("bin"), 0o644))
 	require.NoError(t, os.MkdirAll(filepath.Join(root, processesDirRel), 0o755))
@@ -152,7 +158,7 @@ func TestCollectADPProcmgrRunning(t *testing.T) {
 	}, adp.LegacySystemdUnits)
 
 	root := t.TempDir()
-	marker := filepath.Join(root, "embedded", "bin", "agent-data-plane")
+	marker := installMarkerForTest(t, root, adp, 0)
 	require.NoError(t, os.MkdirAll(filepath.Dir(marker), 0o755))
 	require.NoError(t, os.WriteFile(marker, []byte("bin"), 0o644))
 	require.NoError(t, os.MkdirAll(filepath.Join(root, processesDirRel), 0o755))
@@ -236,7 +242,7 @@ func TestCollectProcmgrConfigAbsent(t *testing.T) {
 	require.True(t, ok)
 
 	root := t.TempDir()
-	marker := filepath.Join(root, ddot.InstallMarkerRels[0])
+	marker := installMarkerForTest(t, root, ddot, 0)
 	require.NoError(t, os.MkdirAll(filepath.Dir(marker), 0o755))
 	require.NoError(t, os.WriteFile(marker, []byte("bin"), 0o644))
 

--- a/pkg/procmgr/coat/collector_test.go
+++ b/pkg/procmgr/coat/collector_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
-//go:build linux
+//go:build linux || darwin
 
 package coat
 
@@ -61,16 +61,31 @@ func (s *mockSession) Disconnect() error {
 	return nil
 }
 
+func serviceSnapshotByID(t *testing.T, snapshot Snapshot, id string) ServiceSnapshot {
+	t.Helper()
+
+	for _, service := range snapshot.Services {
+		if service.ID == id {
+			return service
+		}
+	}
+	require.Failf(t, "missing service snapshot", "service %q was not collected", id)
+	return ServiceSnapshot{}
+}
+
 func setupDDOTInstallFixture(t *testing.T) string {
 	t.Helper()
 
+	ddot, ok := serviceByID("ddot")
+	require.True(t, ok)
+
 	root := t.TempDir()
-	marker := filepath.Join(root, migratableServices[0].InstallMarkerRels[0])
+	marker := filepath.Join(root, ddot.InstallMarkerRels[0])
 	require.NoError(t, os.MkdirAll(filepath.Dir(marker), 0o755))
 	require.NoError(t, os.WriteFile(marker, []byte("bin"), 0o644))
 	require.NoError(t, os.MkdirAll(filepath.Join(root, processesDirRel), 0o755))
 	require.NoError(t, os.WriteFile(
-		filepath.Join(root, processesDirRel, migratableServices[0].ProcmgrConfigFile),
+		filepath.Join(root, processesDirRel, ddot.ProcmgrConfigFile),
 		[]byte("cfg"),
 		0o644,
 	))
@@ -78,13 +93,16 @@ func setupDDOTInstallFixture(t *testing.T) string {
 }
 
 func TestCollectInstalledViaStandaloneMarkerOnly(t *testing.T) {
+	ddot, ok := serviceByID("ddot")
+	require.True(t, ok)
+
 	root := t.TempDir()
-	standalone := filepath.Join(root, migratableServices[0].InstallMarkerRels[1])
+	standalone := filepath.Join(root, ddot.InstallMarkerRels[1])
 	require.NoError(t, os.MkdirAll(filepath.Dir(standalone), 0o755))
 	require.NoError(t, os.WriteFile(standalone, []byte("bin"), 0o644))
 	require.NoError(t, os.MkdirAll(filepath.Join(root, processesDirRel), 0o755))
 	require.NoError(t, os.WriteFile(
-		filepath.Join(root, processesDirRel, migratableServices[0].ProcmgrConfigFile),
+		filepath.Join(root, processesDirRel, ddot.ProcmgrConfigFile),
 		[]byte("cfg"),
 		0o644,
 	))
@@ -92,8 +110,8 @@ func TestCollectInstalledViaStandaloneMarkerOnly(t *testing.T) {
 	collector := NewCollectorWithClient(root, &mockClient{})
 
 	snapshot := collector.Collect(context.Background())
-	require.Len(t, snapshot.Services, 1)
-	assert.True(t, snapshot.Services[0].Installed,
+	service := serviceSnapshotByID(t, snapshot, "ddot")
+	assert.True(t, service.Installed,
 		"standalone datadog-agent-ddot layout uses embedded/bin/otel-agent without ext/ddot")
 }
 
@@ -108,9 +126,8 @@ func TestCollectServiceProcmgrRunning(t *testing.T) {
 	})
 
 	snapshot := collector.Collect(context.Background())
-	require.Len(t, snapshot.Services, 1)
 
-	service := snapshot.Services[0]
+	service := serviceSnapshotByID(t, snapshot, "ddot")
 	assert.Equal(t, "ddot", service.ID)
 	assert.True(t, service.Installed)
 	assert.True(t, service.ProcmgrConfigured)
@@ -118,6 +135,48 @@ func TestCollectServiceProcmgrRunning(t *testing.T) {
 	assert.Equal(t, ManagementModeProcmgr, service.ManagementMode)
 	assert.True(t, snapshot.Daemon.Reachable)
 	assert.True(t, snapshot.Daemon.Ready)
+}
+
+func TestCollectADPProcmgrRunning(t *testing.T) {
+	adp, ok := serviceByID("agent-data-plane")
+	require.True(t, ok)
+	assert.Equal(t, "datadog-agent-data-plane", adp.ProcmgrProcessName)
+	assert.Equal(t, "datadog-agent-data-plane.yaml", adp.ProcmgrConfigFile)
+	assert.Equal(t, []string{
+		"embedded/bin/agent-data-plane",
+		"bin/agent/agent-data-plane",
+	}, adp.InstallMarkerRels)
+	assert.Equal(t, []string{
+		"datadog-agent-data-plane.service",
+		"datadog-agent-data-plane-exp.service",
+	}, adp.LegacySystemdUnits)
+
+	root := t.TempDir()
+	marker := filepath.Join(root, "embedded", "bin", "agent-data-plane")
+	require.NoError(t, os.MkdirAll(filepath.Dir(marker), 0o755))
+	require.NoError(t, os.WriteFile(marker, []byte("bin"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, processesDirRel), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, processesDirRel, "datadog-agent-data-plane.yaml"),
+		[]byte("cfg"),
+		0o644,
+	))
+
+	collector := NewCollectorWithClient(root, &mockClient{
+		daemon: DaemonSnapshot{Reachable: true, Ready: true, RunningProcesses: 1},
+		processes: map[string]ProcessSnapshot{
+			"datadog-agent-data-plane": {Name: "datadog-agent-data-plane", State: pb.ProcessState_RUNNING},
+		},
+	})
+
+	snapshot := collector.Collect(context.Background())
+
+	service := serviceSnapshotByID(t, snapshot, "agent-data-plane")
+	assert.Equal(t, "agent-data-plane", service.ID)
+	assert.True(t, service.Installed)
+	assert.True(t, service.ProcmgrConfigured)
+	assert.Equal(t, pb.ProcessState_RUNNING, service.ProcmgrState)
+	assert.Equal(t, ManagementModeProcmgr, service.ManagementMode)
 }
 
 func TestCollectServiceProcmgrNotRunningStillManaged(t *testing.T) {
@@ -130,9 +189,8 @@ func TestCollectServiceProcmgrNotRunningStillManaged(t *testing.T) {
 	})
 
 	snapshot := collector.Collect(context.Background())
-	require.Len(t, snapshot.Services, 1)
 
-	service := snapshot.Services[0]
+	service := serviceSnapshotByID(t, snapshot, "ddot")
 	assert.Equal(t, ManagementModeProcmgr, service.ManagementMode)
 	assert.Equal(t, pb.ProcessState_STARTING, service.ProcmgrState)
 }
@@ -143,9 +201,8 @@ func TestCollectNoProcmgrNoLegacy(t *testing.T) {
 	collector := NewCollectorWithClient(root, &mockClient{})
 
 	snapshot := collector.Collect(context.Background())
-	require.Len(t, snapshot.Services, 1)
 
-	service := snapshot.Services[0]
+	service := serviceSnapshotByID(t, snapshot, "ddot")
 	assert.False(t, service.Installed)
 	assert.False(t, service.ProcmgrConfigured)
 	assert.Equal(t, ManagementModeNone, service.ManagementMode)
@@ -153,10 +210,13 @@ func TestCollectNoProcmgrNoLegacy(t *testing.T) {
 }
 
 func TestCollectInstallMarkerAbsent(t *testing.T) {
+	ddot, ok := serviceByID("ddot")
+	require.True(t, ok)
+
 	root := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(root, processesDirRel), 0o755))
 	require.NoError(t, os.WriteFile(
-		filepath.Join(root, processesDirRel, migratableServices[0].ProcmgrConfigFile),
+		filepath.Join(root, processesDirRel, ddot.ProcmgrConfigFile),
 		[]byte("cfg"),
 		0o644,
 	))
@@ -164,26 +224,27 @@ func TestCollectInstallMarkerAbsent(t *testing.T) {
 	collector := NewCollectorWithClient(root, &mockClient{})
 
 	snapshot := collector.Collect(context.Background())
-	require.Len(t, snapshot.Services, 1)
 
-	service := snapshot.Services[0]
+	service := serviceSnapshotByID(t, snapshot, "ddot")
 	assert.False(t, service.Installed, "without install marker, Installed must stay false")
 	assert.True(t, service.ProcmgrConfigured)
 	assert.Equal(t, ManagementModeNone, service.ManagementMode)
 }
 
 func TestCollectProcmgrConfigAbsent(t *testing.T) {
+	ddot, ok := serviceByID("ddot")
+	require.True(t, ok)
+
 	root := t.TempDir()
-	marker := filepath.Join(root, migratableServices[0].InstallMarkerRels[0])
+	marker := filepath.Join(root, ddot.InstallMarkerRels[0])
 	require.NoError(t, os.MkdirAll(filepath.Dir(marker), 0o755))
 	require.NoError(t, os.WriteFile(marker, []byte("bin"), 0o644))
 
 	collector := NewCollectorWithClient(root, &mockClient{})
 
 	snapshot := collector.Collect(context.Background())
-	require.Len(t, snapshot.Services, 1)
 
-	service := snapshot.Services[0]
+	service := serviceSnapshotByID(t, snapshot, "ddot")
 	assert.True(t, service.Installed)
 	assert.False(t, service.ProcmgrConfigured)
 	assert.Equal(t, ManagementModeNone, service.ManagementMode)
@@ -203,10 +264,10 @@ func TestCollectDaemonUnreachable(t *testing.T) {
 
 	assert.False(t, snapshot.Daemon.Reachable, "daemon status error should yield empty snapshot")
 	assert.False(t, snapshot.Daemon.Ready)
-	require.Len(t, snapshot.Services, 1)
-	assert.Equal(t, ManagementModeNone, snapshot.Services[0].ManagementMode,
+	service := serviceSnapshotByID(t, snapshot, "ddot")
+	assert.Equal(t, ManagementModeNone, service.ManagementMode,
 		"daemon failure prevents listing processes")
-	assert.Equal(t, pb.ProcessState_UNKNOWN, snapshot.Services[0].ProcmgrState)
+	assert.Equal(t, pb.ProcessState_UNKNOWN, service.ProcmgrState)
 }
 
 func TestCollectDaemonReachableListFails(t *testing.T) {
@@ -222,7 +283,7 @@ func TestCollectDaemonReachableListFails(t *testing.T) {
 
 	assert.True(t, snapshot.Daemon.Reachable)
 	assert.True(t, snapshot.Daemon.Ready)
-	require.Len(t, snapshot.Services, 1)
-	assert.Equal(t, ManagementModeNone, snapshot.Services[0].ManagementMode)
-	assert.Equal(t, pb.ProcessState_UNKNOWN, snapshot.Services[0].ProcmgrState)
+	service := serviceSnapshotByID(t, snapshot, "ddot")
+	assert.Equal(t, ManagementModeNone, service.ManagementMode)
+	assert.Equal(t, pb.ProcessState_UNKNOWN, service.ProcmgrState)
 }

--- a/pkg/procmgr/coat/services.go
+++ b/pkg/procmgr/coat/services.go
@@ -42,6 +42,19 @@ var migratableServices = []MigratableService{
 		},
 		LegacyWindowsService: "datadog-otel-agent",
 	},
+	{
+		ID:                 "agent-data-plane",
+		ProcmgrProcessName: "datadog-agent-data-plane",
+		ProcmgrConfigFile:  "datadog-agent-data-plane.yaml",
+		InstallMarkerRels: []string{
+			"embedded/bin/agent-data-plane",
+			"bin/agent/agent-data-plane",
+		},
+		LegacySystemdUnits: []string{
+			"datadog-agent-data-plane.service",
+			"datadog-agent-data-plane-exp.service",
+		},
+	},
 }
 
 func serviceByID(id string) (MigratableService, bool) {

--- a/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_win_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_win_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/e2e/client/agentclient"
 	windowsagent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 )
 
@@ -394,6 +395,56 @@ func (s *procmgrWindowsSuite) TestADPProcessRunning() {
 	s.Env().RemoteHost.MustExecute(s.platform.checkBinCmd(
 		joinWindowsPath(installPath, "bin", "agent", "agent-data-plane.exe"),
 	))
+}
+
+func (s *procmgrWindowsSuite) TestADPCOATTelemetry() {
+	s.requireCLI()
+	s.waitWindowsADPRunning(90 * time.Second)
+
+	// The COAT reporter refreshes periodically, so wait for its snapshot to include
+	// the ADP process state already confirmed through dd-procmgr.
+	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
+		output := s.Env().Agent.Client.Diagnose(agentclient.WithArgs([]string{"show-metadata", "agent-full-telemetry"}))
+		assert.True(ct, telemetryGaugeIsTrue(output, "runtime__procmgr_process_running", map[string]string{
+			"process": adpProcessName,
+		}), "ADP procmgr running gauge should be emitted: %s", output)
+		assert.True(ct, telemetryGaugeIsTrue(output, "runtime__agent_service_installed", map[string]string{
+			"service": "agent-data-plane",
+		}), "ADP installed gauge should be emitted: %s", output)
+		assert.True(ct, telemetryGaugeIsTrue(output, "runtime__agent_service_procmgr_configured", map[string]string{
+			"service": "agent-data-plane",
+		}), "ADP configured gauge should be emitted: %s", output)
+		assert.True(ct, telemetryGaugeIsTrue(output, "runtime__agent_service_management_mode", map[string]string{
+			"service": "agent-data-plane",
+			"mode":    "procmgr",
+		}), "ADP procmgr management-mode gauge should be emitted: %s", output)
+	}, 7*time.Minute, 10*time.Second)
+}
+
+func telemetryGaugeIsTrue(output, metric string, labels map[string]string) bool {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, metric) {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 2 || (fields[len(fields)-1] != "1" && fields[len(fields)-1] != "1.0") {
+			continue
+		}
+
+		allLabelsMatch := true
+		for key, value := range labels {
+			if !strings.Contains(line, key+`="`+value+`"`) {
+				allLabelsMatch = false
+				break
+			}
+		}
+		if allLabelsMatch {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *procmgrWindowsSuite) TestADPRestartAfterKill() {


### PR DESCRIPTION
## What does this PR do?

Registers Agent Data Plane in the cross-platform `migratableServices` catalog. This adds COAT visibility for ADP’s Linux systemd supervision and reports Windows dd-procmgr process liveness through `runtime.procmgr_process_running{process:agent-data-plane}`.

The collector tests now select snapshots by service ID rather than catalog position, retaining DDOT coverage as the catalog grows and adding ADP coverage.

## Motivation

Windows ADP already runs under dd-procmgr, but was omitted from the COAT catalog. The missing entry prevented independent lower-level liveness telemetry. Linux ADP remains a legacy systemd-supervised migration target, so the shared catalog entry also establishes the intended adoption telemetry there.

## Validation

- `dda inv test --targets=./pkg/procmgr/coat --run-bazel-tests`
- `dda inv linter.go --targets=./pkg/procmgr/coat`

## Release note

No customer-facing release note requested; applying `changelog/no-changelog`.