### PR TITLE
feat(secl): add a capture field to the set action

### DIFF
--- a/pkg/security/rules/monitor/policy_monitor.go
+++ b/pkg/security/rules/monitor/policy_monitor.go
@@ -231,6 +231,7 @@ type RuleSetAction struct {
 	Value        interface{} `json:"value,omitempty"`
 	DefaultValue interface{} `json:"default_value,omitempty"`
 	Field        string      `json:"field,omitempty"`
+	Capture      string      `json:"capture,omitempty"`
 	Expression   string      `json:"expression,omitempty"`
 	Append       bool        `json:"append,omitempty"`
 	Scope        string      `json:"scope,omitempty"`
@@ -347,6 +348,7 @@ func RuleStateFromRule(rule *rules.PolicyRule, policy *rules.PolicyInfo, status 
 				Value:        action.Def.Set.Value,
 				DefaultValue: action.Def.Set.DefaultValue,
 				Field:        action.Def.Set.Field,
+				Capture:      action.Def.Set.Capture,
 				Expression:   action.Def.Set.Expression,
 				Append:       action.Def.Set.Append,
 				Scope:        string(action.Def.Set.Scope),

--- a/pkg/security/rules/monitor/policy_monitor_easyjson.go
+++ b/pkg/security/rules/monitor/policy_monitor_easyjson.go
@@ -1425,6 +1425,12 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor3(
 			} else {
 				out.Field = string(in.String())
 			}
+		case "capture":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.Capture = string(in.String())
+			}
 		case "expression":
 			if in.IsNull() {
 				in.Skip()
@@ -1534,6 +1540,16 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor3(
 			out.RawString(prefix)
 		}
 		out.String(string(in.Field))
+	}
+	if in.Capture != "" {
+		const prefix string = ",\"capture\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Capture))
 	}
 	if in.Expression != "" {
 		const prefix string = ",\"expression\":"

--- a/pkg/security/rules/monitor/policy_monitor_test.go
+++ b/pkg/security/rules/monitor/policy_monitor_test.go
@@ -80,6 +80,63 @@ func TestPolicyMonitorPolicyState(t *testing.T) {
 			},
 		},
 		{
+			// the capture pattern is what distinguishes an action storing part of a
+			// field from one storing the whole of it, so it has to be reported
+			name: "rule with a capture set action",
+			policies: []*testPolicy{
+				{
+					info: rules.PolicyInfo{
+						Name:   "Policy A",
+						Source: "test",
+					},
+					def: rules.PolicyDef{
+						Rules: []*rules.RuleDefinition{
+							{
+								ID:         "rule_a",
+								Expression: `exec.file.path == "/etc/foo/bar"`,
+								Actions: []*rules.ActionDefinition{
+									{
+										Set: &rules.SetDefinition{
+											Name:    "artifact",
+											Field:   "process.file.path", // use field available for both Linux and Windows
+											Capture: "/orchestration/([^/]+)/",
+											Scope:   "process",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedPolicyStates: []*PolicyState{
+				{
+					PolicyMetadata: PolicyMetadata{
+						Name:   "Policy A",
+						Source: "test",
+					},
+					Status: PolicyStatusLoaded,
+					Rules: []*RuleState{
+						{
+							ID:         "rule_a",
+							Expression: `exec.file.path == "/etc/foo/bar"`,
+							Status:     "loaded",
+							Actions: []RuleAction{
+								{
+									Set: &RuleSetAction{
+										Name:    "artifact",
+										Field:   "process.file.path",
+										Capture: "/orchestration/([^/]+)/",
+										Scope:   "process",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "rule with no expression",
 			policies: []*testPolicy{
 				{

--- a/pkg/security/secl/compiler/eval/strings.go
+++ b/pkg/security/secl/compiler/eval/strings.go
@@ -268,6 +268,53 @@ func (s *ScalarStringMatcher) Matches(value string) bool {
 	return s.value == value
 }
 
+// CaptureStringMatcher extracts a single capture group out of a value. Unlike the
+// StringMatcher implementations it is not used to match values, but to pull a
+// substring out of them, and is therefore compiled from a regexp with at least one
+// capture group.
+type CaptureStringMatcher struct {
+	pattern string
+	re      *regexp.Regexp
+}
+
+// Compile a capture pattern. The pattern must be a valid regular expression holding
+// at least one capture group, as only the first one is ever extracted.
+func (c *CaptureStringMatcher) Compile(pattern string) error {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return err
+	}
+
+	if re.NumSubexp() < 1 {
+		return errors.New("no capture group")
+	}
+
+	c.pattern = pattern
+	c.re = re
+
+	return nil
+}
+
+// String implements the stringer interface
+func (c *CaptureStringMatcher) String() string {
+	return c.pattern
+}
+
+// Capture returns the content of the first capture group, and whether the pattern
+// matched the value at all. A value that doesn't match, or that matches without the
+// first group participating, returns false.
+func (c *CaptureStringMatcher) Capture(value string) (string, bool) {
+	// FindStringSubmatchIndex is used over FindStringSubmatch to avoid allocating a
+	// slice of strings for every group: the returned indexes let us slice the input,
+	// which shares its backing array.
+	indexes := c.re.FindStringSubmatchIndex(value)
+	if indexes == nil || indexes[2] < 0 {
+		return "", false
+	}
+
+	return value[indexes[2]:indexes[3]], true
+}
+
 // NewStringMatcher returns a new string matcher
 func NewStringMatcher(kind FieldValueType, pattern string, opts StringCmpOpts) (StringMatcher, error) {
 	if opts.Sanitize != nil {

--- a/pkg/security/secl/compiler/eval/strings.go
+++ b/pkg/security/secl/compiler/eval/strings.go
@@ -305,14 +305,17 @@ func (c *CaptureStringMatcher) String() string {
 // first group participating, returns false.
 func (c *CaptureStringMatcher) Capture(value string) (string, bool) {
 	// FindStringSubmatchIndex is used over FindStringSubmatch to avoid allocating a
-	// slice of strings for every group: the returned indexes let us slice the input,
-	// which shares its backing array.
+	// slice of strings for every group of the pattern
 	indexes := c.re.FindStringSubmatchIndex(value)
 	if indexes == nil || indexes[2] < 0 {
 		return "", false
 	}
 
-	return value[indexes[2]:indexes[3]], true
+	// slicing would share the backing array of the whole field value, keeping it alive
+	// for as long as the captured value is stored. Captures end up in variables that
+	// can be inherited across a process tree and outlive the event by a long time, so
+	// a small artifact must not pin the path it was extracted from.
+	return strings.Clone(value[indexes[2]:indexes[3]]), true
 }
 
 // NewStringMatcher returns a new string matcher

--- a/pkg/security/secl/compiler/eval/strings_test.go
+++ b/pkg/security/secl/compiler/eval/strings_test.go
@@ -259,6 +259,118 @@ func TestRegexp(t *testing.T) {
 	})
 }
 
+func TestCaptureStringMatcher(t *testing.T) {
+	t.Run("ssm-command-id", func(t *testing.T) {
+		var matcher CaptureStringMatcher
+		if err := matcher.Compile("/orchestration/([^/]+)/"); err != nil {
+			t.Fatal(err)
+		}
+
+		value, found := matcher.Capture("/var/lib/amazon/ssm/i-0abc/document/orchestration/a1b2c3d4/awsrunShellScript")
+		if !found {
+			t.Fatal("should have captured")
+		}
+
+		if value != "a1b2c3d4" {
+			t.Errorf("should have captured the command id, got `%s`", value)
+		}
+	})
+
+	t.Run("imds-role", func(t *testing.T) {
+		var matcher CaptureStringMatcher
+		if err := matcher.Compile("/security-credentials/([^/?]+)"); err != nil {
+			t.Fatal(err)
+		}
+
+		value, found := matcher.Capture("/latest/meta-data/iam/security-credentials/my-role?x=1")
+		if !found {
+			t.Fatal("should have captured")
+		}
+
+		if value != "my-role" {
+			t.Errorf("should have captured the role name, got `%s`", value)
+		}
+	})
+
+	t.Run("no-match", func(t *testing.T) {
+		var matcher CaptureStringMatcher
+		if err := matcher.Compile("/orchestration/([^/]+)/"); err != nil {
+			t.Fatal(err)
+		}
+
+		if value, found := matcher.Capture("/etc/passwd"); found {
+			t.Errorf("shouldn't have captured, got `%s`", value)
+		}
+	})
+
+	t.Run("no-capture-group", func(t *testing.T) {
+		var matcher CaptureStringMatcher
+		if err := matcher.Compile("/orchestration/[^/]+/"); err == nil {
+			t.Error("should have failed to compile a pattern without a capture group")
+		}
+	})
+
+	t.Run("non-capturing-group-only", func(t *testing.T) {
+		var matcher CaptureStringMatcher
+		if err := matcher.Compile("/orchestration/(?:[^/]+)/"); err == nil {
+			t.Error("should have failed to compile a pattern with only a non-capturing group")
+		}
+	})
+
+	t.Run("malformed-pattern", func(t *testing.T) {
+		var matcher CaptureStringMatcher
+		if err := matcher.Compile("/orchestration/([^/]+"); err == nil {
+			t.Error("should have failed to compile a malformed pattern")
+		}
+	})
+
+	t.Run("non-participating-group", func(t *testing.T) {
+		var matcher CaptureStringMatcher
+		if err := matcher.Compile("abc(x)?"); err != nil {
+			t.Fatal(err)
+		}
+
+		// the pattern matches, but the optional first group took no part in it
+		if value, found := matcher.Capture("abc"); found {
+			t.Errorf("shouldn't have captured, got `%s`", value)
+		}
+	})
+
+	t.Run("first-group-only", func(t *testing.T) {
+		var matcher CaptureStringMatcher
+		if err := matcher.Compile("/ecs/([0-9a-f-]+)/([0-9a-f-]+)"); err != nil {
+			t.Fatal(err)
+		}
+
+		value, found := matcher.Capture("/ecs/a1b2c3d4-1111/e5f6a7b8-2222")
+		if !found {
+			t.Fatal("should have captured")
+		}
+
+		if value != "a1b2c3d4-1111" {
+			t.Errorf("should have captured the first group only, got `%s`", value)
+		}
+	})
+
+	t.Run("big-or-pattern", func(t *testing.T) {
+		// RegexpStringMatcher takes a fast path for this shape and leaves its compiled
+		// regexp nil, which is why capture cannot reuse it. Make sure we still extract.
+		var matcher CaptureStringMatcher
+		if err := matcher.Compile(".*(restore|recovery|ransom).*"); err != nil {
+			t.Fatal(err)
+		}
+
+		value, found := matcher.Capture("123ransom456.txt")
+		if !found {
+			t.Fatal("should have captured")
+		}
+
+		if value != "ransom" {
+			t.Errorf("should have captured the alternation, got `%s`", value)
+		}
+	})
+}
+
 func BenchmarkRegexpEvaluator(b *testing.B) {
 	b.Run("with stars", func(b *testing.B) {
 		pattern := ".*(restore|recovery|readme|instruction|how_to|ransom).*"

--- a/pkg/security/secl/rules/actions.go
+++ b/pkg/security/secl/rules/actions.go
@@ -18,6 +18,7 @@ type Action struct {
 	InternalCallback    *InternalCallbackDefinition
 	FilterEvaluator     *eval.RuleEvaluator
 	ScopeFieldEvaluator eval.Evaluator
+	CaptureMatcher      *eval.CaptureStringMatcher
 }
 
 // CompileFilter compiles the filter expression
@@ -54,6 +55,21 @@ func (a *Action) CompileScopeField(model eval.Model) error {
 	}
 
 	a.ScopeFieldEvaluator = evaluator
+	return nil
+}
+
+// CompileCaptureMatcher compiles the capture pattern
+func (a *Action) CompileCaptureMatcher() error {
+	if a.Def.Set == nil || len(a.Def.Set.Capture) == 0 {
+		return nil
+	}
+
+	var matcher eval.CaptureStringMatcher
+	if err := matcher.Compile(a.Def.Set.Capture); err != nil {
+		return &ErrCapture{Pattern: a.Def.Set.Capture, Err: err}
+	}
+
+	a.CaptureMatcher = &matcher
 	return nil
 }
 

--- a/pkg/security/secl/rules/errors.go
+++ b/pkg/security/secl/rules/errors.go
@@ -184,6 +184,20 @@ func (e *ErrScopeField) Unwrap() error {
 	return e.Err
 }
 
+// ErrCapture is returned on capture definition error
+type ErrCapture struct {
+	Pattern string
+	Err     error
+}
+
+func (e *ErrCapture) Error() string {
+	return fmt.Sprintf("capture `%s` error: %s", e.Pattern, e.Err)
+}
+
+func (e *ErrCapture) Unwrap() error {
+	return e.Err
+}
+
 // ErrFieldNotAvailable is returned when a field is not available
 type ErrFieldNotAvailable struct {
 	Field        eval.Field

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -226,6 +226,7 @@ type SetDefinition struct {
 	Value                   interface{}            `yaml:"value,omitempty" json:"value,omitempty" jsonschema:"oneof_required=SetWithValue,oneof_type=string;integer;boolean;array"`
 	DefaultValue            interface{}            `yaml:"default_value,omitempty" json:"default_value,omitempty" jsonschema:"oneof_type=string;integer;boolean;array"`
 	Field                   string                 `yaml:"field,omitempty" json:"field,omitempty" jsonschema:"oneof_required=SetWithField"`
+	Capture                 string                 `yaml:"capture,omitempty" json:"capture,omitempty" jsonschema:"description=A regular expression with a single capture group applied to 'field' to extract the value to store"`
 	Expression              string                 `yaml:"expression,omitempty" json:"expression,omitempty" jsonschema:"oneof_required=SetWithExpression"`
 	Append                  bool                   `yaml:"append,omitempty" json:"append,omitempty"`
 	Scope                   Scope                  `yaml:"scope,omitempty" json:"scope,omitempty" jsonschema:"enum=process,enum=container,enum=cgroup"`
@@ -257,6 +258,13 @@ func (s *SetDefinition) PreCheck(_ PolicyLoaderOpts) error {
 
 	if s.Expression != "" && s.DefaultValue == nil && s.Value == nil {
 		return fmt.Errorf("failed to infer type for variable '%s', please set 'default_value'", s.Name)
+	}
+
+	// 'capture' extracts a substring out of the value of 'field', so it is meaningless
+	// without it. Combined with the check above, this also makes 'capture' mutually
+	// exclusive with 'value' and 'expression'.
+	if s.Capture != "" && s.Field == "" {
+		return errors.New("'capture' can only be used along with 'field'")
 	}
 
 	if s.Inherited && s.Scope != ScopeProcess {

--- a/pkg/security/secl/rules/model_test.go
+++ b/pkg/security/secl/rules/model_test.go
@@ -121,3 +121,89 @@ func TestDuration(t *testing.T) {
 		assert.True(t, reflect.DeepEqual(setDef, deserialized))
 	})
 }
+
+func TestSetDefinitionCapture(t *testing.T) {
+	t.Run("yaml round trip", func(t *testing.T) {
+		setDef := SetDefinition{
+			Name:      "ssm_command_id",
+			Field:     "open.file.path",
+			Capture:   "/orchestration/([^/]+)/",
+			Scope:     ScopeProcess,
+			Inherited: true,
+		}
+		bytes, err := yaml.Marshal(setDef)
+		assert.NoError(t, err)
+		var deserialized SetDefinition
+		err = yaml.Unmarshal(bytes, &deserialized)
+		assert.NoError(t, err)
+		assert.True(t, reflect.DeepEqual(setDef, deserialized))
+	})
+
+	t.Run("json round trip", func(t *testing.T) {
+		setDef := SetDefinition{
+			Name:    "imds_iam_role",
+			Field:   "imds.url",
+			Capture: "/security-credentials/([^/?]+)",
+		}
+		bytes, err := json.Marshal(setDef)
+		assert.NoError(t, err)
+		var deserialized SetDefinition
+		err = json.Unmarshal(bytes, &deserialized)
+		assert.NoError(t, err)
+		assert.True(t, reflect.DeepEqual(setDef, deserialized))
+	})
+
+	t.Run("with field", func(t *testing.T) {
+		setDef := SetDefinition{
+			Name:    "ssm_command_id",
+			Field:   "open.file.path",
+			Capture: "/orchestration/([^/]+)/",
+		}
+		assert.NoError(t, setDef.PreCheck(PolicyLoaderOpts{}))
+	})
+
+	// the error strings are asserted rather than just the presence of an error: several of
+	// the cases below are rejected by the pre-existing 'value'/'field'/'expression'
+	// exclusivity check rather than by the 'capture' check, and a bare assert.Error cannot
+	// tell the two apart
+	t.Run("with value", func(t *testing.T) {
+		setDef := SetDefinition{
+			Name:    "ssm_command_id",
+			Value:   "some_value",
+			Capture: "/orchestration/([^/]+)/",
+		}
+		assert.EqualError(t, setDef.PreCheck(PolicyLoaderOpts{}), "'capture' can only be used along with 'field'")
+	})
+
+	t.Run("with expression", func(t *testing.T) {
+		setDef := SetDefinition{
+			Name:         "ssm_command_id",
+			Expression:   "open.file.path",
+			DefaultValue: "",
+			Capture:      "/orchestration/([^/]+)/",
+		}
+		assert.EqualError(t, setDef.PreCheck(PolicyLoaderOpts{}), "'capture' can only be used along with 'field'")
+	})
+
+	// the two cases below never reach the 'capture' check: with nothing else set, and
+	// with 'field' set alongside 'value', the pre-existing exclusivity check rejects them
+	// first. The two mechanisms together are what make 'capture' reachable only through
+	// 'field'
+	t.Run("without field, value or expression", func(t *testing.T) {
+		setDef := SetDefinition{
+			Name:    "ssm_command_id",
+			Capture: "/orchestration/([^/]+)/",
+		}
+		assert.EqualError(t, setDef.PreCheck(PolicyLoaderOpts{}), "either 'value', 'field' or 'expression' must be specified")
+	})
+
+	t.Run("with field and value", func(t *testing.T) {
+		setDef := SetDefinition{
+			Name:    "ssm_command_id",
+			Field:   "open.file.path",
+			Value:   "some_value",
+			Capture: "/orchestration/([^/]+)/",
+		}
+		assert.EqualError(t, setDef.PreCheck(PolicyLoaderOpts{}), "either 'value', 'field' or 'expression' must be specified")
+	})
+}

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -1921,8 +1921,10 @@ func TestActionSetVariableCapture(t *testing.T) {
 func TestActionSetVariableCaptureRuntime(t *testing.T) {
 	testPolicy := &PolicyDef{
 		Rules: []*RuleDefinition{{
+			// matched on the file name so that the test doesn't depend on how patterns
+			// treat path separators: what matters here is the capture, not the match
 			ID:         "capture_rule",
-			Expression: `open.file.path =~ "/var/lib/amazon/ssm/*"`,
+			Expression: `open.file.name == "awsrunShellScript"`,
 			Actions: []*ActionDefinition{{
 				Set: &SetDefinition{
 					Name:      "ssm_command_id",
@@ -1962,29 +1964,42 @@ func TestActionSetVariableCaptureRuntime(t *testing.T) {
 	event.ProcessCacheEntry = &model.ProcessCacheEntry{}
 	event.SetFieldValue("open.flags", syscall.O_RDONLY)
 
+	// the fake field handlers don't derive the basename from the path, so both have to
+	// be set
+	open := func(path string) {
+		if err := event.SetFieldValue("open.file.path", path); err != nil {
+			t.Fatal(err)
+		}
+		if err := event.SetFieldValue("open.file.name", filepath.Base(path)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	// nothing has been captured yet
-	event.SetFieldValue("open.file.path", "/tmp/check")
+	open("/tmp/check")
 	if rs.Evaluate(event) {
 		t.Error("expected event to match no rule")
 	}
 
 	// capture the command id out of the orchestration directory
-	event.SetFieldValue("open.file.path", "/var/lib/amazon/ssm/i-0abc/document/orchestration/a1b2c3d4/awsrunShellScript")
+	open("/var/lib/amazon/ssm/i-0abc/document/orchestration/a1b2c3d4/awsrunShellScript")
 	if !rs.Evaluate(event) {
 		t.Error("expected event to match the capture rule")
 	}
 
-	event.SetFieldValue("open.file.path", "/tmp/check")
+	open("/tmp/check")
 	if !rs.Evaluate(event) {
 		t.Error("expected the captured value to be the command id alone")
 	}
 
 	// the rule matches but the capture pattern doesn't: the variable has to keep its
 	// previous value rather than being overwritten or cleared
-	event.SetFieldValue("open.file.path", "/var/lib/amazon/ssm/i-0abc/document/session/xxx")
-	rs.Evaluate(event)
+	open("/var/lib/amazon/ssm/i-0abc/document/session/awsrunShellScript")
+	if !rs.Evaluate(event) {
+		t.Error("expected event to match the capture rule")
+	}
 
-	event.SetFieldValue("open.file.path", "/tmp/check")
+	open("/tmp/check")
 	if !rs.Evaluate(event) {
 		t.Error("expected a capture miss to leave the variable untouched")
 	}
@@ -2026,6 +2041,7 @@ func BenchmarkRunSetActions(b *testing.B) {
 		event.ProcessCacheEntry = &model.ProcessCacheEntry{}
 		event.SetFieldValue("open.flags", syscall.O_RDONLY)
 		event.SetFieldValue("open.file.path", "/var/lib/amazon/ssm/i-0abc/document/orchestration/a1b2c3d4/awsrunShellScript")
+		event.SetFieldValue("open.file.name", "awsrunShellScript")
 
 		ctx := rs.pool.Get(event)
 		defer rs.pool.Put(ctx)

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -1792,6 +1792,132 @@ func TestActionSetVariableExpression(t *testing.T) {
 	}}, value)
 }
 
+func TestActionSetVariableCapture(t *testing.T) {
+	capturePolicy := func(name string, field string, capture string, isAppend bool) *PolicyDef {
+		return &PolicyDef{
+			Rules: []*RuleDefinition{{
+				ID:         "test_rule",
+				Expression: `open.file.path =~ "/var/lib/amazon/ssm/*"`,
+				Actions: []*ActionDefinition{{
+					Set: &SetDefinition{
+						Name:      name,
+						Scope:     ScopeProcess,
+						Inherited: true,
+						Field:     field,
+						Capture:   capture,
+						Append:    isAppend,
+					},
+				}},
+			}},
+		}
+	}
+
+	t.Run("string-field", func(t *testing.T) {
+		_, errs := loadPolicy(t, capturePolicy("ssm_command_id", "open.file.path", "/orchestration/([^/]+)/", false), PolicyLoaderOpts{})
+		assert.NoError(t, errs.ErrorOrNil())
+	})
+
+	t.Run("array-field", func(t *testing.T) {
+		_, errs := loadPolicy(t, capturePolicy("run_id", "process.envp", "^GITHUB_RUN_ID=(.+)$", false), PolicyLoaderOpts{})
+		require.Error(t, errs.ErrorOrNil())
+		assert.Contains(t, errs.Error(), "'capture' is not supported on array field")
+	})
+
+	t.Run("array-field-with-append", func(t *testing.T) {
+		// 'append' makes the pre-existing array check pass, so capture has to reject it
+		// on its own or it would silently store nothing
+		_, errs := loadPolicy(t, capturePolicy("run_id", "process.envp", "^GITHUB_RUN_ID=(.+)$", true), PolicyLoaderOpts{})
+		require.Error(t, errs.ErrorOrNil())
+		assert.Contains(t, errs.Error(), "'capture' is not supported on array field")
+	})
+
+	t.Run("non-string-field", func(t *testing.T) {
+		_, errs := loadPolicy(t, capturePolicy("some_pid", "process.pid", "([0-9]+)", false), PolicyLoaderOpts{})
+		require.Error(t, errs.ErrorOrNil())
+		assert.Contains(t, errs.Error(), "'capture' is only supported on string fields")
+	})
+
+	t.Run("malformed-pattern", func(t *testing.T) {
+		_, errs := loadPolicy(t, capturePolicy("ssm_command_id", "open.file.path", "/orchestration/([^/]+", false), PolicyLoaderOpts{})
+		require.Error(t, errs.ErrorOrNil())
+		assert.Contains(t, errs.Error(), "capture `/orchestration/([^/]+` error")
+	})
+
+	t.Run("no-capture-group", func(t *testing.T) {
+		_, errs := loadPolicy(t, capturePolicy("ssm_command_id", "open.file.path", "/orchestration/[^/]+/", false), PolicyLoaderOpts{})
+		require.Error(t, errs.ErrorOrNil())
+		assert.Contains(t, errs.Error(), "no capture group")
+	})
+
+	t.Run("without-field", func(t *testing.T) {
+		testPolicy := &PolicyDef{
+			Rules: []*RuleDefinition{{
+				ID:         "test_rule",
+				Expression: `open.file.path == "/tmp/test"`,
+				Actions: []*ActionDefinition{{
+					Set: &SetDefinition{
+						Name:    "ssm_command_id",
+						Value:   "not_a_field",
+						Capture: "/orchestration/([^/]+)/",
+					},
+				}},
+			}},
+		}
+
+		_, errs := loadPolicy(t, testPolicy, PolicyLoaderOpts{})
+		require.Error(t, errs.ErrorOrNil())
+		assert.Contains(t, errs.Error(), "'capture' can only be used along with 'field'")
+	})
+
+	t.Run("per-action-matcher", func(t *testing.T) {
+		// two rules capturing different patterns out of the very same field: the
+		// compiled matcher has to live on the action, not in a per-field cache
+		testPolicy := &PolicyDef{
+			Rules: []*RuleDefinition{
+				{
+					ID:         "capture_ssm",
+					Expression: `open.file.path =~ "/var/lib/amazon/ssm/*"`,
+					Actions: []*ActionDefinition{{
+						Set: &SetDefinition{
+							Name:    "ssm_command_id",
+							Scope:   ScopeProcess,
+							Field:   "open.file.path",
+							Capture: "/orchestration/([^/]+)/",
+						},
+					}},
+				},
+				{
+					ID:         "capture_ecs",
+					Expression: `open.file.path =~ "/var/lib/ecs/*"`,
+					Actions: []*ActionDefinition{{
+						Set: &SetDefinition{
+							Name:    "ecs_task_id",
+							Scope:   ScopeProcess,
+							Field:   "open.file.path",
+							Capture: "/ecs/([0-9a-f-]+)/",
+						},
+					}},
+				},
+			},
+		}
+
+		rs, errs := loadPolicy(t, testPolicy, PolicyLoaderOpts{})
+		require.NoError(t, errs.ErrorOrNil())
+
+		patterns := make(map[string]string)
+		for _, rule := range rs.GetRules() {
+			for _, action := range rule.PolicyRule.Actions {
+				if action.CaptureMatcher != nil {
+					patterns[rule.ID] = action.CaptureMatcher.String()
+				}
+			}
+		}
+
+		assert.Equal(t, "/orchestration/([^/]+)/", patterns["capture_ssm"])
+		assert.Equal(t, "/ecs/([0-9a-f-]+)/", patterns["capture_ecs"])
+	})
+}
+
 func loadPolicy(t *testing.T, testPolicy *PolicyDef, policyOpts PolicyLoaderOpts) (*RuleSet, *multierror.Error) {
 	rs := newRuleSet()
 
@@ -3411,6 +3537,16 @@ rules:
           append: true
           size: 10
           ttl: 10s
+  - id: with_set_action_with_capture
+    description: Rule with a set action capturing part of an event field
+    expression: open.file.path =~ "/var/lib/amazon/ssm/*/document/orchestration/*"
+    actions:
+      - set:
+          name: ssm_command_id
+          scope: process
+          inherited: true
+          field: open.file.path
+          capture: "/orchestration/([^/]+)/"
   - id: with_set_action_with_value
     description: Rule with a set action using a value
     expression: exec.file.name == "foo"

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -1918,6 +1918,153 @@ func TestActionSetVariableCapture(t *testing.T) {
 	})
 }
 
+func TestActionSetVariableCaptureRuntime(t *testing.T) {
+	testPolicy := &PolicyDef{
+		Rules: []*RuleDefinition{{
+			ID:         "capture_rule",
+			Expression: `open.file.path =~ "/var/lib/amazon/ssm/*"`,
+			Actions: []*ActionDefinition{{
+				Set: &SetDefinition{
+					Name:      "ssm_command_id",
+					Scope:     ScopeProcess,
+					Inherited: true,
+					Field:     "open.file.path",
+					Capture:   "/orchestration/([^/]+)/",
+				},
+			}},
+		}, {
+			// only matches if the captured value is the command id alone, and not the
+			// whole path the capture was extracted from
+			ID:         "assert_rule",
+			Expression: `open.file.path == "/tmp/check" && ${process.ssm_command_id} == "a1b2c3d4"`,
+		}},
+	}
+
+	tmpDir := t.TempDir()
+
+	if err := savePolicy(filepath.Join(tmpDir, "test.policy"), testPolicy); err != nil {
+		t.Fatal(err)
+	}
+
+	provider, err := NewPoliciesDirProvider(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loader := NewPolicyLoader(provider)
+
+	rs := newRuleSet()
+	if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err.ErrorOrNil() != nil {
+		t.Fatal(err)
+	}
+
+	event := model.NewFakeEvent()
+	event.Type = uint32(model.FileOpenEventType)
+	event.ProcessCacheEntry = &model.ProcessCacheEntry{}
+	event.SetFieldValue("open.flags", syscall.O_RDONLY)
+
+	// nothing has been captured yet
+	event.SetFieldValue("open.file.path", "/tmp/check")
+	if rs.Evaluate(event) {
+		t.Error("expected event to match no rule")
+	}
+
+	// capture the command id out of the orchestration directory
+	event.SetFieldValue("open.file.path", "/var/lib/amazon/ssm/i-0abc/document/orchestration/a1b2c3d4/awsrunShellScript")
+	if !rs.Evaluate(event) {
+		t.Error("expected event to match the capture rule")
+	}
+
+	event.SetFieldValue("open.file.path", "/tmp/check")
+	if !rs.Evaluate(event) {
+		t.Error("expected the captured value to be the command id alone")
+	}
+
+	// the rule matches but the capture pattern doesn't: the variable has to keep its
+	// previous value rather than being overwritten or cleared
+	event.SetFieldValue("open.file.path", "/var/lib/amazon/ssm/i-0abc/document/session/xxx")
+	rs.Evaluate(event)
+
+	event.SetFieldValue("open.file.path", "/tmp/check")
+	if !rs.Evaluate(event) {
+		t.Error("expected a capture miss to leave the variable untouched")
+	}
+}
+
+func BenchmarkRunSetActions(b *testing.B) {
+	bench := func(b *testing.B, set *SetDefinition) {
+		testPolicy := &PolicyDef{
+			Rules: []*RuleDefinition{{
+				ID:         "bench_rule",
+				Expression: `open.file.path =~ "/var/lib/amazon/ssm/*"`,
+				Actions:    []*ActionDefinition{{Set: set}},
+			}},
+		}
+
+		tmpDir := b.TempDir()
+
+		if err := savePolicy(filepath.Join(tmpDir, "test.policy"), testPolicy); err != nil {
+			b.Fatal(err)
+		}
+
+		provider, err := NewPoliciesDirProvider(tmpDir)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		rs := newRuleSet()
+		if _, errs := rs.LoadPolicies(NewPolicyLoader(provider), PolicyLoaderOpts{}); errs.ErrorOrNil() != nil {
+			b.Fatal(errs)
+		}
+
+		rule := rs.GetRuleByID("bench_rule")
+		if rule == nil {
+			b.Fatal("failed to find bench_rule in ruleset")
+		}
+
+		event := model.NewFakeEvent()
+		event.Type = uint32(model.FileOpenEventType)
+		event.ProcessCacheEntry = &model.ProcessCacheEntry{}
+		event.SetFieldValue("open.flags", syscall.O_RDONLY)
+		event.SetFieldValue("open.file.path", "/var/lib/amazon/ssm/i-0abc/document/orchestration/a1b2c3d4/awsrunShellScript")
+
+		ctx := rs.pool.Get(event)
+		defer rs.pool.Put(ctx)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := rs.runSetActions(event, ctx, rule); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	b.Run("without capture", func(b *testing.B) {
+		bench(b, &SetDefinition{
+			Name:  "ssm_command_id",
+			Scope: ScopeProcess,
+			Field: "open.file.path",
+		})
+	})
+
+	b.Run("with capture", func(b *testing.B) {
+		bench(b, &SetDefinition{
+			Name:    "ssm_command_id",
+			Scope:   ScopeProcess,
+			Field:   "open.file.path",
+			Capture: "/orchestration/([^/]+)/",
+		})
+	})
+
+	b.Run("with capture, no match", func(b *testing.B) {
+		bench(b, &SetDefinition{
+			Name:    "ssm_command_id",
+			Scope:   ScopeProcess,
+			Field:   "open.file.path",
+			Capture: "/this-never-matches/([^/]+)/",
+		})
+	})
+}
+
 func loadPolicy(t *testing.T, testPolicy *PolicyDef, policyOpts PolicyLoaderOpts) (*RuleSet, *multierror.Error) {
 	rs := newRuleSet()
 

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -439,6 +439,32 @@ func (rs *RuleSet) PopulateFieldsWithRuleActionsData(policyRules []*PolicyRule, 
 					continue
 				}
 
+				// 'capture' extracts a substring out of the field value, so it is only
+				// supported on fields holding a single string
+				if actionDef.Set.Capture != "" {
+					baseField, _, isArrayAccess := parseArrayFieldAccess(actionDef.Set.Field)
+					fieldToValidate := actionDef.Set.Field
+					if isArrayAccess {
+						fieldToValidate = baseField
+					}
+
+					_, kind, goType, isArray, err := rs.eventCtor().GetFieldMetadata(fieldToValidate)
+					if err != nil {
+						errs = appendRuleLoadError(errs, rule, fmt.Errorf("failed to get field '%s': %w", fieldToValidate, err))
+						continue
+					}
+
+					if kind != reflect.String {
+						errs = appendRuleLoadError(errs, rule, fmt.Errorf("'capture' is only supported on string fields, but field '%s' of variable '%s' is of type '%s (%s)'", actionDef.Set.Field, actionDef.Set.Name, kind, goType))
+						continue
+					}
+
+					if isArray && !isArrayAccess {
+						errs = appendRuleLoadError(errs, rule, fmt.Errorf("'capture' is not supported on array field '%s' for variable '%s'", actionDef.Set.Field, actionDef.Set.Name))
+						continue
+					}
+				}
+
 				var variableValue = actionDef.Set.DefaultValue
 				if variableValue == nil {
 					variableValue = actionDef.Set.Value
@@ -746,6 +772,12 @@ func (rs *RuleSet) innerAddExpandedRule(pRule *PolicyRule, exRule expandedRule, 
 				if err := action.CompileScopeField(rs.model); err != nil {
 					return model.UnknownCategory, &ErrRuleLoad{Rule: pRule, Err: err}
 				}
+			}
+
+			// compile the capture pattern once, per action: two rules can capture
+			// different patterns out of the same field
+			if err := action.CompileCaptureMatcher(); err != nil {
+				return model.UnknownCategory, &ErrRuleLoad{Rule: pRule, Err: err}
 			}
 
 			if field := action.Def.Set.Field; field != "" {

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -1086,6 +1086,24 @@ func (rs *RuleSet) runSetActions(_ eval.Event, ctx *eval.Context, rule *Rule) er
 						value = evaluator.Eval(ctx)
 					}
 				}
+
+				// extract the correlation artifact out of the field value. A value that
+				// doesn't match is a no-op leaving the variable untouched: capture rules
+				// can be attached to high frequency events, so this must stay silent.
+				if action.CaptureMatcher != nil {
+					strValue, ok := value.(string)
+					if !ok {
+						break
+					}
+
+					captured, found := action.CaptureMatcher.Capture(strValue)
+					if !found {
+						break
+					}
+
+					value = captured
+				}
+
 				if action.Def.Set.Append {
 					if err := mutable.Append(ctx, value); err != nil {
 						if errors.Is(err, eval.ErrScopeNotAvailable) {

--- a/pkg/security/secl/schemas/policy.schema.json
+++ b/pkg/security/secl/schemas/policy.schema.json
@@ -411,6 +411,10 @@
         "field": {
           "type": "string"
         },
+        "capture": {
+          "type": "string",
+          "description": "A regular expression with a single capture group applied to 'field' to extract the value to store"
+        },
         "expression": {
           "type": "string"
         },

--- a/pkg/security/tests/BUILD.bazel
+++ b/pkg/security/tests/BUILD.bazel
@@ -152,6 +152,7 @@ go_test(
         "bpf_test.go",
         "capabilities_test.go",
         "capture_all_syscall_errors_test.go",
+        "capture_test.go",
         "cgroup_test.go",
         "chdir_test.go",
         "chmod_test.go",

--- a/pkg/security/tests/capture_test.go
+++ b/pkg/security/tests/capture_test.go
@@ -1,0 +1,131 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && functionaltests
+
+// Package tests holds tests related files
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/cenkalti/backoff/v7"
+	"github.com/oliveagle/jsonpath"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+)
+
+// TestActionCaptureInherited reproduces the SSM Run Command correlation scenario: the
+// agent creates an orchestration directory named after the CloudTrail SendCommand
+// CommandId, and a silent rule captures that id out of the path into a process scoped
+// inherited variable. Every descendant of the process that touched the directory then
+// carries the id, which is what lets the backend join the kernel activity to the API
+// call that started it.
+func TestActionCaptureInherited(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	// shaped like a real SSM CommandId, so that the value also exercises the scrubber
+	// applied to serialized variables
+	const commandID = "4a1b2c3d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "capture_ssm_command_id",
+			Expression: `open.file.path == "{{.Root}}/document/orchestration/` + commandID + `/awsrunShellScript"`,
+			// the extraction itself is benign, only the artifact it attaches matters
+			Silent: true,
+			Actions: []*rules.ActionDefinition{
+				{
+					Set: &rules.SetDefinition{
+						Name:      "ssm_command_id",
+						Scope:     "process",
+						Inherited: true,
+						Field:     "open.file.path",
+						Capture:   "/orchestration/([^/]+)/",
+					},
+				},
+			},
+		},
+		{
+			// fires on a grandchild of the process that opened the orchestration file,
+			// and only if the variable holds the command id alone rather than the whole
+			// path it was captured from
+			ID: "descendant_carries_command_id",
+			Expression: `open.file.path == "{{.Root}}/descendant-check" && ` +
+				`${process.ssm_command_id} == "` + commandID + `"`,
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	documentDir, _, err := test.Path("document")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(documentDir)
+
+	triggerFile := filepath.Join(documentDir, "orchestration", commandID, "awsrunShellScript")
+	if err := os.MkdirAll(filepath.Dir(triggerFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(triggerFile, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	checkFile, _, err := test.Path("descendant-check")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(checkFile, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(checkFile)
+
+	// the redirections are performed by the shells themselves, so the opens are
+	// attributed to them rather than to a short lived helper process: the outer shell
+	// gets the captured variable, the inner one has to inherit it
+	script := fmt.Sprintf(`: < %s; sh -c ": < %s"`, triggerFile, checkFile)
+
+	test.WaitSignalFromRule(t, func() error {
+		return exec.CommandContext(context.Background(), "sh", "-c", script).Run()
+	}, func(_ *model.Event, rule *rules.Rule) {
+		assertTriggeredRule(t, rule, "descendant_carries_command_id")
+	}, "descendant_carries_command_id")
+
+	// the artifact is only useful to the backend if it survives serialization, and in
+	// particular if the scrubber leaves it intact
+	err = retry(t, func() error {
+		msg := test.msgSender.getMsg("descendant_carries_command_id")
+		if msg == nil {
+			return errors.New("message not found")
+		}
+
+		jsonPathValidation(test, msg.Data, func(_ *testModule, obj interface{}) {
+			value, err := jsonpath.JsonPathLookup(obj, `$.process.variables.ssm_command_id`)
+			if err != nil {
+				t.Errorf("captured variable should be present in the serialized event: %v", err)
+				return
+			}
+			assert.Equal(t, commandID, value, "captured variable should survive serialization untouched")
+		})
+
+		return nil
+	}, backoff.WithMaxTries(10))
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/pkg/security/tests/capture_test.go
+++ b/pkg/security/tests/capture_test.go
@@ -128,4 +128,10 @@ func TestActionCaptureInherited(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	// the extraction itself must stay silent: a rule firing on every benign SSM
+	// operation is exactly what attaching the artifact to real events avoids
+	if msg := test.msgSender.getMsg("capture_ssm_command_id"); msg != nil {
+		t.Error("the silent capture rule should not have sent an event")
+	}
 }

--- a/releasenotes/notes/cws-secl-set-action-capture-93c46e8c1bf048ce.yaml
+++ b/releasenotes/notes/cws-secl-set-action-capture-93c46e8c1bf048ce.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    CWS ``set`` actions accept a new ``capture`` field, a regular expression with a
+    single capture group that is applied to the value of ``field`` to extract part of
+    it. This makes it possible to lift an identifier embedded in an event field, such
+    as a command id inside a file path or an IAM role inside an IMDS url, and store it
+    as a scoped variable rather than storing the whole field value. ``capture`` can
+    only be used together with ``field``, and only on fields holding a single string.
+    A value that does not match the expression leaves the variable untouched.


### PR DESCRIPTION
### What does this PR do?

Extends the SECL `set` action with a new `capture` field: a regular expression with a
single capture group, applied to the value of `field`, whose first group becomes the
variable value.

```yaml
- id: ssm_command_tracking
  expression: open.file.path =~ "/var/lib/amazon/ssm/*/document/orchestration/**"
  silent: true
  actions:
    - set:
        name: ssm_command_id
        scope: process
        inherited: true
        field: open.file.path
        capture: "/orchestration/([^/]+)/"
```

- `eval.CaptureStringMatcher` joins the existing `StringMatcher` family in
  `secl/compiler/eval/strings.go`. `Compile` rejects patterns that don't compile and
  patterns with no capture group; `Capture` uses `FindStringSubmatchIndex` to avoid
  allocating a slice of strings for every group.
- The compiled pattern lives on the `*Action` (next to `ScopeFieldEvaluator`), compiled
  once at policy load by `CompileCaptureMatcher`. It deliberately does **not** live in
  `RuleSet.fieldEvaluators`, which is keyed by field name and shared across rules — two
  rules capturing different patterns out of the same field would otherwise collide.
- Validation is all at load time: `capture` requires `field` (which transitively makes it
  exclusive with `value` and `expression`), and is rejected on non-string and array
  fields. At runtime the only branch is match / no match.
- A value that doesn't match is a silent no-op leaving the variable at its previous
  value. Capture rules can be attached to high frequency events, so a miss must not log
  or clear anything.
- `policy.schema.json` is regenerated. Because it declares `additionalProperties: false`,
  skipping this would make every policy using `capture` fail schema validation.

Only fields holding a single string are supported. Array fields would need per-element
extraction, which is out of scope here.

### Motivation

Workload Protection events are rich at the kernel layer but disconnected from
cloud-layer activity. The identifiers needed to join them frequently already exist
inside WP event fields — an SSM `CommandId` inside a filesystem path, an IAM role inside
an IMDS url — but a rule could match those fields without being able to decompose them.

Storing the whole field value doesn't help: CloudTrail has the bare `a1b2…`, so the
strings aren't equal and there is nothing to join on. Capturing the id and attaching it
to the process with `inherited: true` puts the join key on every descendant event, so the
backend join becomes an exact equality instead of command-line parsing inside a time
window.

Implements the approved RFC "Capturing Correlation Artifact: Structured Join Keys from
SECL Set Actions".

### Describe how you validated your changes

Unit tests (`secl/compiler/eval`, `secl/rules`) cover extraction, the first-group-only
rule, non-participating optional groups, load-time rejection of malformed patterns and
of non-string/array fields, and the two-rules-same-field case that guards the per-action
matcher.

Functional test `TestActionCaptureInherited` on a real kernel covers the end-to-end
scenario: a silent rule captures a UUID-shaped SSM command id out of an orchestration
path, and a **grandchild** shell two levels down fires a rule asserting
`${process.ssm_command_id}` equals the bare id. It also asserts the artifact reaches the
serialized event intact at `$.process.variables.ssm_command_id` — variable values pass
through `scrubber.ScrubString`, so this confirms the scrubber doesn't mangle the join key
— and that no event is sent for the extraction rule itself.

Benchmark added for the set action, since the review raised the cost of evaluating the
pattern on frequently matched rules (linux/arm64):

| Case | ns/op | B/op | allocs/op |
|---|---|---|---|
| set without capture | 106 | 48 | 3 |
| set with capture, match | 335 | 104 | 6 |
| set with capture, no match | 122 | 48 | 3 |

Matching costs ~+230ns over a plain set action; a miss costs ~+16ns and no extra
allocations. Go's `regexp` is RE2, so a pattern is linear in the input length and cannot
backtrack catastrophically regardless of how it is written.

### Additional Notes

Captured values are cloned rather than sliced out of the field value: a Go substring
shares its backing array, so a 36-byte id would otherwise keep the whole path alive for
as long as the variable lived — and these variables are inherited across process trees
and can carry a TTL. That is the `+1 alloc` in the table above.

Note for reviewers: `secl/rules/policy_test.go` and `ruleset_test.go` are `//go:build
linux`, so the package reports 52 passing tests on darwin against 190 on linux. Changes
here need a linux run to be meaningfully verified.

Follow-ups, both out of scope:
- Capture on array fields, which is what env var artifacts (`GITHUB_RUN_ID`,
  `ECS_TASK_ARN`) would need; `exec.envp` currently fails at load.
- The ECS task id example from the RFC, which depends on `process.cgroup.id` exposing the
  relative cgroup path rather than just the leaf container id on the EC2 launch type.
  That still needs to be checked on a real ECS host.