### PR TITLE
Set bazel install_dir in omnibus to expected target location

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -25,7 +25,7 @@ build do
     block do
         # Push all the pieces built with Bazel.
 
-        command "bazel run #{omnibazel_flags} -- //packages/install_dir:install",
+        command "bazel run #{omnibazel_flags} -- //packages/install_dir:install --destdir=#{install_dir}",
             :live_stream => Omnibus.logger.live_stream(:info)
 
         if linux_target?

--- a/omnibus/lib/ostools.rb
+++ b/omnibus/lib/ostools.rb
@@ -69,7 +69,8 @@ end
 def omnibazel_flags()
   flags = []
   flags << "--//packages/agent:flavor=#{ENV['AGENT_FLAVOR']}" if ENV['AGENT_FLAVOR']
-  flags << "--//:install_dir=#{install_dir}"
+  # In macos, omnibus install_dir is the build location, which is different from the expected install location
+  flags << (osx_target? ? "--//:install_dir=/opt/datadog-agent" : "--//:install_dir=#{install_dir}")
   flags << "--//:output_config_dir=#{ENV['OUTPUT_CONFIG_DIR']}"
   flags.join(' ')
 end

--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -146,7 +146,11 @@ def _insert_omnibazel_flags(args: tuple[str, ...]) -> tuple[str, ...]:
     if agent_flavor := os.environ.get("AGENT_FLAVOR"):
         flags.append(f"--//packages/agent:flavor={agent_flavor}")
     if install_dir := os.environ.get("INSTALL_DIR"):
-        flags.append(f"--//:install_dir={install_dir}")
+        # In macos, omnibus install_dir is the build location, which is different from the expected install location
+        if sys.platform == "darwin":
+            flags.append("--//:install_dir=/opt/datadog-agent")
+        else:
+            flags.append(f"--//:install_dir={install_dir}")
         flags.append(f"--//:output_config_dir={os.environ.get("OUTPUT_CONFIG_DIR", "")}")
     if not flags:
         return args


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

It passes `/opt/datadog-agent`, the location where the Agent usually gets installed in macos, as `install_dir` for Bazel commands, instead of the one from omnibus, that points at a temporary directory.

### Motivation

[ABLD-523](https://datadoghq.atlassian.net/browse/ABLD-523)

Omnibus `install_dir` conflates two things: the directory where the build happens, as well as the target location. This is because that matches the model under which Omnibus works, which assumes the built package will be deployed to that same location. However, on macos, we build the Agent in a different location, to avoid overwriting the Agent installation that runs on our macos runners (which have no form of sandboxing). On macos, `install_dir` inside Omnibus still refers to the "build directory". The installation location is set here instead:
https://github.com/DataDog/datadog-agent/blob/f2df68bee8e38ea2202be489c844b45f867f7d3f/omnibus/config/projects/agent.rb#L180

Passing this Omnibus `install_dir` to Bazel commands brings no real advantage, and it's actually harmful, as it causes references (notably, on shebang lines) to point at paths that don't exist in actual installations. On top of that, this causes `install_dir` to be different in CI from locally, reducing our ability to use the CI-populated bazel cache from developers machines.

### Describe how you validated your changes

Installed the arm variant of the package on a VM and made manual confirmation that shebang's are now correct, and RPATH's remain valid (as they're relative).

### Additional Notes

This implementation involves duplication, which is more or less unavoidable at the current hybrid state. I think it's a worthwhile tradeoff at this time.

https://github.com/DataDog/datadog-agent/pull/54037 was a precondition for this change, allowing rpath references to remain correct despite this change.


[ABLD-523]: https://datadoghq.atlassian.net/browse/ABLD-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