### PR TITLE
[incident-58605] Remove http status code tag from e2e check assertion

### DIFF
--- a/release.json
+++ b/release.json
@@ -2,7 +2,7 @@
     "base_branch": "main",
     "current_milestone": "7.83.0",
     "dependencies": {
-        "INTEGRATIONS_CORE_VERSION": "03a491c38a3d78d04ea53ee90cabed57dcdb4b28",
+        "INTEGRATIONS_CORE_VERSION": "1f72c8dde0ce9a8f7afdd990a2c27735afc32a8a",
         "INTEGRATIONS_WHEELS_STORAGE": "stable",
         "JMXFETCH_HASH": "3eb735171a3e41518c4101a6aee06fee8b93092d015769c2e470eecadb4bd11b",
         "JMXFETCH_VERSION": "0.52.0",

--- a/release.json
+++ b/release.json
@@ -2,7 +2,7 @@
     "base_branch": "main",
     "current_milestone": "7.83.0",
     "dependencies": {
-        "INTEGRATIONS_CORE_VERSION": "f60732d6369f3dba70fd128ee707eee6ddd40e67",
+        "INTEGRATIONS_CORE_VERSION": "03a491c38a3d78d04ea53ee90cabed57dcdb4b28",
         "INTEGRATIONS_WHEELS_STORAGE": "stable",
         "JMXFETCH_HASH": "3eb735171a3e41518c4101a6aee06fee8b93092d015769c2e470eecadb4bd11b",
         "JMXFETCH_VERSION": "0.52.0",

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -249,7 +249,6 @@ func (suite *eksSuite) TestNginxFargate() {
 		Expect: testMetricExpectArgs{
 			Tags: &[]string{
 				`^cluster_name:`,
-				`^http_status_code:200$`,
 				`^instance:My_Nginx$`,
 				`^kube_cluster_name:`,
 				"^kube_distribution:eks$",

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -760,7 +760,6 @@ func (suite *k8sSuite) TestNginx() {
 		Expect: testMetricExpectArgs{
 			Tags: suite.testClusterTags([]string{
 				`^cluster_name:`,
-				`^http_status_code:200$`,
 				`^instance:My_Nginx$`,
 				`^kube_cluster_name:`,
 				`^orch_cluster_id:`,


### PR DESCRIPTION
<!-- dd-meta {"pullId":"a449f15b-2400-4205-b5d7-a09f7abd88a3","source":"chat","resourceId":"15d1ac4d-e23d-4000-af02-2fad7efe2a10","workflowId":"e8d532e0-023c-4bba-ae37-93895eabfc25","codeChangeId":"e8d532e0-023c-4bba-ae37-93895eabfc25","sourceType":"bits_ai_sre"} -->
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b1b !-->

### What does this PR do?

Bits AI SRE Investigation • [View in Bits AI SRE Investigation](https://app.datadoghq.com/bits-ai/investigations/071f590d-304e-4ac6-98be-1f6c6b20a7df)

- Removes the obsolete `http_status_code:200` expectation from the Kubernetes and EKS container e2e tests for `network.http.response_time`.
- Keeps the assertions for metric emission and the remaining instance, URL, and cluster tags.

### Motivation

Reverting https://github.com/DataDog/datadog-agent/pull/51093

The pinned integrations-core version includes http_check 13.0.0, which no longer emits `http_status_code` by default. The nginx service AD annotation does not enable the replacement outcome tag, so the existing expectations fail in `new-e2e-containers-k8s-latest` and the equivalent EKS test.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/15d1ac4d-e23d-4000-af02-2fad7efe2a10)

Comment @datadog to request changes