### PR TITLE
bazel: move test.v flag from CI to dd_agent_go_test macro

### DIFF
--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -86,7 +86,7 @@ bazel:test:windows-amd64:
   script:
     - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || echo 'Failed to fetch an API key, no metrics will be emitted'; export DD_API_KEY
     - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --keep_going --remote_download_outputs=toplevel --test_arg=-test.v --build_event_json_file=$BEP_FILE --build_tests_only --config=$FLAVOR //pkg/... //comp/... //cmd/...
+    - bazel test --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE --build_tests_only --config=$FLAVOR //pkg/... //comp/... //cmd/...
     - dda inv -- -e bazel.ensure-test-parity --bep $BEP_FILE --flavor-name $FLAVOR --emit-metrics
 
 # macOS flavor variant: re-installs dda in both script and after_script since
@@ -167,7 +167,7 @@ bazel:test:windows-amd64:base:
   extends: [ .bazel:runner:windows-amd64, .bazel:test ]
   variables:
     POWERSHELL_SCRIPT: >-
-      bazel test --keep_going --build_tests_only --config=base --test_arg=-test.v
+      bazel test --keep_going --build_tests_only --config=base
       --build_event_json_file=$CI_PROJECT_DIR/bazel-bep-base.json
       //pkg/... //comp/... //cmd/...;
       dda inv -- -e bazel.ensure-test-parity

--- a/bazel/rules/go/dd_agent_go_test.bzl
+++ b/bazel/rules/go/dd_agent_go_test.bzl
@@ -19,7 +19,7 @@ def _target_compatible_with(flavor, user_tcw):
         conditions["@platforms//os:" + os_name] = ["@platforms//:incompatible"]
     return user_tcw + select(conditions)
 
-def dd_agent_go_test(name, flavors = None, tags = None, target_compatible_with = None, **kwargs):
+def dd_agent_go_test(name, flavors = None, tags = None, target_compatible_with = None, args = None, **kwargs):
     """Wraps go_test with per-flavor variants.
 
     The flavor-to-gotags mapping and the tag naming scheme are encapsulated
@@ -39,17 +39,23 @@ def dd_agent_go_test(name, flavors = None, tags = None, target_compatible_with =
         target_compatible_with: Optional user-supplied target_compatible_with;
               merged with the per-flavor platform restrictions this macro adds.
               Declared explicitly for the same reason as `tags`.
+        args: Optional user-supplied args; merged with the -test.v this macro
+              adds. Declared explicitly (rather than left in **kwargs) so
+              passing it doesn't collide with the macro's own `args=` on each
+              underlying go_test.
         **kwargs: Remaining attrs forwarded to each go_test (srcs, embed, deps, …).
     """
     if flavors == None:
         flavors = ALL_FLAVORS
     user_tags = tags or []
     user_tcw = [] if target_compatible_with == None else target_compatible_with
+    user_args = args or []
     for flavor in flavors:
         go_test(
             name = name + "_" + flavor,
             gotags = flavor_gotags(flavor),
             tags = user_tags + ["dd_agent_go_test", "flavor_" + flavor],
             target_compatible_with = _target_compatible_with(flavor, user_tcw),
+            args = user_args + ["-test.v"],
             **kwargs
         )


### PR DESCRIPTION
### What does this PR do?

Move `--test-arg=test.v` from CI jobs to the `dd_agent_go_test` macro

### Motivation

This way both local tests & CI tests can share the same command line and hit the cache

### Describe how you validated your changes

### Additional Notes
