### PR TITLE
fix(otel-metrics): handle bucketless duration histograms in CreateDDSketchFromHistogramOfDuration

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/metrics/histograms.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/histograms.go
@@ -72,6 +72,22 @@ func CreateDDSketchFromHistogramOfDuration(dp *pmetric.HistogramDataPoint, unit 
 	bucketCounts := dp.BucketCounts()
 	explicitBounds := dp.ExplicitBounds()
 
+	// A histogram without buckets conveys its population via only sum and count (OTLP
+	// spec) and is interpreted as a single bucket covering (-Inf, +Inf); synthesize it.
+	if bucketCounts.Len() == 0 {
+		bucketCounts = pcommon.NewUInt64Slice()
+		explicitBounds = pcommon.NewFloat64Slice()
+		if dp.HasMin() {
+			bucketCounts.Append(0)
+			explicitBounds.Append(dp.Min())
+		}
+		bucketCounts.Append(dp.Count())
+		if dp.HasMax() {
+			bucketCounts.Append(0)
+			explicitBounds.Append(dp.Max())
+		}
+	}
+
 	if bucketCounts.Len() != explicitBounds.Len()+1 {
 		return nil, errors.New("bucket counts length does not match explicit bounds length")
 	}

--- a/pkg/opentelemetry-mapping-go/otlp/metrics/histograms_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/metrics/histograms_test.go
@@ -507,6 +507,20 @@ func TestCreateDDSketchFromHistogramOfDuration_Nil(t *testing.T) {
 	assert.Equal(t, 0.0, sketch.GetZeroCount())
 }
 
+// OTLP allows a histogram to omit buckets and report only sum/count; it must still
+// convert instead of erroring on the bucketCounts/explicitBounds length mismatch.
+func TestCreateDDSketchFromHistogramOfDuration_NoBuckets(t *testing.T) {
+	dp := pmetric.NewHistogramDataPoint()
+	dp.SetCount(10)
+	dp.SetSum(50)
+	dp.SetMin(1)
+	dp.SetMax(9)
+
+	sketch, err := CreateDDSketchFromHistogramOfDuration(&dp, "ms")
+	require.NoError(t, err)
+	assert.Equal(t, float64(10), sketch.GetCount())
+}
+
 func TestCreateDDSketchFromExponentialHistogramOfDuration(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary
- OTLP allows a histogram to report only sum/count and omit buckets entirely (interpreted as a single bucket covering (-Inf, +Inf)). `CreateDDSketchFromHistogramOfDuration` rejected this shape with a bucket/bounds length mismatch error instead of converting it.
- `default_mapper.go`'s `getSketchBuckets` already synthesizes a single bucket for this exact OTLP case; this mirrors that same handling in `CreateDDSketchFromHistogramOfDuration`.
- Found via a codex review comment on #53167 while adding a new caller of this function; splitting the fix into its own PR to keep that one scoped to its feature.

## Test plan
- [x] `go test ./pkg/opentelemetry-mapping-go/otlp/metrics/...`
- [x] New regression test: `TestCreateDDSketchFromHistogramOfDuration_NoBuckets`