### PR TITLE
Bump DCA SGC for Dependencies

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -47,11 +47,11 @@ static_quality_gate_docker_agent_jmx_arm64:
   max_on_disk_size: 994.71 MiB
   max_on_wire_size: 327.98 MiB
 static_quality_gate_docker_cluster_agent_amd64:
-  max_on_disk_size: 210.47 MiB
-  max_on_wire_size: 74.2 MiB
+  max_on_disk_size: 211.25 MiB
+  max_on_wire_size: 74.4 MiB
 static_quality_gate_docker_cluster_agent_arm64:
-  max_on_disk_size: 223.05 MiB
-  max_on_wire_size: 69.31 MiB
+  max_on_disk_size: 223.75 MiB
+  max_on_wire_size: 69.5 MiB
 static_quality_gate_docker_cws_instrumentation_amd64:
   max_on_disk_size: 7.48 MiB
   max_on_wire_size: 3.43 MiB


### PR DESCRIPTION
### What does this PR do?

Bumps up the Cluster Agent's static quality gate limits to consider various dependency upgrades which consumed most of the limit.

Biggest offenders are: https://github.com/DataDog/datadog-agent/pull/52893, https://github.com/DataDog/datadog-agent/pull/52900, and https://github.com/DataDog/datadog-agent/pull/53561. Adjusts sgc limits accordingly for these major steps in the increase depicted below. The binary size overall increased by about ~2MB but this PR only bumps 0.75MB in the limit.

<img width="1041" height="584" alt="image" src="https://github.com/user-attachments/assets/fdeee6a9-f330-4477-9a2c-09a24a1a7c18" />

<img width="747" height="333" alt="image" src="https://github.com/user-attachments/assets/f80acce2-0188-472c-ba45-0eb9acc8b2d6" />

