### PR TITLE
[cisco-sdwan] Add config detail to max_pages pagination error

### DIFF
--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request.go
@@ -115,7 +115,7 @@ func getMoreEntries[T Content](client *Client, endpoint string, pageInfo PageInf
 	for page := 0; currentPageInfo.MoreEntries || currentPageInfo.HasMoreData; page++ {
 		// Error if max number of pages is reached
 		if page >= client.maxPages {
-			return nil, errors.New("max number of page reached, increase API count or max number of pages")
+			return nil, fmt.Errorf("reached max_pages limit after fetching %d pages and more data remains; increase max_count and/or max_pages to collect all data. current_configs: max_count=%s, max_pages=%d", page, client.maxCount, client.maxPages)
 		}
 
 		log.Tracef("Getting page %d from endpoint %s", page+1+1, endpoint)

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request_test.go
@@ -297,7 +297,8 @@ func TestGetMoreEntriesMaxPages(t *testing.T) {
 	}
 
 	_, err = getMoreEntries[Device](client, "/dataservice/device", pageInfo)
-	require.ErrorContains(t, err, "max number of page reached")
+	require.ErrorContains(t, err, "reached max_pages limit")
+	require.ErrorContains(t, err, "max_pages=20")
 
 	// Ensure endpoint has been called 20 times
 	require.Equal(t, 20, handler.numberOfCalls())


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Enriches the error returned when the Cisco SD-WAN paginated API hits the`max_pages` limit. The error now reports how many pages were fetched, that more data remains, and the current `max_count` / `max_pages` values:

Example:
`reached max_pages limit after fetching 20 pages and more data remains;
increase max_count and/or max_pages to collect all data. current_configs:
max_count=500, max_pages=20`

### Motivation

On large SD-WAN environments endpoints can return more pages than `max_pages` allows, so collection stops and those metrics go missing for the collection period. The previous error was missing how much data was being pulled. Displaying the page count and the current config values helps with being able to tune the collection. 

### Describe how you validated your changes

### Additional Notes
