### PR TITLE
[DSEC-212] Enable data security rust check

### DIFF
--- a/pkg/collector/sharedlibrary/rustchecks/BUILD.bazel
+++ b/pkg/collector/sharedlibrary/rustchecks/BUILD.bazel
@@ -4,8 +4,8 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 # Rust shared-library checks are Linux-only.
 _LINUX = ["@platforms//os:linux"]
 
-# Rust checks are disabled by default; add a check name -> cdylib target entry
-# here to ship it. Uncomment the datasecurity entry below to ship the check.
+# Map of check name -> cdylib target for each Rust check we ship. Add an entry
+# here to ship a new check.
 ENABLED_CHECKS = {
     "datasecurity": "//pkg/collector/sharedlibrary/rustchecks/checks/datasecurity:datasecurity",
 }

--- a/pkg/collector/sharedlibrary/rustchecks/BUILD.bazel
+++ b/pkg/collector/sharedlibrary/rustchecks/BUILD.bazel
@@ -7,7 +7,7 @@ _LINUX = ["@platforms//os:linux"]
 # Rust checks are disabled by default; add a check name -> cdylib target entry
 # here to ship it. Uncomment the datasecurity entry below to ship the check.
 ENABLED_CHECKS = {
-    # "datasecurity": "//pkg/collector/sharedlibrary/rustchecks/checks/datasecurity:datasecurity",
+    "datasecurity": "//pkg/collector/sharedlibrary/rustchecks/checks/datasecurity:datasecurity",
 }
 
 # Stage every enabled cdylib into checks.d with the loader naming convention

--- a/releasenotes/notes/ship-data-security-shared-library-9c1f4a7d2be835a0.yaml
+++ b/releasenotes/notes/ship-data-security-shared-library-9c1f4a7d2be835a0.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add the Data Security feature to scan monitored PostgreSQL databases for
+    sensitive data, driven remotely through Remote Configuration
+    (``DATA_SECURITY_DB_SCAN_TASKS``). Enabled with ``data_security.enabled`` and
+    ``shared_library_check.enabled``.

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,51 +1,51 @@
 static_quality_gate_agent_deb_amd64:
-  max_on_disk_size: 759.22 MiB
-  max_on_wire_size: 181.38 MiB
+  max_on_disk_size: 762.66 MiB
+  max_on_wire_size: 182.52 MiB
 static_quality_gate_agent_deb_amd64_fips:
-  max_on_disk_size: 710.52 MiB
-  max_on_wire_size: 175.48 MiB
+  max_on_disk_size: 714.17 MiB
+  max_on_wire_size: 176.45 MiB
 static_quality_gate_agent_heroku_amd64:
-  max_on_disk_size: 315.23 MiB
-  max_on_wire_size: 80.56 MiB
+  max_on_disk_size: 318.88 MiB
+  max_on_wire_size: 81.49 MiB
 static_quality_gate_agent_msi:
   max_on_disk_size: 657.29 MiB
   max_on_wire_size: 157.89 MiB
 static_quality_gate_agent_rpm_amd64:
-  max_on_disk_size: 759.19 MiB
-  max_on_wire_size: 184.16 MiB
+  max_on_disk_size: 762.63 MiB
+  max_on_wire_size: 186.16 MiB
 static_quality_gate_agent_rpm_amd64_fips:
-  max_on_disk_size: 710.52 MiB
-  max_on_wire_size: 175.6 MiB
+  max_on_disk_size: 714.17 MiB
+  max_on_wire_size: 177.49 MiB
 static_quality_gate_agent_rpm_arm64:
-  max_on_disk_size: 730.63 MiB
-  max_on_wire_size: 165.03 MiB
+  max_on_disk_size: 733.72 MiB
+  max_on_wire_size: 166.82 MiB
 static_quality_gate_agent_rpm_arm64_fips:
-  max_on_disk_size: 688.91 MiB
-  max_on_wire_size: 158.68 MiB
+  max_on_disk_size: 692.25 MiB
+  max_on_wire_size: 159.22 MiB
 static_quality_gate_agent_suse_amd64:
-  max_on_disk_size: 759.19 MiB
-  max_on_wire_size: 184.13 MiB
+  max_on_disk_size: 762.63 MiB
+  max_on_wire_size: 186.13 MiB
 static_quality_gate_agent_suse_amd64_fips:
-  max_on_disk_size: 710.52 MiB
-  max_on_wire_size: 175.74 MiB
+  max_on_disk_size: 714.17 MiB
+  max_on_wire_size: 177.65 MiB
 static_quality_gate_agent_suse_arm64:
-  max_on_disk_size: 730.63 MiB
-  max_on_wire_size: 164.99 MiB
+  max_on_disk_size: 733.72 MiB
+  max_on_wire_size: 166.76 MiB
 static_quality_gate_agent_suse_arm64_fips:
-  max_on_disk_size: 688.91 MiB
-  max_on_wire_size: 158.67 MiB
+  max_on_disk_size: 692.25 MiB
+  max_on_wire_size: 159.2 MiB
 static_quality_gate_docker_agent_amd64:
