### PR TITLE
[DSEC-153] Add AggregatorStub test harness for Rust shared-library checks

### DIFF
--- a/pkg/collector/sharedlibrary/rustchecks/checks/example/src/check.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/example/src/check.rs
@@ -37,8 +37,6 @@ mod tests {
     use core::stubs::{AggregatorStub, RecordedEvent};
     use core::{MetricType, ServiceCheckStatus};
 
-    /// Runs the check against a recording stub and returns it, mirroring the
-    /// `aggregator` fixture used in integrations-core check tests.
     fn run_check() -> AggregatorStub {
         let aggregator = AggregatorStub::new();
         let agent_check = aggregator.agent_check_default();

--- a/pkg/collector/sharedlibrary/rustchecks/checks/example/src/check.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/example/src/check.rs
@@ -35,7 +35,7 @@ mod tests {
     use super::check;
 
     use core::stubs::{AggregatorStub, RecordedEvent};
-    use core::{MetricType, ServiceCheckStatus};
+    use core::{LogLevel, MetricType, ServiceCheckStatus};
 
     fn run_check() -> AggregatorStub {
         let aggregator = AggregatorStub::new();
@@ -53,6 +53,13 @@ mod tests {
         aggregator.assert_metric("hello.gauge", 1.0);
         aggregator.assert_metric_with_type("hello.gauge", MetricType::Gauge, 1.0);
         aggregator.assert_metric_count("hello.gauge", 1);
+    }
+
+    #[test]
+    fn emits_hello_log() {
+        let aggregator = run_check();
+
+        aggregator.assert_log(LogLevel::Info, "hello: example check running");
     }
 
     #[test]
@@ -90,6 +97,7 @@ mod tests {
         assert_eq!(aggregator.metrics().len(), 1);
         assert_eq!(aggregator.service_checks().len(), 1);
         assert_eq!(aggregator.events().len(), 1);
+        assert_eq!(aggregator.logs().len(), 1);
         assert!(aggregator.histogram_buckets().is_empty());
         assert!(aggregator.event_platform_events().is_empty());
     }

--- a/pkg/collector/sharedlibrary/rustchecks/checks/example/src/check.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/example/src/check.rs
@@ -32,9 +32,67 @@ pub fn check(check: &AgentCheck) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    // TODO: replace with a real assertion once a test stub for AgentCheck exists.
+    use super::check;
+
+    use core::stubs::{AggregatorStub, RecordedEvent};
+    use core::{MetricType, ServiceCheckStatus};
+
+    /// Runs the check against a recording stub and returns it, mirroring the
+    /// `aggregator` fixture used in integrations-core check tests.
+    fn run_check() -> AggregatorStub {
+        let aggregator = AggregatorStub::new();
+        let agent_check = aggregator.agent_check_default();
+
+        check(&agent_check).expect("check run should not fail");
+
+        aggregator
+    }
+
     #[test]
-    fn test_check_placeholder() {
-        assert_eq!(1, 1);
+    fn emits_hello_gauge() {
+        let aggregator = run_check();
+
+        aggregator.assert_metric("hello.gauge", 1.0);
+        aggregator.assert_metric_with_type("hello.gauge", MetricType::Gauge, 1.0);
+        aggregator.assert_metric_count("hello.gauge", 1);
+    }
+
+    #[test]
+    fn emits_hello_service_check() {
+        let aggregator = run_check();
+
+        aggregator.assert_service_check("hello.service_check", ServiceCheckStatus::OK);
+    }
+
+    #[test]
+    fn emits_hello_event() {
+        let aggregator = run_check();
+
+        assert_eq!(
+            aggregator.events(),
+            vec![RecordedEvent {
+                title: "hello.event".to_string(),
+                text: "hello.text".to_string(),
+                timestamp: 0,
+                priority: "normal".to_string(),
+                host: String::new(),
+                tags: Vec::new(),
+                alert_type: "info".to_string(),
+                aggregation_key: String::new(),
+                source_type_name: String::new(),
+                event_type: String::new(),
+            }]
+        );
+    }
+
+    #[test]
+    fn emits_exactly_the_expected_submissions() {
+        let aggregator = run_check();
+
+        assert_eq!(aggregator.metrics().len(), 1);
+        assert_eq!(aggregator.service_checks().len(), 1);
+        assert_eq!(aggregator.events().len(), 1);
+        assert!(aggregator.histogram_buckets().is_empty());
+        assert!(aggregator.event_platform_events().is_empty());
     }
 }

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/aggregator.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/aggregator.rs
@@ -6,6 +6,7 @@ use anyhow::{Ok, Result};
 
 /// Replica of the Agent metric type enum
 #[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MetricType {
     Gauge = 0,
     Rate = 1,
@@ -18,6 +19,7 @@ pub enum MetricType {
 
 /// Replica of the Agent service check status
 #[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ServiceCheckStatus {
     OK = 0,
     WARNING = 1,
@@ -42,16 +44,16 @@ pub enum LogLevel {
 /// Replica of the Agent event struct
 #[repr(C)]
 pub struct Event {
-    title: *mut c_char,
-    text: *mut c_char,
-    timestamp: c_long,
-    priority: *mut c_char,
-    host: *mut c_char,
-    tags: *mut *mut c_char,
-    alert_type: *mut c_char,
-    aggregation_key: *mut c_char,
-    source_type_name: *mut c_char,
-    event_type: *mut c_char,
+    pub(crate) title: *mut c_char,
+    pub(crate) text: *mut c_char,
+    pub(crate) timestamp: c_long,
+    pub(crate) priority: *mut c_char,
+    pub(crate) host: *mut c_char,
+    pub(crate) tags: *mut *mut c_char,
+    pub(crate) alert_type: *mut c_char,
+    pub(crate) aggregation_key: *mut c_char,
+    pub(crate) source_type_name: *mut c_char,
+    pub(crate) event_type: *mut c_char,
 }
 
 /// Signature of the submit metric function

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/lib.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/lib.rs
@@ -20,5 +20,5 @@ pub use cstring::to_rust_string;
 pub mod stubs;
 pub use stubs::{
     AggregatorStub, RecordedEvent, RecordedEventPlatformEvent, RecordedHistogramBucket,
-    RecordedMetric, RecordedServiceCheck,
+    RecordedLog, RecordedMetric, RecordedServiceCheck,
 };

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/lib.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/lib.rs
@@ -14,3 +14,11 @@ mod ffi;
 mod cstring;
 pub use cstring::to_cstring;
 pub use cstring::to_rust_string;
+
+// Shared test harness (like integrations-core's `AggregatorStub`). Unreachable
+// from the `Run`/`Version` FFI entrypoints, so the linker strips it from release cdylibs.
+pub mod stubs;
+pub use stubs::{
+    AggregatorStub, RecordedEvent, RecordedEventPlatformEvent, RecordedHistogramBucket,
+    RecordedMetric, RecordedServiceCheck,
+};

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/stubs.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/stubs.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 use std::ffi::{c_char, c_double, c_float, c_int, c_longlong};
 
 use crate::agent_check::AgentCheck;
-use crate::aggregator::{Aggregator, Event, MetricType, ServiceCheckStatus};
+use crate::aggregator::{Aggregator, Event, LogLevel, MetricType, ServiceCheckStatus};
 use crate::config::Config;
 use crate::cstring::to_rust_string;
 
@@ -61,6 +61,13 @@ pub struct RecordedEventPlatformEvent {
     pub event_type: String,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct RecordedLog {
+    pub message: String,
+    /// Raw rtloader `log_level_t` value (see [`crate::LogLevel`]).
+    pub level: c_int,
+}
+
 #[derive(Default)]
 struct Recorded {
     metrics: Vec<RecordedMetric>,
@@ -68,6 +75,7 @@ struct Recorded {
     events: Vec<RecordedEvent>,
     histogram_buckets: Vec<RecordedHistogramBucket>,
     event_platform_events: Vec<RecordedEventPlatformEvent>,
+    logs: Vec<RecordedLog>,
 }
 
 thread_local! {
@@ -214,6 +222,14 @@ extern "C" fn record_event_platform_event(
     RECORDED.with(|r| r.borrow_mut().event_platform_events.push(recorded));
 }
 
+extern "C" fn log_msg(message: *mut c_char, level: c_int) {
+    let recorded = RecordedLog {
+        message: read_cstr(message),
+        level,
+    };
+    RECORDED.with(|r| r.borrow_mut().logs.push(recorded));
+}
+
 /// Records everything a check submits and exposes assertions over it.
 pub struct AggregatorStub {
     check_id: String,
@@ -242,6 +258,7 @@ impl AggregatorStub {
             record_event,
             record_histogram_bucket,
             record_event_platform_event,
+            log_msg,
         );
         AgentCheck::new(
             self.check_id.clone(),
@@ -274,6 +291,10 @@ impl AggregatorStub {
 
     pub fn event_platform_events(&self) -> Vec<RecordedEventPlatformEvent> {
         RECORDED.with(|r| r.borrow().event_platform_events.clone())
+    }
+
+    pub fn logs(&self) -> Vec<RecordedLog> {
+        RECORDED.with(|r| r.borrow().logs.clone())
     }
 
     /// Asserts a metric with `name` and `value` was submitted (any type/tags).
@@ -349,6 +370,20 @@ impl AggregatorStub {
             found,
             "expected an event title={title:?} text={text:?}, but got: {:#?}",
             self.events()
+        );
+    }
+
+    /// Asserts a log line with `level` and `message` was emitted.
+    pub fn assert_log(&self, level: LogLevel, message: &str) {
+        let level = level as c_int;
+        let found = self
+            .logs()
+            .iter()
+            .any(|l| l.level == level && l.message == message);
+        assert!(
+            found,
+            "expected a log level={level} message={message:?}, but got: {:#?}",
+            self.logs()
         );
     }
 }

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/stubs.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/stubs.rs
@@ -1,0 +1,361 @@
+//! Test harness mirroring integrations-core's `AggregatorStub`: records what a
+//! check submits and exposes assertions over it. Submissions are captured in
+//! thread-local storage, so parallel `#[test]`s stay isolated.
+
+use std::cell::RefCell;
+use std::ffi::{c_char, c_double, c_float, c_int, c_longlong};
+
+use crate::agent_check::AgentCheck;
+use crate::aggregator::{Aggregator, Event, MetricType, ServiceCheckStatus};
+use crate::config::Config;
+use crate::cstring::to_rust_string;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RecordedMetric {
+    pub metric_type: MetricType,
+    pub name: String,
+    pub value: f64,
+    pub tags: Vec<String>,
+    pub hostname: String,
+    pub flush_first_value: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RecordedServiceCheck {
+    pub name: String,
+    pub status: ServiceCheckStatus,
+    pub tags: Vec<String>,
+    pub hostname: String,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RecordedEvent {
+    pub title: String,
+    pub text: String,
+    pub timestamp: i64,
+    pub priority: String,
+    pub host: String,
+    pub tags: Vec<String>,
+    pub alert_type: String,
+    pub aggregation_key: String,
+    pub source_type_name: String,
+    pub event_type: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RecordedHistogramBucket {
+    pub name: String,
+    pub value: i64,
+    pub lower_bound: f32,
+    pub upper_bound: f32,
+    pub monotonic: bool,
+    pub hostname: String,
+    pub tags: Vec<String>,
+    pub flush_first_value: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RecordedEventPlatformEvent {
+    pub raw_event: Vec<u8>,
+    pub event_type: String,
+}
+
+#[derive(Default)]
+struct Recorded {
+    metrics: Vec<RecordedMetric>,
+    service_checks: Vec<RecordedServiceCheck>,
+    events: Vec<RecordedEvent>,
+    histogram_buckets: Vec<RecordedHistogramBucket>,
+    event_platform_events: Vec<RecordedEventPlatformEvent>,
+}
+
+thread_local! {
+    static RECORDED: RefCell<Recorded> = RefCell::new(Recorded::default());
+}
+
+/// Copies eagerly: the callbacks free their C strings right after invoking us.
+/// A null/invalid pointer becomes an empty string.
+fn read_cstr(ptr: *const c_char) -> String {
+    to_rust_string(ptr).unwrap_or_default()
+}
+
+fn read_cstr_array(ptr: *mut *mut c_char) -> Vec<String> {
+    if ptr.is_null() {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+    let mut current = ptr;
+    unsafe {
+        while !(*current).is_null() {
+            out.push(read_cstr(*current));
+            current = current.add(1);
+        }
+    }
+    out
+}
+
+fn service_check_status_from_int(value: c_int) -> ServiceCheckStatus {
+    match value {
+        0 => ServiceCheckStatus::OK,
+        1 => ServiceCheckStatus::WARNING,
+        2 => ServiceCheckStatus::CRITICAL,
+        _ => ServiceCheckStatus::UNKNOWN,
+    }
+}
+
+// Recording callbacks, matching the `Aggregator` C-ABI signatures.
+
+#[allow(clippy::too_many_arguments)]
+extern "C" fn record_metric(
+    _check_id: *mut c_char,
+    metric_type: MetricType,
+    name: *mut c_char,
+    value: c_double,
+    tags: *mut *mut c_char,
+    hostname: *mut c_char,
+    flush_first_value: bool,
+) {
+    let metric = RecordedMetric {
+        metric_type,
+        name: read_cstr(name),
+        value,
+        tags: read_cstr_array(tags),
+        hostname: read_cstr(hostname),
+        flush_first_value,
+    };
+    RECORDED.with(|r| r.borrow_mut().metrics.push(metric));
+}
+
+extern "C" fn record_service_check(
+    _check_id: *mut c_char,
+    name: *mut c_char,
+    status: c_int,
+    tags: *mut *mut c_char,
+    hostname: *mut c_char,
+    message: *mut c_char,
+) {
+    let service_check = RecordedServiceCheck {
+        name: read_cstr(name),
+        status: service_check_status_from_int(status),
+        tags: read_cstr_array(tags),
+        hostname: read_cstr(hostname),
+        message: read_cstr(message),
+    };
+    RECORDED.with(|r| r.borrow_mut().service_checks.push(service_check));
+}
+
+extern "C" fn record_event(_check_id: *mut c_char, event: *const Event) {
+    if event.is_null() {
+        return;
+    }
+
+    // Safety: the aggregator passes a valid pointer live for the call.
+    let event = unsafe { &*event };
+    let recorded = RecordedEvent {
+        title: read_cstr(event.title),
+        text: read_cstr(event.text),
+        timestamp: event.timestamp,
+        priority: read_cstr(event.priority),
+        host: read_cstr(event.host),
+        tags: read_cstr_array(event.tags),
+        alert_type: read_cstr(event.alert_type),
+        aggregation_key: read_cstr(event.aggregation_key),
+        source_type_name: read_cstr(event.source_type_name),
+        event_type: read_cstr(event.event_type),
+    };
+    RECORDED.with(|r| r.borrow_mut().events.push(recorded));
+}
+
+#[allow(clippy::too_many_arguments)]
+extern "C" fn record_histogram_bucket(
+    _check_id: *mut c_char,
+    name: *mut c_char,
+    value: c_longlong,
+    lower_bound: c_float,
+    upper_bound: c_float,
+    monotonic: c_int,
+    hostname: *mut c_char,
+    tags: *mut *mut c_char,
+    flush_first_value: bool,
+) {
+    let bucket = RecordedHistogramBucket {
+        name: read_cstr(name),
+        value,
+        lower_bound,
+        upper_bound,
+        monotonic: monotonic != 0,
+        hostname: read_cstr(hostname),
+        tags: read_cstr_array(tags),
+        flush_first_value,
+    };
+    RECORDED.with(|r| r.borrow_mut().histogram_buckets.push(bucket));
+}
+
+extern "C" fn record_event_platform_event(
+    _check_id: *mut c_char,
+    raw_event: *mut c_char,
+    raw_event_size: c_int,
+    event_type: *mut c_char,
+) {
+    // Read by length: the payload may be arbitrary bytes (e.g. protobuf with NULs).
+    let raw_event = if raw_event.is_null() || raw_event_size < 0 {
+        Vec::new()
+    } else {
+        unsafe {
+            std::slice::from_raw_parts(raw_event as *const u8, raw_event_size as usize).to_vec()
+        }
+    };
+    let recorded = RecordedEventPlatformEvent {
+        raw_event,
+        event_type: read_cstr(event_type),
+    };
+    RECORDED.with(|r| r.borrow_mut().event_platform_events.push(recorded));
+}
+
+/// Records everything a check submits and exposes assertions over it.
+pub struct AggregatorStub {
+    check_id: String,
+}
+
+impl Default for AggregatorStub {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AggregatorStub {
+    /// Creates a stub and clears any submissions recorded on this thread.
+    pub fn new() -> Self {
+        RECORDED.with(|r| *r.borrow_mut() = Recorded::default());
+        Self {
+            check_id: "test-check".to_string(),
+        }
+    }
+
+    /// Builds an [`AgentCheck`] wired to this stub. Panics on invalid YAML.
+    pub fn agent_check(&self, init_config: &str, instance_config: &str) -> AgentCheck {
+        let aggregator = Aggregator::new(
+            record_metric,
+            record_service_check,
+            record_event,
+            record_histogram_bucket,
+            record_event_platform_event,
+        );
+        AgentCheck::new(
+            self.check_id.clone(),
+            Config::from_str(init_config).expect("invalid init_config YAML"),
+            Config::from_str(instance_config).expect("invalid instance_config YAML"),
+            aggregator,
+        )
+    }
+
+    /// [`agent_check`](Self::agent_check) with empty configs.
+    pub fn agent_check_default(&self) -> AgentCheck {
+        self.agent_check("{}", "{}")
+    }
+
+    pub fn metrics(&self) -> Vec<RecordedMetric> {
+        RECORDED.with(|r| r.borrow().metrics.clone())
+    }
+
+    pub fn service_checks(&self) -> Vec<RecordedServiceCheck> {
+        RECORDED.with(|r| r.borrow().service_checks.clone())
+    }
+
+    pub fn events(&self) -> Vec<RecordedEvent> {
+        RECORDED.with(|r| r.borrow().events.clone())
+    }
+
+    pub fn histogram_buckets(&self) -> Vec<RecordedHistogramBucket> {
+        RECORDED.with(|r| r.borrow().histogram_buckets.clone())
+    }
+
+    pub fn event_platform_events(&self) -> Vec<RecordedEventPlatformEvent> {
+        RECORDED.with(|r| r.borrow().event_platform_events.clone())
+    }
+
+    /// Asserts a metric with `name` and `value` was submitted (any type/tags).
+    pub fn assert_metric(&self, name: &str, value: f64) {
+        let found = self
+            .metrics()
+            .iter()
+            .any(|m| m.name == name && m.value == value);
+        assert!(
+            found,
+            "expected a metric name={name:?} value={value}, but got: {:#?}",
+            self.metrics()
+        );
+    }
+
+    /// Asserts a metric with `name`, `metric_type` and `value` was submitted.
+    pub fn assert_metric_with_type(&self, name: &str, metric_type: MetricType, value: f64) {
+        let found = self
+            .metrics()
+            .iter()
+            .any(|m| m.name == name && m.metric_type == metric_type && m.value == value);
+        assert!(
+            found,
+            "expected a metric name={name:?} type={metric_type:?} value={value}, but got: {:#?}",
+            self.metrics()
+        );
+    }
+
+    /// Asserts a metric with `name`, `value` and exactly `tags` (unordered).
+    pub fn assert_metric_with_tags(&self, name: &str, value: f64, tags: &[&str]) {
+        let found = self
+            .metrics()
+            .iter()
+            .any(|m| m.name == name && m.value == value && tags_match(&m.tags, tags));
+        assert!(
+            found,
+            "expected a metric name={name:?} value={value} tags={tags:?}, but got: {:#?}",
+            self.metrics()
+        );
+    }
+
+    /// Asserts the number of recorded metrics named `name`.
+    pub fn assert_metric_count(&self, name: &str, count: usize) {
+        let actual = self.metrics().iter().filter(|m| m.name == name).count();
+        assert_eq!(
+            actual,
+            count,
+            "expected {count} metric(s) named {name:?}, found {actual}: {:#?}",
+            self.metrics()
+        );
+    }
+
+    /// Asserts a service check with `name` and `status` was submitted.
+    pub fn assert_service_check(&self, name: &str, status: ServiceCheckStatus) {
+        let found = self
+            .service_checks()
+            .iter()
+            .any(|sc| sc.name == name && sc.status == status);
+        assert!(
+            found,
+            "expected a service check name={name:?} status={status:?}, but got: {:#?}",
+            self.service_checks()
+        );
+    }
+
+    /// Asserts an event with `title` and `text` was submitted.
+    pub fn assert_event(&self, title: &str, text: &str) {
+        let found = self
+            .events()
+            .iter()
+            .any(|e| e.title == title && e.text == text);
+        assert!(
+            found,
+            "expected an event title={title:?} text={text:?}, but got: {:#?}",
+            self.events()
+        );
+    }
+}
+
+fn tags_match(actual: &[String], expected: &[&str]) -> bool {
+    if actual.len() != expected.len() {
+        return false;
+    }
+    expected.iter().all(|t| actual.iter().any(|a| a == t))
+}


### PR DESCRIPTION
### What does this PR do?

Adds a shared `AggregatorStub` test harness (`core::stubs`) for the Rust shared-library checks. It records what a check submits through `AgentCheck` (metrics, service checks, events, histogram buckets, event-platform events) and exposes assertions (`assert_metric`, `assert_service_check`, `assert_event`, …) plus raw getters. The `example` check's tests are wired to it.

It is unreachable from the `Run`/`Version` FFI entrypoints, so the linker strips it from the release cdylibs.

### Motivation

Test Rust checks end to end — run the real `check()` and assert the metrics/events it emits, without a running Agent.

This mirrors integrations-core's [`AggregatorStub`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/stubs/aggregator.py) (used via the `aggregator` fixture, e.g. [`test_interface.py`](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_interface.py)). The Rust harness added here, and the equivalent integrations-core Python:

```rust
// Rust Check Test
let aggregator = AggregatorStub::new();
check(&aggregator.agent_check_default()).expect("check run failed");
aggregator.assert_metric_with_type("hello.gauge", MetricType::Gauge, 1.0);
aggregator.assert_service_check("hello.service_check", ServiceCheckStatus::OK);
aggregator.assert_event("hello.event", "hello.text");
```

```python
## Integrations Core Python Check test
dd_run_check(check)
aggregator.assert_metric('hello.gauge', 1.0, metric_type=aggregator.GAUGE)
aggregator.assert_service_check('hello.service_check', AgentCheck.OK)
aggregator.assert_event('hello.text', msg_title='hello.event')
```

### Describe how you validated your changes

```bash
bazel test //pkg/collector/sharedlibrary/rustchecks/checks/example:example_test
# or: cargo test -p example
```

### Additional Notes

A follow-up uses this harness to test the `datasecurity` check end to end.