### PR TITLE
[NDM-INT] Back off before retrying rate-limited requests

### DIFF
--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request.go
@@ -22,6 +22,10 @@ const (
 	baseRetryBackoff = 1 * time.Second
 	// maxRetryBackoff caps the wait between retries
 	maxRetryBackoff = 30 * time.Second
+	// maxBackoffShift caps the exponent so baseRetryBackoff << attempt cannot
+	// overflow time.Duration for large max_attempts; the wait is bounded by
+	// maxRetryBackoff well before this.
+	maxBackoffShift = 8
 )
 
 var sleep = time.Sleep
@@ -123,6 +127,10 @@ func backoffDuration(attempt int, header http.Header) time.Duration {
 		return retryAfter
 	}
 
+	// Clamp the exponent before shifting so it can't overflow time.Duration
+	if attempt > maxBackoffShift {
+		return maxRetryBackoff
+	}
 	backoff := baseRetryBackoff << attempt
 	if backoff > maxRetryBackoff {
 		return maxRetryBackoff

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request.go
@@ -11,9 +11,20 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+const (
+	// baseRetryBackoff is the initial wait before retrying a rate-limited request
+	baseRetryBackoff = 1 * time.Second
+	// maxRetryBackoff caps the wait between retries
+	maxRetryBackoff = 30 * time.Second
+)
+
+var sleep = time.Sleep
 
 // newRequest creates a new request for this client.
 func (client *Client) newRequest(method, uri string, body io.Reader) (*http.Request, error) {
@@ -21,7 +32,7 @@ func (client *Client) newRequest(method, uri string, body io.Reader) (*http.Requ
 }
 
 // do exec a request with authentication
-func (client *Client) do(req *http.Request) ([]byte, int, error) {
+func (client *Client) do(req *http.Request) ([]byte, int, http.Header, error) {
 	// Cross-forgery token
 	client.authenticationMutex.Lock()
 	req.Header.Add("X-XSRF-TOKEN", client.token)
@@ -30,7 +41,7 @@ func (client *Client) do(req *http.Request) ([]byte, int, error) {
 	log.Tracef("Executing cisco sd-wan api request %s %s", req.Method, req.URL.Path)
 	resp, err := client.httpClient.Do(req)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 	log.Tracef("Executed cisco sd-wan api request %d %s %s", resp.StatusCode, req.Method, req.URL.Path)
 
@@ -41,15 +52,15 @@ func (client *Client) do(req *http.Request) ([]byte, int, error) {
 		// clear auth to trigger re-authentication
 		client.clearAuth()
 		// Return 401 on auth errors
-		return nil, 401, nil
+		return nil, 401, nil, nil
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, resp.StatusCode, err
+		return nil, resp.StatusCode, resp.Header, err
 	}
 
-	return body, resp.StatusCode, nil
+	return body, resp.StatusCode, resp.Header, nil
 }
 
 // get executes a GET request to the given endpoint with the given query params
@@ -67,6 +78,7 @@ func (client *Client) get(endpoint string, params map[string]string) ([]byte, er
 
 	var bytes []byte
 	var statusCode int
+	var header http.Header
 
 	for attempts := 0; attempts < client.maxAttempts; attempts++ {
 		err = client.authenticate()
@@ -74,15 +86,64 @@ func (client *Client) get(endpoint string, params map[string]string) ([]byte, er
 			return nil, err
 		}
 
-		bytes, statusCode, err = client.do(req)
+		bytes, statusCode, header, err = client.do(req)
 
 		if err == nil && isValidStatusCode(statusCode) {
 			// Got a valid response, stop retrying
 			return bytes, nil
 		}
+
+		// On transient failures, wait before retrying (honor Retry-After, otherwise exponential backoff)
+		if isRetryable(statusCode, err) && attempts < client.maxAttempts-1 {
+			wait := backoffDuration(attempts, header)
+			log.Debugf("Cisco sd-wan api transient failure on %s (status %d), retrying in %s", endpoint, statusCode, wait)
+			sleep(wait)
+		}
 	}
 
 	return nil, fmt.Errorf("%s http responded with %d code", endpoint, statusCode)
+}
+
+// isRetryable reports whether a failed request is worth waiting on and retrying:
+// network errors, rate-limiting (429) and transient server errors (5xx). Auth
+// failures (401) are excluded as they trigger immediate re-authentication.
+func isRetryable(statusCode int, err error) bool {
+	if err != nil {
+		return true
+	}
+	return statusCode == http.StatusTooManyRequests || statusCode >= 500
+}
+
+// backoffDuration returns how long to wait before retrying a rate-limited request
+func backoffDuration(attempt int, header http.Header) time.Duration {
+	if retryAfter := parseRetryAfter(header); retryAfter > 0 {
+		if retryAfter > maxRetryBackoff {
+			return maxRetryBackoff
+		}
+		return retryAfter
+	}
+
+	backoff := baseRetryBackoff << attempt
+	if backoff > maxRetryBackoff {
+		return maxRetryBackoff
+	}
+	return backoff
+}
+
+// parseRetryAfter parses the Retry-After header, which may be a number of seconds or
+// an HTTP date. It returns 0 when the header is absent or invalid.
+func parseRetryAfter(header http.Header) time.Duration {
+	value := header.Get("Retry-After")
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		return time.Duration(seconds) * time.Second
+	}
+	if date, err := http.ParseTime(value); err == nil {
+		return date.Sub(timeNow())
+	}
+	return 0
 }
 
 // get wraps client.get with generic type content and unmarshalling (methods can't use generics)

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request_test.go
@@ -7,9 +7,11 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -89,7 +91,7 @@ func TestDoRequest(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://"+serverURL(server)+"/test", nil)
 	require.NoError(t, err)
 
-	body, statusCode, err := client.do(req)
+	body, statusCode, _, err := client.do(req)
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, statusCode)
@@ -121,7 +123,7 @@ func TestDoRequestBadRequest(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://"+serverURL(server)+"/test", nil)
 	require.NoError(t, err)
 
-	body, statusCode, err := client.do(req)
+	body, statusCode, _, err := client.do(req)
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, statusCode)
@@ -154,7 +156,7 @@ func TestDoRequestError(t *testing.T) {
 	req, err := http.NewRequest("GET", "", nil)
 	require.NoError(t, err)
 
-	body, statusCode, err := client.do(req)
+	body, statusCode, _, err := client.do(req)
 
 	require.ErrorContains(t, err, "unsupported protocol scheme")
 	require.Equal(t, 0, statusCode)
@@ -218,6 +220,44 @@ func TestGetRequestRetries(t *testing.T) {
 	require.ErrorContains(t, err, "http responded with 400 code")
 	require.Equal(t, []byte(nil), resp)
 	require.Equal(t, 10, handler.numberOfCalls())
+}
+
+func TestGetRequestRetriesOn429(t *testing.T) {
+	var waits []time.Duration
+	originalSleep := sleep
+	sleep = func(d time.Duration) { waits = append(waits, d) }
+	defer func() { sleep = originalSleep }()
+
+	mux := setupCommonServerMux()
+	handler := newHandler(func(w http.ResponseWriter, _ *http.Request, calls int32) {
+		w.Header().Set("Content-Type", "application/json")
+		// Rate-limit the first two attempts, then succeed
+		if calls < 3 {
+			w.Header().Set("Retry-After", "2")
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte("rate limited"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	mux.HandleFunc("/test", handler.Func)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, err := testClient(server)
+	require.NoError(t, err)
+
+	client.maxAttempts = 5
+
+	resp, err := client.get("/test", nil)
+	require.NoError(t, err)
+	require.Equal(t, []byte("ok"), resp)
+	require.Equal(t, 3, handler.numberOfCalls())
+	// Honored Retry-After (2s) before each of the two retries
+	require.Equal(t, []time.Duration{2 * time.Second, 2 * time.Second}, waits)
 }
 
 func TestGetRequestUnmarshalling(t *testing.T) {
@@ -469,6 +509,28 @@ func TestGetNextPaginationParams(t *testing.T) {
 				require.ErrorContains(t, err, tt.expectedError)
 			}
 			require.Equal(t, tt.expectedParams, nextParams)
+		})
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		err        error
+		retryable  bool
+	}{
+		{name: "network error", statusCode: 0, err: errors.New("connection reset"), retryable: true},
+		{name: "rate limited", statusCode: http.StatusTooManyRequests, retryable: true},
+		{name: "server error", statusCode: http.StatusServiceUnavailable, retryable: true},
+		{name: "auth failure", statusCode: http.StatusUnauthorized, retryable: false},
+		{name: "bad request", statusCode: http.StatusBadRequest, retryable: false},
+		{name: "success", statusCode: http.StatusOK, retryable: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.retryable, isRetryable(tt.statusCode, tt.err))
 		})
 	}
 }

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/request_test.go
@@ -535,6 +535,13 @@ func TestIsRetryable(t *testing.T) {
 	}
 }
 
+func TestBackoffDuration(t *testing.T) {
+	// baseline exponential
+	require.Equal(t, 2*time.Second, backoffDuration(1, http.Header{}))
+	// high attempt must saturate, not overflow to a non-positive wait
+	require.Equal(t, maxRetryBackoff, backoffDuration(40, http.Header{}))
+}
+
 func TestIsValidStatusCode(t *testing.T) {
 	tests := []struct {
 		code    int


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Adds backoff before retrying failed Cisco SD-WAN API requests.

Previously, the agent retried failed requests with no delay. On an HTTP 429 response, it immediately retried, was rate-limited again, and eventually dropped the cycle's data after exhausting all retry attempts.

Retries now wait before retrying transient failures (HTTP 429, 5xx responses, and network errors). Authentication failures  continue to retry immediately because they trigger re-authentication.

### Motivation
A large deployments for SD-WAN were hitting vManage API rate limits and silently losing metrics for the affected collection cycle. 

This change only recovers from rate limiting. Sustained rate limiting still requires tuning the collection (max_pages, min_collection_interval, etc) or increasing the vManage API rate limit.

### Describe how you validated your changes

### Additional Notes
