### PR TITLE
[VULN-84904] fix(cluster-agent): require the local IPC token on admin API endpoints

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -173,23 +173,27 @@ func StopServer() {
 // As we have 2 different tokens for the validation, we need to validate accordingly.
 func validateToken(ipc ipc.Component) func(http.Handler) http.Handler {
 	dcaTokenValidator := util.TokenValidator(util.GetDCAAuthToken)
-	localTokenGetter := util.TokenValidator(ipc.GetAuthToken)
+	localTokenValidator := util.TokenValidator(ipc.GetAuthToken)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			path := r.URL.String()
-			var isValid bool
-			// If communication is intra-pod
-			if !isExternalPath(path) {
-				if err := localTokenGetter(w, r); err == nil {
-					isValid = true
-				}
+			// Node Agent paths use the cluster-wide DCA token, every other path is
+			// local/admin-only and requires the local IPC token. The two are not
+			// interchangeable: falling back would expose /stop, /flare and /config
+			// to any pod holding the DCA token.
+			// Match on the path alone. isExternalPath counts slash-separated
+			// segments, so including the query string would let a slash in a
+			// query value pad an admin path until it matched an external rule.
+			validateRequestToken := localTokenValidator
+			if isExternalPath(r.URL.Path) {
+				validateRequestToken = dcaTokenValidator
 			}
-			if !isValid {
-				if err := dcaTokenValidator(w, r); err != nil {
-					return
-				}
+
+			// The validator already wrote the error response.
+			if err := validateRequestToken(w, r); err != nil {
+				return
 			}
+
 			next.ServeHTTP(w, r)
 		})
 	}
@@ -209,6 +213,7 @@ func isExternalPath(path string) bool {
 		strings.HasPrefix(path, "/api/v1/cluster/id") && len(strings.Split(path, "/")) == 5 ||
 		strings.HasPrefix(path, "/api/v1/clusterchecks/") && len(strings.Split(path, "/")) == 6 ||
 		strings.HasPrefix(path, "/api/v1/endpointschecks/") && len(strings.Split(path, "/")) == 6 ||
+		strings.HasPrefix(path, "/api/v1/info/node/") && len(strings.Split(path, "/")) == 6 ||
 		strings.HasPrefix(path, "/api/v1/instrumentation/") && len(strings.Split(path, "/")) == 5 ||
 		strings.HasPrefix(path, "/api/v1/metadata/namespace/") && len(strings.Split(path, "/")) == 6 ||
 		strings.HasPrefix(path, "/api/v1/tags/cf/apps/") && len(strings.Split(path, "/")) == 7 ||

--- a/cmd/cluster-agent/api/server_test.go
+++ b/cmd/cluster-agent/api/server_test.go
@@ -6,7 +6,6 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,65 +19,231 @@ import (
 )
 
 func TestValidateTokenMiddleware(t *testing.T) {
+	const dcaToken = "abc123"
+
 	mockConfig := configmock.New(t)
-	mockConfig.SetInTest("cluster_agent.auth_token", "abc123")
+	mockConfig.SetInTest("cluster_agent.auth_token", dcaToken)
 	util.InitDCAAuthToken(mockConfig)
 	ipcComp := ipcmock.New(t)
+	localToken := ipcComp.GetAuthToken()
 
 	tests := []struct {
-		path, authToken    string
+		name string
+		// method defaults to GET when empty.
+		method    string
+		path      string
+		authToken string
+		// authHeader, when set, is sent verbatim instead of a bearer authToken.
+		authHeader string
+		// omitAuthHeader sends no Authorization header at all.
+		omitAuthHeader     bool
 		expectedStatusCode int
+		// expectHandlerRun guards against the wrapped handler executing its side
+		// effects even though the middleware rejected the request.
+		expectHandlerRun bool
 	}{
+		// External paths are called by Node Agents and authenticate with the
+		// cluster-wide DCA token.
 		{
-			"/api/v1/metadata",
-			"abc123",
-			http.StatusForbidden,
+			name:               "external path with DCA token",
+			path:               "/api/v1/metadata/node/namespace/pod",
+			authToken:          dcaToken,
+			expectedStatusCode: http.StatusOK,
+			expectHandlerRun:   true,
 		},
 		{
-			"/api/v1/metadata/node/namespace/pod",
-			"abc123",
-			http.StatusOK,
+			name:               "external path with invalid token",
+			path:               "/api/v1/metadata/node/namespace/pod",
+			authToken:          "imposter",
+			expectedStatusCode: http.StatusForbidden,
+			expectHandlerRun:   false,
 		},
 		{
-			"/api/v1/metadata/node/namespace/pod",
-			"imposter",
-			http.StatusForbidden,
+			name:               "version with DCA token",
+			path:               "/version",
+			authToken:          dcaToken,
+			expectedStatusCode: http.StatusOK,
+			expectHandlerRun:   true,
 		},
 		{
-			"/version",
-			"abc123",
-			http.StatusOK,
+			name:               "version with invalid token",
+			path:               "/version",
+			authToken:          "bandit!",
+			expectedStatusCode: http.StatusForbidden,
+			expectHandlerRun:   false,
 		},
 		{
-			"/api/v1/cluster/id",
-			"abc123",
-			http.StatusOK,
+			name:               "cluster id with DCA token",
+			path:               "/api/v1/cluster/id",
+			authToken:          dcaToken,
+			expectedStatusCode: http.StatusOK,
+			expectHandlerRun:   true,
 		},
 		{
-			"/version",
-			"bandit!",
-			http.StatusForbidden,
+			name:               "node info with DCA token",
+			path:               "/api/v1/info/node/some-node",
+			authToken:          dcaToken,
+			expectedStatusCode: http.StatusOK,
+			expectHandlerRun:   true,
+		},
+		{
+			name:               "node annotations with query string and DCA token",
+			path:               "/api/v1/annotations/node/some-node?filter=kubelet",
+			authToken:          dcaToken,
+			expectedStatusCode: http.StatusOK,
+			expectHandlerRun:   true,
+		},
+		{
+			name:               "external path rejects the local token",
+			path:               "/version",
+			authToken:          localToken,
+			expectedStatusCode: http.StatusForbidden,
+			expectHandlerRun:   false,
+		},
+
+		// Local/admin paths must only ever accept the local IPC token. The DCA
+		// token is a cluster-wide shared secret mounted into every Node Agent
+		// pod, so it must not reach these handlers (VULN-84904).
+		{
+			name:               "admin stop rejects the DCA token",
+			path:               "/stop",
+			authToken:          dcaToken,
+			expectedStatusCode: http.StatusForbidden,
+			expectHandlerRun:   false,
+		},
+		{
+			name:               "admin config rejects the DCA token",
+			path:               "/config",
+			authToken:          dcaToken,
+			expectedStatusCode: http.StatusForbidden,
+			expectHandlerRun:   false,
+		},
+		{
+			name:               "admin flare rejects the DCA token",
+			path:               "/flare",
+			authToken:          dcaToken,
+			expectedStatusCode: http.StatusForbidden,
+			expectHandlerRun:   false,
+		},
+		{
+			name:               "all-metadata rejects the DCA token",
+			path:               "/api/v1/metadata",
+			authToken:          dcaToken,
+			expectedStatusCode: http.StatusForbidden,
+			expectHandlerRun:   false,
+		},
+		{
+			name:               "clusterchecks rebalance rejects the DCA token",
+			path:               "/api/v1/clusterchecks/rebalance",
+			authToken:          dcaToken,
+			expectedStatusCode: http.StatusForbidden,
+			expectHandlerRun:   false,
+		},
+		{
+			name:               "admin stop accepts the local token",
+			path:               "/stop",
+			authToken:          localToken,
+			expectedStatusCode: http.StatusOK,
+			expectHandlerRun:   true,
+		},
+		{
+			name:               "all-metadata accepts the local token",
+			path:               "/api/v1/metadata",
+			authToken:          localToken,
+			expectedStatusCode: http.StatusOK,
+			expectHandlerRun:   true,
+		},
+		{
+			name:               "admin path with invalid token",
+			path:               "/stop",
+			authToken:          "imposter",
+			expectedStatusCode: http.StatusForbidden,
+			expectHandlerRun:   false,
+		},
+
+		// A slash inside the query string must not be counted as a path segment.
+		// isExternalPath gates on the number of slash-separated segments, so an
+		// admin path one segment short of an external rule could otherwise be
+		// padded until it matched, downgrading it to DCA-token authentication
+		// while the router still dispatched the admin handler.
+		{
+			name:               "admin rebalance rejects a DCA token padded with a query-string slash",
+			method:             "POST",
+			path:               "/api/v1/clusterchecks/rebalance?x=/y",
+			authToken:          dcaToken,
+			expectedStatusCode: http.StatusForbidden,
+			expectHandlerRun:   false,
+		},
+		{
+			name:               "all-endpointschecks rejects a DCA token padded with a query-string slash",
+			path:               "/api/v1/endpointschecks/configs?x=/y",
+			authToken:          dcaToken,
+			expectedStatusCode: http.StatusForbidden,
+			expectHandlerRun:   false,
+		},
+		{
+			name:               "external path still accepts the DCA token with a slash in the query",
+			path:               "/api/v1/annotations/node/some-node?filter=a/b",
+			authToken:          dcaToken,
+			expectedStatusCode: http.StatusOK,
+			expectHandlerRun:   true,
+		},
+
+		// A missing or malformed Authorization header is a 401, not a 403.
+		{
+			name:               "missing authorization header",
+			path:               "/stop",
+			omitAuthHeader:     true,
+			expectedStatusCode: http.StatusUnauthorized,
+			expectHandlerRun:   false,
+		},
+		{
+			name:               "unsupported authorization scheme",
+			path:               "/stop",
+			authHeader:         "Basic dXNlcjpwYXNzd29yZA==",
+			expectedStatusCode: http.StatusUnauthorized,
+			expectHandlerRun:   false,
+		},
+		{
+			name:               "bearer with no token",
+			path:               "/stop",
+			authHeader:         "Bearer",
+			expectedStatusCode: http.StatusForbidden,
+			expectHandlerRun:   false,
 		},
 	}
 
-	for i, tt := range tests {
-		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
-			req, err := http.NewRequest("GET", tt.path, nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			method := tt.method
+			if method == "" {
+				method = "GET"
+			}
+
+			req, err := http.NewRequest(method, tt.path, nil)
 			require.NoError(t, err)
 
-			req.Header.Add("Authorization", "Bearer "+tt.authToken)
+			switch {
+			case tt.omitAuthHeader:
+			case tt.authHeader != "":
+				req.Header.Add("Authorization", tt.authHeader)
+			default:
+				req.Header.Add("Authorization", "Bearer "+tt.authToken)
+			}
 
 			rr := httptest.NewRecorder()
 
-			nopHandler := func(w http.ResponseWriter, _ *http.Request) {
+			handlerRun := false
+			handler := validateToken(ipcComp)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				handlerRun = true
 				w.WriteHeader(http.StatusOK)
-			}
-
-			handler := validateToken(ipcComp)(http.HandlerFunc(nopHandler))
+			}))
 
 			handler.ServeHTTP(rr, req)
 
 			assert.Equal(t, tt.expectedStatusCode, rr.Code)
+			assert.Equal(t, tt.expectHandlerRun, handlerRun,
+				"wrapped handler execution did not match expectation")
 		})
 	}
 }

