### PR TITLE
perf(ebpf): prune unused compile inputs

### DIFF
--- a/bazel/rules/ebpf/BUILD.bazel
+++ b/bazel/rules/ebpf/BUILD.bazel
@@ -1,5 +1,22 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_test.bzl", "py_test")
 load("//bazel/rules/ebpf:cgo_godefs_test.bzl", "cgo_godefs_test_suite")
+
+py_binary(
+    name = "clang_with_unused_inputs",
+    srcs = ["clang_with_unused_inputs.py"],
+    visibility = ["//visibility:private"],
+)
+
+py_test(
+    name = "clang_with_unused_inputs_test",
+    srcs = [
+        "clang_with_unused_inputs.py",
+        "clang_with_unused_inputs_test.py",
+    ],
+    main = "clang_with_unused_inputs_test.py",
+)
 
 string_flag(
     name = "target_arch",

--- a/bazel/rules/ebpf/clang_with_unused_inputs.py
+++ b/bazel/rules/ebpf/clang_with_unused_inputs.py
@@ -6,7 +6,7 @@
 """Run clang and report declared inputs absent from its dependency file."""
 
 import argparse
-import os
+import posixpath
 import shlex
 import subprocess
 import sys
@@ -18,12 +18,12 @@ def parse_depfile(path: Path) -> set[str]:
     _, separator, prerequisites = content.partition(":")
     if not separator:
         raise ValueError(f"invalid dependency file: {path}")
-    return {os.path.normpath(item) for item in shlex.split(prerequisites)}
+    return {posixpath.normpath(item) for item in shlex.split(prerequisites)}
 
 
 def find_unused_inputs(declared_inputs: list[str], used_inputs: set[str]) -> list[str]:
-    normalized_used_inputs = {os.path.normpath(path) for path in used_inputs}
-    return sorted(path for path in declared_inputs if os.path.normpath(path) not in normalized_used_inputs)
+    normalized_used_inputs = {posixpath.normpath(path) for path in used_inputs}
+    return sorted(path for path in declared_inputs if posixpath.normpath(path) not in normalized_used_inputs)
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:

--- a/bazel/rules/ebpf/clang_with_unused_inputs.py
+++ b/bazel/rules/ebpf/clang_with_unused_inputs.py
@@ -1,0 +1,57 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026-present Datadog, Inc.
+
+"""Run clang and report declared inputs absent from its dependency file."""
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+def parse_depfile(path: Path) -> set[str]:
+    content = path.read_text(encoding="utf-8").replace("\\\r\n", "").replace("\\\n", "")
+    _, separator, prerequisites = content.partition(":")
+    if not separator:
+        raise ValueError(f"invalid dependency file: {path}")
+    return {os.path.normpath(item) for item in shlex.split(prerequisites)}
+
+
+def find_unused_inputs(declared_inputs: list[str], used_inputs: set[str]) -> list[str]:
+    normalized_used_inputs = {os.path.normpath(path) for path in used_inputs}
+    return sorted(path for path in declared_inputs if os.path.normpath(path) not in normalized_used_inputs)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(fromfile_prefix_chars="@")
+    parser.add_argument("--compiler", required=True)
+    parser.add_argument("--depfile", required=True, type=Path)
+    parser.add_argument("--unused-inputs-list", required=True, type=Path)
+    parser.add_argument("--declared-input", action="append", default=[])
+    parser.add_argument("compiler_args", nargs=argparse.REMAINDER)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    compiler_args = args.compiler_args
+    if compiler_args[:1] == ["--"]:
+        compiler_args = compiler_args[1:]
+
+    result = subprocess.run([args.compiler, *compiler_args], check=False)
+    if result.returncode:
+        return result.returncode
+
+    used_inputs = parse_depfile(args.depfile)
+    unused_inputs = find_unused_inputs(args.declared_input, used_inputs)
+    content = "".join(f"{path}\n" for path in unused_inputs)
+    args.unused_inputs_list.write_text(content, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/bazel/rules/ebpf/clang_with_unused_inputs_test.py
+++ b/bazel/rules/ebpf/clang_with_unused_inputs_test.py
@@ -1,0 +1,90 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026-present Datadog, Inc.
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from bazel.rules.ebpf.clang_with_unused_inputs import find_unused_inputs, main, parse_args, parse_depfile
+
+
+class ClangWithUnusedInputsTest(unittest.TestCase):
+    def test_parse_depfile(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            depfile = Path(directory) / "program.d"
+            depfile.write_text(
+                "program.bc: source.c \\\n include/used.h include/escaped\\ header.h\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                parse_depfile(depfile),
+                {"source.c", "include/used.h", "include/escaped header.h"},
+            )
+
+    def test_find_unused_inputs_normalizes_paths(self) -> None:
+        self.assertEqual(
+            find_unused_inputs(
+                ["source.c", "include/used.h", "include/unused.h"],
+                {"source.c", "include/../include/used.h"},
+            ),
+            ["include/unused.h"],
+        )
+
+    def test_parse_args_expands_multiline_param_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            params = Path(directory) / "wrapper.params"
+            params.write_text(
+                "--compiler\nclang\n"
+                "--depfile\nprogram.d\n"
+                "--unused-inputs-list\nprogram.unused\n"
+                "--declared-input\nsource.c\n"
+                "--\n",
+                encoding="utf-8",
+            )
+
+            args = parse_args([f"@{params}", "-MD"])
+
+            self.assertEqual(args.compiler, "clang")
+            self.assertEqual(args.declared_input, ["source.c"])
+            self.assertEqual(args.compiler_args, ["--", "-MD"])
+
+    def test_main_writes_unused_inputs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            depfile = Path(directory) / "program.d"
+            depfile.write_text("program.bc: source.c include/used.h\n", encoding="utf-8")
+            unused_inputs = Path(directory) / "program.unused_inputs"
+
+            with mock.patch(
+                "bazel.rules.ebpf.clang_with_unused_inputs.subprocess.run",
+                return_value=mock.Mock(returncode=0),
+            ) as run:
+                result = main(
+                    [
+                        "--compiler",
+                        "clang",
+                        "--depfile",
+                        str(depfile),
+                        "--unused-inputs-list",
+                        str(unused_inputs),
+                        "--declared-input",
+                        "source.c",
+                        "--declared-input",
+                        "include/used.h",
+                        "--declared-input",
+                        "include/unused.h",
+                        "--",
+                        "-MD",
+                    ]
+                )
+
+            self.assertEqual(result, 0)
+            self.assertEqual(unused_inputs.read_text(encoding="utf-8"), "include/unused.h\n")
+            run.assert_called_once_with(["clang", "-MD"], check=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bazel/rules/ebpf/ebpf.bzl
+++ b/bazel/rules/ebpf/ebpf.bzl
@@ -97,6 +97,8 @@ def _ebpf_prog_impl(ctx):
 
     # --- Step 1: .c -> .bc (clang) ---
     bc_file = ctx.actions.declare_file(ctx.label.name + ".bc")
+    dep_file = ctx.actions.declare_file(ctx.label.name + ".d")
+    unused_inputs_file = ctx.actions.declare_file(ctx.label.name + ".unused_inputs")
 
     clang_args = ctx.actions.args()
     if ctx.attr.core:
@@ -139,20 +141,36 @@ def _ebpf_prog_impl(ctx):
             for d in kernel_header_dirs:
                 clang_args.add("-isystem", repo_root + "/" + d)
 
+    clang_args.add("-MD")
+    clang_args.add("-MF", dep_file)
     clang_args.add("-c", src)
     clang_args.add("-o", bc_file)
 
+    action_inputs = depset(
+        [src] + kernel_header_inputs,
+        transitive = [header_files],
+    )
+
+    wrapper_args = ctx.actions.args()
+    wrapper_args.add("--compiler", tc.clang_bpf)
+    wrapper_args.add("--depfile", dep_file)
+    wrapper_args.add("--unused-inputs-list", unused_inputs_file)
+    wrapper_args.add_all(action_inputs, before_each = "--declared-input")
+    wrapper_args.add("--")
+    wrapper_args.use_param_file("@%s", use_always = True)
+    wrapper_args.set_param_file_format("multiline")
+
     ctx.actions.run(
-        inputs = depset(
-            [src] + kernel_header_inputs,
-            transitive = [header_files],
-        ),
-        outputs = [bc_file],
-        executable = tc.clang_bpf,
-        arguments = [clang_args],
+        inputs = action_inputs,
+        outputs = [bc_file, dep_file, unused_inputs_file],
+        executable = ctx.executable._clang_with_unused_inputs,
+        tools = [tc.clang_bpf],
+        arguments = [wrapper_args, clang_args],
         mnemonic = "EbpfClang",
         resource_set = resource_set_for(cpu_cores = 1, mem_mb = 1024),
         progress_message = "Compiling eBPF %{label} (.c -> .bc)",
+        toolchain = _TOOLCHAIN_TYPE,
+        unused_inputs_list = unused_inputs_file,
     )
 
     # --- Step 2: .bc -> .o (llc) ---
@@ -234,6 +252,12 @@ _ebpf_prog = rule(
         "target_arch": attr.string(
             doc = "Explicit target architecture override (x86_64 or aarch64). " +
                   "Takes precedence over the --//bazel/rules/ebpf:target_arch flag.",
+        ),
+        "_clang_with_unused_inputs": attr.label(
+            default = "//bazel/rules/ebpf:clang_with_unused_inputs",
+            executable = True,
+            cfg = "exec",
+            doc = "Clang wrapper that reports unused declared inputs.",
         ),
         "_target_arch_flag": attr.label(
             default = "//bazel/rules/ebpf:target_arch",


### PR DESCRIPTION
### What does this PR do?

Adds action-level dependency pruning to `ebpf_prog` compilation. Clang emits a dependency file with `-MD -MF`, and a small wrapper converts the used-header list into Bazel's `unused_inputs_list` format.

This lets Bazel retain only headers actually consumed by each eBPF compilation action after its first execution.

### Motivation

The eBPF targets depend on broad `cc_library` header collections. Changing an unrelated declared header therefore recompiles every program sharing that collection during local development.

Using `unused_inputs_list` restores granular local incremental behavior without changing the LLVM BPF toolchain. Fresh remote-cache lookups still use the complete declared input set.

Tracks [ABLD-446](https://datadoghq.atlassian.net/browse/ABLD-446).

### Describe how you validated your changes

- `bazel test //bazel/rules/ebpf:clang_with_unused_inputs_test`
- Built CO-RE target `//pkg/ebpf/c:ksyms_iter` in the Linux ARM64 build image
- Built prebuilt target `//pkg/network/ebpf/c/prebuilt:tracer`; its action reported 44,555 unused inputs
- Changed a reported-unused source header and confirmed the subsequent build did not execute `EbpfClang`
- Ran Buildifier and Ruff checks on changed files

### Additional Notes

Dependency flags are added by the eBPF compile action, not by the LLVM BPF toolchain.

[ABLD-446]: https://datadoghq.atlassian.net/browse/ABLD-446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