### PR TITLE
[DADP-162] Handle Prometheus counter resets in Agent Telemetry

### DIFF
--- a/comp/core/agenttelemetry/impl/agenttelemetry.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry.go
@@ -471,8 +471,8 @@ func convertPromCountersToDatadogCountersValues(metrics []*dto.Metric, prevPromM
 		key := keyNames[i]
 		curValue := m.GetCounter().GetValue()
 
-		// Adjust the counter value if found
-		if prevValue, ok := prevPromMetricValues[key]; ok {
+		// A lower cumulative value marks a producer reset, so its current value is the delta.
+		if prevValue, ok := prevPromMetricValues[key]; ok && curValue >= prevValue {
 			*m.GetCounter().Value -= prevValue
 		}
 

--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -190,6 +190,26 @@ func testMetricFamily(metricType dto.MetricType, metrics ...*dto.Metric) *dto.Me
 	return &dto.MetricFamily{Name: &name, Type: &metricType, Metric: metrics}
 }
 
+func TestConvertPromCountersTreatsDecreaseAsReset(t *testing.T) {
+	previousValues := make(map[string]float64)
+
+	for _, testCase := range []struct {
+		current float64
+		want    float64
+	}{
+		{current: 100, want: 100},
+		{current: 175, want: 75},
+		{current: 20, want: 20},
+		{current: 35, want: 15},
+	} {
+		metric := testCounterMetric(testCase.current)
+		convertPromCountersToDatadogCountersValues([]*dto.Metric{metric}, previousValues, []string{"test-counter"})
+
+		require.Equal(t, testCase.want, metric.GetCounter().GetValue())
+		require.Equal(t, testCase.current, previousValues["test-counter"])
+	}
+}
+
 func metricLabels(metric *dto.Metric) map[string]string {
 	labels := make(map[string]string, len(metric.GetLabel()))
 	for _, label := range metric.GetLabel() {


### PR DESCRIPTION
### What does this PR do?

Makes Agent Telemetry's Prometheus-counter conversion reset-aware. When a cumulative counter decreases between collections, the Agent now reports the new current value as the reporting-period delta instead of producing a negative value.

### Motivation

A producer such as Agent Data Plane can restart independently of the Core Agent. Its DogStatsD client byte counters then start at zero while the Core Agent retains the prior cumulative observation. Subtracting the stale baseline produces an invalid negative byte count.

### Describe how you validated your changes

- Added a regression sequence covering initial observation (`100`), normal growth (`175` → `75`), reset (`20` → `20`), and post-reset growth (`35` → `15`).
- `dda inv test --targets=./comp/core/agenttelemetry/impl`
- `dda inv linter.go --targets=./comp/core/agenttelemetry/impl`
- Independent code-review pass found no actionable issues.

### Additional Notes

This intentionally applies the standard reset rule to all Prometheus counters handled by Agent Telemetry. It does not add or expose RAR session identifiers as metric labels.
