### PR TITLE
Pin integrations-core to PR 24708 for E2E testing

### DIFF
--- a/release.json
+++ b/release.json
@@ -2,7 +2,7 @@
     "base_branch": "main",
     "current_milestone": "7.83.0",
     "dependencies": {
-        "INTEGRATIONS_CORE_VERSION": "f60732d6369f3dba70fd128ee707eee6ddd40e67",
+        "INTEGRATIONS_CORE_VERSION": "f47edabf6ed7baf288036e3dde182918f85373e7",
         "INTEGRATIONS_WHEELS_STORAGE": "stable",
         "JMXFETCH_HASH": "3eb735171a3e41518c4101a6aee06fee8b93092d015769c2e470eecadb4bd11b",
         "JMXFETCH_VERSION": "0.52.0",


### PR DESCRIPTION
### What does this PR do?

Pins `INTEGRATIONS_CORE_VERSION` to `f47edabf6ed7baf288036e3dde182918f85373e7`, the current HEAD of DataDog/integrations-core#24708.

### Motivation

Build an Agent containing the persistent v2 TUF metadata change so it can be tested end to end before merging the integrations-core PR.

### Describe how you validated your changes

- Verified the commit matches the current HEAD of DataDog/integrations-core#24708 and is reachable from its remote branch.
- Validated `release.json` with `python3 -m json.tool`.
- Confirmed the PR changes only the integrations-core pin.
- Repository pre-commit and pre-push hooks passed.

### Additional Notes

Test-only draft PR; not intended to merge.
