### PR TITLE
Fix issues with connecting to lowercase cdb$root for custom queries

### DIFF
--- a/pkg/collector/corechecks/oracle/custom_queries.go
+++ b/pkg/collector/corechecks/oracle/custom_queries.go
@@ -91,7 +91,7 @@ func (c *Check) CustomQueries() error {
 		if !c.connectedToPdb {
 			pdb = q.Pdb
 			if pdb == "" {
-				pdb = "cdb$root"
+				pdb = "CDB$ROOT"
 			}
 			_, err := c.dbCustomQueries.Exec(fmt.Sprintf(`alter session set container = "%s"`, strings.ReplaceAll(pdb, `"`, `""`)))
 			if err != nil {


### PR DESCRIPTION
When running custom queries and not specifying a custom pdb parameter, the agent connects to cdb$root. Recently we added logic to always put the container database name in double-quotes before running the custom queries: https://github.com/DataDog/datadog-agent/pull/46637
This was to prevent sql-injection from the custom string passed in as pdb.

We saw this cause an issue for some customers with certain Oracle versions. The quotes on "cdb$root" were preventing Oracle from normalizing the capitalization, and causing the agent to fail here with ORA-65000: missing or invalid pluggable database name. Since the CDB$ROOT should be always be capitalized in Oracle, we should have it capitalized when wrapping it in quotes.

Motivation
https://datadoghq.atlassian.net/browse/SDBM-2820

### Describe how you validated your changes

### Additional Notes