-  max_on_disk_size: 814.81 MiB
-  max_on_wire_size: 275.7 MiB
+  max_on_disk_size: 818.25 MiB
+  max_on_wire_size: 277.3 MiB
 static_quality_gate_docker_agent_arm64:
-  max_on_disk_size: 815.96 MiB
-  max_on_wire_size: 263.67 MiB
+  max_on_disk_size: 819.09 MiB
+  max_on_wire_size: 265.25 MiB
 static_quality_gate_docker_agent_jmx_amd64:
-  max_on_disk_size: 1005.57 MiB
-  max_on_wire_size: 344.32 MiB
+  max_on_disk_size: 1009.01 MiB
+  max_on_wire_size: 345.91 MiB
 static_quality_gate_docker_agent_jmx_arm64:
-  max_on_disk_size: 995.64 MiB
-  max_on_wire_size: 328.27 MiB
+  max_on_disk_size: 998.77 MiB
+  max_on_wire_size: 329.84 MiB
 static_quality_gate_docker_cluster_agent_amd64:
   max_on_disk_size: 211.25 MiB
   max_on_wire_size: 74.4 MiB

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,5 +1,5 @@
 static_quality_gate_agent_deb_amd64:
-  max_on_disk_size: 762.66 MiB
+  max_on_disk_size: 762.87 MiB
   max_on_wire_size: 182.52 MiB
 static_quality_gate_agent_deb_amd64_fips:
   max_on_disk_size: 714.17 MiB
@@ -11,40 +11,40 @@ static_quality_gate_agent_msi:
   max_on_disk_size: 657.29 MiB
   max_on_wire_size: 157.89 MiB
 static_quality_gate_agent_rpm_amd64:
-  max_on_disk_size: 762.63 MiB
+  max_on_disk_size: 762.84 MiB
   max_on_wire_size: 186.16 MiB
 static_quality_gate_agent_rpm_amd64_fips:
   max_on_disk_size: 714.17 MiB
   max_on_wire_size: 177.49 MiB
 static_quality_gate_agent_rpm_arm64:
-  max_on_disk_size: 733.72 MiB
+  max_on_disk_size: 733.97 MiB
   max_on_wire_size: 166.82 MiB
 static_quality_gate_agent_rpm_arm64_fips:
   max_on_disk_size: 692.25 MiB
   max_on_wire_size: 159.22 MiB
 static_quality_gate_agent_suse_amd64:
-  max_on_disk_size: 762.63 MiB
+  max_on_disk_size: 762.84 MiB
   max_on_wire_size: 186.13 MiB
 static_quality_gate_agent_suse_amd64_fips:
   max_on_disk_size: 714.17 MiB
   max_on_wire_size: 177.65 MiB
 static_quality_gate_agent_suse_arm64:
-  max_on_disk_size: 733.72 MiB
+  max_on_disk_size: 733.97 MiB
   max_on_wire_size: 166.76 MiB
 static_quality_gate_agent_suse_arm64_fips:
   max_on_disk_size: 692.25 MiB
   max_on_wire_size: 159.2 MiB
 static_quality_gate_docker_agent_amd64:
-  max_on_disk_size: 818.25 MiB
+  max_on_disk_size: 818.46 MiB
   max_on_wire_size: 277.3 MiB
 static_quality_gate_docker_agent_arm64:
-  max_on_disk_size: 819.09 MiB
+  max_on_disk_size: 819.30 MiB
   max_on_wire_size: 265.25 MiB
 static_quality_gate_docker_agent_jmx_amd64:
-  max_on_disk_size: 1009.01 MiB
+  max_on_disk_size: 1009.22 MiB
   max_on_wire_size: 345.91 MiB
 static_quality_gate_docker_agent_jmx_arm64:
-  max_on_disk_size: 998.77 MiB
+  max_on_disk_size: 998.98 MiB
   max_on_wire_size: 329.84 MiB
 static_quality_gate_docker_cluster_agent_amd64:
   max_on_disk_size: 211.25 MiB


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Ships the `datasecurity` Rust shared-library check by enabling it in `ENABLED_CHECKS`, so its cdylib is bundled with the Agent build.

### Motivation

Enable the Data Security feature (RC-driven PostgreSQL scanning via the `DATA_SECURITY_DB_SCAN_TASKS` product) so it can be turned on with `data_security.enabled` + `shared_library_check.enabled`.

### Describe how you validated your changes

The feature was already validated end-to-end in previous PRs. This PR only flips the check on for shipping.

### Decision Record
https://datadoghq.atlassian.net/wiki/spaces/ABLD/pages/7034209304/Data+Security+-+Quality+Gates+Decision+Records

### Note
Last [commit](https://github.com/DataDog/datadog-agent/pull/54204/changes/269c5d4dd6128dcc1023e4a7d5aff3135eee4c5d) compensate what was lost after rebasing on main (post PR merge https://github.com/DataDog/datadog-agent/pull/54419)  