### PR TITLE
fix(gpu): disable deprecated eBPF probes by default

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -330,6 +330,104 @@ func TestDisabledCollectorsWithSystemProbe(t *testing.T) {
 	require.True(t, foundEbpf, "ebpf collector should be created when not disabled")
 }
 
+// ebpfOnlyMetricNames lists the metrics that only the ebpf collector can produce. Every
+// other GPU metric has an NVML-based source, so it survives with the eBPF probes off.
+//
+// The probes are deprecated and disabled by default, which makes this list the set of
+// metrics a default install does not get. Adding an entry here is a customer-visible
+// change and belongs in a release note; if a metric gains an NVML source, remove it.
+var ebpfOnlyMetricNames = []string{"process.core.usage"}
+
+// TestMetricNamesWithoutEBPFProbes pins the metric surface of the default configuration.
+//
+// With gpu_monitoring.enable_ebpf_probes disabled (the default) the check leaves
+// SystemProbeCache nil, so BuildCollectors never creates the ebpf collector. That must
+// cost us exactly ebpfOnlyMetricNames and nothing else: any other metric going missing is
+// a silent regression for everyone who did not opt back in.
+func TestMetricNamesWithoutEBPFProbes(t *testing.T) {
+	withProbes := collectMetricNames(t, seededSystemProbeCache())
+	withoutProbes := collectMetricNames(t, nil)
+
+	for _, name := range ebpfOnlyMetricNames {
+		require.Contains(t, withProbes, name,
+			"%s should be emitted when the eBPF probes are enabled", name)
+		require.NotContains(t, withoutProbes, name,
+			"%s has no NVML source, so it cannot be emitted with the eBPF probes disabled", name)
+	}
+
+	for name := range withProbes {
+		if slices.Contains(ebpfOnlyMetricNames, name) {
+			continue
+		}
+		require.Contains(t, withoutProbes, name,
+			"%s disappeared when the eBPF probes were disabled: either give it an NVML source or add it to ebpfOnlyMetricNames", name)
+	}
+}
+
+// collectMetricNames builds the full collector set for the given system-probe cache (nil
+// meaning the eBPF probes are disabled) and returns every metric name it emits.
+func collectMetricNames(t *testing.T, spCache *SystemProbeCache) map[string]struct{} {
+	t.Helper()
+
+	// One device is enough: the assertions are about which metric names exist, not
+	// their values, and every extra mock device costs an event-set wait per Collect.
+	devices := setupMockDevices(t,
+		testutil.WithDeviceCount(1),
+		testutil.WithMIGDisabled(),
+		testutil.WithCapabilities(testutil.Capabilities{GPM: true, NvLinkGenerationSupported: 6, NvLinkLinkCount: 2}),
+		testutil.WithMockAllFunctions(),
+		testutil.WithArchitecture("blackwell"),
+	)
+
+	eventsGatherer := NewDeviceEventsGatherer()
+	require.NoError(t, eventsGatherer.Start())
+	t.Cleanup(func() { require.NoError(t, eventsGatherer.Stop()) })
+
+	deps := &CollectorDependencies{
+		DeviceEventsGatherer: eventsGatherer,
+		PRMCache:             &PRMCache{},
+		SystemProbeCache:     spCache,
+		Workloadmeta:         testutil.GetWorkloadMetaMockWithDefaultGPUs(t),
+	}
+	seedPRMCacheForDevices(t, deps.PRMCache, devices)
+
+	collectors, err := BuildCollectors(devices, deps, nil)
+	require.NoError(t, err)
+
+	names := make(map[string]struct{})
+	for _, collector := range collectors {
+		metrics, err := collector.Collect()
+		require.NoError(t, err, "collector %s failed to collect", collector.Name())
+		for _, metric := range metrics {
+			names[metric.Name] = struct{}{}
+		}
+	}
+
+	return names
+}
+
+// seededSystemProbeCache returns a cache holding one active process on the default mock
+// device, which is what the ebpf collector needs in order to emit per-process metrics.
+func seededSystemProbeCache() *SystemProbeCache {
+	return &SystemProbeCache{
+		stats: &model.GPUStats{
+			ProcessMetrics: []model.ProcessStatsTuple{
+				{
+					Key: model.ProcessStatsKey{
+						PID:        123,
+						DeviceUUID: testutil.DefaultGpuUUID,
+					},
+					UtilizationMetrics: model.UtilizationMetrics{
+						UsedCores:     50,
+						ActiveTimePct: 25,
+						Memory:        model.MemoryMetrics{CurrentBytes: 1024},
+					},
+				},
+			},
+		},
+	}
+}
+
 func seedPRMCacheForDevices(t *testing.T, cache *PRMCache, devices []ddnvml.Device) {
 	t.Helper()
 

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -379,9 +379,14 @@ func collectMetricNames(t *testing.T, spCache *SystemProbeCache) map[string]stru
 		testutil.WithArchitecture("blackwell"),
 	)
 
