### PR TITLE
Fix issues with specifying cdb$root in quotes

### DIFF
--- a/pkg/collector/corechecks/oracle/custom_queries.go
+++ b/pkg/collector/corechecks/oracle/custom_queries.go
@@ -91,13 +91,19 @@ func (c *Check) CustomQueries() error {
 		if !c.connectedToPdb {
 			pdb = q.Pdb
 			if pdb == "" {
-				pdb = "cdb$root"
-			}
-			_, err := c.dbCustomQueries.Exec(fmt.Sprintf(`alter session set container = "%s"`, strings.ReplaceAll(pdb, `"`, `""`)))
-			if err != nil {
-				allErrors = concatenateError(allErrors, fmt.Sprintf("failed to set container %s %s", pdb, err))
-				reconnectOnConnectionError(c, &c.dbCustomQueries, err)
-				continue
+				_, err := c.dbCustomQueries.Exec(`alter session set container = cdb$root`)
+				if err != nil {
+					allErrors = concatenateError(allErrors, fmt.Sprintf("failed to set container to cdb$root %s", err))
+					reconnectOnConnectionError(c, &c.dbCustomQueries, err)
+					continue
+				}
+			} else {
+				_, err := c.dbCustomQueries.Exec(fmt.Sprintf(`alter session set container = "%s"`, strings.ReplaceAll(pdb, `"`, `""`)))
+				if err != nil {
+					allErrors = concatenateError(allErrors, fmt.Sprintf("failed to set container %s %s", pdb, err))
+					reconnectOnConnectionError(c, &c.dbCustomQueries, err)
+					continue
+				}
 			}
 		}
 		rows, err := c.dbCustomQueries.Queryx(q.Query)

--- a/pkg/collector/corechecks/oracle/custom_queries.go
+++ b/pkg/collector/corechecks/oracle/custom_queries.go
@@ -97,6 +97,7 @@ func (c *Check) CustomQueries() error {
 					reconnectOnConnectionError(c, &c.dbCustomQueries, err)
 					continue
 				}
+				pdb = "cdb$root"
 			} else {
 				_, err := c.dbCustomQueries.Exec(fmt.Sprintf(`alter session set container = "%s"`, strings.ReplaceAll(pdb, `"`, `""`)))
 				if err != nil {

--- a/pkg/collector/corechecks/oracle/custom_queries.go
+++ b/pkg/collector/corechecks/oracle/custom_queries.go
@@ -90,21 +90,18 @@ func (c *Check) CustomQueries() error {
 		var pdb string
 		if !c.connectedToPdb {
 			pdb = q.Pdb
+			var alterSQL string
 			if pdb == "" {
-				_, err := c.dbCustomQueries.Exec(`alter session set container = cdb$root`)
-				if err != nil {
-					allErrors = concatenateError(allErrors, fmt.Sprintf("failed to set container to cdb$root %s", err))
-					reconnectOnConnectionError(c, &c.dbCustomQueries, err)
-					continue
-				}
 				pdb = "cdb$root"
+				alterSQL = `alter session set container = cdb$root`
 			} else {
-				_, err := c.dbCustomQueries.Exec(fmt.Sprintf(`alter session set container = "%s"`, strings.ReplaceAll(pdb, `"`, `""`)))
-				if err != nil {
-					allErrors = concatenateError(allErrors, fmt.Sprintf("failed to set container %s %s", pdb, err))
-					reconnectOnConnectionError(c, &c.dbCustomQueries, err)
-					continue
-				}
+				alterSQL = fmt.Sprintf(`alter session set container = "%s"`, strings.ReplaceAll(pdb, `"`, `""`))
+			}
+			_, err := c.dbCustomQueries.Exec(alterSQL)
+			if err != nil {
+				allErrors = concatenateError(allErrors, fmt.Sprintf("failed to set container to %s %s", pdb, err))
+				reconnectOnConnectionError(c, &c.dbCustomQueries, err)
+				continue
 			}
 		}
 		rows, err := c.dbCustomQueries.Queryx(q.Query)

--- a/pkg/collector/corechecks/oracle/custom_queries_test.go
+++ b/pkg/collector/corechecks/oracle/custom_queries_test.go
@@ -332,3 +332,34 @@ func TestGlobalCustomQueries(t *testing.T) {
 	defer c.Teardown()
 	assertCustomQuery(t, &c, s)
 }
+
+func TestDefaultContainerNotQuoted(t *testing.T) {
+    db, dbMock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+    require.NoError(t, err)
+    defer db.Close()
+
+    dbMock.ExpectExec(`alter session set container = cdb$root`).
+        WillReturnResult(sqlmock.NewResult(1, 1))
+    rows := sqlmock.NewRows([]string{"val"}).AddRow(1)
+    dbMock.ExpectQuery("SELECT val FROM t").WillReturnRows(rows)
+
+    q := config.CustomQuery{
+        MetricPrefix: "oracle.defaultcontainer",
+        // Pdb intentionally omitted
+        Query:        "SELECT val FROM t",
+        Columns:      []config.CustomQueryColumns{{Name: "val", Type: "gauge"}},
+    }
+
+    chk, sender := newDbDoesNotExistCheck(t, "", "")
+    chk.Run()
+    sender.SetupAcceptAll()
+    sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+    sender.On("Commit").Return()
+
+    chk.config.InstanceConfig.CustomQueries = []config.CustomQuery{q}
+    chk.dbCustomQueries = sqlx.NewDb(db, "sqlmock")
+
+    err = chk.CustomQueries()
+    assert.NoError(t, err)
+    assert.NoError(t, dbMock.ExpectationsWereMet())
+}


### PR DESCRIPTION
When running custom queries and not specifying a custom `pdb` parameter, the agent connects to `cdb$root`. Recently we added logic to always put the container database name in double-quotes before running the custom queries: https://github.com/DataDog/datadog-agent/pull/46637
This was to prevent sql-injection from the custom string passed in as `pdb`.

We saw this cause an issue for some customers with certain Oracle versions. The quotes on `"cdb$root"` were preventing Oracle from normalizing the capitalization, and causing the agent to fail here with `ORA-65000: missing or invalid pluggable database name`.

With this change, we still use quotes on user-provided PDB names, however we do not use quotes for the default root name. This should both prevent any SQL injection mentioned in #46637 and also resolve this new issue.

### Motivation
https://datadoghq.atlassian.net/browse/SDBM-2820

### Describe how you validated your changes

### Additional Notes
