### PR TITLE
[DSEC-179] add scanned columns and scanned row counts

### DIFF
--- a/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/backend/mod.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/backend/mod.rs
@@ -8,15 +8,34 @@ use crate::config::SubTask;
 #[cfg(feature = "engine-postgres")]
 mod postgres;
 
-/// A data-source engine that runs a sub task's query and returns the result as
-/// a `{ column: [values] }` map ready for the scanner.
+/// One scanned column's name and its source data type (e.g. `text`, `varchar`).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ScannedColumn {
+    pub name: String,
+    pub data_type: String,
+}
+
+/// The result of running a sub task's query: the `{ column: [values] }` map fed
+/// to the scanner, plus metadata describing what was scanned.
+#[derive(Debug, Default)]
+pub struct ScanData {
+    /// Column-oriented values consumed by the scanner.
+    pub columns: Value,
+    /// The scanned columns (name + source data type), in query order.
+    pub scanned_columns: Vec<ScannedColumn>,
+    /// Number of rows returned by the query and scanned.
+    pub scanned_row_count: i64,
+}
+
+/// A data-source engine that runs a sub task's query and returns the scanned
+/// columns and their values ready for the scanner.
 pub trait ScanEngine: Sync {
     /// Engine name, matched against the sub task platform.
     fn name(&self) -> &'static str;
-    /// Runs the sub task's query and returns its columns.
+    /// Runs the sub task's query and returns its columns and scan metadata.
     // TODO(dsec-173): return an `Event` (dd-sensitive-data-scanner) per backend
     // instead of a `Value`, to avoid the intermediate JSON map and its copies.
-    fn fetch_data(&self, sub_task: &SubTask) -> Result<Value>;
+    fn fetch_data(&self, sub_task: &SubTask) -> Result<ScanData>;
 }
 
 /// Compiled engines. Add a new engine here behind its `engine-*` feature.
@@ -37,7 +56,7 @@ fn engine_for(platform: &str) -> Result<&'static dyn ScanEngine> {
 }
 
 /// Runs the sub task on the engine selected by its entity platform.
