### PR TITLE
refactor(kubelet): Retire legacy Python check through integrations-core

### DIFF
--- a/cmd/agent/dist/conf.d/kubelet.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/kubelet.d/conf.yaml.default
@@ -1,0 +1,589 @@
+## @param ad_identifiers - list of strings - required
+## A list of container identifiers that are used by Autodiscovery to identify
+## which container the check should be run against. For more information, see:
+## https://docs.datadoghq.com/agent/guide/ad_identifiers/
+#
+ad_identifiers:
+  - _kubelet
+
+## All options defined here are available to all instances.
+#
+init_config:
+
+    ## @param proxy - mapping - optional
+    ## Set HTTP or HTTPS proxies for all instances. Use the `no_proxy` list
+    ## to specify hosts that must bypass proxies.
+    ##
+    ## The SOCKS protocol is also supported like so:
+    ##
+    ##   socks5://user:pass@host:port
+    ##
+    ## Using the scheme `socks5` causes the DNS resolution to happen on the
+    ## client, rather than on the proxy server. This is in line with `curl`,
+    ## which uses the scheme to decide whether to do the DNS resolution on
+    ## the client or proxy. If you want to resolve the domains on the proxy
+    ## server, use `socks5h` as the scheme.
+    #
+    # proxy:
+    #   http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
+    #   https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
+    #   no_proxy:
+    #   - <HOSTNAME_1>
+    #   - <HOSTNAME_2>
+
+    ## @param skip_proxy - boolean - optional - default: false
+    ## If set to `true`, this makes the check bypass any proxy
+    ## settings enabled and attempt to reach services directly.
+    #
+    # skip_proxy: false
+
+    ## @param timeout - number - optional - default: 10
+    ## The timeout for connecting to services.
+    #
+    # timeout: 10
+
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Additionally, this sets the default `service` for every log source.
+    #
+    # service: <SERVICE>
+
+## Every instance is scheduled independently of the others.
+#
+instances:
+
+  -
+    ## @param cadvisor_metrics_endpoint - string - optional - default: http://10.8.0.1:10255/metrics/cadvisor
+    ## 1.7.6+ clusters expose container metrics in the prometheus format.
+    ## This is the default setting. See next section for legacy clusters.
+    ##
+    ## URL of the cadvisor metrics prometheus endpoint.
+    ## Pass an empty string, or set the cadvisor_port option to disable cadvisor metrics collection.
+    #
+    # cadvisor_metrics_endpoint: http://10.8.0.1:10255/metrics/cadvisor
+
+    ## @param kubelet_metrics_endpoint - string - optional - default: http://10.8.0.1:10255/metrics
+    ## URL of the kubelet metrics prometheus endpoint
+    ## Pass an empty string to disable kubelet metrics collection.
+    #
+    # kubelet_metrics_endpoint: http://10.8.0.1:10255/metrics
+
+    ## @param probes_metrics_endpoint - string - optional - default: http://10.8.0.1:10255/metrics/probes
+    ## URL of the probe metrics prometheus endpoint
+    ## Pass an empty string to disable probe metrics collection.
+    #
+    # probes_metrics_endpoint: http://10.8.0.1:10255/metrics/probes
+
+    ## @param cadvisor_port - integer - optional - default: 4194
+    ## Metric collection for legacy (< 1.7.6) clusters via the kubelet's cadvisor port.
+    ## This port is closed by default on k8s 1.7+ and OpenShift, enable it
+    ## via the `--cadvisor-port=4194` kubelet option.
+    ##
+    ## Port to connect to, uncomment and set accordingly to enable collection.
+    #
+    # cadvisor_port: 4194
+
+    ## @param enabled_rates - list of strings - optional
+    ## Allow list of rate type metrics to collect from cadvisor.
+    #
+    # enabled_rates:
+    #   - cpu.*
+    #   - network.*
+
+    ## @param enabled_gauges - list of strings - optional
+    ## Allow list of gauge type metrics to collect from cadvisor.
+    #
+    # enabled_gauges:
+    #   - filesystem.*
+
+    ## @param health_service_check - boolean - optional - default: true
+    ## Send a service check reporting about the health of the Prometheus endpoint.
+    ## The service check is named <NAMESPACE>.prometheus.health
+    #
+    # health_service_check: true
+
+    ## @param label_to_hostname - string - optional
+    ## Override the hostname with the value of one label.
+    #
+    # label_to_hostname: <LABEL>
+
+    ## @param label_joins - mapping - optional
+    ## Allows targeting a metric to retrieve its label with a 1:1 mapping.
+    #
+    # label_joins:
+    #   target_metric:
+    #     label_to_match: <MATCHED_LABEL>
+    #     labels_to_get:
+    #     - <EXTRA_LABEL_1>
+    #     - <EXTRA_LABEL_2>
+
+    ## @param labels_mapper - mapping - optional
+    ## The label mapper allows you to rename labels.
+    ## Format is <LABEL_TO_RENAME>: <NEW_LABEL_NAME>
+    #
+    # labels_mapper:
+    #   flavor: origin
+
+    ## @param type_overrides - mapping - optional
+    ## Override a type in the Prometheus payload or type an untyped metric (ignored by default).
+    ## Supported <METRIC_TYPE> are `gauge`, `counter`, `histogram`, and `summary`.
+    ## The "*" wildcard can be used to match multiple metric names.
+    #
+    # type_overrides:
+    #   <METRIC_NAME>: <METRIC_TYPE>
+
+    ## @param send_histograms_buckets - boolean - optional - default: true
+    ## Set send_histograms_buckets to true to send the histograms bucket.
+    #
+    # send_histograms_buckets: true
+
+    ## @param send_distribution_buckets - boolean - optional - default: false
+    ## Set `send_distribution_buckets` to `true` to send histograms as Datadog distribution metrics.
+    ##
+    ## Learn more about distribution metrics: https://docs.datadoghq.com/developers/metrics/distributions/
+    #
+    # send_distribution_buckets: false
+
+    ## @param send_monotonic_counter - boolean - optional - default: true
+    ## Set send_monotonic_counter to true to send counters as monotonic counter.
+    #
+    # send_monotonic_counter: true
+
+    ## @param send_distribution_counts_as_monotonic - boolean - optional - default: false
+    ## If set to true, sends histograms and summary counters as monotonic counters (instead of gauges).
+    #
+    # send_distribution_counts_as_monotonic: false
+
+    ## @param send_distribution_sums_as_monotonic - boolean - optional - default: false
+    ## If set to true, sends histograms and summary sums as monotonic counters (instead of gauges).
+    #
+    # send_distribution_sums_as_monotonic: false
+
+    ## @param use_process_start_time - boolean - optional - default: false
+    ## Whether to enable a heuristic for reporting counter values on the first scrape. When true,
+    ## the first time an endpoint is scraped, check `process_start_time_seconds` to decide whether zero
+    ## initial value can be assumed for counters. This requires keeping metrics in memory until the entire
+    ## response is received.
+    #
+    # use_process_start_time: false
+
+    ## @param exclude_labels - list of strings - optional
+    ## A list of labels to be excluded. May be used in conjunction with `include_labels`.
+    ## Labels defined in `excluded labels` will take precedence in case of overlap.
+    #
+    # exclude_labels:
+    #   - timestamp
+
+    ## @param include_labels - list of strings - optional
+    ## A list of labels to include. May be used in conjunction with `exclude_labels`.
+    ## Labels defined in `excluded labels` will take precedence in case of overlap.
+    #
+    # include_labels: []
+
+    ## @param bearer_token_auth - boolean or string - optional - default: false
+    ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
+    ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
+    #
+    # bearer_token_auth: false
+
+    ## @param bearer_token_path - string - optional
+    ## The path to a Kubernetes service account bearer token file. Make sure the file exists and is mounted correctly.
+    ## Note: bearer_token_auth should be set to true to enable adding the token to HTTP headers for authentication.
+    #
+    # bearer_token_path: <TOKEN_PATH>
+
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
+    ## @param ignore_metrics - list of strings - optional
+    ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
+    ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.
+    #
+    # ignore_metrics:
+    #   - <IGNORED_METRIC_NAME>
+    #   - <SUBSTRING_*>
+    #   - <*_SUBSTRING>
+
+    ## @param ignore_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label key and values are ignored.
+    ## Use the "*" wildcard to match all label values.
+    #
+    # ignore_metrics_by_labels:
+    #   <KEY_1>:
+    #   - <LABEL_1>
+    #   - <LABEL_2>
+    #   <KEY_2>:
+    #   - '*'
+
+    ## @param ignore_tags - list of strings - optional
+    ## A list of regular expressions used to ignore tags added by autodiscovery and entries in the `tags` option.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
+
+    ## @param proxy - mapping - optional
+    ## This overrides the `proxy` setting in `init_config`.
+    ##
+    ## Set HTTP or HTTPS proxies for this instance. Use the `no_proxy` list
+    ## to specify hosts that must bypass proxies.
+    ##
+    ## The SOCKS protocol is also supported, for example:
+    ##
+    ##   socks5://user:pass@host:port
+    ##
+    ## Using the scheme `socks5` causes the DNS resolution to happen on the
+    ## client, rather than on the proxy server. This is in line with `curl`,
+    ## which uses the scheme to decide whether to do the DNS resolution on
+    ## the client or proxy. If you want to resolve the domains on the proxy
+    ## server, use `socks5h` as the scheme.
+    #
+    # proxy:
+    #   http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
+    #   https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
+    #   no_proxy:
+    #   - <HOSTNAME_1>
+    #   - <HOSTNAME_2>
+
+    ## @param skip_proxy - boolean - optional - default: false
+    ## This overrides the `skip_proxy` setting in `init_config`.
+    ##
+    ## If set to `true`, this makes the check bypass any proxy
+    ## settings enabled and attempt to reach services directly.
+    #
+    # skip_proxy: false
+
+    ## @param auth_type - string - optional - default: basic
+    ## The type of authentication to use. The available types (and related options) are:
+    ## ```
+    ##   - basic
+    ##     |__ username
+    ##     |__ password
+    ##     |__ use_legacy_auth_encoding
+    ##   - digest
+    ##     |__ username
+    ##     |__ password
+    ##   - ntlm
+    ##     |__ ntlm_domain
+    ##     |__ password
+    ##   - kerberos
+    ##     |__ kerberos_auth
+    ##     |__ kerberos_cache
+    ##     |__ kerberos_delegate
+    ##     |__ kerberos_force_initiate
+    ##     |__ kerberos_hostname
+    ##     |__ kerberos_keytab
+    ##     |__ kerberos_principal
+    ##   - aws
+    ##     |__ aws_region
+    ##     |__ aws_host
+    ##     |__ aws_service
+    ## ```
+    ## The `aws` auth type relies on boto3 to automatically gather AWS credentials, for example: from `.aws/credentials`.
+    ## Details: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials
+    #
+    # auth_type: basic
+
+    ## @param use_legacy_auth_encoding - boolean - optional - default: true
+    ## When `auth_type` is set to `basic`, this determines whether to encode as `latin1` rather than `utf-8`.
+    #
+    # use_legacy_auth_encoding: true
+
+    ## @param username - string - optional
+    ## The username to use if services are behind basic or digest auth.
+    #
+    # username: <USERNAME>
+
+    ## @param password - string - optional
+    ## The password to use if services are behind basic or NTLM auth.
+    #
+    # password: <PASSWORD>
+
+    ## @param ntlm_domain - string - optional
+    ## If your services use NTLM authentication, specify
+    ## the domain used in the check. For NTLM Auth, append
+    ## the username to domain, not as the `username` parameter.
+    #
+    # ntlm_domain: <NTLM_DOMAIN>\<USERNAME>
+
+    ## @param kerberos_auth - string - optional - default: disabled
+    ## If your services use Kerberos authentication, you can specify the Kerberos
+    ## strategy to use between:
+    ##
+    ##   - required
+    ##   - optional
+    ##   - disabled
+    ##
+    ## See https://github.com/requests/requests-kerberos#mutual-authentication
+    #
+    # kerberos_auth: disabled
+
+    ## @param kerberos_cache - string - optional
+    ## Sets the KRB5CCNAME environment variable.
+    ## It should point to a credential cache with a valid TGT.
+    #
+    # kerberos_cache: <KERBEROS_CACHE>
+
+    ## @param kerberos_delegate - boolean - optional - default: false
+    ## Set to `true` to enable Kerberos delegation of credentials to a server that requests delegation.
+    ##
+    ## See https://github.com/requests/requests-kerberos#delegation
+    #
+    # kerberos_delegate: false
+
+    ## @param kerberos_force_initiate - boolean - optional - default: false
+    ## Set to `true` to preemptively initiate the Kerberos GSS exchange and
+    ## present a Kerberos ticket on the initial request (and all subsequent).
+    ##
+    ## See https://github.com/requests/requests-kerberos#preemptive-authentication
+    #
+    # kerberos_force_initiate: false
+
+    ## @param kerberos_hostname - string - optional
+    ## Override the hostname used for the Kerberos GSS exchange if its DNS name doesn't
+    ## match its Kerberos hostname, for example: behind a content switch or load balancer.
+    ##
+    ## See https://github.com/requests/requests-kerberos#hostname-override
+    #
+    # kerberos_hostname: <KERBEROS_HOSTNAME>
+
+    ## @param kerberos_principal - string - optional
+    ## Set an explicit principal, to force Kerberos to look for a
+    ## matching credential cache for the named user.
+    ##
+    ## See https://github.com/requests/requests-kerberos#explicit-principal
+    #
+    # kerberos_principal: <KERBEROS_PRINCIPAL>
+
+    ## @param kerberos_keytab - string - optional
+    ## Set the path to your Kerberos key tab file.
+    #
+    # kerberos_keytab: <KEYTAB_FILE_PATH>
+
+    ## @param auth_token - mapping - optional
+    ## This allows for the use of authentication information from dynamic sources.
+    ## Both a reader and writer must be configured.
+    ##
+    ## The available readers are:
+    ##
+    ##   - type: file
+    ##     path (required): The absolute path for the file to read from.
+    ##     pattern: A regular expression pattern with a single capture group used to find the
+    ##              token rather than using the entire file, for example: Your secret is (.+)
+    ##   - type: oauth
+    ##     url (required): The token endpoint.
+    ##     client_id (required): The client identifier.
+    ##     client_secret (required): The client secret.
+    ##     basic_auth: Whether the provider expects credentials to be transmitted in
+    ##                 an HTTP Basic Auth header. The default is: false
+    ##     options: Mapping of additional options to pass to the provider, such as the audience
+    ##              or the scope. For example:
+    ##                 options:
+    ##                   audience: https://example.com
+    ##                   scope: read:example
+    ##
+    ## The available writers are:
+    ##
+    ##   - type: header
+    ##     name (required): The name of the field, for example: Authorization
+    ##     value: The template value, for example `Bearer <TOKEN>`. The default is: <TOKEN>
+    ##     placeholder: The substring in `value` to replace with the token, defaults to: <TOKEN>
+    #
+    # auth_token:
+    #   reader:
+    #     type: <READER_TYPE>
+    #     <OPTION_1>: <VALUE_1>
+    #     <OPTION_2>: <VALUE_2>
+    #   writer:
+    #     type: <WRITER_TYPE>
+    #     <OPTION_1>: <VALUE_1>
+    #     <OPTION_2>: <VALUE_2>
+
+    ## @param aws_region - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the region.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_region: <AWS_REGION>
+
+    ## @param aws_host - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
+    ##
+    ## Note: This setting is not necessary for official integrations.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_host: <AWS_HOST>
+
+    ## @param aws_service - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the service code. For a list
+    ## of available service codes, see https://docs.aws.amazon.com/general/latest/gr/rande.html
+    ##
+    ## Note: This setting is not necessary for official integrations.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_service: <AWS_SERVICE>
+
+    ## @param tls_verify - boolean - optional - default: true
+    ## Instructs the check to validate the TLS certificate of services.
+    #
+    # tls_verify: true
+
+    ## @param tls_use_host_header - boolean - optional - default: false
+    ## If a `Host` header is set, this enables its use for SNI (matching against the TLS certificate CN or SAN).
+    #
+    # tls_use_host_header: false
+
+    ## @param tls_ignore_warning - boolean - optional - default: false
+    ## If `tls_verify` is disabled, security warnings are logged by the check.
+    ## Disable those by setting `tls_ignore_warning` to true.
+    #
+    # tls_ignore_warning: false
+
+    ## @param tls_cert - string - optional
+    ## The path to a single file in PEM format containing a certificate as well as any
+    ## number of CA certificates needed to establish the certificate's authenticity for
+    ## use when connecting to services. It may also contain an unencrypted private key to use.
+    #
+    # tls_cert: <CERT_PATH>
+
+    ## @param tls_private_key - string - optional
+    ## The unencrypted private key to use for `tls_cert` when connecting to services. This is
+    ## required if `tls_cert` is set and it does not already contain a private key.
+    #
+    # tls_private_key: <PRIVATE_KEY_PATH>
+
+    ## @param tls_ca_cert - string - optional
+    ## The path to a file of concatenated CA certificates in PEM format or a directory
+    ## containing several CA certificates in PEM format. If a directory, the directory
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
+    #
+    # tls_ca_cert: <CA_CERT_PATH>
+
+    ## @param tls_protocols_allowed - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocols_allowed:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
+    ## @param tls_ciphers - list of strings - optional
+    ## The list of ciphers suites to use when connecting to an endpoint. If not specified,
+    ## `ALL` ciphers are used. For list of ciphers see:
+    ## https://www.openssl.org/docs/man1.0.2/man1/ciphers.html
+    #
+    # tls_ciphers:
+    #   - TLS_AES_256_GCM_SHA384
+    #   - TLS_CHACHA20_POLY1305_SHA256
+    #   - TLS_AES_128_GCM_SHA256
+
+    ## @param headers - mapping - optional
+    ## The headers parameter allows you to send specific headers with every request.
+    ## You can use it for explicitly specifying the host header or adding headers for
+    ## authorization purposes.
+    ##
+    ## This overrides any default headers.
+    #
+    # headers:
+    #   Host: <ALTERNATIVE_HOSTNAME>
+    #   X-Auth-Token: <AUTH_TOKEN>
+
+    ## @param extra_headers - mapping - optional
+    ## Additional headers to send with every request.
+    #
+    # extra_headers:
+    #   Host: <ALTERNATIVE_HOSTNAME>
+    #   X-Auth-Token: <AUTH_TOKEN>
+
+    ## @param timeout - number - optional - default: 10
+    ## The timeout for accessing services.
+    ##
+    ## This overrides the `timeout` setting in `init_config`.
+    #
+    # timeout: 10
+
+    ## @param connect_timeout - number - optional
+    ## The connect timeout for accessing services. Defaults to `timeout`.
+    #
+    # connect_timeout: <CONNECT_TIMEOUT>
+
+    ## @param read_timeout - number - optional
+    ## The read timeout for accessing services. Defaults to `timeout`.
+    #
+    # read_timeout: <READ_TIMEOUT>
+
+    ## @param request_size - number - optional - default: 10
+    ## The number of kibibytes (KiB) to read from streaming HTTP responses at a time.
+    #
+    # request_size: 10
+
+    ## @param log_requests - boolean - optional - default: false
+    ## Whether or not to debug log the HTTP(S) requests made, including the method and URL.
+    #
+    # log_requests: false
+
+    ## @param persist_connections - boolean - optional - default: false
+    ## Whether or not to persist cookies and use connection pooling for improved performance.
+    #
+    # persist_connections: false
+
+    ## @param allow_redirects - boolean - optional - default: true
+    ## Whether or not to allow URL redirection.
+    #
+    # allow_redirects: true
+
+    ## @param tags - list of strings - optional
+    ## A list of tags to attach to every metric and service check emitted by this instance.
+    ##
+    ## Learn more about tagging at https://docs.datadoghq.com/tagging
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>
+
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Overrides any `service` defined in the `init_config` section.
+    #
+    # service: <SERVICE>
+
+    ## @param min_collection_interval - number - optional - default: 20
+    ## This changes the collection interval of the check. For more information, see:
+    ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+    #
+    min_collection_interval: 20
+
+    ## @param empty_default_hostname - boolean - optional - default: false
+    ## This forces the check to send metrics with no hostname.
+    ##
+    ## This is useful for cluster-level checks.
+    #
+    # empty_default_hostname: false
+
+    ## @param metric_patterns - mapping - optional
+    ## A mapping of metrics to include or exclude, with each entry being a regular expression.
+    ##
+    ## Metrics defined in `exclude` will take precedence in case of overlap.
+    #
+    # metric_patterns:
+    #   include:
+    #   - <INCLUDE_REGEX>
+    #   exclude:
+    #   - <EXCLUDE_REGEX>

