### PR TITLE
fix(e2e/discovery): Run node-json-server from where json-server is installed

### DIFF
--- a/test/new-e2e/tests/discovery/testdata/provision/provision.sh
+++ b/test/new-e2e/tests/discovery/testdata/provision/provision.sh
@@ -3,6 +3,10 @@
 set -e
 
 install_systemd_unit() {
+  # Must be reset per call: it is only assigned when --workdir is passed, so
+  # without this it would leak into every subsequent unit.
+  local workdir=""
+
   while [[ $# -ge 2 ]]; do
     case $1 in
       --workdir)
@@ -97,7 +101,12 @@ popd
 
 # Install our own services
 ## Node
-install_systemd_unit "node-json-server" "$NVM_DIR/nvm-exec npx json-server --port 8084 /home/ubuntu/e2e-test/node/json-server/db.json" "8084" ""
+# Run from the directory json-server was installed into above. npx resolves the
+# package relative to the working directory, and systemd units default to /,
+# where it is not found; npx then stages a fresh download from the npm registry
+# on every start of the unit, which is slow, network-dependent, and fails
+# outright if the registry is unreachable.
+install_systemd_unit --workdir "/home/ubuntu" "node-json-server" "$NVM_DIR/nvm-exec npx json-server --port 8084 /home/ubuntu/e2e-test/node/json-server/db.json" "8084" ""
 install_systemd_unit "node-instrumented" "$NVM_DIR/nvm-exec node /home/ubuntu/e2e-test/node/instrumented/server.js" "8085" ""
 
 ## Python


### PR DESCRIPTION
### What does this PR do?

Gives the `node-json-server` fixture unit a `WorkingDirectory`, so it stops depending on the npm registry every time it starts.

The unit had no `WorkingDirectory` and so ran with systemd's default of `/`. `npx` resolves a package relative to the working directory, so it never found the `json-server` that provisioning installs into `/home/ubuntu` and instead staged a fresh download from the registry.

Also resets `workdir` per `install_systemd_unit` call. It is only assigned when `--workdir` is passed, so without this the new `--workdir` would leak into every unit installed afterwards. Nothing was affected before, because `rails-svc` was the only caller passing it and it is installed last.

### Motivation

DSCVR-621. `node-json-server` is the fixture with the highest and most variable startup latency of the six, and it is one of the two services that blew the assertion budget in that ticket. In job 1890377724 the only matching process in workloadmeta was `npm exec json-server …` — the `node` grandchild npm eventually spawns, which is the process the test actually matches on, did not exist yet — and the unit had restarted, consistent with npm still resolving from the registry.

Making a test fixture reach out to a public registry on every service start is worth removing regardless of that flake: it is unbounded, it fails when the registry is unreachable, and it is entirely avoidable since provisioning already installed the package locally.

### Describe how you validated your changes

Verified in a container with the same Node and npm as the fixture (v20.20.2 / 10.8.2 vs the fixture's 20.20.1), with `json-server@1.0.0-beta.15` installed into `/home/ubuntu` exactly as provisioning does:

| Case | Time to LISTEN | npx staging download | Works with `--network none`? |
|---|---|---|---|
| `cwd=/` (before) | 3s | 1 entry in `/root/.npm/_npx` | **No** — hangs indefinitely, no output |
| `cwd=/` warm | 0s | reuses cache | n/a |
| `cwd=/home/ubuntu` (after) | 2s | **0 entries** | **Yes** |

The registry dependency is what this removes; the 3s vs 2s difference is not the point, since registry latency in CI is not something I can measure from here.

The process tree is unchanged in shape, which matters because the test matches on the `node` grandchild:

```
npm exec json-s   npm exec json-server --port 8084 …
└─ sh             sh -c json-server --port 8084 …
   └─ node        node /home/ubuntu/node_modules/.bin/json-server --port 8084 …   (cwd=/home/ubuntu)
   └─ node        node /root/.npm/_npx/<hash>/node_modules/.bin/json-server …     (cwd=/)
```

Also:

- `bash -n` on the provision script.
- Exercised `install_systemd_unit` in a container: confirmed `WorkingDirectory=/home/ubuntu` is emitted for `node-json-server`, and that `node-instrumented`, installed immediately afterwards without `--workdir`, gets none (1 vs 0 occurrences).
- `new-e2e-discovery` passes on this branch.
