### PR TITLE
[WP] Fix ICMPv4 packet flow classification

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/network/pid_resolver.h
+++ b/pkg/security/ebpf/c/include/helpers/network/pid_resolver.h
@@ -14,7 +14,6 @@ __attribute__((always_inline)) s64 get_flow_pid(struct pid_route_t *key) {
             return 0;
         }
     }
-
     return value->pid;
 }
 
@@ -27,13 +26,23 @@ __attribute__((always_inline)) void resolve_pid_from_flow_pid(struct packet_t *p
         pid_route.addr[0] = pkt->translated_ns_flow.flow.saddr[0];
         pid_route.addr[1] = pkt->translated_ns_flow.flow.saddr[1];
         pid_route.port = pkt->translated_ns_flow.flow.tcp_udp.sport;
+        if (pkt->translated_ns_flow.flow.l4_protocol == IPPROTO_TCP || pkt->translated_ns_flow.flow.l4_protocol == IPPROTO_UDP) {
+            pid_route.port = pkt->ns_flow.flow.tcp_udp.sport;
+        } else if (pkt->translated_ns_flow.flow.l4_protocol == IPPROTO_ICMP) {
+            pid_route.port = pkt->ns_flow.flow.icmp.id;
+        }
         pid_route.netns = pkt->translated_ns_flow.netns;
+
         break;
     }
     case INGRESS: {
         pid_route.addr[0] = pkt->translated_ns_flow.flow.daddr[0];
         pid_route.addr[1] = pkt->translated_ns_flow.flow.daddr[1];
-        pid_route.port = pkt->translated_ns_flow.flow.tcp_udp.dport;
+        if (pkt->translated_ns_flow.flow.l4_protocol == IPPROTO_TCP || pkt->translated_ns_flow.flow.l4_protocol == IPPROTO_UDP) {
+            pid_route.port = pkt->ns_flow.flow.tcp_udp.dport;
+        } else if (pkt->translated_ns_flow.flow.l4_protocol == IPPROTO_ICMP) {
+            pid_route.port = pkt->ns_flow.flow.icmp.id;
+        }
         pid_route.netns = pkt->translated_ns_flow.netns;
         break;
     }

