### PR TITLE
fix(e2e/discovery): Capture fixture service diagnostics on failure

### DIFF
--- a/test/new-e2e/tests/discovery/linux_test.go
+++ b/test/new-e2e/tests/discovery/linux_test.go
@@ -173,14 +173,24 @@ func (s *linuxTestSuite) testLogs(t *testing.T) {
 // endpoints.
 const sysprobeSocket = "/opt/datadog-agent/run/sysprobe.sock"
 
-func (s *linuxTestSuite) dumpDebugInfo(t *testing.T) {
-	host := s.Env().RemoteHost
+// logDiagnostic runs a diagnostic command and logs its output.
+//
+// Failures are deliberately tolerated. These only run once a test has already
+// failed, and several of them legitimately exit non-zero in exactly the
+// situations worth debugging: systemctl status for an inactive unit, ps for a
+// process which has since exited (which is what a crash-looping service looks
+// like), curl if the agent is not running. Using MustExecute directly would
+// replace the original failure with an error about the diagnostic itself.
+func (s *linuxTestSuite) logDiagnostic(t *testing.T, label, cmd string) {
+	t.Logf("%s:\n%s", label, s.Env().RemoteHost.MustExecute(cmd+" 2>&1 || true"))
+}
 
+func (s *linuxTestSuite) dumpDebugInfo(t *testing.T) {
 	// This is very useful for debugging, but we probably don't want to decode
 	// and assert based on this in this E2E test since this is an internal
 	// interface between the agent and system-probe.
-	t.Log("system-probe discovery state", host.MustExecute(
-		"sudo curl -s --unix-socket "+sysprobeSocket+" http://unix/discovery/state"))
+	s.logDiagnostic(t, "system-probe discovery state",
+		"sudo curl -s --unix-socket "+sysprobeSocket+" http://unix/discovery/state")
 
 	pids := s.fixtureServicePIDs(services)
 	if len(pids) > 0 {
@@ -189,22 +199,22 @@ func (s *linuxTestSuite) dumpDebugInfo(t *testing.T) {
 		// minute by default), so a value below that explains a service which
 		// was never reported, and one which keeps resetting across dumps means
 		// the service is crash-looping rather than starting slowly.
-		t.Log("fixture service processes", host.MustExecute(
-			"sudo ps -o pid,ppid,etimes,comm,args -p "+strings.Join(pids, ",")))
+		s.logDiagnostic(t, "fixture service processes",
+			"sudo ps -o pid,ppid,etimes,comm,args -p "+strings.Join(pids, ","))
 
 		// /discovery/services is the only endpoint which reports what
 		// discovery actually sees. It is caller-driven, so it has to be told
 		// which PIDs to look at, and it only accepts POST with a JSON body.
 		params := fmt.Sprintf(`{"new_pids":[%s]}`, strings.Join(pids, ","))
-		t.Log("system-probe discovery services", host.MustExecute(
+		s.logDiagnostic(t, "system-probe discovery services",
 			"sudo curl -s -X POST -H 'Content-Type: application/json' -d '"+params+"'"+
-				" --unix-socket "+sysprobeSocket+" http://unix/discovery/services"))
+				" --unix-socket "+sysprobeSocket+" http://unix/discovery/services")
 	}
 
 	s.dumpServiceDiagnostics(t, services)
 
-	t.Log("workloadmeta store", host.MustExecute("sudo datadog-agent workload-list --verbose"))
-	t.Log("agent status", host.MustExecute("sudo datadog-agent status"))
+	s.logDiagnostic(t, "workloadmeta store", "sudo datadog-agent workload-list --verbose")
+	s.logDiagnostic(t, "agent status", "sudo datadog-agent status")
 }
 
 // fixtureServicePIDs returns the PIDs in the cgroup of each of the given
@@ -227,18 +237,13 @@ func (s *linuxTestSuite) fixtureServicePIDs(servicesList []string) []string {
 // Restart=always with RestartSec=1), leaves no trace in the test output and is
 // indistinguishable from discovery being slow to report it.
 func (s *linuxTestSuite) dumpServiceDiagnostics(t *testing.T, servicesList []string) {
-	host := s.Env().RemoteHost
-
-	t.Log("listening sockets", host.MustExecute("sudo ss -ltnp || true"))
+	s.logDiagnostic(t, "listening sockets", "sudo ss -ltnp")
 
 	for _, service := range servicesList {
-		// systemctl status exits non-zero for an inactive or failed unit,
-		// which is exactly the case being debugged, so keep the output and
-		// ignore the exit code.
-		t.Logf("%s systemctl status:\n%s", service,
-			host.MustExecute("sudo systemctl status --no-pager --full "+service+" || true"))
-		t.Logf("%s journal:\n%s", service,
-			host.MustExecute("sudo journalctl --no-pager -n 100 -u "+service+" 2>&1 || true"))
+		s.logDiagnostic(t, service+" systemctl status",
+			"sudo systemctl status --no-pager --full "+service)
+		s.logDiagnostic(t, service+" journal",
+			"sudo journalctl --no-pager -n 100 -u "+service)
 	}
 }
 

--- a/test/new-e2e/tests/discovery/linux_test.go
+++ b/test/new-e2e/tests/discovery/linux_test.go
@@ -204,7 +204,14 @@ func (s *linuxTestSuite) dumpDebugInfo(t *testing.T) {
 
 		// /discovery/services is the only endpoint which reports what
 		// discovery actually sees. It is caller-driven, so it has to be told
-		// which PIDs to look at, and it only accepts POST with a JSON body.
+		// which PIDs to look at, and system-probe-lite serves it for POST only
+		// and rejects a request without an explicit Content-Type.
+		//
+		// The body is built by hand because it is defined by core.Params in
+		// pkg/discovery/core, which belongs to the main module that this one
+		// does not depend on. Keep the field name in sync with it: unknown
+		// fields are ignored without an error, so a rename there would make
+		// this log an empty service list rather than fail visibly.
 		params := fmt.Sprintf(`{"new_pids":[%s]}`, strings.Join(pids, ","))
 		s.logDiagnostic(t, "system-probe discovery services",
 			"sudo curl -s -X POST -H 'Content-Type: application/json' -d '"+params+"'"+

--- a/test/new-e2e/tests/discovery/linux_test.go
+++ b/test/new-e2e/tests/discovery/linux_test.go
@@ -169,18 +169,77 @@ func (s *linuxTestSuite) testLogs(t *testing.T) {
 	}, 2*time.Minute, 10*time.Second)
 }
 
+// sysprobeSocket is the socket on which system-probe serves the discovery
+// endpoints.
+const sysprobeSocket = "/opt/datadog-agent/run/sysprobe.sock"
+
 func (s *linuxTestSuite) dumpDebugInfo(t *testing.T) {
+	host := s.Env().RemoteHost
+
 	// This is very useful for debugging, but we probably don't want to decode
 	// and assert based on this in this E2E test since this is an internal
 	// interface between the agent and system-probe.
-	discoveredServices := s.Env().RemoteHost.MustExecute("sudo curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/discovery/debug")
-	t.Log("system-probe services", discoveredServices)
+	t.Log("system-probe discovery state", host.MustExecute(
+		"sudo curl -s --unix-socket "+sysprobeSocket+" http://unix/discovery/state"))
 
-	workloadmetaStore := s.Env().RemoteHost.MustExecute("sudo datadog-agent workload-list --verbose")
-	t.Log("workloadmeta store", workloadmetaStore)
+	pids := s.fixtureServicePIDs(services)
+	if len(pids) > 0 {
+		// ELAPSED is the first thing to look at: discovery never asks about a
+		// process younger than discovery.service_collection_min_process_age (1
+		// minute by default), so a value below that explains a service which
+		// was never reported, and one which keeps resetting across dumps means
+		// the service is crash-looping rather than starting slowly.
+		t.Log("fixture service processes", host.MustExecute(
+			"sudo ps -o pid,ppid,etimes,comm,args -p "+strings.Join(pids, ",")))
 
-	status := s.Env().RemoteHost.MustExecute("sudo datadog-agent status")
-	t.Log("agent status", status)
+		// /discovery/services is the only endpoint which reports what
+		// discovery actually sees. It is caller-driven, so it has to be told
+		// which PIDs to look at, and it only accepts POST with a JSON body.
+		params := fmt.Sprintf(`{"new_pids":[%s]}`, strings.Join(pids, ","))
+		t.Log("system-probe discovery services", host.MustExecute(
+			"sudo curl -s -X POST -H 'Content-Type: application/json' -d '"+params+"'"+
+				" --unix-socket "+sysprobeSocket+" http://unix/discovery/services"))
+	}
+
+	s.dumpServiceDiagnostics(t, services)
+
+	t.Log("workloadmeta store", host.MustExecute("sudo datadog-agent workload-list --verbose"))
+	t.Log("agent status", host.MustExecute("sudo datadog-agent status"))
+}
+
+// fixtureServicePIDs returns the PIDs in the cgroup of each of the given
+// services. Using the cgroup rather than the unit's main PID matters because
+// the process the tests match on is not always the main one: node-json-server
+// runs through npm, which spawns the node process that serves the port.
+func (s *linuxTestSuite) fixtureServicePIDs(servicesList []string) []string {
+	var pids []string
+	for _, service := range servicesList {
+		procs := s.Env().RemoteHost.MustExecute(fmt.Sprintf(
+			"cat /sys/fs/cgroup/system.slice/%s.service/cgroup.procs 2>/dev/null || true", service))
+		pids = append(pids, strings.Fields(procs)...)
+	}
+	return pids
+}
+
+// dumpServiceDiagnostics logs the state of the fixture services themselves.
+// The journal is the only place their output ends up, so without this a
+// service which fails to start, or which crash-loops (the units are
+// Restart=always with RestartSec=1), leaves no trace in the test output and is
+// indistinguishable from discovery being slow to report it.
+func (s *linuxTestSuite) dumpServiceDiagnostics(t *testing.T, servicesList []string) {
+	host := s.Env().RemoteHost
+
+	t.Log("listening sockets", host.MustExecute("sudo ss -ltnp || true"))
+
+	for _, service := range servicesList {
+		// systemctl status exits non-zero for an inactive or failed unit,
+		// which is exactly the case being debugged, so keep the output and
+		// ignore the exit code.
+		t.Logf("%s systemctl status:\n%s", service,
+			host.MustExecute("sudo systemctl status --no-pager --full "+service+" || true"))
+		t.Logf("%s journal:\n%s", service,
+			host.MustExecute("sudo journalctl --no-pager -n 100 -u "+service+" 2>&1 || true"))
+	}
 }
 
 func (s *linuxTestSuite) testProcessCheckWithServiceDiscovery(agentConfigStr string, systemProbeConfigStr string, mode discoveryMode) {

--- a/test/new-e2e/tests/discovery/linux_test.go
+++ b/test/new-e2e/tests/discovery/linux_test.go
@@ -179,8 +179,14 @@ const sysprobeSocket = "/opt/datadog-agent/run/sysprobe.sock"
 // failed, and several of them legitimately exit non-zero in exactly the
 // situations worth debugging: systemctl status for an inactive unit, ps for a
 // process which has since exited (which is what a crash-looping service looks
-// like), curl if the agent is not running. Using MustExecute directly would
-// replace the original failure with an error about the diagnostic itself.
+// like), curl if the agent is not running.
+//
+// The exit status is swallowed by the remote shell rather than handled here
+// because Execute() returns no output at all once the command fails: it blanks
+// stdout and folds it into the error instead, so the output being collected
+// would only be reachable by formatting an error. The redirect is redundant
+// with the framework's use of CombinedOutput, and only kept so that wanting
+// stderr is stated here rather than relying on that.
 func (s *linuxTestSuite) logDiagnostic(t *testing.T, label, cmd string) {
 	t.Logf("%s:\n%s", label, s.Env().RemoteHost.MustExecute(cmd+" 2>&1 || true"))
 }


### PR DESCRIPTION
### What does this PR do?

Makes `dumpDebugInfo` in the discovery E2E suite produce usable output again.

It queried `/discovery/debug`, which was removed in fd2b24d0b81 ("discovery: remove old discovery check", #39417). Every failure since has logged a 404 body instead of any discovery state — `Not found` in `system-probe-lite` mode (system-probe-lite's `NOTFOUND` constant) and `404 page not found` in `system-probe` mode (Go's `ServeMux` default). Both strings are visible in every failure of the two jobs behind DSCVR-621.

Replaced with endpoints that still exist, plus the information needed to tell *"discovery did not report the service"* apart from *"the fixture service was not running"* — a distinction the previous output could not make at all:

- `GET /discovery/state` — which implementation is live.
- `POST /discovery/services` for the fixture services' PIDs. This is the only endpoint that reports what discovery actually sees. It is caller-driven, so it must be told which PIDs to inspect, and it is POST-only with a JSON body in `system-probe-lite`.
- `ps` `ELAPSED` per fixture PID. Discovery never asks about a process younger than `discovery.service_collection_min_process_age` (1 minute by default), so a value below that explains a missing service on its own, and one that keeps resetting across dumps means the service is crash-looping rather than booting slowly.
- `systemctl status` and `journalctl` per fixture service. The journal is the only place a fixture's own output ends up.
- `ss -ltnp`. Discovery only reports a process once it has a listening socket.

PIDs come from each unit's cgroup rather than its main PID, because the process the tests match on is not always the main one: `node-json-server` runs through npm, which spawns the `node` process that serves the port.

### Motivation

DSCVR-621. Investigating that flake, the suite's own diagnostics contributed nothing: `/discovery/debug` returned a 404 body in all four failing subtests of both jobs, and nothing recorded the fixture services' state, so it was impossible to tell from CI output whether discovery had failed to report a running service or the service had never started. Determining that required reconstructing process lifetimes from `workload-list` dumps.

In the two failures behind the ticket the fixture service was in fact not running — `ruby3.0` appears in only one of four `workload-list` dumps of job 1874204604, created 9s before the dump was taken. `journalctl` would have said why in one line.

### Describe how you validated your changes

Since a green CI run does not exercise any of this — `dumpDebugInfo` only runs after a failure, and I confirmed the passing `new-e2e-discovery` job contains none of the new log markers — the endpoints and commands were verified directly.

**Endpoints**, against a `system-probe-lite` built from this tree and driven with the exact command strings this PR sends:

| Request | Response |
|---|---|
| `GET /discovery/state` | `{"implementation":"system-probe-lite"}` |
| `POST /discovery/services`, `{"new_pids":[…]}` + `Content-Type` | `{"services":[{"pid":…,"generated_name":…}],…}` |
| `GET /discovery/debug` (the call being removed) | `Not found` — the exact string seen in every DSCVR-621 failure |
| `POST /discovery/services` with no `Content-Type` | `Bad request` |
| `POST` with a misspelled field | `{"services":[],…}` — unknown fields ignored silently |
| malformed JSON | `Bad request` |

The misspelled-field row is why the field name is called out in a comment: an empty result is indistinguishable from "matched no services", and `core.Params` cannot be imported here because it belongs to the main module, which `test/new-e2e` does not depend on.

**Commands and their exit codes**, on Ubuntu 22.04 / systemd 249 / cgroup v2, matching the image the tests run on: `ps` for an exited PID exits 1 and `curl` to a missing socket exits 7, so both are routed through a helper that keeps the output and drops the status — otherwise a crash-looping fixture (a PID that dies between the cgroup read and `ps`) would have replaced the real failure with an error about the diagnostic. Also confirmed there that `ps`'s header is `ELAPSED`, comma-separated PID lists work, a missing `cgroup.procs` is handled, and `ss -ltn` prints `0.0.0.0:<port>` followed by padding.

Additionally:

- `dda inv linter.go --targets=./test/new-e2e/tests/discovery` — clean.
- `new-e2e-discovery` passes on this branch.
- `ss` is already used against these images elsewhere in the E2E suite (`test/new-e2e/tests/agent-metric-pipelines/common/adp.go`, `test/new-e2e/tests/agent-platform/common/bound-port/unix.go`).
- No assertions are added or changed — this only affects what is logged when a test has already failed.

Not verified: the `system.slice/<svc>.service/cgroup.procs` path against the actual fixture units. The cgroup v2 layout was checked on a matching host, but not with these unit names.

### Additional Notes

Diagnostics only, deliberately: this does not attempt to fix the flake. #54206 builds on this one and addresses the cause.
