### PR TITLE
Dont require the go fmt binary in codegen, fix bazel support

### DIFF
--- a/tasks/schema/codegen_init_settings.py
+++ b/tasks/schema/codegen_init_settings.py
@@ -1,8 +1,6 @@
 import ast
 import os
 import re
-import subprocess
-import sys
 
 file_header = """// Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.

--- a/tasks/schema/codegen_init_settings.py
+++ b/tasks/schema/codegen_init_settings.py
@@ -217,7 +217,7 @@ class CodeGeneratorTarget:
             print('Output %s' % filename)
             out_filename = os.path.join(out_dir, filename)
             with open(out_filename, "w") as f:
-                f.write(gofmt('\n'.join(self.filesystem[filename])))
+                f.write('\n'.join(self.filesystem[filename]))
 
 
 def join_key(prefix, field):
@@ -391,7 +391,7 @@ def as_go_value(text, split_lines=False):
             res.append(f"{key}: {val}")
 
     if split_lines:
-        return f"{{\n{',\n '.join(res)},\n}}"
+        return f"{{\n\t\t{',\n\t\t'.join(res)},\n\t}}"
     return f"{{{', '.join(res)}}}"
 
 
@@ -851,24 +851,7 @@ def run_constant_codegen(core_schema, system_probe_schema, outsource_dir):
         print('Output %s' % filename)
         out_filename = os.path.join(outsource_dir, filename)
         with open(out_filename, "w") as f:
-            f.write(gofmt('\n'.join(sourcecode)))
-
-
-def gofmt(source):
-    """
-    Format Go source code with gofmt and return the result.
-    """
-    try:
-        return subprocess.run(
-            ["gofmt"],
-            input=source,
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout
-    except subprocess.CalledProcessError as e:
-        print(e.stderr)
-        sys.exit(1)
+            f.write('\n'.join(sourcecode))
 
 
 def run_codegen(schema, filename_filter, hints, keep_orig_order, outsource_dir):

--- a/tasks/schema/codegen_init_settings.py
+++ b/tasks/schema/codegen_init_settings.py
@@ -19,42 +19,40 @@ constant_header = """//
 //
 """
 
-core_agent_stubs = """
-func agent(config pkgconfigmodel.Setup) {
-    initEverything(config)
+core_agent_stubs = """func agent(config pkgconfigmodel.Setup) {
+	initEverything(config)
 }
 
-func aggregator(_ pkgconfigmodel.Setup) {}
-func anomalyDetection(_ pkgconfigmodel.Setup) {}
-func autoconfig(_ pkgconfigmodel.Setup) {}
-func autoscaling(_ pkgconfigmodel.Setup) {}
-func cloudfoundry(_ pkgconfigmodel.Setup) {}
-func containerd(_ pkgconfigmodel.Setup) {}
-func containerSyspath(_ pkgconfigmodel.Setup) {}
-func cri(_ pkgconfigmodel.Setup) {}
-func debugging(_ pkgconfigmodel.Setup) {}
-func dogstatsd(_ pkgconfigmodel.Setup) {}
-func fips(_ pkgconfigmodel.Setup) {}
-func fleet(_ pkgconfigmodel.Setup) {}
-func forwarder(_ pkgconfigmodel.Setup) {}
-func kubernetes(_ pkgconfigmodel.Setup) {}
-func logsagent(_ pkgconfigmodel.Setup) {}
-func OTLP(_ pkgconfigmodel.Setup) {}
-func podman(_ pkgconfigmodel.Setup) {}
-func remoteconfig(_ pkgconfigmodel.Setup) {}
-func remoteflags(_ pkgconfigmodel.Setup) {}
-func serializer(_ pkgconfigmodel.Setup) {}
-func serverless(_ pkgconfigmodel.Setup) {}
-func setupAPM(_ pkgconfigmodel.Setup) {}
+func aggregator(_ pkgconfigmodel.Setup)               {}
+func anomalyDetection(_ pkgconfigmodel.Setup)         {}
+func autoconfig(_ pkgconfigmodel.Setup)               {}
+func autoscaling(_ pkgconfigmodel.Setup)              {}
+func cloudfoundry(_ pkgconfigmodel.Setup)             {}
+func containerd(_ pkgconfigmodel.Setup)               {}
+func containerSyspath(_ pkgconfigmodel.Setup)         {}
+func cri(_ pkgconfigmodel.Setup)                      {}
+func debugging(_ pkgconfigmodel.Setup)                {}
+func dogstatsd(_ pkgconfigmodel.Setup)                {}
+func fips(_ pkgconfigmodel.Setup)                     {}
+func fleet(_ pkgconfigmodel.Setup)                    {}
+func forwarder(_ pkgconfigmodel.Setup)                {}
+func kubernetes(_ pkgconfigmodel.Setup)               {}
+func logsagent(_ pkgconfigmodel.Setup)                {}
+func OTLP(_ pkgconfigmodel.Setup)                     {}
+func podman(_ pkgconfigmodel.Setup)                   {}
+func remoteconfig(_ pkgconfigmodel.Setup)             {}
+func remoteflags(_ pkgconfigmodel.Setup)              {}
+func serializer(_ pkgconfigmodel.Setup)               {}
+func serverless(_ pkgconfigmodel.Setup)               {}
+func setupAPM(_ pkgconfigmodel.Setup)                 {}
 func setupMultiRegionFailover(_ pkgconfigmodel.Setup) {}
 func setupPrivateActionRunner(_ pkgconfigmodel.Setup) {}
-func setupProcesses(_ pkgconfigmodel.Setup) {}
-func telemetry(_ pkgconfigmodel.Setup) {}
-func vector(_ pkgconfigmodel.Setup) {}
+func setupProcesses(_ pkgconfigmodel.Setup)           {}
+func telemetry(_ pkgconfigmodel.Setup)                {}
+func vector(_ pkgconfigmodel.Setup)                   {}
 """
 
-sysprobe_stubs = """
-func initCWSSystemProbeConfig(_ pkgconfigmodel.Setup) {}
+sysprobe_stubs = """func initCWSSystemProbeConfig(_ pkgconfigmodel.Setup) {}
 func initUSMSystemProbeConfig(_ pkgconfigmodel.Setup) {}
 """
 
@@ -217,7 +215,7 @@ class CodeGeneratorTarget:
             print('Output %s' % filename)
             out_filename = os.path.join(out_dir, filename)
             with open(out_filename, "w") as f:
-                f.write('\n'.join(self.filesystem[filename]))
+                f.write('\n'.join(self.filesystem[filename]) + '\n')
 
 
 def join_key(prefix, field):
@@ -385,14 +383,29 @@ def as_go_value(text, split_lines=False):
         for elem in obj:
             res.append(value_to_gostr(elem))
     else:  # assume dict/map
+        indent_size = calc_indent_size(obj)
         for k, v in obj.items():
             key = value_to_gostr(k)
             val = value_to_gostr(v)
-            res.append(f"{key}: {val}")
+            pad_space = calc_pad_space(key, indent_size)
+            res.append(f"{key}:{' '*pad_space} {val}")
 
     if split_lines:
         return f"{{\n\t\t{',\n\t\t'.join(res)},\n\t}}"
     return f"{{{', '.join(res)}}}"
+
+
+def calc_indent_size(obj):
+    max_size = 0
+    for k in obj.keys():
+        key = value_to_gostr(k)
+        if len(key) > max_size:
+            max_size = len(key)
+    return max_size
+
+
+def calc_pad_space(lhs, indent_size):
+    return max(indent_size - len(lhs), 0)
 
 
 def get_golang_type_tag(curr):
@@ -729,16 +742,15 @@ def gen_delegated_auth_map(core_schema, system_probe_schema, core_out, system_pr
         return keys
 
     def emit(out, keys):
-        out.append("""
-            type delegatedAuthConfig struct {
-              apiKeyPath        string
-              delegatedAuthPath string
-              description       string
-            }
+        out.append("""type delegatedAuthConfig struct {
+	apiKeyPath        string
+	delegatedAuthPath string
+	description       string
+}
 
-            // delegatedAuthKeys list all the \"delegated_auth\" configuration section.
-            // This list is used to fully initialize authentication through cloud provider instead of API key
-            var delegatedAuthKeys = []delegatedAuthConfig{""")
+// delegatedAuthKeys list all the \"delegated_auth\" configuration section.
+// This list is used to fully initialize authentication through cloud provider instead of API key
+var delegatedAuthKeys = []delegatedAuthConfig{""")
 
         for key in keys:
             parent_section_name = key.rsplit(".")[0]
@@ -749,12 +761,11 @@ def gen_delegated_auth_map(core_schema, system_probe_schema, core_out, system_pr
             if parent_section_name == "":
                 parent_section_name = "global"
 
-            out.append(f"""
-                {{
-                  apiKeyPath: "{parent_section}api_key",
-                  delegatedAuthPath : "{parent_section}delegated_auth",
-                  description: "{parent_section_name}",
-                }},""")
+            out.append(f"""	{{
+		apiKeyPath:        "{parent_section}api_key",
+		delegatedAuthPath: "{parent_section}delegated_auth",
+		description:       "{parent_section_name}",
+	}},""")
         out.append("}")
         out.append("")
 
@@ -811,8 +822,10 @@ def gen_generate_const(core_schema, system_probe_schema, core_out, system_probe_
     core_out.append("// Constants generated from settings tagged with a `generate_const:<name>` label.")
     core_out.append("// Each constant's value is the default of its associated setting.")
     core_out.append("const (")
+    magic_value = calc_const_indent(consts)
     for name in sorted(consts):
-        core_out.append(f"\t{name} = {consts[name]['value']}")
+        pad_space = magic_value - len(name)
+        core_out.append(f"\t{name}{' '*pad_space} = {consts[name]['value']}")
     core_out.append(")")
     core_out.append("")
 
@@ -824,6 +837,14 @@ constant_generators = [
     gen_delegated_auth_map,
     gen_generate_const,
 ]
+
+
+def calc_const_indent(list_names):
+    max_size = 0
+    for name in list_names:
+        if len(name) > max_size:
+            max_size = len(name)
+    return max_size
 
 
 def run_constant_codegen(core_schema, system_probe_schema, outsource_dir):

--- a/tasks/unit_tests/schema_codegen_tests.py
+++ b/tasks/unit_tests/schema_codegen_tests.py
@@ -1,5 +1,6 @@
 import filecmp
 import os
+import re
 import shutil
 import tempfile
 import unittest
@@ -83,7 +84,7 @@ class TestCodegenInitSettings(unittest.TestCase):
                 "describe": "map with split lines",
                 "split_lines": True,
                 "input": "{'a': 'apple', 'b': 'banana'}",
-                "expect": "{\n\"a\": \"apple\",\n \"b\": \"banana\",\n}",
+                "expect": "{\n\t\t\"a\": \"apple\",\n\t\t\"b\": \"banana\",\n\t}",
             },
         ]
         for c in cases:
@@ -164,12 +165,13 @@ class TestGenerateConst(unittest.TestCase):
         codegen.gen_generate_const(core, sysprobe, core_out, sysprobe_out)
 
         src = '\n'.join(core_out)
+        # Remove white space added by codegen's formatter
+        contents = re.sub(' +', ' ', src)
         # DefaultSite is emitted exactly once despite three references, and the block is valid Go.
-        self.assertEqual(src.count('DefaultSite ='), 1)
-        self.assertIn('DefaultSecurityAgentCmdPort = 5010', src)
-        self.assertIn('DefaultSite = "datadoghq.com"', src)
+        self.assertEqual(contents.count('DefaultSite ='), 1)
+        self.assertIn('DefaultSecurityAgentCmdPort = 5010', contents)
+        self.assertIn('DefaultSite = "datadoghq.com"', contents)
         self.assertEqual(sysprobe_out, [])
-        codegen.gofmt('package setup\n' + src)  # must be gofmt-able (valid Go)
 
     def test_conflicting_defaults_raise(self):
         # Same constant tagged on two settings with different defaults must fail codegen.

--- a/tasks/unit_tests/testdata/schema_codegen/basic_full_agent_settings.gen
+++ b/tasks/unit_tests/testdata/schema_codegen/basic_full_agent_settings.gen
@@ -12,6 +12,7 @@ import (
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
+
 func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("my_setting", "abc")
 }

--- a/tasks/unit_tests/testdata/schema_codegen/basic_settings.gen
+++ b/tasks/unit_tests/testdata/schema_codegen/basic_settings.gen
@@ -12,6 +12,7 @@ import (
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
+
 func initCoreAgentFull(config pkgconfigmodel.Setup) {
 }
 


### PR DESCRIPTION
### What does this PR do?

Remove the requirement of the `go fmt` binary in the schema codegen. Instead, have each step of generation output the correct indention, which is relatively straight-forward because the codegen output has no nesting.

### Motivation

Fixes blaze support.

### Describe how you validated your changes

Unit tests cover this.

### Additional Notes
