### PR TITLE
pkg/security/sbom: build the file index once per scan

### DIFF
--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -578,7 +578,6 @@ func (r *Resolver) doScan(sbom *SBOM) ([]sbomtypes.PackageWithInstalledFiles, er
 
 		if report, lastErr = r.generateSBOM(containerProcRootPath); lastErr == nil {
 			sbom.usrMerged = isUsrMerged(containerProcRootPath)
-			sbom.setReport(report)
 			scanned = true
 			break
 		}


### PR DESCRIPTION
### What does this PR do?

Removes a redundant `setReport` call in the SBOM resolver's scan path, so the file->package index is built once per scan instead of twice.

### Motivation

`doScan` called `setReport`, which builds the murmur3 file->package index and the per-package metadata for the whole workload. Its only caller then rebuilt the same index from the same report and overwrote the result, so the first copy became garbage immediately.

That index is sized to the total number of installed files in the image, making it the largest structure a scan produces, so this doubled the peak allocation of a scan for no reason.

### Describe how you validated your changes

`dda inv test --targets=./pkg/security/resolvers/sbom/`

### Additional Notes
