### PR TITLE
Remove the leftover package rpm database copy when writing fails

### DIFF
--- a/pkg/security/resolvers/sbom/collectorv2/rpm.go
+++ b/pkg/security/resolvers/sbom/collectorv2/rpm.go
@@ -17,9 +17,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
+
 	sbomtypes "github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom/types"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
-	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
 )
 
 var rpmdbPaths = []string{
@@ -141,7 +142,7 @@ func splitFileName(filename string) (name, ver, rel string, err error) {
 	return name, ver, rel, nil
 }
 
-func writeFileToTemp(root *os.Root, path string) (string, error) {
+func writeFileToTemp(root *os.Root, path string) (_ string, err error) {
 	srcFile, err := root.Open(path)
 	if err != nil {
 		return "", fmt.Errorf("failed to open source file %s: %w", path, err)
@@ -152,18 +153,24 @@ func writeFileToTemp(root *os.Root, path string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp file: %w", err)
 	}
+	defer func() {
+		if err != nil {
+			// remove any partially-written file
+			os.Remove(tmpFile.Name())
+		}
+	}()
 	defer tmpFile.Close()
 
-	if _, err := io.Copy(tmpFile, srcFile); err != nil {
+	if _, err = io.Copy(tmpFile, srcFile); err != nil {
 		return "", fmt.Errorf("failed to copy source file %s to temp file: %w", path, err)
 	}
 
 	// important to handle close errors when writing to a file
-	if err := tmpFile.Sync(); err != nil {
+	if err = tmpFile.Sync(); err != nil {
 		return "", fmt.Errorf("failed to sync temp file: %w", err)
 	}
 
-	if err := tmpFile.Close(); err != nil {
+	if err = tmpFile.Close(); err != nil {
 		return "", fmt.Errorf("failed to close temp file: %w", err)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Deletes the temporary copy of a rpm package database when writing fails.

### Motivation

System-probe copies each rpm package database to a temporary file before it can read it. When that write failed, the partial file was left behind, leaking disk space. Running out of space is itself one of the reasons the write fails, which makes it self-reinforcing: each failure leaves more behind and brings the next one closer to failing.

### Describe how you validated your changes

### Additional Notes
