### PR TITLE
fix(private-action-runner): connect deployed rshell to host systemd

### DIFF
--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
@@ -33,8 +33,10 @@ import (
 )
 
 const (
-	defaultProcPath         = "/proc"
-	containerizedPathPrefix = "/host"
+	defaultProcPath                 = "/proc"
+	defaultSystemdMachineIDPath     = "/etc/machine-id"
+	defaultSystemdManagerSocketPath = "/run/dbus/system_bus_socket"
+	containerizedPathPrefix         = "/host"
 )
 
 // statFn is the function used to check path existence. It defaults to os.Stat
@@ -284,6 +286,7 @@ func (h *RunCommandHandler) Run(
 		interp.ProcPath(resolveProcPath()),
 		interp.AllowedCommands(effectiveAllowedCommands),
 		interp.AllowedSystemServices(effectiveAllowedSystemServices),
+		interp.WithSystemdTarget(resolveSystemdTarget()),
 		interp.WithMode(h.mode),
 	)
 	if err != nil {
@@ -332,4 +335,27 @@ func resolveProcPath() string {
 		}
 	}
 	return defaultProcPath
+}
+
+// resolveSystemdTarget selects host-mounted systemd endpoints in containerized
+// deployments when both are available. The zero value keeps rshell's local
+// defaults for host installations and containers without these mounts.
+func resolveSystemdTarget() interp.SystemdTargetConfig {
+	if !env.IsContainerized() {
+		return interp.SystemdTargetConfig{}
+	}
+
+	machineIDPath := path.Join(containerizedPathPrefix, defaultSystemdMachineIDPath)
+	if _, err := statFn(machineIDPath); err != nil {
+		return interp.SystemdTargetConfig{}
+	}
+	managerSocketPath := path.Join(containerizedPathPrefix, defaultSystemdManagerSocketPath)
+	if _, err := statFn(managerSocketPath); err != nil {
+		return interp.SystemdTargetConfig{}
+	}
+
+	return interp.SystemdTargetConfig{
+		MachineIDPath:    machineIDPath,
+		ManagerBusSocket: managerSocketPath,
+	}
 }

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
@@ -931,6 +931,64 @@ func TestResolveProcPathContainerizedWithoutHostMount(t *testing.T) {
 	assert.Equal(t, "/proc", result)
 }
 
+func TestResolveSystemdTargetBareMetal(t *testing.T) {
+	t.Setenv("DOCKER_DD_AGENT", "")
+	overrideStatFn(t, mockStatFn(map[string]bool{
+		"/host/etc/machine-id":             true,
+		"/host/run/dbus/system_bus_socket": true,
+	}))
+
+	result := resolveSystemdTarget()
+
+	assert.Empty(t, result)
+}
+
+func TestResolveSystemdTargetContainerizedWithHostMounts(t *testing.T) {
+	t.Setenv("DOCKER_DD_AGENT", "true")
+	overrideStatFn(t, mockStatFn(map[string]bool{
+		"/host/etc/machine-id":             true,
+		"/host/run/dbus/system_bus_socket": true,
+	}))
+
+	result := resolveSystemdTarget()
+
+	assert.Equal(t, interp.SystemdTargetConfig{
+		MachineIDPath:    "/host/etc/machine-id",
+		ManagerBusSocket: "/host/run/dbus/system_bus_socket",
+	}, result)
+}
+
+func TestResolveSystemdTargetRequiresBothHostMounts(t *testing.T) {
+	t.Setenv("DOCKER_DD_AGENT", "true")
+
+	tests := []struct {
+		name     string
+		existing map[string]bool
+	}{
+		{
+			name: "missing machine ID",
+			existing: map[string]bool{
+				"/host/run/dbus/system_bus_socket": true,
+			},
+		},
+		{
+			name: "missing manager bus socket",
+			existing: map[string]bool{
+				"/host/etc/machine-id": true,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			overrideStatFn(t, mockStatFn(test.existing))
+
+			result := resolveSystemdTarget()
+
+			assert.Empty(t, result)
+		})
+	}
+}
+
 // --- runRemediationCommand ---
 
 // TestNewRshellBundleRegistersBothModes verifies the bundle exposes both

