### PR TITLE
smp: build a release-branch baseline image when stale

### DIFF
--- a/.gitlab/test/functional_test/regression_detector.yml
+++ b/.gitlab/test/functional_test/regression_detector.yml
@@ -102,18 +102,23 @@ single_machine_performance-regression_detector-merge_base_check:
                       # expected duration, which would go stale as build times
                       # and runner queue depths change.
                       #
-                      # To reproduce these calls outside GitLab CI, mint a token
-                      # with `dda inv auth.gitlab` and send it as `PRIVATE-TOKEN`
-                      # instead of `JOB-TOKEN` -- job tokens only exist inside a
-                      # running job. `CI_API_V4_URL` is
-                      # https://gitlab.ddbuild.io/api/v4 and `CI_PROJECT_ID` is
-                      # 4670 for this project.
-                      #
                       # `POST /trigger/pipeline`, not `POST /pipeline`: GitLab
                       # allowlists `CI_JOB_TOKEN` for the former only, and it
                       # authenticates through a `token` body parameter rather
                       # than a header. `tasks/pipeline.py` starts child
                       # pipelines the same way, for the same reason.
+                      #
+                      # This call therefore cannot be reproduced verbatim outside
+                      # a running job, since job tokens exist only inside one. A
+                      # personal token minted with `dda inv auth.gitlab` works
+                      # the other way around: it may use `POST /pipeline`, but is
+                      # not a valid `token` value for the trigger endpoint, which
+                      # accepts only trigger and job tokens. So the equivalent
+                      # local command is the `PRIVATE-TOKEN` one printed below,
+                      # aimed at a different endpoint on purpose.
+                      #
+                      # `CI_API_V4_URL` is https://gitlab.ddbuild.io/api/v4 and
+                      # `CI_PROJECT_ID` is 4670 for this project.
                       #
                       # The trailing `|| true` keeps this best-effort. The runner
                       # runs this script under `set -eo pipefail`, where a bare

--- a/.gitlab/test/functional_test/regression_detector.yml
+++ b/.gitlab/test/functional_test/regression_detector.yml
@@ -43,7 +43,6 @@ single_machine_performance-regression_detector-merge_base_check:
           echo "Merge base is ${SMP_MERGE_BASE}"
           BASELINE_SHA="${SMP_MERGE_BASE}"
       fi
-    - BASELINE_COMMIT_TIME=$(git -c log.showSignature=false show --no-patch --format=%ct ${BASELINE_SHA})
     # Setup AWS credentials for single-machine-performance AWS account to check ECR images
     - AWS_NAMED_PROFILE="single-machine-performance"
     - SMP_ACCOUNT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SMP_ACCOUNT account_id) || exit $?