--- a/releasenotes/notes/fix-dca-admin-endpoint-auth-fallthrough-ece161f2fba8d98c.yaml
+++ b/releasenotes/notes/fix-dca-admin-endpoint-auth-fallthrough-ece161f2fba8d98c.yaml
@@ -1,0 +1,24 @@
+---
+security:
+  - |
+    Cluster Agent local administrative API endpoints, such as ``/stop``,
+    ``/flare``, ``/config`` and ``/api/v1/clusterchecks/rebalance``, now
+    strictly require the Cluster Agent's local IPC token. Previously a failed
+    local token check fell through to validating the ``cluster_agent.auth_token``
+    shared secret, which is distributed to every Node Agent, so any holder of
+    that token could invoke these endpoints. Such requests received a ``403``
+    response after the endpoint's side effect had already run, so past abuse is
+    not apparent from response statuses alone.
+  - |
+    The Cluster Agent no longer takes the query string into account when
+    deciding which credential authenticates an API request. A ``/`` in a query
+    value could previously pad an administrative path until it matched a Node
+    Agent path, causing it to accept the shared ``cluster_agent.auth_token``
+    instead of the local IPC token.
+fixes:
+  - |
+    Fixed the Cluster Agent rejecting Node Agent requests to
+    ``/api/v1/info/node/<nodeName>`` with a ``403`` response. This endpoint,
+    used to detect the Kubernetes distribution from the node's kubelet version,
+    was missing from the list of paths authenticated with the Cluster Agent
+    token.


