### PR TITLE
Add semantic-core as codeowner for mappings.json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -547,6 +547,8 @@
 /pkg/trace/telemetry/                   @DataDog/apm-trace-storage
 
 /pkg/trace/transform/                   @DataDog/opentelemetry
+
+/pkg/trace/semantics/mappings.json       @DataDog/agent-apm @DataDog/semantic-core
 /comp/core/autodiscovery/listeners/           @DataDog/container-platform
 /comp/core/autodiscovery/listeners/cloudfoundry*.go  @DataDog/agent-integrations
 /comp/core/autodiscovery/listeners/snmp*.go   @DataDog/network-device-monitoring-core


### PR DESCRIPTION
Adds @DataDog/semantic-core as a codeowner for pkg/trace/semantics/mappings.json, alongside @DataDog/agent-apm. This file and the equivalencies it defines are maintained by the Semantic Core team, and the produced data must stay synced with their pipelines.