### PR TITLE
perf(scrubber): skip `uriPasswordReplacer` on lines without `@`

### DIFF
--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -127,6 +127,7 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 	// URI Generic Syntax
 	// https://tools.ietf.org/html/rfc3986
 	uriPasswordReplacer := Replacer{
+		Hints: []string{"@"}, // regex cannot match without it, so skipping spares a backtracking scan
 		Regex: regexp.MustCompile(`(?i)([a-z][a-z0-9+-.]+://|\b)([^:\s]+):([^\s|"]+)@`),
 		Repl:  []byte(`$1$2:********@`),
 


### PR DESCRIPTION
### What does this PR do?
Add a `"@"` hint to the scrubber's `uriPasswordReplacer`, so the regex only runs on lines that can possibly match.

### Motivation
The pattern ends in a mandatory literal `@`, yet carried no hint, so it ran on every scrubbed line.
Its leading `([a-z][a-z0-9+-.]+://|\b)` alternation starts at every word boundary, and the 2 greedy negated classes then scan for a terminating `@`.
A typical agent log line has many colons and no `@`, which is the backtracking worst case: profiling a Windows unit-test timeout showed scrubbing at 33% of CPU, over half of it this one replacer.

### Describe how you validated your changes
Scrubbing a 300-byte agent log line drops from ~250us to ~115us.

`pkg/serverless/metrics` under `-race -covermode=atomic` drops from ~7.35s to ~6.15s.

693 tests pass across `pkg/util/scrubber`, `pkg/util/log` and `comp/core/secrets/impl`.

### Additional Notes
The hint is exactly equivalent to the regex: the trailing `@` is not optional, quantified, nor inside an alternation, so no match can exist without one.