### PR TITLE
Log errors when secret can't be resolve at startup

### DIFF
--- a/cmd/secret-generic-connector/backend/kubernetes/secrets_test.go
+++ b/cmd/secret-generic-connector/backend/kubernetes/secrets_test.go
@@ -142,7 +142,7 @@ func TestGetSecretOutput(t *testing.T) {
 			name:          "key not found in secret",
 			secretString:  "secrets-x/my-secrets;nonexistent",
 			expectError:   true,
-			errorContains: "backend does not provide secret key",
+			errorContains: "backend does not provide requested secret",
 		},
 	}
 
@@ -208,7 +208,7 @@ func TestGetSecretOutputEdgeCases(t *testing.T) {
 			name:          "multiple semicolons",
 			secretString:  "secrets-x/my-secrets;password;extra",
 			expectError:   true,
-			errorContains: "backend does not provide secret key",
+			errorContains: "backend does not provide requested secret",
 		},
 		{
 			name:          "multiple slashes",

--- a/cmd/secret-generic-connector/secret/secret.go
+++ b/cmd/secret-generic-connector/secret/secret.go
@@ -25,7 +25,7 @@ type Output struct {
 }
 
 // ErrKeyNotFound is returned when the secret key is not found
-var ErrKeyNotFound = errors.New("backend does not provide secret key")
+var ErrKeyNotFound = errors.New("backend does not provide requested secret")
 
 const (
 	// DefaultMaxFileReadSize is the maximum file size (10 MB) that can be read as a secret

--- a/comp/core/secrets/impl/secrets.go
+++ b/comp/core/secrets/impl/secrets.go
@@ -35,7 +35,7 @@ import (
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	"github.com/DataDog/datadog-agent/comp/core/secrets/utils"
 	"github.com/DataDog/datadog-agent/comp/core/status"
-	"github.com/DataDog/datadog-agent/comp/core/telemetry/def"
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
@@ -528,6 +528,29 @@ func (r *secretResolver) shouldResolvedSecret(handle string, origin string, imag
 	return true
 }
 
+func (r *secretResolver) registerError(origin string, err error) {
+	// Unwrap per-handle errors from errors.Join so each appears as its own
+	// bullet in the 'agent secret' status output.
+	type multiErr interface{ Unwrap() []error }
+
+	msg := []string{}
+	if joined, ok := err.(multiErr); ok {
+		for _, e := range joined.Unwrap() {
+			msg = append(msg, fmt.Sprintf("'%s' %s", origin, e))
+		}
+	} else {
+		msg = append(msg, fmt.Sprintf("from '%s': %s", origin, err))
+	}
+
+	for _, m := range msg {
+		if _, ok := r.unresolvedSecrets[m]; !ok {
+			r.unresolvedSecrets[m] = struct{}{}
+			log.Error(m)
+		}
+		log.Flush()
+	}
+}
+
 // Resolve replaces all encoded secrets in data by executing "secret_backend_command" once if all secrets aren't
 // present in the cache.
 func (r *secretResolver) Resolve(data []byte, origin string, imageName string, kubeNamespace string, notify bool) ([]byte, error) {
@@ -600,16 +623,7 @@ func (r *secretResolver) Resolve(data []byte, origin string, imageName string, k
 			secretResponse, fetchErr = r.fetchSecret(newHandles)
 		}
 		if fetchErr != nil {
-			// Unwrap per-handle errors from errors.Join so each appears as its own
-			// bullet in the 'agent secret' status output.
-			type multiErr interface{ Unwrap() []error }
-			if joined, ok := fetchErr.(multiErr); ok {
-				for _, e := range joined.Unwrap() {
-					r.unresolvedSecrets[fmt.Sprintf("'%s' %s", origin, e)] = struct{}{}
-				}
-			} else {
-				r.unresolvedSecrets[fmt.Sprintf("from %s: %s", origin, fetchErr)] = struct{}{}
-			}
+			r.registerError(origin, fetchErr)
 			resolveErr = errors.New("could not resolve secret handle(s), see 'agent secret' for details")
 		}
 


### PR DESCRIPTION
### What does this PR do?

When secrets fail to be resolve from datadog.yaml it prevents the Agent from starting. Not having the error in the log prevents any troubleshooting when running in a container.