### PR TITLE
[DSEC-223] Update sds-result and emit total matches

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -667,6 +667,7 @@
 /pkg/proto/datadog/languagedetection    @DataDog/container-experiences
 /pkg/proto/datadog/privateactionrunner  @DataDog/action-platform
 /pkg/proto/datadog/process              @DataDog/container-experiences
+/pkg/proto/datadog/sds                  @DataDog/sensitive-data-scanner
 /pkg/proto/datadog/trace                @DataDog/agent-apm
 /pkg/proto/datadog/workloadmeta         @DataDog/container-platform
 /pkg/remoteconfig/                      @DataDog/remote-config

--- a/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/scanning/mod.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/scanning/mod.rs
@@ -53,19 +53,24 @@ impl Scanner {
     }
 }
 
-/// Groups hits into `(column, rule)` pairs and counts matched rows.
+/// Groups hits into `(column, rule)` pairs and counts matched rows and total
+/// matches.
 fn aggregate_matches(rule_ids: &[String], hits: &[RuleMatch]) -> Result<Vec<Match>> {
-    let mut rows: HashMap<(&str, usize), HashSet<&Path>> = HashMap::new();
-    // Bucket each hit by (column, rule), collecting its distinct row paths.
+    // For each (column, rule): the distinct matched row paths and the total
+    // number of matches (a single row may contain several matches).
+    let mut buckets: HashMap<(&str, usize), (HashSet<&Path>, i64)> = HashMap::new();
     for hit in hits {
-        rows.entry((column_name_from_path(&hit.path), hit.rule_index))
-            .or_default()
-            .insert(&hit.path);
+        let (paths, count_matches) = buckets
+            .entry((column_name_from_path(&hit.path), hit.rule_index))
+            .or_default();
+        paths.insert(&hit.path);
+        *count_matches += 1;
     }
 
     // Convert to matches.
-    rows.into_iter()
-        .map(|((column, rule_index), paths)| {
+    buckets
+        .into_iter()
+        .map(|((column, rule_index), (paths, count_matches))| {
             // return an error if the rule index is unknown.
             let rule_id = rule_ids
                 .get(rule_index)
@@ -75,6 +80,7 @@ fn aggregate_matches(rule_ids: &[String], hits: &[RuleMatch]) -> Result<Vec<Matc
                 rule_id,
                 column_name: column.to_string(),
                 count_matched_rows: paths.len() as i64,
+                count_matches,
                 ..Default::default()
             })
         })

--- a/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/scanning/tests.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/scanning/tests.rs
@@ -169,6 +169,7 @@ scan_data: []
             rule_id: "email".to_string(),
             column_name: "email".to_string(),
             count_matched_rows: 2,
+            count_matches: 2,
             ..Default::default()
         }]
     );
@@ -205,6 +206,7 @@ scan_data: []
             rule_id: "token".to_string(),
             column_name: "note".to_string(),
             count_matched_rows: 1,
+            count_matches: 1,
             ..Default::default()
         }]
     );
@@ -241,6 +243,7 @@ scan_data: []
             rule_id: "code".to_string(),
             column_name: "code".to_string(),
             count_matched_rows: 1,
+            count_matches: 1,
             ..Default::default()
         }]
     );
@@ -259,7 +262,7 @@ scan_data: []
     );
 
     // A single row holds two emails: both match the rule, but they share the
-    // same row path, so the row is counted once.
+    // same row path, so the row is counted once while both matches are counted.
     let data = json!({ "email": ["alice@corp.io and bob@corp.io"] });
 
     let matches = scanner.scan(data).expect("failed to scan data");
@@ -270,6 +273,7 @@ scan_data: []
             rule_id: "email".to_string(),
             column_name: "email".to_string(),
             count_matched_rows: 1,
+            count_matches: 2,
             ..Default::default()
         }]
     );
@@ -305,6 +309,7 @@ scan_data: []
             rule_id: "credit-card".to_string(),
             column_name: "card".to_string(),
             count_matched_rows: 1,
+            count_matches: 1,
             ..Default::default()
         }]
     );
@@ -353,6 +358,7 @@ scan_data: []
             rule_id: "email".to_string(),
             column_name: "foo[bar]".to_string(),
             count_matched_rows: 1,
+            count_matches: 1,
             ..Default::default()
         }]
     );
@@ -382,6 +388,7 @@ scan_data: []
             rule_id: "email".to_string(),
             column_name: "first.last".to_string(),
             count_matched_rows: 2,
+            count_matches: 2,
             ..Default::default()
         }]
     );

--- a/pkg/proto/datadog/sds/sds_result.proto
+++ b/pkg/proto/datadog/sds/sds_result.proto
@@ -94,6 +94,7 @@ message SdsResultPayload {
     int64 table_row_count = 6;
     int64 scanned_row_count = 7;
     repeated ScannedColumn scanned_columns = 8;
+    string entity_id = 9;
 
     message ScannedColumn {
       string name = 1;
@@ -154,6 +155,7 @@ message SdsResultPayload {
     string column_name = 2;
     int64 count_matched_rows = 3;
     int64 count_total_rows = 4 [deprecated = true]; //  rely on ScanLocation.RdsTable.table_row_count
+    int64 count_matches = 5;
   }
 
   message ScanMetadata {

--- a/releasenotes/notes/data-security-count-matches-d440e9e587843938.yaml
+++ b/releasenotes/notes/data-security-count-matches-d440e9e587843938.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Data Security scan results now report the total number of sensitive-data
+    matches found in each column (``count_matches``), in addition to the number
+    of distinct rows that contain a match. This gives more accurate visibility
+    when a single row contains several matches.


### PR DESCRIPTION
### What does this PR do?

- Update `sds_result` proto schema to the last version
- Populates `count_matches` in the datasecurity check: total matches per `(column, rule)`, distinct from `count_matched_rows` which counts rows.
- Adds a CODEOWNERS entry for `/pkg/proto/datadog/sds`.

### Motivation

Emit the total number of matches, not just the number of matched rows (a single row can contain several matches).
