### PR TITLE
Remove outdated macOS support note from network_path conf example

### DIFF
--- a/cmd/agent/dist/conf.d/network_path.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/network_path.d/conf.yaml.example
@@ -12,7 +12,6 @@ init_config:
     # timeout: 1000
 
 # Network Path integration is used to monitor individual endpoints.
-# Supported platforms are Linux and Windows. macOS is not supported yet.
 instances:
   - ## @param hostname - string - required
     ## Hostname or IP of the target endpoint to monitor via Network Path.


### PR DESCRIPTION
## Summary
- Removes the stale comment stating Network Path only supports Linux and Windows from `cmd/agent/dist/conf.d/network_path.d/conf.yaml.example`, since macOS is now supported.

## Test plan
- N/A (comment-only change to an example config file)