### PR TITLE
fix(statstracker): implement GoString to avoid racy reflection reads

### DIFF
--- a/pkg/util/statstracker/stats_tracker.go
+++ b/pkg/util/statstracker/stats_tracker.go
@@ -178,3 +178,13 @@ func (s *Tracker) Info() []string {
 		fmt.Sprintf("24h Peak Latency: %s", time.Duration(s.MovingPeak())),
 	}
 }
+
+// GoString implements fmt.GoStringer so that printing a *Tracker with %#v (e.g. from a
+// debug dump) goes through the locked accessors instead of reflection reading the
+// fields directly, which would race with Add().
+func (s *Tracker) GoString() string {
+	return fmt.Sprintf(
+		"&statstracker.Tracker{allTimeAvg: %d, allTimePeak: %d, movingAvg: %d, movingPeak: %d}",
+		s.AllTimeAvg(), s.AllTimePeak(), s.MovingAvg(), s.MovingPeak(),
+	)
+}

--- a/pkg/util/statstracker/stats_tracker.go
+++ b/pkg/util/statstracker/stats_tracker.go
@@ -180,11 +180,18 @@ func (s *Tracker) Info() []string {
 }
 
 // GoString implements fmt.GoStringer so that printing a *Tracker with %#v (e.g. from a
-// debug dump) goes through the locked accessors instead of reflection reading the
-// fields directly, which would race with Add().
+// debug dump) reads all fields while holding the lock, instead of via unsynchronized
+// reflection, which would race with Add(). The lock itself is deliberately omitted:
+// a *sync.Mutex's internal state is touched by atomic CAS from any goroutine contending
+// on it, regardless of who currently holds it, so reflecting over it is racy on its own.
 func (s *Tracker) GoString() string {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	return fmt.Sprintf(
-		"&statstracker.Tracker{allTimeAvg: %d, allTimePeak: %d, movingAvg: %d, movingPeak: %d}",
-		s.AllTimeAvg(), s.AllTimePeak(), s.MovingAvg(), s.MovingPeak(),
+		"&statstracker.Tracker{allTimeAvg:%#v, allTimePeak:%#v, totalPoints:%#v, timeFrame:%#v, bucketFrame:%#v, avgPointsHead:%#v, peakPointsHead:%#v, aggregatedAvgPoints:%#v, aggregatedPeakPoints:%#v, timeProvider:%#v}",
+		s.allTimeAvg, s.allTimePeak, s.totalPoints, s.timeFrame, s.bucketFrame,
+		s.avgPointsHead, s.peakPointsHead, s.aggregatedAvgPoints, s.aggregatedPeakPoints,
+		s.timeProvider,
 	)
 }

--- a/pkg/util/statstracker/stats_tracker_test.go
+++ b/pkg/util/statstracker/stats_tracker_test.go
@@ -6,6 +6,7 @@
 package statstracker
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -151,6 +152,39 @@ func TestAllTimePeak(t *testing.T) {
 
 	assert.Equal(t, int64(20), s.AllTimePeak())
 
+}
+
+func TestGoStringReadsFieldsUnderLock(t *testing.T) {
+	_, s := setupStatsTracker(3*time.Second, time.Second)
+	s.Add(10)
+	s.Add(20)
+
+	dump := fmt.Sprintf("%#v", s)
+
+	assert.Contains(t, dump, "allTimeAvg:15")
+	assert.Contains(t, dump, "allTimePeak:20")
+	assert.Contains(t, dump, "totalPoints:2")
+	assert.Contains(t, dump, "timeFrame:3000000000")
+	assert.Contains(t, dump, "bucketFrame:1000000000")
+}
+
+// TestGoStringConcurrentWithAdd reproduces the scenario that raced in production: something
+// dumping a *Tracker with %#v (e.g. LogSource.Dump()) while Add() is running concurrently.
+// Run with -race.
+func TestGoStringConcurrentWithAdd(_ *testing.T) {
+	_, s := setupStatsTracker(3*time.Second, time.Second)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := range 1000 {
+			s.Add(int64(i))
+		}
+	}()
+	for range 1000 {
+		_ = fmt.Sprintf("%#v", s)
+	}
+	<-done
 }
 
 func TestAllTimeAvg(t *testing.T) {


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Fixes a data race where `LogSource.Dump()` printed a `*statstracker.Tracker` with `%#v`, which falls back to `fmt`'s reflection-based struct printer and reads every field directly, bypassing `Tracker`'s own lock and racing with `Add()`. `Tracker` now implements `GoString()` so `%#v`/reflection-based printing goes through the locked accessors instead.

### Motivation

Found via `-race` in a live deployment log (`Dump()` racing with the pipeline sender's `Tracker.Add()`).

### Describe how you validated your changes

CI, unit tests

### Additional Notes