### PR TITLE
[AGENT-16614] [AGENT-16559] [AGENT-16582] [TEEP-8018] fix(installer): tolerate legacy procmgr retirement failures

### DIFF
--- a/pkg/fleet/installer/packages/datadog_agent_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_linux.go
@@ -228,29 +228,48 @@ func installFilesystem(ctx HookContext) (err error) {
 // A host that upgraded from datadog-agent-procmgrd.service could otherwise run two dd-procmgrd
 // instances (socket and processes.d conflicts).
 func retireLegacyProcmgrUnits(ctx HookContext) error {
-	switch service.GetServiceManagerType() {
+	serviceManager := service.GetServiceManagerType()
+	log.Debugf("retire legacy procmgr units: service manager %q", serviceManager)
+	switch serviceManager {
 	case service.SystemdType:
 	default:
+		log.Debugf("retire legacy procmgr units: skipping, systemd not in use")
 		return nil
 	}
 	running, err := systemd.IsRunning()
 	if err != nil {
-		return err
+		log.Debugf("retire legacy procmgr units: check systemd running failed: %v", err)
+		return fmt.Errorf("check systemd running: %w", err)
 	}
+	log.Debugf("retire legacy procmgr units: systemd running=%t", running)
 	if running {
+		log.Debugf("retire legacy procmgr units: stopping units %v", legacyProcmgrUnitNames)
 		if err := systemd.StopUnits(ctx, legacyProcmgrUnitNames...); err != nil {
-			return err
+			log.Debugf("retire legacy procmgr units: stop failed: %v", err)
+			return fmt.Errorf("stop legacy procmgr units: %w", err)
 		}
+		log.Debugf("retire legacy procmgr units: disabling units %v", legacyProcmgrUnitNames)
 		if err := systemd.DisableUnits(ctx, legacyProcmgrUnitNames...); err != nil {
-			return err
+			log.Debugf("retire legacy procmgr units: disable failed: %v", err)
+			return fmt.Errorf("disable legacy procmgr units: %w", err)
 		}
+	} else {
+		log.Debugf("retire legacy procmgr units: skipping stop/disable, systemd not running")
 	}
 	for _, unitsPath := range systemdUnitInstallPaths {
+		log.Debugf("retire legacy procmgr units: removing unit files from %q", unitsPath)
 		if err := legacyProcmgrUnitPaths.EnsureAbsent(ctx, unitsPath); err != nil {
-			return err
+			log.Debugf("retire legacy procmgr units: remove unit files from %q failed: %v", unitsPath, err)
+			return fmt.Errorf("remove legacy procmgr unit files from %s: %w", unitsPath, err)
 		}
 	}
-	return systemd.Reload(ctx)
+	log.Debugf("retire legacy procmgr units: reloading systemd")
+	if err := systemd.Reload(ctx); err != nil {
+		log.Debugf("retire legacy procmgr units: reload failed: %v", err)
+		return fmt.Errorf("reload systemd after retiring legacy procmgr units: %w", err)
+	}
+	log.Debugf("retire legacy procmgr units: done")
+	return nil
 }
 
 const parExecutorProcmgrConfigName = "datadog-agent-action-executor.yaml"

--- a/pkg/fleet/installer/packages/datadog_agent_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_linux.go
@@ -219,7 +219,7 @@ func installFilesystem(ctx HookContext) (err error) {
 
 	// 7. Stop and remove legacy procmgr unit names so only datadog-agent-procmgr.service runs dd-procmgrd
 	if err = retireLegacyProcmgrUnits(ctx); err != nil {
-		return fmt.Errorf("failed to retire legacy procmgr units: %w", err)
+		log.Warnf("failed to retire legacy procmgr units: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?
Apply best-effort only when removing legacy (`procmgrd`) systemd unit files.
This is a simpler take on [[AGENT-16614] [AGENT-16559] [AGENT-16582] [TEEP-8018] fix(installer): tolerate legacy procmgr retirement failures](https://github.com/DataDog/datadog-agent/pull/54046).

### Motivation
In hardened SELinux, this step may fail, which would prevent the rest of the `installer postinst` from running and leave the system with an incomplete agent upgrade. Legacy systemd unit should already have been stopped and removed by the execution of the `installer prerm --update` from the upgraded package.

### Describe how you validated your changes
CI

### Additional Notes
If it's deemed safe, the whole `retireLegacyProcmgrUnits` step may be removed in the future.

[AGENT-16614]: https://datadoghq.atlassian.net/browse/AGENT-16614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AGENT-16559]: https://datadoghq.atlassian.net/browse/AGENT-16559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AGENT-16582]: https://datadoghq.atlassian.net/browse/AGENT-16582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TEEP-8018]: https://datadoghq.atlassian.net/browse/TEEP-8018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