### PR TITLE
Remove duplicate Kubernetes Node ListWatch in workloadmeta

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -131,8 +131,7 @@ func (c *WorkloadMetaCollector) processEvents(evBundle workloadmeta.EventBundle)
 		entityID := entity.GetID()
 
 		if entityID.Kind == workloadmeta.KindKubeletMetrics ||
-			entityID.Kind == workloadmeta.KindKubelet ||
-			entityID.Kind == workloadmeta.KindKubernetesNode {
+			entityID.Kind == workloadmeta.KindKubelet {
 			// No tags. Ignore
 			continue
 		}
@@ -163,6 +162,8 @@ func (c *WorkloadMetaCollector) processEvents(evBundle workloadmeta.EventBundle)
 				tagInfos = append(tagInfos, c.handleContainerImage(ev)...)
 			case workloadmeta.KindKubernetesMetadata:
 				tagInfos = append(tagInfos, c.handleKubeMetadata(ev)...)
+			case workloadmeta.KindKubernetesNode:
+				tagInfos = append(tagInfos, c.handleKubeNode(ev)...)
 			case workloadmeta.KindProcess:
 				tagInfos = append(tagInfos, c.handleProcess(ev)...)
 			case workloadmeta.KindKubernetesDeployment:
@@ -725,6 +726,40 @@ func (c *WorkloadMetaCollector) handleKubeDeployment(ev workloadmeta.Event) []*t
 	}
 
 	return tagInfos
