### PR TITLE
ci(otel): bump docker_image_build_otel to 40m

### DIFF
--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -30,6 +30,10 @@ docker_image_build_otel:
   # tests on non-DinD runners. DinD runners avoid the code path entirely (Docker
   # is reached over TCP), which is why the same image worked there before.
   tags: ["docker-in-docker:amd64"]
+  # Override the 30m timeout inherited from .docker_build_job_definition. On
+  # release branches the docker registry cache isn't used, so the build (and its
+  # apt install steps) can run noticeably slower and occasionally exceed 30m.
+  timeout: 40m
   variables:
     KUBERNETES_MEMORY_REQUEST: 32Gi
     KUBERNETES_MEMORY_LIMIT: 32Gi


### PR DESCRIPTION
<!-- dd-meta {"pullId":"85d6d914-64f6-4b37-8f7c-1ba194c0bb03","source":"chat","resourceId":"b8d6938f-7f08-41d0-a8c8-9807ed2b5daa","workflowId":"5de1b7df-86d8-46aa-8919-e2c00f797a7d","codeChangeId":"5de1b7df-86d8-46aa-8919-e2c00f797a7d","sourceType":"slack"} -->
### What does this PR do?

Adds a `timeout: 40m` override to the `docker_image_build_otel` GitLab CI job in `.gitlab/test/integration_test/otel.yml`. Previously the job inherited the `timeout: 30m` from `.docker_build_job_definition` (in `.gitlab/deploy/container_build/docker_linux.yml`).

### Motivation

The `docker_image_build_otel` job has been intermittently hitting its 30-minute timeout and failing repeatedly on the `7.x rc.7` release pipeline, blocking the release since Friday evening. The job typically completes in under 22 minutes, but on release branches the docker registry cache is not used (unlike main pipelines), so the build — including `apt install` steps that were observed taking ~8 minutes — runs noticeably slower and occasionally exceeds 30m. This is an external slowdown rather than a code regression, so raising the ceiling unblocks the release. The DDOT/otel image built here is consumed internally, so the failure cannot be skipped.

### Describe how you validated your changes

- Confirmed `docker_image_build_otel` extends `.docker_build_job_definition`, which defines `timeout: 30m`, and that the job had no prior `timeout` override, so its effective timeout was 30m.
- Verified the new `timeout: 40m` is set at the job (top) level — the correct GitLab CI keyword scope — mirroring the pattern used by `docker_build_dogstatsd_amd64`/`_arm64` (`timeout: 20m`), so it overrides the inherited value.
- Verified YAML placement and indentation of the edit.

### Additional Notes

`timeout` is a GitLab CI job-level keyword; defining it directly on the job overrides the value inherited via `extends`.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b8d6938f-7f08-41d0-a8c8-9807ed2b5daa)

Comment @datadog to request changes