### PR TITLE
Unset ambient proxy env vars in tests broken by fabric-proxy sidecar

### DIFF
--- a/comp/otelcol/otlp/components/exporter/datadogexporter/host_metadata_test.go
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/host_metadata_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -162,6 +163,16 @@ func createTestFactory(t *testing.T, serverAddr string) exporter.Factory {
 }
 
 func TestHostMetadata_FromTraces(t *testing.T) {
+	os.Unsetenv("HTTP_PROXY")
+	os.Unsetenv("http_proxy")
+	os.Unsetenv("HTTPS_PROXY")
+	os.Unsetenv("https_proxy")
+	os.Unsetenv("NO_PROXY")
+	os.Unsetenv("no_proxy")
+	os.Unsetenv("DD_PROXY_HTTP")
+	os.Unsetenv("DD_PROXY_HTTPS")
+	os.Unsetenv("DD_PROXY_NO_PROXY")
+
 	c := make(chan payload.HostMetadata)
 	server := createTestServer(t, c)
 	defer server.Close()

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -1124,6 +1125,16 @@ func TestDefaultForwarder_SwallowsErrors(t *testing.T) {
 // path (NewFactoryForOSSExporter, f.s == nil) also uses OTelSyncForwarder when
 // the UseSyncForwarder gate is on, and propagates intake errors back to the caller.
 func TestOSSSyncForwarder_PropagatesErrors(t *testing.T) {
+	os.Unsetenv("HTTP_PROXY")
+	os.Unsetenv("http_proxy")
+	os.Unsetenv("HTTPS_PROXY")
+	os.Unsetenv("https_proxy")
+	os.Unsetenv("NO_PROXY")
+	os.Unsetenv("no_proxy")
+	os.Unsetenv("DD_PROXY_HTTP")
+	os.Unsetenv("DD_PROXY_HTTPS")
+	os.Unsetenv("DD_PROXY_NO_PROXY")
+
 	restore := setSyncForwarderGate(t, true)
 	defer restore()
 

--- a/comp/trace/config/impl/config_test.go
+++ b/comp/trace/config/impl/config_test.go
@@ -582,6 +582,16 @@ func TestDisableLoggingConfig(t *testing.T) {
 }
 
 func TestFullYamlConfig(t *testing.T) {
+	os.Unsetenv("HTTP_PROXY")
+	os.Unsetenv("http_proxy")
+	os.Unsetenv("HTTPS_PROXY")
+	os.Unsetenv("https_proxy")
+	os.Unsetenv("NO_PROXY")
+	os.Unsetenv("no_proxy")
+	os.Unsetenv("DD_PROXY_HTTP")
+	os.Unsetenv("DD_PROXY_HTTPS")
+	os.Unsetenv("DD_PROXY_NO_PROXY")
+
 	config := buildConfigComponentFromYAML(t, true, "./testdata/full.yaml")
 	cfg := config.Object()
 

--- a/pkg/fleet/installer/env/env_test.go
+++ b/pkg/fleet/installer/env/env_test.go
@@ -13,6 +13,16 @@ import (
 )
 
 func TestFromEnv(t *testing.T) {
+	os.Unsetenv("HTTP_PROXY")
+	os.Unsetenv("http_proxy")
+	os.Unsetenv("HTTPS_PROXY")
+	os.Unsetenv("https_proxy")
+	os.Unsetenv("NO_PROXY")
+	os.Unsetenv("no_proxy")
+	os.Unsetenv("DD_PROXY_HTTP")
+	os.Unsetenv("DD_PROXY_HTTPS")
+	os.Unsetenv("DD_PROXY_NO_PROXY")
+
 	tests := []struct {
 		name     string
 		envVars  map[string]string


### PR DESCRIPTION
### What does this PR do?

Makes 4 tests hermetic to ambient `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY`/`DD_PROXY_*` environment variables by unsetting them before the test runs.

### Motivation

Fabric Egress Gateway injects `HTTP_PROXY`/`HTTPS_PROXY` into the job environment, which broke the non-Bazel tests jobs (https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1903066118). Same class of issue as #54096.

### Describe how you validated your changes

- Ran tests locally with a dummy HTTP_PROXY set
- CI run with fast tests disabled so that this is hopefully the last PR for that kind of issue

### Additional Notes

This will become useless once we switch the tests to bazel since environment hermeticity is provided by default there
