### PR TITLE
[CONTINT-5530] Fix GKE Autopilot Pulumi scenario

### DIFF
--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -702,6 +702,16 @@ func buildLinuxHelmValuesAutopilot(baseName, agentImagePath, agentImageTag, clus
 		"datadog": pulumi.Map{
 			"apiKeyExistingSecret": pulumi.String(baseName + "-datadog-credentials"),
 			"appKeyExistingSecret": pulumi.String(baseName + "-datadog-credentials"),
+			"logs": pulumi.Map{
+				"enabled":             pulumi.Bool(true),
+				"containerCollectAll": pulumi.Bool(true),
+			},
+			"processAgent": pulumi.Map{
+				"processCollection": pulumi.Bool(true),
+			},
+			"kubelet": pulumi.Map{
+				"useApiServer": pulumi.Bool(true),
+			},
 		},
 		"clusterAgent": pulumi.Map{
 			"enabled": pulumi.Bool(true),

--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -702,10 +702,6 @@ func buildLinuxHelmValuesAutopilot(baseName, agentImagePath, agentImageTag, clus
 		"datadog": pulumi.Map{
 			"apiKeyExistingSecret": pulumi.String(baseName + "-datadog-credentials"),
 			"appKeyExistingSecret": pulumi.String(baseName + "-datadog-credentials"),
-			"logs": pulumi.Map{
-				"enabled":             pulumi.Bool(true),
-				"containerCollectAll": pulumi.Bool(true),
-			},
 			"processAgent": pulumi.Map{
 				"processCollection": pulumi.Bool(true),
 			},

--- a/test/e2e-framework/scenarios/gcp/gke/run.go
+++ b/test/e2e-framework/scenarios/gcp/gke/run.go
@@ -69,6 +69,15 @@ func Run(ctx *pulumi.Context) error {
 			k8sAgentOptions = append(
 				k8sAgentOptions,
 				kubernetesagentparams.WithGKEAutopilot(),
+				// maintain backwards compatibility and avoid
+				// setting logs/container collect all to be unconditionally true
+				// for all GKE Autopilot scenarios
+				kubernetesagentparams.WithHelmValues(`
+datadog:
+  logs:
+    enabled: true
+    containerCollectAll: true
+`),
 			)
 		}
 


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Enables log collection and `useAPIServer` on the kubelet check for the GKE Autopilot pilot Pulumi scenario.

### Motivation
Without manual overrides the scenario was broken.

### Describe how you validated your changes
Ran pulumi up

### Additional Notes
