### PR TITLE
refactor(kubelet): Remove legacy Python check

### DIFF
--- a/deps/agent_integrations/source_packages.bzl
+++ b/deps/agent_integrations/source_packages.bzl
@@ -21,6 +21,9 @@ ARM_EXCLUSIONS = ["ibm_ace", "ibm_mq"]
 EXCLUSIONS = [
     "tokumx",  # py2-only, unsupported by current Agent
 ]
+WHEEL_EXCLUSIONS = [
+    "kubelet",  # Implemented by the Agent core; configuration files are still bundled.
+]
 
 INTEGRATION_CONFIGURATION_FILENAMES = [
     "conf.yaml.example",
@@ -63,7 +66,18 @@ def _integration_source_packages_impl(rctx):
         struct(name = name, configuration_targets = [])
         for name in ["datadog_checks_base", "datadog_checks_downloader"]
     ]
-    integrations = collect_integrations(rctx, arm_incompatible_integrations = ARM_EXCLUSIONS)
+    integrations = collect_integrations(
+        rctx,
+        arm_incompatible_integrations = ARM_EXCLUSIONS,
+        wheel_exclusions = WHEEL_EXCLUSIONS,
+    )
+
+    requirements_path = rctx.path("requirements-agent-release.txt")
+    requirements = rctx.read(requirements_path)
+    rctx.file(
+        requirements_path,
+        filter_integration_requirements(requirements, WHEEL_EXCLUSIONS),
+    )
 
     # Individual packages that need to be built get their own BUILD file for building them as wheels.
     for package in base_packages + integrations:
@@ -85,16 +99,17 @@ def _integration_source_packages_impl(rctx):
 
     return rctx.repo_metadata(reproducible = True)
 
-def collect_integrations(rctx, *, arm_incompatible_integrations = []):
+def collect_integrations(rctx, *, arm_incompatible_integrations = [], wheel_exclusions = []):
     """Collects toplevel integration packages and their metadata.
 
     Args:
       rctx: The repository_ctx to use.
       arm_incompatible_integrations: Integrations that can't be shipped for ARM systems.
+      wheel_exclusions: Integrations whose configuration files, but not Python wheels, are shipped.
 
     Returns:
       A list of integration package structs, sorted by name, each containing `name`,
-      `configuration_targets` and `platforms` fields.
+      `configuration_targets`, `platforms`, and `ship_wheel` fields.
     """
     manifest_platform_overrides = _load_manifest_platform_overrides(rctx)
 
@@ -121,9 +136,19 @@ def collect_integrations(rctx, *, arm_incompatible_integrations = []):
             name = integration_name,
             configuration_targets = _configuration_targets(rctx, integration_name),
             platforms = platforms,
+            ship_wheel = integration_name not in wheel_exclusions,
         ))
 
     return integrations
+
+def filter_integration_requirements(requirements, excluded_integrations):
+    """Remove unbundled integrations from requirements-agent-release.txt content."""
+    excluded_packages = ["datadog-{}".format(name.replace("_", "-")) for name in excluded_integrations]
+    return "\n".join([
+        line
+        for line in requirements.split("\n")
+        if line.split("==")[0] not in excluded_packages
+    ])
 
 def _bazel_platforms_for_integration(integration_name, supported_platforms, *, arm_incompatible_integrations = []):
     platforms = []
@@ -268,7 +293,10 @@ pkg_files(
 
 def _root_build_file(base_packages, integrations, commit):
     base_wheel_srcs = ["//{}:wheel".format(package.name) for package in base_packages]
-    integrations_select = _render_platform_select(integrations, "//{}:wheel")
+    integrations_select = _render_platform_select(
+        [integration for integration in integrations if integration.ship_wheel],
+        "//{}:wheel",
+    )
     integrations_configuration_select = _render_platform_select(
         [
             integration

--- a/deps/agent_integrations/source_packages_test.bzl
+++ b/deps/agent_integrations/source_packages_test.bzl
@@ -1,7 +1,7 @@
 """Tests for integrations-core source package collection."""
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load(":source_packages.bzl", "collect_integrations")
+load(":source_packages.bzl", "collect_integrations", "filter_integration_requirements")
 
 LINUX_X86_64 = "@@//:linux_x86_64"
 LINUX_ARM64 = "@@//:linux_arm64"
@@ -92,6 +92,17 @@ override_linux = ["linux"]
             ]),
             "pyproject.toml": "",
         },
+        "kubelet": {
+            "datadog_checks": {
+                "kubelet": {
+                    "data": {
+                        "conf.yaml.example": "",
+                    },
+                },
+            },
+            "manifest.json": _manifest(ALL_SUPPORTED_TAGS),
+            "pyproject.toml": "",
+        },
         "no_manifest_no_override": {
             "pyproject.toml": "",
         },
@@ -114,9 +125,10 @@ override_linux = ["linux"]
     integrations = _integration_by_name(collect_integrations(
         rctx,
         arm_incompatible_integrations = ["ibm_mq"],
+        wheel_exclusions = ["kubelet"],
     ))
 
-    asserts.equals(env, 4, len(integrations))
+    asserts.equals(env, 5, len(integrations))
     asserts.equals(env, [LINUX_X86_64, MACOS_X86_64, WINDOWS_X86_64], integrations["ibm_mq"].platforms)
     asserts.equals(
         env,
@@ -129,6 +141,8 @@ override_linux = ["linux"]
         integrations["override_all"].platforms,
     )
     asserts.equals(env, [LINUX_X86_64, LINUX_ARM64], integrations["override_linux"].platforms)
