### PR TITLE
feat(containers): include node Agent performance telemetry

### DIFF
--- a/pkg/collector/corechecks/containers/agentperformance/telemetry.go
+++ b/pkg/collector/corechecks/containers/agentperformance/telemetry.go
@@ -29,6 +29,7 @@ const (
 	MemoryLimit = "memory_limit"
 
 	nodeAgentComponent                  = "agent"
+	datadogComponentLabelKey            = "agent.datadoghq.com/component"
 	clusterAgentComponent               = "cluster-agent"
 	clusterChecksAgentComponentHelm     = "clusterchecks-agent"
 	clusterChecksAgentComponentOperator = "cluster-checks-runner"
@@ -149,7 +150,11 @@ func agentPodKind(pod *workloadmeta.KubernetesPod) (string, bool) {
 		return "", false
 	}
 	switch component := pod.Labels[kubernetes.KubeAppComponentLabelKey]; component {
-	case nodeAgentComponent, clusterAgentComponent:
+	case nodeAgentComponent:
+		if pod.Labels[datadogComponentLabelKey] == nodeAgentComponent {
+			return component, true
+		}
+	case clusterAgentComponent:
 		return component, true
 	case clusterChecksAgentComponentHelm, clusterChecksAgentComponentOperator:
 		// consolidate component name difference between helm and operator

--- a/pkg/collector/corechecks/containers/agentperformance/telemetry.go
+++ b/pkg/collector/corechecks/containers/agentperformance/telemetry.go
@@ -28,6 +28,7 @@ const (
 	// MemoryLimit is the metric name for container runtime memory limits.
 	MemoryLimit = "memory_limit"
 
+	nodeAgentComponent                  = "agent"
 	clusterAgentComponent               = "cluster-agent"
 	clusterChecksAgentComponentHelm     = "clusterchecks-agent"
 	clusterChecksAgentComponentOperator = "cluster-checks-runner"
@@ -60,25 +61,25 @@ func newRecorder(tm telemetry.Component) *Recorder {
 			subsystem,
 			ContainerRestarts,
 			[]string{kindTag, tags.KubePod},
-			"Sum of kubernetes.containers.restarts for Datadog Cluster Agent pods",
+			"Sum of kubernetes.containers.restarts for Datadog Agent pods",
 		),
 		containersTerminated: tm.NewGauge(
 			subsystem,
 			ContainerTerminated,
 			[]string{kindTag, tags.KubePod, "reason"},
-			"Sum of kubernetes.containers.*.terminated for Datadog Cluster Agent pods",
+			"Sum of kubernetes.containers.*.terminated for Datadog Agent pods",
 		),
 		memoryUsage: tm.NewGauge(
 			subsystem,
 			MemoryUsage,
 			[]string{kindTag, tags.KubePod},
-			"Sum of container runtime memory usage for Datadog Cluster Agent pods",
+			"Sum of container runtime memory usage for Datadog Agent pods",
 		),
 		memoryLimits: tm.NewGauge(
 			subsystem,
 			MemoryLimit,
 			[]string{kindTag, tags.KubePod},
-			"Sum of container runtime memory limits for Datadog Cluster Agent pods",
+			"Sum of container runtime memory limits for Datadog Agent pods",
 		),
 	}
 }
@@ -94,7 +95,7 @@ func (t *Recorder) ResetKubeletMetrics() {
 }
 
 // RecordMetric adds a metric to the COAT aggregate when it belongs to
-// a Datadog Cluster Agent or Cluster Check Runner pod.
+// a Datadog Agent, Cluster Agent, or Cluster Check Runner pod.
 func (t *Recorder) RecordMetric(metricName string, value *float64, pod *workloadmeta.KubernetesPod, reason string) {
 	if value == nil || pod == nil {
 		return
@@ -112,7 +113,7 @@ func (t *Recorder) RecordMetric(metricName string, value *float64, pod *workload
 }
 
 func (t *Recorder) resetRuntimeMetrics() {
-	for _, kind := range []string{clusterAgentComponent, clusterChecksAgentComponentOperator} {
+	for _, kind := range []string{nodeAgentComponent, clusterAgentComponent, clusterChecksAgentComponentOperator} {
 		match := map[string]string{kindTag: kind}
 		t.memoryUsage.DeletePartialMatch(match)
 		t.memoryLimits.DeletePartialMatch(match)
@@ -120,7 +121,7 @@ func (t *Recorder) resetRuntimeMetrics() {
 }
 
 func (t *Recorder) resetKubeletMetrics() {
-	for _, kind := range []string{clusterAgentComponent, clusterChecksAgentComponentOperator} {
+	for _, kind := range []string{nodeAgentComponent, clusterAgentComponent, clusterChecksAgentComponentOperator} {
 		match := map[string]string{kindTag: kind}
 		t.containersRestarts.DeletePartialMatch(match)
 		t.containersTerminated.DeletePartialMatch(match)
@@ -148,7 +149,7 @@ func agentPodKind(pod *workloadmeta.KubernetesPod) (string, bool) {
 		return "", false
 	}
 	switch component := pod.Labels[kubernetes.KubeAppComponentLabelKey]; component {
-	case clusterAgentComponent:
+	case nodeAgentComponent, clusterAgentComponent:
 		return component, true
 	case clusterChecksAgentComponentHelm, clusterChecksAgentComponentOperator:
 		// consolidate component name difference between helm and operator

--- a/pkg/collector/corechecks/containers/agentperformance/telemetry.go
+++ b/pkg/collector/corechecks/containers/agentperformance/telemetry.go
@@ -151,6 +151,9 @@ func agentPodKind(pod *workloadmeta.KubernetesPod) (string, bool) {
 	}
 	switch component := pod.Labels[kubernetes.KubeAppComponentLabelKey]; component {
 	case nodeAgentComponent:
+		// The generic Kubernetes component label is not a Datadog identity. Node Agent
+		// manifests set this vendor-specific label too, preventing unrelated workloads
+		// from entering COAT telemetry as Datadog Agent pods.
 		if pod.Labels[datadogComponentLabelKey] == nodeAgentComponent {
 			return component, true
 		}

--- a/pkg/collector/corechecks/containers/agentperformance/telemetry_test.go
+++ b/pkg/collector/corechecks/containers/agentperformance/telemetry_test.go
@@ -43,8 +43,14 @@ func TestRecorderComponent(t *testing.T) {
 			expectedOK:   true,
 		},
 		{
-			name:       "other component",
-			pod:        newTestPod("agent", "metadata-pod"),
+			name:         "node agent",
+			pod:          newTestPod("agent", "metadata-pod"),
+			expectedKind: "agent",
+			expectedOK:   true,
+		},
+		{
+			name:       "unrelated component",
+			pod:        newTestPod("unrelated-component", "metadata-pod"),
 			expectedOK: false,
 		},
 		{
@@ -77,7 +83,7 @@ func TestRecordAgentMetricUsesPodMetadata(t *testing.T) {
 	agentPerformance.RecordMetric(MemoryUsage, ptr(100), newTestPod(clusterAgentComponent, "metadata-pod"), "")
 	agentPerformance.RecordMetric(MemoryUsage, ptr(50), newTestPod(clusterChecksAgentComponentHelm, "clusterchecks-agent-helm-pod"), "")
 	agentPerformance.RecordMetric(MemoryUsage, ptr(25), newTestPod(clusterChecksAgentComponentOperator, "clusterchecks-agent-operator-pod"), "")
-	agentPerformance.RecordMetric(MemoryUsage, ptr(99), newTestPod("agent", "other-pod"), "")
+	agentPerformance.RecordMetric(MemoryUsage, ptr(99), newTestPod("unrelated-component", "other-pod"), "")
 	agentPerformance.RecordMetric(MemoryUsage, ptr(98), newTestPod(clusterAgentComponent, ""), "")
 	agentPerformance.RecordMetric(ContainerTerminated, ptr(1), newTestPod(clusterAgentComponent, "metadata-pod"), "oomkilled")
 	agentPerformance.RecordMetric(ContainerTerminated, ptr(99), newTestPod(clusterAgentComponent, "metadata-pod"), "")
@@ -85,9 +91,34 @@ func TestRecordAgentMetricUsesPodMetadata(t *testing.T) {
 	assertGaugeValue(t, tel, MemoryUsage, clusterAgentComponent, "metadata-pod", 100)
 	assertGaugeValue(t, tel, MemoryUsage, clusterChecksAgentComponentOperator, "clusterchecks-agent-helm-pod", 50)
 	assertGaugeValue(t, tel, MemoryUsage, clusterChecksAgentComponentOperator, "clusterchecks-agent-operator-pod", 25)
-	assertGaugeMissing(t, tel, MemoryUsage, "agent", "other-pod")
+	assertGaugeMissing(t, tel, MemoryUsage, "unrelated-component", "other-pod")
 	assertGaugeMissing(t, tel, MemoryUsage, clusterAgentComponent, "")
 	assertTerminatedGaugeValue(t, tel, clusterAgentComponent, "metadata-pod", "oomkilled", 1)
+}
+
+func TestRecorderTelemetryAggregatesNodeAgentPodMetrics(t *testing.T) {
+	tel := telemetrymock.New(t)
+	agentPerformance := newRecorder(tel)
+	agentPerformance.resetRuntimeMetrics()
+
+	nodeAgentPod := newTestPod("agent", "node-agent-pod")
+	agentPerformance.RecordMetric(MemoryUsage, ptr(10), nodeAgentPod, "")
+	agentPerformance.RecordMetric(MemoryUsage, ptr(5), nodeAgentPod, "")
+
+	assertGaugeValue(t, tel, MemoryUsage, "agent", "node-agent-pod", 15)
+}
+
+func TestRecorderTelemetryKeepsNodeAndClusterAgentsSeparateByKind(t *testing.T) {
+	tel := telemetrymock.New(t)
+	agentPerformance := newRecorder(tel)
+	agentPerformance.resetRuntimeMetrics()
+
+	const podName = "agent-pod"
+	agentPerformance.RecordMetric(MemoryUsage, ptr(10), newTestPod(clusterAgentComponent, podName), "")
+	agentPerformance.RecordMetric(MemoryUsage, ptr(5), newTestPod("agent", podName), "")
+
+	assertGaugeValue(t, tel, MemoryUsage, clusterAgentComponent, podName, 10)
+	assertGaugeValue(t, tel, MemoryUsage, "agent", podName, 5)
 }
 
 func TestRecorderTelemetryAggregatesSelectedComponents(t *testing.T) {
@@ -117,6 +148,10 @@ func TestRecorderTelemetryResetClearsStaleValues(t *testing.T) {
 	agentPerformance.record(MemoryLimit, 20, clusterChecksAgentComponentOperator, "clusterchecks-agent-pod", "")
 	agentPerformance.record(ContainerRestarts, 2, clusterChecksAgentComponentOperator, "clusterchecks-agent-pod", "")
 	agentPerformance.record(ContainerTerminated, 1, clusterAgentComponent, "cluster-agent-pod", "error")
+	agentPerformance.record(MemoryUsage, 30, "agent", "node-agent-pod", "")
+	agentPerformance.record(MemoryLimit, 40, "agent", "node-agent-pod", "")
+	agentPerformance.record(ContainerRestarts, 3, "agent", "node-agent-pod", "")
+	agentPerformance.record(ContainerTerminated, 2, "agent", "node-agent-pod", "error")
 	agentPerformance.resetKubeletMetrics()
 	agentPerformance.resetRuntimeMetrics()
 
@@ -124,6 +159,10 @@ func TestRecorderTelemetryResetClearsStaleValues(t *testing.T) {
 	assertGaugeMissing(t, tel, MemoryLimit, clusterChecksAgentComponentOperator, "clusterchecks-agent-pod")
 	assertGaugeMissing(t, tel, ContainerRestarts, clusterChecksAgentComponentOperator, "clusterchecks-agent-pod")
 	assertTerminatedGaugeMissing(t, tel, clusterAgentComponent, "cluster-agent-pod", "error")
+	assertGaugeMissing(t, tel, MemoryUsage, "agent", "node-agent-pod")
+	assertGaugeMissing(t, tel, MemoryLimit, "agent", "node-agent-pod")
+	assertGaugeMissing(t, tel, ContainerRestarts, "agent", "node-agent-pod")
+	assertTerminatedGaugeMissing(t, tel, "agent", "node-agent-pod", "error")
 }
 
 func TestRecorderTelemetrySplitResets(t *testing.T) {

--- a/pkg/collector/corechecks/containers/agentperformance/telemetry_test.go
+++ b/pkg/collector/corechecks/containers/agentperformance/telemetry_test.go
@@ -44,9 +44,14 @@ func TestRecorderComponent(t *testing.T) {
 		},
 		{
 			name:         "node agent",
-			pod:          newTestPod("agent", "metadata-pod"),
-			expectedKind: "agent",
+			pod:          newNodeAgentTestPod("metadata-pod"),
+			expectedKind: nodeAgentComponent,
 			expectedOK:   true,
+		},
+		{
+			name:       "node agent missing Datadog identity",
+			pod:        newTestPod(nodeAgentComponent, "metadata-pod"),
+			expectedOK: false,
 		},
 		{
 			name:       "unrelated component",
@@ -101,7 +106,7 @@ func TestRecorderTelemetryAggregatesNodeAgentPodMetrics(t *testing.T) {
 	agentPerformance := newRecorder(tel)
 	agentPerformance.resetRuntimeMetrics()
 
-	nodeAgentPod := newTestPod("agent", "node-agent-pod")
+	nodeAgentPod := newNodeAgentTestPod("node-agent-pod")
 	agentPerformance.RecordMetric(MemoryUsage, ptr(10), nodeAgentPod, "")
 	agentPerformance.RecordMetric(MemoryUsage, ptr(5), nodeAgentPod, "")
 
@@ -115,7 +120,7 @@ func TestRecorderTelemetryKeepsNodeAndClusterAgentsSeparateByKind(t *testing.T) 
 
 	const podName = "agent-pod"
 	agentPerformance.RecordMetric(MemoryUsage, ptr(10), newTestPod(clusterAgentComponent, podName), "")
-	agentPerformance.RecordMetric(MemoryUsage, ptr(5), newTestPod("agent", podName), "")
+	agentPerformance.RecordMetric(MemoryUsage, ptr(5), newNodeAgentTestPod(podName), "")
 
 	assertGaugeValue(t, tel, MemoryUsage, clusterAgentComponent, podName, 10)
 	assertGaugeValue(t, tel, MemoryUsage, "agent", podName, 5)
@@ -148,10 +153,11 @@ func TestRecorderTelemetryResetClearsStaleValues(t *testing.T) {
 	agentPerformance.record(MemoryLimit, 20, clusterChecksAgentComponentOperator, "clusterchecks-agent-pod", "")
 	agentPerformance.record(ContainerRestarts, 2, clusterChecksAgentComponentOperator, "clusterchecks-agent-pod", "")
 	agentPerformance.record(ContainerTerminated, 1, clusterAgentComponent, "cluster-agent-pod", "error")
-	agentPerformance.record(MemoryUsage, 30, "agent", "node-agent-pod", "")
-	agentPerformance.record(MemoryLimit, 40, "agent", "node-agent-pod", "")
-	agentPerformance.record(ContainerRestarts, 3, "agent", "node-agent-pod", "")
-	agentPerformance.record(ContainerTerminated, 2, "agent", "node-agent-pod", "error")
+	nodeAgentPod := newNodeAgentTestPod("node-agent-pod")
+	agentPerformance.RecordMetric(MemoryUsage, ptr(30), nodeAgentPod, "")
+	agentPerformance.RecordMetric(MemoryLimit, ptr(40), nodeAgentPod, "")
+	agentPerformance.RecordMetric(ContainerRestarts, ptr(3), nodeAgentPod, "")
+	agentPerformance.RecordMetric(ContainerTerminated, ptr(2), nodeAgentPod, "error")
 	agentPerformance.resetKubeletMetrics()
 	agentPerformance.resetRuntimeMetrics()
 
@@ -189,6 +195,12 @@ func TestRecorderTelemetrySplitResets(t *testing.T) {
 	assertGaugeValue(t, tel, MemoryLimit, clusterAgentComponent, "cluster-agent-pod", 20)
 	assertGaugeMissing(t, tel, ContainerRestarts, clusterAgentComponent, "cluster-agent-pod")
 	assertTerminatedGaugeMissing(t, tel, clusterAgentComponent, "cluster-agent-pod", "containercannotrun")
+}
+
+func newNodeAgentTestPod(podName string) *workloadmeta.KubernetesPod {
+	pod := newTestPod(nodeAgentComponent, podName)
+	pod.Labels[datadogComponentLabelKey] = nodeAgentComponent
+	return pod
 }
 
 func newTestPod(component string, podName string) *workloadmeta.KubernetesPod {


### PR DESCRIPTION
### Human Summary

Extends the existing `agent_performance.*` COAT metrics currently emitted for the Cluster Agent to also emit for the main Datadog Agent pod. This is in preparation for launching ADP to customers as we want to have clear before/after signals for resource consumption when we default ADP to on.

### What does this PR do?

Implements part of [DADP-158](https://datadoghq.atlassian.net/browse/DADP-158): extend the existing Kubernetes `agent_performance.*` telemetry to node Agent pods labeled `app.kubernetes.io/component=agent`.

- Emits node-Agent-pod series as `kind:agent`, keeping them distinct from `kind:cluster-agent` with the existing `kind` and `pod_name` tags.
- Preserves whole-pod aggregation across the node Agent pod's containers and all existing metric/tag names.
- Clears node Agent runtime and Kubelet series during recorder resets to avoid stale telemetry.

### Motivation

DADP-158 needs resource and lifecycle telemetry for the full node Agent pod before ADP rollout comparison. The previous selector accepted only Cluster Agent and Cluster Checks Runner pods, excluding node Agent pods and their sidecars.

### Describe how you validated your changes

- `dda inv test --targets=./pkg/collector/corechecks/containers/agentperformance/...`
- `dda inv test --targets=./pkg/collector/corechecks/containers/generic/...`
- `dda inv test --targets=./pkg/collector/corechecks/containers/kubelet/...`

### Additional Notes

This is PR 1 of DADP-158. The CPU metric work is intentionally deferred to a follow-up PR.


[DADP-158]: https://datadoghq.atlassian.net/browse/DADP-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