+}
+
+func (c *WorkloadMetaCollector) handleKubeNode(ev workloadmeta.Event) []*types.TagInfo {
+	node := ev.Entity.(*workloadmeta.KubernetesNode)
+
+	groupResource := "nodes"
+
+	labelsAsTags := c.k8sResourcesLabelsAsTags[groupResource]
+	annotationsAsTags := c.k8sResourcesAnnotationsAsTags[groupResource]
+
+	if len(labelsAsTags)+len(annotationsAsTags) == 0 {
+		return nil
+	}
+
+	tagList := taglist.NewTagList()
+	c.addResourceLabelsAndAnnotationsAsTags(groupResource, node.Labels, node.Annotations, tagList)
+
+	low, orch, high, standard := tagList.Compute()
+
+	if len(low)+len(orch)+len(high)+len(standard) == 0 {
+		return nil
+	}
+
+	return []*types.TagInfo{
+		{
+			Source:               nodeSource,
+			EntityID:             common.BuildTaggerEntityID(node.EntityID),
+			HighCardTags:         high,
+			OrchestratorCardTags: orch,
+			LowCardTags:          low,
+			StandardTags:         standard,
+			IsComplete:           ev.IsComplete,
+		},
+	}
 }
 
 func (c *WorkloadMetaCollector) handleKubeMetadata(ev workloadmeta.Event) []*types.TagInfo {

--- a/comp/core/tagger/collectors/workloadmeta_main.go
+++ b/comp/core/tagger/collectors/workloadmeta_main.go
@@ -37,6 +37,7 @@ const (
 	containerImageSource      = workloadmetaCollectorName + "-" + string(workloadmeta.KindContainerImageMetadata)
 	processSource             = workloadmetaCollectorName + "-" + string(workloadmeta.KindProcess)
 	kubeMetadataSource        = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesMetadata)
+	nodeSource                = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesNode)
 	deploymentSource          = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesDeployment)
 	kueueQueueSource          = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesKueueQueue)
 	kueueResourceFlavorSource = workloadmetaCollectorName + "-" + string(workloadmeta.KindKubernetesKueueResourceFlavor)

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -4083,19 +4083,18 @@ func TestHandleDelete(t *testing.T) {
 }
 
 func TestHandleDeleteKubernetesNode(t *testing.T) {
-	// KubernetesNode entities carry no tags and are excluded from tagging in
-	// processEvents. Deleting one must not panic by falling through to
-	// common.BuildTaggerEntityID, which has no case for KindKubernetesNode.
-
+	nodeEntityID := workloadmeta.EntityID{
+		Kind: workloadmeta.KindKubernetesNode,
+		ID:   "node-foobar",
+	}
 	node := &workloadmeta.KubernetesNode{
-		EntityID: workloadmeta.EntityID{
-			Kind: workloadmeta.KindKubernetesNode,
-			ID:   "node-foobar",
-		},
+		EntityID: nodeEntityID,
 		EntityMeta: workloadmeta.EntityMeta{
 			Name: "node-foobar",
 		},
 	}
+
+	nodeTaggerEntityID := types.NewEntityID(types.KubernetesNode, nodeEntityID.ID)
 
 	store := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
 		fx.Provide(func() log.Component { return logmock.New(t) }),
@@ -4106,19 +4105,128 @@ func TestHandleDeleteKubernetesNode(t *testing.T) {
 	cfg := configmock.New(t)
 	collector := NewWorkloadMetaCollector(context.Background(), cfg, store, nil)
 
-	eventBundle := workloadmeta.EventBundle{
-		Events: []workloadmeta.Event{
-			{
-				Type:   workloadmeta.EventTypeUnset,
-				Entity: node,
-			},
+	expected := []*types.TagInfo{
+		{
+			Source:       nodeSource,
+			EntityID:     nodeTaggerEntityID,
+			DeleteEntity: true,
 		},
-		Ch: make(chan struct{}),
 	}
 
-	assert.NotPanics(t, func() {
-		collector.processEvents(eventBundle)
+	actual := collector.handleDelete(workloadmeta.Event{
+		Type:   workloadmeta.EventTypeUnset,
+		Entity: node,
 	})
+
+	assertTagInfoListEqual(t, expected, actual)
+}
+
+func TestHandleKubeNode(t *testing.T) {
+	const nodeName = "node-foobar"
+
+	nodeEntityID := workloadmeta.EntityID{
+		Kind: workloadmeta.KindKubernetesNode,
+		ID:   nodeName,
+	}
+
+	nodeTaggerEntityID := types.NewEntityID(types.KubernetesNode, nodeEntityID.ID)
+
+	store := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		fx.Provide(func() log.Component { return logmock.New(t) }),
+		fx.Provide(func() config.Component { return config.NewMock(t) }),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+
+	tests := []struct {
+		name                          string
+		k8sResourcesAnnotationsAsTags map[string]map[string]string
+		k8sResourcesLabelsAsTags      map[string]map[string]string
+		node                          workloadmeta.KubernetesNode
+		expected                      []*types.TagInfo
+	}{
+		{
+			name: "node with no matching labels/annotations for annotations/labels as tags. should return nil to avoid empty tagger entity",
+			k8sResourcesAnnotationsAsTags: map[string]map[string]string{
+				"nodes": {
+					"node_tier": "node_tier",
+				},
+			},
+			k8sResourcesLabelsAsTags: map[string]map[string]string{
+				"nodes": {
+					"node_env": "node_env",
+				},
+			},
+			node: workloadmeta.KubernetesNode{
+				EntityID: nodeEntityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: nodeName,
+					Labels: map[string]string{
+						"a": "dev",
+					},
+					Annotations: map[string]string{
+						"b": "some_tier",
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "node with generic labels/annotations as tags",
+			k8sResourcesAnnotationsAsTags: map[string]map[string]string{
+				"nodes": {
+					"node_tier": "node_tier",
+				},
+			},
+			k8sResourcesLabelsAsTags: map[string]map[string]string{
+				"nodes": {
+					"node_env": "node_env",
+				},
+			},
+			node: workloadmeta.KubernetesNode{
+				EntityID: nodeEntityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: nodeName,
+					Labels: map[string]string{
+						"node_env": "dev",
+						"foo":      "bar",
+					},
+					Annotations: map[string]string{
+						"node_tier":     "some_tier",
+						"node_security": "critical",
+					},
+				},
+			},
+			expected: []*types.TagInfo{
+				{
+					Source:               nodeSource,
+					EntityID:             nodeTaggerEntityID,
+					HighCardTags:         []string{},
+					OrchestratorCardTags: []string{},
+					LowCardTags: []string{
+						"node_env:dev",
+						"node_tier:some_tier",
+					},
+					StandardTags: []string{},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			cfg := configmock.New(t)
+			collector := NewWorkloadMetaCollector(context.Background(), cfg, store, nil)
+
+			collector.initK8sResourcesMetaAsTags(test.k8sResourcesLabelsAsTags, test.k8sResourcesAnnotationsAsTags)
+
+			actual := collector.handleKubeNode(workloadmeta.Event{
+				Type:   workloadmeta.EventTypeSet,
+				Entity: &test.node,
+			})
+
+			assertTagInfoListEqual(tt, test.expected, actual)
+		})
+	}
 }
 
 type fakeProcessor struct {

--- a/comp/core/tagger/common/entity_id_builder.go
+++ b/comp/core/tagger/common/entity_id_builder.go
@@ -29,6 +29,8 @@ func BuildTaggerEntityID(entityID workloadmeta.EntityID) types.EntityID {
 		return types.NewEntityID(types.KubernetesDeployment, entityID.ID)
 	case workloadmeta.KindKubernetesMetadata:
 		return types.NewEntityID(types.KubernetesMetadata, entityID.ID)
+	case workloadmeta.KindKubernetesNode:
+		return types.NewEntityID(types.KubernetesNode, entityID.ID)
 	case workloadmeta.KindKubernetesKueueQueue:
 		return types.NewEntityID(types.KubernetesKueueQueue, entityID.ID)
 	case workloadmeta.KindKubernetesKueueResourceFlavor:

--- a/comp/core/tagger/types/entity_id.go
+++ b/comp/core/tagger/types/entity_id.go
@@ -73,6 +73,8 @@ const (
 	KubernetesDeployment EntityIDPrefix = "deployment"
 	// KubernetesMetadata is the prefix `kubernetes_metadata`
 	KubernetesMetadata EntityIDPrefix = "kubernetes_metadata"
+	// KubernetesNode is the prefix `kubernetes_node`
+	KubernetesNode EntityIDPrefix = "kubernetes_node"
 	// KubernetesKueueQueue is the prefix `kubernetes_kueue_queue`
 	KubernetesKueueQueue EntityIDPrefix = "kubernetes_kueue_queue"
 	// KueueResourceFlavor is the prefix `kueue_resource_flavor`
@@ -104,6 +106,7 @@ func AllPrefixesSet() map[EntityIDPrefix]struct{} {
 		Host:                   {},
 		KubernetesDeployment:   {},
 		KubernetesMetadata:     {},
+		KubernetesNode:         {},
 		KubernetesKueueQueue:   {},
 		KueueResourceFlavor:    {},
 		KueueWorkload:          {},

--- a/comp/core/tagger/types/filter_builder_test.go
+++ b/comp/core/tagger/types/filter_builder_test.go
@@ -59,6 +59,7 @@ func TestFilterBuilderOps(t *testing.T) {
 					KueueResourceFlavor:    {},
 					KueueWorkload:          {},
 					KubernetesMetadata:     {},
+					KubernetesNode:         {},
 					KubernetesPodUID:       {},
 					Process:                {},
 					InternalID:             {},

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -84,7 +84,11 @@ func resourcesWithMetadataCollectionEnabled(cfg config.Reader) []string {
 }
 
 // resourcesWithRequiredMetadataCollection returns the list of resources that we
-// need to collect metadata from in order to make other enabled features work
+// need to collect metadata from in order to make other enabled features work.
+// Pods, Deployments and Nodes are excluded here because they have their own
+// dedicated stores and informers in workloadmeta, and tag extraction for
+// labels/annotations-as-tags reads directly from those (e.g. KindKubernetesNode)
+// instead of the generic metadata store.
 func resourcesWithRequiredMetadataCollection(cfg config.Reader) []string {
 	// resources that we need to collect metadata from in order to make other enabled features work
 	var res []string
@@ -93,7 +97,7 @@ func resourcesWithRequiredMetadataCollection(cfg config.Reader) []string {
 
 	for groupResource, labelsAsTags := range metadataAsTags.GetResourcesLabelsAsTags() {
 
-		if strings.HasPrefix(groupResource, "pods") || strings.HasPrefix(groupResource, "deployments") || len(labelsAsTags) == 0 {
+		if strings.HasPrefix(groupResource, "pods") || strings.HasPrefix(groupResource, "deployments") || groupResource == "nodes" || len(labelsAsTags) == 0 {
 			continue
 		}
 		requestedResource := groupResourceToGVRString(groupResource)
@@ -103,7 +107,7 @@ func resourcesWithRequiredMetadataCollection(cfg config.Reader) []string {
 	}
 
 	for groupResource, annotationsAsTags := range metadataAsTags.GetResourcesAnnotationsAsTags() {
-		if strings.HasPrefix(groupResource, "pods") || strings.HasPrefix(groupResource, "deployments") || len(annotationsAsTags) == 0 {
+		if strings.HasPrefix(groupResource, "pods") || strings.HasPrefix(groupResource, "deployments") || groupResource == "nodes" || len(annotationsAsTags) == 0 {
 			continue
 		}
 		requestedResource := groupResourceToGVRString(groupResource)

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -631,7 +631,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "",
 			},
-			expectedResources: []string{"//nodes"},
+			expectedResources: nil,
 		},
 		{
 			name: "duplicate versions for the same group/resource should not be allowed",
@@ -639,7 +639,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "apps/deployments apps/statefulsets apps//deployments apps/v1/statefulsets apps/v1/daemonsets",
 			},
-			expectedResources: []string{"//nodes", "apps/v1/daemonsets"},
+			expectedResources: []string{"apps/v1/daemonsets"},
 		},
 		{
 			name: "with generic resource tagging based on annotations and/or labels configured",
@@ -651,7 +651,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"kubernetes_resources_labels_as_tags":              `{"deployments.apps": {"x-team": "team"}, "custom.example.com": {"x-team": "team"}}`,
 				"kubernetes_resources_annotations_as_tags":         `{"namespaces": {"x-team": "team"}}`,
 			},
-			expectedResources: []string{"//nodes", "//namespaces", "example.com//custom"},
+			expectedResources: []string{"//namespaces", "example.com//custom"},
 		},
 		{
 			name: "generic resources tagging should be exclude invalid resources",
@@ -663,7 +663,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"kubernetes_resources_labels_as_tags":              `{"-invalid": {"x-team": "team"}, "invalid.exa_mple.com": {"x-team": "team"}}`,
 				"kubernetes_resources_annotations_as_tags":         `{"in valid.example.com": {"x-team": "team"}, "invalid.example.com-": {"x-team": "team"}}`,
 			},
-			expectedResources: []string{"//nodes"},
+			expectedResources: nil,
 		},
 		{
 			name: "deployments should be excluded from metadata collection",
@@ -673,7 +673,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "apps/daemonsets apps/deployments",
 			},
-			expectedResources: []string{"apps//daemonsets", "//nodes"},
+			expectedResources: []string{"apps//daemonsets"},
 		},
 		{
 			name: "pods should be excluded from metadata collection",
@@ -682,7 +682,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "apps/daemonsets pods",
 			},
-			expectedResources: []string{"apps//daemonsets", "//nodes"},
+			expectedResources: []string{"apps//daemonsets"},
 		},
 		{
 			name: "resources explicitly requested",
@@ -690,7 +690,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "apps/deployments apps/statefulsets example.com/custom",
 			},
-			expectedResources: []string{"//nodes", "apps//statefulsets", "example.com//custom"},
+			expectedResources: []string{"apps//statefulsets", "example.com//custom"},
 		},
 		{
 			name: "non-core resources whose name merely ends in nodes should not be excluded",
@@ -698,7 +698,19 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.enabled":   true,
 				"cluster_agent.kube_metadata_collection.resources": "storage.k8s.io/csinodes metrics.k8s.io/nodes",
 			},
-			expectedResources: []string{"//nodes", "storage.k8s.io//csinodes", "metrics.k8s.io//nodes"},
+			expectedResources: []string{"storage.k8s.io//csinodes", "metrics.k8s.io//nodes"},
+		},
+		{
+			name: "core nodes are excluded from metadata collection even with node labels/annotations as tags configured",
+			cfg: map[string]interface{}{
+				"kubernetes_node_labels_as_tags": map[string]string{
+					"label1": "tag1",
+				},
+				"kubernetes_node_annotations_as_tags": map[string]string{
+					"annotation1": "tag1",
+				},
+			},
+			expectedResources: nil,
 		},
 		{
 			name: "namespaces needed for namespace labels as tags",
@@ -707,7 +719,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 					"label1": "tag1",
 				},
 			},
-			expectedResources: []string{"//nodes", "//namespaces"},
+			expectedResources: []string{"//namespaces"},
 		},
 		{
 			name: "namespaces needed for namespace annotations as tags",
@@ -716,7 +728,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 					"annotation1": "tag1",
 				},
 			},
-			expectedResources: []string{"//nodes", "//namespaces"},
+			expectedResources: []string{"//namespaces"},
 		},
 		{
 			name: "namespaces needed for namespace labels and annotations as tags",
@@ -724,7 +736,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"kubernetes_namespace_labels_as_tags":      `{"label1": "tag1"}`,
 				"kubernetes_namespace_annotations_as_tags": `{"annotation1": "tag2"}`,
 			},
-			expectedResources: []string{"//nodes", "//namespaces"},
+			expectedResources: []string{"//namespaces"},
 		},
 		{
 			name: "resources explicitly requested and also needed for namespace labels as tags",
@@ -733,7 +745,7 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.resources": "namespaces apps/deployments",
 				"kubernetes_namespace_labels_as_tags":              `{"label1": "tag1"}`,
 			},
-			expectedResources: []string{"//nodes", "//namespaces"}, // namespaces are not duplicated
+			expectedResources: []string{"//namespaces"}, // namespaces are not duplicated
 		},
 		{
 			name: "resources explicitly requested with apm enabled and also needed for namespace labels as tags",
@@ -743,14 +755,14 @@ func TestResourcesWithMetadataCollectionEnabled(t *testing.T) {
 				"cluster_agent.kube_metadata_collection.resources":                       "namespaces apps/deployments",
 				"kubernetes_namespace_labels_as_tagkubernetes_namespace_labels_as_tagss": `{"label1": "tag1"}`,
 			},
-			expectedResources: []string{"//nodes", "//namespaces"}, // namespaces are not duplicated
+			expectedResources: []string{"//namespaces"}, // namespaces are not duplicated
 		},
 		{
 			name: "apm enabled enables namespace collection",
 			cfg: map[string]interface{}{
 				"apm_config.instrumentation.enabled": true,
 			},
-			expectedResources: []string{"//nodes", "//namespaces"},
+			expectedResources: []string{"//namespaces"},
 		},
 	}
 

--- a/comp/core/workloadmeta/def/filter.go
+++ b/comp/core/workloadmeta/def/filter.go
@@ -19,12 +19,6 @@ type GenericEntityFilterFunc EntityFilterFunc[Entity]
 // any entity.
 func EntityFilterFuncAcceptAll(_ Entity) bool { return true }
 
-// IsNodeMetadata is a filter function that returns true if the metadata
-// belongs to a node.
-var IsNodeMetadata = func(metadata *KubernetesMetadata) bool {
-	return metadata.GVR != nil && metadata.GVR.Group == "" && metadata.GVR.Resource == "nodes"
-}
-
 // IsNamespaceMetadata is a filter function that returns true if the metadata
 // belongs to a namespace.
 var IsNamespaceMetadata = func(metadata *KubernetesMetadata) bool {

--- a/comp/core/workloadmeta/def/filter_test.go
+++ b/comp/core/workloadmeta/def/filter_test.go
@@ -13,49 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func TestIsNodeMetadata(t *testing.T) {
-
-	tests := []struct {
-		name                 string
-		metadataEntity       KubernetesMetadata
-		shouldBeNodeMetadata bool
-	}{
-		{
-			name: "node metadata",
-			metadataEntity: KubernetesMetadata{
-				GVR: &schema.GroupVersionResource{
-					Version:  "v1",
-					Resource: "nodes",
-				},
-			},
-			shouldBeNodeMetadata: true,
-		},
-
-		{
-			name: "node metadata, but not native group",
-			metadataEntity: KubernetesMetadata{
-				GVR: &schema.GroupVersionResource{
-					Group:    "customgroup",
-					Version:  "v1",
-					Resource: "nodes",
-				},
-			},
-			shouldBeNodeMetadata: false,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(tt *testing.T) {
-			if test.shouldBeNodeMetadata {
-				assert.True(tt, IsNodeMetadata(&test.metadataEntity))
-			} else {
-				assert.False(tt, IsNodeMetadata(&test.metadataEntity))
-			}
-		})
-	}
-
-}
-
 func TestIsNamespaceMetadata(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/common.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/common.go
@@ -268,7 +268,7 @@ func entityIDsFromAttributes(attrs pcommon.Map) []types.EntityID {
 	}
 
 	if nodeName, ok := attrs.Get(string(conventions.K8SNodeNameKey)); ok {
-		entityIDs = append(entityIDs, types.NewEntityID(types.KubernetesMetadata, "/nodes//"+nodeName.AsString()))
+		entityIDs = append(entityIDs, types.NewEntityID(types.KubernetesNode, nodeName.AsString()))
 	}
 	if podUID, ok := attrs.Get(string(conventions.K8SPodUIDKey)); ok {
 		entityIDs = append(entityIDs, types.NewEntityID(types.KubernetesPodUID, podUID.AsString()))

--- a/comp/otelcol/otlp/components/processor/infraattributesprocessor/metrics_test.go
+++ b/comp/otelcol/otlp/components/processor/infraattributesprocessor/metrics_test.go
@@ -363,7 +363,7 @@ func TestEntityIDsFromAttributes(t *testing.T) {
 				})
 				return attributes
 			}(),
-			entityIDs: []string{"kubernetes_metadata:///nodes//k8s_node_name_goes_here"},
+			entityIDs: []string{"kubernetes_node://k8s_node_name_goes_here"},
 		},
 		{
 			name: "only process pid",

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common.go
@@ -275,6 +275,8 @@ func getInvolvedObjectTags(involvedObject v1.ObjectReference, taggerInstance tag
 		entityID = types.NewEntityID(types.KubernetesPodUID, string(involvedObject.UID))
 	case deploymentKind:
 		entityID = types.NewEntityID(types.KubernetesDeployment, involvedObject.Namespace+"/"+involvedObject.Name)
+	case nodeKind:
+		entityID = types.NewEntityID(types.KubernetesNode, involvedObject.Name)
 	default:
 		apiGroup := apiserver.GetAPIGroup(involvedObject.APIVersion)
 		resourceType, err := apiserver.GetResourceType(involvedObject.Kind, apiGroup)

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/events_common_test.go
@@ -62,6 +62,7 @@ func Test_getInvolvedObjectTags(t *testing.T) {
 	taggerInstance.SetTags(types.NewEntityID(types.KubernetesDeployment, "default/my-deployment-2"), "workloadmeta-kubernetes_deployment", nil, []string{"deployment_tag:redis-2"}, nil, nil)
 	taggerInstance.SetTags(types.NewEntityID(types.KubernetesMetadata, string(util.GenerateKubeMetadataEntityID("", "namespaces", "", "default"))), "workloadmeta-kubernetes_node", []string{"team:container-int"}, nil, nil, nil)
 	taggerInstance.SetTags(types.NewEntityID(types.KubernetesMetadata, string(util.GenerateKubeMetadataEntityID("api-group", "resourcetypes", "default", "generic-resource"))), "workloadmeta-kubernetes_resource", []string{"generic_tag:generic-resource"}, nil, nil, nil)
+	taggerInstance.SetTags(types.NewEntityID(types.KubernetesNode, "my-node-1"), "workloadmeta-kubernetes_node", []string{"node_tag:my-node-1"}, nil, nil, nil)
 
 	client := fakeclientset.NewClientset()
 	fakeDiscoveryClient := client.Discovery().(*fakediscovery.FakeDiscovery)
@@ -156,6 +157,20 @@ func Test_getInvolvedObjectTags(t *testing.T) {
 				"kube_deployment:my-deployment-2",
 				"team:container-int", // this tag is coming from the namespace
 				"deployment_tag:redis-2",
+			},
+		},
+		{
+			name: "get node basic tags",
+			involvedObject: v1.ObjectReference{
+				Kind: "Node",
+				Name: "my-node-1",
+			},
+			tags: []string{
+				"kube_kind:Node",
+				"kube_name:my-node-1",
+				"kubernetes_kind:Node",
+				"name:my-node-1",
+				"node_tag:my-node-1",
 			},
 		},
 		{

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node.go
@@ -11,7 +11,6 @@ import (
 	model "github.com/DataDog/agent-payload/v5/process"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
-	wmutil "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/common"
@@ -43,10 +42,7 @@ func (h *NodeHandlers) EnrichModel(ctx processors.ProcessorContext, resource, re
 	r := resource.(*corev1.Node)
 	m := resourceModel.(*model.Node)
 
-	entityID := taggertypes.NewEntityID(
-		taggertypes.KubernetesMetadata,
-		string(wmutil.GenerateKubeMetadataEntityID(ctx.GetCollectorGroup(), ctx.GetCollectorName(), "", r.Name)),
-	)
+	entityID := taggertypes.NewEntityID(taggertypes.KubernetesNode, r.Name)
 	taggerTags, err := h.tagger.Tag(entityID, taggertypes.HighCardinality)
 	if err != nil {
 		log.Debugf("Could not retrieve tags for node %s: %s", r.Name, err)

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node_test.go
@@ -23,7 +23,6 @@ import (
 
 	model "github.com/DataDog/agent-payload/v5/process"
 	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
-	wmutil "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processorstest"
 	k8sTransformers "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s"
@@ -41,10 +40,7 @@ func TestNodeHandlers_BeforeCacheCheck(t *testing.T) {
 	}
 
 	ctx := processorstest.NewProcessorContextBeforeCacheCheck("", "nodes")
-	entityID := taggertypes.NewEntityID(
-		taggertypes.KubernetesMetadata,
-		string(wmutil.GenerateKubeMetadataEntityID(ctx.GetCollectorGroup(), ctx.GetCollectorName(), resource.Namespace, resource.Name)),
-	)
+	entityID := taggertypes.NewEntityID(taggertypes.KubernetesNode, resource.Name)
 	tagger := processorstest.NewFakeTagger(map[taggertypes.EntityID][]string{entityID: {"tagger-tag:value"}})
 	handlers := NewNodeHandlers(tagger)
 

--- a/releasenotes-dca/notes/fix-kubernetes-node-dual-listwatch-a137cd0e82feef11.yaml
+++ b/releasenotes-dca/notes/fix-kubernetes-node-dual-listwatch-a137cd0e82feef11.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    The Cluster Agent no longer opens a second, redundant cluster-wide
+    ``ListWatch`` for Kubernetes Nodes. Setting ``kubernetes_node_labels_as_tags``
+    or ``kubernetes_node_annotations_as_tags`` used to start an extra
+    Node metadata watch in addition to the one already used to populate the
+    Node cache; that extra watch has been removed and label/annotation-as-tags
+    extraction now relies solely on the existing Node cache.


### PR DESCRIPTION
## Summary

Follow-up to #53880. The setting `kubernetes_node_labels_as_tags`/`kubernetes_node_annotations_as_tags` still caused the Cluster Agent to open a second generic `PartialObjectMetadata` redundant cluster-wide `ListWatch` for Nodes.

## Test plan

Used the following injector-dev definition to test out the migration.
```
platform:
  type: kind
  name: node-tagger-verify
  reset: false
helm:
  versions:
    agent: "7.81.0"
    cluster_agent:
      version: "7.81.0"
      build: {}
  config:
    datadog:
      kubelet:
        tlsVerify: false
      nodeLabelsAsTags:
        kubernetes.io/hostname: kube_node_hostname
```
When running `agent tagger-list` we can see that we no longer have the `kubemetadata:///nodes` object and just the new `kubernetes_node://` object:
```
=== Entity internal://global-entity-id ===
== Source workloadmeta-static ==
Tags: [orch_cluster_id:31b4f96c-4585-4432-b22e-686b69e06bf8]
===

=== Entity kubernetes_capabilities://kube-capability-id ===
== Source workloadmeta-kubernetes_capabilities ==
Tags: [kube_server_version:v1.31.0]
===

=== Entity kubernetes_node://node-tagger-verify-control-plane ===
== Source workloadmeta-kubernetes_node ==
Tags: [kube_node_hostname:node-tagger-verify-control-plane]
===
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)