### PR TITLE
fix(e2e/discovery): Wait for fixture services to listen before asserting

### DIFF
--- a/test/new-e2e/tests/discovery/linux_test.go
+++ b/test/new-e2e/tests/discovery/linux_test.go
@@ -69,6 +69,18 @@ var services = []string{
 	"rails-svc",
 }
 
+// servicePorts is the TCP port each service listens on, matching the systemd
+// units installed by testdata/provision/provision.sh. Used to wait for a
+// service to be ready rather than merely started, see waitForServicesListening.
+var servicePorts = map[string]int{
+	"python-svc":          8082,
+	"python-instrumented": 8083,
+	"python-restricted":   8086,
+	"node-json-server":    8084,
+	"node-instrumented":   8085,
+	"rails-svc":           7777,
+}
+
 func TestLinuxTestSuite(t *testing.T) {
 	agentParams := []func(*agentparams.Params) error{
 		agentparams.WithAgentConfig(agentConfigStr),
@@ -732,6 +744,50 @@ func (s *linuxTestSuite) stopServices() {
 func (s *linuxTestSuite) startServicesFromList(servicesList []string) {
 	for _, service := range servicesList {
 		s.Env().RemoteHost.MustExecute("sudo systemctl start " + service)
+	}
+	s.waitForServicesListening(servicesList)
+}
+
+// waitForServicesListening waits until every given service is listening on its
+// port.
+//
+// The units are Type=simple, so systemctl start returns as soon as the process
+// has been forked, well before the application has booted and called listen().
+// Discovery only reports a process once it has a listening socket, and it only
+// looks again every discovery.service_collection_interval (1 minute by
+// default), so a service which is slow to bind costs a full discovery cycle for
+// every scan it misses. Waiting here keeps the budget of the assertions below
+// covering the discovery pipeline only, and makes a fixture which fails to
+// start report itself as such instead of as a discovery timeout.
+func (s *linuxTestSuite) waitForServicesListening(servicesList []string) {
+	t := s.T()
+	t.Helper()
+
+	var notListening []string
+	ok := assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		// ss is used elsewhere in the e2e tests, so it is available on these
+		// images.
+		listening := s.Env().RemoteHost.MustExecuteOn(c, "sudo ss -ltn")
+
+		notListening = nil
+		for _, service := range servicesList {
+			port, found := servicePorts[service]
+			if !found {
+				continue
+			}
+			// The local address column is printed as *:port, 0.0.0.0:port or
+			// [::]:port, so match on the port with its trailing separator to
+			// avoid matching a longer port which happens to share the prefix.
+			if !strings.Contains(listening, fmt.Sprintf(":%d ", port)) {
+				notListening = append(notListening, fmt.Sprintf("%s(:%d)", service, port))
+			}
+		}
+		assert.Empty(c, notListening, "services not listening yet: %v", notListening)
+	}, 3*time.Minute, 5*time.Second)
+	if !ok {
+		s.dumpServiceDiagnostics(t, servicesList)
+		require.FailNowf(t, "fixture services failed to start",
+			"not listening: %v", notListening)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Waits for each fixture service to actually be listening on its port before the discovery assertions start.

`startServicesFromList` issued `systemctl start` and returned. The units are `Type=simple`, so that returns at fork — long before the application has booted and called `listen()`. The 3 minute per-service budget was therefore covering two unrelated things: the discovery pipeline, and the service's own startup.

The pipeline part is bounded and deterministic:

| Stage | Value |
|---|---|
| Discovery scan cycle (`discovery.service_collection_interval`) | 60s |
| Minimum process age before a PID is queried (`discovery.service_collection_min_process_age`) | 60s |
| Process check interval (`process_config.intervals.process`) | 10s |
| Process must have existed in the previous check run | +1 cycle |
| Test waits for ≥2 payloads | +2 cycles |

A service that is already listening is reported within about 60s (next scan) + 20s (two process checks) = **80s**. That is exactly the maximum observed across passing runs, and the durations are identical run to run: `node-json-server` takes 60.00s / 30.00s / 80.00s / 50.00s in its four mode combinations, in both the passing retries and the passing halves of the failing jobs.

The startup part is not bounded. Discovery only returns a service once the process has a listening socket, so each scan missed while a service is still booting costs a full 60s. With 180s − 80s = ~100s of slack, the assertions tolerate **one** missed scan (140s) and not **two** (200s).

Waiting for the port keeps the 3 minute budget covering the pipeline only, and makes a fixture that fails to come up report itself as such — via the `dumpServiceDiagnostics` added in #54205 — instead of as an unexplained discovery timeout.

### Motivation

DSCVR-621. Both failures behind that ticket were the fixture not running, not the discovery pipeline being slow, so raising the timeout would not have fixed either:

- **job 1874204604 / `rails-svc`** — the rails process is absent from workloadmeta in three of the four debug dumps, while python and node are present in all four (including the two dumps from the `ProcessCollectionDisabled` variant, so the absence is real rather than a config artifact). In the one dump where it appears it is nine seconds old, about four minutes after `systemctl start`. It failed in all four mode combinations across ~20 minutes. So the service was not running for most of the job. Its failure cadence and cause are not established — nothing recorded the fixture's own output — but no assertion timeout helps a service that is not there.
- **job 1890377724 / `node-json-server`** — the only matching process in workloadmeta is `npm exec json-server …` (`Comm: npm exec json-s`), which can never satisfy the test's matcher, since `matchProcess` requires `Args[0]`, `Exe` or `Comm` to equal `"node"` exactly. The process the test matches is the `node` grandchild npm spawns, which does not exist until npm has finished resolving. Its sibling `node-instrumented`, started in the same second, was discovered with complete service discovery data.

Note that this change does not claim to make either failure pass. It makes the failure legible and correctly attributed, and stops the assertion budget being consumed by something it was never sized for.

### Describe how you validated your changes

- `dda inv linter.go --targets=./test/new-e2e/tests/discovery` — clean.
- `new-e2e-discovery` passes on this branch.
- Every fixture honours `PORT`, so the ports in `servicePorts` match what each service binds: `python/server.py` reads `PORT`, `instrumented.py` calls into it, `node/instrumented/server.js` reads `process.env.PORT`, `json-server` is passed `--port 8084` explicitly, and `rails server` picks up `PORT`.
- `ss` is available on these images — it is already used against them by `test/new-e2e/tests/agent-metric-pipelines/common/adp.go` and `test/new-e2e/tests/agent-platform/common/bound-port/unix.go`. Its `Local Address:Port` column prints as `0.0.0.0:<port>` followed by padding, verified on Ubuntu 22.04 / iproute2, which is why the match is on the port plus its trailing separator rather than a bare substring.

A green run does not exercise the new code path meaningfully: the gate returns in a couple of seconds when the fixtures are healthy, which is the normal case. It confirms no regression rather than confirming the fix.
