### PR TITLE
host-profiler: make converter tests independent of cgroup namespace

### DIFF
--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -9,6 +9,7 @@ package converters
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"os"
 	"path/filepath"
@@ -20,6 +21,19 @@ import (
 	"go.uber.org/zap"
 	"go.yaml.in/yaml/v3"
 )
+
+// noContainerID stands in for cgroup.GetSelfContainerID, which otherwise succeeds when the
+// cgroup namespace is the host's (e.g. `cgroup: host` in cmd/host-profiler/docker-compose.yml)
+// and injects an extra container-attribute processor, mismatching every golden file.
+func noContainerID() (string, error) { return "", errors.New("not running in a container") }
+
+// newTestConverterWithoutAgent stubs out the container ID lookup so conversions do not
+// depend on the ambient cgroup namespace.
+func newTestConverterWithoutAgent(logger *zap.Logger, selfContainerID func() (string, error)) confmap.Converter {
+	conv := newConverterWithoutAgent(confmap.ConverterSettings{Logger: logger}).(*converterWithoutAgent)
+	conv.selfContainerID = selfContainerID
+	return conv
+}
 
 var updateGolden = flag.Bool("update", false, "update golden test files")
 
@@ -375,7 +389,19 @@ func TestConverterWithoutAgent(t *testing.T) {
 		},
 	}
 
-	runSuccessTests(t, newConverterWithoutAgent(confmap.ConverterSettings{Logger: zap.NewNop()}), tests)
+	runSuccessTests(t, newTestConverterWithoutAgent(zap.NewNop(), noContainerID), tests)
+}
+
+func TestConverterWithoutAgentContainerID(t *testing.T) {
+	const containerID = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	conv := newTestConverterWithoutAgent(zap.NewNop(), func() (string, error) { return containerID, nil })
+	runSuccessTests(t, conv, []testCase{
+		{
+			name:     "internal-metrics-adds-container-id-processor",
+			provided: "no_agent/metrics-container-id/in.yaml",
+			expected: "no_agent/metrics-container-id/out.yaml",
+		},
+	})
 }
 
 func TestConverterWithoutAgentErrors(t *testing.T) {
@@ -437,5 +463,5 @@ func TestConverterWithoutAgentErrors(t *testing.T) {
 		},
 	}
 
