### PR TITLE
Wait for the Oracle database to be ready in tests

### DIFF
--- a/pkg/collector/corechecks/oracle/init_test.go
+++ b/pkg/collector/corechecks/oracle/init_test.go
@@ -8,10 +8,12 @@
 package oracle
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,6 +63,41 @@ func (c *minimalT) runCleanups() {
 	}
 }
 
+const (
+	dbReadyAttempts = 60
+	dbReadyInterval = 5 * time.Second
+)
+
+// waitForDatabase polls until the database accepts queries, returning the connected
+// check. Locally the compose healthcheck gates startup, but in CI the database runs as
+// a GitLab service container with no readiness gating, so the test binary can start
+// before Oracle has registered its service with the listener. Connecting immediately
+// then fails with ORA-12514 and takes the whole suite down with it.
+func waitForDatabase(t *minimalT) (Check, error) {
+	var lastErr error
+	for attempt := 1; attempt <= dbReadyAttempts; attempt++ {
+		c, _ := newSysCheck(t, "", "")
+		// Run establishes the connection; its error surfaces through the query below.
+		c.Run()
+		if c.db == nil {
+			lastErr = errors.New("no database connection established")
+		} else if _, err := c.db.Exec("SELECT 1 FROM dual"); err != nil {
+			lastErr = err
+		} else {
+			if attempt > 1 {
+				fmt.Printf("Database ready after %d attempts\n", attempt)
+			}
+			return c, nil
+		}
+		c.Teardown()
+		if attempt == 1 {
+			fmt.Printf("Waiting for the database to accept queries: %s\n", lastErr)
+		}
+		time.Sleep(dbReadyInterval)
+	}
+	return Check{}, fmt.Errorf("gave up after %d attempts: %w", dbReadyAttempts, lastErr)
+}
+
 func TestMain(m *testing.M) {
 	t := &minimalT{}
 	defer func() {
@@ -78,18 +115,17 @@ func TestMain(m *testing.M) {
 		return
 	}
 
-	print("Running initdb.d sql files...")
 	// This is a bit of a hack to get a db connection without a testing.T
 	// Ideally we should pull the connection logic out
 	// to make it more accessible for testing
-	sysCheck, _ := newSysCheck(t, "", "")
-	t.Cleanup(sysCheck.Teardown)
-	sysCheck.Run()
-	_, err := sysCheck.db.Exec("SELECT 1 FROM dual")
+	sysCheck, err := waitForDatabase(t)
 	if err != nil {
-		fmt.Printf("Error executing select check: %s\n", err)
+		fmt.Printf("Database never became ready: %s\n", err)
 		os.Exit(1)
 	}
+	t.Cleanup(sysCheck.Teardown)
+
+	print("Running initdb.d sql files...")
 
 	initDbPath := "./compose/initdb.d"
 	files, _ := os.ReadDir(initDbPath)


### PR DESCRIPTION
### What does this PR do?

Makes `TestMain` in the Oracle check's test suite poll until the database accepts
queries, instead of connecting once and calling `os.Exit(1)` if that fails.
Up to 60 attempts, 5 seconds apart.

### Motivation

The `oracle: [21.3.0-xe]` functional test job is flaky — of the 12 most recent
`main` pipelines I sampled, 3 passed. Every failure I looked at was the same
error, on the very first connection:

```
ORA-12514: TNS:listener does not currently know of service requested in connect descriptor
```

That is service registration, not a bad credential or a wrong host: the listener
is up but the database has not registered with it yet.

The readiness poll for this suite lives inside `start_docker` in
`tasks/oracle.py`, which is gated on:

```python
if not os.environ.get("CI") and not os.environ.get("SKIP_DOCKER"):
    start_docker(ctx, verbose)
```

So locally the compose healthcheck holds `go test` back until Oracle answers.
In CI that branch is skipped, the database is a GitLab service container with no
readiness gating, and `go test` starts immediately. `TestMain`'s first query then
fails and `os.Exit(1)` takes the entire suite down with it, which is why the job
fails wholesale rather than reporting individual test failures.

The wait goes in `TestMain` rather than `tasks/oracle.py` because that's where the
fatal connection actually happens, and it already has the Oracle driver at hand.
That also covers a local run with `SKIP_DOCKER=1`.

The job is `allow_failure: true` today (incident-51958), so this does not change
whether pipelines pass — it changes whether we get usable Oracle test results.

### Describe how you validated your changes

Test-only change. `go vet -tags "test oracle oracle_test" ./pkg/collector/corechecks/oracle/...`
is clean.

I could **not** reproduce the race or verify the fix locally: the
`oracle:21.3.0-xe` image is amd64-only and the instance dies on Apple Silicon
under emulation with `ORA-00600 [OSDEP_INTERNAL]` / `ORA-27302: skgpiidcompa`.
So the diagnosis above is read off the code and the CI logs, not reproduced.
The CI signal is the real validation: if the theory is right the Oracle job
should get past `TestMain` consistently from here.

Worth a sanity check from whoever owns incident-51958 before merging, in case
there's a known second cause I'm papering over.

### Additional Notes

No release note: no shipped code changes.

Found while trying to get live-database probe output for #54188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
