### PR TITLE
[Backport 7.81.x] Unset ambient proxy env vars in tests broken by fabric-proxy sidecar

### DIFF
--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -33,6 +33,20 @@ func (suite *ConfigTestSuite) SetupTest() {
 	configmock.New(suite.T())
 	suite.T().Setenv("DD_API_KEY", "")
 	suite.T().Setenv("DD_SITE", "")
+	// LoadProxyFromEnv treats a present-but-empty var as set, so these must be
+	// unset rather than set to "" - otherwise DD_PROXY_* short-circuits the
+	// HTTP_PROXY/HTTPS_PROXY/NO_PROXY fallback even when a test sets those.
+	// The lowercase variants are cleared too since LoadProxyFromEnv falls
+	// back to them when the uppercase ones aren't set.
+	os.Unsetenv("HTTP_PROXY")
+	os.Unsetenv("http_proxy")
+	os.Unsetenv("HTTPS_PROXY")
+	os.Unsetenv("https_proxy")
+	os.Unsetenv("NO_PROXY")
+	os.Unsetenv("no_proxy")
+	os.Unsetenv("DD_PROXY_HTTP")
+	os.Unsetenv("DD_PROXY_HTTPS")
+	os.Unsetenv("DD_PROXY_NO_PROXY")
 }
 
 func TestNoURIsProvided(t *testing.T) {

--- a/cmd/serverless-init/mode/initcontainer_mode_test.go
+++ b/cmd/serverless-init/mode/initcontainer_mode_test.go
@@ -109,6 +109,8 @@ func TestJavaTracerIsAutoInstrumented(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	fs.Create("/dd_tracer/java/")
 
+	t.Setenv("JAVA_TOOL_OPTIONS", "")
+
 	autoInstrumentTracer(fs)
 
 	assert.Equal(t, "-javaagent:/dd_tracer/java/dd-java-agent.jar", os.Getenv("JAVA_TOOL_OPTIONS"))

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/host_metadata_test.go
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/host_metadata_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -159,6 +160,16 @@ func createTestFactory(t *testing.T, serverAddr string) exporter.Factory {
 }
 
 func TestHostMetadata_FromTraces(t *testing.T) {
+	os.Unsetenv("HTTP_PROXY")
+	os.Unsetenv("http_proxy")
+	os.Unsetenv("HTTPS_PROXY")
+	os.Unsetenv("https_proxy")
+	os.Unsetenv("NO_PROXY")
+	os.Unsetenv("no_proxy")
+	os.Unsetenv("DD_PROXY_HTTP")
+	os.Unsetenv("DD_PROXY_HTTPS")
+	os.Unsetenv("DD_PROXY_NO_PROXY")
+
 	c := make(chan payload.HostMetadata)
 	server := createTestServer(t, c)
 	defer server.Close()

--- a/comp/trace/config/impl/config_test.go
+++ b/comp/trace/config/impl/config_test.go
@@ -566,6 +566,16 @@ func TestDisableLoggingConfig(t *testing.T) {
 }
 
 func TestFullYamlConfig(t *testing.T) {
+	os.Unsetenv("HTTP_PROXY")
+	os.Unsetenv("http_proxy")
+	os.Unsetenv("HTTPS_PROXY")
+	os.Unsetenv("https_proxy")
+	os.Unsetenv("NO_PROXY")
+	os.Unsetenv("no_proxy")
+	os.Unsetenv("DD_PROXY_HTTP")
+	os.Unsetenv("DD_PROXY_HTTPS")
+	os.Unsetenv("DD_PROXY_NO_PROXY")
+
 	config := buildConfigComponentFromYAML(t, true, "./testdata/full.yaml")
 	cfg := config.Object()
 

--- a/pkg/fleet/installer/env/env_test.go
+++ b/pkg/fleet/installer/env/env_test.go
@@ -13,6 +13,16 @@ import (
 )
 
 func TestFromEnv(t *testing.T) {
+	os.Unsetenv("HTTP_PROXY")
+	os.Unsetenv("http_proxy")
+	os.Unsetenv("HTTPS_PROXY")
+	os.Unsetenv("https_proxy")
+	os.Unsetenv("NO_PROXY")
+	os.Unsetenv("no_proxy")
+	os.Unsetenv("DD_PROXY_HTTP")
+	os.Unsetenv("DD_PROXY_HTTPS")
+	os.Unsetenv("DD_PROXY_NO_PROXY")
+
 	tests := []struct {
 		name     string
 		envVars  map[string]string


### PR DESCRIPTION
Backport 49c89a3cae261c281ea082a8ae1f4894ff190bc6 from #54207. Also includes https://github.com/DataDog/datadog-agent/commit/f6a64a0788f5e69ed28a55c686600b1dbe81e7ec from https://github.com/DataDog/datadog-agent/pull/54096.

----

Makes 4 tests hermetic to ambient
`HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY`/`DD_PROXY_*` environment variables by unsetting them before the test runs.

Fabric Egress Gateway injects `HTTP_PROXY`/`HTTPS_PROXY` into the job environment, which broke the non-Bazel tests jobs
(https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1903066118). Same class of issue as #54096.

- Ran tests locally with a dummy HTTP_PROXY set
- CI run with fast tests disabled so that this is hopefully the last PR for that kind of issue

This will become useless once we switch the tests to bazel since environment hermeticity is provided by default there

(cherry picked from commit 49c89a3cae261c281ea082a8ae1f4894ff190bc6)

<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
