### PR TITLE
[ABLD-461] Remove target_compatible_with=linux from pkg/logs/tailers/journald

### DIFF
--- a/pkg/logs/launchers/journald/BUILD.bazel
+++ b/pkg/logs/launchers/journald/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/logs/launchers/journald",
     visibility = ["//visibility:public"],
+    # keep
     deps = [
         "//comp/core/tagger/def",
         "//comp/logs-library/pipeline",
@@ -21,8 +22,12 @@ go_library(
         "//pkg/logs/tailers/journald",
         "//pkg/util/log",
         "//pkg/util/startstop",
-        "@com_github_coreos_go_systemd_v22//sdjournal",
-    ],
+    ] + select({
+        "@platforms//os:linux": [
+            "@com_github_coreos_go_systemd_v22//sdjournal",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 dd_agent_go_test(
@@ -34,6 +39,7 @@ dd_agent_go_test(
         "fips",
         "iot",
     ],
+    # keep
     deps = [
         "//comp/core/tagger/fx-mock",
         "//comp/logs-library/pipeline",
@@ -46,5 +52,10 @@ dd_agent_go_test(
         "//pkg/logs/tailers/journald",
         "@com_github_coreos_go_systemd_v22//sdjournal",
         "@com_github_stretchr_testify//assert",
-    ],
+    ] + select({
+        "@platforms//os:linux": [
+            "@com_github_coreos_go_systemd_v22//sdjournal",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/pkg/logs/launchers/journald/BUILD.bazel
+++ b/pkg/logs/launchers/journald/BUILD.bazel
@@ -50,7 +50,6 @@ dd_agent_go_test(
         "//pkg/logs/sources",
         "//pkg/logs/tailers",
         "//pkg/logs/tailers/journald",
-        "@com_github_coreos_go_systemd_v22//sdjournal",
         "@com_github_stretchr_testify//assert",
     ] + select({
         "@platforms//os:linux": [

--- a/pkg/logs/tailers/journald/BUILD.bazel
+++ b/pkg/logs/tailers/journald/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/logs/tailers/journald",
     visibility = ["//visibility:public"],
+    # keep
     deps = [
         "//comp/core/tagger/def",
         "//comp/core/tagger/tags",
@@ -27,8 +28,12 @@ go_library(
         "//pkg/logs/sources",
         "//pkg/util/cache",
         "//pkg/util/log",
-        "@com_github_coreos_go_systemd_v22//sdjournal",
-    ],
+    ] + select({
+        "@platforms//os:linux": [
+            "@com_github_coreos_go_systemd_v22//sdjournal",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 dd_agent_go_test(
@@ -43,7 +48,6 @@ dd_agent_go_test(
         "fips",
         "iot",
     ],
-    target_compatible_with = ["@platforms//os:linux"],  # keep
     deps = [
         "//comp/core/tagger/fx-mock",
         "//comp/logs/agent/config",

--- a/pkg/logs/tailers/journald/BUILD.bazel
+++ b/pkg/logs/tailers/journald/BUILD.bazel
@@ -48,6 +48,7 @@ dd_agent_go_test(
         "fips",
         "iot",
     ],
+    # keep
     deps = [
         "//comp/core/tagger/fx-mock",
         "//comp/logs/agent/config",
@@ -56,7 +57,11 @@ dd_agent_go_test(
         "//pkg/logs/message",
         "//pkg/logs/sources",
         "//pkg/util/cache",
-        "@com_github_coreos_go_systemd_v22//sdjournal",
         "@com_github_stretchr_testify//assert",
-    ],
+    ] + select({
+        "@platforms//os:linux": [
+            "@com_github_coreos_go_systemd_v22//sdjournal",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/pkg/logs/tailers/journald/BUILD.bazel
+++ b/pkg/logs/tailers/journald/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "tailer_util.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/logs/tailers/journald",
-    target_compatible_with = ["@platforms//os:linux"],  # keep
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/tagger/def",


### PR DESCRIPTION
### What does this PR do?
- Remove an tcw tag that is not needed now that the package switched to dd_agent_go_test
- discovered in another PR and pulling it out to make that easier to review.

### Motivation
Needed to get //cmd/agent:agent to build for macos and windows.

### Describe how you validated your changes
CI