-	runErrorTests(t, newConverterWithoutAgent(confmap.ConverterSettings{Logger: zap.NewNop()}), tests)
+	runErrorTests(t, newTestConverterWithoutAgent(zap.NewNop(), noContainerID), tests)
 }

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -56,12 +56,16 @@ type internalHealthMetricsPipelineResolution struct {
 //   - If profiling::symbol_uploader::enabled == true, convert api_key/app_key to strings in each endpoint
 //   - If no profiling is used & configured, add minimal one with symbol_uploader: false
 //   - remove hpflare extensions
-type converterWithoutAgent struct{}
+type converterWithoutAgent struct {
+	// selfContainerID resolves the container ID of the running process. A field rather than
+	// a direct cgroup.GetSelfContainerID call so tests can stub the ambient cgroup state.
+	selfContainerID func() (string, error)
+}
 
 func newConverterWithoutAgent(convSettings confmap.ConverterSettings) confmap.Converter {
 	logger := convSettings.Logger
 	slog.SetDefault(slog.New(zapslog.NewHandler(logger.Core())))
-	return &converterWithoutAgent{}
+	return &converterWithoutAgent{selfContainerID: cgroup.GetSelfContainerID}
 }
 
 func (c *converterWithoutAgent) Convert(_ context.Context, conf *confmap.Conf) error {
@@ -594,7 +598,7 @@ func (c *converterWithoutAgent) addInternalHealthMetricsPipeline(conf confMap, p
 
 	metricsProcessors := []any{reservedFilterProcessor, reservedCumulativeToDeltaProcessor}
 
-	if containerID, err := cgroup.GetSelfContainerID(); err == nil {
+	if containerID, err := c.selfContainerID(); err == nil {
 		containerIDProcessor := confMap{
 			"attributes": []any{confMap{
 				"key":    version.OTelContainerIDKey,

--- a/comp/host-profiler/collector/impl/converters/converters_test.go
+++ b/comp/host-profiler/collector/impl/converters/converters_test.go
@@ -303,7 +303,7 @@ func TestEnsureErrorWhenIntermediateNotMap(t *testing.T) {
 func TestConverterWithoutAgentLogsViaOTelLogger(t *testing.T) {
 	logger, logs := newObserverLogger(zap.WarnLevel)
 
-	conv := newConverterWithoutAgent(confmap.ConverterSettings{Logger: logger})
+	conv := newTestConverterWithoutAgent(logger, noContainerID)
 	conf := confmap.NewFromStringMap(loadTestData(t, "no_agent/symbol-up-disabled/in.yaml"))
 
 	err := conv.Convert(context.Background(), conf)
@@ -324,7 +324,7 @@ func TestConverterWithoutAgentLogsViaOTelLogger(t *testing.T) {
 func TestConverterWithoutAgentLogsHostArchWarning(t *testing.T) {
 	logger, logs := newObserverLogger(zap.DebugLevel)
 
-	conv := newConverterWithoutAgent(confmap.ConverterSettings{Logger: logger})
+	conv := newTestConverterWithoutAgent(logger, noContainerID)
 	conf := confmap.NewFromStringMap(loadTestData(t, "no_agent/preserve-host-arch/in.yaml"))
 
 	err := conv.Convert(context.Background(), conf)
@@ -370,7 +370,7 @@ func TestConverterWithoutAgentPreservesExpandedValues(t *testing.T) {
 	}
 
 	conf := confmap.NewFromStringMap(configData)
-	err := newConverterWithoutAgent(confmap.ConverterSettings{Logger: zap.NewNop()}).Convert(t.Context(), conf)
+	err := newTestConverterWithoutAgent(zap.NewNop(), noContainerID).Convert(t.Context(), conf)
 	require.NoError(t, err)
 
 	convertedMap := xconfmap.ToStringMapRaw(conf)

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-container-id/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-container-id/in.yaml
@@ -1,0 +1,17 @@
+receivers:
+  profiling:
+    symbol_uploader:
+      enabled: false
+service:
+  pipelines:
+    profiles:
+      processors: []
+      receivers:
+      - profiling
+      exporters:
+      - otlp_http
+exporters:
+  otlp_http:
+    headers:
+      dd-api-key: test-api-key
+    profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles

--- a/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-container-id/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/testdata/no_agent/metrics-container-id/out.yaml
@@ -1,0 +1,85 @@
+exporters:
+    otlp_http:
+        compression: zstd
+        headers:
+            dd-api-key: test-api-key
+            dd-evp-origin: host-profiler-standalone
+            dd-evp-origin-version: 7.0.0-test
+            dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
+        metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
+        profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
+processors:
+    cumulativetodelta/dd-hp-internal: {}
+    ddhostname/dd-autoconfigured: {}
+    filter/dd-hp-drop-internal:
+        metrics:
+            exclude:
+                match_type: regexp
+                metric_names:
+                    - ^scrape_.*$
+                    - ^up$
+                    - ^promhttp_metric_handler_errors_total$
+    resource/dd-autoconfigured-container-attribute:
+        attributes:
+            - action: insert
+              key: container.id
+              value: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: telemetry.distro.name
+              value: host-profiler-standalone
+            - action: upsert
+              key: telemetry.distro.version
+              value: 7.0.0-test
+    resourcedetection/dd-autoconfigured:
+        detectors:
+            - system
+        system:
+            resource_attributes:
+                host.arch:
+                    enabled: true
+                host.name:
+                    enabled: false
+                os.type:
+                    enabled: false
+receivers:
+    profiling:
+        symbol_uploader:
+            enabled: false
+    prometheus/dd-hp-internal:
+        config:
+            scrape_configs:
+                - fallback_scrape_protocol: PrometheusText0.0.4
+                  job_name: host-profiler-internal
+                  metric_name_escaping_scheme: underscores
+                  metric_name_validation_scheme: legacy
+                  scrape_interval: 60s
+                  scrape_protocols:
+                    - PrometheusText0.0.4
+                  static_configs:
+                    - targets:
+                        - localhost:8888
+service:
+    pipelines:
+        metrics/profiler-internal-health:
+            exporters:
+                - otlp_http
+            processors:
+                - filter/dd-hp-drop-internal
+                - cumulativetodelta/dd-hp-internal
+                - resource/dd-autoconfigured-container-attribute
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
+                - resource/dd-profiler-internal-metadata
+            receivers:
+                - prometheus/dd-hp-internal
+        profiles:
+            exporters:
+                - otlp_http
+            processors:
+                - resourcedetection/dd-autoconfigured
+                - ddhostname/dd-autoconfigured
+                - resource/dd-profiler-internal-metadata
+            receivers:
+                - profiling


### PR DESCRIPTION
### What does this PR do?

Injects the container ID lookup in `converterWithoutAgent` through a struct field so it can be stubbed, and stubs it in the converter tests. Adds `testdata/no_agent/metrics-container-id` covering the injection path with a fixed ID.

Runtime behavior is unchanged — the real constructor still wires the field to `cgroup.GetSelfContainerID`.

### Motivation

All 13 `internal-metrics-*`-style tests in `comp/host-profiler/collector/impl/converters` fail when the tests run with the host's cgroup namespace.

`addInternalHealthMetricsPipeline` calls `cgroup.GetSelfContainerID()` to tag internal health metrics with the profiler's own container ID. That lookup reads the process's cgroup, so its result depends on how the test host is containerized:

| Environment | `/proc/self/cgroup` | Lookup |
|---|---|---|
| macOS host | n/a (non-linux stub) | fails |
| container, private cgroupns (CI default) | `0::/` | fails |
| container, `cgroup: host` | `0::/docker/03e6667d…` | **succeeds** |

### Describe how you validated your changes

Ran the package in all three environments.


🤖 Generated with [Claude Code](https://claude.com/claude-code)