--- a/cmd/agent/dist/conf.d/kubelet.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/kubelet.d/conf.yaml.example
@@ -1,0 +1,581 @@
+## All options defined here are available to all instances.
+#
+init_config:
+
+    ## @param proxy - mapping - optional
+    ## Set HTTP or HTTPS proxies for all instances. Use the `no_proxy` list
+    ## to specify hosts that must bypass proxies.
+    ##
+    ## The SOCKS protocol is also supported like so:
+    ##
+    ##   socks5://user:pass@host:port
+    ##
+    ## Using the scheme `socks5` causes the DNS resolution to happen on the
+    ## client, rather than on the proxy server. This is in line with `curl`,
+    ## which uses the scheme to decide whether to do the DNS resolution on
+    ## the client or proxy. If you want to resolve the domains on the proxy
+    ## server, use `socks5h` as the scheme.
+    #
+    # proxy:
+    #   http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
+    #   https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
+    #   no_proxy:
+    #   - <HOSTNAME_1>
+    #   - <HOSTNAME_2>
+
+    ## @param skip_proxy - boolean - optional - default: false
+    ## If set to `true`, this makes the check bypass any proxy
+    ## settings enabled and attempt to reach services directly.
+    #
+    # skip_proxy: false
+
+    ## @param timeout - number - optional - default: 10
+    ## The timeout for connecting to services.
+    #
+    # timeout: 10
+
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Additionally, this sets the default `service` for every log source.
+    #
+    # service: <SERVICE>
+
+## Every instance is scheduled independently of the others.
+#
+instances:
+
+  -
+    ## @param cadvisor_metrics_endpoint - string - optional - default: http://10.8.0.1:10255/metrics/cadvisor
+    ## 1.7.6+ clusters expose container metrics in the prometheus format.
+    ## This is the default setting. See next section for legacy clusters.
+    ##
+    ## URL of the cadvisor metrics prometheus endpoint.
+    ## Pass an empty string, or set the cadvisor_port option to disable cadvisor metrics collection.
+    #
+    # cadvisor_metrics_endpoint: http://10.8.0.1:10255/metrics/cadvisor
+
+    ## @param kubelet_metrics_endpoint - string - optional - default: http://10.8.0.1:10255/metrics
+    ## URL of the kubelet metrics prometheus endpoint
+    ## Pass an empty string to disable kubelet metrics collection.
+    #
+    # kubelet_metrics_endpoint: http://10.8.0.1:10255/metrics
+
+    ## @param probes_metrics_endpoint - string - optional - default: http://10.8.0.1:10255/metrics/probes
+    ## URL of the probe metrics prometheus endpoint
+    ## Pass an empty string to disable probe metrics collection.
+    #
+    # probes_metrics_endpoint: http://10.8.0.1:10255/metrics/probes
+
+    ## @param cadvisor_port - integer - optional - default: 4194
+    ## Metric collection for legacy (< 1.7.6) clusters via the kubelet's cadvisor port.
+    ## This port is closed by default on k8s 1.7+ and OpenShift, enable it
+    ## via the `--cadvisor-port=4194` kubelet option.
+    ##
+    ## Port to connect to, uncomment and set accordingly to enable collection.
+    #
+    # cadvisor_port: 4194
+
+    ## @param enabled_rates - list of strings - optional
+    ## Allow list of rate type metrics to collect from cadvisor.
+    #
+    # enabled_rates:
+    #   - cpu.*
+    #   - network.*
+
+    ## @param enabled_gauges - list of strings - optional
+    ## Allow list of gauge type metrics to collect from cadvisor.
+    #
+    # enabled_gauges:
+    #   - filesystem.*
+
+    ## @param health_service_check - boolean - optional - default: true
+    ## Send a service check reporting about the health of the Prometheus endpoint.
+    ## The service check is named <NAMESPACE>.prometheus.health
+    #
+    # health_service_check: true
+
+    ## @param label_to_hostname - string - optional
+    ## Override the hostname with the value of one label.
+    #
+    # label_to_hostname: <LABEL>
+
+    ## @param label_joins - mapping - optional
+    ## Allows targeting a metric to retrieve its label with a 1:1 mapping.
+    #
+    # label_joins:
+    #   target_metric:
+    #     label_to_match: <MATCHED_LABEL>
+    #     labels_to_get:
+    #     - <EXTRA_LABEL_1>
+    #     - <EXTRA_LABEL_2>
+
+    ## @param labels_mapper - mapping - optional
+    ## The label mapper allows you to rename labels.
+    ## Format is <LABEL_TO_RENAME>: <NEW_LABEL_NAME>
+    #
+    # labels_mapper:
+    #   flavor: origin
+
+    ## @param type_overrides - mapping - optional
+    ## Override a type in the Prometheus payload or type an untyped metric (ignored by default).
+    ## Supported <METRIC_TYPE> are `gauge`, `counter`, `histogram`, and `summary`.
+    ## The "*" wildcard can be used to match multiple metric names.
+    #
+    # type_overrides:
+    #   <METRIC_NAME>: <METRIC_TYPE>
+
+    ## @param send_histograms_buckets - boolean - optional - default: true
+    ## Set send_histograms_buckets to true to send the histograms bucket.
+    #
+    # send_histograms_buckets: true
+
+    ## @param send_distribution_buckets - boolean - optional - default: false
+    ## Set `send_distribution_buckets` to `true` to send histograms as Datadog distribution metrics.
+    ##
+    ## Learn more about distribution metrics: https://docs.datadoghq.com/developers/metrics/distributions/
+    #
+    # send_distribution_buckets: false
+
+    ## @param send_monotonic_counter - boolean - optional - default: true
+    ## Set send_monotonic_counter to true to send counters as monotonic counter.
+    #
+    # send_monotonic_counter: true
+
+    ## @param send_distribution_counts_as_monotonic - boolean - optional - default: false
+    ## If set to true, sends histograms and summary counters as monotonic counters (instead of gauges).
+    #
+    # send_distribution_counts_as_monotonic: false
+
+    ## @param send_distribution_sums_as_monotonic - boolean - optional - default: false
+    ## If set to true, sends histograms and summary sums as monotonic counters (instead of gauges).
+    #
+    # send_distribution_sums_as_monotonic: false
+
+    ## @param use_process_start_time - boolean - optional - default: false
+    ## Whether to enable a heuristic for reporting counter values on the first scrape. When true,
+    ## the first time an endpoint is scraped, check `process_start_time_seconds` to decide whether zero
+    ## initial value can be assumed for counters. This requires keeping metrics in memory until the entire
+    ## response is received.
+    #
+    # use_process_start_time: false
+
+    ## @param exclude_labels - list of strings - optional
+    ## A list of labels to be excluded. May be used in conjunction with `include_labels`.
+    ## Labels defined in `excluded labels` will take precedence in case of overlap.
+    #
+    # exclude_labels:
+    #   - timestamp
+
+    ## @param include_labels - list of strings - optional
+    ## A list of labels to include. May be used in conjunction with `exclude_labels`.
+    ## Labels defined in `excluded labels` will take precedence in case of overlap.
+    #
+    # include_labels: []
+
+    ## @param bearer_token_auth - boolean or string - optional - default: false
+    ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
+    ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
+    #
+    # bearer_token_auth: false
+
+    ## @param bearer_token_path - string - optional
+    ## The path to a Kubernetes service account bearer token file. Make sure the file exists and is mounted correctly.
+    ## Note: bearer_token_auth should be set to true to enable adding the token to HTTP headers for authentication.
+    #
+    # bearer_token_path: <TOKEN_PATH>
+
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
+    ## @param ignore_metrics - list of strings - optional
+    ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
+    ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.
+    #
+    # ignore_metrics:
+    #   - <IGNORED_METRIC_NAME>
+    #   - <SUBSTRING_*>
+    #   - <*_SUBSTRING>
+
+    ## @param ignore_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label key and values are ignored.
+    ## Use the "*" wildcard to match all label values.
+    #
+    # ignore_metrics_by_labels:
+    #   <KEY_1>:
+    #   - <LABEL_1>
+    #   - <LABEL_2>
+    #   <KEY_2>:
+    #   - '*'
+
+    ## @param ignore_tags - list of strings - optional
+    ## A list of regular expressions used to ignore tags added by autodiscovery and entries in the `tags` option.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
+
+    ## @param proxy - mapping - optional
+    ## This overrides the `proxy` setting in `init_config`.
+    ##
+    ## Set HTTP or HTTPS proxies for this instance. Use the `no_proxy` list
+    ## to specify hosts that must bypass proxies.
+    ##
+    ## The SOCKS protocol is also supported, for example:
+    ##
+    ##   socks5://user:pass@host:port
+    ##
+    ## Using the scheme `socks5` causes the DNS resolution to happen on the
+    ## client, rather than on the proxy server. This is in line with `curl`,
+    ## which uses the scheme to decide whether to do the DNS resolution on
+    ## the client or proxy. If you want to resolve the domains on the proxy
+    ## server, use `socks5h` as the scheme.
+    #
+    # proxy:
+    #   http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
+    #   https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
+    #   no_proxy:
+    #   - <HOSTNAME_1>
+    #   - <HOSTNAME_2>
+
+    ## @param skip_proxy - boolean - optional - default: false
+    ## This overrides the `skip_proxy` setting in `init_config`.
+    ##
+    ## If set to `true`, this makes the check bypass any proxy
+    ## settings enabled and attempt to reach services directly.
+    #
+    # skip_proxy: false
+
+    ## @param auth_type - string - optional - default: basic
+    ## The type of authentication to use. The available types (and related options) are:
+    ## ```
+    ##   - basic
+    ##     |__ username
+    ##     |__ password
+    ##     |__ use_legacy_auth_encoding
+    ##   - digest
+    ##     |__ username
+    ##     |__ password
+    ##   - ntlm
+    ##     |__ ntlm_domain
+    ##     |__ password
+    ##   - kerberos
+    ##     |__ kerberos_auth
+    ##     |__ kerberos_cache
+    ##     |__ kerberos_delegate
+    ##     |__ kerberos_force_initiate
+    ##     |__ kerberos_hostname
+    ##     |__ kerberos_keytab
+    ##     |__ kerberos_principal
+    ##   - aws
+    ##     |__ aws_region
+    ##     |__ aws_host
+    ##     |__ aws_service
+    ## ```
+    ## The `aws` auth type relies on boto3 to automatically gather AWS credentials, for example: from `.aws/credentials`.
+    ## Details: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials
+    #
+    # auth_type: basic
+
+    ## @param use_legacy_auth_encoding - boolean - optional - default: true
+    ## When `auth_type` is set to `basic`, this determines whether to encode as `latin1` rather than `utf-8`.
+    #
+    # use_legacy_auth_encoding: true
+
+    ## @param username - string - optional
+    ## The username to use if services are behind basic or digest auth.
+    #
+    # username: <USERNAME>
+
+    ## @param password - string - optional
+    ## The password to use if services are behind basic or NTLM auth.
+    #
+    # password: <PASSWORD>
+
+    ## @param ntlm_domain - string - optional
+    ## If your services use NTLM authentication, specify
+    ## the domain used in the check. For NTLM Auth, append
+    ## the username to domain, not as the `username` parameter.
+    #
+    # ntlm_domain: <NTLM_DOMAIN>\<USERNAME>
+
+    ## @param kerberos_auth - string - optional - default: disabled
+    ## If your services use Kerberos authentication, you can specify the Kerberos
+    ## strategy to use between:
+    ##
+    ##   - required
+    ##   - optional
+    ##   - disabled
+    ##
+    ## See https://github.com/requests/requests-kerberos#mutual-authentication
+    #
+    # kerberos_auth: disabled
+
+    ## @param kerberos_cache - string - optional
+    ## Sets the KRB5CCNAME environment variable.
+    ## It should point to a credential cache with a valid TGT.
+    #
+    # kerberos_cache: <KERBEROS_CACHE>
+
+    ## @param kerberos_delegate - boolean - optional - default: false
+    ## Set to `true` to enable Kerberos delegation of credentials to a server that requests delegation.
+    ##
+    ## See https://github.com/requests/requests-kerberos#delegation
+    #
+    # kerberos_delegate: false
+
+    ## @param kerberos_force_initiate - boolean - optional - default: false
+    ## Set to `true` to preemptively initiate the Kerberos GSS exchange and
+    ## present a Kerberos ticket on the initial request (and all subsequent).
+    ##
+    ## See https://github.com/requests/requests-kerberos#preemptive-authentication
+    #
+    # kerberos_force_initiate: false
+
+    ## @param kerberos_hostname - string - optional
+    ## Override the hostname used for the Kerberos GSS exchange if its DNS name doesn't
+    ## match its Kerberos hostname, for example: behind a content switch or load balancer.
+    ##
+    ## See https://github.com/requests/requests-kerberos#hostname-override
+    #
+    # kerberos_hostname: <KERBEROS_HOSTNAME>
+
+    ## @param kerberos_principal - string - optional
+    ## Set an explicit principal, to force Kerberos to look for a
+    ## matching credential cache for the named user.
+    ##
+    ## See https://github.com/requests/requests-kerberos#explicit-principal
+    #
+    # kerberos_principal: <KERBEROS_PRINCIPAL>
+
+    ## @param kerberos_keytab - string - optional
+    ## Set the path to your Kerberos key tab file.
+    #
+    # kerberos_keytab: <KEYTAB_FILE_PATH>
+
+    ## @param auth_token - mapping - optional
+    ## This allows for the use of authentication information from dynamic sources.
+    ## Both a reader and writer must be configured.
+    ##
+    ## The available readers are:
+    ##
+    ##   - type: file
+    ##     path (required): The absolute path for the file to read from.
+    ##     pattern: A regular expression pattern with a single capture group used to find the
+    ##              token rather than using the entire file, for example: Your secret is (.+)
+    ##   - type: oauth
+    ##     url (required): The token endpoint.
+    ##     client_id (required): The client identifier.
+    ##     client_secret (required): The client secret.
+    ##     basic_auth: Whether the provider expects credentials to be transmitted in
+    ##                 an HTTP Basic Auth header. The default is: false
+    ##     options: Mapping of additional options to pass to the provider, such as the audience
+    ##              or the scope. For example:
+    ##                 options:
+    ##                   audience: https://example.com
+    ##                   scope: read:example
+    ##
+    ## The available writers are:
+    ##
+    ##   - type: header
+    ##     name (required): The name of the field, for example: Authorization
+    ##     value: The template value, for example `Bearer <TOKEN>`. The default is: <TOKEN>
+    ##     placeholder: The substring in `value` to replace with the token, defaults to: <TOKEN>
+    #
+    # auth_token:
+    #   reader:
+    #     type: <READER_TYPE>
+    #     <OPTION_1>: <VALUE_1>
+    #     <OPTION_2>: <VALUE_2>
+    #   writer:
+    #     type: <WRITER_TYPE>
+    #     <OPTION_1>: <VALUE_1>
+    #     <OPTION_2>: <VALUE_2>
+
+    ## @param aws_region - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the region.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_region: <AWS_REGION>
+
+    ## @param aws_host - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
+    ##
+    ## Note: This setting is not necessary for official integrations.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_host: <AWS_HOST>
+
+    ## @param aws_service - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the service code. For a list
+    ## of available service codes, see https://docs.aws.amazon.com/general/latest/gr/rande.html
+    ##
+    ## Note: This setting is not necessary for official integrations.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_service: <AWS_SERVICE>
+
+    ## @param tls_verify - boolean - optional - default: true
+    ## Instructs the check to validate the TLS certificate of services.
+    #
+    # tls_verify: true
+
+    ## @param tls_use_host_header - boolean - optional - default: false
+    ## If a `Host` header is set, this enables its use for SNI (matching against the TLS certificate CN or SAN).
+    #
+    # tls_use_host_header: false
+
+    ## @param tls_ignore_warning - boolean - optional - default: false
+    ## If `tls_verify` is disabled, security warnings are logged by the check.
+    ## Disable those by setting `tls_ignore_warning` to true.
+    #
+    # tls_ignore_warning: false
+
+    ## @param tls_cert - string - optional
+    ## The path to a single file in PEM format containing a certificate as well as any
+    ## number of CA certificates needed to establish the certificate's authenticity for
+    ## use when connecting to services. It may also contain an unencrypted private key to use.
+    #
+    # tls_cert: <CERT_PATH>
+
+    ## @param tls_private_key - string - optional
+    ## The unencrypted private key to use for `tls_cert` when connecting to services. This is
+    ## required if `tls_cert` is set and it does not already contain a private key.
+    #
+    # tls_private_key: <PRIVATE_KEY_PATH>
+
+    ## @param tls_ca_cert - string - optional
+    ## The path to a file of concatenated CA certificates in PEM format or a directory
+    ## containing several CA certificates in PEM format. If a directory, the directory
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
+    #
+    # tls_ca_cert: <CA_CERT_PATH>
+
+    ## @param tls_protocols_allowed - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocols_allowed:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
+    ## @param tls_ciphers - list of strings - optional
+    ## The list of ciphers suites to use when connecting to an endpoint. If not specified,
+    ## `ALL` ciphers are used. For list of ciphers see:
+    ## https://www.openssl.org/docs/man1.0.2/man1/ciphers.html
+    #
+    # tls_ciphers:
+    #   - TLS_AES_256_GCM_SHA384
+    #   - TLS_CHACHA20_POLY1305_SHA256
+    #   - TLS_AES_128_GCM_SHA256
+
+    ## @param headers - mapping - optional
+    ## The headers parameter allows you to send specific headers with every request.
+    ## You can use it for explicitly specifying the host header or adding headers for
+    ## authorization purposes.
+    ##
+    ## This overrides any default headers.
+    #
+    # headers:
+    #   Host: <ALTERNATIVE_HOSTNAME>
+    #   X-Auth-Token: <AUTH_TOKEN>
+
+    ## @param extra_headers - mapping - optional
+    ## Additional headers to send with every request.
+    #
+    # extra_headers:
+    #   Host: <ALTERNATIVE_HOSTNAME>
+    #   X-Auth-Token: <AUTH_TOKEN>
+
+    ## @param timeout - number - optional - default: 10
+    ## The timeout for accessing services.
+    ##
+    ## This overrides the `timeout` setting in `init_config`.
+    #
+    # timeout: 10
+
+    ## @param connect_timeout - number - optional
+    ## The connect timeout for accessing services. Defaults to `timeout`.
+    #
+    # connect_timeout: <CONNECT_TIMEOUT>
+
+    ## @param read_timeout - number - optional
+    ## The read timeout for accessing services. Defaults to `timeout`.
+    #
+    # read_timeout: <READ_TIMEOUT>
+
+    ## @param request_size - number - optional - default: 10
+    ## The number of kibibytes (KiB) to read from streaming HTTP responses at a time.
+    #
+    # request_size: 10
+
+    ## @param log_requests - boolean - optional - default: false
+    ## Whether or not to debug log the HTTP(S) requests made, including the method and URL.
+    #
+    # log_requests: false
+
+    ## @param persist_connections - boolean - optional - default: false
+    ## Whether or not to persist cookies and use connection pooling for improved performance.
+    #
+    # persist_connections: false
+
+    ## @param allow_redirects - boolean - optional - default: true
+    ## Whether or not to allow URL redirection.
+    #
+    # allow_redirects: true
+
+    ## @param tags - list of strings - optional
+    ## A list of tags to attach to every metric and service check emitted by this instance.
+    ##
+    ## Learn more about tagging at https://docs.datadoghq.com/tagging
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>
+
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Overrides any `service` defined in the `init_config` section.
+    #
+    # service: <SERVICE>
+
+    ## @param min_collection_interval - number - optional - default: 20
+    ## This changes the collection interval of the check. For more information, see:
+    ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+    #
+    min_collection_interval: 20
+
+    ## @param empty_default_hostname - boolean - optional - default: false
+    ## This forces the check to send metrics with no hostname.
+    ##
+    ## This is useful for cluster-level checks.
+    #
+    # empty_default_hostname: false
+
+    ## @param metric_patterns - mapping - optional
+    ## A mapping of metrics to include or exclude, with each entry being a regular expression.
+    ##
+    ## Metrics defined in `exclude` will take precedence in case of overlap.
+    #
+    # metric_patterns:
+    #   include:
+    #   - <INCLUDE_REGEX>
+    #   exclude:
+    #   - <EXCLUDE_REGEX>

