### PR TITLE
[DSEC-155] Route Rust shared library check logs through the agent logger

### DIFF
--- a/pkg/collector/aggregator/aggregator.go
+++ b/pkg/collector/aggregator/aggregator.go
@@ -165,25 +165,26 @@ func SubmitHistogramBucket(checkID *C.char, metricName *C.char, value C.longlong
 
 // SubmitLog routes a log line emitted by a shared library check through the
 // agent logger, mirroring how python checks log via LogMessage. The level
-// values match the core::LogLevel enum used on the Rust side.
+// values are the rtloader log_level_t severities (shared cb_log_t contract),
+// matching the core::LogLevel enum on the Rust side.
 //
 //export SubmitLog
 func SubmitLog(message *C.char, level C.int) {
 	msg := C.GoString(message)
 
 	switch level {
-	case 0: // Trace
-		log.Trace(msg)
-	case 1: // Debug
-		log.Debug(msg)
-	case 2: // Info
-		log.Info(msg)
-	case 3: // Warn
-		log.Warn(msg)
-	case 4: // Error
-		log.Error(msg)
-	case 5: // Critical
+	case 50: // CRITICAL
 		log.Critical(msg)
+	case 40: // ERROR
+		log.Error(msg)
+	case 30: // WARNING
+		log.Warn(msg)
+	case 20: // INFO
+		log.Info(msg)
+	case 10: // DEBUG
+		log.Debug(msg)
+	case 7: // TRACE
+		log.Trace(msg)
 	default:
 		log.Info(msg)
 	}

--- a/pkg/collector/aggregator/aggregator.go
+++ b/pkg/collector/aggregator/aggregator.go
@@ -163,11 +163,12 @@ func SubmitHistogramBucket(checkID *C.char, metricName *C.char, value C.longlong
 	sender.OpenmetricsBucket(_name, _value, _lowerBound, _upperBound, _monotonic, _hostname, _tags, _flushFirstValue)
 }
 
-// SubmitLog routes a shared library check's log line through the agent logger.
+// LogMsg routes a shared library check's log line through the agent logger.
 // Levels must stay in sync with the LogLevel enum in pkg/collector/sharedlibrary/rustchecks/core/src/aggregator.rs.
+// Not named LogMessage to avoid a cgo symbol collision with pkg/collector/python's LogMessage export.
 //
-//export SubmitLog
-func SubmitLog(message *C.char, level C.int) {
+//export LogMsg
+func LogMsg(message *C.char, level C.int) {
 	msg := C.GoString(message)
 
 	switch level {

--- a/pkg/collector/aggregator/aggregator.go
+++ b/pkg/collector/aggregator/aggregator.go
@@ -163,6 +163,32 @@ func SubmitHistogramBucket(checkID *C.char, metricName *C.char, value C.longlong
 	sender.OpenmetricsBucket(_name, _value, _lowerBound, _upperBound, _monotonic, _hostname, _tags, _flushFirstValue)
 }
 
+// SubmitLog routes a log line emitted by a shared library check through the
+// agent logger, mirroring how python checks log via LogMessage. The level
+// values match the core::LogLevel enum used on the Rust side.
+//
+//export SubmitLog
+func SubmitLog(message *C.char, level C.int) {
+	msg := C.GoString(message)
+
+	switch level {
+	case 0: // Trace
+		log.Trace(msg)
+	case 1: // Debug
+		log.Debug(msg)
+	case 2: // Info
+		log.Info(msg)
+	case 3: // Warn
+		log.Warn(msg)
+	case 4: // Error
+		log.Error(msg)
+	case 5: // Critical
+		log.Critical(msg)
+	default:
+		log.Info(msg)
+	}
+}
+
 // SubmitEventPlatformEvent is the method exposed to scripts to submit event platform events
 //
 //export SubmitEventPlatformEvent

--- a/pkg/collector/aggregator/aggregator.go
+++ b/pkg/collector/aggregator/aggregator.go
@@ -163,10 +163,8 @@ func SubmitHistogramBucket(checkID *C.char, metricName *C.char, value C.longlong
 	sender.OpenmetricsBucket(_name, _value, _lowerBound, _upperBound, _monotonic, _hostname, _tags, _flushFirstValue)
 }
 
-// SubmitLog routes a log line emitted by a shared library check through the
-// agent logger, mirroring how python checks log via LogMessage. The level
-// values are the rtloader log_level_t severities (shared cb_log_t contract),
-// matching the core::LogLevel enum on the Rust side.
+// SubmitLog routes a shared library check's log line through the agent logger.
+// Levels must stay in sync with the LogLevel enum in pkg/collector/sharedlibrary/rustchecks/core/src/aggregator.rs.
 //
 //export SubmitLog
 func SubmitLog(message *C.char, level C.int) {

--- a/pkg/collector/aggregator/callbacks.go
+++ b/pkg/collector/aggregator/callbacks.go
@@ -25,12 +25,14 @@ extern void SubmitServiceCheck(char *, char *, int, char **, char *, char *);
 extern void SubmitEvent(char *, event_t *);
 extern void SubmitHistogramBucket(char *, char *, long long, float, float, int, char *, char **, bool);
 extern void SubmitEventPlatformEvent(char *, char *, int, char *);
+extern void SubmitLog(char *, int);
 
 static void *submitMetricPtr(void)             { return (void *)SubmitMetric; }
 static void *submitServiceCheckPtr(void)       { return (void *)SubmitServiceCheck; }
 static void *submitEventPtr(void)              { return (void *)SubmitEvent; }
 static void *submitHistogramBucketPtr(void)    { return (void *)SubmitHistogramBucket; }
 static void *submitEventPlatformEventPtr(void) { return (void *)SubmitEventPlatformEvent; }
+static void *submitLogPtr(void)                { return (void *)SubmitLog; }
 */
 import "C"
 
@@ -43,6 +45,7 @@ type Callbacks struct {
 	Event              unsafe.Pointer
 	HistogramBucket    unsafe.Pointer
 	EventPlatformEvent unsafe.Pointer
+	Log                unsafe.Pointer
 }
 
 // GetCallbacks returns the submit callback pointers owned by this package.
@@ -53,5 +56,6 @@ func GetCallbacks() Callbacks {
 		Event:              unsafe.Pointer(C.submitEventPtr()),
 		HistogramBucket:    unsafe.Pointer(C.submitHistogramBucketPtr()),
 		EventPlatformEvent: unsafe.Pointer(C.submitEventPlatformEventPtr()),
+		Log:                unsafe.Pointer(C.submitLogPtr()),
 	}
 }

--- a/pkg/collector/aggregator/callbacks.go
+++ b/pkg/collector/aggregator/callbacks.go
@@ -25,14 +25,14 @@ extern void SubmitServiceCheck(char *, char *, int, char **, char *, char *);
 extern void SubmitEvent(char *, event_t *);
 extern void SubmitHistogramBucket(char *, char *, long long, float, float, int, char *, char **, bool);
 extern void SubmitEventPlatformEvent(char *, char *, int, char *);
-extern void SubmitLog(char *, int);
+extern void LogMsg(char *, int);
 
 static void *submitMetricPtr(void)             { return (void *)SubmitMetric; }
 static void *submitServiceCheckPtr(void)       { return (void *)SubmitServiceCheck; }
 static void *submitEventPtr(void)              { return (void *)SubmitEvent; }
 static void *submitHistogramBucketPtr(void)    { return (void *)SubmitHistogramBucket; }
 static void *submitEventPlatformEventPtr(void) { return (void *)SubmitEventPlatformEvent; }
-static void *submitLogPtr(void)                { return (void *)SubmitLog; }
+static void *logMsgPtr(void)                   { return (void *)LogMsg; }
 */
 import "C"
 
@@ -45,7 +45,7 @@ type Callbacks struct {
 	Event              unsafe.Pointer
 	HistogramBucket    unsafe.Pointer
 	EventPlatformEvent unsafe.Pointer
-	Log                unsafe.Pointer
+	LogMsg             unsafe.Pointer
 }
 
 // GetCallbacks returns the submit callback pointers owned by this package.
@@ -56,6 +56,6 @@ func GetCallbacks() Callbacks {
 		Event:              unsafe.Pointer(C.submitEventPtr()),
 		HistogramBucket:    unsafe.Pointer(C.submitHistogramBucketPtr()),
 		EventPlatformEvent: unsafe.Pointer(C.submitEventPlatformEventPtr()),
-		Log:                unsafe.Pointer(C.submitLogPtr()),
+		LogMsg:             unsafe.Pointer(C.logMsgPtr()),
 	}
 }

--- a/pkg/collector/sharedlibrary/ffi/ffi.h
+++ b/pkg/collector/sharedlibrary/ffi/ffi.h
@@ -17,6 +17,7 @@ typedef struct aggregator_s {
     cb_submit_event_t cb_submit_event;
     cb_submit_histogram_bucket_t cb_submit_histogram_bucket;
     cb_submit_event_platform_event_t cb_submit_event_platform_event;
+    cb_log_t cb_log;
 } aggregator_t;
 
 // run function, entrypoint of checks

--- a/pkg/collector/sharedlibrary/ffi/ffi.h
+++ b/pkg/collector/sharedlibrary/ffi/ffi.h
@@ -17,7 +17,7 @@ typedef struct aggregator_s {
     cb_submit_event_t cb_submit_event;
     cb_submit_histogram_bucket_t cb_submit_histogram_bucket;
     cb_submit_event_platform_event_t cb_submit_event_platform_event;
-    cb_log_t cb_log;
+    cb_log_t cb_log_msg;
 } aggregator_t;
 
 // run function, entrypoint of checks

--- a/pkg/collector/sharedlibrary/ffi/library_loader.go
+++ b/pkg/collector/sharedlibrary/ffi/library_loader.go
@@ -38,7 +38,7 @@ const aggregator_t *build_aggregator(void *m, void *sc, void *e, void *h, void *
 	aggregator.cb_submit_event = (cb_submit_event_t)e;
 	aggregator.cb_submit_histogram_bucket = (cb_submit_histogram_bucket_t)h;
 	aggregator.cb_submit_event_platform_event = (cb_submit_event_platform_event_t)ep;
-	aggregator.cb_log = (cb_log_t)l;
+	aggregator.cb_log_msg = (cb_log_t)l;
 	return &aggregator;
 }
 */
@@ -211,7 +211,7 @@ func NewSharedLibraryLoader(folderPath string) (*SharedLibraryLoader, error) {
 	cb := aggregator.GetCallbacks()
 	return &SharedLibraryLoader{
 		folderPath: folderPath,
-		aggregator: C.build_aggregator(cb.Metric, cb.ServiceCheck, cb.Event, cb.HistogramBucket, cb.EventPlatformEvent, cb.Log),
+		aggregator: C.build_aggregator(cb.Metric, cb.ServiceCheck, cb.Event, cb.HistogramBucket, cb.EventPlatformEvent, cb.LogMsg),
 		permission: permission,
 	}, nil
 }

--- a/pkg/collector/sharedlibrary/ffi/library_loader.go
+++ b/pkg/collector/sharedlibrary/ffi/library_loader.go
@@ -31,13 +31,14 @@ import (
 // package. The void* to callback-type casts are done here in C so this package
 // never references the aggregator's exported symbols in its own cgo link (which
 // fails on the MinGW/Windows linker).
-const aggregator_t *build_aggregator(void *m, void *sc, void *e, void *h, void *ep) {
+const aggregator_t *build_aggregator(void *m, void *sc, void *e, void *h, void *ep, void *l) {
 	static aggregator_t aggregator;
 	aggregator.cb_submit_metric = (cb_submit_metric_t)m;
 	aggregator.cb_submit_service_check = (cb_submit_service_check_t)sc;
 	aggregator.cb_submit_event = (cb_submit_event_t)e;
 	aggregator.cb_submit_histogram_bucket = (cb_submit_histogram_bucket_t)h;
 	aggregator.cb_submit_event_platform_event = (cb_submit_event_platform_event_t)ep;
+	aggregator.cb_log = (cb_log_t)l;
 	return &aggregator;
 }
 */
@@ -210,7 +211,7 @@ func NewSharedLibraryLoader(folderPath string) (*SharedLibraryLoader, error) {
 	cb := aggregator.GetCallbacks()
 	return &SharedLibraryLoader{
 		folderPath: folderPath,
-		aggregator: C.build_aggregator(cb.Metric, cb.ServiceCheck, cb.Event, cb.HistogramBucket, cb.EventPlatformEvent),
+		aggregator: C.build_aggregator(cb.Metric, cb.ServiceCheck, cb.Event, cb.HistogramBucket, cb.EventPlatformEvent, cb.Log),
 		permission: permission,
 	}, nil
 }

--- a/pkg/collector/sharedlibrary/rustchecks/checks/example/src/check.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/example/src/check.rs
@@ -4,6 +4,8 @@ use core::*;
 
 /// Check implementation
 pub fn check(check: &AgentCheck) -> Result<()> {
+    check.log_info("hello: example check running");
+
     check.gauge("hello.gauge", 1.0, &Vec::new(), "", false)?;
     check.service_check(
         "hello.service_check",

--- a/pkg/collector/sharedlibrary/rustchecks/checks/example/src/check.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/example/src/check.rs
@@ -4,7 +4,7 @@ use core::*;
 
 /// Check implementation
 pub fn check(check: &AgentCheck) -> Result<()> {
-    check.log_info("hello: example check running");
+    check.log(LogLevel::Info, "hello: example check running");
 
     check.gauge("hello.gauge", 1.0, &Vec::new(), "", false)?;
     check.service_check(

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/agent_check.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/agent_check.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use super::aggregator::{Aggregator, MetricType, ServiceCheckStatus};
+use super::aggregator::{Aggregator, LogLevel, MetricType, ServiceCheckStatus};
 use super::config::Config;
 
 use std::ffi::{c_int, c_long};
@@ -260,5 +260,43 @@ impl AgentCheck {
             raw_event.len() as c_int,
             event_track_type,
         )
+    }
+
+    /// Logs a message through the Agent logger at the given level, the same way
+    /// python checks log via `self.log`. Logging is best effort: a message that
+    /// cannot be converted to a C string (interior NUL byte) is dropped rather
+    /// than surfaced to the caller.
+    pub fn log(&self, level: LogLevel, message: &str) {
+        let _ = self.aggregator.log(level, message);
+    }
+
+    /// Logs at the TRACE level.
+    pub fn log_trace(&self, message: &str) {
+        self.log(LogLevel::Trace, message);
+    }
+
+    /// Logs at the DEBUG level.
+    pub fn log_debug(&self, message: &str) {
+        self.log(LogLevel::Debug, message);
+    }
+
+    /// Logs at the INFO level.
+    pub fn log_info(&self, message: &str) {
+        self.log(LogLevel::Info, message);
+    }
+
+    /// Logs at the WARN level.
+    pub fn log_warn(&self, message: &str) {
+        self.log(LogLevel::Warn, message);
+    }
+
+    /// Logs at the ERROR level.
+    pub fn log_error(&self, message: &str) {
+        self.log(LogLevel::Error, message);
+    }
+
+    /// Logs at the CRITICAL level.
+    pub fn log_critical(&self, message: &str) {
+        self.log(LogLevel::Critical, message);
     }
 }

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/agent_check.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/agent_check.rs
@@ -262,10 +262,7 @@ impl AgentCheck {
         )
     }
 
-    /// Logs a message through the Agent logger at the given level, the same way
-    /// python checks log via `self.log`. Logging is best effort: a message that
-    /// cannot be converted to a C string (interior NUL byte) is dropped rather
-    /// than surfaced to the caller.
+    /// Logs a message through the Agent logger at the given level.
     pub fn log(&self, level: LogLevel, message: &str) {
         let _ = self.aggregator.log(level, message);
     }

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/agent_check.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/agent_check.rs
@@ -266,34 +266,4 @@ impl AgentCheck {
     pub fn log(&self, level: LogLevel, message: &str) {
         let _ = self.aggregator.log(level, message);
     }
-
-    /// Logs at the TRACE level.
-    pub fn log_trace(&self, message: &str) {
-        self.log(LogLevel::Trace, message);
-    }
-
-    /// Logs at the DEBUG level.
-    pub fn log_debug(&self, message: &str) {
-        self.log(LogLevel::Debug, message);
-    }
-
-    /// Logs at the INFO level.
-    pub fn log_info(&self, message: &str) {
-        self.log(LogLevel::Info, message);
-    }
-
-    /// Logs at the WARN level.
-    pub fn log_warn(&self, message: &str) {
-        self.log(LogLevel::Warn, message);
-    }
-
-    /// Logs at the ERROR level.
-    pub fn log_error(&self, message: &str) {
-        self.log(LogLevel::Error, message);
-    }
-
-    /// Logs at the CRITICAL level.
-    pub fn log_critical(&self, message: &str) {
-        self.log(LogLevel::Critical, message);
-    }
 }

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/aggregator.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/aggregator.rs
@@ -27,9 +27,8 @@ pub enum ServiceCheckStatus {
 
 /// Log level of a message routed to the Agent logger.
 ///
-/// The discriminants are the rtloader `log_level_t` values (the `cb_log`
-/// callback shares rtloader's `cb_log_t` type), so they stay compatible with
-/// the numeric levels used by the Go `SubmitLog` handler and python checks.
+/// Enums are the rtloader `log_level_t` values, i.e. the same levels
+/// as python checks use.
 #[repr(C)]
 pub enum LogLevel {
     Trace = 7,

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/aggregator.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/aggregator.rs
@@ -27,15 +27,17 @@ pub enum ServiceCheckStatus {
 
 /// Log level of a message routed to the Agent logger.
 ///
-/// The discriminants must match the `SubmitLog` handler on the Go side.
+/// The discriminants are the rtloader `log_level_t` values (the `cb_log`
+/// callback shares rtloader's `cb_log_t` type), so they stay compatible with
+/// the numeric levels used by the Go `SubmitLog` handler and python checks.
 #[repr(C)]
 pub enum LogLevel {
-    Trace = 0,
-    Debug = 1,
-    Info = 2,
-    Warn = 3,
-    Error = 4,
-    Critical = 5,
+    Trace = 7,
+    Debug = 10,
+    Info = 20,
+    Warn = 30,
+    Error = 40,
+    Critical = 50,
 }
 
 /// Replica of the Agent event struct

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/aggregator.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/aggregator.rs
@@ -25,6 +25,19 @@ pub enum ServiceCheckStatus {
     UNKNOWN = 3,
 }
 
+/// Log level of a message routed to the Agent logger.
+///
+/// The discriminants must match the `SubmitLog` handler on the Go side.
+#[repr(C)]
+pub enum LogLevel {
+    Trace = 0,
+    Debug = 1,
+    Info = 2,
+    Warn = 3,
+    Error = 4,
+    Critical = 5,
+}
+
 /// Replica of the Agent event struct
 #[repr(C)]
 pub struct Event {
@@ -88,6 +101,12 @@ type SubmitEventPlatformEvent = extern "C" fn(
     *mut c_char, // event type
 );
 
+/// Signature of the log function
+type SubmitLog = extern "C" fn(
+    *mut c_char, // message
+    c_int,       // level
+);
+
 /// Aggregator stores Go callbacks for submissions
 ///
 /// The check stores a pointer to the Aggregator structure declared in Cgo
@@ -99,6 +118,7 @@ pub struct Aggregator {
     cb_submit_event: SubmitEvent,
     cb_submit_histogram_bucket: SubmitHistogramBucket,
     cb_submit_event_platform_event: SubmitEventPlatformEvent,
+    cb_log: SubmitLog,
 }
 
 impl Aggregator {
@@ -108,6 +128,7 @@ impl Aggregator {
         cb_submit_event: SubmitEvent,
         cb_submit_histogram_bucket: SubmitHistogramBucket,
         cb_submit_event_platform_event: SubmitEventPlatformEvent,
+        cb_log: SubmitLog,
     ) -> Self {
         Self {
             cb_submit_metric,
@@ -115,6 +136,7 @@ impl Aggregator {
             cb_submit_event,
             cb_submit_histogram_bucket,
             cb_submit_event_platform_event,
+            cb_log,
         }
     }
 
@@ -312,6 +334,13 @@ impl Aggregator {
             cstr_event_type.as_ptr(),
         );
 
+        Ok(())
+    }
+
+    /// Routes a log line through the Agent logger.
+    pub fn log(&self, level: LogLevel, message: &str) -> Result<()> {
+        let cstr_message = CStringGuard::new(message)?;
+        (self.cb_log)(cstr_message.as_ptr(), level as c_int);
         Ok(())
     }
 }

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/aggregator.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/aggregator.rs
@@ -103,7 +103,7 @@ type SubmitEventPlatformEvent = extern "C" fn(
 );
 
 /// Signature of the log function
-type SubmitLog = extern "C" fn(
+type LogMsg = extern "C" fn(
     *mut c_char, // message
     c_int,       // level
 );
@@ -119,7 +119,7 @@ pub struct Aggregator {
     cb_submit_event: SubmitEvent,
     cb_submit_histogram_bucket: SubmitHistogramBucket,
     cb_submit_event_platform_event: SubmitEventPlatformEvent,
-    cb_log: SubmitLog,
+    cb_log_msg: LogMsg,
 }
 
 impl Aggregator {
@@ -129,7 +129,7 @@ impl Aggregator {
         cb_submit_event: SubmitEvent,
         cb_submit_histogram_bucket: SubmitHistogramBucket,
         cb_submit_event_platform_event: SubmitEventPlatformEvent,
-        cb_log: SubmitLog,
+        cb_log_msg: LogMsg,
     ) -> Self {
         Self {
             cb_submit_metric,
@@ -137,7 +137,7 @@ impl Aggregator {
             cb_submit_event,
             cb_submit_histogram_bucket,
             cb_submit_event_platform_event,
-            cb_log,
+            cb_log_msg,
         }
     }
 
@@ -341,7 +341,7 @@ impl Aggregator {
     /// Routes a log line through the Agent logger.
     pub fn log(&self, level: LogLevel, message: &str) -> Result<()> {
         let cstr_message = CStringGuard::new(message)?;
-        (self.cb_log)(cstr_message.as_ptr(), level as c_int);
+        (self.cb_log_msg)(cstr_message.as_ptr(), level as c_int);
         Ok(())
     }
 }

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/lib.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/lib.rs
@@ -3,7 +3,7 @@ mod agent_check;
 pub use agent_check::AgentCheck;
 
 mod aggregator;
-pub use aggregator::{Aggregator, Event, MetricType, ServiceCheckStatus};
+pub use aggregator::{Aggregator, Event, LogLevel, MetricType, ServiceCheckStatus};
 
 mod config;
 pub use config::Config;

--- a/releasenotes/notes/sharedlibrary-check-logging-7ce575de195229d9.yaml
+++ b/releasenotes/notes/sharedlibrary-check-logging-7ce575de195229d9.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Logs emitted by shared library checks are now routed through the Datadog
+    Agent logger, so their output is formatted and level-filtered consistently
+    with other checks instead of being written directly to standard output.


### PR DESCRIPTION
### What does this PR do?

Wires logging for Rust shared-library checks to the **agent logger** (`pkg/util/log`), so their output is formatted and level-filtered like every other check instead of being written raw to stdout.

A `cb_log` callback is added to the shared-library callback table and routed to a new `SubmitLog` export; the Rust side exposes `check.log` on `AgentCheck`.

### Motivation

Python checks are already wired to the agent logger: `self.log.*` reaches Go via a registered callback.

```go
// pkg/collector/python/init.go
set_log_cb(rtloader, LogMessage);
```

Rust shared-library checks had **no** such path, so they fell back to `println!`/`eprintln!`. This PR adds the equivalent arm for Rust checks:

```
Python check → LogMessage (pkg/collector/python)     ─┐
                                                      ├─→ pkg/util/log → agent logger
Rust check   → LogMsg  (pkg/collector/aggregator)    ─┘   ← added by this PR
```

Both callbacks converge on [the same `pkg/util/log` sink](https://github.com/DataDog/datadog-agent/blob/main/pkg/util/log/log.go#L733).

### How logging should be done in a Rust check

```rust
// checks/example/src/check.rs
check.log(LogLevel::Info, "hello: example check running");
```

### Describe how you validated your changes

Ran the agent locally against a check that uses the new `log` method. The lines now flow through the agent logger (note `LogMsg` as the source and the `CORE | INFO` formatting):

```
2026-08-03 14:46:12 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:40 in CheckStarted) | check:example | Runningcheck...
2026-08-03 14:46:12 CEST | CORE | INFO | (pkg/collector/aggregator/aggregator.go:182 in LogMsg) | hello: example check running
2026-08-03 14:46:12 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:59 in CheckFinished) | check:example | Done running check
```

You can see also below for the sake of comparison how python checks logs (example postgres):

```bash
2026-08-01 16:44:20 CEST | CORE | INFO | (pkg/collector/python/datadog_agent.go:152 in LogMessage) | postgres:b275a89ee4b56433 | (postgres.py:665) | Using incremental query metrics collector
2026-08-01 16:44:20 CEST | CORE | INFO | (pkg/collector/python/datadog_agent.go:152 in LogMessage) | postgres:b275a89ee4b56433 | (utils.py:412) | [server:localhost,port:5432,db:dbm,database_hostname:demo-org-453996-dsec-test-agent,database_instance:dbm-postgres,dd.internal.resource:database_instance:dbm-postgres,postgresql_version:16.14,system_identifier:7659729328004702242,replication_role:master,job:query-metrics] Starting job loop
2026-08-01 16:44:20 CEST | CORE | INFO | (pkg/collector/python/datadog_agent.go:152 in LogMessage) | postgres:b275a89ee4b56433 | (utils.py:412) | [server:localhost,port:5432,db:dbm,database_hostname:demo-org-453996-dsec-test-agent,database_instance:dbm-postgres,dd.internal.resource:database_instance:dbm-postgres,postgresql_version:16.14,system_identifier:7659729328004702242,replication_role:master,job:query-samples] Starting job loop
2026-08-01 16:44:20 CEST | CORE | INFO | (pkg/collector/python/datadog_agent.go:152 in LogMessage) | postgres:b275a89ee4b56433 | (utils.py:412) | [server:localhost,port:5432,db:dbm,database_hostname:demo-org-453996-dsec-test-agent,database_instance:dbm-postgres,dd.internal.resource:database_instance:dbm-postgres,postgresql_version:16.14,system_identifier:7659729328004702242,replication_role:master,job:database-metadata] Starting job loop
2026-08-01 16:44:20 CEST | CORE | INFO | (pkg/collector/python/datadog_agent.go:152 in LogMessage) | postgres:b275a89ee4b56433 | (utils.py:412) | [server:localhost,port:5432,db:dbm,database_hostname:demo-org-453996-dsec-test-agent,database_instance:dbm-postgres,dd.internal.resource:database_instance:dbm-postgres,postgresql_version:16.14,system_identifier:7659729328004702242,replication_role:master,job:data-observability] Starting job loop
2026-08-01 16:44:20 CEST | CORE | INFO | (pkg/collector/python/datadog_agent.go:152 in LogMessage) | postgres:b275a89ee4b56433 | (utils.py:412) | [server:localhost,port:5432,db:dbm,database_hostname:demo-org-453996-dsec-test-agent,database_instance:dbm-postgres,dd.internal.resource:database_instance:dbm-postgres,postgresql_version:16.14,system_identifier:7659729328004702242,replication_role:master,job:data-security] Starting job loop
```

### Additional Notes

A follow-up PR will update the `datasecurity` check to use this `log` method, replacing its remaining `println!`/`eprintln!` calls.