### PR TITLE
Support bazel queries over `@cpython` on non-windows

### DIFF
--- a/bazel/rules/visual_studio.bzl
+++ b/bazel/rules/visual_studio.bzl
@@ -4,6 +4,21 @@
 load("@rules_python//python/private:repo_utils.bzl", "repo_utils")  # buildifier: disable=bzl-visibility
 
 def _visual_studio_impl(ctx):
+    # Create a dummy non-working version of the repository on non-windows
+    # so that (unconfigured) queries can traverse targets that depend on
+    # this repository even when it can't be made available
+    if not ctx.os.name.startswith("windows"):
+        ctx.file("dummy_msbuild")
+        ctx.file("BUILD.bazel", """
+filegroup(
+    name = "msbuild",
+    srcs = ["dummy_msbuild"],
+    visibility = ["//visibility:public"],
+    target_compatible_with = ["@platforms//:incompatible"],
+)
+""")
+        return ctx.repo_metadata()
+
     # vswhere is a tool that lets us inspect existing Visual Studio installations
     ctx.report_progress("Download vswhere.exe")
     ctx.download(

--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -110,6 +110,7 @@ run_binary(
         ]
     ],
     tool = "build_python.bat",
+    target_compatible_with = ["@platforms//os:windows"],
     visibility = ["//visibility:public"],
 )
 
@@ -462,6 +463,7 @@ select_file(
     name = "python_stable_lib_linux",
     srcs = ":python_unix",
     subpath = "lib/libpython3.so",
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 pkg_files(


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

It allows full use of bazel `cquery` and `query` that pass through `@cpython//...`, via two specific changes:

- Adds compatibility attributes to a couple of targets to make them correctly reflect what they support.
- Adds a _dummy_ path for the Visual Studio rule such that it doesn't fail during analysis on non-Windows.

### Motivation

These queries were "broken by default":

```
❯ bazel cquery @cpython//...
INFO: Repo +visual_studio+visual_studio defined by rule visual_studio in @@//bazel/rules:visual_studio.bzl
INFO: repository @@+visual_studio+visual_studio' used the following cache hits instead of downloading the corresponding file.
 * Hash 'c54f3b7c9164ea9a0db8641e81ecdda80c2664ef5a47c4191406f848cc07c662' for https://github.com/microsoft/vswhere/releases/download/3.1.7/vswhere.exe
If the definition of 'repository @@+visual_studio+visual_studio' was updated, verify that the hashes were also updated.
ERROR: /Users/alex.lopez/worktrees/datadog-agent/firefight/bazel/rules/visual_studio.bzl:25:17: An error occurred during the fetch of repository '+visual_studio+visual_studio':
   Traceback (most recent call last):
	File "/Users/alex.lopez/worktrees/datadog-agent/firefight/bazel/rules/visual_studio.bzl", line 25, column 17, in _visual_studio_impl
		fail("Environment variable '%s' is not defined" % ctx.attr.path_variable)
Error in fail: Environment variable 'VSTUDIO_ROOT' is not defined
ERROR: no such package '@@+visual_studio+visual_studio//': Environment variable 'VSTUDIO_ROOT' is not defined
ERROR: /Users/alex.lopez/Library/Caches/bazel/_bazel_alex.lopez/da6835c6a438804ff327c6dd2bb66dd1/external/+http_archive+cpython/BUILD.bazel:53:11: @@+http_archive+cpython//:python_win depends on @@+visual_studio+visual_studio//:msbuild in repository @@+visual_studio+visual_studio which failed to fetch. no such package '@@+visual_studio+visual_studio//': Environment variable 'VSTUDIO_ROOT' is not defined
ERROR: Analysis of target '@@+http_archive+cpython//:headers_win' failed; build aborted: Analysis failed
INFO: Elapsed time: 2.801s
INFO: 0 processes.
ERROR: Build did NOT complete successfully
```

And

```
bazel query 'rdeps(@cpython//..., @libpcap//:pcap)'
INFO: Repo +visual_studio+visual_studio defined by rule visual_studio in @@//bazel/rules:visual_studio.bzl
INFO: repository @@+visual_studio+visual_studio' used the following cache hits instead of downloading the corresponding file.
 * Hash 'c54f3b7c9164ea9a0db8641e81ecdda80c2664ef5a47c4191406f848cc07c662' for https://github.com/microsoft/vswhere/releases/download/3.1.7/vswhere.exe
If the definition of 'repository @@+visual_studio+visual_studio' was updated, verify that the hashes were also updated.
ERROR: /Users/alex.lopez/worktrees/datadog-agent/firefight/bazel/rules/visual_studio.bzl:25:17: An error occurred during the fetch of repository '+visual_studio+visual_studio':
   Traceback (most recent call last):
	File "/Users/alex.lopez/worktrees/datadog-agent/firefight/bazel/rules/visual_studio.bzl", line 25, column 17, in _visual_studio_impl
		fail("Environment variable '%s' is not defined" % ctx.attr.path_variable)
Error in fail: Environment variable 'VSTUDIO_ROOT' is not defined
ERROR: Evaluation of query "rdeps(@cpython//..., @libpcap//:pcap)" failed: preloading transitive closure failed: no such package '@@+visual_studio+visual_studio//': Environment variable 'VSTUDIO_ROOT' is not defined
```

### Describe how you validated your changes

The previously failing queries now work without errors.

### Additional Notes
