### PR TITLE
fix(aix): compress config schema without bazel on AIX build hosts

### DIFF
--- a/packaging/aix/build.sh
+++ b/packaging/aix/build.sh
@@ -73,6 +73,7 @@ check_tool() {
 check_tool git        git
 check_tool curl       curl
 check_tool xz         xz
+check_tool zstd       zstd
 check_tool make       make
 check_tool cmake      cmake
 check_tool gcc        gcc

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -144,10 +144,7 @@ def build(
 
     flavor_cmd = "iot-agent" if flavor.is_iot() else "agent"
 
-    # AIX build hosts do not have bazel; the compressed schema files are
-    # committed to the repo and do not need regeneration there.
-    if sys.platform != "aix":
-        schema_compress(ctx)
+    schema_compress(ctx)
 
     with gitlab_section("Build agent", collapsed=True):
         go_build(

--- a/tasks/schema/generate.py
+++ b/tasks/schema/generate.py
@@ -5,6 +5,7 @@ Schema generation tasks
 import json
 import os
 import shutil
+import sys
 import tempfile
 
 import yaml
@@ -78,7 +79,48 @@ yaml.add_representer(str, str_presenter)
 
 @task
 def compress(ctx, output_dir=COMPRESS_DIR):
+    """
+    Compress the schema files for embedding into the Go binary.
+
+    Uses bazel, except on AIX build hosts, which don't have bazel: there,
+    transparently falls back to `_compress_no_bazel`.
+    """
+    if sys.platform == "aix":
+        _compress_no_bazel(ctx, output_dir)
+        return
     bazel(ctx, "run", "//pkg/config/schema:install_compressed", "--", f"--destdir={os.path.abspath(output_dir)}")
+
+
+# Must match the ZSTD_ARGS in pkg/config/schema/BUILD.bazel: --no-check to
+# match DataDog/zstd Go library behavior (no XXH64 frame checksum), -5 to
+# match DataDog/zstd's DefaultCompression.
+_ZSTD_ARGS = "--no-check -5"
+
+
+def _compress_no_bazel(ctx, output_dir=COMPRESS_DIR):
+    """
+    Compress the schema files without bazel.
+
+    Reimplements the pipeline in pkg/config/schema/BUILD.bazel (inline $refs,
+    strip build-time-only keys, zstd-compress) by calling the same helpers
+    bazel wraps as py_binary tools, plus a system `zstd` binary. Used on
+    build hosts that cannot run bazel (e.g. AIX).
+    """
+    compressed_dir = os.path.join(output_dir, "compressed")
+    os.makedirs(compressed_dir, exist_ok=True)
+
+    for name, top_schema in (
+        ("core_schema", CORE_SCHEMA_MAIN_FILE),
+        ("system-probe_schema", SYSTEM_PROBE_SCHEMA_MAIN_FILE),
+    ):
+        embedded_fd, embedded_path = tempfile.mkstemp(suffix=".yaml")
+        os.close(embedded_fd)
+        try:
+            produce_byproduct("embedded", top_schema, embedded_path)
+            out_path = os.path.join(compressed_dir, f"{name}.yaml.zstd")
+            ctx.run(f"zstd --force {_ZSTD_ARGS} {embedded_path} -o {out_path}")
+        finally:
+            os.remove(embedded_path)
 
 
 _SUBSCHEMA_DIALECT = "https://json-schema.org/draft/2020-12/schema"


### PR DESCRIPTION
### What does this PR do?

Makes `schema.compress` transparently fall back to a bazel-free implementation on AIX (no bazel there), instead of skipping schema compression entirely.

### Motivation

AIX build hosts have no bazel, so `agent.build` was skipping `schema.compress` outright, leaving no embedded schema for runtime config validation on AIX.

### Describe how you validated your changes

Ran `python3.12 -m invoke schema.compress` on a real AIX host and diffed the decompressed output's SHA256 against a `bazel run //pkg/config/schema:install_compressed` build — byte-identical.

### Additional Notes