### PR TITLE
fix(lab): make --no-agent take precedence over --load-image

### DIFF
--- a/.dda/extend/pythonpath/lab/providers/local/kind.py
+++ b/.dda/extend/pythonpath/lab/providers/local/kind.py
@@ -63,7 +63,7 @@ class KindOptions(ProviderOptions):
     @property
     def wants_agent(self) -> bool:
         """Check if agent installation is requested."""
-        return not self.no_agent or self.build_agent or bool(self.load_image)
+        return not self.no_agent
 
 
 @register_provider

--- a/tasks/unit_tests/lab_kind_provider_tests.py
+++ b/tasks/unit_tests/lab_kind_provider_tests.py
@@ -1,0 +1,46 @@
+import importlib
+import sys
+import unittest
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+
+def click_option(*_args, **_kwargs):
+    return lambda function: function
+
+
+LAB_PYTHONPATH = Path(__file__).parents[2] / ".dda" / "extend" / "pythonpath"
+sys.path.insert(0, str(LAB_PYTHONPATH))
+
+click_module = ModuleType("click")
+click_module.__dict__["option"] = click_option
+with patch.dict(sys.modules, {"click": click_module}):
+    kind_provider = importlib.import_module("lab.providers.local.kind")
+
+
+class TestKindOptions(unittest.TestCase):
+    def test_no_agent_wins_over_load_image(self):
+        options = kind_provider.KindOptions(name="dev", no_agent=True, load_image="myagent:dev")
+
+        self.assertFalse(options.wants_agent)
+
+
+class TestKindProvider(unittest.TestCase):
+    @patch("lab.kind.show_cluster_info")
+    @patch("lab.kind.load_image")
+    @patch("lab.kind.create_cluster")
+    @patch("lab.kind.cluster_exists", return_value=False)
+    def test_no_agent_loads_image_without_installing(
+        self, _cluster_exists, _create_cluster, load_image, _show_cluster_info
+    ):
+        app = MagicMock()
+        provider = kind_provider.KindProvider()
+        options = kind_provider.KindOptions(name="dev", no_agent=True, load_image="myagent:dev")
+
+        with patch.object(provider, "_install_agent") as install_agent:
+            metadata = provider.create(app, options)
+
+        load_image.assert_called_once_with(app, "dev", "myagent:dev")
+        install_agent.assert_not_called()
+        self.assertFalse(metadata["agent_installed"])


### PR DESCRIPTION
### What does this PR do?

Makes `--no-agent` authoritative when deciding whether to install the Datadog Agent in a local Kind cluster.

An image passed with `--load-image` is still loaded into the cluster, but the Helm installation is skipped and the returned metadata reports `agent_installed: false`.

### Motivation

`--no-agent --load-image myagent:dev` currently loads the image and then attempts an Agent installation. This contradicts the documented `--no-agent` behavior and unnecessarily requires Helm and an API key.

Loading an image without deploying it is useful for subsequent manual work in the cluster.

### Describe how you validated your changes

Added targeted tests covering the option precedence and the provider creation flow. The behavioral test verifies that the image is loaded, `_install_agent()` is not called, and the metadata reports that the Agent is not installed.

```text
python3 -m unittest discover -s tasks/unit_tests -p 'lab_kind_provider_tests.py' -v
uvx ruff check .dda/extend/pythonpath/lab/providers/local/kind.py tasks/unit_tests/lab_kind_provider_tests.py
uvx ruff format --check .dda/extend/pythonpath/lab/providers/local/kind.py tasks/unit_tests/lab_kind_provider_tests.py
```

### Additional Notes

None.
