### PR TITLE
fix(devcontainer): don't remap UID on macOS

### DIFF
--- a/tasks/devcontainer.py
+++ b/tasks/devcontainer.py
@@ -95,20 +95,21 @@ def setup(
     ]
     if devcontainer.get("image") and "amd64" in devcontainer["image"].casefold():
         devcontainer["runArgs"].append("--platform=linux/amd64")
-    if sys.platform != "win32":
-        # The image's entrypoint realigns its user to this UID/GID so writes to bind
-        # mounts keep host ownership. We pass them as explicit `docker run` env vars
-        # because no devcontainer variable resolves to the host UID/GID. (`os.getuid`/
-        # `os.getgid` are absent on Windows, but the platform check short-circuits first.)
-        devcontainer["runArgs"] += ["-e", f"HOST_UID={os.getuid()}", "-e", f"HOST_GID={os.getgid()}"]
+    # We deliberately do not pass HOST_UID/HOST_GID or set updateRemoteUserUID: the dev
+    # container CLI owns `dd`'s UID alignment. On Linux it rewrites /etc/passwd at
+    # image-build time (race-free), so the image entrypoint's runtime realign is a no-op; on
+    # macOS/Windows it leaves the container UID alone, which is correct because the Docker VM
+    # file sharing maps writes to the host user regardless of the container UID. Passing
+    # HOST_UID would re-arm the entrypoint's runtime `usermod`, which -- under the
+    # --cap-add=SYS_PTRACE below -- races the CLI's `docker exec -u dd` (onCreateCommand) and
+    # aborts startup (exit 137).
     devcontainer["features"] = {}
-    # Keep the image's entrypoint, which realigns `dd` to the host's UID/GID and runs
-    # the image's startup before exec'ing its long-running command. Otherwise the dev
-    # container CLI replaces the entrypoint with its own keep-alive command and skips
-    # that setup.
+    # Keep the image's entrypoint, which runs the image's startup (user shell, shared roots,
+    # background services) before exec'ing its long-running command. Otherwise the dev
+    # container CLI replaces the entrypoint with its own keep-alive command and skips that
+    # setup.
     devcontainer["overrideCommand"] = False
-    # The image provides this user, and its entrypoint realigns it to the host's UID/GID
-    # (via HOST_UID/HOST_GID above).
+    # The image provides this user; the dev container CLI aligns its UID (see above).
     devcontainer["remoteUser"] = "dd"
     # The host home directory is `USERPROFILE` on Windows and `HOME` elsewhere. We use a
     # single variable rather than concatenating both, because some Windows shells also


### PR DESCRIPTION
### What does this PR do?

Stops the dev container from realigning its `dd` user to the host UID on macOS. `tasks/devcontainer.py` now passes `HOST_UID`/`HOST_GID` **only on Linux**, and sets `updateRemoteUserUID: false`.

### Motivation

On macOS the Docker VM's file sharing (virtiofs on Colima/OrbStack, gRPC-FUSE/virtiofs on Docker Desktop) already maps container writes back to the host user regardless of the container UID, so the realignment is unnecessary. Worse, the dev-env image entrypoint's `usermod -u dd` races the dev container CLI's `docker exec -u dd` (onCreateCommand) and aborts the container:

```
usermod: user dd is currently used by process N   ->  exit 137
```

Docker Desktop happened to win that race; Colima's `docker exec` timing loses it, so startup fails reliably there — which matters now that engineering is migrating off Docker Desktop to Colima. On native-Linux hosts the IDs are still passed, since bind mounts there preserve the host UID and the realignment is genuinely required.

### Describe how you validated your changes

Full `dda inv devcontainer.start` (`devcontainer up` → entrypoint + `install-tools` + `deps`, 191 modules) → `{"outcome":"success"}` on macOS (Apple Silicon) / Colima `vz`+`virtiofs`.

### ⚠️ Also required for macOS: the dev-env image fix

This PR is independently correct, but macOS/Colima startup hits a **second, independent** crash: the image entrypoint's `chown -R` of the home dir dies on a unix socket in a bind-mounted `~/.ssh` over virtiofs. That is fixed in **DataDog/datadog-agent-buildimages#1292**, which requires the `datadog/agent-dev-env-linux` image to be **rebuilt and rolled out**. Both this PR and that image bump are needed for macOS to be fully green.

### Possible Drawbacks / Trade-offs

None on Linux (behavior unchanged). On macOS/Windows the image-side UID realignment no longer runs, which is the intended fix.

### Release note

Dev-tooling change under `tasks/`, no user-facing impact — `changelog/no-changelog`.