-pub fn fetch_data(sub_task: &SubTask) -> Result<Value> {
+pub fn fetch_data(sub_task: &SubTask) -> Result<ScanData> {
     engine_for(&sub_task.entity.platform)?.fetch_data(sub_task)
 }
 

--- a/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/backend/mod.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/backend/mod.rs
@@ -20,6 +20,8 @@ pub struct ScannedColumn {
 #[derive(Debug, Default)]
 pub struct ScanData {
     /// Column-oriented values consumed by the scanner.
+    // TODO(dsec-173): return an `Event` (dd-sensitive-data-scanner) per backend
+    // instead of a `Value`, to avoid the intermediate JSON map and its copies.
     pub columns: Value,
     /// The scanned columns (name + source data type), in query order.
     pub scanned_columns: Vec<ScannedColumn>,
@@ -33,8 +35,6 @@ pub trait ScanEngine: Sync {
     /// Engine name, matched against the sub task platform.
     fn name(&self) -> &'static str;
     /// Runs the sub task's query and returns its columns and scan metadata.
-    // TODO(dsec-173): return an `Event` (dd-sensitive-data-scanner) per backend
-    // instead of a `Value`, to avoid the intermediate JSON map and its copies.
     fn fetch_data(&self, sub_task: &SubTask) -> Result<ScanData>;
 }
 

--- a/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/backend/postgres.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/backend/postgres.rs
@@ -72,8 +72,7 @@ fn connect(sub_task: &SubTask) -> Result<Client> {
 fn rows_to_scan_data(rows: &[Row]) -> ScanData {
     let scanned_row_count = rows.len() as i64;
 
-    // With no rows the query result carries no column metadata, so nothing was
-    // scanned.
+    // TODO(dsec-229): add column metadata when the query returns no rows.
     let Some(first) = rows.first() else {
         return ScanData::default();
     };

--- a/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/backend/postgres.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/backend/postgres.rs
@@ -5,7 +5,7 @@ use postgres::types::Type;
 use postgres::{Client, Config, NoTls, Row};
 use serde_json::{Map, Value};
 
-use crate::backend::ScanEngine;
+use crate::backend::{ScanData, ScanEngine, ScannedColumn};
 use crate::config::SubTask;
 
 pub struct PostgresEngine;
@@ -16,7 +16,7 @@ impl ScanEngine for PostgresEngine {
         "postgres"
     }
 
-    fn fetch_data(&self, sub_task: &SubTask) -> Result<Value> {
+    fn fetch_data(&self, sub_task: &SubTask) -> Result<ScanData> {
         // TODO(dsec-161): prevent reinitializing the connection for each sub task;
         // reuse a pooled/cached connection across sub tasks sharing the same target.
         let mut client = connect(sub_task)?;
@@ -25,7 +25,7 @@ impl ScanEngine for PostgresEngine {
             .query(sub_task.query.as_str(), &[])
             .context("running postgres query")?;
 
-        Ok(rows_to_columns(&rows))
+        Ok(rows_to_scan_data(&rows))
     }
 }
 
@@ -65,27 +65,40 @@ fn connect(sub_task: &SubTask) -> Result<Client> {
     config.connect(NoTls).context("connecting to postgres")
 }
 
-/// Turns query rows into a column-oriented map, e.g.
-/// `{ "email": ["a@b.com", "c@d.com"], "name": ["alice", "bob"] }`.
-fn rows_to_columns(rows: &[Row]) -> Value {
+/// Turns query rows into the scanner input plus scan metadata. The values are a
+/// column-oriented map, e.g.
+/// `{ "email": ["a@b.com", "c@d.com"], "name": ["alice", "bob"] }`, and the
+/// metadata reports the scanned columns (name + Postgres type) and row count.
+fn rows_to_scan_data(rows: &[Row]) -> ScanData {
+    let scanned_row_count = rows.len() as i64;
+
+    // With no rows the query result carries no column metadata, so nothing was
+    // scanned.
     let Some(first) = rows.first() else {
-        return Value::Object(Map::new());
+        return ScanData::default();
     };
 
-    // Keep only supported columns (the scanner reads strings) and collect
-    // each one's values across all rows.
-    let columns: Map<String, Value> = first
-        .columns()
-        .iter()
-        .enumerate()
-        .filter(|(_, c)| is_supported_type(c.type_()))
-        .map(|(i, c)| {
-            let values: Vec<Value> = rows.iter().map(|row| cell_to_value(row, i)).collect();
-            (c.name().to_string(), Value::Array(values))
-        })
-        .collect();
+    // Keep only supported columns (the scanner reads strings) and collect each
+    // one's values across all rows alongside its name and Postgres type.
+    let mut columns = Map::new();
+    let mut scanned_columns = Vec::new();
+    for (i, column) in first.columns().iter().enumerate() {
+        if !is_supported_type(column.type_()) {
+            continue;
+        }
+        let values: Vec<Value> = rows.iter().map(|row| cell_to_value(row, i)).collect();
+        columns.insert(column.name().to_string(), Value::Array(values));
+        scanned_columns.push(ScannedColumn {
+            name: column.name().to_string(),
+            data_type: column.type_().name().to_string(),
+        });
+    }
 
-    Value::Object(columns)
+    ScanData {
+        columns: Value::Object(columns),
+        scanned_columns,
+        scanned_row_count,
+    }
 }
 
 /// Postgres string/text types the scanner can read directly.

--- a/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/check.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/check.rs
@@ -4,8 +4,8 @@ use shlib_core::*;
 use crate::backend;
 use crate::config::{CheckConfig, SubTask};
 use crate::constants::SDS_RESULT_EVENT_TYPE;
-use crate::proto::{self, Status as ScanStatus, TableMatch};
-use crate::result::build_sds_result;
+use crate::proto::{self, Status as ScanStatus};
+use crate::result::{ScanOutcome, build_sds_result};
 use crate::scanning::Scanner;
 
 /// Check entrypoint.
@@ -50,13 +50,13 @@ fn run_sub_task(
     // TODO(DSEC-180): time the scan and populate task metadata started_at / ended_at
     // A sub task failure is reported inside the payload (status=ERROR) rather
     // than aborting the check, so every sub task produces exactly one event.
-    let (status, failure_reason, matches) = match run_scan(scanner, sub_task) {
-        Ok(matches) => {
+    let (status, failure_reason, outcome) = match run_scan(scanner, sub_task) {
+        Ok(outcome) => {
             println!(
                 "datasecurity: sub task succeeded ({} match(es))",
-                matches.len()
+                outcome.matches.len()
             );
-            (ScanStatus::Success, String::new(), matches)
+            (ScanStatus::Success, String::new(), outcome)
         }
         Err(err) => {
             let reason = format!("{err:#}");
@@ -64,12 +64,12 @@ fn run_sub_task(
                 "datasecurity: sub task {} failed: {reason}",
                 sub_task.sub_task_id
             );
-            (ScanStatus::Error, reason, Vec::new())
+            (ScanStatus::Error, reason, ScanOutcome::default())
         }
     };
 
     // Build the SDS result protobuf for this sub task.
-    let payload = build_sds_result(config, sub_task, status, &failure_reason, matches);
+    let payload = build_sds_result(config, sub_task, status, &failure_reason, outcome);
 
     // Emit the protobuf on the `sds-result` event platform track.
     check.event_platform_event_bytes(&proto::encode(&payload), SDS_RESULT_EVENT_TYPE)?;
@@ -77,10 +77,17 @@ fn run_sub_task(
     Ok(())
 }
 
-/// Fetches the sub task's data and scans it, returning the matches.
+/// Fetches the sub task's data and scans it, returning the matches and the
+/// scanned-table statistics.
 /// TODO(dsec-161): add tests for the scan.
-/// TODO(dsec-179): Return the number of rows scanned and additional info
-fn run_scan(scanner: &Scanner, sub_task: &SubTask) -> Result<Vec<TableMatch>> {
+fn run_scan(scanner: &Scanner, sub_task: &SubTask) -> Result<ScanOutcome> {
     let data = backend::fetch_data(sub_task).context("fetching sub task data")?;
-    scanner.scan(data).context("scanning sub task data")
+    let matches = scanner
+        .scan(data.columns)
+        .context("scanning sub task data")?;
+    Ok(ScanOutcome {
+        matches,
+        scanned_columns: data.scanned_columns,
+        scanned_row_count: data.scanned_row_count,
+    })
 }

--- a/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/proto.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/proto.rs
@@ -23,7 +23,9 @@ pub mod datadog {
 pub use datadog::sds::{
     ScanningSource, SdsResultPayload, scanning_source,
     sds_result_payload::{
-        PostgresTable, Resource, ScanLocation, ScanMetadata, ScanResult, TableMatch, scan_location,
+        PostgresTable, Resource, ScanLocation, ScanMetadata, ScanResult, TableMatch,
+        postgres_table::ScannedColumn as PostgresScannedColumn,
+        scan_location,
         scan_metadata::{ScanTaskMetadata, scan_task_metadata::Status},
     },
 };

--- a/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/result.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/result.rs
@@ -1,7 +1,21 @@
+use crate::backend::ScannedColumn;
 use crate::config::{CheckConfig, SubTask};
 use crate::proto::{
-    self, ScanMetadata, ScanResult, ScanTaskMetadata, SdsResultPayload, Status, TableMatch,
+    self, PostgresScannedColumn, ScanMetadata, ScanResult, ScanTaskMetadata, SdsResultPayload,
+    Status, TableMatch,
 };
+
+/// The result of scanning one sub task: the matches plus the statistics
+/// reported in the result's `PostgresTable` location.
+#[derive(Debug, Default)]
+pub(crate) struct ScanOutcome {
+    /// One entry per `(column, rule)` that matched.
+    pub matches: Vec<TableMatch>,
+    /// The columns that were scanned (name + source data type).
+    pub scanned_columns: Vec<ScannedColumn>,
+    /// Number of rows returned by the query and scanned.
+    pub scanned_row_count: i64,
+}
 
 /// Builds the `SdsResultPayload` protobuf for one sub task.
 pub(crate) fn build_sds_result(
@@ -9,7 +23,7 @@ pub(crate) fn build_sds_result(
     sub_task: &SubTask,
     status: Status,
     failure_reason: &str,
-    matches: Vec<TableMatch>,
+    outcome: ScanOutcome,
 ) -> SdsResultPayload {
     let entity = &sub_task.entity;
 
@@ -22,7 +36,16 @@ pub(crate) fn build_sds_result(
                 database_name: entity.database.clone(),
                 schema_name: entity.schema.clone(),
                 table_name: entity.table.clone(),
-                // TODO(DSEC-179): populate row counts and scanned_columns.
+                scanned_row_count: outcome.scanned_row_count,
+                scanned_columns: outcome
+                    .scanned_columns
+                    .into_iter()
+                    .map(|column| PostgresScannedColumn {
+                        name: column.name,
+                        data_type: column.data_type,
+                    })
+                    .collect(),
+                // TODO(DSEC-179): populate table_row_count if possible.
                 ..Default::default()
             },
         )),
@@ -31,7 +54,7 @@ pub(crate) fn build_sds_result(
 
     // TODO(DSEC-180): populate duration, started_at and ended_at.
     let scan_result = ScanResult {
-        table_matches: matches,
+        table_matches: outcome.matches,
         location: Some(location),
         scan_metadata: Some(ScanMetadata {
             scan_task_metadata: Some(ScanTaskMetadata {

--- a/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/result.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/result.rs
@@ -45,7 +45,7 @@ pub(crate) fn build_sds_result(
                         data_type: column.data_type,
                     })
                     .collect(),
-                // TODO(DSEC-179): populate table_row_count if possible.
+                // TODO(DSEC-227): populate table_row_count if possible.
                 ..Default::default()
             },
         )),
@@ -79,7 +79,7 @@ pub(crate) fn build_sds_result(
             .iter()
             .map(|rule| rule.id.clone())
             .collect(),
-        // The scanning source is the Agent. TODO(DSEC-179): populate hostname and
+        // The scanning source is the Agent. TODO(DSEC-228): populate hostname and
         // agent version once the check receives them (not provided via config yet).
         scanning_source: Some(proto::ScanningSource {
             source: Some(proto::scanning_source::Source::Agent(

--- a/releasenotes/notes/datasecurity-scanned-columns-row-counts-d22e425bb145dbf4.yaml
+++ b/releasenotes/notes/datasecurity-scanned-columns-row-counts-d22e425bb145dbf4.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    The data security check now reports the number of scanned rows and the
+    list of scanned columns (name and data type) for each scanned table in its
+    scan results.


### PR DESCRIPTION
### What does this PR do?

Populates `scanned_row_count` and `scanned_columns` (name + source data type) in the data security check's SDS result payload for each scanned Postgres table. The backend engine now returns a `ScanOutcome` (matches + scanned columns + scanned row count) instead of just the matches.

### Motivation

These fields were previously left empty (`TODO(DSEC-179)`). Reporting which columns were scanned and how many rows were read gives visibility into scan coverage.
