### PR TITLE
Revert "Revert "gohai: fall back to node IP for containerized agents without host networking""

### DIFF
--- a/comp/metadata/host/impl/host.go
+++ b/comp/metadata/host/impl/host.go
@@ -189,7 +189,7 @@ func (h *host) writePayloadAsJSON(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (h *host) writeGohaiPayload(w http.ResponseWriter, _ *http.Request) {
-	payload := gohai.GetPayloadWithProcesses(h.hostname, h.config.GetBool("metadata_ip_resolution_from_hostname"), env.IsContainerized())
+	payload := gohai.GetPayloadWithProcesses(h.hostname, h.config.GetBool("metadata_ip_resolution_from_hostname"), env.IsContainerized(), h.config.GetString("kubernetes_kubelet_host"))
 	jsonPayload, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
 		httputils.SetJSONError(w, h.log.Errorf("Unable to marshal gohai metadata payload: %s", err), 500)

--- a/comp/metadata/host/impl/payload.go
+++ b/comp/metadata/host/impl/payload.go
@@ -45,7 +45,7 @@ func (h *host) getPayload(ctx context.Context) *Payload {
 	}
 
 	if h.config.GetBool("enable_gohai") {
-		gohaiPayload, err := gohai.GetPayloadAsString(h.hostname, h.config.GetBool("metadata_ip_resolution_from_hostname"), env.IsContainerized())
+		gohaiPayload, err := gohai.GetPayloadAsString(h.hostname, h.config.GetBool("metadata_ip_resolution_from_hostname"), env.IsContainerized(), h.config.GetString("kubernetes_kubelet_host"))
 		if err != nil {
 			h.log.Errorf("Could not serialize gohai payload: %s", err)
 		} else {

--- a/pkg/gohai/gohai.go
+++ b/pkg/gohai/gohai.go
@@ -8,9 +8,11 @@
 package gohai
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/gohai/cpu"
 	"github.com/DataDog/datadog-agent/pkg/gohai/filesystem"
@@ -38,6 +40,51 @@ func detectDocker0() bool {
 	return docker0Detected
 }
 
+// fallbackHostLookupTimeout bounds the DNS resolution performed by
+// resolveFallbackHostIPv4. A broken or unreachable resolver for the configured
+// fallback host must only ever delay metadata collection briefly, never hang it
+// indefinitely.
+const fallbackHostLookupTimeout = 2 * time.Second
+
+// resolveFallbackHostIPv4 validates or resolves a fallback host value (e.g. the
+// kubernetes_kubelet_host config, which may be an IP literal or a hostname - see
+// pkg/util/kubernetes/kubelet/kubelet_hosts.go) into a usable IPv4 address string.
+// network.ipaddress is documented as an IPv4 address, so a raw, possibly-non-IP
+// config value must never be written there directly. Returns "" if no usable IPv4
+// address could be determined (including loopback, which is never a meaningful
+// node address here), logging why at debug level.
+func resolveFallbackHostIPv4(host string) string {
+	if host == "" {
+		return ""
+	}
+
+	// PreferGo forces Go's own resolver rather than the cgo resolver used by default
+	// on most platforms, which does not honor context cancellation/timeouts at all.
+	// If host is already an IP literal, LookupIPAddr returns it directly without
+	// performing any actual DNS query.
+	resolver := &net.Resolver{PreferGo: true}
+	ctx, cancel := context.WithTimeout(context.Background(), fallbackHostLookupTimeout)
+	defer cancel()
+
+	addrs, err := resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		log.Debugf("gohai: failed to resolve fallback host %q for network metadata: %s", host, err)
+		return ""
+	}
+
+	for _, addr := range addrs {
+		if addr.IP.IsLoopback() {
+			continue
+		}
+		if ip4 := addr.IP.To4(); ip4 != nil {
+			return ip4.String()
+		}
+	}
+
+	log.Debugf("gohai: fallback host %q did not resolve to a usable IPv4 address", host)
+	return ""
+}
+
 type gohai struct {
 	CPU        interface{} `json:"cpu"`
 	FileSystem interface{} `json:"filesystem"`
@@ -53,30 +100,35 @@ type Payload struct {
 }
 
 // GetPayload builds a payload of every metadata collected with gohai except processes metadata.
-func GetPayload(hostname string, useHostnameResolver, isContainerized bool) *Payload {
+// fallbackHost, when non-empty, is resolved and reported as the host's network IP if the
+// agent is containerized and running without host networking (see getGohaiInfo). It may be
+// an IP literal or a hostname (e.g. the kubernetes_kubelet_host config value).
+func GetPayload(hostname string, useHostnameResolver, isContainerized bool, fallbackHost string) *Payload {
 	return &Payload{
-		Gohai: getGohaiInfo(hostname, useHostnameResolver, isContainerized, false),
+		Gohai: getGohaiInfo(hostname, useHostnameResolver, isContainerized, false, fallbackHost),
 	}
 }
 
-// GetPayloadWithProcesses builds a pyaload of all metdata including processes
-func GetPayloadWithProcesses(hostname string, useHostnameResolver, isContainerized bool) *Payload {
+// GetPayloadWithProcesses builds a pyaload of all metdata including processes. See GetPayload
+// for the meaning of fallbackHost.
+func GetPayloadWithProcesses(hostname string, useHostnameResolver, isContainerized bool, fallbackHost string) *Payload {
 	return &Payload{
-		Gohai: getGohaiInfo(hostname, useHostnameResolver, isContainerized, true),
+		Gohai: getGohaiInfo(hostname, useHostnameResolver, isContainerized, true, fallbackHost),
 	}
 }
 
 // GetPayloadAsString marshals the gohai struct twice (to a string). This allows the gohai payload to be embedded as a
-// string in a JSON. This is required to mimic the metadata format inherited from Agent v5.
-func GetPayloadAsString(hostname string, useHostnameResolver, IsContainerized bool) (string, error) {
-	marshalledPayload, err := json.Marshal(getGohaiInfo(hostname, useHostnameResolver, IsContainerized, false))
+// string in a JSON. This is required to mimic the metadata format inherited from Agent v5. See GetPayload for the
+// meaning of fallbackHost.
+func GetPayloadAsString(hostname string, useHostnameResolver, isContainerized bool, fallbackHost string) (string, error) {
+	marshalledPayload, err := json.Marshal(getGohaiInfo(hostname, useHostnameResolver, isContainerized, false, fallbackHost))
 	if err != nil {
 		return "", err
 	}
 	return string(marshalledPayload), nil
 }
 
-func getGohaiInfo(hostname string, useHostnameResolver, isContainerized, withProcesses bool) *gohai {
+func getGohaiInfo(hostname string, useHostnameResolver, isContainerized, withProcesses bool, fallbackHost string) *gohai {
 	res := new(gohai)
 
 	cpuPayload, warns, err := cpu.CollectInfo().AsJSON()
@@ -142,6 +194,25 @@ func getGohaiInfo(hostname string, useHostnameResolver, isContainerized, withPro
 				log.Debug(warn)
 			}
 			log.Warnf("Failed to retrieve network metadata: %s", err)
+		}
+	} else if resolvedIP := resolveFallbackHostIPv4(fallbackHost); resolvedIP != "" {
+		// Containerized without a detectable docker0 bridge means we can't assume host
+		// networking, so net.Interfaces() would only see the container's own ephemeral
+		// network namespace (e.g. a pod IP that changes on reschedule), not a usable
+		// host-level target. Report the node's real IP instead, when the caller has one
+		// available (e.g. from the Kubernetes Downward API via kubernetes_kubelet_host).
+		fallbackInfo := &network.Info{
+			IPAddress:   resolvedIP,
+			IPAddressV6: utils.NewErrorValue[string](network.ErrAddressNotFound),
+		}
+		fallbackPayload, fallbackWarns, fallbackErr := fallbackInfo.AsJSON()
+		if fallbackErr == nil {
+			res.Network = fallbackPayload
+		} else {
+			for _, warn := range fallbackWarns {
+				log.Debug(warn)
+			}
+			log.Warnf("Failed to build fallback network metadata: %s", fallbackErr)
 		}
 	}
 

--- a/pkg/gohai/gohai_test.go
+++ b/pkg/gohai/gohai_test.go
@@ -12,14 +12,14 @@ import (
 )
 
 func TestGetPayload(t *testing.T) {
-	gohai := GetPayload("hostname", false, false)
+	gohai := GetPayload("hostname", false, false, "")
 	assert.NotNil(t, gohai.Gohai.CPU)
 	assert.NotNil(t, gohai.Gohai.FileSystem)
 	assert.NotNil(t, gohai.Gohai.Memory)
 	assert.NotNil(t, gohai.Gohai.Network)
 	assert.NotNil(t, gohai.Gohai.Platform)
 
-	gohai = GetPayload("hostname", true, false)
+	gohai = GetPayload("hostname", true, false, "")
 	assert.NotNil(t, gohai.Gohai.CPU)
 	assert.NotNil(t, gohai.Gohai.FileSystem)
 	assert.NotNil(t, gohai.Gohai.Memory)
@@ -35,19 +35,73 @@ func TestGetPayloadContainerized(t *testing.T) {
 	docker0Detected = false
 	defer func() { docker0Detected = oldDocker0Detected }()
 
-	gohai := GetPayload("hostname", false, true)
+	gohai := GetPayload("hostname", false, true, "")
 	assert.NotNil(t, gohai.Gohai.CPU)
 	assert.NotNil(t, gohai.Gohai.FileSystem)
 	assert.NotNil(t, gohai.Gohai.Memory)
 	assert.Nil(t, gohai.Gohai.Network)
 	assert.NotNil(t, gohai.Gohai.Platform)
 
-	gohai = GetPayload("hostname", true, true)
+	gohai = GetPayload("hostname", true, true, "")
 	assert.NotNil(t, gohai.Gohai.CPU)
 	assert.NotNil(t, gohai.Gohai.FileSystem)
 	assert.NotNil(t, gohai.Gohai.Memory)
 	assert.Nil(t, gohai.Gohai.Network)
 	assert.NotNil(t, gohai.Gohai.Platform)
+}
+
+func TestGetPayloadContainerizedWithFallbackHost(t *testing.T) {
+	t.Setenv("DOCKER_DD_AGENT", "true")
+
+	detectDocker0()
+	oldDocker0Detected := docker0Detected
+	docker0Detected = false
+	defer func() { docker0Detected = oldDocker0Detected }()
+
+	gohai := GetPayload("hostname", false, true, "10.0.1.23")
+	assert.NotNil(t, gohai.Gohai.CPU)
+	assert.NotNil(t, gohai.Gohai.FileSystem)
+	assert.NotNil(t, gohai.Gohai.Memory)
+	assert.NotNil(t, gohai.Gohai.Platform)
+
+	network, ok := gohai.Gohai.Network.(map[string]interface{})
+	assert.True(t, ok, "expected fallback network payload to be a map")
+	assert.Equal(t, "10.0.1.23", network["ipaddress"])
+}
+
+func TestGetPayloadContainerizedWithUnresolvableFallbackHost(t *testing.T) {
+	t.Setenv("DOCKER_DD_AGENT", "true")
+
+	detectDocker0()
+	oldDocker0Detected := docker0Detected
+	docker0Detected = false
+	defer func() { docker0Detected = oldDocker0Detected }()
+
+	// Neither a valid literal nor a resolvable hostname: must not be written into a
+	// field documented as an IPv4 address, and must not fall back to reporting nothing
+	// silently wrong either - Network should simply stay absent.
+	gohai := GetPayload("hostname", false, true, "this-hostname-does-not-resolve.invalid")
+	assert.Nil(t, gohai.Gohai.Network)
+}
+
+func TestResolveFallbackHostIPv4(t *testing.T) {
+	// valid IPv4 literal passes through unchanged
+	assert.Equal(t, "10.0.1.23", resolveFallbackHostIPv4("10.0.1.23"))
+
+	// loopback literal is rejected, even though it's a valid IPv4
+	assert.Equal(t, "", resolveFallbackHostIPv4("127.0.0.1"))
+
+	// IPv6 literal is rejected (network.ipaddress is documented as IPv4)
+	assert.Equal(t, "", resolveFallbackHostIPv4("2001:db8::1"))
+
+	// hostname that resolves to loopback (e.g. "localhost") is rejected
+	assert.Equal(t, "", resolveFallbackHostIPv4("localhost"))
+
+	// empty input is a no-op
+	assert.Equal(t, "", resolveFallbackHostIPv4(""))
+
+	// hostname that doesn't resolve at all is rejected, not passed through raw
+	assert.Equal(t, "", resolveFallbackHostIPv4("this-hostname-does-not-resolve.invalid"))
 }
 
 func TestGetPayloadContainerizedWithDocker0(t *testing.T) {
@@ -58,14 +112,14 @@ func TestGetPayloadContainerizedWithDocker0(t *testing.T) {
 	docker0Detected = true
 	defer func() { docker0Detected = oldDocker0Detected }()
 
-	gohai := GetPayload("hostname", false, false)
+	gohai := GetPayload("hostname", false, false, "")
 	assert.NotNil(t, gohai.Gohai.CPU)
 	assert.NotNil(t, gohai.Gohai.FileSystem)
 	assert.NotNil(t, gohai.Gohai.Memory)
 	assert.NotNil(t, gohai.Gohai.Network)
 	assert.NotNil(t, gohai.Gohai.Platform)
 
-	gohai = GetPayload("hostname", true, false)
+	gohai = GetPayload("hostname", true, false, "")
 	assert.NotNil(t, gohai.Gohai.CPU)
 	assert.NotNil(t, gohai.Gohai.FileSystem)
 	assert.NotNil(t, gohai.Gohai.Memory)

--- a/releasenotes/notes/report-fallback-host-ip-containerized-6c02c18d1fe71889.yaml
+++ b/releasenotes/notes/report-fallback-host-ip-containerized-6c02c18d1fe71889.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed missing network IP metadata for the Agent when running containerized
+    without host networking (the common case for most Kubernetes deployments).
+    Previously, network metadata collection was skipped entirely in this case.
+    The Agent now falls back to reporting the node's IP address, using the
+    existing ``kubernetes_kubelet_host`` configuration value.


### PR DESCRIPTION
Reverts DataDog/datadog-agent#54222

This was wrongfully reverted as part of [#incident-58496](https://dd.enterprise.slack.com/archives/C0BMP0LBLG0), we can now revert the revert