### PR TITLE
Add pre-push hook validating CWS generated files are up to date

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -149,6 +149,14 @@ repos:
       language: system
       pass_filenames: false
       files: (.*go\.mod|modules\.yml|.*gomodules\.py|.*modules\.py|.*\.proto|.*protobuf\.py)$
+    - id: cws-go-generate
+      name: validate-cws-generated-files
+      description: Validate that the generated CWS files (SECL accessors, BPF map names, docs, ...) are up to date
+      entry: 'dda inv security-agent.cws-go-generate'
+      language: system
+      pass_filenames: false
+      stages: [pre-push]
+      files: ^(pkg/security/.*|docs/cloud-workload-security/.*|bazel/rules/cws_codegen/.*)$
     - id: experiment-systemd-units
       name: validate-experiment-systemd-units
       description: Validate that the generated systemd experimrent units are up to date


### PR DESCRIPTION
### What does this PR do?

Adds a **pre-push** git hook that regenerates the CWS generated files and fails
if any are stale versus what is committed.

- Adds a `--check` mode to the existing `security-agent.cws-go-generate` task:
  it regenerates, then fails (listing the offending files) when regeneration
  produced any change — mirroring CI's `security_go_generate_check` job.
- Adds a `.pre-commit-config.yaml` hook `validate-cws-generated-files` on the
  `pre-push` stage, gated on `pkg/security/**`, `docs/cloud-workload-security/**`
  and the CWS codegen rules so it only runs when relevant files change.

### Motivation

The CWS generated files (SECL accessors, BPF map-name constants, proto mocks,
docs, ...) are produced from sources under `pkg/security`. When a source changes
without regenerating, the failure only surfaces late in CI: the
`security_go_generate_check` job plus every `bazel:test:*` platform and the KMT
secagent/sysprobe suites go red — a single stale file fanned out to ~88 failed
jobs on a recent PR. This hook catches it locally before the push.

**Why pre-push and not pre-commit:** the full `cws-go-generate` is heavy (mockery,
tool installs, a `GOOS=windows` pass, docs, seclwin sync). Running it on every
commit would be painful enough that people bypass it; running it once per push
keeps the fast path fast while still catching drift before it reaches CI.

### Describe how you validated your changes

- `dda inv security-agent.cws-go-generate --check` on a clean tree → exit 0,
  "no generated files were updated" (no spurious diffs).
- Injected a new map into `pkg/security/ebpf/c/include/maps.h` without updating
  the generated file → exit 1, listing `consts_map_names_linux.go` and pointing
  to `dda inv security-agent.cws-go-generate`.
- `dda inv linter.python` passes; a commit confirms the hook does **not** run at
  pre-commit time (pre-push stage only).

### Possible Drawbacks / Trade-offs

Pre-push runs the full CWS regeneration, which takes a few minutes when the gated
files change. It is gated to CWS paths so unrelated pushes are unaffected, and CI's
`security_go_generate_check` remains the authoritative backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)