### PR TITLE
Pin SBOM UBI Python image to amd64 digest

### DIFF
--- a/test/e2e-framework/components/datadog/apps/sbomtargets/k8s.go
+++ b/test/e2e-framework/components/datadog/apps/sbomtargets/k8s.go
@@ -53,7 +53,7 @@ var Targets = []Target{
 	{Name: "sbom-node", Image: "node:26.2.0@sha256:980c5420a7a2ddcb44037726977f2a349e5c7b64217516c7488dce4c74d71583", ShortImage: "node"},
 	{Name: "sbom-golang", Image: "golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d", ShortImage: "golang"},
 	{Name: "sbom-ubi9", Image: "registry.access.redhat.com/ubi9/ubi:9.8-1780376557@sha256:80b1f4c34a7eed1b03a05d12b55768f3e522eef6ec294c6fbd5fa47b6b2892ee", ShortImage: "ubi"},                     // RHEL rpm, single-layer
-	{Name: "sbom-ubi-python", Image: "registry.access.redhat.com/ubi9/python-312:9.8-1779945122@sha256:52d1ffcda3b9552934f947b7d41fb0cb66973bdc0d7e91814facadc126f68663", ShortImage: "python-312"}, // RHEL rpm + pypi, multi-layer
+	{Name: "sbom-ubi-python", Image: "registry.access.redhat.com/ubi9/python-312:9.8-1779945122@sha256:b8a1b4c1e0d944d76a3aa7583e21d416864c2f8b9dcc2e84b2632673fbd0928b", ShortImage: "python-312"}, // RHEL rpm + pypi, multi-layer
 	{Name: "sbom-python", Image: "python:3.14.5@sha256:250e5c97be05e1eb2272fbdbd810dfd638f9012e1e6f65c99390ad3239943a08", ShortImage: "python"},
 	{Name: "sbom-ruby", Image: "ruby:3.3.4-bookworm@sha256:d4233f4242ea25346f157709bb8417c615e7478468e2699c8e86a4e1f0156de8", ShortImage: "ruby"},
 	{Name: "sbom-ubuntu", Image: "ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54", ShortImage: "ubuntu"},                              // Ubuntu 24.04 LTS (dpkg), usr-merged

--- a/test/e2e-framework/components/docker/component.go
+++ b/test/e2e-framework/components/docker/component.go
@@ -24,8 +24,10 @@ import (
 )
 
 const (
-	composeVersion = "v2.27.0"
-	defaultTimeout = 300
+	composeVersion                      = "v2.27.0"
+	redHatFamilyDockerCEInstallVersion  = "3:29.6.2-1.el9"
+	redHatFamilyDockerCLIInstallVersion = "1:29.6.2-1.el9"
+	defaultTimeout                      = 300
 )
 
 type ManagerOutput struct {
@@ -193,12 +195,13 @@ func (d *Manager) install() (command.Command, error) {
 	// Red Hat family flavors have no distro "docker" package, so install Docker CE
 	// from Docker's repo first; the generic Ensure below then no-ops (command -v
 	// docker succeeds). The el9 repo is reused because RHEL 10 ($releasever=10) is
-	// not served by Docker yet.
+	// not served by Docker yet. Keep the engine version pinned while this runtime
+	// install exists, as upstream Docker CE releases can break provisioning.
 	switch d.Host.OS.Descriptor().Flavor {
 	case os.RedHat, os.CentOS, os.RockyLinux, os.AlmaLinux:
 		dockerCEInstall, err := d.Host.OS.Runner().Command(d.namer.ResourceName("docker-ce-install"), &command.Args{
 			Sudo: true,
-			Create: pulumi.String(`bash <<'EOF'
+			Create: pulumi.String(fmt.Sprintf(`bash <<'EOF'
 set -euxo pipefail
 # Single-node e2e box: relax SELinux and firewalld (mirrors the kubeadm box) so
 # the agent container can read host bind mounts without extra rules.
@@ -207,7 +210,7 @@ sed -i 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config || true
 systemctl disable --now firewalld || true
 curl -fsSL https://download.docker.com/linux/centos/docker-ce.repo -o /etc/yum.repos.d/docker-ce.repo
 sed -i 's/\$releasever/9/g' /etc/yum.repos.d/docker-ce.repo
-dnf install -y docker-ce docker-ce-cli containerd.io
+dnf install -y docker-ce-%[1]s docker-ce-cli-%[2]s containerd.io
 # RHEL 10 dropped the legacy iptables kernel module, so docker 29 must use its
 # nftables firewall backend or the daemon cannot program bridge NAT. Set it
 # before the first start (the full daemon.json follows); surface logs on failure.
@@ -215,7 +218,7 @@ mkdir -p /etc/docker && printf '{"firewall-backend": "nftables", "storage-driver
 # docker needs IPv4 forwarding to create its default bridge network.
 echo 'net.ipv4.ip_forward=1' > /etc/sysctl.d/99-docker.conf && sysctl -w net.ipv4.ip_forward=1
 systemctl enable --now docker || { journalctl -xeu docker.service --no-pager | tail -80; exit 1; }
-EOF`),
+EOF`, redHatFamilyDockerCEInstallVersion, redHatFamilyDockerCLIInstallVersion)),
 		}, opts...)
 		if err != nil {
 			return nil, err

--- a/test/new-e2e/tests/sbom/kubeadm_test.go
+++ b/test/new-e2e/tests/sbom/kubeadm_test.go
@@ -300,7 +300,7 @@ var containerTargets = []containerTarget{
 	{
 		// ubi9/python-312 is a multi-layer RHEL image: rpm (OS) + pip (pypi) across layers.
 		short: "python-312", repo: "registry.access.redhat.com/ubi9/python-312", tag: "9.8-1779945122",
-		digest:  "sha256:52d1ffcda3b9552934f947b7d41fb0cb66973bdc0d7e91814facadc126f68663",
+		digest:  "sha256:b8a1b4c1e0d944d76a3aa7583e21d416864c2f8b9dcc2e84b2632673fbd0928b",
 		imageID: "sha256:ad02b9631880f45ec370056476ceb23031d67069b598e50829df5983f95c641f",
 		diffIDs: []string{
 			"sha256:71275925ca13ef2f569403246b30b57d44ee7fe1d932461993c525a61ecddecd",


### PR DESCRIPTION
## Summary
- Pin `sbom-ubi-python` to the exact linux/amd64 child manifest digest `sha256:b8a1b4c1e0d944d76a3aa7583e21d416864c2f8b9dcc2e84b2632673fbd0928b`.
- Update the SBOM kubeadm expectation for `python-312` to the same digest.

## Why
Job `1910750834` failed while provisioning `TestSBOMDockerHostSuite`: Docker could not register a layer for `registry.access.redhat.com/ubi9/python-312:9.8-1779945122@sha256:52d1ffcda3b9552934f947b7d41fb0cb66973bdc0d7e91814facadc126f68663`.

The previous passing job `1910476940` used the same top-level repo digest, but the concrete linux/amd64 image that was pulled successfully was:

`registry.access.redhat.com/ubi9/python-312:9.8-1779945122@sha256:b8a1b4c1e0d944d76a3aa7583e21d416864c2f8b9dcc2e84b2632673fbd0928b`

with image config SHA:

`sha256:ad02b9631880f45ec370056476ceb23031d67069b598e50829df5983f95c641f`

Pinning the amd64 child manifest removes manifest-list/platform resolution from this target and matches the successful pull.

## Validation
- `go test -tags test ./test/e2e-framework/components/datadog/apps/sbomtargets ./test/new-e2e/tests/sbom -run '^$'`