### PR TITLE
chore(agenttelemetry): move new-e2e-agent-telemetry ownership to fleet-remediation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -945,6 +945,7 @@
 /test/new-e2e/tests/agent-subcommands/run*           @DataDog/agent-runtimes
 /test/new-e2e/tests/agent-subcommands/flare*          @DataDog/fleet-remediation
 /test/new-e2e/tests/agent-subcommands/status*         @DataDog/fleet-remediation
+/test/new-e2e/tests/agent-telemetry           @DataDog/fleet-remediation
 /test/new-e2e/tests/autoscaling               @DataDog/container-autoscaling
 /test/new-e2e/tests/containers                @DataDog/container-integrations @DataDog/container-platform
 /test/new-e2e/tests/containers/cluster_agent_sgc_binary_test.go    @DataDog/fleet-automation

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -215,6 +215,7 @@ new-e2e-agent-configuration*            @DataDog/fleet-automation
 new-e2e-agent-subcommands*              @DataDog/fleet-remediation
 new-e2e-agent-runtimes*                 @DataDog/agent-runtimes
 new-e2e-agent-health                    @DataDog/fleet-remediation
+new-e2e-agent-telemetry                 @DataDog/fleet-remediation
 new-e2e-fips-compliance-test*           @DataDog/agent-runtimes
 new-e2e-remote-config                   @DataDog/remote-config
 # --- Containers / orchestration / SSI ---

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -464,7 +464,7 @@ new-e2e-agent-telemetry:
     - !reference [.manual]
   variables:
     TARGETS: ./tests/agent-telemetry
-    TEAM: agent-runtimes
+    TEAM: fleet-remediation
 
 new-e2e-privateactionrunner:
   extends: .new_e2e_template


### PR DESCRIPTION
### What does this PR do?
Moves ownership of the `new-e2e-agent-telemetry` E2E job and `test/new-e2e/tests/agent-telemetry` test path from agent-runtimes to fleet-remediation:
- `.gitlab/test/e2e/e2e.yml`: `TEAM: agent-runtimes` → `TEAM: fleet-remediation`
- `.gitlab/JOBOWNERS`: add `new-e2e-agent-telemetry` entry so failure alerts route to fleet-remediation instead of the generic `new-e2e*` default
- `.github/CODEOWNERS`: add entry for `test/new-e2e/tests/agent-telemetry`

### Motivation
`comp/core/agenttelemetry` is already owned by fleet-remediation; its E2E test job/path ownership was out of sync.

### Describe how you validated your changes
Verified no other CI config references the old team for this job, and confirmed the CODEOWNERS/JOBOWNERS entries follow the same pattern as the neighboring `agent-health` entries (also fleet-remediation).

### Additional Notes