### PR TITLE
host-profiler: default UID/GID build args to workspace ids

### DIFF
--- a/cmd/host-profiler/README.md
+++ b/cmd/host-profiler/README.md
@@ -62,8 +62,8 @@ Create a `.env` file in `cmd/host-profiler` containing:
 
 ```
 DD_SITE=datad0g.com # optional, defaults to "datadoghq.com"
-UID=1234 # required on Datadog workspace, set to the output of `id -u` on the workspace
-GID=1234 # required on Datadog workspace, set to the output of `id -g` on the workspace
+UID=2000 # optional, defaults to 2000; set to the output of `id -u` if your uid differs
+GID=501 # optional, defaults to 501; set to the output of `id -g` if your gid differs
 DD_TAGS="key:value,key1:value2" # optional, defaults to workspace:${workspace-name} on a Datadog workspace
 DD_HOSTPROFILER_DEBUG='{"verbosity":"detailed"}' # optional, enable debug exporter (basic|normal|detailed|none)
 DD_HOSTPROFILER_ADDITIONAL_HTTP_HEADERS='{"x-custom-header":"value"}' # optional, additional HTTP headers on OTLP exporter requests; defaults to workspace metadata on Datadog workspaces

--- a/cmd/host-profiler/docker-compose.yml
+++ b/cmd/host-profiler/docker-compose.yml
@@ -22,8 +22,8 @@ services:
       context: ../..
       dockerfile: tools/host-profiler/Dockerfile
       args:
-        UID: ${UID}
-        GID: ${GID}
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
     privileged: true
     pid: "host"
     cgroup: "host"

--- a/cmd/host-profiler/docker-compose.yml
+++ b/cmd/host-profiler/docker-compose.yml
@@ -22,8 +22,9 @@ services:
       context: ../..
       dockerfile: tools/host-profiler/Dockerfile
       args:
-        UID: ${UID}
-        GID: ${GID}
+        # default user/group ids in Datadog workspaces, also works for uid-squashed mounts (colima/virtiofs)
+        UID: ${UID:-2000}
+        GID: ${GID:-501}
     privileged: true
     pid: "host"
     cgroup: "host"


### PR DESCRIPTION
### What does this PR do?

Provides default values for the `UID`/`GID` build args in the host-profiler dev `docker-compose.yml`, and documents them as optional in the README.

### Motivation

`UID` and `GID` are shell variables that are not exported by default, so `${UID}`/`${GID}` expanded to empty strings unless the user explicitly exported them, breaking `docker compose build`.

They now default to `2000:501`, the default user/group ids in Datadog workspaces. These also work on setups with uid-squashed mounts (colima/virtiofs), where the container uid is irrelevant.

### Describe how you validated your changes

Manually built the host-profiler image with `docker compose build` without exporting `UID`/`GID`.

### Additional Notes

Dev-tooling only change, no impact on shipped artifacts.