### PR TITLE
autodiscovery: re-validate discovery probe results against live filtering before applying

### DIFF
--- a/comp/core/autodiscovery/impl/configmgr.go
+++ b/comp/core/autodiscovery/impl/configmgr.go
@@ -376,6 +376,44 @@ func (cm *reconcilingConfigManager) getActiveServices() map[string]listeners.Ser
 	return res
 }
 
+// expectedFilteredTemplatesLocked returns the templates currently expected to
+// be resolved for svcID: every active template digest indexed under one of
+// the service's AD identifiers, after running the service's FilterTemplates
+// over them. Returns an empty map if the service is not currently active.
+//
+// This is the exact computation reconcileService uses to decide what should
+// be scheduled. It's also used to re-validate a configuration-discovery
+// template against live filtering state immediately before applying an
+// asynchronous probe result (see applyDiscoveredConfigsLocked in
+// configmgr_discovery.go): a probe can take multiple retry cycles to
+// complete, and its result is applied directly from the worker callback,
+// bypassing reconcileService entirely — so without this re-check, a
+// conflicting sibling/static/generic-integration config that appears after
+// the probe was enqueued would have no effect on an already in-flight probe.
+//
+// This method must be called with cm.m locked.
+func (cm *reconcilingConfigManager) expectedFilteredTemplatesLocked(svcID string) map[string]integration.Config {
+	// note that this method can be called in a case where svcID is not in the
+	// activeServices: this occurs when the service is removed.
+	svcAndADIDs := cm.activeServices[svcID]
+
+	templates := map[string]integration.Config{}
+	for _, adID := range svcAndADIDs.adIDs {
+		for _, digest := range cm.templatesByADID.get(adID) {
+			templates[digest] = cm.activeConfigs[digest]
+		}
+	}
+
+	// allow the service to filter those templates, unless we are removing
+	// the service, in which case no resolutions are expected.
+	if svcAndADIDs.svc != nil {
+		// Warning: this must be called with the configs stored in cm.activeConfigs
+		// which contain the compiled matchingPrograms for the config template.
+		svcAndADIDs.svc.FilterTemplates(templates)
+	}
+	return templates
+}
+
 // reconcileService calculates the current set of resolved templates for the
 // given service and calculates the difference from what is currently recorded
 // in cm.serviceResolutions.  It updates cm.serviceResolutions and returns the
@@ -387,9 +425,7 @@ func (cm *reconcilingConfigManager) reconcileService(svcID string) integration.C
 
 	// note that this method can be called in a case where svcID is not in the
 	// activeServices: this occurs when the service is removed.
-	serviceAndADIDs := cm.activeServices[svcID]
-	adIDs := serviceAndADIDs.adIDs // nil slice if service is not defined
-	svc := serviceAndADIDs.svc     // nil if the service is not defined
+	svc := cm.activeServices[svcID].svc // nil if the service is not defined
 
 	// get the existing resolutions for this service
 	existingResolutions, found := cm.serviceResolutions[svcID]
@@ -397,24 +433,9 @@ func (cm *reconcilingConfigManager) reconcileService(svcID string) integration.C
 		existingResolutions = map[string]string{}
 	}
 
-	// determine the matching templates by template digest.  If the service
-	// has been removed, then this slice is empty.
-	expectedResolutions := map[string]integration.Config{}
-	for _, adID := range adIDs {
-		digests := cm.templatesByADID.get(adID)
-		for _, digest := range digests {
-			tpl := cm.activeConfigs[digest]
-			expectedResolutions[digest] = tpl
-		}
-	}
-
-	// allow the service to filter those templates, unless we are removing
-	// the service, in which case no resolutions are expected.
-	if svc != nil {
-		// Warning: this must be called with the configs stored in cm.activeConfigs
-		// which contain the compiled matchingPrograms for the config template.
-		svc.FilterTemplates(expectedResolutions)
-	}
+	// determine the matching, filtered templates.  If the service has been
+	// removed, this is empty.
+	expectedResolutions := cm.expectedFilteredTemplatesLocked(svcID)
 
 	// compare existing to expected, generating changes and modifying
 	// existingResolutions in-place

--- a/comp/core/autodiscovery/impl/configmgr_discovery.go
+++ b/comp/core/autodiscovery/impl/configmgr_discovery.go
@@ -112,6 +112,21 @@ func (cm *reconcilingConfigManager) applyDiscoveredConfigsLocked(svcID, tplDiges
 		// Template was removed while the probe was in flight.
 		return changes
 	}
+
+	// The probe was enqueued (in resolveTemplateForService) when this
+	// template was still expected for the service. A probe can take several
+	// retry cycles to complete, and by the time it does, a sibling config, a
+	// static config, or a generic-integration (openmetrics/prometheus)
+	// config may have appeared that would now cause FilterTemplates to drop
+	// this template. Re-run that same filtering here, immediately before
+	// applying the result, so a slow-arriving probe can't schedule a
+	// duplicate/conflicting check on top of a config that showed up while it
+	// was in flight.
+	if _, stillExpected := cm.expectedFilteredTemplatesLocked(svcID)[tplDigest]; !stillExpected {
+		log.Debugf("autodiscovery: discarding stale discovery result for %s on service %s: no longer expected after re-filtering", tpl.Name, svcID)
+		return changes
+	}
+
 	if len(configs) == 0 {
 		return changes
 	}

