### PR TITLE
Bump dd-compile-policy to v0.1.13

### DIFF
--- a/deps/compile_policy/compile_policy.MODULE.bazel
+++ b/deps/compile_policy/compile_policy.MODULE.bazel
@@ -14,7 +14,7 @@ http_archive(
         "LICENSE": "//deps/compile_policy:LICENSE",
         "LICENSE-3rdparty.csv": "//deps/compile_policy:LICENSE-3rdparty.csv",
     },
-    sha256 = "f32c245da1e0152e981ea6a3531b244bbab42c02666ec9bf37edc52204a96355",
+    sha256 = "9fe6788cee489fa0220837ee22bd5bf1c43ec30e641da12b6597e59a4e79dae0",
     urls = [
         "https://github.com/DataDog/dd-policy-engine/releases/download/v{version}/dd-compile-policy-linux-amd64.tar.gz".format(
             version = VERSION,
@@ -29,7 +29,7 @@ http_archive(
         "LICENSE": "//deps/compile_policy:LICENSE",
         "LICENSE-3rdparty.csv": "//deps/compile_policy:LICENSE-3rdparty.csv",
     },
-    sha256 = "1e9447733ac2a623d59b657b689811695738e040a7dd7be22a368c07cbd52842",
+    sha256 = "88675012e2f5e79b16d5e0b429b4956e3e70fc772d42b956abb75712b85fbb11",
     urls = [
         "https://github.com/DataDog/dd-policy-engine/releases/download/v{version}/dd-compile-policy-linux-arm64.tar.gz".format(
             version = VERSION,
@@ -44,7 +44,7 @@ http_archive(
         "LICENSE": "//deps/compile_policy:LICENSE",
         "LICENSE-3rdparty.csv": "//deps/compile_policy:LICENSE-3rdparty.csv",
     },
-    sha256 = "39cabb8dc85e29837be223d389b6c00b715513e7ffc6fa8a0d69db03fdc66f2e",
+    sha256 = "50a8135d531220b8f9de79c9cc1fc8d11d90f574647830722fd161dc77c8c3af",
     urls = [
         "https://github.com/DataDog/dd-policy-engine/releases/download/v{version}/dd-compile-policy-windows-x64.zip".format(
             version = VERSION,

--- a/deps/compile_policy/compile_policy.MODULE.bazel
+++ b/deps/compile_policy/compile_policy.MODULE.bazel
@@ -2,7 +2,7 @@
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-VERSION = "0.1.2"
+VERSION = "0.1.13"
 
 # Define URLs for each architecture. This is used for the Linux build only; Windows and Darwin are not supported yet.
 # When we do those, we can make this parameterized.


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
`dd-compile-policy` binary is pinned within the Agent at v0.1.2, which predates https://github.com/DataDog/dd-policy-engine/pull/68 in `dd-policy-engine` that added Docker container evaluators (CONTAINER_IMAGE_TAG, CONTAINER_IMAGE_DIGEST, CONTAINER_NAME, CONTAINER_LABEL) to the schema. `dd-compile-policy` embeds its FlatBuffers schema at build time, so the currently pinned binary has no knowledge of these evaluators. When a policy JSON references one, the generic FlatBuffers parser silently resolves it to `STRING_EVAL_UNKNOWN` (enum value 0) instead of erroring, so any WLS rule using a Docker attribute silently compiles into a no-op.

This bumps the pin to v0.1.13, the first release of `dd-policy-engine` that includes the Docker container evaluators.

### Motivation

### Describe how you validated your changes

### Additional Notes