--- a/test/e2e-framework/components/kubernetes/BUILD.bazel
+++ b/test/e2e-framework/components/kubernetes/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "kubernetes",
@@ -29,5 +29,16 @@ go_library(
         "@com_github_masterminds_semver_v3//:semver",
         "@com_github_pulumi_pulumi_kubernetes_sdk_v4//go/kubernetes",
         "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
+    ],
+)
+
+go_test(
+    name = "kubernetes_test",
+    srcs = ["kind_versions_test.go"],
+    embed = [":kubernetes"],
+    gotags = ["test"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/test/e2e-framework/components/kubernetes/kind-cluster.yaml
+++ b/test/e2e-framework/components/kubernetes/kind-cluster.yaml
@@ -5,6 +5,11 @@ nodes:
   extraMounts:
   - hostPath: /proc
     containerPath: /host/proc
+{{- range .ExtraMounts }}
+  - hostPath: {{ printf "%q" .HostPath }}
+    containerPath: {{ printf "%q" .ContainerPath }}
+    readOnly: {{ .ReadOnly }}
+{{- end }}
 {{- if .MountDockerSocket }}
   - hostPath: /var/run/docker.sock
     containerPath: /var/run/docker.sock
@@ -18,6 +23,11 @@ nodes:
   extraMounts:
   - hostPath: /proc
     containerPath: /host/proc
+{{- range $.ExtraMounts }}
+  - hostPath: {{ printf "%q" .HostPath }}
+    containerPath: {{ printf "%q" .ContainerPath }}
+    readOnly: {{ .ReadOnly }}
+{{- end }}
 {{- if $.MountDockerSocket }}
   - hostPath: /var/run/docker.sock
     containerPath: /var/run/docker.sock

--- a/test/e2e-framework/components/kubernetes/kind_versions.go
+++ b/test/e2e-framework/components/kubernetes/kind_versions.go
@@ -30,7 +30,15 @@ type KindConfigFlags struct {
 	NewContainerdRegistryConfig bool             // whether to use the new containerd registry mirror config format (for containerd >= 2.2, used in kubernetes >= v1.32)
 	KubeProxyReplacement        bool             // whether to set kubeProxyMode to "none" in the kind config
 	MountDockerSocket           bool             // whether to bind-mount /var/run/docker.sock from the host into each kind node
+	ExtraMounts                 []KindExtraMount // additional host paths to bind-mount into each kind node
 	WorkerNodes                 []KindWorkerNode // additional worker nodes beyond the control-plane
+}
+
+// KindExtraMount describes a host path bind-mounted into every kind node.
+type KindExtraMount struct {
+	HostPath      string
+	ContainerPath string
+	ReadOnly      bool
 }
 
 // KindWorkerNode describes a kind worker node.

--- a/test/e2e-framework/components/kubernetes/kind_versions_test.go
+++ b/test/e2e-framework/components/kubernetes/kind_versions_test.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package kubernetes
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateKindConfigExtraMounts(t *testing.T) {
+	config, err := generateKindConfig(kindClusterConfig, KindConfigFlags{
+		ExtraMounts: []KindExtraMount{
+			{
+				HostPath:      "/etc/machine-id",
+				ContainerPath: "/host/etc/machine-id",
+				ReadOnly:      true,
+			},
+			{
+				HostPath:      "/run/dbus/system_bus_socket",
+				ContainerPath: "/host/run/dbus/system_bus_socket",
+				ReadOnly:      true,
+			},
+		},
+		WorkerNodes: []KindWorkerNode{{}},
+	})
+	require.NoError(t, err)
+
+	nodes := strings.Split(config, "- role:")
+	require.Len(t, nodes, 3)
+
+	expectedMounts := []string{
+		"  - hostPath: \"/etc/machine-id\"\n    containerPath: \"/host/etc/machine-id\"\n    readOnly: true",
+		"  - hostPath: \"/run/dbus/system_bus_socket\"\n    containerPath: \"/host/run/dbus/system_bus_socket\"\n    readOnly: true",
+	}
+	for nodeIndex, node := range nodes[1:] {
+		for _, expectedMount := range expectedMounts {
+			assert.Contains(t, node, expectedMount, "mount missing from node %d", nodeIndex)
+		}
+	}
+}

--- a/test/new-e2e/tests/privateactionrunner/provisioner.go
+++ b/test/new-e2e/tests/privateactionrunner/provisioner.go
@@ -30,12 +30,18 @@ const (
 	// (helm-charts PR #2517). Drop this override once the e2e framework's global HelmVersion
 	// default is bumped to at least this value.
 	minHelmChartVersion = "3.197.2"
+
+	systemServiceFixture       = "par-e2e.service"
+	hostMachineIDPath          = "/host/etc/machine-id"
+	hostSystemBusSocketPath    = "/host/run/dbus/system_bus_socket"
+	systemServiceOperatorGrant = `{"par-e2e.service":["read"]}`
 )
 
 // parHelmValuesTemplate configures the agent with PAR enabled.
 // Fakeintake URL wiring (DD_DD_URL, DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION) is handled
 // automatically by the e2e framework's configureFakeintake when fakeintake is present.
-// %s parameters: clusterName, runnerURN, privateKeyB64
+// %s parameters: clusterName, runnerURN, privateKeyB64, systemServiceOperatorGrant,
+// hostMachineIDPath (twice), hostSystemBusSocketPath (twice)
 const parHelmValuesTemplate = `
 datadog:
   kubelet:
@@ -53,6 +59,23 @@ agents:
       envDict:
         DD_HOSTNAME: "par-rshell-e2e"
         DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST: "com.datadoghq.remoteaction.rshell.runCommand,com.datadoghq.remoteaction.rshell.runRemediationCommand"
+        DD_PRIVATE_ACTION_RUNNER_RESTRICTED_SHELL_ALLOWED_SYSTEM_SERVICES: '%s'
+  volumes:
+    - name: host-machine-id
+      hostPath:
+        path: %s
+        type: File
+    - name: host-system-bus
+      hostPath:
+        path: %s
+        type: Socket
+  volumeMounts:
+    - name: host-machine-id
+      mountPath: %s
+      readOnly: true
+    - name: host-system-bus
+      mountPath: %s
+      readOnly: true
 `
 
 // parK8sProvisioner provisions a Kind-on-EC2 cluster with:
@@ -89,14 +112,42 @@ func parK8sProvisioner(runnerURN, privateKeyB64 string) provisioners.Provisioner
 				return fmt.Errorf("docker.SetupECRDockerAuth: %w", err)
 			}
 
-			// 3. Create standard Kind cluster. Docker is pre-baked in the AWS e2e AMI;
-			//    NewKindCluster only wires the daemon and asserts compose presence.
-			kindCluster, err := kubeComp.NewKindCluster(&awsEnv, host, name,
-				awsEnv.KubernetesVersion(),
-				utils.PulumiDependsOn(installEcrCmd),
+			// 3. Start a harmless service on the VM so rshell can exercise a real
+			//    systemd manager without touching infrastructure-critical units.
+			service, err := host.OS.Runner().Command(
+				awsEnv.CommonNamer().ResourceName("system-service-fixture"),
+				&command.Args{
+					Create: pulumi.String("systemd-run --unit=" + systemServiceFixture + " /bin/sleep infinity"),
+					Delete: pulumi.String("systemctl stop " + systemServiceFixture),
+					Sudo:   true,
+				},
 			)
 			if err != nil {
-				return fmt.Errorf("kubeComp.NewKindCluster: %w", err)
+				return fmt.Errorf("create system service fixture: %w", err)
+			}
+
+			// 4. Create a Kind cluster and bridge the VM's systemd identity and
+			//    manager bus into its node for the PAR pod's hostPath mounts.
+			kindCluster, err := kubeComp.NewKindClusterWithConfig(&awsEnv, host, name,
+				awsEnv.KubernetesVersion(),
+				kubeComp.KindConfigFlags{
+					ExtraMounts: []kubeComp.KindExtraMount{
+						{
+							HostPath:      "/etc/machine-id",
+							ContainerPath: hostMachineIDPath,
+							ReadOnly:      true,
+						},
+						{
+							HostPath:      "/run/dbus/system_bus_socket",
+							ContainerPath: hostSystemBusSocketPath,
+							ReadOnly:      true,
+						},
+					},
+				},
+				utils.PulumiDependsOn(installEcrCmd, service),
+			)
+			if err != nil {
+				return fmt.Errorf("kubeComp.NewKindClusterWithConfig: %w", err)
 			}
 			if err = kindCluster.Export(ctx, &env.KubernetesCluster.ClusterOutput); err != nil {
 				return fmt.Errorf("kindCluster.Export: %w", err)
@@ -110,7 +161,7 @@ func parK8sProvisioner(runnerURN, privateKeyB64 string) provisioners.Provisioner
 				return fmt.Errorf("kubernetes.NewProvider: %w", err)
 			}
 
-			// 4. Plant test data file on the Kind node (accessible to PAR at /host/var/log/)
+			// 5. Plant test data file on the Kind node (accessible to PAR at /host/var/log/)
 			_, err = host.OS.Runner().Command(
 				awsEnv.CommonNamer().ResourceName("plant-testdata"),
 				&command.Args{
@@ -125,12 +176,22 @@ func parK8sProvisioner(runnerURN, privateKeyB64 string) provisioners.Provisioner
 				return fmt.Errorf("plant testdata: %w", err)
 			}
 
-			// 5. Deploy Datadog agent via Helm with PAR enabled.
+			// 6. Deploy Datadog agent via Helm with PAR enabled.
 			// DD_DD_URL and DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION for the PAR container are
 			// injected automatically by the e2e framework's configureFakeintake.
 			agent, err := helm.NewKubernetesAgent(&awsEnv, name, kubeProvider,
 				kubernetesagentparams.WithFakeintake(fi),
-				kubernetesagentparams.WithHelmValues(fmt.Sprintf(parHelmValuesTemplate, ctx.Stack(), runnerURN, privateKeyB64)),
+				kubernetesagentparams.WithHelmValues(fmt.Sprintf(
+					parHelmValuesTemplate,
+					ctx.Stack(),
+					runnerURN,
+					privateKeyB64,
+					systemServiceOperatorGrant,
+					hostMachineIDPath,
+					hostSystemBusSocketPath,
+					hostMachineIDPath,
+					hostSystemBusSocketPath,
+				)),
 				kubernetesagentparams.WithClusterName(kindCluster.ClusterName),
 				kubernetesagentparams.WithTags([]string{"stackid:" + ctx.Stack()}),
 				kubernetesagentparams.WithHelmChartVersion(minHelmChartVersion),

--- a/test/new-e2e/tests/privateactionrunner/rshell_k8s_test.go
+++ b/test/new-e2e/tests/privateactionrunner/rshell_k8s_test.go
@@ -160,6 +160,46 @@ func (s *parK8sSuite) TestRshellRunCommandBlocksWrite() {
 	assert.NotEqual(s.T(), 0, rshellExitCode(result), "read-only runCommand must reject file-target redirections")
 }
 
+// TestRshellSystemServicePolicy verifies the signed backend grant reaches a
+// deployed PAR and is narrowed by the operator's service policy before rshell
+// talks to the VM's real systemd manager.
+func (s *parK8sSuite) TestRshellSystemServicePolicy() {
+	systemServices := map[string]interface{}{
+		systemServiceFixture: []string{"read", "restart"},
+	}
+
+	readTaskID := uuid.New().String()
+	err := s.Env().FakeIntake.Client().EnqueuePARTask(readTaskID, runRemediationCommandAction, map[string]interface{}{
+		"command":         "systemctl status " + systemServiceFixture,
+		"allowedCommands": []string{"rshell:systemctl"},
+		"systemServices":  systemServices,
+	})
+	s.Require().NoError(err)
+
+	readResult := s.pollResult(readTaskID, 2*time.Minute)
+	s.Require().Equal(0, rshellExitCode(readResult), "unexpected PAR rshell result: %+v", readResult)
+	assert.Contains(s.T(), readResult.Outputs["stdout"], systemServiceFixture)
+	assert.Contains(s.T(), readResult.Outputs["stdout"], "Active: active (running)")
+	assert.Empty(s.T(), readResult.Outputs["stderr"])
+
+	restartTaskID := uuid.New().String()
+	err = s.Env().FakeIntake.Client().EnqueuePARTask(restartTaskID, runRemediationCommandAction, map[string]interface{}{
+		"command":         "systemctl restart " + systemServiceFixture,
+		"allowedCommands": []string{"rshell:systemctl"},
+		"systemServices":  systemServices,
+	})
+	s.Require().NoError(err)
+
+	restartResult := s.pollResult(restartTaskID, 2*time.Minute)
+	assert.Equal(s.T(), 1, rshellExitCode(restartResult), "operator policy must deny restart")
+	assert.Empty(s.T(), restartResult.Outputs["stdout"])
+	assert.Equal(
+		s.T(),
+		"systemctl: system service \""+systemServiceFixture+"\" is not allowed for action \"restart\"\n",
+		restartResult.Outputs["stderr"],
+	)
+}
+
 // --- helpers ---
 
 func (s *parK8sSuite) pollResult(taskID string, timeout time.Duration) *api.PARTaskResult {


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Configures rshell to use the host-mounted systemd machine ID and manager bus when Private Action Runner is containerized, while preserving local defaults when the mounts are unavailable.

It also adds environment-backed coverage to the existing Kind-on-EC2 PAR suite. The provisioner starts a harmless transient service on the VM, bridges the real systemd endpoints through Kind into PAR, and verifies that:

- an allowed `systemctl status` reaches the real service manager; and
- a backend-granted `systemctl restart` is denied after intersection with the operator's read-only policy.

### Motivation

This follows up on review feedback from #53879. Existing tests covered serialization and policy intersection while executing unrelated commands, so regressions in the real systemd connection, required host mounts, or deployment environment would not have been detected.

### Describe how you validated your changes

- `dda inv test --targets=./pkg/privateactionrunner/bundles/remoteaction/rshell`
- `dda inv test --module=test/e2e-framework --targets=./components/kubernetes`
- `dda inv test --module=test/new-e2e --targets=./tests/privateactionrunner --test-run-name='^$'`
- Focused Go linting for all three changed packages
- Helm rendering with chart `3.197.2`
- `git diff --check`

The live environment-backed test needs an Agent image built from this commit, so it was not run against the predecessor branch's stale image. The draft pipeline can provide the matching image.

### Additional Notes

This PR is stacked on #53879 and should be retargeted to `main` after that PR merges. The predecessor already contains the release note for this unreleased feature.
