### PR TITLE
Write agent hostname to /etc/datadog-agent/hostname for WLS host-level scoping

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -14,6 +14,7 @@ import (
 	_ "net/http/pprof" // Blank import used because this isn't directly used in this file
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime"
 	"syscall"
 	"time"
@@ -668,7 +669,11 @@ func startAgent(
 		return log.Errorf("Error while getting hostname, exiting: %v", err)
 	}
 	log.Infof("Hostname is: %s", hostnameDetected)
-	if err := os.WriteFile("/etc/datadog-agent/hostname", []byte(hostnameDetected), 0644); err != nil {
+	confDir := filepath.Dir(cfg.ConfigFileUsed())
+	if confDir == "." {
+		confDir = config.DefaultConfPath
+	}
+	if err := os.WriteFile(filepath.Join(confDir, "hostname"), []byte(hostnameDetected), 0644); err != nil {
 		log.Warnf("Failed to write hostname file: %v", err)
 	}
 

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -668,6 +668,9 @@ func startAgent(
 		return log.Errorf("Error while getting hostname, exiting: %v", err)
 	}
 	log.Infof("Hostname is: %s", hostnameDetected)
+	if err := os.WriteFile("/etc/datadog-agent/hostname", []byte(hostnameDetected), 0644); err != nil {
+		log.Warnf("Failed to write hostname file: %v", err)
+	}
 
 	// start remote configuration management
 	if configUtils.IsRemoteConfigEnabled(cfg) {

--- a/pkg/util/hostname/drift.go
+++ b/pkg/util/hostname/drift.go
@@ -10,8 +10,10 @@ package hostname
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
@@ -159,7 +161,11 @@ func (ds *driftService) checkHostnameDrift(ctx context.Context, cacheHostnameKey
 	if drift.hasDrift {
 		tlmDriftDetected.Inc(drift.state, providerName)
 		cache.Cache.Set(cacheHostnameKey, newData, cache.NoExpiration)
-		if err := os.WriteFile("/etc/datadog-agent/hostname", []byte(hostname), 0644); err != nil {
+		confDir := filepath.Dir(setup.Datadog().ConfigFileUsed())
+		if confDir == "." {
+			confDir = config.DefaultConfPath
+		}
+		if err := os.WriteFile(filepath.Join(confDir, "hostname"), []byte(hostname), 0644); err != nil {
 			log.Warnf("Failed to update hostname file after drift: %v", err)
 		}
 	}

--- a/pkg/util/hostname/drift.go
+++ b/pkg/util/hostname/drift.go
@@ -9,11 +9,13 @@ package hostname
 
 import (
 	"context"
+	"os"
 	"time"
 
 	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // driftService contains configuration for hostname drift detection
@@ -157,5 +159,8 @@ func (ds *driftService) checkHostnameDrift(ctx context.Context, cacheHostnameKey
 	if drift.hasDrift {
 		tlmDriftDetected.Inc(drift.state, providerName)
 		cache.Cache.Set(cacheHostnameKey, newData, cache.NoExpiration)
+		if err := os.WriteFile("/etc/datadog-agent/hostname", []byte(hostname), 0644); err != nil {
+			log.Warnf("Failed to update hostname file after drift: %v", err)
+		}
 	}
 }


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Writes the agent's canonical hostname to `/etc/datadog-agent/hostname` at startup and on drift detection.

### Motivation
The auto_inject shim runs inside a Docker UTS namespace where `gethostname()` returns the container ID instead of the host hostname. A file-based approach lets the shim and host injector read the true host hostname to evaluate WLS hostname-scoped policies.

### Describe how you validated your changes
Built the agent locally in a Lima VM shell using dda inv agent.build and ran it against a dev config. Confirmed that /etc/datadog-agent/hostname was created with the correct hostname after startup.

### Additional Notes
