### PR TITLE
[DSEC-155] Wire datasecurity check to the agent logger

### DIFF
--- a/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/backend/postgres.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/backend/postgres.rs
@@ -36,14 +36,6 @@ fn connect(sub_task: &SubTask) -> Result<Client> {
         bail!("postgres connection host is required");
     }
     let timeout = sub_task.timeout;
-    println!(
-        "datasecurity: connecting to postgres host={} port={} dbname={} user={} timeout={}s",
-        conn.host,
-        conn.port,
-        conn.dbname,
-        conn.username,
-        timeout.as_secs()
-    );
 
     let mut config = Config::new();
     config

--- a/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/check.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/check.rs
@@ -19,11 +19,14 @@ pub fn check(check: &AgentCheck) -> Result<()> {
 /// Check implementation.
 fn run(check: &AgentCheck) -> Result<()> {
     let config = CheckConfig::from_instance(check)?;
-    println!(
-        "datasecurity: check started (task_id={}, {} rule(s), {} sub task(s))",
-        config.task_id,
-        config.scanning_rules.len(),
-        config.scan_data.len()
+    check.log(
+        LogLevel::Info,
+        &format!(
+            "datasecurity: check started (task_id={}, {} rule(s), {} sub task(s))",
+            config.task_id,
+            config.scanning_rules.len(),
+            config.scan_data.len()
+        ),
     );
 
     let scanner = Scanner::new(&config.scanning_rules).context("failed to create sds scanner")?;
@@ -32,7 +35,7 @@ fn run(check: &AgentCheck) -> Result<()> {
         run_sub_task(check, &config, &scanner, sub_task)?;
     }
 
-    println!("datasecurity: check completed");
+    check.log(LogLevel::Info, "datasecurity: check completed");
     Ok(())
 }
 
@@ -42,9 +45,12 @@ fn run_sub_task(
     scanner: &Scanner,
     sub_task: &SubTask,
 ) -> Result<()> {
-    println!(
-        "datasecurity: running sub task (sub_task_id={}, platform={})",
-        sub_task.sub_task_id, sub_task.entity.platform
+    check.log(
+        LogLevel::Info,
+        &format!(
+            "datasecurity: running sub task (sub_task_id={}, platform={})",
+            sub_task.sub_task_id, sub_task.entity.platform
+        ),
     );
 
     // TODO(DSEC-180): time the scan and populate task metadata started_at / ended_at
@@ -52,17 +58,23 @@ fn run_sub_task(
     // than aborting the check, so every sub task produces exactly one event.
     let (status, failure_reason, outcome) = match run_scan(scanner, sub_task) {
         Ok(outcome) => {
-            println!(
-                "datasecurity: sub task succeeded ({} match(es))",
-                outcome.matches.len()
+            check.log(
+                LogLevel::Info,
+                &format!(
+                    "datasecurity: sub task succeeded ({} match(es))",
+                    outcome.matches.len()
+                ),
             );
             (ScanStatus::Success, String::new(), outcome)
         }
         Err(err) => {
             let reason = format!("{err:#}");
-            eprintln!(
-                "datasecurity: sub task {} failed: {reason}",
-                sub_task.sub_task_id
+            check.log(
+                LogLevel::Error,
+                &format!(
+                    "datasecurity: sub task {} failed: {reason}",
+                    sub_task.sub_task_id
+                ),
             );
             (ScanStatus::Error, reason, ScanOutcome::default())
         }


### PR DESCRIPTION
### What does this PR do?

Wires the `datasecurity` check to the new shared-library logging (`check.log_info`/`check.log_error`) and removes all `println!`/`eprintln!` calls.

Stacked on top of #54324 (which adds the logging plumbing).

### Motivation

Use the agent logger instead of raw stdout/stderr, now that shared-library checks can log through it.

### How PR has been validated

Built and ran the agent locally, then triggered the `datasecurity` check. The check's messages now flow through the agent logger (`aggregator.go:182 in LogMsg`) with the standard agent log format instead of raw stdout/stderr:

```
2026-08-03 17:26:09 CEST | CORE | INFO | (pkg/collector/scheduler/scheduler.go:278 in enqueueOnce) | Scheduling check datasecurity for one-time execution
2026-08-03 17:26:09 CEST | CORE | INFO | (comp/collector/collector/impl/collector.go:241 in RunCheck) | Adding an extra runner for the 'datasecurity' long running check
2026-08-03 17:26:09 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:40 in CheckStarted) | check:datasecurity | Running check...
2026-08-03 17:26:09 CEST | CORE | INFO | (pkg/collector/aggregator/aggregator.go:182 in LogMsg) | datasecurity: check started (task_id=F38B0256-A117-48F7-96BD-B0CFBB623329, 2 rule(s), 2 sub task(s))
2026-08-03 17:26:09 CEST | CORE | INFO | (pkg/collector/aggregator/aggregator.go:182 in LogMsg) | datasecurity: running sub task (sub_task_id=CF28D7AC-249D-4970-B076-87D71586B654, platform=postgres)
2026-08-03 17:26:09 CEST | CORE | INFO | (pkg/collector/aggregator/aggregator.go:182 in LogMsg) | datasecurity: sub task succeeded (1 match(es))
2026-08-03 17:26:09 CEST | CORE | INFO | (pkg/collector/aggregator/aggregator.go:182 in LogMsg) | datasecurity: running sub task (sub_task_id=455ECD24-5C11-45AA-801B-5C2C43C8533C, platform=postgres)
2026-08-03 17:26:09 CEST | CORE | INFO | (pkg/collector/aggregator/aggregator.go:182 in LogMsg) | datasecurity: sub task succeeded (0 match(es))
2026-08-03 17:26:09 CEST | CORE | INFO | (pkg/collector/aggregator/aggregator.go:182 in LogMsg) | datasecurity: check completed
2026-08-03 17:26:09 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:59 in CheckFinished) | check:datasecurity | Done running check
2026-08-03 17:26:09 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:65 in CheckFinished) | check:datasecurity | Check's one time execution has finished
```

Made with [Cursor](https://cursor.com)