### PR TITLE
[WP] Ignore unsupported socket types in flow_pid map during snapshot

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/procfs.h
+++ b/pkg/security/ebpf/c/include/hooks/procfs.h
@@ -135,6 +135,11 @@ int hook_path_get(ctx_t *ctx) {
     if (sk == NULL) {
         return 0;
     }
+    // this map only support tcp and udp for now
+    route.l4_protocol = get_protocol_from_sock(sk);
+    if (route.l4_protocol != IPPROTO_TCP && route.l4_protocol != IPPROTO_UDP) {
+        return 0;
+    }
 
     route.netns = get_netns_from_sock(sk);
     if (route.netns == 0) {
@@ -146,7 +151,6 @@ int hook_path_get(ctx_t *ctx) {
         // without a port we can't do much, leave early
         return 0;
     }
-    route.l4_protocol = get_protocol_from_sock(sk);
     u16 family = get_family_from_sock_common((void *)sk);
     if (family == AF_INET6) {
         bpf_probe_read(&route.addr, sizeof(u64) * 2, &sk->__sk_common.skc_v6_rcv_saddr);


### PR DESCRIPTION
### What does this PR do?
This PR prevents keys unrelated to UDP or TCP sockets from being added to the `flow_pid` map when reading socket from procfs.

### Motivation
The current mechanism is designed specifically for UDP and TCP. We should avoid adding other socket types until we support parsing them from procfs info