### PR TITLE
fix(fleet/installer/env): isolate TestFromEnv from ambient proxy env vars

### DIFF
--- a/pkg/fleet/installer/env/env_test.go
+++ b/pkg/fleet/installer/env/env_test.go
@@ -44,7 +44,7 @@ func TestFromEnv(t *testing.T) {
 				Hostname:   "",
 				HTTPProxy:  "",
 				HTTPSProxy: "",
-				NoProxy:    os.Getenv("NO_PROXY"), // Default value from the environment, as some test envs set it
+				NoProxy:    "",
 			},
 		},
 		{
@@ -174,8 +174,7 @@ func TestFromEnv(t *testing.T) {
 				InstallScript: InstallScriptEnv{
 					APMInstrumentationEnabled: APMInstrumentationNotSet,
 				},
-				Tags:    []string{},
-				NoProxy: os.Getenv("NO_PROXY"), // Default value from the environment, as some test envs set it
+				Tags: []string{},
 			},
 		},
 		{
@@ -205,16 +204,21 @@ func TestFromEnv(t *testing.T) {
 				DefaultPackagesVersionOverride: map[string]string{},
 				Tags:                           []string{},
 				Hostname:                       "",
-				NoProxy:                        os.Getenv("NO_PROXY"), // Default value from the environment, as some test envs set it
 			},
 		},
+	}
+
+	// Some CI runners inject an egress-proxy sidecar that sets these (and their
+	// lowercase forms, which getProxySetting also falls back to) in the pod
+	// environment; clear them so the ambient environment can't leak into expectations.
+	for _, key := range []string{envHTTPProxy, envHTTPSProxy, envNoProxy, "http_proxy", "https_proxy", "no_proxy"} {
+		t.Setenv(key, "")
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for key, value := range tt.envVars {
-				os.Setenv(key, value)
-				defer os.Unsetenv(key)
+				t.Setenv(key, value)
 			}
 			tt.expected.FIPSMode = pkgfips.BuiltForFIPS()
 			result := FromEnv()


### PR DESCRIPTION
## Summary
- CI runner pods with an egress-gateway sidecar inject `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` (and lowercase variants) into the pod environment, which leaked into `TestFromEnv`'s expectations and caused deterministic failures on affected runners (e.g. `dogstatsd`, `heroku`, `iot` unit-test flavors), on subtests `Empty environment variables`, `APM libraries parsing`, `deprecated apm lang`.
- `TestFromEnv` now clears these proxy env vars via `t.Setenv` before running subtests, and per-subtest env vars are also set with `t.Setenv` (auto-restoring) instead of `os.Setenv`/`defer os.Unsetenv`, so isolation holds even if a future subtest sets one of these keys.

## Test plan
- [x] `dda inv test --targets=./pkg/fleet/installer/env` passes
- [x] Reproduced the original failure by exporting `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` (including lowercase forms) before running the tests; confirmed they pass with this fix and fail without it