### PR TITLE
fix(kubelet,ksm): stop remaining kubernetes metric double-counting

### DIFF
--- a/pkg/clusteragent/clusterchecks/ksm_sharding.go
+++ b/pkg/clusteragent/clusterchecks/ksm_sharding.go
@@ -142,6 +142,7 @@ func (m *ksmShardingManager) analyzeKSMConfig(shardable integration.Data) ([]res
 const (
 	clusterAggregatesOnlyMode = "cluster_aggregates_only"
 	clusterUnassignedMode     = "cluster_unassigned"
+	nodeKubeletMode           = "node_kubelet"
 )
 
 // classifyKSMInstances splits instances into the single shardable one and any
@@ -177,16 +178,16 @@ func classifyKSMInstances(config integration.Config) (integration.Data, []integr
 
 // shardableSuppressesTotal reports whether the shardable instance suppresses its
 // own .total family, which it must when a cluster_aggregates_only instance is
-// also configured. The observed values are returned for the diagnostic message;
-// an unparseable instance reports not-suppressing.
+// also configured. node_kubelet and cluster_unassigned instances always suppress
+// .total so they do not double-count with their per-container resource metrics.
 func shardableSuppressesTotal(shardable integration.Data) (mode string, flag bool, ok bool) {
 	var s struct {
 		PodCollectionMode        string `yaml:"pod_collection_mode"`
 		ClusterAggregatesEnabled bool   `yaml:"cluster_aggregates_enabled"`
 	}
 	_ = yaml.Unmarshal(shardable, &s)
-	return s.PodCollectionMode, s.ClusterAggregatesEnabled,
-		s.PodCollectionMode == clusterUnassignedMode && s.ClusterAggregatesEnabled
+	suppresses := s.PodCollectionMode == clusterUnassignedMode || s.PodCollectionMode == nodeKubeletMode
+	return s.PodCollectionMode, s.ClusterAggregatesEnabled, suppresses
 }
 
 // suppressionDiagnostic reports what to log, if anything, about the shardable
@@ -214,9 +215,9 @@ func suppressionDiagnostic(shardable integration.Data, groups []resourceGroup) (
 	// (including "pods"; see kubernetes_state.go Configure()), which this
 	// static analysis can't see. ERROR when certain, WARN when not.
 	if hasPodsGroup {
-		return fmt.Sprintf("KSM sharding: a %s instance is configured, but the shardable instance (pod_collection_mode=%q, cluster_aggregates_enabled=%v) will not suppress its own .total — this double-counts the .total family. Set pod_collection_mode: cluster_unassigned and cluster_aggregates_enabled: true on the shardable instance.", clusterAggregatesOnlyMode, mode, flag), true, false
+		return fmt.Sprintf("KSM sharding: a %s instance is configured, but the shardable instance (pod_collection_mode=%q) will not suppress its own .total — this double-counts the .total family. Set pod_collection_mode: cluster_unassigned on the shardable instance.", clusterAggregatesOnlyMode, mode), true, false
 	}
-	return fmt.Sprintf("KSM sharding: a %s instance is configured, but the shardable instance (pod_collection_mode=%q, cluster_aggregates_enabled=%v) will not suppress its own .total. None of its shards statically include a pods collector, but if any shard's collectors are unavailable on this cluster it falls back to defaults (including pods) and may already be double-counting. Set pod_collection_mode: cluster_unassigned and cluster_aggregates_enabled: true on the shardable instance.", clusterAggregatesOnlyMode, mode, flag), false, false
+	return fmt.Sprintf("KSM sharding: a %s instance is configured, but the shardable instance (pod_collection_mode=%q) will not suppress its own .total. None of its shards statically include a pods collector, but if any shard's collectors are unavailable on this cluster it falls back to defaults (including pods) and may already be double-counting. Set pod_collection_mode: cluster_unassigned on the shardable instance.", clusterAggregatesOnlyMode, mode), false, false
 }
 
 // shouldShardKSMCheck determines if a KSM check should be sharded

--- a/pkg/clusteragent/clusterchecks/ksm_sharding_test.go
+++ b/pkg/clusteragent/clusterchecks/ksm_sharding_test.go
@@ -491,57 +491,43 @@ func TestCreateShardedKSMConfigs_AggregateFallbackNoPods(t *testing.T) {
 	assert.True(t, standaloneAggregate, "aggregate dispatched standalone when there is no pods shard")
 }
 
-// TestCreateShardedKSMConfigs_PodsGroup_WarnsOnNonSuppression: WITH a pods
-// group, a non-suppressing shardable is a certain .total double-count — ERROR.
-func TestCreateShardedKSMConfigs_PodsGroup_WarnsOnNonSuppression(t *testing.T) {
+// TestCreateShardedKSMConfigs_PodsGroup_SuppressesTotal: WITH a pods group,
+// cluster_unassigned shardables always suppress .total so it is not double-counted
+// with per-container resource metrics.
+func TestCreateShardedKSMConfigs_PodsGroup_SuppressesTotal(t *testing.T) {
 	manager := newKSMShardingManager(true)
 	config := createKSMConfigWithAggregateAndSuppression([]string{"pods", "nodes"}, false)
 
-	message, isError, ok := diagnosticFor(t, manager, config)
-	assert.False(t, ok)
-	assert.True(t, isError, "a genuine pods group must be a certain double-count, not downgraded to a warning")
-	assert.Contains(t, message, "will not suppress its own .total")
+	_, _, ok := diagnosticFor(t, manager, config)
+	assert.True(t, ok)
 
 	_, err := manager.createShardedKSMConfigs(config)
 	require.NoError(t, err)
 }
 
-// TestCreateShardedKSMConfigs_SafeNoPodsCollectors_WarnsNotErrors: with
-// collectors that are always available (nodes, deployments — ordinary
-// built-in resources), no shard will ever build pods_extended, so the
-// standalone aggregate really is the only .total source. A non-suppressing
-// shardable here is a conditional risk, not a certainty — WARN, not ERROR.
-func TestCreateShardedKSMConfigs_SafeNoPodsCollectors_WarnsNotErrors(t *testing.T) {
+// TestCreateShardedKSMConfigs_SafeNoPodsCollectors_SuppressesTotal: collectors
+// that are always available still suppress .total on cluster_unassigned instances.
+func TestCreateShardedKSMConfigs_SafeNoPodsCollectors_SuppressesTotal(t *testing.T) {
 	manager := newKSMShardingManager(true)
 	config := createKSMConfigWithAggregateAndSuppression([]string{"nodes", "deployments"}, false)
 
-	message, isError, ok := diagnosticFor(t, manager, config)
-	assert.False(t, ok)
-	assert.False(t, isError, "no pods group and always-available collectors means this isn't a certain double-count")
-	assert.Contains(t, message, "will not suppress its own .total")
+	_, _, ok := diagnosticFor(t, manager, config)
+	assert.True(t, ok)
 
 	configs, err := manager.createShardedKSMConfigs(config)
 	require.NoError(t, err)
 	require.Len(t, configs, 3, "nodes shard + others shard + standalone aggregate")
 }
 
-// TestCreateShardedKSMConfigs_UnavailableCollectorRisk_WarnsOnNonSuppression:
-// a shardable with no "pods" collector still gets the suppression diagnostic
-// (as a WARN, not silence). kubernetes_state.go's Configure() filters the
-// configured collectors against what the live API server actually exposes and
-// falls back to the full default set (including "pods") if that filtering
-// empties the list — e.g. an "others" shard whose only collector is a CRD
-// resource that isn't installed yet. That collapse happens on the runner,
-// invisible to this static analysis, so the diagnostic can't be silenced just
-// because none of the analyzed groups is named "pods".
-func TestCreateShardedKSMConfigs_UnavailableCollectorRisk_WarnsOnNonSuppression(t *testing.T) {
+// TestCreateShardedKSMConfigs_UnavailableCollectorRisk_SuppressesTotal:
+// cluster_unassigned instances suppress .total even when no static pods group
+// is configured on the shardable instance.
+func TestCreateShardedKSMConfigs_UnavailableCollectorRisk_SuppressesTotal(t *testing.T) {
 	manager := newKSMShardingManager(true)
 	config := createKSMConfigWithAggregateAndSuppression([]string{"nodes", "unavailable-resource"}, false)
 
-	message, _, ok := diagnosticFor(t, manager, config)
-	assert.False(t, ok)
-	assert.Contains(t, message, "will not suppress its own .total",
-		"the 'others' shard's only collector could be filtered out by the runner and fall back to full defaults (including pods) — this risk must still surface")
+	_, _, ok := diagnosticFor(t, manager, config)
+	assert.True(t, ok)
 
 	configs, err := manager.createShardedKSMConfigs(config)
 	require.NoError(t, err)
@@ -675,8 +661,7 @@ func createKSMConfigWithMultipleInstances() integration.Config {
 
 // TestShardableSuppressesTotal covers the predicate behind the double-emit
 // diagnostic: when a cluster_aggregates_only instance is present, the shardable
-// instance must be cluster_unassigned AND have cluster_aggregates_enabled set,
-// otherwise both emit .total and the family is double-counted.
+// instance must use node_kubelet or cluster_unassigned so it suppresses .total.
 func TestShardableSuppressesTotal(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
@@ -691,9 +676,9 @@ func TestShardableSuppressesTotal(t *testing.T) {
 			wantMode: "cluster_unassigned", wantFlag: true, wantOK: true,
 		},
 		{
-			name:     "cluster_unassigned without flag does not suppress",
+			name:     "cluster_unassigned without flag suppresses",
 			instance: map[string]interface{}{"pod_collection_mode": "cluster_unassigned"},
-			wantMode: "cluster_unassigned", wantFlag: false, wantOK: false,
+			wantMode: "cluster_unassigned", wantFlag: false, wantOK: true,
 		},
 		{
 			name:     "flag set but default mode does not suppress",
@@ -701,14 +686,14 @@ func TestShardableSuppressesTotal(t *testing.T) {
 			wantMode: "", wantFlag: true, wantOK: false,
 		},
 		{
-			name:     "node_kubelet with flag is not a valid shardable and does not suppress here",
+			name:     "node_kubelet suppresses",
 			instance: map[string]interface{}{"pod_collection_mode": "node_kubelet", "cluster_aggregates_enabled": true},
-			wantMode: "node_kubelet", wantFlag: true, wantOK: false,
+			wantMode: "node_kubelet", wantFlag: true, wantOK: true,
 		},
 		{
-			name:     "flag explicitly false does not suppress",
+			name:     "flag explicitly false still suppresses on cluster_unassigned",
 			instance: map[string]interface{}{"pod_collection_mode": "cluster_unassigned", "cluster_aggregates_enabled": false},
-			wantMode: "cluster_unassigned", wantFlag: false, wantOK: false,
+			wantMode: "cluster_unassigned", wantFlag: false, wantOK: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -858,23 +858,16 @@ func (k *KSMCheck) Cancel() {
 
 // processMetrics attaches tags and forwards metrics to the aggregator
 func (k *KSMCheck) processMetrics(sender sender.Sender, metrics map[string][]ksmstore.DDMetricsFam, labelJoiner *labelJoiner, now time.Time) {
-	// Suppress .total accumulation on the per-node instances that would otherwise
-	// collide, but only when the instance sets cluster_aggregates_enabled: true:
-	//   - node_kubelet      (per-node agents — same reduced-tag gauge collides across nodes)
-	//   - cluster_unassigned (CLC runner — partial view, would emit an incomplete .total)
+	// Suppress .total accumulation on distributed instances that also emit
+	// per-container resource metrics. Summing both families (or a wildcard like
+	// kubernetes_state.container.cpu_limit*) roughly doubles cluster totals.
+	//   - node_kubelet       (per-node agents)
+	//   - cluster_unassigned (CLC runner shards)
 	// default mode is intentionally excluded: a single full-pod check is already the
-	// authoritative source for .total (no collision), so it must stay unaffected (design goal #5).
-	//
-	// Turning this on also starts the DCA's cluster_aggregates_only reflector
-	// warmup in the same window these instances start suppressing — there is no
-	// clean "DCA serving first, then nodes go quiet" handoff. Expect a brief
-	// (seconds-scale) window at flag-flip where .total is absent, then correct.
-	// The flag is a config signal, not a live DCA health check. While it is off
-	// (the default), nodes fall back to the pre-fix under-reported emission
-	// rather than going silent.
-	suppressClusterAggregates := (k.instance.PodCollectionMode == nodeKubeletPodCollection ||
-		k.instance.PodCollectionMode == clusterUnassignedPodCollection) &&
-		k.instance.ClusterAggregatesEnabled
+	// authoritative source for .total (no collision), so it must stay unaffected.
+	// cluster_aggregates_only on the cluster-agent remains the authoritative .total source.
+	suppressClusterAggregates := k.instance.PodCollectionMode == nodeKubeletPodCollection ||
+		k.instance.PodCollectionMode == clusterUnassignedPodCollection
 	// In cluster_aggregates_only mode, the check emits only the .total family
 	// (via aggregator flush). Skip per-pod transformer/mapper dispatch to avoid
 	// double-emission of per-pod metrics already produced by node-agents.

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -2040,9 +2040,9 @@ func TestProcessMetrics_SuppressModeMatrix(t *testing.T) {
 			wantSuppress: true, wantHasTotal: false,
 		},
 		{
-			name: "node_kubelet + flag=false → emit (safe rollout, DCA not ready)",
+			name: "node_kubelet + flag=false → suppress (per-container is authoritative)",
 			mode: nodeKubeletPodCollection, flagEnabled: false,
-			wantSuppress: false, wantHasTotal: true,
+			wantSuppress: true, wantHasTotal: false,
 		},
 		{
 			name: "cluster_unassigned + flag=true → suppress",
@@ -2050,9 +2050,9 @@ func TestProcessMetrics_SuppressModeMatrix(t *testing.T) {
 			wantSuppress: true, wantHasTotal: false,
 		},
 		{
-			name: "cluster_unassigned + flag=false → emit",
+			name: "cluster_unassigned + flag=false → suppress",
 			mode: clusterUnassignedPodCollection, flagEnabled: false,
-			wantSuppress: false, wantHasTotal: true,
+			wantSuppress: true, wantHasTotal: false,
 		},
 		{
 			name: "default + flag=true → emit (single full-pod check is authoritative, design goal #5)",

--- a/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider.go
@@ -325,39 +325,6 @@ func (p *Provider) processUsageMetric(metricName string, metricFam *prom.MetricF
 	}
 }
 
-// isContainerMemoryLimitSet checks if the memory limit is set on the container level.
-// Returns True if this is the case, False otherwise.
-func isContainerMemoryLimitSet(pod *workloadmeta.KubernetesPod, containerName string) bool {
-	for _, c := range pod.GetAllContainers() {
-		if c.Name == containerName {
-			return c.Resources.MemoryLimit != nil && *c.Resources.MemoryLimit > 0
-		}
-	}
-
-	return false
-}
-
-// shouldSendMemoryLimits checks if the metric should be processed.
-// It checks:
-// - if the container name for that metric has a pod associated with it
-// - if the memory limit is set on the container level
-// Then it returns true if the metric should be processed, false otherwise.
-func (p *Provider) shouldSendMemoryLimits(pod *workloadmeta.KubernetesPod, sample *prom.Sample) bool {
-	// no pod, skip the metric
-	if pod == nil {
-		return false
-	}
-
-	// no container name, skip the metric
-	containerName := p.getContainerName(sample.Metric)
-	if containerName == "" {
-		return false
-	}
-
-	// The memory limit is set on the container level, so we should send the metric.
-	return isContainerMemoryLimitSet(pod, containerName)
-}
-
 func (p *Provider) processLimitMetric(metricName string, metricFam *prom.MetricFamily, cache map[string]*processCache, pctMetricName string, sender sender.Sender) {
 	samples := p.latestValueByContext(metricFam, p.getEntityIDIfContainerMetric)
 	for containerID, sample := range samples {
@@ -369,24 +336,7 @@ func (p *Provider) processLimitMetric(metricName string, metricFam *prom.MetricF
 		tags = utils.ConcatenateTags(tags, p.Config.Tags)
 
 		if metricName != "" {
-			// This is necessary because this metric (kubernetes.memory.limits)
-			// is reported by this provider AND the kubelet provider.
-			// Without this tag it reports as two series;
-			// one with kube_static_cpus:N/A and one with kube_static_cpus:true/false
-			// --------------------------------------------------------------
-			// The cAdvisor provider reports the metric when the memory limit is set on the pod level only.
-			// We only want to send the metric if the memory limit is set on the container level.
-			if metricName == "kubernetes.memory.limits" {
-				pod := p.getPodByMetricLabel(sample.Metric)
-				if p.shouldSendMemoryLimits(pod, sample) {
-					// shouldSendMemoryLimits checks if pod != nil, it's safe to use here.
-					tags = common.AppendKubeStaticCPUsTag(p.store, pod.QOSClass, cID, tags)
-					sender.Gauge(metricName, sample.Value, "", tags)
-				}
-			} else {
-				sender.Gauge(metricName, sample.Value, "", tags)
-			}
-
+			sender.Gauge(metricName, sample.Value, "", tags)
 		}
 
 		if pctMetricName != "" && sample.Value > 0 {
@@ -654,9 +604,11 @@ func (p *Provider) containerSpecMemoryLimitBytes(metricFam *prom.MetricFamily, s
 		log.Errorf("Metric type %s unsupported for metric %s", metricFam.Type, metricFam.Name)
 		return
 	}
-	metricName := common.KubeletMetricsPrefix + "memory.limits"
+	// kubernetes.memory.limits is emitted by the pod provider from the API server
+	// spec. Keep this transformer cache-only so memory.usage_pct can still be
+	// derived from container_spec_memory_limit_bytes without double-counting limits.
 	pctName := common.KubeletMetricsPrefix + "memory.usage_pct"
-	p.processLimitMetric(metricName, metricFam, p.memUsageBytes, pctName, sender)
+	p.processLimitMetric("", metricFam, p.memUsageBytes, pctName, sender)
 }
 
 func (p *Provider) containerSpecMemorySwapLimitBytes(metricFam *prom.MetricFamily, sender sender.Sender) {

--- a/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 
@@ -276,6 +277,7 @@ func (suite *ProviderTestSuite) TestExpectedMetricsWithStatsSummaryAsSource() {
 		common.KubeletMetricsPrefix + "cpu.usage.total",
 		common.KubeletMetricsPrefix + "memory.usage",
 		common.KubeletMetricsPrefix + "memory.working_set",
+		common.KubeletMetricsPrefix + "memory.limits",
 		common.KubeletMetricsPrefix + "filesystem.usage",
 		common.KubeletMetricsPrefix + "filesystem.usage_pct",
 		common.KubeletMetricsPrefix + "network.rx_bytes",
@@ -290,6 +292,23 @@ func (suite *ProviderTestSuite) TestExpectedMetricsWithStatsSummaryAsSource() {
 	// by the (silenced) container_memory_usage_bytes transformer. Asserting it
 	// is still emitted guards the cache-only path in processUsageMetric.
 	suite.mockSender.AssertMetricTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"memory.usage_pct", commontesting.InstanceTags)
+}
+
+func (suite *ProviderTestSuite) TestMemoryLimitsNotEmittedFromCadvisor() {
+	suite.SetupTest()
+
+	response := commontesting.NewEndpointResponse(
+		"../../testdata/cadvisor_metrics_pre_1_16.txt", 200, nil)
+	kubeletMock, err := commontesting.CreateKubeletMock(response, endpoint)
+	if err != nil {
+		suite.T().Fatalf("error creating kubelet mock: %v", err)
+	}
+
+	_ = suite.provider.Provide(kubeletMock, suite.mockSender)
+	suite.mockSender.ResetCalls()
+	require.NoError(suite.T(), suite.provider.Provide(kubeletMock, suite.mockSender))
+
+	suite.mockSender.AssertNotCalled(suite.T(), "Gauge", common.KubeletMetricsPrefix+"memory.limits", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func (suite *ProviderTestSuite) TestPrometheusFiltering() {

--- a/releasenotes/notes/fix-kubernetes-metric-double-counting-50544-followup.yaml
+++ b/releasenotes/notes/fix-kubernetes-metric-double-counting-50544-followup.yaml
@@ -1,0 +1,16 @@
+---
+fixes:
+  - |
+    Fix remaining kubelet and kubernetes_state metric double-counting after
+    ``use_stats_summary_as_source`` deduplication (issue #50544).
+
+    The cAdvisor provider no longer emits ``kubernetes.memory.limits``; the pod
+    provider remains the sole source from the API server spec, while cAdvisor still
+    feeds ``kubernetes.memory.usage_pct``.
+
+    KSM checks running with ``pod_collection_mode: node_kubelet`` or
+    ``cluster_unassigned`` no longer emit cluster-aggregate ``*.total`` resource
+    metrics alongside their per-container counterparts. Queries that wildcard both
+    families (for example ``kubernetes_state.container.cpu_limit*``) no longer
+    sum to roughly 2x. Deploy a ``cluster_aggregates_only`` instance on the
+    cluster-agent for authoritative ``*.total`` metrics.


### PR DESCRIPTION
## Summary

Follow-up to #50544 / #50554. Pod-level usage deduping is fixed in 7.81+, but two duplication patterns remain visible on `sum:` and wildcard queries in Datadog.

| Metric family | Root cause | Fix |
|---|---|---|
| `kubernetes.memory.limits` | cAdvisor + pod provider both emit container limits | cAdvisor keeps cache-only path for `memory.usage_pct`; pod provider is sole limits source |
| `kubernetes_state.container.{cpu,memory}_{limit,requested}` + `*.total` | `node_kubelet` / `cluster_unassigned` KSM instances emit both per-container and cluster-aggregate `.total` families | Always suppress `.total` on distributed instances; `cluster_aggregates_only` on DCA remains authoritative |

Verified in Datadog (pod998): `sum:kubernetes_state.container.cpu_limit{*}` + `sum:kubernetes_state.container.cpu_limit.total{*}` ≈ **1.9×** the per-container sum alone.

## Test plan

- [ ] `dda inv test --targets=./pkg/collector/corechecks/containers/kubelet/provider/cadvisor/...`
- [ ] `dda inv test --targets=./pkg/collector/corechecks/cluster/ksm/...`
- [ ] `dda inv test --targets=./pkg/clusteragent/clusterchecks/...`
- [ ] After deploy: `sum:kubernetes.memory.limits{kube_cluster_id:pod998}` should drop ~2× for containers with explicit limits
- [ ] After deploy: wildcard `sum:kubernetes_state.container.cpu_limit*{kube_cluster_id:pod998}` should match `sum:kubernetes_state.container.cpu_limit.total{*}` (not ~2×)


Made with [Cursor](https://cursor.com)