--- a/comp/core/autodiscovery/impl/configmgr_discovery_test.go
+++ b/comp/core/autodiscovery/impl/configmgr_discovery_test.go
@@ -295,89 +295,103 @@ func (h *midFlightDiscoverySuppressionHarness) releaseAndAssertSuppressed(t *tes
 	}
 }
 
-// TestConfigMgr_Discovery_StaleProbeResultSuppressedBySiblingArrivingMidFlight
-// reproduces the DSCVR-626 race: FilterTemplates only runs synchronously when
-// reconcileService runs, so it can't affect a probe that's already in
+// TestConfigMgr_Discovery_StaleProbeResultSuppressedByMidFlightConflict
+// reproduces the DSCVR-626 race: FilterTemplates only runs synchronously
+// inside reconcileService, so it can't affect a probe that's already in
 // flight. Without a re-check immediately before applying the probe result, a
-// sibling config that arrives for the same service *after* the probe was
-// enqueued but *before* it completes — e.g. an annotation change adding an
-// openmetrics config to the same container — would still get scheduled on
-// top of that sibling, defeating the point of the filtering. This test pins
-// down that applyDiscoveredConfigsLocked re-validates against live filtering
-// state before scheduling.
-func TestConfigMgr_Discovery_StaleProbeResultSuppressedBySiblingArrivingMidFlight(t *testing.T) {
-	// Mirrors filterTemplatesDiscovery's generic-integration-sibling rule:
-	// drop every discovery template while an openmetrics/prometheus sibling
-	// is present, regardless of Name.
-	filterTemplates := func(configs map[string]integration.Config) {
-		hasGenericSibling := false
-		for _, cfg := range configs {
-			if cfg.Discovery == nil && len(cfg.Instances) > 0 && (cfg.Name == "openmetrics" || cfg.Name == "prometheus") {
-				hasGenericSibling = true
+// conflicting generic-integration config that arrives for the same service
+// or host *after* the probe was enqueued but *before* it completes would
+// still get scheduled on top of it, defeating the point of the filtering.
+//
+// Both subtests below end up dropping the discovery digest for the same
+// (test-local, faked) reason — that part is deliberately trivial. What
+// actually differs, and is the point of having two cases, is *how* the
+// conflicting config reaches the config manager, which exercises two
+// different branches of processNewConfig:
+//
+//   - "sibling template arrives": the conflict has AD identifiers, so it IS
+//     a template. This DOES trigger a synchronous reconcileService for the
+//     affected service — but that alone changes nothing, because a
+//     discovery digest is never recorded in existingResolutions while its
+//     probe is pending, so reconcileService has nothing to unschedule. This
+//     proves the apply-time re-check matters even when reconcile does run.
+//   - "static config arrives host-wide": the conflict has no AD
+//     identifiers, so it's non-template. This NEVER triggers
+//     reconcileService for any already-active service at all (see the TODO
+//     in processNewConfig) — it only updates the shared StaticConfigIndex.
+//     This proves the apply-time re-check is the *only* thing that can catch
+//     this case; there's no reconcile to even race against.
+//
+// In both cases, applyDiscoveredConfigsLocked must re-validate against live
+// filtering state before scheduling the (stale) probe result.
+func TestConfigMgr_Discovery_StaleProbeResultSuppressedByMidFlightConflict(t *testing.T) {
+	t.Run("sibling template arrives for the same service", func(t *testing.T) {
+		// Mirrors filterTemplatesDiscovery's generic-integration-sibling rule:
+		// drop every discovery template while an openmetrics/prometheus
+		// sibling is present, regardless of Name.
+		filterTemplates := func(configs map[string]integration.Config) {
+			hasGenericSibling := false
+			for _, cfg := range configs {
+				if cfg.Discovery == nil && len(cfg.Instances) > 0 && (cfg.Name == "openmetrics" || cfg.Name == "prometheus") {
+					hasGenericSibling = true
+				}
+			}
+			if !hasGenericSibling {
+				return
+			}
+			for digest, cfg := range configs {
+				if cfg.Discovery != nil {
+					delete(configs, digest)
+				}
 			}
 		}
-		if !hasGenericSibling {
-			return
+		h := newMidFlightDiscoverySuppressionHarness(t, nil, filterTemplates)
+
+		// While the probe is in flight, a sibling openmetrics config for the
+		// same service arrives. Having AD identifiers makes this a template,
+		// so it triggers a real (but ultimately inconsequential)
+		// reconcileService for the service.
+		sibling := integration.Config{
+			Name:          "openmetrics",
+			ADIdentifiers: []string{"krakend"},
+			Instances:     []integration.Data{[]byte("openmetrics_endpoint: http://10.0.0.1:9091/metrics")},
 		}
-		for digest, cfg := range configs {
-			if cfg.Discovery != nil {
-				delete(configs, digest)
+		changes, _ := h.cm.processNewConfig(sibling)
+		assertConfigsMatch(t, changes.Schedule, matchName("openmetrics"))
+
+		h.releaseAndAssertSuppressed(t)
+	})
+
+	t.Run("static config arrives host-wide", func(t *testing.T) {
+		idx := listeners.NewStaticConfigIndex()
+		// Mirrors filterTemplatesDiscovery's static-index rule: drop every
+		// discovery template while a host-wide generic-integration static
+		// config is present in the shared index.
+		filterTemplates := func(configs map[string]integration.Config) {
+			if !idx.Has("openmetrics") && !idx.Has("prometheus") {
+				return
+			}
+			for digest, cfg := range configs {
+				if cfg.Discovery != nil {
+					delete(configs, digest)
+				}
 			}
 		}
-	}
-	h := newMidFlightDiscoverySuppressionHarness(t, nil, filterTemplates)
+		h := newMidFlightDiscoverySuppressionHarness(t, idx, filterTemplates)
 
-	// While the probe is in flight, a sibling openmetrics config for the same
-	// service arrives.
-	sibling := integration.Config{
-		Name:          "openmetrics",
-		ADIdentifiers: []string{"krakend"},
-		Instances:     []integration.Data{[]byte("openmetrics_endpoint: http://10.0.0.1:9091/metrics")},
-	}
-	changes, _ := h.cm.processNewConfig(sibling)
-	assertConfigsMatch(t, changes.Schedule, matchName("openmetrics"))
-
-	h.releaseAndAssertSuppressed(t)
-}
-
-// TestConfigMgr_Discovery_StaleProbeResultSuppressedByStaticConfigArrivingMidFlight
-// covers the host-wide variant: a *static* (non-template) generic-integration
-// config appearing while the probe is in flight — e.g. from a Kubernetes
-// Service's prometheus.io/scrape annotation, or a conf.d file picked up by
-// autoconf_config_files_poll. Crucially, adding a static config never
-// triggers reconcileService for any already-active service (see the
-// processNewConfig comment in configmgr.go) — it only updates the shared
-// StaticConfigIndex — so the apply-time re-check is the *only* thing that can
-// catch this case.
-func TestConfigMgr_Discovery_StaleProbeResultSuppressedByStaticConfigArrivingMidFlight(t *testing.T) {
-	idx := listeners.NewStaticConfigIndex()
-	// Mirrors filterTemplatesDiscovery's static-index rule: drop every
-	// discovery template while a host-wide generic-integration static
-	// config is present in the shared index.
-	filterTemplates := func(configs map[string]integration.Config) {
-		if !idx.Has("openmetrics") && !idx.Has("prometheus") {
-			return
+		// A static openmetrics config arrives while the probe is in flight.
+		// It has no AD identifiers, so it's non-template and never touches
+		// reconcileService — only the shared index.
+		staticOpenmetrics := integration.Config{
+			Name:      "openmetrics",
+			Instances: []integration.Data{[]byte("openmetrics_endpoint: http://10.0.0.2:9091/metrics")},
 		}
-		for digest, cfg := range configs {
-			if cfg.Discovery != nil {
-				delete(configs, digest)
-			}
-		}
-	}
-	h := newMidFlightDiscoverySuppressionHarness(t, idx, filterTemplates)
+		changes, _ := h.cm.processNewConfig(staticOpenmetrics)
+		assertConfigsMatch(t, changes.Schedule, matchName("openmetrics"))
+		assert.True(t, idx.Has("openmetrics"))
 
-	// A static openmetrics config arrives while the probe is in flight. It is
-	// not a template (no AD identifiers), so it never touches reconcileService
-	// — only the shared index.
-	staticOpenmetrics := integration.Config{
-		Name:      "openmetrics",
-		Instances: []integration.Data{[]byte("openmetrics_endpoint: http://10.0.0.2:9091/metrics")},
-	}
-	changes, _ := h.cm.processNewConfig(staticOpenmetrics)
-	assertConfigsMatch(t, changes.Schedule, matchName("openmetrics"))
-	assert.True(t, idx.Has("openmetrics"))
-
-	h.releaseAndAssertSuppressed(t)
+		h.releaseAndAssertSuppressed(t)
+	})
 }
 
 // makeDiscoveryCM is a small constructor used by the lifecycle tests below.

--- a/comp/core/autodiscovery/impl/configmgr_discovery_test.go
+++ b/comp/core/autodiscovery/impl/configmgr_discovery_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/discoverer"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 )
@@ -200,6 +201,166 @@ func TestConfigMgr_DiscoveryTemplate_ServiceDeletionCancels(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, settled, disco.called.Load(),
 		"no further probes should fire after the service is removed (started at %d)", settled)
+}
+
+// TestConfigMgr_Discovery_StaleProbeResultSuppressedBySiblingArrivingMidFlight
+// reproduces the DSCVR-626 race: FilterTemplates only runs synchronously when
+// reconcileService runs, so it can't affect a probe that's already in
+// flight. Without a re-check immediately before applying the probe result, a
+// sibling config that arrives for the same service *after* the probe was
+// enqueued but *before* it completes — e.g. an annotation change adding an
+// openmetrics config to the same container — would still get scheduled on
+// top of that sibling, defeating the point of the filtering. This test pins
+// down that applyDiscoveredConfigsLocked re-validates against live filtering
+// state before scheduling.
+func TestConfigMgr_Discovery_StaleProbeResultSuppressedBySiblingArrivingMidFlight(t *testing.T) {
+	mockResolver := MockSecretResolver{}
+
+	probeStarted := make(chan struct{})
+	release := make(chan struct{})
+	disco := newStubDiscoverer(func(_, _ string) (string, error) {
+		close(probeStarted)
+		<-release
+		return `[{"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics"}]}]`, nil
+	})
+	cm := newReconcilingConfigManager(&mockResolver, nil, nil, disco, nil).(*reconcilingConfigManager)
+	cm.start()
+	t.Cleanup(cm.stop)
+
+	tpl := integration.Config{
+		Name:          "krakend",
+		ADIdentifiers: []string{"krakend"},
+		Discovery:     &integration.DiscoveryConfig{},
+	}
+	svc := &dummyService{
+		ID:            "docker://k1",
+		ADIdentifiers: []string{"krakend"},
+		Hosts:         map[string]string{"main": "10.0.0.1"},
+	}
+	// Mirrors filterTemplatesDiscovery's generic-integration-sibling rule:
+	// drop every discovery template while an openmetrics/prometheus sibling
+	// is present, regardless of Name.
+	svc.filterTemplates = func(configs map[string]integration.Config) {
+		hasGenericSibling := false
+		for _, cfg := range configs {
+			if cfg.Discovery == nil && len(cfg.Instances) > 0 && (cfg.Name == "openmetrics" || cfg.Name == "prometheus") {
+				hasGenericSibling = true
+			}
+		}
+		if !hasGenericSibling {
+			return
+		}
+		for digest, cfg := range configs {
+			if cfg.Discovery != nil {
+				delete(configs, digest)
+			}
+		}
+	}
+
+	_, _ = cm.processNewConfig(tpl)
+	_ = cm.processNewService(svc)
+
+	select {
+	case <-probeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("probe never started")
+	}
+
+	// While the probe is in flight, a sibling openmetrics config for the same
+	// service arrives.
+	sibling := integration.Config{
+		Name:          "openmetrics",
+		ADIdentifiers: []string{"krakend"},
+		Instances:     []integration.Data{[]byte("openmetrics_endpoint: http://10.0.0.1:9091/metrics")},
+	}
+	changes, _ := cm.processNewConfig(sibling)
+	assertConfigsMatch(t, changes.Schedule, matchName("openmetrics"))
+
+	// Now let the stale probe complete.
+	close(release)
+
+	select {
+	case discovered := <-cm.discoveredChanges():
+		t.Fatalf("krakend discovery should have been suppressed by the sibling that arrived mid-flight, got: %+v", discovered)
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+// TestConfigMgr_Discovery_StaleProbeResultSuppressedByStaticConfigArrivingMidFlight
+// covers the host-wide variant: a *static* (non-template) generic-integration
+// config appearing while the probe is in flight — e.g. from a Kubernetes
+// Service's prometheus.io/scrape annotation, or a conf.d file picked up by
+// autoconf_config_files_poll. Crucially, adding a static config never
+// triggers reconcileService for any already-active service (see the
+// processNewConfig comment in configmgr.go) — it only updates the shared
+// StaticConfigIndex — so the apply-time re-check is the *only* thing that can
+// catch this case.
+func TestConfigMgr_Discovery_StaleProbeResultSuppressedByStaticConfigArrivingMidFlight(t *testing.T) {
+	mockResolver := MockSecretResolver{}
+	idx := listeners.NewStaticConfigIndex()
+
+	probeStarted := make(chan struct{})
+	release := make(chan struct{})
+	disco := newStubDiscoverer(func(_, _ string) (string, error) {
+		close(probeStarted)
+		<-release
+		return `[{"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics"}]}]`, nil
+	})
+	cm := newReconcilingConfigManager(&mockResolver, nil, idx, disco, nil).(*reconcilingConfigManager)
+	cm.start()
+	t.Cleanup(cm.stop)
+
+	tpl := integration.Config{
+		Name:          "krakend",
+		ADIdentifiers: []string{"krakend"},
+		Discovery:     &integration.DiscoveryConfig{},
+	}
+	svc := &dummyService{
+		ID:            "docker://k1",
+		ADIdentifiers: []string{"krakend"},
+		Hosts:         map[string]string{"main": "10.0.0.1"},
+	}
+	// Mirrors filterTemplatesDiscovery's static-index rule: drop every
+	// discovery template while a host-wide generic-integration static
+	// config is present in the shared index.
+	svc.filterTemplates = func(configs map[string]integration.Config) {
+		if !idx.Has("openmetrics") && !idx.Has("prometheus") {
+			return
+		}
+		for digest, cfg := range configs {
+			if cfg.Discovery != nil {
+				delete(configs, digest)
+			}
+		}
+	}
+
+	_, _ = cm.processNewConfig(tpl)
+	_ = cm.processNewService(svc)
+
+	select {
+	case <-probeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("probe never started")
+	}
+
+	// A static openmetrics config arrives while the probe is in flight. It is
+	// not a template (no AD identifiers), so it never touches reconcileService
+	// — only the shared index.
+	staticOpenmetrics := integration.Config{
+		Name:      "openmetrics",
+		Instances: []integration.Data{[]byte("openmetrics_endpoint: http://10.0.0.2:9091/metrics")},
+	}
+	changes, _ := cm.processNewConfig(staticOpenmetrics)
+	assertConfigsMatch(t, changes.Schedule, matchName("openmetrics"))
+	assert.True(t, idx.Has("openmetrics"))
+
+	close(release)
+
+	select {
+	case discovered := <-cm.discoveredChanges():
+		t.Fatalf("krakend discovery should have been suppressed by the static openmetrics config that arrived mid-flight, got: %+v", discovered)
+	case <-time.After(300 * time.Millisecond):
+	}
 }
 
 // makeDiscoveryCM is a small constructor used by the lifecycle tests below.

--- a/comp/core/autodiscovery/impl/configmgr_discovery_test.go
+++ b/comp/core/autodiscovery/impl/configmgr_discovery_test.go
@@ -203,17 +203,23 @@ func TestConfigMgr_DiscoveryTemplate_ServiceDeletionCancels(t *testing.T) {
 		"no further probes should fire after the service is removed (started at %d)", settled)
 }
 
-// TestConfigMgr_Discovery_StaleProbeResultSuppressedBySiblingArrivingMidFlight
-// reproduces the DSCVR-626 race: FilterTemplates only runs synchronously when
-// reconcileService runs, so it can't affect a probe that's already in
-// flight. Without a re-check immediately before applying the probe result, a
-// sibling config that arrives for the same service *after* the probe was
-// enqueued but *before* it completes — e.g. an annotation change adding an
-// openmetrics config to the same container — would still get scheduled on
-// top of that sibling, defeating the point of the filtering. This test pins
-// down that applyDiscoveredConfigsLocked re-validates against live filtering
-// state before scheduling.
-func TestConfigMgr_Discovery_StaleProbeResultSuppressedBySiblingArrivingMidFlight(t *testing.T) {
+// midFlightDiscoverySuppressionHarness sets up a configmgr with a "krakend"
+// discovery template + service whose probe is blocked on a channel, so tests
+// can deterministically inject a conflicting config while the probe is in
+// flight and then verify the (stale) result gets suppressed once released.
+// Used by the DSCVR-626 regression tests below.
+type midFlightDiscoverySuppressionHarness struct {
+	cm        *reconcilingConfigManager
+	release   chan struct{}
+	processed chan struct{}
+}
+
+// newMidFlightDiscoverySuppressionHarness builds the harness, installs
+// filterTemplates on the service (it should mirror whichever
+// filterTemplatesDiscovery rule the test wants to exercise), and blocks until
+// the probe has actually started.
+func newMidFlightDiscoverySuppressionHarness(t *testing.T, staticConfigIndex *listeners.StaticConfigIndex, filterTemplates func(map[string]integration.Config)) *midFlightDiscoverySuppressionHarness {
+	t.Helper()
 	mockResolver := MockSecretResolver{}
 
 	probeStarted := make(chan struct{})
@@ -223,7 +229,7 @@ func TestConfigMgr_Discovery_StaleProbeResultSuppressedBySiblingArrivingMidFligh
 		<-release
 		return `[{"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics"}]}]`, nil
 	})
-	cm := newReconcilingConfigManager(&mockResolver, nil, nil, disco, nil).(*reconcilingConfigManager)
+	cm := newReconcilingConfigManager(&mockResolver, nil, staticConfigIndex, disco, nil).(*reconcilingConfigManager)
 	cm.start()
 	t.Cleanup(cm.stop)
 
@@ -255,10 +261,55 @@ func TestConfigMgr_Discovery_StaleProbeResultSuppressedBySiblingArrivingMidFligh
 		ADIdentifiers: []string{"krakend"},
 		Hosts:         map[string]string{"main": "10.0.0.1"},
 	}
+	svc.filterTemplates = filterTemplates
+
+	_, _ = cm.processNewConfig(tpl)
+	_ = cm.processNewService(svc)
+
+	select {
+	case <-probeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("probe never started")
+	}
+
+	return &midFlightDiscoverySuppressionHarness{cm: cm, release: release, processed: processed}
+}
+
+// releaseAndAssertSuppressed unblocks the in-flight probe and asserts that
+// its result never reaches discoveredChanges(). It waits deterministically
+// for the wrapped callback to finish (see newMidFlightDiscoverySuppressionHarness)
+// before checking the channel, rather than sleeping a fixed duration.
+func (h *midFlightDiscoverySuppressionHarness) releaseAndAssertSuppressed(t *testing.T) {
+	t.Helper()
+	close(h.release)
+	select {
+	case <-h.processed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("discovery callback never processed the released probe result")
+	}
+
+	select {
+	case discovered := <-h.cm.discoveredChanges():
+		t.Fatalf("krakend discovery should have been suppressed by the conflicting config that arrived mid-flight, got: %+v", discovered)
+	default:
+	}
+}
+
+// TestConfigMgr_Discovery_StaleProbeResultSuppressedBySiblingArrivingMidFlight
+// reproduces the DSCVR-626 race: FilterTemplates only runs synchronously when
+// reconcileService runs, so it can't affect a probe that's already in
+// flight. Without a re-check immediately before applying the probe result, a
+// sibling config that arrives for the same service *after* the probe was
+// enqueued but *before* it completes — e.g. an annotation change adding an
+// openmetrics config to the same container — would still get scheduled on
+// top of that sibling, defeating the point of the filtering. This test pins
+// down that applyDiscoveredConfigsLocked re-validates against live filtering
+// state before scheduling.
+func TestConfigMgr_Discovery_StaleProbeResultSuppressedBySiblingArrivingMidFlight(t *testing.T) {
 	// Mirrors filterTemplatesDiscovery's generic-integration-sibling rule:
 	// drop every discovery template while an openmetrics/prometheus sibling
 	// is present, regardless of Name.
-	svc.filterTemplates = func(configs map[string]integration.Config) {
+	filterTemplates := func(configs map[string]integration.Config) {
 		hasGenericSibling := false
 		for _, cfg := range configs {
 			if cfg.Discovery == nil && len(cfg.Instances) > 0 && (cfg.Name == "openmetrics" || cfg.Name == "prometheus") {
@@ -274,15 +325,7 @@ func TestConfigMgr_Discovery_StaleProbeResultSuppressedBySiblingArrivingMidFligh
 			}
 		}
 	}
-
-	_, _ = cm.processNewConfig(tpl)
-	_ = cm.processNewService(svc)
-
-	select {
-	case <-probeStarted:
-	case <-time.After(time.Second):
-		t.Fatal("probe never started")
-	}
+	h := newMidFlightDiscoverySuppressionHarness(t, nil, filterTemplates)
 
 	// While the probe is in flight, a sibling openmetrics config for the same
 	// service arrives.
@@ -291,25 +334,10 @@ func TestConfigMgr_Discovery_StaleProbeResultSuppressedBySiblingArrivingMidFligh
 		ADIdentifiers: []string{"krakend"},
 		Instances:     []integration.Data{[]byte("openmetrics_endpoint: http://10.0.0.1:9091/metrics")},
 	}
-	changes, _ := cm.processNewConfig(sibling)
+	changes, _ := h.cm.processNewConfig(sibling)
 	assertConfigsMatch(t, changes.Schedule, matchName("openmetrics"))
 
-	// Let the stale probe complete, and wait deterministically for the
-	// wrapped callback to finish running (it closes `processed` synchronously
-	// after onDiscoveryResult returns, so any delivery to discoveredChanges()
-	// has already happened by then) before checking the channel.
-	close(release)
-	select {
-	case <-processed:
-	case <-time.After(2 * time.Second):
-		t.Fatal("discovery callback never processed the released probe result")
-	}
-
-	select {
-	case discovered := <-cm.discoveredChanges():
-		t.Fatalf("krakend discovery should have been suppressed by the sibling that arrived mid-flight, got: %+v", discovered)
-	default:
-	}
+	h.releaseAndAssertSuppressed(t)
 }
 
 // TestConfigMgr_Discovery_StaleProbeResultSuppressedByStaticConfigArrivingMidFlight
@@ -322,52 +350,11 @@ func TestConfigMgr_Discovery_StaleProbeResultSuppressedBySiblingArrivingMidFligh
 // StaticConfigIndex — so the apply-time re-check is the *only* thing that can
 // catch this case.
 func TestConfigMgr_Discovery_StaleProbeResultSuppressedByStaticConfigArrivingMidFlight(t *testing.T) {
-	mockResolver := MockSecretResolver{}
 	idx := listeners.NewStaticConfigIndex()
-
-	probeStarted := make(chan struct{})
-	release := make(chan struct{})
-	disco := newStubDiscoverer(func(_, _ string) (string, error) {
-		close(probeStarted)
-		<-release
-		return `[{"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics"}]}]`, nil
-	})
-	cm := newReconcilingConfigManager(&mockResolver, nil, idx, disco, nil).(*reconcilingConfigManager)
-	cm.start()
-	t.Cleanup(cm.stop)
-
-	// Wrap the worker callback so the test can wait deterministically for the
-	// released probe result to be fully processed (scheduled or dropped)
-	// before checking discoveredChanges() — a fixed sleep could pass even if
-	// the callback hadn't run yet under a slow/stalled scheduler.
-	processed := make(chan struct{})
-	cm.discoveryWorker.Stop()
-	cm.discoveryWorker = discoverer.NewWorker(
-		disco,
-		cmServiceLookup{cm},
-		func(svcID, tplDigest string, configs []integration.Config) {
-			cm.onDiscoveryResult(svcID, tplDigest, configs)
-			close(processed)
-		},
-		discoverer.Config{},
-		nil,
-	)
-	cm.discoveryWorker.Start()
-
-	tpl := integration.Config{
-		Name:          "krakend",
-		ADIdentifiers: []string{"krakend"},
-		Discovery:     &integration.DiscoveryConfig{},
-	}
-	svc := &dummyService{
-		ID:            "docker://k1",
-		ADIdentifiers: []string{"krakend"},
-		Hosts:         map[string]string{"main": "10.0.0.1"},
-	}
 	// Mirrors filterTemplatesDiscovery's static-index rule: drop every
 	// discovery template while a host-wide generic-integration static
 	// config is present in the shared index.
-	svc.filterTemplates = func(configs map[string]integration.Config) {
+	filterTemplates := func(configs map[string]integration.Config) {
 		if !idx.Has("openmetrics") && !idx.Has("prometheus") {
 			return
 		}
@@ -377,15 +364,7 @@ func TestConfigMgr_Discovery_StaleProbeResultSuppressedByStaticConfigArrivingMid
 			}
 		}
 	}
-
-	_, _ = cm.processNewConfig(tpl)
-	_ = cm.processNewService(svc)
-
-	select {
-	case <-probeStarted:
-	case <-time.After(time.Second):
-		t.Fatal("probe never started")
-	}
+	h := newMidFlightDiscoverySuppressionHarness(t, idx, filterTemplates)
 
 	// A static openmetrics config arrives while the probe is in flight. It is
 	// not a template (no AD identifiers), so it never touches reconcileService
@@ -394,26 +373,11 @@ func TestConfigMgr_Discovery_StaleProbeResultSuppressedByStaticConfigArrivingMid
 		Name:      "openmetrics",
 		Instances: []integration.Data{[]byte("openmetrics_endpoint: http://10.0.0.2:9091/metrics")},
 	}
-	changes, _ := cm.processNewConfig(staticOpenmetrics)
+	changes, _ := h.cm.processNewConfig(staticOpenmetrics)
 	assertConfigsMatch(t, changes.Schedule, matchName("openmetrics"))
 	assert.True(t, idx.Has("openmetrics"))
 
-	// Let the stale probe complete, and wait deterministically for the
-	// wrapped callback to finish running (it closes `processed` synchronously
-	// after onDiscoveryResult returns, so any delivery to discoveredChanges()
-	// has already happened by then) before checking the channel.
-	close(release)
-	select {
-	case <-processed:
-	case <-time.After(2 * time.Second):
-		t.Fatal("discovery callback never processed the released probe result")
-	}
-
-	select {
-	case discovered := <-cm.discoveredChanges():
-		t.Fatalf("krakend discovery should have been suppressed by the static openmetrics config that arrived mid-flight, got: %+v", discovered)
-	default:
-	}
+	h.releaseAndAssertSuppressed(t)
 }
 
 // makeDiscoveryCM is a small constructor used by the lifecycle tests below.

--- a/comp/core/autodiscovery/impl/configmgr_discovery_test.go
+++ b/comp/core/autodiscovery/impl/configmgr_discovery_test.go
@@ -227,6 +227,24 @@ func TestConfigMgr_Discovery_StaleProbeResultSuppressedBySiblingArrivingMidFligh
 	cm.start()
 	t.Cleanup(cm.stop)
 
+	// Wrap the worker callback so the test can wait deterministically for the
+	// released probe result to be fully processed (scheduled or dropped)
+	// before checking discoveredChanges() — a fixed sleep could pass even if
+	// the callback hadn't run yet under a slow/stalled scheduler.
+	processed := make(chan struct{})
+	cm.discoveryWorker.Stop()
+	cm.discoveryWorker = discoverer.NewWorker(
+		disco,
+		cmServiceLookup{cm},
+		func(svcID, tplDigest string, configs []integration.Config) {
+			cm.onDiscoveryResult(svcID, tplDigest, configs)
+			close(processed)
+		},
+		discoverer.Config{},
+		nil,
+	)
+	cm.discoveryWorker.Start()
+
 	tpl := integration.Config{
 		Name:          "krakend",
 		ADIdentifiers: []string{"krakend"},
@@ -276,13 +294,21 @@ func TestConfigMgr_Discovery_StaleProbeResultSuppressedBySiblingArrivingMidFligh
 	changes, _ := cm.processNewConfig(sibling)
 	assertConfigsMatch(t, changes.Schedule, matchName("openmetrics"))
 
-	// Now let the stale probe complete.
+	// Let the stale probe complete, and wait deterministically for the
+	// wrapped callback to finish running (it closes `processed` synchronously
+	// after onDiscoveryResult returns, so any delivery to discoveredChanges()
+	// has already happened by then) before checking the channel.
 	close(release)
+	select {
+	case <-processed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("discovery callback never processed the released probe result")
+	}
 
 	select {
 	case discovered := <-cm.discoveredChanges():
 		t.Fatalf("krakend discovery should have been suppressed by the sibling that arrived mid-flight, got: %+v", discovered)
-	case <-time.After(300 * time.Millisecond):
+	default:
 	}
 }
 
@@ -309,6 +335,24 @@ func TestConfigMgr_Discovery_StaleProbeResultSuppressedByStaticConfigArrivingMid
 	cm := newReconcilingConfigManager(&mockResolver, nil, idx, disco, nil).(*reconcilingConfigManager)
 	cm.start()
 	t.Cleanup(cm.stop)
+
+	// Wrap the worker callback so the test can wait deterministically for the
+	// released probe result to be fully processed (scheduled or dropped)
+	// before checking discoveredChanges() — a fixed sleep could pass even if
+	// the callback hadn't run yet under a slow/stalled scheduler.
+	processed := make(chan struct{})
+	cm.discoveryWorker.Stop()
+	cm.discoveryWorker = discoverer.NewWorker(
+		disco,
+		cmServiceLookup{cm},
+		func(svcID, tplDigest string, configs []integration.Config) {
+			cm.onDiscoveryResult(svcID, tplDigest, configs)
+			close(processed)
+		},
+		discoverer.Config{},
+		nil,
+	)
+	cm.discoveryWorker.Start()
 
 	tpl := integration.Config{
 		Name:          "krakend",
@@ -354,12 +398,21 @@ func TestConfigMgr_Discovery_StaleProbeResultSuppressedByStaticConfigArrivingMid
 	assertConfigsMatch(t, changes.Schedule, matchName("openmetrics"))
 	assert.True(t, idx.Has("openmetrics"))
 
+	// Let the stale probe complete, and wait deterministically for the
+	// wrapped callback to finish running (it closes `processed` synchronously
+	// after onDiscoveryResult returns, so any delivery to discoveredChanges()
+	// has already happened by then) before checking the channel.
 	close(release)
+	select {
+	case <-processed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("discovery callback never processed the released probe result")
+	}
 
 	select {
 	case discovered := <-cm.discoveredChanges():
 		t.Fatalf("krakend discovery should have been suppressed by the static openmetrics config that arrived mid-flight, got: %+v", discovered)
-	case <-time.After(300 * time.Millisecond):
+	default:
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

A configuration-discovery probe is enqueued asynchronously (via the `discoverer.Worker`) and can take several retry cycles to complete. Its result was applied via `applyDiscoveredConfigsLocked` without re-checking whether the template was still expected for the service at that point — so if, while the probe was in flight, a conflicting config appeared for the same service/host, the stale probe result would still get scheduled on top of it once it arrived.

This was flagged during review of #54263: https://github.com/DataDog/datadog-agent/pull/54263#discussion_r3683730962 — the finding was actually pre-existing (shared by the same-name-sibling and static-config checks that predate #54263), not introduced by it, so it's being fixed here as its own change.

### The fix

- Factored the "compute matching templates, then run `svc.FilterTemplates` over them" logic that `reconcileService` already does into a new `expectedFilteredTemplatesLocked` helper (`configmgr.go`).
- `applyDiscoveredConfigsLocked` (`configmgr_discovery.go`) now calls this helper immediately before applying a probe result, and discards the result if the template digest is no longer present — i.e. some filter (any of them, not just the generic-integration one) would now drop it given the current live state.

## Motivation

Close a race window where config discovery could still schedule a duplicate/conflicting check on top of conflicting config.

## Describe how to test/verify your changes

Added two regression tests in `comp/core/autodiscovery/impl/configmgr_discovery_test.go` that use a stub discoverer blocked on a channel to deterministically inject a conflicting config while a probe is in flight, then verify the probe's eventual result is dropped:
- `TestConfigMgr_Discovery_StaleProbeResultSuppressedBySiblingArrivingMidFlight` — a sibling `openmetrics` template config arrives for the same service.
- `TestConfigMgr_Discovery_StaleProbeResultSuppressedByStaticConfigArrivingMidFlight` — a static (non-template) `openmetrics` config arrives, only updating the shared `StaticConfigIndex`.

Both tests fail against the pre-fix code (confirmed locally by reverting the fix) and pass with it. Full `comp/core/autodiscovery/...` suite (917 tests) passes with `-race`.