### PR TITLE
refactor(privileged-logs): extract OpenPathWithoutSymlinks into common

### DIFF
--- a/pkg/privileged-logs/common/BUILD.bazel
+++ b/pkg/privileged-logs/common/BUILD.bazel
@@ -1,8 +1,38 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "common",
-    srcs = ["types.go"],
+    srcs = [
+        "open_linux.go",
+        "types.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/pkg/privileged-logs/common",
     visibility = ["//visibility:public"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@org_golang_x_sys//unix",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+dd_agent_go_test(
+    name = "common_test",
+    srcs = ["open_linux_test.go"],
+    embed = [":common"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/pkg/privileged-logs/common/open_linux.go
+++ b/pkg/privileged-logs/common/open_linux.go
@@ -5,7 +5,7 @@
 
 //go:build linux
 
-package module
+package common
 
 import (
 	"fmt"
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// openPathWithoutSymlinks opens a file by traversing each path component with
+// OpenPathWithoutSymlinks opens a file by traversing each path component with
 // O_NOFOLLOW, to ensure that the actual filesystem structure matches the path
 // passed to the function.  On newer kernels, this could be done with openat2(2)
 // and RESOLVE_NO_SYMLINKS.
@@ -25,7 +25,10 @@ import (
 // os.OpenInRoot(), since all of those follow symlinks on the root directory
 // itself, but for our use case, the root directory itself can not be trusted to
 // not have changed since the time the path was validated.
-func openPathWithoutSymlinks(path string) (*os.File, error) {
+//
+// This function is shared by the privileged-logs module (server side,
+// root-running system-probe) and the privileged-logs client (agent side).
+func OpenPathWithoutSymlinks(path string) (*os.File, error) {
 	if !filepath.IsAbs(path) {
 		return nil, fmt.Errorf("path must be absolute: %s", path)
 	}

--- a/pkg/privileged-logs/common/open_linux_test.go
+++ b/pkg/privileged-logs/common/open_linux_test.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenPathWithoutSymlinksNoSymlink(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "test.log")
+	require.NoError(t, os.WriteFile(logFile, []byte("hello"), 0644))
+
+	f, err := OpenPathWithoutSymlinks(logFile)
+	require.NoError(t, err)
+	defer f.Close()
+
+	buf := make([]byte, 5)
+	n, err := f.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(buf[:n]))
+}
+
+func TestOpenPathWithoutSymlinksSymlinkInFile(t *testing.T) {
+	dir := t.TempDir()
+	realFile := filepath.Join(dir, "real.log")
+	require.NoError(t, os.WriteFile(realFile, []byte("secret"), 0644))
+
+	link := filepath.Join(dir, "link.log")
+	require.NoError(t, os.Symlink(realFile, link))
+
+	f, err := OpenPathWithoutSymlinks(link)
+	assert.Error(t, err)
+	assert.Nil(t, f)
+	// O_NOFOLLOW on the final component should give ELOOP
+	assert.ErrorIs(t, err, syscall.ELOOP)
+}
+
+func TestOpenPathWithoutSymlinksSymlinkInParentDirectory(t *testing.T) {
+	dir := t.TempDir()
+	realDir := filepath.Join(dir, "real")
+	require.NoError(t, os.Mkdir(realDir, 0755))
+
+	logFile := filepath.Join(realDir, "test.log")
+	require.NoError(t, os.WriteFile(logFile, []byte("hello"), 0644))
+
+	linkDir := filepath.Join(dir, "link")
+	require.NoError(t, os.Symlink(realDir, linkDir))
+
+	f, err := OpenPathWithoutSymlinks(filepath.Join(linkDir, "test.log"))
+	assert.Error(t, err)
+	assert.Nil(t, f)
+	// O_DIRECTORY|O_NOFOLLOW on a symlinked directory component is rejected.
+	assert.ErrorIs(t, err, syscall.ENOTDIR)
+}
+
+func TestOpenPathWithoutSymlinksSymlinkSwap(t *testing.T) {
+	// Simulate the attacker scenario: open a real file, swap it to a symlink,
+	// confirm the second open is rejected.
+	dir := t.TempDir()
+	realFile := filepath.Join(dir, "real.log")
+	require.NoError(t, os.WriteFile(realFile, []byte("benign"), 0644))
+
+	// First open should succeed (path is a real file at this point)
+	f, err := OpenPathWithoutSymlinks(realFile)
+	require.NoError(t, err)
+	f.Close()
+
+	// Attacker swaps the file for a symlink to a sensitive target
+	sensitiveFile := filepath.Join(dir, "sensitive.dat")
+	require.NoError(t, os.WriteFile(sensitiveFile, []byte("SECRET"), 0644))
+	require.NoError(t, os.Remove(realFile))
+	require.NoError(t, os.Symlink(sensitiveFile, realFile))
+
+	// Second open must fail with ELOOP, not return the sensitive file
+	f2, err := OpenPathWithoutSymlinks(realFile)
+	assert.Error(t, err)
+	assert.Nil(t, f2)
+	assert.ErrorIs(t, err, syscall.ELOOP)
+}

--- a/pkg/privileged-logs/module/BUILD.bazel
+++ b/pkg/privileged-logs/module/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     srcs = [
         "handler.go",
         "module.go",
-        "open.go",
         "validate.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/privileged-logs/module",
@@ -17,14 +16,12 @@ go_library(
             "//pkg/system-probe/api/module",
             "//pkg/util/log",
             "@com_github_hashicorp_golang_lru_v2//simplelru",
-            "@org_golang_x_sys//unix",
         ],
         "@rules_go//go/platform:linux": [
             "//pkg/privileged-logs/common",
             "//pkg/system-probe/api/module",
             "//pkg/util/log",
             "@com_github_hashicorp_golang_lru_v2//simplelru",
-            "@org_golang_x_sys//unix",
         ],
         "//conditions:default": [],
     }),
@@ -40,11 +37,13 @@ dd_agent_go_test(
     embed = [":module"],
     deps = select({
         "@rules_go//go/platform:android": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/log",
             "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:linux": [
+            "//pkg/privileged-logs/common",
             "//pkg/util/log",
             "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",

--- a/pkg/privileged-logs/module/open_test.go
+++ b/pkg/privileged-logs/module/open_test.go
@@ -14,16 +14,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/privileged-logs/common"
 )
 
-// openPathWithoutSymlinksAndCheckFDs wraps openPathWithoutSymlinks and verifies
-// that no file descriptors are leaked. For success cases, it checks that exactly
-// one FD is opened. For error cases, it checks that no FDs are leaked.
+// openPathWithoutSymlinksAndCheckFDs wraps common.OpenPathWithoutSymlinks and
+// verifies that no file descriptors are leaked. For success cases, it checks
+// that exactly one FD is opened. For error cases, it checks that no FDs are
+// leaked.
 func openPathWithoutSymlinksAndCheckFDs(t *testing.T, path string) (*os.File, error) {
 	t.Helper()
 	fdsBefore := countOpenFDs(t)
 
-	file, err := openPathWithoutSymlinks(path)
+	file, err := common.OpenPathWithoutSymlinks(path)
 
 	if err != nil {
 		fdsAfter := countOpenFDs(t)

--- a/pkg/privileged-logs/module/validate.go
+++ b/pkg/privileged-logs/module/validate.go
@@ -15,6 +15,8 @@ import (
 	"path/filepath"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/DataDog/datadog-agent/pkg/privileged-logs/common"
 )
 
 func isAllowed(path, allowedPrefix string) bool {
@@ -85,10 +87,10 @@ func validateAndOpenWithPrefix(path, allowedPrefix string, toctou func()) (*os.F
 		return nil, fmt.Errorf("non-log file not allowed: %s", resolvedPath)
 	}
 
-	// We use openPathWithoutSymlinks on the resolved path to verify each
+	// We use common.OpenPathWithoutSymlinks on the resolved path to verify each
 	// component with O_NOFOLLOW to ensure that none of the path components
 	// were replaced with symlinks after we called EvalSymlinks.
-	file, err = openPathWithoutSymlinks(resolvedPath)
+	file, err = common.OpenPathWithoutSymlinks(resolvedPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open path %s: %w", resolvedPath, err)
 	}


### PR DESCRIPTION
### What does this PR do?

Moves the `O_NOFOLLOW` directory-walk helper (`openPathWithoutSymlinks`) out of
`pkg/privileged-logs/module` (the system-probe-side privileged logs module)
and into a new shared `pkg/privileged-logs/common` package, exporting it as
`OpenPathWithoutSymlinks`. This is a pure move/rename — **no behavior
change**.

### Motivation

This is PR 1 of a 4-PR stack that splits up #51746 for easier review (see
that PR's description for full context on the underlying fix:
disabling symlink-following for `process_log`-discovered paths, DSCVR-475).

A follow-up PR in this stack (#54303) needs the same symlink-safe open helper on the
*agent-side* privileged-logs client, not just the system-probe-side module —
this refactor makes that helper shared and reusable before any new behavior
is introduced, so the next PR's diff is scoped to the actual new capability
rather than mixed with a package move.

### Describe how you validated your changes

- `dda inv system-probe.build` and `dda inv test --targets=./pkg/privileged-logs/...` pass.
- The moved test file (`common/open_linux_test.go`) is a straight port of the
  existing `TestOpenPathWithoutSymlinks` subtests, so behavior coverage is
  unchanged.