### PR TITLE
fix(rtloader): release the GIL when Python interpreter initialization fails

### DIFF
--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -124,7 +124,11 @@ bool Three::init()
     if (PyStatus_Exception(status)) {
         setError("Failed to initialize Python" + (status.err_msg ? ": " + std::string(status.err_msg) : ""));
         PyConfig_Clear(&_config);
-        return false;
+        // Py_InitializeFromConfig may have already created the GIL and implicitly
+        // granted it to this thread before failing later in the init sequence (e.g.
+        // while importing `encodings`). Route through the same cleanup as every
+        // other failure path so the GIL is released instead of leaked forever.
+        goto done;
     }
 
     // Clean up the configuration


### PR DESCRIPTION
### What does this PR do?
Releases the GIL when `Py_InitializeFromConfig` fails inside `Three::init()`, instead of leaking it forever.

### Motivation
`Py_InitializeFromConfig` can implicitly grant the calling thread the GIL before ultimately failing later in the init sequence (e.g. when it can't import `encodings`). The early `return false` on that path skipped the usual `done:` cleanup that calls `PyEval_SaveThread()`, so the GIL was never released. Any other thread later calling `ensure_gil()`/`PyGILState_Ensure()` (e.g. the autodiscovery scheduler loading a check) then blocks forever, which in turn deadlocks Agent shutdown since the scheduler holds its own lock while blocked.

### Describe how you validated your changes
Reproduced locally with a `python_home` pointing at a stdlib missing the `encodings` package, forcing `Py_InitializeFromConfig` to fail. Had a separate OS thread (pinned via `runtime.LockOSThread`, mirroring the real scheduler/worker split) call `ensure_gil()` afterwards:
- Before this fix: `ensure_gil()` never returns (confirmed hang).
- After this fix: `ensure_gil()` returns immediately, no hang, no crash.

### Additional Notes
Companion, independent fix: #54332 (resets `rtloader` to nil on the Go side, as defense in depth regardless of this fix). Each fix resolves the hang on its own; landing both is the most robust option.