+	// Stop the gatherer before returning instead of registering a t.Cleanup: its
+	// worker goroutine reads the global NVML mock, and the caller invokes this
+	// helper again, which installs a fresh one. A t.Cleanup would not run until
+	// the whole test ends, leaving the first worker racing the second setup.
+	// Stop() joins the worker, so the two can never overlap.
 	eventsGatherer := NewDeviceEventsGatherer()
 	require.NoError(t, eventsGatherer.Start())
-	t.Cleanup(func() { require.NoError(t, eventsGatherer.Stop()) })
+	defer func() { require.NoError(t, eventsGatherer.Stop()) }()
 
 	deps := &CollectorDependencies{
 		DeviceEventsGatherer: eventsGatherer,

--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -1273,8 +1273,8 @@ properties:
     type: object
     visibility: public
     description: |-
-      Configuration for the GPU Monitoring module, which uses eBPF probes to collect
-      per-process GPU metrics on Linux hosts (kernel 5.8+).
+      Configuration for the GPU Monitoring module, which collects per-process GPU
+      metrics on Linux hosts.
       Required for GPU monitoring on non-containerized Linux hosts alongside
       gpu.enabled: true in datadog.yaml.
     tags: []
@@ -1285,8 +1285,8 @@ properties:
         default: false
         visibility: public
         description: |-
-          Set to true to enable the GPU Monitoring module. This loads the eBPF programs
-          that collect per-process GPU utilization, memory, and performance metrics.
+          Set to true to enable the GPU Monitoring module, which collects per-process
+          GPU utilization, memory, and performance metrics through NVML.
           Must be used together with gpu.enabled: true in datadog.yaml.
       attacher_detailed_logs:
         node_type: setting
@@ -1318,6 +1318,11 @@ properties:
         node_type: setting
         type: boolean
         default: false
+        visibility: public
+        description: |-
+          Set to true to additionally load the GPU Monitoring eBPF probes, which collect
+          the gpu.process.core.usage metric. Requires Linux kernel 5.8 or later.
+          These probes are deprecated and are disabled by default.
       enable_fatbin_parsing:
         node_type: setting
         type: boolean

--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -1287,6 +1287,15 @@ properties:
         description: |-
           Set to true to enable the GPU Monitoring module, enabling collection of privileged metrics.
           Must be used together with gpu.enabled: true in datadog.yaml.
+      enable_ebpf_probes:
+        node_type: setting
+        type: boolean
+        default: false
+        visibility: public
+        description: |-
+          Set to true to additionally load the GPU Monitoring eBPF probes, which collect
+          the gpu.process.core.usage metric. Requires Linux kernel 5.8 or later.
+          These probes are deprecated and are disabled by default.
       attacher_detailed_logs:
         node_type: setting
         type: boolean
@@ -1313,15 +1322,6 @@ properties:
         format: duration
         tags:
         - golang_type:duration
-      enable_ebpf_probes:
-        node_type: setting
-        type: boolean
-        default: false
-        visibility: public
-        description: |-
-          Set to true to additionally load the GPU Monitoring eBPF probes, which collect
-          the gpu.process.core.usage metric. Requires Linux kernel 5.8 or later.
-          These probes are deprecated and are disabled by default.
       enable_fatbin_parsing:
         node_type: setting
         type: boolean

--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -1317,7 +1317,7 @@ properties:
       enable_ebpf_probes:
         node_type: setting
         type: boolean
-        default: true
+        default: false
       enable_fatbin_parsing:
         node_type: setting
         type: boolean

--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -1273,8 +1273,8 @@ properties:
     type: object
     visibility: public
     description: |-
-      Configuration for the GPU Monitoring module, which collects per-process GPU
-      metrics on Linux hosts.
+      Configuration for the GPU Monitoring module, which collects GPU
+      metrics that require privileged access. Only for Linux hosts.
       Required for GPU monitoring on non-containerized Linux hosts alongside
       gpu.enabled: true in datadog.yaml.
     tags: []
@@ -1285,8 +1285,7 @@ properties:
         default: false
         visibility: public
         description: |-
-          Set to true to enable the GPU Monitoring module, which collects per-process
-          GPU utilization, memory, and performance metrics through NVML.
+          Set to true to enable the GPU Monitoring module, enabling collection of privileged metrics.
           Must be used together with gpu.enabled: true in datadog.yaml.
       attacher_detailed_logs:
         node_type: setting

--- a/pkg/config/setup/system_probe_settings.go
+++ b/pkg/config/setup/system_probe_settings.go
@@ -326,7 +326,7 @@ func initMainSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logon_duration.enabled", false)
 	config.BindEnvAndSetDefault("fleet_policies_dir", "")
 	config.BindEnvAndSetDefault("gpu_monitoring.enabled", false)
-	config.BindEnvAndSetDefault("gpu_monitoring.enable_ebpf_probes", true)
+	config.BindEnvAndSetDefault("gpu_monitoring.enable_ebpf_probes", false)
 	config.BindEnvAndSetDefault("gpu_monitoring.nvml_lib_path", "")
 	config.BindEnvAndSetDefault("gpu_monitoring.process_scan_interval_seconds", 5)
 	config.BindEnvAndSetDefault("gpu_monitoring.initial_process_sync", true)

--- a/pkg/config/system-probe_template.yaml
+++ b/pkg/config/system-probe_template.yaml
@@ -251,8 +251,7 @@
 
 #   # @param enabled - boolean - optional - default: false
 #   # @env DD_GPU_MONITORING_ENABLED - boolean - optional - default: false
-#   # Set to true to enable the GPU Monitoring module, which collects per-process
-#   # GPU utilization, memory, and performance metrics through NVML.
+#   # Set to true to enable the GPU Monitoring module, enabling collection of privileged metrics.
 #   # Must be used together with gpu.enabled: true in datadog.yaml.
 #
 #   enabled: false

--- a/pkg/config/system-probe_template.yaml
+++ b/pkg/config/system-probe_template.yaml
@@ -242,8 +242,8 @@
 ########################################
 
 ## @param gpu_monitoring - custom object - optional
-## Configuration for the GPU Monitoring module, which uses eBPF probes to collect
-## per-process GPU metrics on Linux hosts (kernel 5.8+).
+## Configuration for the GPU Monitoring module, which collects per-process GPU
+## metrics on Linux hosts.
 ## Required for GPU monitoring on non-containerized Linux hosts alongside
 ## gpu.enabled: true in datadog.yaml.
 #
@@ -251,11 +251,19 @@
 
 #   # @param enabled - boolean - optional - default: false
 #   # @env DD_GPU_MONITORING_ENABLED - boolean - optional - default: false
-#   # Set to true to enable the GPU Monitoring module. This loads the eBPF programs
-#   # that collect per-process GPU utilization, memory, and performance metrics.
+#   # Set to true to enable the GPU Monitoring module, which collects per-process
+#   # GPU utilization, memory, and performance metrics through NVML.
 #   # Must be used together with gpu.enabled: true in datadog.yaml.
 #
 #   enabled: false
+
+#   # @param enable_ebpf_probes - boolean - optional - default: false
+#   # @env DD_GPU_MONITORING_ENABLE_EBPF_PROBES - boolean - optional - default: false
+#   # Set to true to additionally load the GPU Monitoring eBPF probes, which collect
+#   # the gpu.process.core.usage metric. Requires Linux kernel 5.8 or later.
+#   # These probes are deprecated and are disabled by default.
+#
+#   enable_ebpf_probes: false
 
 {{- if (eq .OS "windows") }}
 

--- a/pkg/config/system-probe_template.yaml
+++ b/pkg/config/system-probe_template.yaml
@@ -242,8 +242,8 @@
 ########################################
 
 ## @param gpu_monitoring - custom object - optional
-## Configuration for the GPU Monitoring module, which collects per-process GPU
-## metrics on Linux hosts.
+## Configuration for the GPU Monitoring module, which collects GPU
+## metrics that require privileged access. Only for Linux hosts.
 ## Required for GPU monitoring on non-containerized Linux hosts alongside
 ## gpu.enabled: true in datadog.yaml.
 #

--- a/releasenotes/notes/disable-gpu-ebpf-probes-by-default-52386987e7f3edee.yaml
+++ b/releasenotes/notes/disable-gpu-ebpf-probes-by-default-52386987e7f3edee.yaml
@@ -1,0 +1,14 @@
+---
+deprecations:
+  - |
+    The eBPF probes for GPU Monitoring are deprecated and are now disabled by
+    default. Set ``gpu_monitoring.enable_ebpf_probes`` to ``true`` in
+    ``system-probe.yaml`` to keep using them.
+upgrade:
+  - |
+    Because the eBPF probes for GPU Monitoring are now disabled by default, the
+    ``gpu.process.core.usage`` metric is no longer collected by default: it is
+    the only GPU metric produced exclusively by those probes. The closest
+    replacement is ``gpu.process.sm_active``, which is collected through NVML.
+    Set ``gpu_monitoring.enable_ebpf_probes`` to ``true`` to restore the
+    previous behavior. All other GPU metrics are unaffected.

--- a/releasenotes/notes/disable-gpu-ebpf-probes-by-default-52386987e7f3edee.yaml
+++ b/releasenotes/notes/disable-gpu-ebpf-probes-by-default-52386987e7f3edee.yaml
@@ -4,11 +4,3 @@ deprecations:
     The eBPF probes for GPU Monitoring are deprecated and are now disabled by
     default. Set ``gpu_monitoring.enable_ebpf_probes`` to ``true`` in
     ``system-probe.yaml`` to keep using them.
-upgrade:
-  - |
-    Because the eBPF probes for GPU Monitoring are now disabled by default, the
-    ``gpu.process.core.usage`` metric is no longer collected by default: it is
-    the only GPU metric produced exclusively by those probes. The closest
-    replacement is ``gpu.process.sm_active``, which is collected through NVML.
-    Set ``gpu_monitoring.enable_ebpf_probes`` to ``true`` to restore the
-    previous behavior. All other GPU metrics are unaffected.

--- a/test/new-e2e/tests/gpu/capabilities.go
+++ b/test/new-e2e/tests/gpu/capabilities.go
@@ -89,7 +89,9 @@ func (c *hostCapabilities) Agent() agentclient.Agent {
 // UNIX socket present in the root filesystem.
 func (c *hostCapabilities) QuerySysprobe(path string) (string, error) {
 	sysprobeSocket := "/opt/datadog-agent/run/sysprobe.sock"
-	cmd := fmt.Sprintf("sudo curl -s --unix-socket %s http://unix/%s", sysprobeSocket, path)
+	// --fail makes curl exit non-zero on an HTTP error status, so callers see a
+	// failed request instead of the error page as a successful response body.
+	cmd := fmt.Sprintf("sudo curl -s --fail --unix-socket %s http://unix/%s", sysprobeSocket, path)
 	return c.suite.Env().RemoteHost.Execute(cmd)
 }
 
@@ -235,7 +237,9 @@ func (c *kubernetesCapabilities) QuerySysprobe(path string) (string, error) {
 
 	pod := pods.Items[0]
 
-	cmd := []string{"curl", "-s", "--unix-socket", "/var/run/sysprobe/sysprobe.sock", "http://unix/" + path}
+	// --fail makes curl exit non-zero on an HTTP error status, so callers see a
+	// failed request instead of the error page as a successful response body.
+	cmd := []string{"curl", "-s", "--fail", "--unix-socket", "/var/run/sysprobe/sysprobe.sock", "http://unix/" + path}
 	stdout, stderr, err := c.suite.Env().KubernetesCluster.KubernetesClient.PodExec(agentNamespace, pod.Name, "agent", cmd)
 	return stdout + " " + stderr, err
 }

--- a/test/new-e2e/tests/gpu/testdata/config/system_probe_config.yaml
+++ b/test/new-e2e/tests/gpu/testdata/config/system_probe_config.yaml
@@ -3,3 +3,7 @@ system_probe_config:
   enabled: true
 gpu_monitoring:
   enabled: true
+  # The eBPF probes are deprecated and disabled by default. This suite asserts on
+  # gpu.process.core.usage, which only they can produce, so ask for them explicitly
+  # instead of relying on the default.
+  enable_ebpf_probes: true


### PR DESCRIPTION
### What does this PR do?

Re-lands #54053, which flipped `system_probe.gpu_monitoring.enable_ebpf_probes` from `true` to `false`. The two behavioral lines are identical to the original; everything else here is the test coverage that was missing the first time.

- `pkg/config/setup/system_probe_settings.go` — default `true` → `false`
- `pkg/config/schema/yaml/system-probe_schema.yaml` — default `true` → `false`
- `test/new-e2e/tests/gpu/testdata/config/system_probe_config.yaml` — the GPU e2e suite now sets `enable_ebpf_probes: true` explicitly instead of inheriting it
- `pkg/collector/corechecks/gpu/nvidia/collector_test.go` — new `TestMetricNamesWithoutEBPFProbes`, pinning the metric surface of the default configuration
- `test/new-e2e/tests/gpu/capabilities.go` — `curl --fail` in `QuerySysprobe`
- release note — adds an `upgrade` section naming the metric that stops being collected

### Motivation

The eBPF probes for GPU Monitoring are deprecated. Some customers still have the previously recommended `gpu.privilegedMode` enabled, and these probes have caused crashes on NVIDIA GB300 Grace Blackwell Ultra machines: the arm64 uprobe single-step handler intermittently resumes the probed process at the wrong PC, corrupting whatever GPU process the probe fired in.

#54053 was auto-reverted in #54180 because it broke `new-e2e-gpu` on `main`:

```
TestGPUHostSuiteUbuntu2204/TestVectorAddProgramDetected
  Error:    "0" is not greater than "0"
  Messages: no metric values found for metric gpu.process.core.usage
```

`gpu.process.core.usage` is the one GPU metric produced only by the eBPF collector — every other metric has an NVML source. The suite relied on the default being `true`, so it now asks for the probes by name and keeps covering that path.

The default configuration is covered instead by a unit test that asserts turning the probes off costs *exactly* the metrics declared eBPF-only and nothing else. That inverts the failure mode: the next accidental metric drop fails in its own PR rather than on `main`.

The job didn't run on #54053 because `.on_gpu_or_e2e_changes` doesn't include `pkg/config/**`, and that PR touched nothing else. This PR touches `test/new-e2e/tests/gpu/**`, so the GPU suite runs here and validates the new default before merge.

While in `capabilities.go`: `QuerySysprobe` used `curl -s` without `--fail`, so the `/gpu/check` endpoint's 503 `"GPU eBPF probes are disabled"` body came back as a successful response. `TestGPUSysprobeEndpointIsResponding` was therefore passing green with the probes disabled — it could not fail. Fixed for both the host and Kubernetes paths.

### Describe how you validated your changes

- `TestMetricNamesWithoutEBPFProbes` — passes. Confirms `process.core.usage` is emitted with the probes on, absent with them off, and that **no other metric** disappears.
- Full `pkg/collector/corechecks/gpu/nvidia` package — passes, 27.3s.
- `TestConfigurePRMCacheRequiresPRMEndpoint` — passes with the new default, confirming an explicit `enable_ebpf_probes: true` still builds the eBPF collector. This is a default change, not a forced disable.
- Both run on linux with the `nvml,test` tags; the GPU e2e suite runs in this PR's pipeline.

### Additional Notes

**Known coverage gap.** With the e2e suite pinned to probes-on, nothing at the e2e level exercises the shipped default — the unit test proves the metric set is right, but not that system-probe starts and stays healthy with the GPU module loaded probe-less. Closing that needs a second GPU suite variant and one more GPU runner slot. Deliberately deferred.

**Cgroup permissions are unaffected.** `configure_cgroup_perms` is a separate flag, and in `cmd/system-probe/modules/gpu.go` the cgroup call sits outside the `EnableEBPFProbes` block, so permission setup still runs with the probes off.

**`gpu.process.core.usage` has consumers.** Several dashboards query it. The `upgrade` release note points at `gpu.process.sm_active` as the closest NVML equivalent. Whether the out-of-the-box GPU integration dashboard uses it has not been checked — that asset lives outside this repo.

**The deprecation is prose-only.** Nothing in the code marks the flag or the probes as deprecated: no warning when a user explicitly opts back in, no removal target. Worth doing, but it belongs with the root-cause decision on the arm64 uprobe bug rather than here.
