### PR TITLE
smp: trigger rebuild for stale baseline image

### DIFF
--- a/.gitlab/test/functional_test/regression_detector.yml
+++ b/.gitlab/test/functional_test/regression_detector.yml
@@ -36,6 +36,18 @@ single_machine_performance-regression_detector-merge_base_check:
           # On the base branch, use the parent commit as the baseline
           BASELINE_SHA=$(git rev-parse "${CI_COMMIT_SHA}^")
           echo "On base branch, using parent commit ${BASELINE_SHA} as initial baseline"
+      elif [[ "$SMP_BASE_BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]]; then
+          # On a branch targeting a release branch (e.g. a backport PR), use
+          # the release branch's tip as the baseline instead of the merge
+          # base. Release branches get an SMP image built unconditionally on
+          # every commit (see .if_release_branch/.on_main_or_release_branch
+          # in .gitlab-ci.yml), so the tip reliably has a recent image. The
+          # merge base, by contrast, can go stale while a backport PR sits in
+          # review and the release branch keeps moving -- and once it's
+          # stale enough to lack an image, the one-shot age-check bypass
+          # below can't help, because it only protects the merge base itself.
+          BASELINE_SHA=$(git rev-parse "origin/${SMP_BASE_BRANCH}")
+          echo "Targeting release branch ${SMP_BASE_BRANCH}, using its tip ${BASELINE_SHA} as initial baseline"
       else
           # On a dev branch, compute the merge base with the base branch
           echo "Looking for merge base for branch ${SMP_BASE_BRANCH}"
@@ -43,7 +55,6 @@ single_machine_performance-regression_detector-merge_base_check:
           echo "Merge base is ${SMP_MERGE_BASE}"
           BASELINE_SHA="${SMP_MERGE_BASE}"
       fi
-    - BASELINE_COMMIT_TIME=$(git -c log.showSignature=false show --no-patch --format=%ct ${BASELINE_SHA})
     # Setup AWS credentials for single-machine-performance AWS account to check ECR images
     - AWS_NAMED_PROFILE="single-machine-performance"
     - SMP_ACCOUNT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SMP_ACCOUNT account_id) || exit $?
@@ -68,6 +79,10 @@ single_machine_performance-regression_detector-merge_base_check:
     # that we can still use it on predecessor commits that are usually older than
     # the current commit under test -- this check gives us a fast-fail condition so
     # we avoid wasting time checking for expired images in common cases.
+    #
+    # For branches targeting a release branch, BASELINE_SHA is already the
+    # release branch's tip (set above), which normally has a fresh image and
+    # clears this bypass without needing special-casing here.
     - echo "Checking if image exists for commit ${BASELINE_SHA}..."
     - |
       while [[ ! $(aws ecr describe-images --region us-west-2 --profile single-machine-performance --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${BASELINE_SHA}-7-full-amd64") ]]
@@ -78,7 +93,7 @@ single_machine_performance-regression_detector-merge_base_check:
           BASELINE_COMMIT_TIME=$(git -c log.showSignature=false show --no-patch --format=%ct ${BASELINE_SHA})
           if [[ ${BASELINE_COMMIT_TIME} -le ${FOUR_DAYS_BEFORE_NOW} ]]
           then
-              echo "ERROR: Merge-base of this branch is too old for SMP. Please update your branch by merging an up-to-date main branch into your branch or by rebasing it on an up-to-date main branch."
+              echo "ERROR: Baseline commit for this branch is too old for SMP. Please update your branch by merging or rebasing it onto an up-to-date ${SMP_BASE_BRANCH} branch."
               datadog-ci tag --level job --tags smp_merge_base_failure_reason:"branch_too_old"
               exit 1
           fi

--- a/.gitlab/test/functional_test/regression_detector.yml
+++ b/.gitlab/test/functional_test/regression_detector.yml
@@ -65,6 +65,38 @@ single_machine_performance-regression_detector-merge_base_check:
     - aws configure set aws_secret_access_key "$SMP_BOT_KEY" --profile ${AWS_NAMED_PROFILE}
     - aws configure set region us-west-2 --profile ${AWS_NAMED_PROFILE}
 
+    # If a release branch's own tip has no published image (e.g. a dormant
+    # release branch whose last image aged out of ECR), trigger a full
+    # pipeline on that branch to rebuild it. This can't rescue the current
+    # run -- a rebuild takes far longer than this job's timeout -- but it
+    # means a developer can just re-run this job once the triggered
+    # pipeline finishes, instead of noticing the failure and rebuilding by
+    # hand. Best-effort: a failure here is logged and does not change this
+    # job's own pass/fail outcome.
+    #
+    # This intentionally only applies to release branches, not to dev
+    # branches targeting main. Rebuilding a base branch's own image this
+    # way costs two pipelines run in sequence -- the triggered rebuild,
+    # then a re-run of this pipeline to pick up the image it published --
+    # roughly double the wait. For a dev branch targeting main, that
+    # penalty isn't worth paying: main gets frequent commits, so the
+    # merge-base with main almost always already has an image in ECR from
+    # some other recent PR, and if it doesn't, merging or rebasing onto an
+    # up-to-date main is a single pipeline, not two. Release branches
+    # don't have that option -- they can go long stretches without a
+    # commit, so their tip image can go stale with no cheaper way to
+    # refresh it than rebuilding it directly.
+    - |
+      if [[ "$SMP_BASE_BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]] && [[ ! $(aws ecr describe-images --region us-west-2 --profile single-machine-performance --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${BASELINE_SHA}-7-full-amd64") ]]; then
+          echo "No image published for ${SMP_BASE_BRANCH} tip (${BASELINE_SHA}) -- triggering a pipeline on ${SMP_BASE_BRANCH} to rebuild it"
+          curl --silent --show-error --fail \
+              --request POST \
+              --header "JOB-TOKEN: ${CI_JOB_TOKEN}" \
+              --data "ref=${SMP_BASE_BRANCH}" \
+              "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/pipeline" \
+            || echo "WARNING: failed to trigger rebuild pipeline on ${SMP_BASE_BRANCH} -- a developer will need to trigger one manually"
+      fi
+
     # Check if image exists for the baseline SHA, walking backwards on the
     # commit graph until a container corresponding to the possible baseline is
     # found, or the possible baseline commit is too old. If the commit is too


### PR DESCRIPTION
## Summary

Stacked on #54152 (please review that one first).

When a release branch's own tip has no published SMP baseline image
(e.g. a dormant release branch whose last image aged out of ECR after
4 days per lifecycle policy), the `merge_base_check` job now triggers a
full pipeline on that branch via the GitLab Pipelines API
(`POST .../pipeline`, authenticated with the job's own `CI_JOB_TOKEN`,
no new secrets needed) to rebuild and republish the image.

This can't rescue the currently-failing run -- a rebuild takes far
longer than this job's 10-minute timeout -- but it means a developer
can just re-run `merge_base_check` once the triggered pipeline
finishes, instead of noticing the failure and rebuilding by hand. The
trigger is best-effort: a failure to call the API is logged as a
warning and does not change `merge_base_check`'s own pass/fail
outcome.

This intentionally only applies to release branches, not to dev
branches targeting `main`. Rebuilding a base branch's own image this
way costs two pipelines run in sequence -- the triggered rebuild, then
a re-run of this pipeline to pick up the image it published -- roughly
double the wait. That penalty is worth paying for release branches:
they can go long stretches without a commit, so their tip image can go
stale with no cheaper way to refresh it than rebuilding it directly.
Dev branches targeting `main` don't have this problem in practice --
`main` gets frequent commits, so the merge-base almost always already
has a cached image from some other recent PR, and if it doesn't,
merging/rebasing onto an up-to-date `main` is a single pipeline, not
two.

## What this does not fix

- Does not rescue the run that discovered the missing image -- it only
  pre-warms the image for a later manual retry.
- No dedup/throttle: if multiple backport PRs targeting the same
  dormant release branch fail around the same time, each independently
  triggers its own full pipeline. Accepted as rare and low-cost.
- ECR tags are immutable; if a triggered pipeline races another
  publish of the same tag, one publish job fails outright. This fails
  only that one job in that one pipeline -- it doesn't corrupt the
  registry or cascade.

## Test plan

- `dda inv linter.gitlab-ci-shellcheck` and `dda inv linter.gitlab-ci`
  both pass locally (9/9 pipeline contexts).
- This is CI-environment-dependent (GitLab API auth, real ECR image
  publish timing) and can't be meaningfully dry-run locally beyond the
  linters above. Real verification is against live CI: forcing or
  observing a dormant release branch with a missing tip image and
  confirming the triggered pipeline actually starts.

## Additional notes

Follow-up to #54152, which fixes the more common case (a backport PR's
merge-base going stale while the release branch itself still has a
fresh tip image). This PR addresses the deeper case where the release
branch's own tip image has also expired.