### PR TITLE
Reduce empty process command line debug logging

### DIFF
--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -46,6 +46,7 @@ const (
 	configStripProcArgs        = "process_config.strip_proc_arguments"
 	configDisallowList         = "process_config.blacklist_patterns"
 	configIgnoreZombies        = "process_config.ignore_zombie_processes"
+	emptyCmdlinePIDSampleSize  = 5
 )
 
 // NewProcessCheck returns an instance of the ProcessCheck.
@@ -485,8 +486,23 @@ func fmtProcesses(
 	now time.Time,
 ) map[string][]*model.Process {
 	procsByCtr := make(map[string][]*model.Process)
+	debugLoggingEnabled := log.ShouldLog(log.DebugLvl)
+	traceLoggingEnabled := log.ShouldLog(log.TraceLvl)
+	emptyCmdlineCount := 0
+	emptyCmdlinePIDs := make([]int32, 0, emptyCmdlinePIDSampleSize)
 
 	for _, fp := range procs {
+		if len(fp.Cmdline) == 0 {
+			if traceLoggingEnabled {
+				log.Tracef("Empty commandline for pid:%d using exe:[%s] to check if the process should be skipped", fp.Pid, []string{fp.Exe})
+			}
+			if debugLoggingEnabled {
+				emptyCmdlineCount++
+				if len(emptyCmdlinePIDs) < emptyCmdlinePIDSampleSize {
+					emptyCmdlinePIDs = append(emptyCmdlinePIDs, fp.Pid)
+				}
+			}
+		}
 		if skipProcess(disallowList, fp, lastProcs, zombiesIgnored) {
 			continue
 		}
@@ -537,6 +553,9 @@ func fmtProcesses(
 			procsByCtr[proc.ContainerId] = make([]*model.Process, 0)
 		}
 		procsByCtr[proc.ContainerId] = append(procsByCtr[proc.ContainerId], proc)
+	}
+	if emptyCmdlineCount > 0 {
+		log.Debugf("Used executable paths to evaluate filters for %d processes with empty command lines; sample_pids=%v", emptyCmdlineCount, emptyCmdlinePIDs)
 	}
 
 	scrubber.IncrementCacheAge()
@@ -655,7 +674,6 @@ func skipProcess(
 	cl := fp.Cmdline
 	if len(cl) == 0 {
 		cl = []string{fp.Exe}
-		log.Debugf("Empty commandline for pid:%d using exe:[%s] to check if the process should be skipped", fp.Pid, cl)
 	}
 	if isDisallowListed(cl, disallowList) {
 		return true

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -37,7 +37,8 @@ const (
 	// C.sysconf(C._SC_CLK_TCK)
 	DefaultClockTicks = float64(100)
 	// More than 5760 to work around https://golang.org/issue/24015.
-	blockSize = 8192
+	blockSize                 = 8192
+	emptyCmdlinePIDSampleSize = 5
 )
 
 var (
@@ -243,6 +244,10 @@ func (p *probe) ProcessesByPID(now time.Time, collectStats bool) (map[int32]*Pro
 	}
 
 	procsByPID := make(map[int32]*Process, len(pids))
+	debugLoggingEnabled := log.ShouldLog(log.DebugLvl)
+	traceLoggingEnabled := log.ShouldLog(log.TraceLvl)
+	emptyCmdlineCount := 0
+	emptyCmdlinePIDs := make([]int32, 0, emptyCmdlinePIDSampleSize)
 	for _, pid := range pids {
 		pathForPID := filepath.Join(p.procRootLoc, strconv.Itoa(int(pid)))
 		if !filesystem.FileExists(pathForPID) {
@@ -265,7 +270,15 @@ func (p *probe) ProcessesByPID(now time.Time, collectStats bool) (map[int32]*Pro
 			} else if p.ignoreZombieProcesses {
 				continue
 			}
-			log.Debugf("process with empty cmdline not skipped pid:%d", pid)
+			if traceLoggingEnabled {
+				log.Tracef("process with empty cmdline not skipped pid:%d", pid)
+			}
+			if debugLoggingEnabled {
+				emptyCmdlineCount++
+				if len(emptyCmdlinePIDs) < emptyCmdlinePIDSampleSize {
+					emptyCmdlinePIDs = append(emptyCmdlinePIDs, pid)
+				}
+			}
 		}
 
 		// On linux, setting the `collectStats` parameter to false will only prevent collection of memory stats.
@@ -312,6 +325,9 @@ func (p *probe) ProcessesByPID(now time.Time, collectStats bool) (map[int32]*Pro
 			} // use -1 values to represent "no permission"
 		}
 		procsByPID[pid] = proc
+	}
+	if emptyCmdlineCount > 0 {
+		log.Debugf("Found %d processes with empty command lines that were not skipped; sample_pids=%v", emptyCmdlineCount, emptyCmdlinePIDs)
 	}
 
 	return procsByPID, nil


### PR DESCRIPTION
### What does this PR do?

Moves the per-process empty-command-line messages from debug to trace in both process collection paths.

At debug level, each scan now emits one aggregate summary with:

- the total number of affected processes
- up to five sample PIDs

Process collection and filtering behavior is unchanged.

### Motivation

On hosts with large process tables, an empty command line can generate tens of thousands of debug messages per collection interval. That volume can rapidly rotate the Agent logs and hide the diagnostic history needed to investigate collection or intake lag.

Keeping the per-PID detail at trace preserves it for targeted troubleshooting, while the bounded debug summary still shows the scale of the condition and provides representative PIDs.

### Describe how you validated your changes

- Pre-commit hooks passed.
- Pre-push Go tests and golangci-lint passed.
- Focused Bazel tests passed:
  - `//pkg/process/checks:checks_test_base`
  - `//pkg/process/procutil:procutil_test_base` with `TestProcessesByPIDTest(FS|IgnoringZombiesFS)`
- `git diff --check` passed.

### Additional Notes

The full procutil Bazel suite also exposed an existing `TestProcfsChange` fixture failure unrelated to these logging paths; the directly affected procutil tests pass.