### PR TITLE
[CONTP-1926] feat(instrumentation): support Argo Rollout target for DDI checks and logs

### DIFF
--- a/comp/core/workloadfilter/util/workloadmeta/BUILD.bazel
+++ b/comp/core/workloadfilter/util/workloadmeta/BUILD.bazel
@@ -21,6 +21,7 @@ dd_agent_go_test(
     deps = [
         "//comp/core/workloadmeta/def",
         "//pkg/proto/pbgo/core",
+        "//pkg/util/kubernetes",
         "@com_github_stretchr_testify//assert",
     ],
 )

--- a/comp/core/workloadfilter/util/workloadmeta/create.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create.go
@@ -43,14 +43,16 @@ func CreatePod(pod *workloadmeta.KubernetesPod) *workloadfilter.Pod {
 			Name:        pod.Name,
 			Namespace:   pod.Namespace,
 			Annotations: pod.Annotations,
-			Rootowner:   resolveRootOwner(pod.Owners),
+			Rootowner:   resolveRootOwner(pod.Owners, pod.Labels),
 		},
 	}
 }
 
 // resolveRootOwner determines the root owner of a pod by walking the owner chain.
 // For example, a pod owned by a ReplicaSet resolves to the parent Deployment.
-func resolveRootOwner(owners []workloadmeta.KubernetesPodOwner) *core.FilterRootOwner {
+// Pod labels are used to disambiguate owners that share a naming scheme, such as
+// Argo Rollouts, whose ReplicaSets are named like Deployment ones.
+func resolveRootOwner(owners []workloadmeta.KubernetesPodOwner, podLabels map[string]string) *core.FilterRootOwner {
 	if len(owners) == 0 {
 		return nil
 	}
@@ -65,6 +67,14 @@ func resolveRootOwner(owners []workloadmeta.KubernetesPodOwner) *core.FilterRoot
 
 	switch owner.Kind {
 	case kubernetes.ReplicaSetKind:
+		// Argo Rollouts manage ReplicaSets named like Deployment ones (`<owner>-<hash>`),
+		// so the rollout pod label is the only way to tell the two apart here.
+		if _, isRollout := podLabels[kubernetes.ArgoRolloutLabelKey]; isRollout {
+			if rollout := kubernetes.ParseDeploymentForReplicaSet(owner.Name); rollout != "" {
+				return &core.FilterRootOwner{Kind: kubernetes.RolloutKind, Name: rollout}
+			}
+			return &core.FilterRootOwner{Kind: owner.Kind, Name: owner.Name}
+		}
 		if deployment := kubernetes.ParseDeploymentForReplicaSet(owner.Name); deployment != "" {
 			return &core.FilterRootOwner{Kind: kubernetes.DeploymentKind, Name: deployment}
 		}

--- a/comp/core/workloadfilter/util/workloadmeta/create.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create.go
@@ -68,8 +68,9 @@ func resolveRootOwner(owners []workloadmeta.KubernetesPodOwner, podLabels map[st
 	switch owner.Kind {
 	case kubernetes.ReplicaSetKind:
 		// Argo Rollouts manage ReplicaSets named like Deployment ones (`<owner>-<hash>`),
-		// so the rollout pod label is the only way to tell the two apart here.
-		if _, isRollout := podLabels[kubernetes.ArgoRolloutLabelKey]; isRollout {
+		// so the rollout pod label is the only way to tell the two apart here. A real
+		// Rollout always sets a non-empty hash, so an empty value is not one.
+		if podLabels[kubernetes.ArgoRolloutLabelKey] != "" {
 			if rollout := kubernetes.ParseDeploymentForReplicaSet(owner.Name); rollout != "" {
 				return &core.FilterRootOwner{Kind: kubernetes.RolloutKind, Name: rollout}
 			}

--- a/comp/core/workloadfilter/util/workloadmeta/create.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create.go
@@ -50,8 +50,6 @@ func CreatePod(pod *workloadmeta.KubernetesPod) *workloadfilter.Pod {
 
 // resolveRootOwner determines the root owner of a pod by walking the owner chain.
 // For example, a pod owned by a ReplicaSet resolves to the parent Deployment.
-// Pod labels are used to disambiguate owners that share a naming scheme, such as
-// Argo Rollouts, whose ReplicaSets are named like Deployment ones.
 func resolveRootOwner(owners []workloadmeta.KubernetesPodOwner, podLabels map[string]string) *core.FilterRootOwner {
 	if len(owners) == 0 {
 		return nil

--- a/comp/core/workloadfilter/util/workloadmeta/create_test.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create_test.go
@@ -12,15 +12,17 @@ import (
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 )
 
 func boolPtr(b bool) *bool { return &b }
 
 func TestResolveRootOwner(t *testing.T) {
 	tests := []struct {
-		name     string
-		owners   []workloadmeta.KubernetesPodOwner
-		expected *core.FilterRootOwner
+		name      string
+		owners    []workloadmeta.KubernetesPodOwner
+		podLabels map[string]string
+		expected  *core.FilterRootOwner
 	}{
 		{
 			name:     "no owners",
@@ -31,6 +33,18 @@ func TestResolveRootOwner(t *testing.T) {
 			name:     "ReplicaSet resolves to Deployment",
 			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "ReplicaSet", Name: "my-app-6d4f5b7c8", Controller: boolPtr(true)}},
 			expected: &core.FilterRootOwner{Kind: "Deployment", Name: "my-app"},
+		},
+		{
+			name:      "ReplicaSet with Argo rollout label resolves to Rollout",
+			owners:    []workloadmeta.KubernetesPodOwner{{Kind: "ReplicaSet", Name: "my-rollout-9b8dc4bd6", Controller: boolPtr(true)}},
+			podLabels: map[string]string{kubernetes.ArgoRolloutLabelKey: "9b8dc4bd6"},
+			expected:  &core.FilterRootOwner{Kind: "Rollout", Name: "my-rollout"},
+		},
+		{
+			name:      "ReplicaSet with Argo rollout label but no hash suffix stays as ReplicaSet",
+			owners:    []workloadmeta.KubernetesPodOwner{{Kind: "ReplicaSet", Name: "invalid-name", Controller: boolPtr(true)}},
+			podLabels: map[string]string{kubernetes.ArgoRolloutLabelKey: "invalid"},
+			expected:  &core.FilterRootOwner{Kind: "ReplicaSet", Name: "invalid-name"},
 		},
 		{
 			name:     "Job resolves to CronJob",
@@ -76,7 +90,7 @@ func TestResolveRootOwner(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := resolveRootOwner(tt.owners)
+			result := resolveRootOwner(tt.owners, tt.podLabels)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -96,4 +110,21 @@ func TestCreatePodWithRootOwner(t *testing.T) {
 	assert.NotNil(t, result.FilterPod.Rootowner)
 	assert.Equal(t, "Deployment", result.FilterPod.Rootowner.Kind)
 	assert.Equal(t, "my-app", result.FilterPod.Rootowner.Name)
+}
+
+func TestCreatePodWithRolloutRootOwner(t *testing.T) {
+	pod := &workloadmeta.KubernetesPod{
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:      "my-rollout-9b8dc4bd6-abc12",
+			Namespace: "default",
+			Labels:    map[string]string{kubernetes.ArgoRolloutLabelKey: "9b8dc4bd6"},
+		},
+		Owners: []workloadmeta.KubernetesPodOwner{
+			{Kind: "ReplicaSet", Name: "my-rollout-9b8dc4bd6", Controller: boolPtr(true)},
+		},
+	}
+	result := CreatePod(pod)
+	assert.NotNil(t, result.FilterPod.Rootowner)
+	assert.Equal(t, "Rollout", result.FilterPod.Rootowner.Kind)
+	assert.Equal(t, "my-rollout", result.FilterPod.Rootowner.Name)
 }

--- a/comp/core/workloadfilter/util/workloadmeta/create_test.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create_test.go
@@ -47,6 +47,12 @@ func TestResolveRootOwner(t *testing.T) {
 			expected:  &core.FilterRootOwner{Kind: "ReplicaSet", Name: "invalid-name"},
 		},
 		{
+			name:      "ReplicaSet with empty Argo rollout label resolves to Deployment",
+			owners:    []workloadmeta.KubernetesPodOwner{{Kind: "ReplicaSet", Name: "my-app-6d4f5b7c8", Controller: boolPtr(true)}},
+			podLabels: map[string]string{kubernetes.ArgoRolloutLabelKey: ""},
+			expected:  &core.FilterRootOwner{Kind: "Deployment", Name: "my-app"},
+		},
+		{
 			name:     "Job resolves to CronJob",
 			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "Job", Name: "backup-1562319360", Controller: boolPtr(true)}},
 			expected: &core.FilterRootOwner{Kind: "CronJob", Name: "backup"},

--- a/pkg/clusteragent/instrumentation/handlers/checks.go
+++ b/pkg/clusteragent/instrumentation/handlers/checks.go
@@ -62,7 +62,7 @@ func (h *ChecksHandler) HasSection(cr *datadoghq.DatadogInstrumentation) bool {
 // SupportsTarget returns whether Autodiscovery check delivery supports the target kind.
 func (h *ChecksHandler) SupportsTarget(ref autoscalingv2.CrossVersionObjectReference) bool {
 	switch ref.Kind {
-	case kubernetes.DeploymentKind, kubernetes.DaemonSetKind, kubernetes.StatefulSetKind, kubernetes.CronJobKind, kubernetes.JobKind:
+	case kubernetes.DeploymentKind, kubernetes.DaemonSetKind, kubernetes.StatefulSetKind, kubernetes.CronJobKind, kubernetes.JobKind, kubernetes.RolloutKind:
 		return true
 	case kubernetes.ServiceKind:
 		// Service target support is backed by endpoint slices CR provider. If Endpointslice collection

--- a/pkg/clusteragent/instrumentation/handlers/checks_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/checks_test.go
@@ -134,6 +134,7 @@ func TestSupportsTarget(t *testing.T) {
 		{"CronJob", true},
 		{"Job", true},
 		{"Service", true},
+		{"Rollout", true},
 		{"ReplicaSet", false},
 		{"Pod", false},
 		{"", false},

--- a/pkg/clusteragent/instrumentation/handlers/logs.go
+++ b/pkg/clusteragent/instrumentation/handlers/logs.go
@@ -55,7 +55,7 @@ func (h *LogsHandler) HasSection(cr *datadoghq.DatadogInstrumentation) bool {
 // SupportsTarget returns whether log delivery supports the target kind.
 func (h *LogsHandler) SupportsTarget(ref autoscalingv2.CrossVersionObjectReference) bool {
 	switch ref.Kind {
-	case kubernetes.DeploymentKind, kubernetes.DaemonSetKind, kubernetes.StatefulSetKind, kubernetes.CronJobKind, kubernetes.JobKind:
+	case kubernetes.DeploymentKind, kubernetes.DaemonSetKind, kubernetes.StatefulSetKind, kubernetes.CronJobKind, kubernetes.JobKind, kubernetes.RolloutKind:
 		return true
 	default:
 		return false

--- a/pkg/clusteragent/instrumentation/handlers/logs_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/logs_test.go
@@ -80,6 +80,7 @@ func TestLogsSupportsTarget(t *testing.T) {
 		{"StatefulSet", true},
 		{"CronJob", true},
 		{"Job", true},
+		{"Rollout", true},
 		{"Service", false},
 		{"ReplicaSet", false},
 		{"Pod", false},

--- a/releasenotes-dca/notes/ddi-argo-rollout-target-1a4c0f6b2e7d9a35.yaml
+++ b/releasenotes-dca/notes/ddi-argo-rollout-target-1a4c0f6b2e7d9a35.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    ``DatadogInstrumentation`` checks and logs configurations can now target Argo
+    ``Rollout`` workloads.
+upgrade:
+  - |
+    Pods managed by an Argo ``Rollout`` now resolve to a root owner of kind
+    ``Rollout`` instead of ``Deployment`` in workload filtering. Container filter
+    rules matching such pods on ``rootowner.kind == "Deployment"`` must be updated
+    to use ``Rollout``.

--- a/releasenotes-dca/notes/ddi-argo-rollout-target-1a4c0f6b2e7d9a35.yaml
+++ b/releasenotes-dca/notes/ddi-argo-rollout-target-1a4c0f6b2e7d9a35.yaml
@@ -3,9 +3,3 @@ features:
   - |
     ``DatadogInstrumentation`` checks and logs configurations can now target Argo
     ``Rollout`` workloads.
-upgrade:
-  - |
-    Pods managed by an Argo ``Rollout`` now resolve to a root owner of kind
-    ``Rollout`` instead of ``Deployment`` in workload filtering. Container filter
-    rules matching such pods on ``rootowner.kind == "Deployment"`` must be updated
-    to use ``Rollout``.


### PR DESCRIPTION
### What does this PR do?

Lets a `DatadogInstrumentation` CR target an Argo `Rollout` for its checks and logs sections.

Rollout pods are owned by a ReplicaSet named `{rollout}-{hash}`, identical to Deployment-owned ones, so `resolveRootOwner` previously resolved them to a phantom `Deployment`. It now uses the `rollouts-pod-template-hash` pod label (the same disambiguator the workload autoscaling pod watcher uses) to emit a `Rollout` root owner instead, and both handlers accept `Rollout` in `SupportsTarget`. No CEL change is needed — `rootOwnerCELFilter` injects the target kind verbatim.

### Motivation

Argo Rollouts is widely used for advanced rollout strategies; workloads managed by it could not be targeted at all.

### Describe how you validated your changes

Unit tests for the resolver (`TestResolveRootOwner`, `TestCreatePodWithRolloutRootOwner`) and for both handlers' `SupportsTarget`.

#### Manual QA

Injector dev scenario

<details><summary>rollout.yaml</summary>
<p>

```yaml
---
apiVersion: v1
kind: Service
metadata:
  name: rollout-sample
spec:
  selector:
    app: rollout-sample
  ports:
    - name: http
      port: 8080
      targetPort: 8080
---
apiVersion: argoproj.io/v1alpha1
kind: Rollout
metadata:
  name: rollout-sample
spec:
  replicas: 2
  revisionHistoryLimit: 2
  selector:
    matchLabels:
      app: rollout-sample
  template:
    metadata:
      labels:
        app: rollout-sample
    spec:
      containers:
        - name: app
          image: busybox:latest
          command: ["sh", "-c", "while true; do echo 'rollout-sample running'; sleep 30; done"]
          ports:
            - containerPort: 8080
        - name: sidecar
          image: busybox:latest
          command: ["sh", "-c", "while true; do echo 'demo-service running'; sleep 30; done"]
          ports:
            - containerPort: 8081
  strategy:
    canary:
      steps:
        - setWeight: 100
```

</p>
</details> 

<details><summary>instrumentation.yaml</summary>
<p>

```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogInstrumentation
metadata:
  name: rollout-sample
spec:
  targetRef:
    apiVersion: argoproj.io/v1alpha1
    kind: Rollout
    name: rollout-sample
  config:
    checks:
      - integration: "http_check"
        containerName: sidecar
        instances:
          - url: "http://%%host%%:%%port%%/status"
    logs:
      - containerName: app
        tags:
          - service:rollout-sample
```

</p>
</details> 

<details><summary>scenario.yaml</summary>
<p>

```yaml
platform:
  type: "kind"
  name: "instrumentation-crd-rollout"
  reset: false
operator:
  localChartPath: "/Users/mathew.estafanous/go/src/github.com/DataDog/helm-charts/charts/datadog-operator"
  versions:
    agent:
      build: {}
    cluster_agent:
      build: {}
    operator: "1.29.0-rc.3"
    injector: "0.60.0"
  manifests:
    - path: "rollout.yaml"
      namespace: "cache"
    - path: "instrumentation.yaml"
      namespace: "cache"
  config:
    apiVersion: datadoghq.com/v2alpha1
    kind: DatadogAgent
    metadata:
      name: datadog
      annotations:
        agent.datadoghq.com/instrumentation-crd-enabled: "true"
    spec:
      features:
        logCollection:
          enabled: true
          containerCollectAll: false
        admissionController:
          enabled: true
      global:
        clusterName: "mathewe-ddi-rollout-demo"
        checksTagCardinality: "high"
        logLevel: "info"
        kubelet:
          tlsVerify: false
      override:
        clusterAgent:
          replicas: 1
```

</p>
</details> 

<img width="700" height="506" alt="image" src="https://github.com/user-attachments/assets/0571508a-b432-43b5-ae39-a89efd958495" />

<img width="497" height="160" alt="image" src="https://github.com/user-attachments/assets/b3265c7d-98e4-4afb-8e1c-73382d74a770" />
