### PR TITLE
chore(codeowners): assign network_config_management.d conf.yaml.example to ndm-integrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -272,6 +272,7 @@
 /cmd/agent/dist/conf.d/oracle.d/    @DataDog/database-monitoring
 /cmd/agent/dist/conf.d/oracle-dbm.d/    @DataDog/database-monitoring
 /cmd/agent/dist/conf.d/network_path.d/  @DataDog/network-path
+/cmd/agent/dist/conf.d/network_config_management.d/  @DataDog/ndm-integrations
 /cmd/agent/dist/conf.d/orchestrator_ecs.d/  @DataDog/ecs-experiences
 /cmd/agent/dist/conf.d/sbom.d/          @DataDog/agent-security @DataDog/container-integrations
 /cmd/agent/dist/conf.d/snmp.d/          @DataDog/network-device-monitoring-core


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Adds a CODEOWNERS entry so `@DataDog/ndm-integrations` owns `cmd/agent/dist/conf.d/network_config_management.d/`.

### Motivation
This directory currently falls under the blanket `@DataDog/agent-integrations` rule for `/cmd/agent/dist/conf.d/`, but the Network Config Management (NCM) check itself is owned by `@DataDog/ndm-integrations`, per existing CODEOWNERS entries for related paths:

- `/comp/networkconfigmanagement` — NCM component
- `/pkg/networkconfigmanagement/` — NCM config/core logic
- `/pkg/collector/corechecks/networkconfigmanagement/` — NCM core check
- `/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement` — NCM remote action bundle (shared with `@DataDog/action-platform`)

This gap surfaced concretely in #54330, which updated `conf.yaml.example` for this check — the review request was routed to `@DataDog/agent-integrations` instead of `@DataDog/ndm-integrations`, the team that actually owns the check.

### Describe how you validated your changes
- Confirmed no other CODEOWNERS pattern currently matches `cmd/agent/dist/conf.d/network_config_management.d/` more specifically than the blanket `/cmd/agent/dist/conf.d/` rule.
- Visual diff review; no code/build changes.

### Additional Notes
