### PR TITLE
test(e2e): Add CSI driver v1.1.1 GKE allowlist

### DIFF
--- a/test/e2e-framework/scenarios/gcp/gke/workloadcsiallowlist.yaml
+++ b/test/e2e-framework/scenarios/gcp/gke/workloadcsiallowlist.yaml
@@ -131,3 +131,73 @@ matchingCriteria:
     - hostPath:
         path: /var/run/datadog
       name: dsd-socket
+---
+apiVersion: auto.gke.io/v1
+kind: WorkloadAllowlist
+metadata:
+  annotations:
+    autopilot.gke.io/no-connect: "true"
+  name: datadog-datadog-csi-driver-daemonset-exemption-v1.1.1
+exemptions:
+  - autogke-no-write-mode-hostpath
+  - autogke-no-host-port
+  - autogke-default-linux-capabilities
+  - autogke-disallow-privilege
+matchingCriteria:
+  containers:
+    - env:
+        - name: NODE_ID
+        - name: DD_APM_ENABLED
+      envFrom:
+        - secretRef:
+            name: ^datadog-.*
+      image: ^(eu\.|asia\.)?gcr\.io\/datadoghq\/csi-driver(:[0-9]+\.[0-9]+\.[0-9]+)?$
+      name: csi-node-driver
+      securityContext:
+        privileged: true # privileged security context is needed to perform volume mounts on other pods.
+      args:
+        - --apm-host-socket-path=/var/run/datadog/apm.socket
+        - --dsd-host-socket-path=/var/run/datadog/dsd.socket
+      volumeMounts:
+        - name: plugin-dir # stores the socket on which CSI node server service is exposed. It is created by the node server and needs to be writeable.
+          mountPath: /csi
+        - name: storage-dir # stores the data and database for the CSI driver.
+          mountPath: /var/lib/datadog-csi-driver
+        - name: apm-socket
+          mountPath: /var/run/datadog
+          readOnly: true
+        - mountPath: /var/lib/kubelet/pods  # write mode is required to perform a volume mount. csi driver has to create a subdirectory under /var/lib/kubelet/pods/<pod-uid>/volumes/kubernetes.io~csi/datadog/mount.
+          name: mountpoint-dir
+    - name: csi-node-driver-registrar
+      image: ^registry\.k8s\.io/sig-storage/csi-node-driver-registrar(:[0-9]+\.[0-9]+\.[0-9]+)?$
+      args:
+        - "--csi-address=$(ADDRESS)"
+        - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+      env:
+        - name: ADDRESS
+        - name: DRIVER_REG_SOCK_PATH
+      volumeMounts:
+        - name: plugin-dir
+          mountPath: /csi
+          readOnly: true
+        - name: registration-dir
+          mountPath: /registration # registration-dir needs to be writeable to store the registration information and register the driver with kubelet.
+  volumes:
+    - name: plugin-dir
+      hostPath:
+        path: /var/lib/kubelet/plugins/datadog.csi/driver
+    - name: storage-dir
+      hostPath:
+        path: /var/lib/kubelet/plugins/datadog.csi/storage
+    - name: registration-dir
+      hostPath:
+        path: /var/lib/kubelet/plugins_registry
+    - hostPath:
+        path: /var/lib/kubelet/pods
+      name: mountpoint-dir
+    - hostPath:
+        path: /var/run/datadog
+      name: apm-socket
+    - hostPath:
+        path: /var/run/datadog
+      name: dsd-socket


### PR DESCRIPTION
### What does this PR do?

Adds the `datadog-datadog-csi-driver-daemonset-exemption-v1.1.1` `WorkloadAllowlist` to the GCP GKE E2E fixture alongside the existing v1.0.1 and v1.1.0 documents.

The new allowlist permits the CSI node driver registrar image from `registry.k8s.io`, matching the registry used by the current CSI driver chart.

### Motivation

The Datadog CSI driver chart now uses the v1.1.1 allowlist after migrating the registrar image from `k8s.gcr.io` to `registry.k8s.io`. GKE Autopilot E2E clusters must install that allowlist before deploying the updated DaemonSet.

Keeping all three documents preserves compatibility with tests that exercise older chart versions.

### Describe how you validated your changes

- Verified the v1.1.1 document is byte-for-byte identical to the source manifest in `datadog-gke-workload-allowlist`.
- Parsed the combined YAML and verified the three allowlist names and ordering.
- Ran `git diff --check`.
- Passed the repository pre-commit and pre-push hooks.
