### PR TITLE
fix(lab): correctly parse untagged images from registries with ports

### DIFF
--- a/.dda/extend/pythonpath/lab/agent.py
+++ b/.dda/extend/pythonpath/lab/agent.py
@@ -147,6 +147,8 @@ To check agent status:
 
 def _parse_image(image: str) -> tuple[str, str]:
     """Parse image string into (repository, tag)."""
-    if ":" in image:
-        return image.rsplit(":", 1)
+    last_colon = image.rfind(":")
+    last_slash = image.rfind("/")
+    if last_colon > last_slash:
+        return image[:last_colon], image[last_colon + 1 :]
     return image, "latest"

--- a/tasks/unit_tests/lab_agent_tests.py
+++ b/tasks/unit_tests/lab_agent_tests.py
@@ -1,0 +1,25 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+AGENT_MODULE_PATH = Path(__file__).parents[2] / ".dda" / "extend" / "pythonpath" / "lab" / "agent.py"
+AGENT_MODULE_SPEC = importlib.util.spec_from_file_location("lab.agent", AGENT_MODULE_PATH)
+assert AGENT_MODULE_SPEC is not None
+assert AGENT_MODULE_SPEC.loader is not None
+AGENT_MODULE = importlib.util.module_from_spec(AGENT_MODULE_SPEC)
+AGENT_MODULE_SPEC.loader.exec_module(AGENT_MODULE)
+
+
+class TestParseImage(unittest.TestCase):
+    def test_parse_image(self):
+        test_cases = (
+            ("datadog/agent", ("datadog/agent", "latest")),
+            ("datadog/agent:dev", ("datadog/agent", "dev")),
+            ("localhost:5000/datadog/agent", ("localhost:5000/datadog/agent", "latest")),
+            ("localhost:5000/datadog/agent:dev", ("localhost:5000/datadog/agent", "dev")),
+        )
+
+        for image, expected in test_cases:
+            with self.subTest(image=image):
+                self.assertEqual(AGENT_MODULE._parse_image(image), expected)


### PR DESCRIPTION
### What does this PR do?

Updates the lab image parser to distinguish a registry port from an image tag. A colon is now treated as a tag separator only when it appears after the final slash.

Adds unit coverage for tagged and untagged images, both with and without a registry port.

### Motivation

An untagged image such as `localhost:5000/datadog/agent` was parsed as repository `localhost` and tag `5000/datadog/agent`. Those incorrect values were then passed to the Helm image settings.

### Describe how you validated your changes

Ran the targeted unit test:

```text
python3 -m unittest discover -s tasks/unit_tests -p 'lab_agent_tests.py' -v
```

Also ran Python compilation and `git diff --check` for the changed files.

### Additional Notes

Digest references remain outside the scope of this change.