### PR DESCRIPTION
### What does this PR do?

Hardens Cluster Agent API authentication by selecting exactly one credential per request and stopping immediately when validation fails.

- Local administrative endpoints now require the local IPC token and no longer fall back to the cluster-wide DCA token.
- Authentication decisions use r.URL.Path, preventing query-string slashes from changing path classification.
- /api/v1/info/node/{nodeName} is correctly classified as a Node Agent endpoint.
- Tests verify both response codes and that rejected requests never reach the wrapped handler.

### Motivation

[VULN-84904](https://datadoghq.atlassian.net/browse/VULN-84904).

A failed local IPC-token check could fall through to DCA-token validation, allowing holders of the cluster-wide token to execute local administrative handlers despite receiving a 403 response.

The path classifier also included query strings, enabling / characters in query values to misclassify administrative routes as external. Finally, the Node Agent’s node-info endpoint was missing from the external-route list, causing legitimate requests to be rejected.

This change makes the authentication boundary explicit, terminal, and consistent with each endpoint’s intended caller.

### Describe how you validated your changes

unit test

#### e2e test

All requests originated from inside a Node Agent pod, where the cluster-wide DCA token is mounted. Authentication failures should return only 403 with the 22-byte invalid session token response; any additional output would indicate that the rejected handler executed.

| Request (DCA token unless noted) | Result |
|---|---|
| `GET /config` | 403, 22 B only — no config leaked |
| `POST /flare` | 403, 22 B only — no flare produced |
| `GET /config` + local IPC token | 200, 65803 B config — positive control |
| `GET /config` + bogus token | 403, 22 B only |
| `POST /api/v1/clusterchecks/rebalance?x=/y` | 403, 22 B only — dispatch state unchanged |
| `GET /api/v1/endpointschecks/configs?x=/y` | 403, 22 B only |
| `GET /api/v1/annotations/node/<node>?filter=a/b` | 200 — reverse-direction fix confirmed |
| `GET /api/v1/info/node/<node>` | 200, kubelet/kernel/machineID |
| `GET /version`, `/api/v1/cluster/id`, `/api/v1/tags/node/<node>` | 200 |
| `GET /config` with no Authorization header | 401 `no session token provided` |
| `POST /stop` | 403 in 10.6 ms, process untouched |

C

[VULN-84904]: https://datadoghq.atlassian.net/browse/VULN-84904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