### PR TITLE
feat(agent-telemetry): export ADP client byte counters

### DIFF
--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -2795,6 +2795,28 @@ func TestDefaultAndNoDefaultPromRegistries(t *testing.T) {
 	assert.Equal(t, 20.0, m2.Value)
 }
 
+func TestDefaultProfilesExportRARClientByteCounters(t *testing.T) {
+	config := getCommonYAMLConfig(true, "")
+	tel := makeTelMock(t)
+	counter := tel.NewCounter("dogstatsd_client", "bytes_sent", []string{"emitter"}, "")
+	counter.Add(100, "agent-data-plane")
+
+	sender := &senderMock{}
+	runner := newRunnerMock()
+	a := getTestAtel(t, tel, config, sender, nil, runner)
+	require.True(t, a.enabled)
+
+	a.start()
+	runner.(*runnerMock).run()
+
+	require.Len(t, sender.sentMetrics, 1)
+	require.Equal(t, "dogstatsd_client.bytes_sent", sender.sentMetrics[0].name)
+	require.Len(t, sender.sentMetrics[0].metrics, 1)
+	metric := sender.sentMetrics[0].metrics[0]
+	assert.Equal(t, 100.0, metric.GetCounter().GetValue())
+	assert.Equal(t, map[string]string{"emitter": "agent-data-plane"}, metricLabels(metric))
+}
+
 func TestDefaultProfilesDoNotListMandatoryEmitter(t *testing.T) {
 	cfg, err := parseConfig(configmock.NewFromYAML(t, defaultProfiles))
 	require.NoError(t, err)
@@ -2818,6 +2840,10 @@ func TestDefaultProfilesDoNotListMandatoryEmitter(t *testing.T) {
 	}{
 		{name: "dogstatsd.udp_packets_bytes"},
 		{name: "dogstatsd.uds_packets_bytes"},
+		{name: "dogstatsd_client.bytes_sent"},
+		{name: "dogstatsd_client.bytes_dropped"},
+		{name: "dogstatsd_client.bytes_dropped_queue"},
+		{name: "dogstatsd_client.bytes_dropped_writer"},
 		{name: "logs.bytes_sent", aggregateTotal: true},
 		{name: "logs.encoded_bytes_sent", preserveTags: []string{"compression_kind"}, aggregateTotal: true},
 		{name: "point.sent", preserveTags: []string{"domain"}},

--- a/comp/core/agenttelemetry/impl/defaultProfiles.yaml
+++ b/comp/core/agenttelemetry/impl/defaultProfiles.yaml
@@ -34,6 +34,10 @@ profiles:
     metrics:
       - name: dogstatsd.udp_packets_bytes
       - name: dogstatsd.uds_packets_bytes
+      - name: dogstatsd_client.bytes_sent
+      - name: dogstatsd_client.bytes_dropped
+      - name: dogstatsd_client.bytes_dropped_queue
+      - name: dogstatsd_client.bytes_dropped_writer
       - name: logs.bytes_missed
       - name: logs.bytes_sent
         aggregate_total: true

--- a/comp/core/remoteagentregistry/impl/services_test.go
+++ b/comp/core/remoteagentregistry/impl/services_test.go
@@ -220,6 +220,47 @@ func TestGetTelemetry(t *testing.T) {
 	}, protocmp.Transform()))
 }
 
+func TestGetTelemetryCollectsADPClientByteCounters(t *testing.T) {
+	provides, lc, _, telemetryComp, ipcComp := buildComponent(t)
+	lc.Start(context.Background())
+	component := provides.Comp
+
+	promText := `
+# TYPE dogstatsd_client__bytes_sent counter
+dogstatsd_client__bytes_sent 100
+# TYPE dogstatsd_client__bytes_dropped counter
+dogstatsd_client__bytes_dropped 7
+# TYPE dogstatsd_client__bytes_dropped_queue counter
+dogstatsd_client__bytes_dropped_queue 5
+# TYPE dogstatsd_client__bytes_dropped_writer counter
+dogstatsd_client__bytes_dropped_writer 2
+`
+	_ = buildAndRegisterRemoteAgent(t, ipcComp, component, "agent-data-plane", "Agent Data Plane", "123",
+		withTelemetryProvider(promText),
+	)
+
+	metrics, err := telemetryComp.Gather(false)
+	require.NoError(t, err)
+	metricsByName := make(map[string]*io_prometheus_client.MetricFamily, len(metrics))
+	for _, metric := range metrics {
+		metricsByName[metric.GetName()] = metric
+	}
+
+	for metricName, expectedValue := range map[string]float64{
+		"dogstatsd_client__bytes_sent":           100,
+		"dogstatsd_client__bytes_dropped":        7,
+		"dogstatsd_client__bytes_dropped_queue":  5,
+		"dogstatsd_client__bytes_dropped_writer": 2,
+	} {
+		metricFamily := metricsByName[metricName]
+		require.NotNil(t, metricFamily, metricName)
+		assert.Equal(t, io_prometheus_client.MetricType_COUNTER, metricFamily.GetType(), metricName)
+		require.Len(t, metricFamily.GetMetric(), 1, metricName)
+		assert.Equal(t, expectedValue, metricFamily.GetMetric()[0].GetCounter().GetValue(), metricName)
+		assert.Equal(t, "agent-data-plane", metricFamily.GetMetric()[0].GetLabel()[0].GetValue(), metricName)
+	}
+}
+
 func TestGetTelemetryAuthoritativeEmitter(t *testing.T) {
 	testCases := []struct {
 		name               string


### PR DESCRIPTION
### What does this PR do?

Adds the four `dogstatsd_client.*` byte-counter names to the default Agent Telemetry profile, selecting ADP’s RAR-provided counters for COAT.

### Motivation

[DADP-162](https://datadoghq.atlassian.net/browse/DADP-162) requires DogStatsD client byte telemetry from both ADP and the Core Agent. The [ASUP-79 metric specification](https://datadoghq.atlassian.net/browse/ASUP-79) describes the payload contract. This profile-enrollment PR pairs with [saluki#2239](https://github.com/DataDog/saluki/pull/2239) and [documentation#38659](https://github.com/DataDog/documentation/pull/38659).

### Describe how you validated your changes

- `dda inv test --targets=./comp/core/agenttelemetry/impl,./comp/core/remoteagentregistry/impl --timeout=120`
- `dda inv linter.go --targets=./comp/core/agenttelemetry/impl,./comp/core/remoteagentregistry/impl --timeout=10`
- Added a default-profile test that registers an ADP-style `dogstatsd_client__bytes_sent` counter with `emitter=agent-data-plane` and verifies that Agent Telemetry emits it.
- Added a Remote Agent Registry test that parses all four ADP Prometheus counter families and verifies their counter type, values, and injected `emitter` label.

### Additional Notes

The separate RAR session-aware counter-reset follow-up handles independent ADP restarts. This PR does not add direct Core Agent DogStatsD emission.

[DADP-162]: https://datadoghq.atlassian.net/browse/DADP-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