### PR TITLE
Add NO_PARALLEL hint to Oracle tablespace queries

### DIFF
--- a/pkg/collector/corechecks/oracle/tablespaces.go
+++ b/pkg/collector/corechecks/oracle/tablespaces.go
@@ -14,7 +14,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle/common"
 )
 
-const tablespaceQuery12 = `SELECT
+// All four tablespace queries below carry a NO_PARALLEL hint. Tablespace collection reads
+// small dictionary views, so it has nothing to gain from parallel execution, and the hint
+// stops Oracle choosing it anyway: an object-level DEGREE on the underlying dictionary
+// tables makes the optimizer go parallel regardless of parallel_degree_policy, and on a
+// large cluster that turns a trivial query into thousands of parallel server executions.
+
+const tablespaceQuery12 = `SELECT /*+ NO_PARALLEL */
   c.name pdb_name,
   t.tablespace_name tablespace_name,
   NVL(m.used_space * t.block_size, 0) used,
@@ -29,7 +35,7 @@ FROM
 WHERE
   m.con_id(+) = t.con_id and m.tablespace_name(+) = t.tablespace_name and c.con_id(+) = t.con_id`
 
-const tablespaceQuery11 = `SELECT
+const tablespaceQuery11 = `SELECT /*+ NO_PARALLEL */
   t.tablespace_name tablespace_name,
   NVL(m.used_space * t.block_size, 0) used,
   NVL(m.tablespace_size * t.block_size, 0) size_,
@@ -44,7 +50,8 @@ WHERE
   m.tablespace_name(+) = t.tablespace_name`
 
 const (
-	maxSizeQuery12 = `SELECT
+	// NO_PARALLEL for the reason given above tablespaceQuery12.
+	maxSizeQuery12 = `SELECT /*+ NO_PARALLEL */
   c.name pdb_name,
   f.tablespace_name tablespace_name,
   COALESCE(SUM(CASE WHEN autoextensible = 'YES' THEN maxbytes ELSE bytes END), 0) maxsize
@@ -52,7 +59,7 @@ FROM cdb_data_files f, v$containers c
 WHERE c.con_id(+) = f.con_id
 GROUP BY c.name, f.tablespace_name`
 
-	maxSizeQuery11 = `SELECT
+	maxSizeQuery11 = `SELECT /*+ NO_PARALLEL */
     f.tablespace_name tablespace_name,
     COALESCE(SUM(CASE WHEN autoextensible = 'YES' THEN maxbytes ELSE bytes END), 0) maxsize
     FROM dba_data_files f

--- a/releasenotes/notes/oracle-tablespace-no-parallel-4c1e9a37b6d2f508.yaml
+++ b/releasenotes/notes/oracle-tablespace-no-parallel-4c1e9a37b6d2f508.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Oracle tablespace collection queries now carry a ``NO_PARALLEL`` hint. An
+    object-level parallel degree on the underlying dictionary objects could make
+    Oracle run these queries in parallel even with ``parallel_degree_policy`` set
+    to ``MANUAL``, which on large clusters produced a very high degree of
+    parallelism and significant CPU consumption for a query that reads only small
+    dictionary views.


### PR DESCRIPTION
### What does this PR do?

Adds `/*+ NO_PARALLEL */` to the four Oracle tablespace collection query constants —
usage and max-size, in both their `CDB_*` and `DBA_*` variants. Nothing else changes:
same views, same columns, same metrics and tags.

### Motivation

SDBM-2824. A 12-node Exadata RAC cluster ran the tablespace usage query at a degree of
parallelism near 1,700 — roughly 1.4M parallel server executions and 35K+ CPU-seconds
per hour, for a query that reads small dictionary views and can never benefit from
parallel execution.

The Agent injects no `PARALLEL` hint and the database has `parallel_degree_policy` set
to `MANUAL`, which leaves an object-level `PARALLEL` degree on the underlying dictionary
objects as the explanation. The Agent cannot detect or influence that, so a hint is the
only defense available from our side, and it covers every RAC and Exadata deployment
rather than one customer.

Per the [19c SQL Language Reference][hint], `NO_PARALLEL` "instructs the optimizer to run
the statement serially... It also overrides a `PARALLEL` parameter in the DDL that created
or altered the table," and the hint has been statement-level since 11.2. So one hint per
statement is the complete fix — no per-object hints needed.

[hint]: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/Comments.html

### Describe how you validated your changes

Not run against a live database. Two properties make that acceptable:

- A hint is a SQL comment. Any version that does not recognize `NO_PARALLEL` ignores it
  silently, so the worst case on the oldest supported database is a no-op — never a
  syntax error or a failed collection. This covers the `legacyIntegrationCompatibilityMode`
  and pre-12c paths as well as the multitenant one.
- It is a statement-level optimizer directive, so it cannot alter the result set. The
  columns, metrics, and tags are unchanged, and no test asserts the SQL text of these
  constants (the tablespace tests are `oracle_test`-tagged integration tests that assert
  emitted metrics against a live database).

### Additional Notes

Supersedes #54188, which instead switched the non-CDB path to the `DBA_*` views. That
regresses documented installs: the [non-CDB grant list][grants] covers `CDB_TABLESPACES`
and `CDB_TABLESPACE_USAGE_METRICS` but not the `DBA_*` pair, so the swapped query fails
with `ORA-00942`. The existing queries return correct results on a non-CDB; only the
parallelism needed addressing.

One case the docs don't spell out: `NO_PARALLEL_INDEX` is documented separately as
covering a `PARALLEL` degree set on an *index*. "Run the statement serially" should
include index access paths, but if a reviewer knows otherwise, that would argue for
adding it.

Scope is deliberately limited to the tablespace queries, which is where the incident
surfaced. Other dictionary-reading queries in this check (statements, locks, processes,
sysmetrics) are exposed to the same object-level `DEGREE` mechanism in principle; they
have not been audited here and would be a follow-up if the same pattern shows up.

[grants]: https://docs.datadoghq.com/database_monitoring/setup_oracle/selfhosted/#grant-the-user-access-to-the-database

🤖 Generated with [Claude Code](https://claude.com/claude-code)
