### PR TITLE
fix(dataobs): don't drop same-host sibling instances from remainder

### DIFF
--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -29,7 +29,7 @@ import (
 type activeConfigEntry struct {
 	checkConfig integration.Config
 	baseCfg     *integration.Config // the original matched postgres config (full, all instances)
-	matchHost   string              // host this DO config targets (DBIdentifier.Host)
+	matchHost   string              // resolved instanceIdentity (host:port) of the instance this DO config targets
 }
 
 // managedBaseEntry tracks a base postgres config that has at least one instance targeted by a
@@ -141,7 +141,12 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 		c.activeConfigs[configID] = activeConfigEntry{
 			checkConfig: checkConfig,
 			baseCfg:     baseCfg,
-			matchHost:   payload.DBIdentifier.Host,
+			// Use the resolved identity of the instance findMatchingConfig actually selected
+			// rather than payload.DBIdentifier.Host verbatim: the payload host can be a bare
+			// host shared by several instances on different ports, and matching buildRemainder
+			// against that bare string would exclude every sibling instance on that host, not
+			// just the one selected here.
+			matchHost: instanceIdentity(instance),
 		}
 		c.activeConfigsMu.Unlock()
 		changes.Schedule = append(changes.Schedule, checkConfig)
@@ -269,12 +274,12 @@ func (c *component) reconcileBases(changes *integration.ConfigChanges) {
 // matchedHosts. Returns nil when no instances remain (every instance is DO-managed). Instances
 // whose YAML cannot be parsed are kept, so a config we cannot classify is never silently dropped.
 //
-// Matching uses instanceMatchesHost — the same logic that selected the instance for scheduling —
-// so an instance is excluded from the remainder exactly when a DO query action runs it as its own
-// check. matchedHosts holds DBIdentifier.Host values verbatim, which for sap_hana are the
-// "host:port" form (e.g. "172.17.128.2:39041") while the instance keys host under "server" with a
-// separate "port"; comparing the raw "host" key alone would never match and would duplicate the
-// instance.
+// Matching uses instanceMatchesHost against each entry's resolved instanceIdentity (host:port,
+// falling back to bare host only when the instance has no port), not the raw DBIdentifier.Host
+// from the RC payload — a payload host can be bare and shared by several instances on different
+// ports (e.g. two postgres instances both on "dbhost"), and matching against that bare string
+// would exclude every instance on the host from the remainder instead of only the one actually
+// selected as the DO check.
 func buildRemainder(base *integration.Config, matchedHosts map[string]bool) *integration.Config {
 	kept := make([]integration.Data, 0, len(base.Instances))
 	for _, instanceData := range base.Instances {
@@ -386,6 +391,17 @@ func instancePort(instance map[string]any) (int, bool) {
 		return int(v), true
 	}
 	return 0, false
+}
+
+// instanceIdentity returns a canonical "host:port" identity for an instance, falling back to the
+// bare host when no port is present. Unlike matching against a possibly-bare payload host, this
+// always disambiguates instances that share a host but differ by port.
+func instanceIdentity(instance map[string]any) string {
+	host := instanceHost(instance)
+	if port, ok := instancePort(instance); ok {
+		return fmt.Sprintf("%s:%d", host, port)
+	}
+	return host
 }
 
 // buildCheckConfig creates a check config with data_observability queries injected.

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -370,14 +370,14 @@ func matchesIdentifier(instance map[string]any, dbID *DBIdentifier) bool {
 // instance is targeted by a DO query action.
 func instanceMatchesHost(instance map[string]any, targetHost string) bool {
 	host := instanceHost(instance)
-	if host == targetHost {
-		return true
-	}
-	// Try matching "host:port" form — sap_hana backends include the port in the identifier.
+	// Try the more specific "host:port" form first — sap_hana backends include the port in the
+	// identifier, and this form disambiguates instances that share a host but differ by port.
 	if port, ok := instancePort(instance); ok {
-		return fmt.Sprintf("%s:%d", host, port) == targetHost
+		if fmt.Sprintf("%s:%d", host, port) == targetHost {
+			return true
+		}
 	}
-	return false
+	return host == targetHost
 }
 
 // instancePort returns the port number for an integration instance, if present.

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -274,12 +274,13 @@ func (c *component) reconcileBases(changes *integration.ConfigChanges) {
 // matchedHosts. Returns nil when no instances remain (every instance is DO-managed). Instances
 // whose YAML cannot be parsed are kept, so a config we cannot classify is never silently dropped.
 //
-// Matching uses instanceMatchesHost against each entry's resolved instanceIdentity (host:port,
-// falling back to bare host only when the instance has no port), not the raw DBIdentifier.Host
-// from the RC payload — a payload host can be bare and shared by several instances on different
-// ports (e.g. two postgres instances both on "dbhost"), and matching against that bare string
-// would exclude every instance on the host from the remainder instead of only the one actually
-// selected as the DO check.
+// Matching compares each instance's own resolved instanceIdentity against matchedHosts by exact
+// string equality, not the raw DBIdentifier.Host from the RC payload and not the looser
+// host-or-host:port matching instanceMatchesHost does for that payload host. A payload host can
+// be bare and shared by several instances on different ports (e.g. two postgres instances both on
+// "dbhost"), and a loose match against that bare string — or against the resolved identity of a
+// portless matched instance — would incorrectly exclude sibling instances that do have a port,
+// instead of only the one actually selected as the DO check.
 func buildRemainder(base *integration.Config, matchedHosts map[string]bool) *integration.Config {
 	kept := make([]integration.Data, 0, len(base.Instances))
 	for _, instanceData := range base.Instances {
@@ -301,15 +302,14 @@ func buildRemainder(base *integration.Config, matchedHosts map[string]bool) *int
 	return &remainder
 }
 
-// instanceTargeted reports whether any host in matchedHosts targets this instance, using the same
-// host-matching semantics as scheduling.
+// instanceTargeted reports whether this instance is the exact instance a DO config resolved to,
+// by comparing its own instanceIdentity against matchedHosts. Exact identity equality — rather
+// than the looser bare-or-host:port matching used to resolve a payload host to an instance in the
+// first place — ensures a portless matched identity (e.g. "dbhost") can never accidentally match a
+// sibling instance that does have a port (e.g. "dbhost" host with port 5433): that sibling's own
+// identity is "dbhost:5433", which is exactly equal to nothing but itself.
 func instanceTargeted(instance map[string]any, matchedHosts map[string]bool) bool {
-	for host := range matchedHosts {
-		if instanceMatchesHost(instance, host) {
-			return true
-		}
-	}
-	return false
+	return matchedHosts[instanceIdentity(instance)]
 }
 
 // sameConfig reports whether two optional configs are equivalent by autodiscovery digest.

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -766,6 +766,64 @@ func TestOnRCUpdate_SameHostDifferentPorts_KeepsSiblingPortInRemainder(t *testin
 	assert.Equal(t, []int{siblingPort}, portsOf(*remainder), "remainder must keep the untargeted sibling port")
 }
 
+// TestOnRCUpdate_PortlessMatchedInstance_KeepsPortedSiblingInRemainder is a regression test for a
+// matched instance that omits "port" (e.g. relying on the default) while a sibling instance on the
+// same host has an explicit, different port. The resolved identity of the portless matched
+// instance falls back to the bare host, which a naive host-or-host:port match against the sibling
+// would still hit (the sibling's bare host is identical), wrongly excluding the ported sibling
+// from the remainder. Exact instanceIdentity equality must not match the sibling, since the
+// sibling's own identity includes its port.
+func TestOnRCUpdate_PortlessMatchedInstance_KeepsPortedSiblingInRemainder(t *testing.T) {
+	const sharedHost = "dbhost"
+	const siblingPort = 5433
+	postgresCfg := integration.Config{
+		Name:     "postgres",
+		Provider: "file",
+		Instances: []integration.Data{
+			integration.Data(fmt.Sprintf("host: %s\ndata_observability:\n  enabled: true\n", sharedHost)),
+			integration.Data(fmt.Sprintf("host: %s\nport: %d\ndata_observability:\n  enabled: true\n", sharedHost, siblingPort)),
+		},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
+
+	payload := DOQueryPayload{
+		ConfigID:     "cfg-portless",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: sharedHost},
+		Queries:      []QuerySpec{{Type: "run_query", Query: "SELECT 1", IntervalSeconds: 60, TimeoutSeconds: 10}},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-portless": {Config: payloadJSON},
+	})
+
+	require.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-portless"].State)
+
+	// Exactly two configs scheduled: the DO check for the portless instance and the remainder
+	// holding only the ported sibling. A remainder with zero instances would mean the sibling on
+	// port 5433 was wrongly dropped.
+	require.Len(t, changes.Schedule, 2)
+
+	var doCfg, remainder *integration.Config
+	for i := range changes.Schedule {
+		var instance map[string]any
+		require.NoError(t, yaml.Unmarshal(changes.Schedule[i].Instances[0], &instance))
+		if _, hasQueries := instance["data_observability"].(map[string]any)["queries"]; hasQueries {
+			doCfg = &changes.Schedule[i]
+		} else {
+			remainder = &changes.Schedule[i]
+		}
+	}
+	require.NotNil(t, doCfg, "a DO check config should be scheduled")
+	require.NotNil(t, remainder, "a remainder config should be scheduled")
+
+	var remainderInstance map[string]any
+	require.NoError(t, yaml.Unmarshal(remainder.Instances[0], &remainderInstance))
+	assert.Equal(t, sharedHost, remainderInstance["host"])
+	assert.Equal(t, siblingPort, remainderInstance["port"], "remainder must keep the ported sibling, not drop it via the portless matched identity")
+}
+
 // TestOnRCUpdate_MultipleDOConfigsSameBase verifies that two DO configs targeting two different
 // instances of the same base config never leave an instance both in the remainder and as a DO
 // check (which would double-run it). With both instances targeted, no remainder is scheduled.

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -699,6 +699,73 @@ func TestOnRCUpdate_SapHana_ExcludesTargetedInstanceFromRemainder(t *testing.T) 
 	assert.Equal(t, []string{siblingServer}, serversOf(*remainder), "remainder must exclude the targeted server and keep only the sibling")
 }
 
+// TestOnRCUpdate_SameHostDifferentPorts_KeepsSiblingPortInRemainder is a regression test for a
+// bare-host DBIdentifier (as postgres backends send) matching more than one instance on the same
+// base config. Two postgres instances share host "dbhost" but differ by port; the DO payload
+// targets the bare host, which findMatchingConfig resolves to the first instance (port 5432).
+// buildRemainder must exclude only that resolved instance from the remainder — matching against
+// the bare payload host directly would also match the sibling on port 5433 and wrongly drop it,
+// silently stopping its normal DBM collection.
+func TestOnRCUpdate_SameHostDifferentPorts_KeepsSiblingPortInRemainder(t *testing.T) {
+	const sharedHost = "dbhost"
+	const targetedPort = 5432
+	const siblingPort = 5433
+	postgresCfg := integration.Config{
+		Name:     "postgres",
+		Provider: "file",
+		Instances: []integration.Data{
+			integration.Data(fmt.Sprintf("host: %s\nport: %d\ndata_observability:\n  enabled: true\n", sharedHost, targetedPort)),
+			integration.Data(fmt.Sprintf("host: %s\nport: %d\ndata_observability:\n  enabled: true\n", sharedHost, siblingPort)),
+		},
+	}
+	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
+
+	payload := DOQueryPayload{
+		ConfigID:     "cfg-samehost",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: sharedHost},
+		Queries:      []QuerySpec{{Type: "run_query", Query: "SELECT 1", IntervalSeconds: 60, TimeoutSeconds: 10}},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	statuses, changes := collectStatuses(c, map[string]state.RawConfig{
+		"path/cfg-samehost": {Config: payloadJSON},
+	})
+
+	require.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-samehost"].State)
+
+	// Exactly two configs scheduled: the DO check for the targeted port and the remainder holding
+	// only the untargeted sibling port. A remainder with zero instances (or none scheduled) would
+	// mean the sibling on port 5433 was wrongly dropped.
+	require.Len(t, changes.Schedule, 2)
+
+	portsOf := func(cfg integration.Config) []int {
+		ports := make([]int, 0, len(cfg.Instances))
+		for _, instanceData := range cfg.Instances {
+			var instance map[string]any
+			require.NoError(t, yaml.Unmarshal(instanceData, &instance))
+			ports = append(ports, instance["port"].(int))
+		}
+		return ports
+	}
+
+	var doCfg, remainder *integration.Config
+	for i := range changes.Schedule {
+		var instance map[string]any
+		require.NoError(t, yaml.Unmarshal(changes.Schedule[i].Instances[0], &instance))
+		if _, hasQueries := instance["data_observability"].(map[string]any)["queries"]; hasQueries {
+			doCfg = &changes.Schedule[i]
+		} else {
+			remainder = &changes.Schedule[i]
+		}
+	}
+	require.NotNil(t, doCfg, "a DO check config should be scheduled")
+	require.NotNil(t, remainder, "a remainder config should be scheduled")
+
+	assert.Equal(t, []int{targetedPort}, portsOf(*doCfg), "DO check should carry only the targeted port")
+	assert.Equal(t, []int{siblingPort}, portsOf(*remainder), "remainder must keep the untargeted sibling port")
+}
+
 // TestOnRCUpdate_MultipleDOConfigsSameBase verifies that two DO configs targeting two different
 // instances of the same base config never leave an instance both in the remainder and as a DO
 // check (which would double-run it). With both instances targeted, no remainder is scheduled.

--- a/releasenotes/notes/fix-dataobs-samehost-remainder-1a29d7f448866340.yaml
+++ b/releasenotes/notes/fix-dataobs-samehost-remainder-1a29d7f448866340.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fix a bug where a Data Observability query action targeting a bare host
+    shared by multiple database instances on different ports (e.g. two
+    postgres instances on the same host) could drop every instance on that
+    host from the remaining file-provider configuration, silently stopping
+    normal DBM collection on the untargeted ports. Only the instance actually
+    selected as the Data Observability check is now excluded.


### PR DESCRIPTION
### What does this PR do?

Follow-up to #54200 (and its backport #54210), fixing a related bug flagged by review on the backport: [comment](https://github.com/DataDog/datadog-agent/pull/54210#discussion_r3674530359).

`buildRemainder` decided which instances to keep by matching against the DO payload's raw `DBIdentifier.Host` verbatim. For postgres this host is often bare (no port), and can be shared by multiple instances on different ports. `findMatchingConfig`/`matchesIdentifier` correctly resolve that bare host to a single instance to convert into a DO check, but `buildRemainder` re-matched *every* instance against the same bare string — so all instances sharing that host (not just the one selected as the DO check) were excluded from the remainder, silently stopping normal DBM collection on the other ports.

Fix: store the resolved `instanceIdentity` (`host:port`, falling back to bare host only when no port is present) of the actually-matched instance instead of the raw payload host.

A [follow-up review comment](https://github.com/DataDog/datadog-agent/pull/54215#discussion_r3675128492) pointed out that the initial fix still had a gap: `instanceTargeted` matched candidates against `matchedHosts` using the same loose bare-or-host:port logic used to *resolve* a payload host to an instance. When the matched instance itself had no port (falling back to a bare-host identity), that loose match could also hit a sibling instance on the same host that does have an explicit port, wrongly dropping it from the remainder. Fixed by comparing each instance's own `instanceIdentity` against `matchedHosts` with exact string equality instead, so only the specific matched instance is ever excluded.

Also reordered `instanceMatchesHost` (used only for the initial bare-or-host:port resolution) to check the more specific host:port form first — a pure readability change, no behavior difference.

### Motivation

Two postgres instances on the same host but different ports (e.g. `dbhost:5432` and `dbhost:5433`) would previously both be dropped from the remainder when a DO query action targeted the bare host `dbhost`, leaving the untargeted port unmonitored. The same could happen even for a single targeted/sibling pair when the targeted instance omits its port and relies on the default.

### Describe how you validated your changes

- Added `TestOnRCUpdate_SameHostDifferentPorts_KeepsSiblingPortInRemainder`, reproducing the scenario from the original review comment: asserts the DO check carries only the targeted port and the remainder keeps the untargeted sibling port.
- Added `TestOnRCUpdate_PortlessMatchedInstance_KeepsPortedSiblingInRemainder`, reproducing the follow-up review comment's scenario: a portless matched instance must not drop a ported sibling on the same host. Verified this test fails without the fix and passes with it.
- `dda inv test --targets=./comp/dataobs/queryactions/impl` — all 38 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)