--- a/.gitlab/test/functional_test/regression_detector.yml
+++ b/.gitlab/test/functional_test/regression_detector.yml
@@ -95,8 +95,24 @@ single_machine_performance-regression_detector-merge_base_check:
               if [[ "$SMP_BASE_BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]]
               then
                   SMP_BASE_TIP=$(git rev-parse "origin/${SMP_BASE_BRANCH}")
-                  if [[ ! $(aws ecr describe-images --region us-west-2 --profile single-machine-performance --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${SMP_BASE_TIP}-7-full-amd64") ]]
+                  # Trigger only on a *confirmed* miss. Throttling, expired
+                  # credentials and network errors all leave `describe-images`
+                  # stdout empty too, so the `[[ ! $(...) ]]` test the loop
+                  # above uses cannot tell "no such image" from "could not
+                  # check". Guessing wrong is cheap in that loop -- it steps
+                  # back one commit -- but here it starts an ~860-job pipeline,
+                  # and the two failures correlate: credentials expiring
+                  # mid-loop is itself a way to reach this branch spuriously.
+                  # The distinguishing information is on stderr, so capture
+                  # that and discard stdout. `if VAR=$(...)` is exempt from
+                  # `set -e`.
+                  if SMP_ECR_ERROR=$(aws ecr describe-images --region us-west-2 --profile single-machine-performance --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${SMP_BASE_TIP}-7-full-amd64" 2>&1 >/dev/null)
                   then
+                      echo "A baseline image already exists for the ${SMP_BASE_BRANCH} tip (${SMP_BASE_TIP})"
+                  elif [[ "${SMP_ECR_ERROR}" != *ImageNotFoundException* ]]
+                  then
+                      echo "WARNING: could not determine whether a baseline image exists for the ${SMP_BASE_BRANCH} tip (${SMP_BASE_TIP}), so not triggering a rebuild: ${SMP_ECR_ERROR}"
+                  else
                       echo "No baseline image exists for the ${SMP_BASE_BRANCH} tip (${SMP_BASE_TIP}) - triggering a pipeline to build one now"
                       # Report the triggered pipeline's URL rather than an
                       # expected duration, which would go stale as build times
@@ -120,15 +136,17 @@ single_machine_performance-regression_detector-merge_base_check:
                       # `CI_API_V4_URL` is https://gitlab.ddbuild.io/api/v4 and
                       # `CI_PROJECT_ID` is 4670 for this project.
                       #
-                      # The trailing `|| true` keeps this best-effort. The runner
-                      # runs this script under `set -eo pipefail`, where a bare
-                      # `VAR=$(failing-cmd)` aborts the block -- which would skip
-                      # the warning and self-service output below, the most useful
-                      # thing this branch prints. `--fail` also makes curl exit
-                      # nonzero on an HTTP error while emitting nothing, so the
-                      # empty-string checks below are what actually detect failure.
+                      # The trailing `|| true` on both lines keeps this
+                      # best-effort. The runner runs this script under
+                      # `set -eo pipefail`, where a bare `VAR=$(failing-cmd)`
+                      # aborts the block -- which would skip the warning and
+                      # self-service output below, the most useful thing this
+                      # branch prints. `--fail` also makes curl exit nonzero on
+                      # an HTTP error while emitting nothing, and `jq` exits
+                      # nonzero on a non-JSON body, so the empty-string check
+                      # below is what actually detects failure.
                       SMP_REBUILD_PIPELINE=$(curl --silent --show-error --fail --request POST --data "token=${CI_JOB_TOKEN}" --data "ref=${SMP_BASE_BRANCH}" "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/trigger/pipeline" || true)
-                      SMP_REBUILD_PIPELINE_URL=$(echo "${SMP_REBUILD_PIPELINE}" | jq -r '.web_url // empty')
+                      SMP_REBUILD_PIPELINE_URL=$(echo "${SMP_REBUILD_PIPELINE}" | jq -r '.web_url // empty' || true)
                       if [[ -z "${SMP_REBUILD_PIPELINE_URL}" ]]
                       then
                           SMP_REBUILD_TRIGGERED="false"

--- a/.gitlab/test/functional_test/regression_detector.yml
+++ b/.gitlab/test/functional_test/regression_detector.yml
@@ -117,6 +117,12 @@ single_machine_performance-regression_detector-merge_base_check:
                       # the normal case here, not an edge case. Newlines outside
                       # strings are only whitespace, so stripping them all leaves
                       # the fields read below intact.
+                      # `POST /trigger/pipeline`, not `POST /pipeline`: GitLab
+                      # allowlists `CI_JOB_TOKEN` for the former only, and it
+                      # authenticates through a `token` body parameter rather
+                      # than a header. `tasks/pipeline.py` starts child
+                      # pipelines the same way, for the same reason.
+                      #
                       # The trailing `|| true` keeps this best-effort. The runner
                       # runs this script under `set -eo pipefail`, where a bare
                       # `VAR=$(failing-cmd)` aborts the block -- which would skip
@@ -124,7 +130,7 @@ single_machine_performance-regression_detector-merge_base_check:
                       # thing this branch prints. `--fail` also makes curl exit
                       # nonzero on an HTTP error while emitting nothing, so the
                       # empty-string checks below are what actually detect failure.
-                      SMP_REBUILD_PIPELINE=$(curl --silent --show-error --fail --request POST --header "JOB-TOKEN: ${CI_JOB_TOKEN}" --data "ref=${SMP_BASE_BRANCH}" "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/pipeline" | tr -d '\n\r' || true)
+                      SMP_REBUILD_PIPELINE=$(curl --silent --show-error --fail --request POST --data "token=${CI_JOB_TOKEN}" --data "ref=${SMP_BASE_BRANCH}" "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/trigger/pipeline" | tr -d '\n\r' || true)
                       SMP_REBUILD_PIPELINE_URL=$(echo "${SMP_REBUILD_PIPELINE}" | jq -r '.web_url // empty')
                       if [[ -z "${SMP_REBUILD_PIPELINE_URL}" ]]
                       then

--- a/.gitlab/test/functional_test/regression_detector.yml
+++ b/.gitlab/test/functional_test/regression_detector.yml
@@ -77,7 +77,119 @@ single_machine_performance-regression_detector-merge_base_check:
           BASELINE_COMMIT_TIME=$(git -c log.showSignature=false show --no-patch --format=%ct ${BASELINE_SHA})
           if [[ ${BASELINE_COMMIT_TIME} -le ${FOUR_DAYS_BEFORE_NOW} ]]
           then
-              echo "ERROR: Merge-base of this branch is too old for SMP. Please update your branch by merging an up-to-date main branch into your branch or by rebasing it on an up-to-date main branch."
+              echo "ERROR: Baseline commit (${BASELINE_SHA}) for this branch (${CI_COMMIT_BRANCH}) is too old for SMP. Please update your branch by merging or rebasing it onto an up-to-date ${SMP_BASE_BRANCH} branch."
+              # Updating onto ${SMP_BASE_BRANCH} makes its tip this branch's new
+              # merge base, so the next pipeline needs a baseline image for that
+              # tip. A release branch can sit idle long enough for its tip's
+              # image to age out of ECR, in which case that next pipeline fails
+              # here too -- costing another image build, which takes 40-60
+              # minutes once started plus unknown runner queue time. Start the
+              # build now so it overlaps with the update instead of following it.
+              #
+              # Release branches only: a merge base with main has almost always
+              # been built already by some other recent pipeline, and updating
+              # onto main costs one pipeline rather than two.
+              #
+              # Best-effort -- a failure to trigger is reported but does not
+              # change this job's outcome, which is a failure either way.
+              if [[ "$SMP_BASE_BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]]
+              then
+                  SMP_BASE_TIP=$(git rev-parse "origin/${SMP_BASE_BRANCH}")
+                  if [[ ! $(aws ecr describe-images --region us-west-2 --profile single-machine-performance --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${SMP_BASE_TIP}-7-full-amd64") ]]
+                  then
+                      echo "No baseline image exists for the ${SMP_BASE_BRANCH} tip (${SMP_BASE_TIP}) - triggering a pipeline to build one now"
+                      # Report the triggered pipeline's URL rather than an
+                      # expected duration, which would go stale as build times
+                      # and runner queue depths change.
+                      #
+                      # To reproduce these calls outside GitLab CI, mint a token
+                      # with `dda inv auth.gitlab` and send it as `PRIVATE-TOKEN`
+                      # instead of `JOB-TOKEN` -- job tokens only exist inside a
+                      # running job. `CI_API_V4_URL` is
+                      # https://gitlab.ddbuild.io/api/v4 and `CI_PROJECT_ID` is
+                      # 4670 for this project.
+                      #
+                      # The API embeds each commit's message verbatim, including
+                      # raw newlines, which makes the response invalid JSON that
+                      # jq refuses to parse (RFC 8259 requires control characters
+                      # in strings to be escaped). Release-branch tips are written
+                      # by release automation with multi-line messages, so this is
+                      # the normal case here, not an edge case. Newlines outside
+                      # strings are only whitespace, so stripping them all leaves
+                      # the fields read below intact.
+                      # The trailing `|| true` keeps this best-effort. The runner
+                      # runs this script under `set -eo pipefail`, where a bare
+                      # `VAR=$(failing-cmd)` aborts the block -- which would skip
+                      # the warning and self-service output below, the most useful
+                      # thing this branch prints. `--fail` also makes curl exit
+                      # nonzero on an HTTP error while emitting nothing, so the
+                      # empty-string checks below are what actually detect failure.
+                      SMP_REBUILD_PIPELINE=$(curl --silent --show-error --fail --request POST --header "JOB-TOKEN: ${CI_JOB_TOKEN}" --data "ref=${SMP_BASE_BRANCH}" "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/pipeline" | tr -d '\n\r' || true)
+                      SMP_REBUILD_PIPELINE_URL=$(echo "${SMP_REBUILD_PIPELINE}" | jq -r '.web_url // empty')
+                      if [[ -z "${SMP_REBUILD_PIPELINE_URL}" ]]
+                      then
+                          SMP_REBUILD_TRIGGERED="false"
+                          echo "WARNING: could not trigger a pipeline on ${SMP_BASE_BRANCH} - one may need to be started manually"
+                      else
+                          SMP_REBUILD_TRIGGERED="true"
+                          echo "Triggered ${SMP_REBUILD_PIPELINE_URL} on ${SMP_BASE_BRANCH}"
+                          # Within that pipeline, single_machine_performance-full-amd64-a7
+                          # is the job that publishes the baseline image to SMP's ECR
+                          # registry, so link it directly rather than making the reader
+                          # find it. The jobs endpoint has no name filter and a full
+                          # pipeline runs more jobs than one page holds (~800, so ~9
+                          # pages), hence the paging. Stopping on an empty page also
+                          # covers the error cases, including a job token that is not
+                          # permitted to read this endpoint; the job name is reported
+                          # instead when the lookup comes up empty. That fallback
+                          # needs the same `|| true` as above -- a 403 body is empty,
+                          # but only if `set -e` does not kill the block first.
+                          SMP_REBUILD_PIPELINE_ID=$(echo "${SMP_REBUILD_PIPELINE}" | jq -r '.id')
+                          SMP_REBUILD_JOB_URL=""
+                          SMP_JOBS_PAGE=1
+                          while [[ -z "${SMP_REBUILD_JOB_URL}" ]] && [[ ${SMP_JOBS_PAGE} -le 50 ]]
+                          do
+                              SMP_JOBS_PAGE_BODY=$(curl --silent --show-error --fail --header "JOB-TOKEN: ${CI_JOB_TOKEN}" "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/pipelines/${SMP_REBUILD_PIPELINE_ID}/jobs?per_page=100&page=${SMP_JOBS_PAGE}" | tr -d '\n\r' || true)
+                              if [[ -z $(echo "${SMP_JOBS_PAGE_BODY}" | jq -r '.[]?.id' | head -1) ]]
+                              then
+                                  break
+                              fi
+                              SMP_REBUILD_JOB_URL=$(echo "${SMP_JOBS_PAGE_BODY}" | jq -r '.[] | select(.name == "single_machine_performance-full-amd64-a7") | .web_url' | head -1)
+                              SMP_JOBS_PAGE=$((SMP_JOBS_PAGE + 1))
+                          done
+                          if [[ -n "${SMP_REBUILD_JOB_URL}" ]]
+                          then
+                              echo "The baseline image for ${SMP_BASE_TIP} is published by ${SMP_REBUILD_JOB_URL}"
+                          else
+                              echo "The baseline image for ${SMP_BASE_TIP} is published by the single_machine_performance-full-amd64-a7 job in that pipeline"
+                          fi
+                      fi
+                      echo "NOTE: this job will keep failing until that image is published to SMP's ECR registry, so wait for it before re-running this job."
+                      # Give a self-service path to starting the build. Needed
+                      # when the trigger above failed, and also when a triggered
+                      # pipeline dies for reasons outside this job -- CI runners
+                      # are taken offline for maintenance periodically, which
+                      # kills the pipelines on them.
+                      #
+                      # `dda inv auth.gitlab` prints feature-flag lines to stdout
+                      # before the token, so the `tail -1` is load-bearing: without
+                      # it those lines land in the header value and curl fails with
+                      # "curl: (43) bad argument".
+                      echo "To start that pipeline yourself -- if the trigger above failed, or if the"
+                      echo "pipeline is cancelled, e.g. by CI runner maintenance -- either open"
+                      echo "    https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/new?ref=${SMP_BASE_BRANCH}"
+                      echo "and click the blue \"New pipeline\" button, or run this command from a"
+                      echo "datadog-agent checkout:"
+                      echo "    curl --silent --show-error --fail \\"
+                      echo "        --request POST \\"
+                      echo "        --header \"PRIVATE-TOKEN: \$(dda inv auth.gitlab | tail -1)\" \\"
+                      echo "        --data \"ref=${SMP_BASE_BRANCH}\" \\"
+                      echo "        \"${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/pipeline\""
+                      # Report the outcome, not the attempt -- tagging "true"
+                      # unconditionally would hide the trigger's failure rate.
+                      datadog-ci tag --level job --tags smp_baseline_rebuild_triggered:"${SMP_REBUILD_TRIGGERED}"
+                  fi
+              fi
               datadog-ci tag --level job --tags smp_merge_base_failure_reason:"branch_too_old"
               exit 1
           fi

--- a/.gitlab/test/functional_test/regression_detector.yml
+++ b/.gitlab/test/functional_test/regression_detector.yml
@@ -109,14 +109,6 @@ single_machine_performance-regression_detector-merge_base_check:
                       # https://gitlab.ddbuild.io/api/v4 and `CI_PROJECT_ID` is
                       # 4670 for this project.
                       #
-                      # The API embeds each commit's message verbatim, including
-                      # raw newlines, which makes the response invalid JSON that
-                      # jq refuses to parse (RFC 8259 requires control characters
-                      # in strings to be escaped). Release-branch tips are written
-                      # by release automation with multi-line messages, so this is
-                      # the normal case here, not an edge case. Newlines outside
-                      # strings are only whitespace, so stripping them all leaves
-                      # the fields read below intact.
                       # `POST /trigger/pipeline`, not `POST /pipeline`: GitLab
                       # allowlists `CI_JOB_TOKEN` for the former only, and it
                       # authenticates through a `token` body parameter rather
@@ -130,7 +122,7 @@ single_machine_performance-regression_detector-merge_base_check:
                       # thing this branch prints. `--fail` also makes curl exit
                       # nonzero on an HTTP error while emitting nothing, so the
                       # empty-string checks below are what actually detect failure.
-                      SMP_REBUILD_PIPELINE=$(curl --silent --show-error --fail --request POST --data "token=${CI_JOB_TOKEN}" --data "ref=${SMP_BASE_BRANCH}" "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/trigger/pipeline" | tr -d '\n\r' || true)
+                      SMP_REBUILD_PIPELINE=$(curl --silent --show-error --fail --request POST --data "token=${CI_JOB_TOKEN}" --data "ref=${SMP_BASE_BRANCH}" "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/trigger/pipeline" || true)
                       SMP_REBUILD_PIPELINE_URL=$(echo "${SMP_REBUILD_PIPELINE}" | jq -r '.web_url // empty')
                       if [[ -z "${SMP_REBUILD_PIPELINE_URL}" ]]
                       then
@@ -139,36 +131,12 @@ single_machine_performance-regression_detector-merge_base_check:
                       else
                           SMP_REBUILD_TRIGGERED="true"
                           echo "Triggered ${SMP_REBUILD_PIPELINE_URL} on ${SMP_BASE_BRANCH}"
-                          # Within that pipeline, single_machine_performance-full-amd64-a7
-                          # is the job that publishes the baseline image to SMP's ECR
-                          # registry, so link it directly rather than making the reader
-                          # find it. The jobs endpoint has no name filter and a full
-                          # pipeline runs more jobs than one page holds (~800, so ~9
-                          # pages), hence the paging. Stopping on an empty page also
-                          # covers the error cases, including a job token that is not
-                          # permitted to read this endpoint; the job name is reported
-                          # instead when the lookup comes up empty. That fallback
-                          # needs the same `|| true` as above -- a 403 body is empty,
-                          # but only if `set -e` does not kill the block first.
-                          SMP_REBUILD_PIPELINE_ID=$(echo "${SMP_REBUILD_PIPELINE}" | jq -r '.id')
-                          SMP_REBUILD_JOB_URL=""
-                          SMP_JOBS_PAGE=1
-                          while [[ -z "${SMP_REBUILD_JOB_URL}" ]] && [[ ${SMP_JOBS_PAGE} -le 50 ]]
-                          do
-                              SMP_JOBS_PAGE_BODY=$(curl --silent --show-error --fail --header "JOB-TOKEN: ${CI_JOB_TOKEN}" "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/pipelines/${SMP_REBUILD_PIPELINE_ID}/jobs?per_page=100&page=${SMP_JOBS_PAGE}" | tr -d '\n\r' || true)
-                              if [[ -z $(echo "${SMP_JOBS_PAGE_BODY}" | jq -r '.[]?.id' | head -1) ]]
-                              then
-                                  break
-                              fi
-                              SMP_REBUILD_JOB_URL=$(echo "${SMP_JOBS_PAGE_BODY}" | jq -r '.[] | select(.name == "single_machine_performance-full-amd64-a7") | .web_url' | head -1)
-                              SMP_JOBS_PAGE=$((SMP_JOBS_PAGE + 1))
-                          done
-                          if [[ -n "${SMP_REBUILD_JOB_URL}" ]]
-                          then
-                              echo "The baseline image for ${SMP_BASE_TIP} is published by ${SMP_REBUILD_JOB_URL}"
-                          else
-                              echo "The baseline image for ${SMP_BASE_TIP} is published by the single_machine_performance-full-amd64-a7 job in that pipeline"
-                          fi
+                          # Name the job that publishes the image rather than
+                          # linking it. Resolving its URL means listing the
+                          # pipeline's jobs, and GitLab allowlists `CI_JOB_TOKEN`
+                          # for only `GET /job` out of the whole Jobs API, so that
+                          # lookup cannot succeed from here whatever it is given.
+                          echo "The baseline image for ${SMP_BASE_TIP} is published by the single_machine_performance-full-amd64-a7 job, listed at ${SMP_REBUILD_PIPELINE_URL}/builds"
                       fi
                       echo "NOTE: this job will keep failing until that image is published to SMP's ECR registry, so wait for it before re-running this job."
                       # Give a self-service path to starting the build. Needed


### PR DESCRIPTION
## Summary

Fixes the SMP Regression Detector's `merge_base_check` job failing on
backport PRs targeting a release branch (concrete case: #54082,
targeting `7.81.x`).

A backport PR's merge base with its release branch drifts stale while the
PR sits in review and the release branch keeps moving. Once the merge
base is old enough that its SMP agent image has aged out of ECR (4-day
lifecycle policy), the backward-walk loop steps to still-older commits
and the age gate fails the job immediately, so the PR gets no
regression-detector coverage at all. The one-shot age-check bypass from
#48930 doesn't help: it exempts the initial candidate from the *age
gate*, but not from the image being *absent*.

The remedy a developer has to apply is to merge or rebase onto the
release branch tip, which makes that tip the new merge base. But a
release branch can be idle long enough that its own tip image has also
aged out, in which case the next pipeline fails here for the same reason
— costing a second image build of 40-60 minutes plus unknown runner
queue time.

So when the age gate trips on a release-branch target, this checks
whether the tip has an image in ECR and triggers a pipeline to build one
if — and only if — it is confirmed absent. The build then **overlaps** with the update the developer
is being asked to make, instead of following it. The trigger uses the
job's own `CI_JOB_TOKEN` against `POST /projects/:id/trigger/pipeline`, so
no new secrets are involved, and it's best-effort — a failure is logged as
a warning and doesn't change the job's outcome, which is a failure either
way.

The failure log tells the developer what to wait for: the triggered
pipeline's URL, the name of the job in it that publishes the baseline image
to SMP's ECR registry (`single_machine_performance-full-amd64-a7`) plus the
pipeline's job listing to find it in, and an explicit note that
`merge_base_check` will keep failing until that image is published. No time
estimate — build times and runner queue depths change, so a URL stays
accurate and a duration wouldn't.

It also prints two self-service ways to start that pipeline: the
`/-/pipelines/new?ref=<branch>` page (branch dropdown, input-variable
fields, blue "New pipeline" button) and a copy-pasteable `curl` invocation
wrapped to stay under 80 columns. That covers the case where the automatic
trigger fails, and also the case where a triggered pipeline dies for
reasons outside this job — CI runners get taken offline for maintenance,
which kills the pipelines running on them. Either way it keeps developers
from having to open a ticket with SMP.

**The baseline stays the merge base.** It remains an ancestor of the
commit under test, so the A/B comparison still measures only this PR's
changes. An earlier revision of this PR substituted the release branch
tip as the baseline instead; that broke the ancestor invariant, and since
SMP reports differences as percentages relative to the baseline, the
intervening release-branch commits would land in the comparison *and* in
the denominator, with no way to recover this PR's true effect. That
approach has been dropped.

Also drops a dead pre-loop `BASELINE_COMMIT_TIME` computation (always
overwritten inside the loop before being read) and rewords the age-gate
error, which told users to update against `main` even when targeting a
release branch.

This supersedes and subsumes #54153, now closed.

## Why release branches only

For a `main`-targeting branch, the merge base has almost always been
built already by some other recent pipeline, and updating onto `main` is
one pipeline rather than two. Release branches don't have that property —
they can go long stretches without a commit, so their tip image ages out
with no cheaper way to refresh it.

## Notes

- **The ECR check distinguishes "absent" from "couldn't tell."** Throttling,
  expired credentials and network errors all leave `describe-images` stdout
  empty, exactly like a missing tag, so the `[[ ! $(...) ]]` idiom used by the
  pre-existing walk-back loop cannot tell them apart. Guessing wrong is cheap
  in that loop — it steps back one commit — but here it would start an
  ~860-job pipeline. Worse, the two failures correlate: credentials expiring
  partway through the loop makes every subsequent check look like a miss,
  walking the baseline back until the age gate trips, which is itself the path
  that reaches this check. So the check captures stderr instead and branches
  on it: exit 0 means the image exists, an error without
  `ImageNotFoundException` warns and triggers nothing, and only a confirmed
  miss triggers a rebuild. The `elif` is written as
  `!= *ImageNotFoundException*` so the trigger body keeps its indentation —
  this is a YAML block scalar, where reindenting changes the script the runner
  executes. The idiom at the walk-back loop is deliberately left alone.
- **`CI_JOB_TOKEN` is an allowlist, not a permission scope**, and that
  shapes both halves of this block. Out of the whole Pipelines API a job
  token may call only `PUT .../pipelines/:id/metadata`; the one
  pipeline-creating endpoint open to it is
  `POST /projects/:id/trigger/pipeline`, which authenticates through a
  `token` body parameter rather than a header. `tasks/pipeline.py:364`
  starts child pipelines the same way for the same reason. Out of the whole
  Jobs API it may call only `GET /job` — so resolving the publishing job's
  URL by listing the pipeline's jobs is impossible from here, and the log
  names the job and links the pipeline's `/builds` listing instead of
  linking the job directly.
- The in-job `curl` and the emitted self-service `curl` deliberately target
  *different* endpoints. A personal token minted with `dda inv auth.gitlab`
  is the mirror image of a job token here: it can use `POST /pipeline`, but
  is not a valid `token` value for the trigger endpoint, which accepts only
  trigger and job tokens. So the in-job call cannot be reproduced verbatim
  outside a running job, and the printed command is the local equivalent
  rather than the same call with a different header. The `tail -1` on
  `dda inv auth.gitlab` is load-bearing too — it prints feature-flag lines
  to stdout ahead of the token, and without the `tail` those land in the
  header value and `curl` fails with `curl: (43) bad argument`. Both points
  are in comments next to the in-job `curl` for anyone copying it.
- The in-job `curl` ends in `|| true`. Runner executes these script blocks
  under `set -eo pipefail`, where a bare `VAR=$(failing-cmd)` aborts the
  block outright — which would skip the warning, the `NOTE:`, and the
  self-service output, i.e. everything useful on that path. The surrounding
  empty-string check is what actually detects failure. (The existing
  walk-back loop's `if [[ ! $(aws ...) ]]` is exempt from `-e` because the
  substitution sits inside `[[ ]]`; a bare assignment isn't.)
- A job-token trigger yields a pipeline with `source=pipeline` linked to the
  triggering job, where `POST /pipeline` would yield an unlinked
  `source=api`. That in principle exposes the rebuild to auto-cancellation
  when the developer next pushes — checked and clear:
  `auto_cancel_pending_pipelines` is unset on this project, and of the 14
  `source=pipeline` pipelines on `7.81.x`, 7 succeeded and 7 failed, none
  cancelled. `.if_triggered_pipeline` is `"trigger" || "pipeline"`, so jobs
  gated on it still run.
- `smp_baseline_rebuild_triggered` reports the outcome (`true`/`false`), not
  the attempt, so the trigger's failure rate stays visible.
- `git rev-parse "origin/${SMP_BASE_BRANCH}"` adds no new dependency on
  ref availability: the release-branch regex means it only runs on
  release-targeting dev branches, and reaching that line requires having
  already passed `git merge-base ... origin/${SMP_BASE_BRANCH}` earlier in
  the same job.
- If the release branch advances past the commit whose image gets built
  here, the walk-back from the developer's new merge base reaches that
  commit anyway, and it's still an ancestor of the branch head.

## What this does *not* fix

- No rescue for the run that discovers the problem: an image build far
  exceeds this job's 10-minute timeout. The developer re-runs after
  updating their branch.
- No dedup or throttle: several backport PRs against the same dormant
  release branch each trigger their own pipeline.
- ECR tags are immutable, so a racing publish fails one of them.

## Test plan

**What this PR's own CI can and cannot tell you.** This is a
`main`-targeting branch with a fresh merge base, so the release-branch arm
never fires and *none* of the added lines execute in these pipelines. A
green `merge_base_check` here confirms the YAML parses and the common path
is untouched — nothing more. The evidence that the trigger works is
pipeline `125026350` below, not this PR's CI.

- [x] `dda inv linter.gitlab-ci-shellcheck` passes (no findings for this
      job; the two pre-existing `SC2086` infos in the walk-back loop are
      untouched)
- [x] `dda inv linter.gitlab-ci` passes (9 rule contexts)
- [x] Job YAML parses and the modified script block passes `bash -n`
- [x] Verified the emitted self-service `curl` works as printed (`POST`
      with `PRIVATE-TOKEN` + `tail -1`), and that the
      `/-/pipelines/new?ref=<branch>` page loads with a branch dropdown and
      input-variable fields
- [x] Verified against the live API that
      `single_machine_performance-full-amd64-a7` is present in a
      release-branch pipeline, and that the trigger endpoint's response
      carries the `web_url` this reads (its Pipeline object has no `commit`
      field, unlike the jobs endpoint)
- [x] **Answered: no.** `CI_JOB_TOKEN` is *not* permitted to read
      `/projects/:id/pipelines/:id/jobs` — the job-token allowlist grants
      `GET /job` and nothing else out of the Jobs API. The earlier check had
      only been run with a `PRIVATE-TOKEN`, a different authorization path.
      The paging loop that depended on it was therefore dead code in CI and
      has been removed
- [x] Verified the trigger endpoint doesn't merely return 201 but actually
      produces the image: pipeline
      [`125026350`](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/125026350)
      on `7.81.x` (`source=pipeline`, 863 jobs) ran
      `single_machine_performance-full-amd64-a7` to `success`
- [x] Simulated all five `describe-images` outcomes under the runner's
      `set -eo pipefail` — image present, `ImageNotFoundException`,
      `ThrottlingException`, `ExpiredTokenException`, and a connection failure.
      Only the confirmed miss triggers; the three inconclusive cases warn
      without triggering; the block completes rather than aborting in all five
- [x] Verified `auto_cancel_pending_pipelines` is unset on project 4670 and
      that no `source=pipeline` pipeline on `7.81.x` has been cancelled
- [x] A `main`-targeting dev-branch PR still resolves `BASELINE_SHA` via
      `git merge-base`, unchanged: `merge_base_check` succeeds on this PR's
      own pipelines (e.g. job `1906602380` in pipeline `127850497`)
- [ ] Re-run `merge_base_check` on a backport PR with a stale merge base
      against a dormant release branch: confirm it fails with the
      update-your-branch message, logs the trigger, and a pipeline appears
      on the release branch
- [ ] Confirm a backport PR with a fresh merge base passes with baseline
      == merge base and triggers nothing