--- a/pkg/security/ebpf/c/include/helpers/network/pid_resolver.h
+++ b/pkg/security/ebpf/c/include/helpers/network/pid_resolver.h
@@ -25,7 +25,7 @@ __attribute__((always_inline)) void resolve_pid_from_flow_pid(struct packet_t *p
     case EGRESS: {
         pid_route.addr[0] = pkt->translated_ns_flow.flow.saddr[0];
         pid_route.addr[1] = pkt->translated_ns_flow.flow.saddr[1];
-        pid_route.port = pkt->translated_ns_flow.flow.tcp_udp.sport;
+        // then we only support TCP, UDP and ICMP for now
         if (pkt->translated_ns_flow.flow.l4_protocol == IPPROTO_TCP || pkt->translated_ns_flow.flow.l4_protocol == IPPROTO_UDP) {
             pid_route.port = pkt->ns_flow.flow.tcp_udp.sport;
         } else if (pkt->translated_ns_flow.flow.l4_protocol == IPPROTO_ICMP) {
@@ -38,6 +38,7 @@ __attribute__((always_inline)) void resolve_pid_from_flow_pid(struct packet_t *p
     case INGRESS: {
         pid_route.addr[0] = pkt->translated_ns_flow.flow.daddr[0];
         pid_route.addr[1] = pkt->translated_ns_flow.flow.daddr[1];
+        // then we only support TCP, UDP and ICMP for now
         if (pkt->translated_ns_flow.flow.l4_protocol == IPPROTO_TCP || pkt->translated_ns_flow.flow.l4_protocol == IPPROTO_UDP) {
             pid_route.port = pkt->ns_flow.flow.tcp_udp.dport;
         } else if (pkt->translated_ns_flow.flow.l4_protocol == IPPROTO_ICMP) {

--- a/pkg/security/ebpf/c/include/helpers/network/skb.h
+++ b/pkg/security/ebpf/c/include/helpers/network/skb.h
@@ -1,0 +1,65 @@
+#ifndef _HELPERS_NETWORK_SKB_H_
+#define _HELPERS_NETWORK_SKB_H_
+
+__attribute__((always_inline)) unsigned char *sk_buff_head(struct sk_buff *skb) {
+    unsigned char *h = NULL;
+    u64 offset;
+    LOAD_CONSTANT("sk_buff_head_offset", offset);
+    bpf_probe_read(&h, sizeof(h), (void *)skb + offset);
+    return h;
+}
+
+__attribute__((always_inline)) u16 sk_buff_network_header(struct sk_buff *skb) {
+    u16 net_head = 0;
+    u64 offset;
+    LOAD_CONSTANT("sk_buff_transport_header_offset", offset);
+    bpf_probe_read(&net_head, sizeof(net_head), (void *)skb + offset + 2);
+    return net_head;
+}
+
+// Parses an IPv4 ICMP echo request from a kernel sk_buff and fills key fields.
+// Returns 1 on success, 0 otherwise.
+__attribute__((always_inline)) int parse_icmp_echo_flow_key_from_skb(struct sk_buff *skb, struct pid_route_t *key) {
+    unsigned char *head = sk_buff_head(skb);
+    if (head == NULL) {
+        return 0;
+    }
+
+    u16 net_head = sk_buff_network_header(skb);
+    if (net_head == 0) {
+        return 0;
+    }
+
+    struct iphdr iph;
+    bpf_probe_read(&iph, sizeof(iph), head + net_head);
+    if (iph.version != 4) {
+        return 0;
+    }
+    if (iph.protocol != IPPROTO_ICMP) {
+        return 0;
+    }
+
+    u8 ihl = iph.ihl;
+    if (ihl < 5) {
+        return 0;
+    }
+
+    struct icmphdr icmph;
+    bpf_probe_read(&icmph, sizeof(icmph), head + net_head + (ihl * 4));
+    if (icmph.type != ICMP_ECHO) {
+        return 0;
+    }
+
+    u16 ident = 0;
+    bpf_probe_read(&ident, sizeof(ident), &icmph.un.echo.id);
+    key->port = htons(ident);
+    if (key->port == 0) {
+        return 0;
+    }
+
+    key->l4_protocol = IPPROTO_ICMP;
+    bpf_probe_read(&key->addr[0], sizeof(u32), &iph.saddr);
+    return 1;
+}
+
+#endif

--- a/pkg/security/ebpf/c/include/hooks/network/flow.h
+++ b/pkg/security/ebpf/c/include/hooks/network/flow.h
@@ -6,13 +6,113 @@
 #include "helpers/network/pid_resolver.h"
 #include "helpers/network/utils.h"
 #include "helpers/network/flow.h"
+#include "helpers/network/skb.h"
+__attribute__((always_inline)) int register_flow_pid_classify_entry(struct sock *sk, u64 pid, struct pid_route_t *key) {
+    struct pid_route_entry_t value = {};
+
+    #if defined(DEBUG_NETWORK_FLOW)
+    print_route(key);
+    #endif
+
+    struct sock_meta_t *meta = get_sock_meta(sk);
+    if (meta != NULL) {
+        if (meta->existing_route.port != 0 || meta->existing_route.addr[0] != 0 || meta->existing_route.addr[1] != 0) {
+            struct pid_route_t tmp_route = meta->existing_route;
+
+            if (can_delete_route(&tmp_route, sk)) {
+
+                #if defined(DEBUG_NETWORK_FLOW)
+                bpf_printk("|    flushing previous route:");
+                print_route(&tmp_route);
+                #endif
+
+                bpf_map_delete_elem(&flow_pid, &tmp_route);
+            }
+
+            tmp_route.addr[0] = 0;
+            tmp_route.addr[1] = 0;
+
+            if (can_delete_route(&tmp_route, sk)) {
+            #if defined(DEBUG_NETWORK_FLOW)
+                bpf_printk("|    flushing previous empty route:");
+                print_route(&tmp_route);
+            #endif
+            bpf_map_delete_elem(&flow_pid, &tmp_route);
+            }
+        }
+    } else {
+       #if defined(DEBUG_NETWORK_FLOW)
+        bpf_printk("|    no sock_meta entry !");
+       #endif
+    }
+
+    if (key->port == 0) {
+        return 0;
+    }
+
+    u32 tid = (u32)pid;
+    value.pid = pid >> 32;
+    value.type = FLOW_CLASSIFICATION_ENTRY;
+    value.owner_sk = sk;
+
+    if (!can_delete_route(key, sk)) {
+
+       #if defined(DEBUG_NETWORK_FLOW)
+        bpf_printk("|--> skipped because of owner_sk");
+       #endif
+
+        return 0;
+    }
+
+    if (meta != NULL) {
+        meta->existing_route = *key;
+    }
+
+    if (key->netns != 0) {
+        bpf_map_update_elem(&netns_cache, &tid, &key->netns, BPF_ANY);
+    }
+    bpf_map_update_elem(&flow_pid, key, &value, BPF_ANY);
+
+   #if defined(DEBUG_NETWORK_FLOW)
+    print_route(key);
+    print_route_entry(&value);
+    bpf_printk("|--> new flow registered ! %d, %lu", value.pid, key->netns);
+   #endif
+
+    return 0;
+}
+// Registers IPv4 ICMP echo flows by parsing the packet in ip_finish_output.
+HOOK_ENTRY("ip_finish_output")
+int hook_ip_finish_output(ctx_t *ctx) {
+    u64 pid = bpf_get_current_pid_tgid();
+    if (pid == 0) {
+        return 0;
+    }
+
+    struct sock *sk = (struct sock *)CTX_PARM2(ctx);
+    struct sk_buff *skb = (struct sk_buff *)CTX_PARM3(ctx);
+    if (sk == NULL || skb == NULL) {
+        return 0;
+    }
+
+    if (get_protocol_from_sock(sk) != IPPROTO_ICMP) {
+        return 0;
+    }
+
+    struct pid_route_t key = {};
+    if (!parse_icmp_echo_flow_key_from_skb(skb, &key)) {
+        return 0;
+    }
+
+    key.netns = get_netns_from_sock(sk);
+    return register_flow_pid_classify_entry(sk, pid, &key);
+}
 
 HOOK_ENTRY("security_sk_classify_flow")
 int hook_security_sk_classify_flow(ctx_t *ctx) {
     struct sock *sk = (struct sock *)CTX_PARM1(ctx);
     struct flowi *fl = (struct flowi *)CTX_PARM2(ctx);
     struct pid_route_t key = {};
-    struct pid_route_entry_t value = {};
     union flowi_uli uli;
 
     #if defined(DEBUG_NETWORK_FLOW)
@@ -32,9 +132,14 @@ int hook_security_sk_classify_flow(ctx_t *ctx) {
         return 0;
     }
 
-    u64 id = bpf_get_current_pid_tgid();
-    if (id == 0) {
+    u64 pid = bpf_get_current_pid_tgid();
+    if (pid == 0) {
         // we only care about packet sent from an actual task
+        return 0;
+    }
+
+    if (get_protocol_from_sock(sk) == IPPROTO_ICMP) {
+        // IPv4 ICMP is registered from the packet in ip_finish_output.
         return 0;
     }
 
@@ -84,77 +189,7 @@ int hook_security_sk_classify_flow(ctx_t *ctx) {
     print_route(&key);
     #endif
 
-    // check if the socket already has an active flow
-    struct sock_meta_t *meta = get_sock_meta(sk);
-    if (meta != NULL) {
-        if (meta->existing_route.port != 0 || meta->existing_route.addr[0] != 0 || meta->existing_route.addr[1] != 0) {
-            struct pid_route_t tmp_route = meta->existing_route;
-
-            if (can_delete_route(&tmp_route, sk)) {
-
-                #if defined(DEBUG_NETWORK_FLOW)
-                bpf_printk("|    flushing previous route:");
-                print_route(&tmp_route);
-                #endif
-
-                bpf_map_delete_elem(&flow_pid, &tmp_route);
-            }
-
-            // check with an empty IP address
-            tmp_route.addr[0] = 0;
-            tmp_route.addr[1] = 0;
-
-            if (can_delete_route(&tmp_route, sk)) {
-                #if defined(DEBUG_NETWORK_FLOW)
-                bpf_printk("|    flushing previous empty route:");
-                print_route(&tmp_route);
-                #endif
-
-                bpf_map_delete_elem(&flow_pid, &tmp_route);
-            }
-        }
-    } else {
-        #if defined(DEBUG_NETWORK_FLOW)
-        bpf_printk("|    no sock_meta entry !");
-        #endif
-    }
-
-    // Register service PID
-    if (key.port != 0) {
-        u32 tid = (u32)id;
-        value.pid = id >> 32;
-        value.type = FLOW_CLASSIFICATION_ENTRY;
-        value.owner_sk = sk;
-
-        // check if there is already an entry for key, and if so, make sure we can override it
-        if (!can_delete_route(&key, sk)) {
-
-            #if defined(DEBUG_NETWORK_FLOW)
-            bpf_printk("|--> skipped because of owner_sk");
-            #endif
-
-            // we don't want to override the existing entry
-            return 0;
-        }
-
-        if (meta != NULL) {
-            // register the new route in the sock_active_pid_route map
-            meta->existing_route = key;
-        }
-
-        if (key.netns != 0) {
-            bpf_map_update_elem(&netns_cache, &tid, &key.netns, BPF_ANY);
-        }
-
-        bpf_map_update_elem(&flow_pid, &key, &value, BPF_ANY);
-
-        #if defined(DEBUG_NETWORK_FLOW)
-        print_route(&key);
-        print_route_entry(&value);
-        bpf_printk("|--> new flow registered ! %d, %lu", value.pid, key.netns);
-        #endif
-    }
-    return 0;
+    return register_flow_pid_classify_entry(sk, pid, &key);
 }
 
 __attribute__((always_inline)) int trace_nat_manip_pkt(struct nf_conn *ct) {

--- a/pkg/security/ebpf/c/include/hooks/network/tc.h
+++ b/pkg/security/ebpf/c/include/hooks/network/tc.h
@@ -99,7 +99,6 @@ int classifier_raw_packet_egress(struct __sk_buff *skb) {
         return TC_ACT_UNSPEC;
     }
     resolve_pid(skb, pkt);
-
     if (pkt->pid) {
         pkt->cgroup_id = get_cgroup_id(pkt->pid);
     }

--- a/pkg/security/ebpf/c/include/hooks/procfs.h
+++ b/pkg/security/ebpf/c/include/hooks/procfs.h
@@ -142,12 +142,13 @@ int hook_path_get(ctx_t *ctx) {
     }
 
     route.port = get_skc_num_from_sock_common((void *)sk);
-    if (route.port == 0) {
+    route.l4_protocol = get_protocol_from_sock(sk);
+    u16 family = get_family_from_sock_common((void *)sk);
+    // we allow ICMP traffic to be captured with no port
+    if (route.port == 0 && route.l4_protocol != IPPROTO_ICMP) {
         // without a port we can't do much, leave early
         return 0;
     }
-    route.l4_protocol = get_protocol_from_sock(sk);
-    u16 family = get_family_from_sock_common((void *)sk);
     if (family == AF_INET6) {
         bpf_probe_read(&route.addr, sizeof(u64) * 2, &sk->__sk_common.skc_v6_rcv_saddr);
         bpf_map_update_elem(&flow_pid, &route, &value, BPF_ANY);

--- a/pkg/security/ebpf/c/prebuilt/probe.c
+++ b/pkg/security/ebpf/c/prebuilt/probe.c
@@ -4,6 +4,7 @@
 #include <linux/types.h>
 #include <linux/version.h>
 
+#include <linux/skbuff.h>
 #include <net/sock.h>
 #include <net/netfilter/nf_conntrack.h>
 #include <net/netfilter/nf_nat.h>

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -55,6 +55,7 @@ func NetworkSelectors(hasFentry, hasCgroupSocket, haveIOURing bool) []manager.Pr
 			hookFunc("hook_sk_common_release"),
 			hookFunc("hook_path_get"),
 			hookFunc("hook_proc_fd_link"),
+			hookFunc("hook_ip_finish_output"),
 		}},
 
 		&manager.BestEffort{Selectors: []manager.ProbesSelector{

--- a/pkg/security/ebpf/probes/flow.go
+++ b/pkg/security/ebpf/probes/flow.go
@@ -21,6 +21,12 @@ func getFlowProbes() []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_ip_finish_output",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_inet_release",
 			},
 		},

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -126,10 +126,10 @@ const (
 	OffsetNameFlowI6StructULI           = "flowi6_uli_offset"
 	OffsetNameSockStructSKProtocol      = "sock_sk_protocol_offset" // kernel >= 5.6
 	// TODO: needed for l4_protocol resolution, see network/flow.h
-	OffsetNameFlowI4StructProto = "flowi4_proto_offset"
-	OffsetNameFlowI6StructProto = "flowi6_proto_offset"
-	OffsetNameRtnlLinkOpsKind   = "rtnl_link_ops_kind_offset"
-	OffsetNameSkBuffHead          = "sk_buff_head_offset"
+	OffsetNameFlowI4StructProto     = "flowi4_proto_offset"
+	OffsetNameFlowI6StructProto     = "flowi6_proto_offset"
+	OffsetNameRtnlLinkOpsKind       = "rtnl_link_ops_kind_offset"
+	OffsetNameSkBuffHead            = "sk_buff_head_offset"
 	OffsetNameSkBuffTransportHeader = "sk_buff_transport_header_offset"
 
 	// nsproxy offsets

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -129,6 +129,8 @@ const (
 	OffsetNameFlowI4StructProto = "flowi4_proto_offset"
 	OffsetNameFlowI6StructProto = "flowi6_proto_offset"
 	OffsetNameRtnlLinkOpsKind   = "rtnl_link_ops_kind_offset"
+	OffsetNameSkBuffHead          = "sk_buff_head_offset"
+	OffsetNameSkBuffTransportHeader = "sk_buff_transport_header_offset"
 
 	// nsproxy offsets
 	OffsetNameNsproxyMntNs = "nsproxy_mnt_ns_offset"

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -148,6 +148,8 @@ func computeCallbacksTable() map[string]func(*kernel.Version) uint64 {
 		OffsetNameFlowI4StructProto:           getFlowiProtoOffset,
 		OffsetNameFlowI6StructProto:           getFlowiProtoOffset,
 		OffsetNameMountMntNs:                  getMountMntNsOffset,
+		OffsetNameSkBuffHead:                  getSkBuffHeadOffset,
+		OffsetNameSkBuffTransportHeader:       getSkBuffTransportHeaderOffset,
 		OffsetNameMountMountpoint:             getMountMountpointOffset,
 		OffsetNameTaskStructCred:              getTaskStructCredOffset,
 		OffsetNameTaskStructSignal:            getTaskStructSignalOffset,
@@ -839,6 +841,36 @@ func getFlowi6SAddrOffset(kv *kernel.Version) uint64 {
 
 func getFlowi6ULIOffset(kv *kernel.Version) uint64 {
 	return getFlowi6SAddrOffset(kv) + 20
+}
+
+func getSkBuffHeadOffset(kv *kernel.Version) uint64 {
+	offset := uint64(192)
+
+	switch {
+	case kv.IsRH7Kernel():
+		offset = 176
+	case kv.IsInRangeCloseOpen(kernel.Kernel4_14, kernel.Kernel4_19):
+		offset = 176
+	case kv.IsInRangeCloseOpen(kernel.Kernel4_19, kernel.Kernel5_0):
+		offset = 184
+	}
+
+	return offset
+}
+
+func getSkBuffTransportHeaderOffset(kv *kernel.Version) uint64 {
+	offset := uint64(120)
+
+	switch {
+	case kv.IsRH7Kernel():
+		offset = 104
+	case kv.IsInRangeCloseOpen(kernel.Kernel4_14, kernel.Kernel4_19):
+		offset = 104
+	case kv.IsInRangeCloseOpen(kernel.Kernel4_19, kernel.Kernel5_0):
+		offset = 112
+	}
+
+	return offset
 }
 
 func ubuntuAbiVersionCheck(kv *kernel.Version, minAbiPerFlavor map[string]int) bool {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3757,6 +3757,8 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameSockCommonStructSKCNum, "struct sock_common", "skc_num")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameSockStructSKProtocol, "struct sock", "sk_protocol")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameRtnlLinkOpsKind, "struct rtnl_link_ops", "kind")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameSkBuffHead, "struct sk_buff", "head")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameSkBuffTransportHeader, "struct sk_buff", "transport_header")
 	constantFetcher.AppendOffsetofRequestWithFallbacks(
 		constantfetch.OffsetNameFlowI4StructProto,
 		constantfetch.TypeFieldPair{

--- a/pkg/security/secl/compiler/ast/secl.go
+++ b/pkg/security/secl/compiler/ast/secl.go
@@ -28,27 +28,7 @@ type ParsingContext struct {
 
 // NewParsingContext returns a new parsing context
 func NewParsingContext(withRuleCache bool) *ParsingContext {
-	seclLexer := lexer.Must(ebnf.New(`
-Comment = ("#" | "//") { "\u0000"…"\uffff"-"\n" } .
-CIDR = IP "/" digit { digit } .
-IP = (ipv4 | ipv6) .
-Variable = "${" (alpha | "_") { "_" | alpha | digit | "." } "}" .
-FieldReference = "%{" (alpha | "_") { "_" | alpha | digit | "." | "[" | "]" } "}" .
-Duration = digit { digit } ("m" | "s" | "m" | "h") { "s" } .
-Regexp = "r\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
-Ident = (alpha | "_") { "_" | alpha | digit | "." | "[" | "]" } .
-String = "\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
-Pattern = "~\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
-Int = [ "-" | "+" ] digit { digit } .
-Punct = ( "!" | "=" | "<" | ">" | "+" | "-" | "[" | "]" | "(" | ")" | "," | "&" | "|" | "~" | "^" | "%" ).
-Whitespace = ( " " | "\t" | "\n" ) { " " | "\t" | "\n" } .
-ipv4 = (digit { digit } "." digit { digit } "." digit { digit } "." digit { digit }) .
-ipv6 = ( [hex { hex }] ":" [hex { hex }] ":" [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }]) .
-hex = "a"…"f" | "A"…"F" | "0"…"9" .
-alpha = "a"…"z" | "A"…"Z" .
-digit = "0"…"9" .
-any = "\u0000"…"\uffff" .
-`))
+	seclLexer := seclLexer()
 
 	var ruleCache map[string]*Rule
 	if withRuleCache {
@@ -75,6 +55,45 @@ func buildParser(obj interface{}, lexer lexer.Definition) *participle.Parser {
 		panic(err)
 	}
 	return parser
+}
+
+// RuleGrammarEBNF returns the Participle EBNF for SECL rules.
+func RuleGrammarEBNF() string {
+	return buildParser(&Rule{}, seclLexer()).String()
+}
+
+// MacroGrammarEBNF returns the Participle EBNF for SECL macros.
+func MacroGrammarEBNF() string {
+	return buildParser(&Macro{}, seclLexer()).String()
+}
+
+// ExpressionGrammarEBNF returns the Participle EBNF for SECL expressions.
+func ExpressionGrammarEBNF() string {
+	return buildParser(&Expression{}, seclLexer()).String()
+}
+
+func seclLexer() lexer.Definition {
+	return lexer.Must(ebnf.New(`
+Comment = ("#" | "//") { "\u0000"…"\uffff"-"\n" } .
+CIDR = IP "/" digit { digit } .
+IP = (ipv4 | ipv6) .
+Variable = "${" (alpha | "_") { "_" | alpha | digit | "." } "}" .
+FieldReference = "%{" (alpha | "_") { "_" | alpha | digit | "." | "[" | "]" } "}" .
+Duration = digit { digit } ("m" | "s" | "m" | "h") { "s" } .
+Regexp = "r\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
+Ident = (alpha | "_") { "_" | alpha | digit | "." | "[" | "]" } .
+String = "\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
+Pattern = "~\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
+Int = [ "-" | "+" ] digit { digit } .
+Punct = ( "!" | "=" | "<" | ">" | "+" | "-" | "[" | "]" | "(" | ")" | "," | "&" | "|" | "~" | "^" | "%" ).
+Whitespace = ( " " | "\t" | "\n" ) { " " | "\t" | "\n" } .
+ipv4 = (digit { digit } "." digit { digit } "." digit { digit } "." digit { digit }) .
+ipv6 = ( [hex { hex }] ":" [hex { hex }] ":" [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }]) .
+hex = "a"…"f" | "A"…"F" | "0"…"9" .
+alpha = "a"…"z" | "A"…"Z" .
+digit = "0"…"9" .
+any = "\u0000"…"\uffff" .
+`))
 }
 
 func unquoteLiteral(t lexer.Token) (lexer.Token, error) {

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -528,6 +528,122 @@ func TestRawPacketDropMetricAccuracyWithReload(t *testing.T) {
 	waitForMetric(ruleID1, totalExpected)
 }
 
+func TestNetworkFilterICMPPingIsolation(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	if testEnvironment == DockerEnvironment {
+		t.Skip("skip test spawning docker containers on docker")
+	}
+
+	checkKernelCompatibility(t, "network feature", isRawPacketNotSupported)
+
+	if _, err := whichNonFatal("docker"); err != nil {
+		t.Skip("skip test where docker is unavailable")
+	}
+
+	const pingHost = "1.1.1.1"
+
+	// 1) Launch the container
+	cmdWrapper, err := newDockerCmdWrapper("/tmp", "/tmp", "alpine", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cmdWrapper.start(); err != nil {
+		t.Fatal(err)
+	}
+	defer cmdWrapper.stop()
+	t.Logf("container started: %s (%s)", cmdWrapper.containerName, cmdWrapper.containerID)
+
+	// 2) Launch ping before the agent and stream its output
+	pingCmd := cmdWrapper.Command("/bin/ping", []string{"-c", "5", pingHost}, nil)
+	stdout, err := pingCmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stderr, err := pingCmd.StderrPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	linesCh := make(chan string, 32)
+	readLines := func(r io.Reader) {
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			linesCh <- scanner.Text()
+		}
+	}
+
+	if err := pingCmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	pingDone := make(chan error, 1)
+	go func() {
+		pingDone <- pingCmd.Wait()
+	}()
+
+	go readLines(stdout)
+	go readLines(stderr)
+
+	// 3) Launch the agent with an ICMP-specific cgroup drop rule
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{
+		{
+			ID:         "test_rule_network_filter_icmp_ping",
+			Expression: `exec.comm == "ping"`,
+			Actions: []*rules.ActionDefinition{
+				{
+					NetworkFilter: &rules.NetworkFilterDefinition{
+						BPFFilter: "icmp and dst host " + pingHost,
+						Scope:     "cgroup",
+						Policy:    "drop",
+					},
+				},
+			},
+		},
+	}, withStaticOpts(testOpts{networkRawPacketEnabled: true}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	// 4) Verify that pings fail by inspecting the ping process output
+	timeout := time.After(10 * time.Second)
+	for {
+		select {
+		case line := <-linesCh:
+			if pingOutputShowsPacketLoss(line) {
+				return
+			}
+		case err := <-pingDone:
+			if err == nil {
+				t.Fatal("ping completed without packet loss")
+			}
+			t.Fatalf("ping exited without packet loss: %v", err)
+		case <-timeout:
+			t.Fatal("timeout waiting for packet loss in ping output")
+		}
+	}
+}
+
+func pingOutputShowsPacketLoss(line string) bool {
+	const suffix = "% packet loss"
+	idx := strings.Index(line, suffix)
+	if idx == -1 {
+		return false
+	}
+
+	start := idx - 1
+	for start >= 0 && line[start] >= '0' && line[start] <= '9' {
+		start--
+	}
+	if start == idx-1 {
+		return false
+	}
+
+	pct, err := strconv.Atoi(line[start+1 : idx])
+	return err == nil && pct > 0
+}
+
 func TestRawPacketActionWithSignature(t *testing.T) {
 	if testEnvironment == DockerEnvironment {
 		t.Skip("skipping cgroup ID test in docker")


### PR DESCRIPTION
### What does this PR do?
This PR adds IPv4 ICMP flow registration so CWS can attribute outbound ICMP packets to the correct process on the TC path. It enables network_filter actions (e.g. cgroup-scoped drop of ongoing ping traffic) for processes that were already running before the agent started.

ICMP flows are registered from ip_finish_output by parsing the skb and keying flow_pid on the ICMP echo identifier, matching what the TC classifier already uses for lookup.

### Motivation
Network isolation depends on resolving the emitting process (and its cgroup) from packets observed in TC.

When a process started before the agent — or when socket creation was missed — CWS falls back to the flow_pid map. TCP/UDP flows were already populated via security_sk_classify_flow, but:

- that hook runs too early for ICMP where the address is chosen at runtime, so the source address we get is often still 0.0.0.0;
- ICMP has no usable L4 port; the echo identifier in the packet must be used instead.

By registering ICMP flows later in the transmit path and keying on the ICMP echo id, ICMP follows the same flow_pid → PID → cgroup resolution chain as TCP/UDP, so ongoing ICMP traffic can be attributed and filtered correctly.