### PR TITLE
otel: opt into port-aware no_proxy matching for integration_tests_otel

### DIFF
--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -10,6 +10,10 @@ integration_tests_otel:
   variables:
     KUBERNETES_MEMORY_REQUEST: 16Gi
     KUBERNETES_MEMORY_LIMIT: 16Gi
+    # The Agent's legacy no_proxy matching compares the full host:port against
+    # bare no_proxy entries, so it never bypasses the proxy for loopback test
+    # servers bound to ephemeral ports. Opt into the port-aware matching.
+    DD_NO_PROXY_NONEXACT_MATCH: "true"
   script:
     - !reference [.retrieve_linux_go_deps]
     - dda inv -- check-otel-build


### PR DESCRIPTION
## Summary
- `integration_tests_otel` times out when the CI runner has a fabric-proxy injected. The Agent's legacy `no_proxy` bypass logic compares the full `host:port` against bare `no_proxy` entries, so it never bypasses the proxy for loopback test servers/health checks bound to ephemeral ports — those calls get routed through the proxy, which has no route to them and hangs instead of failing fast, until the job times out.
- Sets `DD_NO_PROXY_NONEXACT_MATCH: "true"` on the job so it uses the port-aware `no_proxy` matching path (`golang.org/x/net/http/httpproxy`) instead of the legacy exact-match path.
- This is a targeted CI-level workaround, not a fix to the underlying Agent behavior (the legacy exact-match logic in `pkg/util/http/transport.go` still has the same defect for other callers). Proposing this narrowly scoped fix first since the existence of `no_proxy_nonexact_match` as a deprecation-flagged, opt-in setting suggests the team is already aware of this gap and staging a fix; happy to also raise the broader fix if the team wants it.

## Test plan
- [x] `integration_tests_otel` passes in CI on this branch under fabric-proxy-injected runners without timing out