--- a/cmd/agent/dist/core_checks.bzl
+++ b/cmd/agent/dist/core_checks.bzl
@@ -16,6 +16,7 @@ AGENT_CORECHECKS = [
     "go_expvar",
     "io",
     "jmx",
+    "kubelet",
     "kubernetes_apiserver",
     "load",
     "memory",

--- a/pkg/collector/corechecks/containers/kubelet/BUILD.bazel
+++ b/pkg/collector/corechecks/containers/kubelet/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//pkg/collector/corechecks/containers/kubelet/provider/probe",
         "//pkg/collector/corechecks/containers/kubelet/provider/slis",
         "//pkg/collector/corechecks/containers/kubelet/provider/summary",
-        "//pkg/config/setup",
         "//pkg/util/kubernetes/kubelet",
         "//pkg/util/log",
         "//pkg/util/option",

--- a/pkg/collector/corechecks/containers/kubelet/kubelet.go
+++ b/pkg/collector/corechecks/containers/kubelet/kubelet.go
@@ -9,8 +9,6 @@
 package kubelet
 
 import (
-	"fmt"
-
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
@@ -29,7 +27,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/provider/probe"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/provider/slis"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/provider/summary"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
@@ -119,10 +116,6 @@ func Factory(store workloadmeta.Component, filterStore workloadfilter.Component,
 
 // Configure configures the check
 func (k *KubeletCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string, provider string) error {
-	if !pkgconfigsetup.Datadog().GetBool("kubelet_core_check_enabled") {
-		return fmt.Errorf("%w: kubelet core check is disabled", check.ErrSkipCheckInstance)
-	}
-
 	err := k.CommonConfigure(senderManager, initConfig, config, source, provider)
 	if err != nil {
 		return err

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -9250,10 +9250,6 @@ properties:
     type: integer
     default: 0
     comment: not exposed yet. In seconds. 0 means use workloadmeta default
-  kubelet_core_check_enabled:
-    node_type: setting
-    type: boolean
-    default: true
   kubelet_use_api_server:
     node_type: setting
     type: boolean

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -2157,7 +2157,6 @@ func kubernetes(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("kubernetes_https_kubelet_port", 10250)
 
 	config.BindEnvAndSetDefault("kubelet_tls_verify", true)
-	config.BindEnvAndSetDefault("kubelet_core_check_enabled", true)
 	config.BindEnvAndSetDefault("collect_kubernetes_events", false)
 	config.BindEnvAndSetDefault("kubernetes_events_source_detection.enabled", false)
 	config.BindEnvAndSetDefault("kubelet_client_ca", "")

--- a/release.json
+++ b/release.json
@@ -2,7 +2,7 @@
     "base_branch": "main",
     "current_milestone": "7.83.0",
     "dependencies": {
-        "INTEGRATIONS_CORE_VERSION": "f60732d6369f3dba70fd128ee707eee6ddd40e67",
+        "INTEGRATIONS_CORE_VERSION": "c73df3eeb7bf523785e202b5c4fd7d00b7e0aac7",
         "INTEGRATIONS_WHEELS_STORAGE": "stable",
         "JMXFETCH_HASH": "3eb735171a3e41518c4101a6aee06fee8b93092d015769c2e470eecadb4bd11b",
         "JMXFETCH_VERSION": "0.52.0",

--- a/releasenotes/notes/remove-python-kubelet-check-096ff2dd57a3f462.yaml
+++ b/releasenotes/notes/remove-python-kubelet-check-096ff2dd57a3f462.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    The Agent no longer bundles the legacy Python kubelet check and removes the
+    ``kubelet_core_check_enabled`` setting. The Go kubelet core check now always
+    handles kubelet configurations. This affects installations that set
+    ``kubelet_core_check_enabled: false`` to select the Python implementation;
+    remove that setting before upgrading.


### PR DESCRIPTION
### What does this PR do?

Retires the Python kubelet fallback through the established cross-repository flow:

- pins `integrations-core` to DataDog/integrations-core#24745, where the `datadog-kubelet` Python project is removed
- moves `conf.yaml.default` and `conf.yaml.example` into the Agent's core-check configuration tree
- removes `kubelet_core_check_enabled` from configuration setup and schema
- removes the Go check's fallback guard, so kubelet configurations are always handled by the core check

Because the pinned integrations commit no longer has `kubelet/pyproject.toml`, the existing Agent packaging discovery naturally omits the wheel and `datadog_checks/kubelet` from embedded Python. No Agent-specific wheel exclusion is introduced.

### Motivation

The Go kubelet core check has been the default since #25033. The Python implementation now only supports the explicit `kubelet_core_check_enabled: false` rollback path, while still occupying the embedded Python site-packages directory.

This follows the same ownership model used for core-only checks such as NTP and Datadog CSI Driver: runtime code and configuration live in `datadog-agent`; public integration assets remain in `integrations-core`.

### Describe how you validated your changes

- `dda inv test --targets=./pkg/collector/corechecks/containers/kubelet/...,./pkg/config/setup --build-exclude=systemd` (449 tests passed)
- `dda inv schema.lint`
- `bazel run //bazel/buildifier`
- `bazel test //deps/agent_integrations:source_packages_tests`
- `bazel build //cmd/agent/dist/conf.d:base_checks_files`
- queried `@integration_source_packages` and confirmed there is no kubelet package target, wheel reference, or `datadog-kubelet` release requirement
- queried `//cmd/agent/dist/conf.d:base_checks_files` and confirmed both Agent-owned kubelet configuration files are packaged
- pre-push `go-mod-tidy`, `go-test`, and `go-linter` hooks passed

The companion integrations-core branch also passes CI configuration, release requirements, CODEOWNERS, labeler, README, metadata, and service-check validations.

### Additional Notes

Depends on DataDog/integrations-core#24745.

Draft #54294 remains unchanged so its CI results can be compared with this established two-repository approach. This PR supersedes that implementation direction and deliberately does not add a wheel-exclusion mechanism.

This changes cross-platform package assembly, so RC validation is requested.
