### PR TITLE
fix(python): reset rtloader handle on init failure

### DIFF
--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -451,12 +451,7 @@ func Initialize(paths ...string) error {
 	// Init RtLoader machinery
 	if C.init(rtloader) == 0 {
 		err := "could not initialize rtloader: " + C.GoString(C.get_error(rtloader))
-		// init() failed: rtloader is unusable (and may have leaked the GIL). Reset the
-		// global so newStickyLock() correctly short-circuits with ErrNotInitialized
-		// instead of trying to acquire the GIL from a broken interpreter, which can
-		// hang forever. Note: we deliberately don't call C.destroy() here -- Three's
-		// destructor assumes init() completed and unconditionally restores
-		// `_threadState`, which is never set on this failure path.
+		// rtloader failed to initialize, clear the global to avoid trying to use it later
 		rtloader = nil
 		return addExpvarPythonInitErrors(err)
 	}

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -451,6 +451,13 @@ func Initialize(paths ...string) error {
 	// Init RtLoader machinery
 	if C.init(rtloader) == 0 {
 		err := "could not initialize rtloader: " + C.GoString(C.get_error(rtloader))
+		// init() failed: rtloader is unusable (and may have leaked the GIL). Reset the
+		// global so newStickyLock() correctly short-circuits with ErrNotInitialized
+		// instead of trying to acquire the GIL from a broken interpreter, which can
+		// hang forever. Note: we deliberately don't call C.destroy() here -- Three's
+		// destructor assumes init() completed and unconditionally restores
+		// `_threadState`, which is never set on this failure path.
+		rtloader = nil
 		return addExpvarPythonInitErrors(err)
 	}
 

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -415,20 +415,23 @@ func Initialize(paths ...string) error {
 	}
 
 	// Should we track python memory?
+	var pymemTelemetryInterval time.Duration
 	if pkgconfigsetup.Datadog().GetBool("telemetry.python_memory") {
-		var interval time.Duration
 		if pkgconfigsetup.Datadog().GetBool("telemetry.enabled") {
 			// detailed telemetry is enabled
-			interval = 1 * time.Second
+			pymemTelemetryInterval = 1 * time.Second
 		} else if configutils.IsAgentTelemetryEnabled(pkgconfigsetup.Datadog()) {
 			// default telemetry is enabled (emitted every 15 minute)
-			interval = 15 * time.Minute
+			pymemTelemetryInterval = 15 * time.Minute
 		}
+	}
 
-		// interval is 0 if telemetry is disabled
-		if interval > 0 {
-			initPymemTelemetry(interval)
-		}
+	// pymemTelemetryInterval is 0 if telemetry is disabled
+	pymemTelemetryEnabled := pymemTelemetryInterval > 0
+	if pymemTelemetryEnabled {
+		// This must happen before C.init(rtloader) below: it installs the
+		// allocator hooks the interpreter needs to be using from the start.
+		C.init_pymem_stats(rtloader)
 	}
 
 	// Set the PYTHONPATH if needed.
@@ -454,6 +457,11 @@ func Initialize(paths ...string) error {
 		// rtloader failed to initialize, clear the global to avoid trying to use it later
 		rtloader = nil
 		return addExpvarPythonInitErrors(err)
+	}
+
+	// Only start the pymem telemetry worker once we know rtloader initialized successfully
+	if pymemTelemetryEnabled {
+		startPymemTelemetryWorker(pymemTelemetryInterval)
 	}
 
 	// Lock the GIL
@@ -488,9 +496,7 @@ func GetRtLoader() *C.rtloader_t {
 	return rtloader
 }
 
-func initPymemTelemetry(d time.Duration) {
-	C.init_pymem_stats(rtloader)
-
+func startPymemTelemetryWorker(d time.Duration) {
 	// "alloc" for consistency with go memstats and mallochook metrics.
 	alloc := telemetryimpl.GetCompatComponent().NewSimpleCounter("pymem", "alloc", "Total number of bytes allocated by the python interpreter since the start of the agent.")
 	inuse := telemetryimpl.GetCompatComponent().NewSimpleGauge("pymem", "inuse", "Number of bytes currently allocated by the python interpreter.")


### PR DESCRIPTION
### What does this PR do?
Resets the package-global `rtloader` handle to nil when `C.init(rtloader)` fails, instead of leaving it pointing at a broken object.

### Motivation
When `init` fails, the `rtloader` variable is likely in a broken state, this is a simple defensive way to prevent issues.
We've seen deadlocks around this in some broken environments.

Resetting `rtloader` makes future calls fail fast with `ErrNotInitialized` regardless of the GIL's state.

### Describe how you validated your changes
Reproduced locally: forced `Initialize()` to fail (stdlib missing `encodings`), then called `GetPythonIntegrationList()` from a separate thread.
- Before this fix: hangs
- After this fix: returns immediately with `ErrNotInitialized`

### Additional Notes