+    asserts.false(env, integrations["kubelet"].ship_wheel)
+    asserts.equals(env, 1, len(integrations["kubelet"].configuration_targets))
 
     return unittest.end(env)
 
@@ -228,9 +242,31 @@ _collect_integrations_includes_platforms_and_configuration_test = unittest.make(
     _collect_integrations_includes_platforms_and_configuration_impl,
 )
 
+def _filter_integration_requirements_impl(ctx):
+    env = unittest.begin(ctx)
+
+    requirements = """# DO NOT PASS THIS TO PIP DIRECTLY
+--no-index
+datadog-kubelet==10.4.0
+datadog-redisdb==8.6.0
+"""
+    expected = """# DO NOT PASS THIS TO PIP DIRECTLY
+--no-index
+datadog-redisdb==8.6.0
+"""
+
+    asserts.equals(env, expected, filter_integration_requirements(requirements, ["kubelet"]))
+
+    return unittest.end(env)
+
+_filter_integration_requirements_test = unittest.make(
+    _filter_integration_requirements_impl,
+)
+
 def source_packages_test_suite(name):
     unittest.suite(
         name,
         _collect_integrations_uses_manifests_and_overrides_test,
         _collect_integrations_includes_platforms_and_configuration_test,
+        _filter_integration_requirements_test,
     )

--- a/pkg/collector/corechecks/containers/kubelet/BUILD.bazel
+++ b/pkg/collector/corechecks/containers/kubelet/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//pkg/collector/corechecks/containers/kubelet/provider/probe",
         "//pkg/collector/corechecks/containers/kubelet/provider/slis",
         "//pkg/collector/corechecks/containers/kubelet/provider/summary",
-        "//pkg/config/setup",
         "//pkg/util/kubernetes/kubelet",
         "//pkg/util/log",
         "//pkg/util/option",

--- a/pkg/collector/corechecks/containers/kubelet/kubelet.go
+++ b/pkg/collector/corechecks/containers/kubelet/kubelet.go
@@ -9,8 +9,6 @@
 package kubelet
 
 import (
-	"fmt"
-
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
@@ -29,7 +27,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/provider/probe"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/provider/slis"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/provider/summary"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
@@ -119,10 +116,6 @@ func Factory(store workloadmeta.Component, filterStore workloadfilter.Component,
 
 // Configure configures the check
 func (k *KubeletCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string, provider string) error {
-	if !pkgconfigsetup.Datadog().GetBool("kubelet_core_check_enabled") {
-		return fmt.Errorf("%w: kubelet core check is disabled", check.ErrSkipCheckInstance)
-	}
-
 	err := k.CommonConfigure(senderManager, initConfig, config, source, provider)
 	if err != nil {
 		return err

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -9250,10 +9250,6 @@ properties:
     type: integer
     default: 0
     comment: not exposed yet. In seconds. 0 means use workloadmeta default
-  kubelet_core_check_enabled:
-    node_type: setting
-    type: boolean
-    default: true
   kubelet_use_api_server:
     node_type: setting
     type: boolean

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -2157,7 +2157,6 @@ func kubernetes(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("kubernetes_https_kubelet_port", 10250)
 
 	config.BindEnvAndSetDefault("kubelet_tls_verify", true)
-	config.BindEnvAndSetDefault("kubelet_core_check_enabled", true)
 	config.BindEnvAndSetDefault("collect_kubernetes_events", false)
 	config.BindEnvAndSetDefault("kubernetes_events_source_detection.enabled", false)
 	config.BindEnvAndSetDefault("kubelet_client_ca", "")

--- a/releasenotes/notes/remove-python-kubelet-check-096ff2dd57a3f462.yaml
+++ b/releasenotes/notes/remove-python-kubelet-check-096ff2dd57a3f462.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    The Agent no longer bundles the legacy Python kubelet check and removes the
+    ``kubelet_core_check_enabled`` setting. The Go kubelet core check now always
+    handles kubelet configurations. This affects installations that set
+    ``kubelet_core_check_enabled: false`` to select the Python implementation;
+    remove that setting before upgrading.


### PR DESCRIPTION
### What does this PR do?

Stops bundling the legacy `datadog-kubelet` Python wheel with Agent packages and removes the `kubelet_core_check_enabled` setting and fallback guard.

The kubelet integration's configuration files remain packaged for the Go core check. The generated `requirements-agent-release.txt` is also filtered so it no longer claims that `datadog-kubelet` ships with the Agent.

### Motivation

The Go kubelet check has been the default since #25033. The legacy Python implementation was retained as a fallback for installations that set `kubelet_core_check_enabled: false`, and #36526 made that fallback explicit when Go check loader priority changed.

The Go check now owns the `kubelet` check name and the same integration configuration. Keeping the Python wheel and rollback flag adds package size and a second implementation path without serving the default configuration.

This is an upgrade change for users that explicitly disabled the core check; the release note calls out that the setting should be removed.

### Describe how you validated your changes

- `dda inv test --targets=./pkg/collector/corechecks/containers/kubelet/...,./pkg/config/setup --build-exclude=systemd` (449 tests passed)
- `bazel test //deps/agent_integrations:source_packages_tests`
- `dda inv schema.lint`
- `bazel run //bazel/buildifier`
- `uvx reno lint`
- Queried the generated `@integration_source_packages` repository and confirmed:
  - `kubelet:wheel` is absent from `integrations_wheels`
  - `kubelet:configuration_files` remains in `integrations_configuration_files`
  - `datadog-kubelet` is absent from the generated `requirements-agent-release.txt`
- Pre-push `go-mod-tidy`, `go-test`, and `go-linter` hooks passed

### Additional Notes

This touches cross-platform package assembly, so the PR requests RC validation.
