### PR TITLE
[CWS] Fix glob bypass

### DIFF
--- a/pkg/security/secl/compiler/eval/glob.go
+++ b/pkg/security/secl/compiler/eval/glob.go
@@ -104,7 +104,15 @@ func (g *Glob) matchesPrefix(filename string) bool {
 		return true
 	}
 
-	return PatternMatchesWithSegments(elp, elf, g.caseInsensitive) && i+1 == len(g.prefix)
+	if !PatternMatchesWithSegments(elp, elf, g.caseInsensitive) {
+		return false
+	}
+
+	// The concrete segment matched. Accept when it is the last prefix element,
+	// or when the only remaining element is a trailing "**", so that a pattern
+	// like "/a/b/**" also matches the subtree root "/a/b" itself (kernel-reported
+	// directory paths carry no trailing slash).
+	return i+1 == len(g.prefix) || (i+2 == len(g.prefix) && g.prefix[i+1].pattern == "**")
 }
 
 func (g *Glob) matchesSuffix(filename string) bool {

--- a/pkg/security/secl/compiler/eval/glob.go
+++ b/pkg/security/secl/compiler/eval/glob.go
@@ -104,7 +104,11 @@ func (g *Glob) matchesPrefix(filename string) bool {
 		return true
 	}
 
-	return PatternMatchesWithSegments(elp, elf, g.caseInsensitive) && i+1 == len(g.prefix)
+	if !PatternMatchesWithSegments(elp, elf, g.caseInsensitive) {
+		return false
+	}
+
+	return i+1 == len(g.prefix) || (i+2 == len(g.prefix) && g.prefix[i+1].pattern == "**")
 }
 
 func (g *Glob) matchesSuffix(filename string) bool {

--- a/pkg/security/secl/compiler/eval/glob_test.go
+++ b/pkg/security/secl/compiler/eval/glob_test.go
@@ -227,6 +227,41 @@ func TestGlobMatches(t *testing.T) {
 		t.Error("should match the filename")
 	}
 
+	// a trailing "**" must also match the subtree root itself, since
+	// kernel-reported directory paths carry no trailing slash
+	if glob, _ := NewGlob("/sys/fs/cgroup/**", false, false); !glob.Matches("/sys/fs/cgroup") {
+		t.Error("should match the filename")
+	}
+
+	if glob, _ := NewGlob("/etc/secret/**", false, false); !glob.Matches("/etc/secret") {
+		t.Error("should match the filename")
+	}
+
+	if glob, _ := NewGlob("/etc/secret/**", false, false); !glob.Matches("/etc/secret/") {
+		t.Error("should match the filename")
+	}
+
+	if glob, _ := NewGlob("/etc/secret/**", false, false); !glob.Matches("/etc/secret/f") {
+		t.Error("should match the filename")
+	}
+
+	if glob, _ := NewGlob("/etc/secret/**", false, false); !glob.Matches("/etc/secret/sub/f") {
+		t.Error("should match the filename")
+	}
+
+	if glob, _ := NewGlob("/etc/**", false, false); !glob.Matches("/etc") {
+		t.Error("should match the filename")
+	}
+
+	// the trailing "**" must not leak to ancestors or prefix-sharing siblings
+	if glob, _ := NewGlob("/etc/secret/**", false, false); glob.Matches("/etc") {
+		t.Error("shouldn't match the filename")
+	}
+
+	if glob, _ := NewGlob("/etc/secret/**", false, false); glob.Matches("/etc/secretary") {
+		t.Error("shouldn't match the filename")
+	}
+
 	if glob, _ := NewGlob("/sys/fs*", false, false); !glob.Matches("/sys/fsa") {
 		t.Error("should match the filename")
 	}
@@ -308,6 +343,9 @@ func FuzzGlob(f *testing.F) {
 	f.Add("/sys/*/cgr*", "/sys/fs/cgroup")
 	f.Add("/sys/fs/cgroup/*", "/sys/fs/cgroup/")
 	f.Add("/sys/fs/cgroup/**", "/sys/fs/cgroup/")
+	f.Add("/sys/fs/cgroup/**", "/sys/fs/cgroup")
+	f.Add("/etc/secret/**", "/etc/secret")
+	f.Add("/etc/**", "/etc")
 	f.Add("/sys/fs*", "/sys/fsa")
 	f.Add("*/*/http*/*b*/test/**", "/var/log/httpd/abc/test/123")
 	f.Add("**", "/var/log/httpd/abc/test/123")


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Make a trailing `/**` glob also match the directory itself. `/etc/secret/**` now matches `/etc/secret`, not only files under it.

### Motivation

Kernel-reported directory paths have no trailing slash, so CWS rules using `/**` missed the directory node and could be bypassed by operating on the directory itself.

### Describe how you validated your changes

Unit tests in `glob_test.go` covering the base directory, children, ancestors, and prefix-sharing siblings (`/etc/secretary`).

### Additional Notes