### PR TITLE
[DOIO-136] Match resolved database identifiers

### DIFF
--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -468,7 +468,7 @@ func renderDatabaseIdentifierWithLookup(
 		values["port"] = strconv.Itoa(defaultPort)
 	}
 
-	resolvedHostname := host
+	var resolvedHostname string
 	if reportedHostname, ok := instance["reported_hostname"].(string); ok && reportedHostname != "" {
 		resolvedHostname = reportedHostname
 	} else {

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -430,30 +430,47 @@ type identifierMatchEvaluation struct {
 }
 
 func evaluateInstanceIdentifier(instance map[string]any, identifier DBIdentifier, integrationName string) identifierMatchEvaluation {
+	switch integrationName {
+	case "postgres":
+		return evaluatePostgresIdentifier(instance, identifier)
+	case "sap_hana":
+		return evaluateSapHanaIdentifier(instance, identifier.Host)
+	default:
+		return identifierMatchEvaluation{strategy: "unsupported_integration"}
+	}
+}
+
+func evaluatePostgresIdentifier(instance map[string]any, identifier DBIdentifier) identifierMatchEvaluation {
 	host := instanceHost(instance)
 	if host == identifier.Host {
 		return identifierMatchEvaluation{matched: true, strategy: "host"}
 	}
-	// Try matching "host:port" form — sap_hana backends include the port in the identifier.
 	if port, ok := instancePort(instance); ok {
 		if fmt.Sprintf("%s:%d", host, port) == identifier.Host {
 			return identifierMatchEvaluation{matched: true, strategy: "host_port"}
 		}
 	}
 
-	defaultTemplate := ""
-	defaultPort := 0
-	if integrationName == "postgres" {
-		defaultTemplate = "$resolved_hostname"
-		defaultPort = defaultPostgresPort
-	}
-	databaseIdentifier, ok := renderDatabaseIdentifier(instance, identifier.AgentHostname, defaultTemplate, defaultPort)
+	databaseIdentifier, ok := renderDatabaseIdentifier(instance, identifier.AgentHostname, "$resolved_hostname", defaultPostgresPort)
 	return identifierMatchEvaluation{
 		matched:            ok && databaseIdentifier == identifier.Host,
 		strategy:           "database_identifier",
 		renderedIdentifier: databaseIdentifier,
 		renderable:         ok,
 	}
+}
+
+func evaluateSapHanaIdentifier(instance map[string]any, targetHost string) identifierMatchEvaluation {
+	host := instanceHost(instance)
+	if host == targetHost {
+		return identifierMatchEvaluation{matched: true, strategy: "host"}
+	}
+	if port, ok := instancePort(instance); ok {
+		if fmt.Sprintf("%s:%d", host, port) == targetHost {
+			return identifierMatchEvaluation{matched: true, strategy: "host_port"}
+		}
+	}
+	return identifierMatchEvaluation{strategy: "sap_hana_endpoint"}
 }
 
 // renderDatabaseIdentifier renders a database_identifier template using the same inputs as the

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -23,6 +23,8 @@ import (
 
 var databaseIdentifierVariablePattern = regexp.MustCompile(`\$\$|\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$[A-Za-z_][A-Za-z0-9_]*`)
 
+const defaultPostgresPort = 5432
+
 // A "base config" is a postgres integration.Config emitted by another provider (typically the
 // file provider reading conf.d/postgres.d/conf.yaml) that a DO query action matched against via
 // findPostgresConfig — i.e. the config as it exists before DO touches it. A single base config
@@ -436,16 +438,18 @@ func instanceMatchesIdentifier(instance map[string]any, identifier DBIdentifier,
 	}
 
 	defaultTemplate := ""
+	defaultPort := 0
 	if integrationName == "postgres" {
 		defaultTemplate = "$resolved_hostname"
+		defaultPort = defaultPostgresPort
 	}
-	databaseIdentifier, ok := renderDatabaseIdentifier(instance, identifier.AgentHostname, defaultTemplate)
+	databaseIdentifier, ok := renderDatabaseIdentifier(instance, identifier.AgentHostname, defaultTemplate, defaultPort)
 	return ok && databaseIdentifier == identifier.Host
 }
 
 // renderDatabaseIdentifier renders a database_identifier template using the same inputs as the
 // Postgres check. Unknown variables stay in the result, matching Python's safe_substitute.
-func renderDatabaseIdentifier(instance map[string]any, agentHostname, defaultTemplate string) (string, bool) {
+func renderDatabaseIdentifier(instance map[string]any, agentHostname, defaultTemplate string, defaultPort int) (string, bool) {
 	template := defaultTemplate
 	if configuredIdentifier, exists := instance["database_identifier"]; exists {
 		databaseIdentifier, ok := configuredIdentifier.(map[string]any)
@@ -469,6 +473,8 @@ func renderDatabaseIdentifier(instance map[string]any, agentHostname, defaultTem
 	values["host"] = host
 	if port, ok := instancePort(instance); ok {
 		values["port"] = strconv.Itoa(port)
+	} else if _, configured := instance["port"]; !configured && defaultPort != 0 {
+		values["port"] = strconv.Itoa(defaultPort)
 	}
 
 	resolvedHostname := host

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -6,6 +6,7 @@
 package queryactionsimpl
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -36,10 +37,15 @@ const defaultPostgresPort = 5432
 // was derived from and the instance identity it targets, so reconcileBases can rebuild the set of
 // postgres instances that should keep running independently of any single DO config.
 type activeConfigEntry struct {
-	checkConfig integration.Config
-	baseCfg     *integration.Config // the original matched postgres config (full, all instances)
-	matchHost   string              // resolved instanceIdentity (host:port) of the instance this DO config targets
+	checkConfig   integration.Config
+	baseCfg       *integration.Config    // the original matched postgres config (full, all instances)
+	matchInstance instanceConfigIdentity // exact source instance this DO config targets
 }
+
+// instanceConfigIdentity identifies the exact integration.Data entry selected from a base
+// config. Endpoint-derived identities are not sufficient: two instances may share host and port
+// while using different database_identifier templates or tags.
+type instanceConfigIdentity [sha256.Size]byte
 
 // managedBaseEntry tracks a base postgres config that has at least one instance targeted by a
 // DO query action. A DO query action only injects data_observability.queries into the targeted
@@ -122,7 +128,7 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 			continue
 		}
 
-		baseCfg, instance, err := c.resolveBaseConfig(configID, &payload.DBIdentifier)
+		baseCfg, instance, matchInstance, err := c.resolveBaseConfig(configID, &payload.DBIdentifier)
 		if err != nil {
 			c.log.Warnf("No matching postgres config for %s: %v", configID, err)
 			applyStatus(path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
@@ -148,14 +154,9 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 
 		c.activeConfigsMu.Lock()
 		c.activeConfigs[configID] = activeConfigEntry{
-			checkConfig: checkConfig,
-			baseCfg:     baseCfg,
-			// Use the resolved identity of the instance findMatchingConfig actually selected
-			// rather than payload.DBIdentifier.Host verbatim: the payload host can be a bare
-			// host shared by several instances on different ports, and matching buildRemainder
-			// against that bare string would exclude every sibling instance on that host, not
-			// just the one selected here.
-			matchHost: instanceIdentity(instance),
+			checkConfig:   checkConfig,
+			baseCfg:       baseCfg,
+			matchInstance: matchInstance,
 		}
 		c.activeConfigsMu.Unlock()
 		changes.Schedule = append(changes.Schedule, checkConfig)
@@ -222,25 +223,25 @@ func (c *component) reconcileBases(changes *integration.ConfigChanges) {
 	c.activeConfigsMu.Lock()
 	defer c.activeConfigsMu.Unlock()
 
-	// Group the instance identities targeted by active DO configs per base config digest.
+	// Group the exact source instances targeted by active DO configs per base config digest.
 	type baseGroup struct {
-		original integration.Config
-		hosts    map[string]bool
+		original  integration.Config
+		instances map[instanceConfigIdentity]bool
 	}
 	desired := make(map[string]*baseGroup)
 	for _, entry := range c.activeConfigs {
 		digest := entry.baseCfg.Digest()
 		g := desired[digest]
 		if g == nil {
-			g = &baseGroup{original: *entry.baseCfg, hosts: make(map[string]bool)}
+			g = &baseGroup{original: *entry.baseCfg, instances: make(map[instanceConfigIdentity]bool)}
 			desired[digest] = g
 		}
-		g.hosts[entry.matchHost] = true
+		g.instances[entry.matchInstance] = true
 	}
 
 	// Newly-managed or changed bases.
 	for digest, g := range desired {
-		remainder := buildRemainder(&g.original, g.hosts)
+		remainder := buildRemainder(&g.original, g.instances)
 		managed, exists := c.managedBases[digest]
 		if !exists {
 			// First DO config to target this base: unschedule the original, schedule the remainder.
@@ -279,26 +280,13 @@ func (c *component) reconcileBases(changes *integration.ConfigChanges) {
 	}
 }
 
-// buildRemainder returns a copy of base containing only the instances NOT targeted by any host in
-// matchedHosts. It returns nil when every instance is DO-managed. Instances whose YAML
-// cannot be parsed are kept, so a config we cannot classify is never silently dropped.
-//
-// Matching compares each instance's own resolved instanceIdentity against matchedHosts by exact
-// string equality, not the raw DBIdentifier.Host from the RC payload and not the looser
-// host-or-host:port matching instanceMatchesHost does for that payload host. A payload host can
-// be bare and shared by several instances on different ports (e.g. two postgres instances both on
-// "dbhost"), and a loose match against that bare string — or against the resolved identity of a
-// portless matched instance — would incorrectly exclude sibling instances that do have a port,
-// instead of only the one actually selected as the DO check.
-func buildRemainder(base *integration.Config, matchedHosts map[string]bool) *integration.Config {
+// buildRemainder returns a copy of base containing only instances that were not selected by a DO
+// config. It returns nil when every instance is DO-managed. Matching the exact source YAML entry
+// preserves siblings even when they share an endpoint but render different database identifiers.
+func buildRemainder(base *integration.Config, matchedInstances map[instanceConfigIdentity]bool) *integration.Config {
 	kept := make([]integration.Data, 0, len(base.Instances))
 	for _, instanceData := range base.Instances {
-		var instance map[string]any
-		if err := yaml.Unmarshal(instanceData, &instance); err != nil {
-			kept = append(kept, instanceData)
-			continue
-		}
-		if instanceTargeted(instance, matchedHosts) {
+		if matchedInstances[identifyInstanceConfig(instanceData)] {
 			continue
 		}
 		kept = append(kept, instanceData)
@@ -311,14 +299,8 @@ func buildRemainder(base *integration.Config, matchedHosts map[string]bool) *int
 	return &remainder
 }
 
-// instanceTargeted reports whether this instance is the exact instance a DO config resolved to,
-// by comparing its own instanceIdentity against matchedHosts. Exact identity equality — rather
-// than the looser bare-or-host:port matching used to resolve a payload host to an instance in the
-// first place — ensures a portless matched identity (e.g. "dbhost") can never accidentally match a
-// sibling instance that does have a port (e.g. "dbhost" host with port 5433): that sibling's own
-// identity is "dbhost:5433", which is exactly equal to nothing but itself.
-func instanceTargeted(instance map[string]any, matchedHosts map[string]bool) bool {
-	return matchedHosts[instanceIdentity(instance)]
+func identifyInstanceConfig(instanceData integration.Data) instanceConfigIdentity {
+	return sha256.Sum256(instanceData)
 }
 
 // sameConfig reports whether two optional configs are equivalent by autodiscovery digest.
@@ -343,15 +325,15 @@ func sameConfig(a, b *integration.Config) bool {
 //
 // Falls back to a fresh search if the stored base no longer has an instance matching dbID (e.g.
 // its host genuinely changed between updates).
-func (c *component) resolveBaseConfig(configID string, dbID *DBIdentifier) (*integration.Config, map[string]any, error) {
+func (c *component) resolveBaseConfig(configID string, dbID *DBIdentifier) (*integration.Config, map[string]any, instanceConfigIdentity, error) {
 	c.activeConfigsMu.Lock()
 	existing, alreadyActive := c.activeConfigs[configID]
 	c.activeConfigsMu.Unlock()
 
 	if alreadyActive {
-		instance, err := c.findMatchingInstance(existing.baseCfg, dbID)
+		instance, identity, err := c.findMatchingInstance(existing.baseCfg, dbID)
 		if instance != nil {
-			return existing.baseCfg, instance, nil
+			return existing.baseCfg, instance, identity, nil
 		}
 		if err != nil {
 			c.log.Warnf("Stored base config for %s no longer parses cleanly, re-resolving: %v", configID, err)
@@ -363,33 +345,33 @@ func (c *component) resolveBaseConfig(configID string, dbID *DBIdentifier) (*int
 // findMatchingConfig finds a supported DB integration config that matches the given identifier
 // and has data_observability.enabled: true. Returns the matching config and the already-parsed
 // instance map to avoid re-parsing YAML in callers.
-func (c *component) findMatchingConfig(dbID *DBIdentifier) (*integration.Config, map[string]any, error) {
+func (c *component) findMatchingConfig(dbID *DBIdentifier) (*integration.Config, map[string]any, instanceConfigIdentity, error) {
 	cfgs := c.ac.GetUnresolvedConfigs()
 
 	var lastParseErr error
 	for cfgIdx := range cfgs {
 		cfg := cfgs[cfgIdx]
-		instance, err := c.findMatchingInstance(&cfg, dbID)
+		instance, identity, err := c.findMatchingInstance(&cfg, dbID)
 		if err != nil {
 			lastParseErr = err
 		}
 		if instance != nil {
-			return &cfg, instance, nil
+			return &cfg, instance, identity, nil
 		}
 	}
 
 	if lastParseErr != nil {
-		return nil, nil, fmt.Errorf("no supported DB config found for identifier: type=%s, host=%s; at least one instance had a YAML parse error: %w",
+		return nil, nil, instanceConfigIdentity{}, fmt.Errorf("no supported DB config found for identifier: type=%s, host=%s; at least one instance had a YAML parse error: %w",
 			dbID.Type, dbID.Host, lastParseErr)
 	}
-	return nil, nil, fmt.Errorf("no supported DB config found for identifier: type=%s, host=%s",
+	return nil, nil, instanceConfigIdentity{}, fmt.Errorf("no supported DB config found for identifier: type=%s, host=%s",
 		dbID.Type, dbID.Host)
 }
 
 // findMatchingInstance searches cfg's instances for one matching dbID with data_observability
 // enabled, returning the first match. Instances whose YAML fails to parse are skipped (logged and
 // recorded as lastErr) rather than aborting the search — a later instance may still match.
-func (c *component) findMatchingInstance(cfg *integration.Config, dbID *DBIdentifier) (map[string]any, error) {
+func (c *component) findMatchingInstance(cfg *integration.Config, dbID *DBIdentifier) (map[string]any, instanceConfigIdentity, error) {
 	if cfg.Name != "postgres" && cfg.Name != "sap_hana" {
 		c.log.Warnf("DO query action: config %s is not a known DO-supported integration", cfg.Name)
 	}
@@ -404,10 +386,10 @@ func (c *component) findMatchingInstance(cfg *integration.Config, dbID *DBIdenti
 		}
 
 		if instanceMatchesIdentifier(instance, *dbID, cfg.Name) && instanceHasDOEnabled(instance) {
-			return instance, nil
+			return instance, identifyInstanceConfig(instanceData), nil
 		}
 	}
-	return nil, lastErr
+	return nil, instanceConfigIdentity{}, lastErr
 }
 
 // matchesIdentifier checks if a Postgres instance matches the given DB identifier. It uses the
@@ -450,6 +432,15 @@ func instanceMatchesIdentifier(instance map[string]any, identifier DBIdentifier,
 // renderDatabaseIdentifier renders a database_identifier template using the same inputs as the
 // Postgres check. Unknown variables stay in the result, matching Python's safe_substitute.
 func renderDatabaseIdentifier(instance map[string]any, agentHostname, defaultTemplate string, defaultPort int) (string, bool) {
+	return renderDatabaseIdentifierWithLookup(instance, agentHostname, defaultTemplate, defaultPort, net.LookupHost)
+}
+
+func renderDatabaseIdentifierWithLookup(
+	instance map[string]any,
+	agentHostname, defaultTemplate string,
+	defaultPort int,
+	lookupHost func(string) ([]string, error),
+) (string, bool) {
 	template := defaultTemplate
 	if configuredIdentifier, exists := instance["database_identifier"]; exists {
 		databaseIdentifier, ok := configuredIdentifier.(map[string]any)
@@ -480,12 +471,56 @@ func renderDatabaseIdentifier(instance map[string]any, agentHostname, defaultTem
 	resolvedHostname := host
 	if reportedHostname, ok := instance["reported_hostname"].(string); ok && reportedHostname != "" {
 		resolvedHostname = reportedHostname
-	} else if isLocalDBHost(host) && agentHostname != "" {
-		resolvedHostname = agentHostname
+	} else {
+		resolvedHostname = resolveDatabaseHostname(host, agentHostname, lookupHost)
 	}
 	values["resolved_hostname"] = resolvedHostname
 
 	return safeSubstitute(template, values), true
+}
+
+// resolveDatabaseHostname mirrors the Postgres check's resolve_db_host behavior used to build
+// $resolved_hostname. Besides local and socket hosts, the check reports the Agent hostname when
+// the database host and Agent hostname resolve to the same IPv4 address.
+func resolveDatabaseHostname(host, agentHostname string, lookupHost func(string) ([]string, error)) string {
+	if strings.HasSuffix(host, ".local") {
+		return host
+	}
+	if isLocalDBHost(host) {
+		if agentHostname != "" {
+			return agentHostname
+		}
+		return host
+	}
+	if agentHostname == "" {
+		return host
+	}
+
+	hostAddresses, err := lookupHost(host)
+	if err != nil {
+		return host
+	}
+	agentAddresses, err := lookupHost(agentHostname)
+	if err != nil {
+		return host
+	}
+	hostIPv4, hostOK := firstIPv4Address(hostAddresses)
+	agentIPv4, agentOK := firstIPv4Address(agentAddresses)
+	if hostOK && agentOK && hostIPv4 == agentIPv4 {
+		return agentHostname
+	}
+	return host
+}
+
+func firstIPv4Address(addresses []string) (string, bool) {
+	for _, address := range addresses {
+		if ip := net.ParseIP(address); ip != nil {
+			if ipv4 := ip.To4(); ipv4 != nil {
+				return ipv4.String(), true
+			}
+		}
+	}
+	return "", false
 }
 
 // templateTagValues exposes each key:value instance tag as a template variable. Duplicate keys
@@ -563,17 +598,6 @@ func instancePort(instance map[string]any) (int, bool) {
 		return port, err == nil
 	}
 	return 0, false
-}
-
-// instanceIdentity returns a canonical "host:port" identity for an instance, falling back to the
-// bare host when no port is present. Unlike matching against a possibly-bare payload host, this
-// always disambiguates instances that share a host but differ by port.
-func instanceIdentity(instance map[string]any) string {
-	host := instanceHost(instance)
-	if port, ok := instancePort(instance); ok {
-		return fmt.Sprintf("%s:%d", host, port)
-	}
-	return host
 }
 
 // buildCheckConfig creates a check config with data_observability queries injected.

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -9,12 +9,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"net"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/robfig/cron/v3"
 	"gopkg.in/yaml.v3"
 )
+
+var databaseIdentifierVariablePattern = regexp.MustCompile(`\$\$|\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$[A-Za-z_][A-Za-z0-9_]*`)
 
 // A "base config" is a postgres integration.Config emitted by another provider (typically the
 // file provider reading conf.d/postgres.d/conf.yaml) that a DO query action matched against via
@@ -24,8 +31,8 @@ import (
 // config that this component derives from it.
 
 // activeConfigEntry stores the scheduled DO check config alongside the base postgres config it
-// was derived from and the host it targets, so reconcileBases can rebuild the set of postgres
-// instances that should keep running independently of any single DO config.
+// was derived from and the instance identity it targets, so reconcileBases can rebuild the set of
+// postgres instances that should keep running independently of any single DO config.
 type activeConfigEntry struct {
 	checkConfig integration.Config
 	baseCfg     *integration.Config // the original matched postgres config (full, all instances)
@@ -213,7 +220,7 @@ func (c *component) reconcileBases(changes *integration.ConfigChanges) {
 	c.activeConfigsMu.Lock()
 	defer c.activeConfigsMu.Unlock()
 
-	// Group the hosts targeted by active DO configs per base config digest.
+	// Group the instance identities targeted by active DO configs per base config digest.
 	type baseGroup struct {
 		original integration.Config
 		hosts    map[string]bool
@@ -271,8 +278,8 @@ func (c *component) reconcileBases(changes *integration.ConfigChanges) {
 }
 
 // buildRemainder returns a copy of base containing only the instances NOT targeted by any host in
-// matchedHosts. Returns nil when no instances remain (every instance is DO-managed). Instances
-// whose YAML cannot be parsed are kept, so a config we cannot classify is never silently dropped.
+// matchedHosts. It returns nil when every instance is DO-managed. Instances whose YAML
+// cannot be parsed are kept, so a config we cannot classify is never silently dropped.
 //
 // Matching compares each instance's own resolved instanceIdentity against matchedHosts by exact
 // string equality, not the raw DBIdentifier.Host from the RC payload and not the looser
@@ -394,36 +401,146 @@ func (c *component) findMatchingInstance(cfg *integration.Config, dbID *DBIdenti
 			continue
 		}
 
-		if matchesIdentifier(instance, dbID) && instanceHasDOEnabled(instance) {
+		if instanceMatchesIdentifier(instance, *dbID, cfg.Name) && instanceHasDOEnabled(instance) {
 			return instance, nil
 		}
 	}
 	return nil, lastErr
 }
 
-// matchesIdentifier checks if an instance matches the given DB identifier.
-// Matching is by host — per-query dbname fields handle database routing.
+// matchesIdentifier checks if a Postgres instance matches the given DB identifier. It uses the
+// resolved database_instance value when configured and falls back to the literal host. Per-query
+// dbname fields handle database routing.
 func matchesIdentifier(instance map[string]any, dbID *DBIdentifier) bool {
-	return instanceMatchesHost(instance, dbID.Host)
+	return instanceMatchesIdentifier(instance, *dbID, "postgres")
 }
 
-// instanceMatchesHost reports whether an integration instance targets the given host.
+// instanceMatchesIdentifier reports whether an integration instance targets the given identifier.
 // sap_hana uses "server" as the host key; postgres uses "host". The target host may be
 // "host:port" (as sent by sap_hana backends) or bare "host", so we match against both the
-// bare host and the "host:port" form built from the instance. This is the single source of
-// truth for host matching, shared by matchesIdentifier (which decides what to schedule) and
-// buildRemainder (which decides what to keep), so the two can never disagree about whether an
-// instance is targeted by a DO query action.
-func instanceMatchesHost(instance map[string]any, targetHost string) bool {
+// bare host and the "host:port" form built from the instance. Postgres also derives its
+// database_instance from a configurable template. Render the same connection and tag values as
+// the Python check and compare the resulting value.
+//
+// This is the single source of truth for selecting the instance to schedule.
+func instanceMatchesIdentifier(instance map[string]any, identifier DBIdentifier, integrationName string) bool {
 	host := instanceHost(instance)
-	// Try the more specific "host:port" form first — sap_hana backends include the port in the
-	// identifier, and this form disambiguates instances that share a host but differ by port.
+	if host == identifier.Host {
+		return true
+	}
+	// Try matching "host:port" form — sap_hana backends include the port in the identifier.
 	if port, ok := instancePort(instance); ok {
-		if fmt.Sprintf("%s:%d", host, port) == targetHost {
+		if fmt.Sprintf("%s:%d", host, port) == identifier.Host {
 			return true
 		}
 	}
-	return host == targetHost
+
+	defaultTemplate := ""
+	if integrationName == "postgres" {
+		defaultTemplate = "$resolved_hostname"
+	}
+	databaseIdentifier, ok := renderDatabaseIdentifier(instance, identifier.AgentHostname, defaultTemplate)
+	return ok && databaseIdentifier == identifier.Host
+}
+
+// renderDatabaseIdentifier renders a database_identifier template using the same inputs as the
+// Postgres check. Unknown variables stay in the result, matching Python's safe_substitute.
+func renderDatabaseIdentifier(instance map[string]any, agentHostname, defaultTemplate string) (string, bool) {
+	template := defaultTemplate
+	if configuredIdentifier, exists := instance["database_identifier"]; exists {
+		databaseIdentifier, ok := configuredIdentifier.(map[string]any)
+		if !ok {
+			return "", false
+		}
+		if configuredTemplate, exists := databaseIdentifier["template"]; exists {
+			var ok bool
+			template, ok = configuredTemplate.(string)
+			if !ok {
+				return "", false
+			}
+		}
+	}
+	if template == "" {
+		return "", false
+	}
+
+	values := templateTagValues(instance)
+	host := instanceHost(instance)
+	values["host"] = host
+	if port, ok := instancePort(instance); ok {
+		values["port"] = strconv.Itoa(port)
+	}
+
+	resolvedHostname := host
+	if reportedHostname, ok := instance["reported_hostname"].(string); ok && reportedHostname != "" {
+		resolvedHostname = reportedHostname
+	} else if isLocalDBHost(host) && agentHostname != "" {
+		resolvedHostname = agentHostname
+	}
+	values["resolved_hostname"] = resolvedHostname
+
+	return safeSubstitute(template, values), true
+}
+
+// templateTagValues exposes each key:value instance tag as a template variable. Duplicate keys
+// are sorted and joined with commas, matching the Postgres check.
+func templateTagValues(instance map[string]any) map[string]string {
+	var tags []string
+	switch configuredTags := instance["tags"].(type) {
+	case []any:
+		for _, configuredTag := range configuredTags {
+			if tag, ok := configuredTag.(string); ok {
+				tags = append(tags, tag)
+			}
+		}
+	case []string:
+		tags = append(tags, configuredTags...)
+	}
+	sort.Strings(tags)
+
+	values := make(map[string]string)
+	for _, tag := range tags {
+		key, value, found := strings.Cut(tag, ":")
+		if !found {
+			continue
+		}
+		if previous, exists := values[key]; exists {
+			values[key] = previous + "," + value
+		} else {
+			values[key] = value
+		}
+	}
+	return values
+}
+
+// isLocalDBHost matches the local-address cases handled by the Postgres check's host resolver.
+func isLocalDBHost(host string) bool {
+	if host == "" || host == "localhost" || strings.HasPrefix(host, "/") {
+		return true
+	}
+	if zoneIndex := strings.LastIndex(host, "%"); zoneIndex >= 0 {
+		host = host[:zoneIndex]
+	}
+	ip := net.ParseIP(strings.TrimSpace(host))
+	return ip != nil && ip.IsLoopback()
+}
+
+// safeSubstitute implements Python string.Template's $name, ${name}, and $$ forms. Unknown
+// variables remain unchanged, matching safe_substitute.
+func safeSubstitute(template string, values map[string]string) string {
+	return databaseIdentifierVariablePattern.ReplaceAllStringFunc(template, func(placeholder string) string {
+		if placeholder == "$$" {
+			return "$"
+		}
+		name := strings.TrimSuffix(strings.TrimPrefix(placeholder, "${"), "}")
+		if name == placeholder {
+			name = strings.TrimPrefix(placeholder, "$")
+		}
+		if value, ok := values[name]; ok {
+			return value
+		}
+		return placeholder
+	})
 }
 
 // instancePort returns the port number for an integration instance, if present.
@@ -435,6 +552,9 @@ func instancePort(instance map[string]any) (int, bool) {
 		return int(v), true
 	case float64:
 		return int(v), true
+	case string:
+		port, err := strconv.Atoi(v)
+		return port, err == nil
 	}
 	return 0, false
 }

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -385,7 +385,18 @@ func (c *component) findMatchingInstance(cfg *integration.Config, dbID *DBIdenti
 			continue
 		}
 
-		if instanceMatchesIdentifier(instance, *dbID, cfg.Name) && instanceHasDOEnabled(instance) {
+		match := evaluateInstanceIdentifier(instance, *dbID, cfg.Name)
+		c.log.Debugf(
+			"Evaluated DO query action database identifier: integration=%s instance_host=%q target=%q strategy=%s rendered_database_identifier=%q renderable=%t matched=%t",
+			cfg.Name,
+			instanceHost(instance),
+			dbID.Host,
+			match.strategy,
+			match.renderedIdentifier,
+			match.renderable,
+			match.matched,
+		)
+		if match.matched && instanceHasDOEnabled(instance) {
 			return instance, identifyInstanceConfig(instanceData), nil
 		}
 	}
@@ -408,14 +419,25 @@ func matchesIdentifier(instance map[string]any, dbID *DBIdentifier) bool {
 //
 // This is the single source of truth for selecting the instance to schedule.
 func instanceMatchesIdentifier(instance map[string]any, identifier DBIdentifier, integrationName string) bool {
+	return evaluateInstanceIdentifier(instance, identifier, integrationName).matched
+}
+
+type identifierMatchEvaluation struct {
+	matched            bool
+	strategy           string
+	renderedIdentifier string
+	renderable         bool
+}
+
+func evaluateInstanceIdentifier(instance map[string]any, identifier DBIdentifier, integrationName string) identifierMatchEvaluation {
 	host := instanceHost(instance)
 	if host == identifier.Host {
-		return true
+		return identifierMatchEvaluation{matched: true, strategy: "host"}
 	}
 	// Try matching "host:port" form — sap_hana backends include the port in the identifier.
 	if port, ok := instancePort(instance); ok {
 		if fmt.Sprintf("%s:%d", host, port) == identifier.Host {
-			return true
+			return identifierMatchEvaluation{matched: true, strategy: "host_port"}
 		}
 	}
 
@@ -426,7 +448,12 @@ func instanceMatchesIdentifier(instance map[string]any, identifier DBIdentifier,
 		defaultPort = defaultPostgresPort
 	}
 	databaseIdentifier, ok := renderDatabaseIdentifier(instance, identifier.AgentHostname, defaultTemplate, defaultPort)
-	return ok && databaseIdentifier == identifier.Host
+	return identifierMatchEvaluation{
+		matched:            ok && databaseIdentifier == identifier.Host,
+		strategy:           "database_identifier",
+		renderedIdentifier: databaseIdentifier,
+		renderable:         ok,
+	}
 }
 
 // renderDatabaseIdentifier renders a database_identifier template using the same inputs as the

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -139,6 +139,27 @@ func TestMatchesIdentifier_DatabaseIdentifierTemplateUsesTags(t *testing.T) {
 	assert.True(t, matchesIdentifier(instance, dbID))
 }
 
+func TestInstanceMatchesIdentifier_SapHanaDoesNotRenderDatabaseIdentifier(t *testing.T) {
+	instance := map[string]any{
+		"server": "sap.internal",
+		"port":   39041,
+		"database_identifier": map[string]any{
+			"template": "rendered-sap-identifier",
+		},
+	}
+
+	assert.False(t, instanceMatchesIdentifier(
+		instance,
+		DBIdentifier{Host: "rendered-sap-identifier"},
+		"sap_hana",
+	))
+	assert.True(t, instanceMatchesIdentifier(
+		instance,
+		DBIdentifier{Host: "sap.internal:39041"},
+		"sap_hana",
+	))
+}
+
 func TestRenderDatabaseIdentifier_UsesAgentHostnameForSameResolvedIPv4(t *testing.T) {
 	instance := map[string]any{
 		"host": "postgres.internal",

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -8,6 +8,7 @@ package queryactionsimpl
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"testing"
 
 	autodiscovery "github.com/DataDog/datadog-agent/comp/core/autodiscovery/def"
@@ -70,6 +71,57 @@ func TestMatchesIdentifier_HostOnly(t *testing.T) {
 		dbID := &DBIdentifier{Type: "self-hosted", Host: "otherhost"}
 		assert.False(t, matchesIdentifier(instance, dbID))
 	})
+
+	t.Run("default identifier uses agent hostname for local host", func(t *testing.T) {
+		dbID := &DBIdentifier{
+			Type:          "self-hosted",
+			Host:          "do-test-postgres-staging",
+			AgentHostname: "do-test-postgres-staging",
+		}
+		assert.True(t, matchesIdentifier(instance, dbID))
+	})
+}
+
+func TestMatchesIdentifier_DatabaseIdentifierTemplate(t *testing.T) {
+	instance := map[string]any{
+		"host": "localhost",
+		"port": 5432,
+		"database_identifier": map[string]any{
+			"template": "$resolved_hostname:$port",
+		},
+	}
+
+	t.Run("uses agent hostname for local host", func(t *testing.T) {
+		dbID := &DBIdentifier{
+			Type:          "self-hosted",
+			Host:          "do-test-postgres-staging:5432",
+			AgentHostname: "do-test-postgres-staging",
+		}
+		assert.True(t, matchesIdentifier(instance, dbID))
+	})
+
+	t.Run("does not match a different port", func(t *testing.T) {
+		dbID := &DBIdentifier{
+			Type:          "self-hosted",
+			Host:          "do-test-postgres-staging:5433",
+			AgentHostname: "do-test-postgres-staging",
+		}
+		assert.False(t, matchesIdentifier(instance, dbID))
+	})
+}
+
+func TestMatchesIdentifier_DatabaseIdentifierTemplateUsesTags(t *testing.T) {
+	instance := map[string]any{
+		"host": "db.internal",
+		"port": 5432,
+		"tags": []any{"env:staging", "env:prod", "team:data-observability"},
+		"database_identifier": map[string]any{
+			"template": "${team}-$env-$host:$port",
+		},
+	}
+	dbID := &DBIdentifier{Type: "self-hosted", Host: "data-observability-prod,staging-db.internal:5432"}
+
+	assert.True(t, matchesIdentifier(instance, dbID))
 }
 
 func TestMatchesIdentifier_RDS(t *testing.T) {
@@ -611,7 +663,7 @@ func TestBuildRemainder_SapHanaServerKey(t *testing.T) {
 			integration.Data(fmt.Sprintf("server: %s\nport: %d\n", siblingServer, port)),
 		},
 	}
-	// matchedHosts holds DBIdentifier.Host verbatim: the "host:port" form for sap_hana.
+	// matchedHosts contains the resolved "host:port" identity for sap_hana.
 	targetedHostPort := fmt.Sprintf("%s:%d", targetedServer, port)
 	siblingHostPort := fmt.Sprintf("%s:%d", siblingServer, port)
 
@@ -628,6 +680,47 @@ func TestBuildRemainder_SapHanaServerKey(t *testing.T) {
 		remainder := buildRemainder(base, map[string]bool{targetedHostPort: true, siblingHostPort: true})
 		assert.Nil(t, remainder, "no instances should remain when every sap_hana server is DO-managed")
 	})
+}
+
+func TestFindMatchingConfig_TemplatedIdentifiersDistinguishPorts(t *testing.T) {
+	postgresCfg := integration.Config{
+		Name:     "postgres",
+		Provider: "file",
+		Instances: []integration.Data{
+			integration.Data("host: localhost\nport: 5432\ndatabase_identifier:\n  template: '$resolved_hostname:$port'\ndata_observability:\n  enabled: true\n"),
+			integration.Data("host: localhost\nport: 5433\ndatabase_identifier:\n  template: '$resolved_hostname:$port'\ndata_observability:\n  enabled: true\n"),
+		},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
+
+	for _, port := range []int{5432, 5433} {
+		t.Run(strconv.Itoa(port), func(t *testing.T) {
+			_, instance, err := c.findMatchingConfig(&DBIdentifier{
+				Type:          "self-hosted",
+				Host:          fmt.Sprintf("do-test-postgres-staging:%d", port),
+				AgentHostname: "do-test-postgres-staging",
+			})
+			require.NoError(t, err)
+			assert.Equal(t, port, instance["port"])
+		})
+	}
+}
+
+func TestBuildRemainder_TemplatedIdentifierExcludesOnlyTargetPort(t *testing.T) {
+	base := &integration.Config{
+		Name:     "postgres",
+		Provider: "file",
+		Instances: []integration.Data{
+			integration.Data("host: localhost\nport: 5432\ndatabase_identifier:\n  template: '$resolved_hostname:$port'\n"),
+			integration.Data("host: localhost\nport: 5433\ndatabase_identifier:\n  template: '$resolved_hostname:$port'\n"),
+		},
+	}
+	remainder := buildRemainder(base, map[string]bool{"localhost:5432": true})
+	require.NotNil(t, remainder)
+	require.Len(t, remainder.Instances, 1)
+	var instance map[string]any
+	require.NoError(t, yaml.Unmarshal(remainder.Instances[0], &instance))
+	assert.Equal(t, 5433, instance["port"])
 }
 
 // TestOnRCUpdate_SapHana_ExcludesTargetedInstanceFromRemainder is the end-to-end regression test

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -139,6 +139,33 @@ func TestMatchesIdentifier_DatabaseIdentifierTemplateUsesTags(t *testing.T) {
 	assert.True(t, matchesIdentifier(instance, dbID))
 }
 
+func TestRenderDatabaseIdentifier_UsesAgentHostnameForSameResolvedIPv4(t *testing.T) {
+	instance := map[string]any{
+		"host": "postgres.internal",
+		"database_identifier": map[string]any{
+			"template": "$resolved_hostname:$port",
+		},
+	}
+	lookup := func(host string) ([]string, error) {
+		addresses := map[string][]string{
+			"postgres.internal": {"10.20.30.40"},
+			"agent.internal":    {"10.20.30.40"},
+		}
+		return addresses[host], nil
+	}
+
+	identifier, ok := renderDatabaseIdentifierWithLookup(
+		instance,
+		"agent.internal",
+		"$resolved_hostname",
+		defaultPostgresPort,
+		lookup,
+	)
+
+	require.True(t, ok)
+	assert.Equal(t, "agent.internal:5432", identifier)
+}
+
 func TestMatchesIdentifier_RDS(t *testing.T) {
 	instance := map[string]any{"host": "mydb.cluster-xxx.us-east-1.rds.amazonaws.com"}
 	dbID := &DBIdentifier{Type: "rds", Host: "mydb.cluster-xxx.us-east-1.rds.amazonaws.com"}
@@ -453,9 +480,9 @@ func TestRemoveActiveConfig_Found(t *testing.T) {
 	doCheckConfig := integration.Config{Name: "postgres", Provider: "do_query_actions"}
 	c := newTestComponent(t)
 	c.activeConfigs["my-config"] = activeConfigEntry{
-		checkConfig: doCheckConfig,
-		baseCfg:     baseCfg,
-		matchHost:   "localhost",
+		checkConfig:   doCheckConfig,
+		baseCfg:       baseCfg,
+		matchInstance: identifyInstanceConfig(integration.Data("host: localhost\n")),
 	}
 	changes := integration.ConfigChanges{}
 
@@ -678,12 +705,10 @@ func TestBuildRemainder_SapHanaServerKey(t *testing.T) {
 			integration.Data(fmt.Sprintf("server: %s\nport: %d\n", siblingServer, port)),
 		},
 	}
-	// matchedHosts contains the resolved "host:port" identity for sap_hana.
-	targetedHostPort := fmt.Sprintf("%s:%d", targetedServer, port)
-	siblingHostPort := fmt.Sprintf("%s:%d", siblingServer, port)
-
 	t.Run("targeted server excluded, sibling kept", func(t *testing.T) {
-		remainder := buildRemainder(base, map[string]bool{targetedHostPort: true})
+		remainder := buildRemainder(base, map[instanceConfigIdentity]bool{
+			identifyInstanceConfig(base.Instances[0]): true,
+		})
 		require.NotNil(t, remainder, "sibling instance must keep the remainder alive")
 		require.Len(t, remainder.Instances, 1, "targeted server must be excluded from the remainder")
 		var instance map[string]any
@@ -692,7 +717,10 @@ func TestBuildRemainder_SapHanaServerKey(t *testing.T) {
 	})
 
 	t.Run("all servers targeted yields nil remainder", func(t *testing.T) {
-		remainder := buildRemainder(base, map[string]bool{targetedHostPort: true, siblingHostPort: true})
+		remainder := buildRemainder(base, map[instanceConfigIdentity]bool{
+			identifyInstanceConfig(base.Instances[0]): true,
+			identifyInstanceConfig(base.Instances[1]): true,
+		})
 		assert.Nil(t, remainder, "no instances should remain when every sap_hana server is DO-managed")
 	})
 }
@@ -710,7 +738,7 @@ func TestFindMatchingConfig_TemplatedIdentifiersDistinguishPorts(t *testing.T) {
 
 	for _, port := range []int{5432, 5433} {
 		t.Run(strconv.Itoa(port), func(t *testing.T) {
-			_, instance, err := c.findMatchingConfig(&DBIdentifier{
+			_, instance, _, err := c.findMatchingConfig(&DBIdentifier{
 				Type:          "self-hosted",
 				Host:          fmt.Sprintf("do-test-postgres-staging:%d", port),
 				AgentHostname: "do-test-postgres-staging",
@@ -730,7 +758,9 @@ func TestBuildRemainder_TemplatedIdentifierExcludesOnlyTargetPort(t *testing.T) 
 			integration.Data("host: localhost\nport: 5433\ndatabase_identifier:\n  template: '$resolved_hostname:$port'\n"),
 		},
 	}
-	remainder := buildRemainder(base, map[string]bool{"localhost:5432": true})
+	remainder := buildRemainder(base, map[instanceConfigIdentity]bool{
+		identifyInstanceConfig(base.Instances[0]): true,
+	})
 	require.NotNil(t, remainder)
 	require.Len(t, remainder.Instances, 1)
 	var instance map[string]any
@@ -872,6 +902,48 @@ func TestOnRCUpdate_SameHostDifferentPorts_KeepsSiblingPortInRemainder(t *testin
 
 	assert.Equal(t, []int{targetedPort}, portsOf(*doCfg), "DO check should carry only the targeted port")
 	assert.Equal(t, []int{siblingPort}, portsOf(*remainder), "remainder must keep the untargeted sibling port")
+}
+
+// Two instances can share host and port while custom templates and tags give them distinct
+// database identifiers. Selecting one must not prune the other from the base remainder.
+func TestOnRCUpdate_SameEndpointDifferentIdentifiers_KeepsSiblingInRemainder(t *testing.T) {
+	const sharedHost = "dbhost"
+	postgresCfg := integration.Config{
+		Name:     "postgres",
+		Provider: "file",
+		Instances: []integration.Data{
+			integration.Data("host: dbhost\nport: 5432\ntags:\n  - env:staging\ndatabase_identifier:\n  template: '$env-$host:$port'\ndata_observability:\n  enabled: true\n"),
+			integration.Data("host: dbhost\nport: 5432\ntags:\n  - env:prod\ndatabase_identifier:\n  template: '$env-$host:$port'\ndata_observability:\n  enabled: true\n"),
+		},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
+	payloadJSON, err := json.Marshal(DOQueryPayload{
+		ConfigID:     "cfg-prod",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "prod-" + sharedHost + ":5432"},
+		Queries:      []QuerySpec{{Type: "run_query", Query: "SELECT 1", IntervalSeconds: 60, TimeoutSeconds: 10}},
+	})
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-prod": {Config: payloadJSON},
+	})
+
+	require.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-prod"].State)
+	require.Len(t, changes.Schedule, 2)
+
+	var remainder *integration.Config
+	for i := range changes.Schedule {
+		var instance map[string]any
+		require.NoError(t, yaml.Unmarshal(changes.Schedule[i].Instances[0], &instance))
+		if _, hasQueries := instance["data_observability"].(map[string]any)["queries"]; !hasQueries {
+			remainder = &changes.Schedule[i]
+		}
+	}
+	require.NotNil(t, remainder)
+	require.Len(t, remainder.Instances, 1)
+	var sibling map[string]any
+	require.NoError(t, yaml.Unmarshal(remainder.Instances[0], &sibling))
+	assert.Equal(t, []any{"env:staging"}, sibling["tags"])
 }
 
 // TestOnRCUpdate_PortlessMatchedInstance_KeepsPortedSiblingInRemainder is a regression test for a

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -166,6 +166,22 @@ func TestRenderDatabaseIdentifier_UsesAgentHostnameForSameResolvedIPv4(t *testin
 	assert.Equal(t, "agent.internal:5432", identifier)
 }
 
+func TestRenderDatabaseIdentifier_UsesDefaultPostgresTemplate(t *testing.T) {
+	identifier, ok := renderDatabaseIdentifierWithLookup(
+		map[string]any{"host": "localhost"},
+		"agent.internal",
+		"$resolved_hostname:$port",
+		defaultPostgresPort,
+		func(string) ([]string, error) {
+			t.Fatal("local database hosts should not require a DNS lookup")
+			return nil, nil
+		},
+	)
+
+	require.True(t, ok)
+	assert.Equal(t, "agent.internal:5432", identifier)
+}
+
 func TestMatchesIdentifier_RDS(t *testing.T) {
 	instance := map[string]any{"host": "mydb.cluster-xxx.us-east-1.rds.amazonaws.com"}
 	dbID := &DBIdentifier{Type: "rds", Host: "mydb.cluster-xxx.us-east-1.rds.amazonaws.com"}

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -108,6 +108,21 @@ func TestMatchesIdentifier_DatabaseIdentifierTemplate(t *testing.T) {
 		}
 		assert.False(t, matchesIdentifier(instance, dbID))
 	})
+
+	t.Run("uses default Postgres port", func(t *testing.T) {
+		instanceWithoutPort := map[string]any{
+			"host": "localhost",
+			"database_identifier": map[string]any{
+				"template": "$resolved_hostname:$port",
+			},
+		}
+		dbID := &DBIdentifier{
+			Type:          "self-hosted",
+			Host:          "do-test-postgres-staging:5432",
+			AgentHostname: "do-test-postgres-staging",
+		}
+		assert.True(t, matchesIdentifier(instanceWithoutPort, dbID))
+	})
 }
 
 func TestMatchesIdentifier_DatabaseIdentifierTemplateUsesTags(t *testing.T) {

--- a/comp/dataobs/queryactions/impl/queryactions_test.go
+++ b/comp/dataobs/queryactions/impl/queryactions_test.go
@@ -178,15 +178,14 @@ func TestStream_RCCallback_DeliverChangesToChannel(t *testing.T) {
 	}
 }
 
-// TestStream_ChannelReplace_PreservesUnschedule verifies that when a new RC update
-// arrives while the previous update is still buffered in outCh (unread by autodiscovery),
-// the dropped update's Unschedule entries are merged into the new update.
-//
-// Only Unschedule entries are preserved from the dropped update — dropped Schedule entries
-// are discarded because the latest RC snapshot is authoritative. This prevents stale
-// Schedule entries from resurrecting configs that the new snapshot intentionally removed.
+// TestStream_ChannelReplace_PreservesUnschedule covers a capacity-one channel replacement:
+// update 2 is still waiting for autodiscovery when update 3 arrives, so update 2 must be
+// removed from the channel to make room. Its Schedule entries are stale and must be dropped,
+// but its Unschedule entries must be carried into update 3; otherwise configs already
+// processed from update 1 would remain running in autodiscovery.
 func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
-	// Two separate postgres instances so each RC config can match a distinct one.
+	// Use two instances because applying one query action splits the base config into two
+	// scheduled configs: the matched instance with its query and the unmatched remainder.
 	postgresCfg := integration.Config{
 		Name: "postgres",
 		Instances: []integration.Data{
@@ -204,8 +203,9 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 	triggerRC := waitSubscribe(t, rc)
 	noStatus := func(string, state.ApplyStatus) {}
 
-	// Update 1: schedule cfg-A. Drain it to simulate autodiscovery processing it —
-	// cfg-A is now "in autodiscovery".
+	// Update 1 targets db-a. Consume the update to simulate autodiscovery applying both
+	// scheduled configs: cfg-A for db-a and the unchanged db-b remainder. We save their
+	// digests because both must later be removed, not merely an arbitrary pair of configs.
 	payload1 := buildPayloadJSON(t, "cfg-A", "db-a.internal", singleQuery)
 	triggerRC(map[string]state.RawConfig{"path/cfg-A": {Config: payload1}}, noStatus)
 	update1 := <-outCh
@@ -215,17 +215,17 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 		update1ScheduleDigests = append(update1ScheduleDigests, cfg.Digest())
 	}
 
-	// Update 2: remove cfg-A (empty queries = disable). Channel is now empty — writes directly.
-	// Disabling produces Unschedule=[cfg-A DO config, db-b remainder] and
-	// Schedule=[base config restoration].
+	// Update 2 removes cfg-A. It therefore unschedules both configs applied in update 1 and
+	// schedules the original two-instance base config as their replacement. Leave this update
+	// unread so it occupies the channel when update 3 arrives.
 	removeA, _ := json.Marshal(DOQueryPayload{ConfigID: "cfg-A"})
 	triggerRC(map[string]state.RawConfig{"path/cfg-A": {Config: removeA}}, noStatus)
-	// DON'T read outCh — leave update 2 buffered.
+	// Do not read outCh: update 2 must remain buffered for this regression scenario.
 
-	// Update 3: schedule cfg-B. Channel is FULL with update 2.
-	// sendChanges must drain the full channel and merge update 2's Unschedule into update 3.
-	// Only Unschedule from the dropped update is preserved; dropped Schedule (base config
-	// restoration) is discarded since the new snapshot is authoritative.
+	// Update 3 targets db-b while update 2 is buffered. The latest snapshot schedules cfg-B
+	// for db-b plus the db-a remainder, and unschedules the original base config. sendChanges
+	// must also carry forward update 2's two Unschedules, but must discard update 2's now-stale
+	// base restoration.
 	payload3 := buildPayloadJSON(t, "cfg-B", "db-b.internal", singleQuery)
 	triggerRC(map[string]state.RawConfig{"path/cfg-B": {Config: payload3}}, noStatus)
 
@@ -233,8 +233,8 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 	case changes := <-outCh:
 		require.Len(t, changes.Schedule, 2, "should contain cfg-B and its remainder (dropped base restoration is discarded)")
 
-		// The stale base restoration from update 2 must not be scheduled. The latest snapshot
-		// instead schedules cfg-B and a remainder containing db-a.
+		// Assert the identities and roles of the two latest configs, not only their count. This
+		// catches the regression where update 2's stale base restoration survives replacement.
 		scheduledHosts := make(map[string]bool, len(changes.Schedule))
 		for _, cfg := range changes.Schedule {
 			assert.NotEqual(t, postgresCfg.Digest(), cfg.Digest(), "dropped base restoration must not be scheduled")
@@ -256,8 +256,9 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 		}
 		assert.Equal(t, map[string]bool{"db-a.internal": true, "db-b.internal": true}, scheduledHosts)
 
-		// Both configs scheduled by update 1 must be unscheduled even though update 2 was
-		// replaced in the channel. Update 3 additionally unschedules the original base.
+		// The final update must remove exactly three configs: cfg-A and the db-b remainder from
+		// update 1, carried forward from dropped update 2, plus the original base removed by
+		// update 3. Comparing digests ensures no stale update-1 config remains active.
 		expectedUnscheduleDigests := append(append([]string(nil), update1ScheduleDigests...), postgresCfg.Digest())
 		actualUnscheduleDigests := make([]string, 0, len(changes.Unschedule))
 		for _, cfg := range changes.Unschedule {

--- a/comp/dataobs/queryactions/impl/queryactions_test.go
+++ b/comp/dataobs/queryactions/impl/queryactions_test.go
@@ -189,8 +189,8 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 	postgresCfg := integration.Config{
 		Name: "postgres",
 		Instances: []integration.Data{
-			integration.Data("host: localhost\ndbname: db-a\ndata_observability:\n  enabled: true\n"),
-			integration.Data("host: localhost\ndbname: db-b\ndata_observability:\n  enabled: true\n"),
+			integration.Data("host: db-a.internal\ndbname: db-a\ndata_observability:\n  enabled: true\n"),
+			integration.Data("host: db-b.internal\ndbname: db-b\ndata_observability:\n  enabled: true\n"),
 		},
 	}
 	c, rc := newStreamComponent(t, []integration.Config{postgresCfg})
@@ -205,10 +205,10 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 
 	// Update 1: schedule cfg-A. Drain it to simulate autodiscovery processing it —
 	// cfg-A is now "in autodiscovery".
-	payload1 := buildPayloadJSON(t, "cfg-A", "localhost", singleQuery)
+	payload1 := buildPayloadJSON(t, "cfg-A", "db-a.internal", singleQuery)
 	triggerRC(map[string]state.RawConfig{"path/cfg-A": {Config: payload1}}, noStatus)
 	update1 := <-outCh
-	require.Len(t, update1.Schedule, 1, "update 1 should schedule cfg-A")
+	require.Len(t, update1.Schedule, 2, "update 1 should schedule cfg-A and the db-b remainder")
 
 	// Update 2: remove cfg-A (empty queries = disable). Channel is now empty — writes directly.
 	// Disabling produces: Unschedule=[cfg-A DO config], Schedule=[base config restoration].
@@ -220,13 +220,13 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 	// sendChanges must drain the full channel and merge update 2's Unschedule into update 3.
 	// Only Unschedule from the dropped update is preserved; dropped Schedule (base config
 	// restoration) is discarded since the new snapshot is authoritative.
-	payload3 := buildPayloadJSON(t, "cfg-B", "localhost", singleQuery)
+	payload3 := buildPayloadJSON(t, "cfg-B", "db-b.internal", singleQuery)
 	triggerRC(map[string]state.RawConfig{"path/cfg-B": {Config: payload3}}, noStatus)
 
 	select {
 	case changes := <-outCh:
-		require.Len(t, changes.Schedule, 1, "should contain only cfg-B schedule (dropped base restoration is discarded)")
-		require.Len(t, changes.Unschedule, 2, "should contain cfg-A Unschedule from dropped + cfg-B's base config Unschedule")
+		require.Len(t, changes.Schedule, 2, "should contain cfg-B and its remainder (dropped base restoration is discarded)")
+		require.Len(t, changes.Unschedule, 3, "should contain cfg-A and remainder Unschedules from dropped + cfg-B's base config Unschedule")
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for merged ConfigChanges")
 	}

--- a/comp/dataobs/queryactions/impl/queryactions_test.go
+++ b/comp/dataobs/queryactions/impl/queryactions_test.go
@@ -178,11 +178,24 @@ func TestStream_RCCallback_DeliverChangesToChannel(t *testing.T) {
 	}
 }
 
-// TestStream_ChannelReplace_PreservesUnschedule covers a capacity-one channel replacement:
-// update 2 is still waiting for autodiscovery when update 3 arrives, so update 2 must be
-// removed from the channel to make room. Its Schedule entries are stale and must be dropped,
-// but its Unschedule entries must be carried into update 3; otherwise configs already
-// processed from update 1 would remain running in autodiscovery.
+// TestStream_ChannelReplace_PreservesUnschedule covers this capacity-one channel sequence:
+//
+//	update 1 (consumed by autodiscovery)
+//	  Schedule:   cfg-A(db-a + query), remainder-b(db-b without queries)
+//	  Active now: cfg-A, remainder-b
+//
+//	update 2 (left buffered in outCh)
+//	  Unschedule: cfg-A, remainder-b
+//	  Schedule:   original base config
+//
+//	update 3 arrives while update 2 occupies outCh
+//	  Unschedule: original base config
+//	  Schedule:   remainder-a(db-a without queries), cfg-B(db-b + query)
+//
+// sendChanges removes update 2 from the full channel. It prepends update 2's Unschedules to
+// update 3 so autodiscovery still removes cfg-A and remainder-b, which it activated from
+// update 1. It discards update 2's Schedule because restoring the original base config is
+// stale once update 3 applies cfg-B.
 func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 	// Use two instances because applying one query action splits the base config into two
 	// scheduled configs: the matched instance with its query and the unmatched remainder.
@@ -204,8 +217,9 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 	noStatus := func(string, state.ApplyStatus) {}
 
 	// Update 1 targets db-a. Consume the update to simulate autodiscovery applying both
-	// scheduled configs: cfg-A for db-a and the unchanged db-b remainder. We save their
-	// digests because both must later be removed, not merely an arbitrary pair of configs.
+	// scheduled configs. Their digests are their identities in Unschedule: saving them here
+	// lets the final assertion prove that sendChanges carried forward the exact two removals
+	// from buffered update 2, rather than merely returning two Unschedule entries.
 	payload1 := buildPayloadJSON(t, "cfg-A", "db-a.internal", singleQuery)
 	triggerRC(map[string]state.RawConfig{"path/cfg-A": {Config: payload1}}, noStatus)
 	update1 := <-outCh
@@ -256,9 +270,10 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 		}
 		assert.Equal(t, map[string]bool{"db-a.internal": true, "db-b.internal": true}, scheduledHosts)
 
-		// The final update must remove exactly three configs: cfg-A and the db-b remainder from
-		// update 1, carried forward from dropped update 2, plus the original base removed by
-		// update 3. Comparing digests ensures no stale update-1 config remains active.
+		// The final update must remove exactly three configs: cfg-A and remainder-b (identified
+		// by the update-1 digests), carried forward from dropped update 2, plus the original base
+		// removed by update 3. Without the first two exact digests, autodiscovery would keep one
+		// or both update-1 configs active alongside cfg-B.
 		expectedUnscheduleDigests := append(append([]string(nil), update1ScheduleDigests...), postgresCfg.Digest())
 		actualUnscheduleDigests := make([]string, 0, len(changes.Unschedule))
 		for _, cfg := range changes.Unschedule {

--- a/comp/dataobs/queryactions/impl/queryactions_test.go
+++ b/comp/dataobs/queryactions/impl/queryactions_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 // mockRCClient implements rcclient.Component for tests.
@@ -209,9 +210,14 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 	triggerRC(map[string]state.RawConfig{"path/cfg-A": {Config: payload1}}, noStatus)
 	update1 := <-outCh
 	require.Len(t, update1.Schedule, 2, "update 1 should schedule cfg-A and the db-b remainder")
+	update1ScheduleDigests := make([]string, 0, len(update1.Schedule))
+	for _, cfg := range update1.Schedule {
+		update1ScheduleDigests = append(update1ScheduleDigests, cfg.Digest())
+	}
 
 	// Update 2: remove cfg-A (empty queries = disable). Channel is now empty — writes directly.
-	// Disabling produces: Unschedule=[cfg-A DO config], Schedule=[base config restoration].
+	// Disabling produces Unschedule=[cfg-A DO config, db-b remainder] and
+	// Schedule=[base config restoration].
 	removeA, _ := json.Marshal(DOQueryPayload{ConfigID: "cfg-A"})
 	triggerRC(map[string]state.RawConfig{"path/cfg-A": {Config: removeA}}, noStatus)
 	// DON'T read outCh — leave update 2 buffered.
@@ -226,7 +232,38 @@ func TestStream_ChannelReplace_PreservesUnschedule(t *testing.T) {
 	select {
 	case changes := <-outCh:
 		require.Len(t, changes.Schedule, 2, "should contain cfg-B and its remainder (dropped base restoration is discarded)")
-		require.Len(t, changes.Unschedule, 3, "should contain cfg-A and remainder Unschedules from dropped + cfg-B's base config Unschedule")
+
+		// The stale base restoration from update 2 must not be scheduled. The latest snapshot
+		// instead schedules cfg-B and a remainder containing db-a.
+		scheduledHosts := make(map[string]bool, len(changes.Schedule))
+		for _, cfg := range changes.Schedule {
+			assert.NotEqual(t, postgresCfg.Digest(), cfg.Digest(), "dropped base restoration must not be scheduled")
+			require.Len(t, cfg.Instances, 1)
+			var instance map[string]any
+			require.NoError(t, yaml.Unmarshal(cfg.Instances[0], &instance))
+			host, _ := instance["host"].(string)
+			scheduledHosts[host] = true
+			doConfig, _ := instance["data_observability"].(map[string]any)
+			_, hasQueries := doConfig["queries"]
+			switch host {
+			case "db-a.internal":
+				assert.False(t, hasQueries, "db-a should be the plain remainder instance")
+			case "db-b.internal":
+				assert.True(t, hasQueries, "db-b should be the latest DO check")
+			default:
+				t.Errorf("unexpected scheduled host %q", host)
+			}
+		}
+		assert.Equal(t, map[string]bool{"db-a.internal": true, "db-b.internal": true}, scheduledHosts)
+
+		// Both configs scheduled by update 1 must be unscheduled even though update 2 was
+		// replaced in the channel. Update 3 additionally unschedules the original base.
+		expectedUnscheduleDigests := append(append([]string(nil), update1ScheduleDigests...), postgresCfg.Digest())
+		actualUnscheduleDigests := make([]string, 0, len(changes.Unschedule))
+		for _, cfg := range changes.Unschedule {
+			actualUnscheduleDigests = append(actualUnscheduleDigests, cfg.Digest())
+		}
+		assert.ElementsMatch(t, expectedUnscheduleDigests, actualUnscheduleDigests)
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for merged ConfigChanges")
 	}

--- a/comp/dataobs/queryactions/impl/types.go
+++ b/comp/dataobs/queryactions/impl/types.go
@@ -14,8 +14,8 @@ type DOQueryPayload struct {
 }
 
 // DBIdentifier identifies a database cluster to target.
-// Type describes the hosting kind (e.g. "self-hosted", "rds"). Instance matching
-// is by host only; per-query dbname fields handle database routing.
+// Type describes the hosting kind (e.g. "self-hosted", "rds"). Host contains the resolved
+// database_instance identifier. Per-query dbname fields handle database routing.
 type DBIdentifier struct {
 	Type          string `json:"type"`
 	Host          string `json:"host"`

--- a/releasenotes/notes/data-observability-resolved-db-identifier-ebbeb19d097b0f99.yaml
+++ b/releasenotes/notes/data-observability-resolved-db-identifier-ebbeb19d097b0f99.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Data Observability query actions now match PostgreSQL checks by their
+    resolved database identifier. Queries now run when the identifier uses an
+    agent hostname override or a ``database_identifier`` template.


### PR DESCRIPTION
### What does this PR do?

The Data Observability query-action matcher now renders PostgreSQL `database_identifier` templates before matching remote configuration. It uses the RC payload's agent hostname for local database addresses and keeps literal `host` and `host:port` matching as a fallback.

### Motivation

Queries were dropped when the backend used a resolved `database_instance` value that differed from the check's literal host. This affected local PostgreSQL instances that used an agent hostname override or a template such as `$resolved_hostname:$port`.

### Describe how you validated your changes

Ran:

`bazel test //comp/dataobs/queryactions/impl:impl_test_base`

The tests cover default and explicit identifier templates, agent hostname overrides, tag substitution, literal-host fallback, port isolation, and remainder reconciliation.

### Additional notes

The workspace does not include the `dda` wrapper, so its local commit and push hooks could not run. Remote CI remains the full lint and test gate.

Closes https://linear.app/datadog/issue/DOIO-136
