### PR TITLE
fix(cluster-agent): restore rate_limit_queries telemetry after external metrics refactor

### DIFF
--- a/pkg/util/kubernetes/autoscalers/processor.go
+++ b/pkg/util/kubernetes/autoscalers/processor.go
@@ -222,6 +222,7 @@ func (p *Processor) QueryExternalMetric(queries []string, timeWindow time.Durati
 	_ = group.Wait()
 
 	log.Debugf("Processed %d chunks with %d chunks in global error", len(chunks), responsesGlobalErrors)
+	p.updateRateLimitingMetrics()
 	return responses
 }
 


### PR DESCRIPTION
### What does this PR do?

Restores the call to `updateRateLimitingMetrics()` at the end of `QueryExternalMetric`, so the cluster-agent again publishes `rate_limit_queries_{limit,remaining,period,reset}` on its Prometheus metrics endpoint.

### Motivation

#33272 refactored external metrics querying to run chunks in parallel but dropped the `updateRateLimitingMetrics()` call that used to run after queries completed. The helper and gauges still exist, but only `rate_limit_queries_remaining_min` is updated today (inside `queryDatadogExternal`). Integrations and dashboards expecting `datadog.cluster_agent.datadog.rate_limit_queries.limit` (and related metrics) see no data on DCA 7.66+.

### Describe how you validated your changes

```bash
GOWORK=off GOTOOLCHAIN=auto go test -tags "kubeapiserver,test" ./pkg/util/kubernetes/autoscalers/... -count=1
```

### Additional Notes

`QueryExternalMetric` still documents that it updates rate limit statistics; this restores that behavior without changing query batching semantics.

Made with [Cursor](https://cursor.com)