### PR TITLE
configfilesdiscovery: collect redis env vars

### DIFF
--- a/comp/core/configfilesdiscovery/impl/collectors/helpers.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/helpers.go
@@ -71,67 +71,72 @@ func resolveConfigPath(configPath string, workingDir string) (string, bool) {
 	return path.Clean(path.Join(workingDir, configPath)), true
 }
 
-// findConfigPath tries the runtime-native command first, then falls back to
-// command lines discovered from live processes. Returns the resolved path and
-// whether a command line for the service was found.
-func findConfigPath(
-	ctx context.Context,
-	reader configfilesdiscoveryimpl.ConfigReader,
-	findConfigArg func([]string) (string, bool),
-	matchesCommandline func([]string) bool,
-) (string, bool, error) {
-	commandline, runtimeErr := reader.ReadRuntimeCommandline(ctx)
-	runtimeCommandMatched := false
-	if runtimeErr == nil {
-		runtimeCommandMatched = matchesCommandline(commandline.Args)
-		if configArg, found := findConfigArg(commandline.Args); found {
-			runtimeCommandMatched = true
-			if configPath, resolved := resolveConfigPath(configArg, commandline.WorkingDir); resolved {
-				return configPath, true, nil
-			}
-		}
-	}
-
-	var configPath string
-	liveCommandMatched := false
-	for _, commandline := range reader.ReadLiveProcessCommandlines(ctx) {
-		if matchesCommandline(commandline.Args) {
-			liveCommandMatched = true
-		}
-		configArg, found := findConfigArg(commandline.Args)
-		if !found {
-			continue
-		}
-		resolvedPath, resolved := resolveConfigPath(configArg, commandline.WorkingDir)
-		if !resolved {
-			return "", true, runtimeErr
-		}
-		if configPath != "" && configPath != resolvedPath {
-			return "", true, runtimeErr
-		}
-		configPath = resolvedPath
-	}
-	if configPath != "" {
-		return configPath, true, nil
-	}
-	if liveCommandMatched {
-		return "", true, nil
-	}
-	return "", runtimeCommandMatched, runtimeErr
-}
-
-// readConfigFile discovers and reads an explicit config file, or falls back to
-// ordered groups of default paths when no command line for the service is
-// found. The first group with readable files wins, and exactly one file must be
-// readable within that group. Returns the file and whether one was selected.
+// readConfigFile discovers and reads a command-line config file, then considers
+// fallbackConfigArg before ordered groups of default paths. The first group with
+// readable files wins, and exactly one file must be readable within that group.
+// Returns the file and whether one was selected.
 func readConfigFile(
 	ctx context.Context,
 	reader configfilesdiscoveryimpl.ConfigReader,
 	findConfigArg func([]string) (string, bool),
 	matchesCommandline func([]string) bool,
+	fallbackConfigArg string,
 	defaultPathGroups ...[]string,
 ) (configfilesdiscoveryimpl.ConfigFile, bool, error) {
-	configPath, commandMatched, commandlineErr := findConfigPath(ctx, reader, findConfigArg, matchesCommandline)
+	// Runtime metadata has highest precedence and provides the working directory
+	// needed to resolve a relative config argument or fallbackConfigArg.
+	commandline, commandlineErr := reader.ReadRuntimeCommandline(ctx)
+	runtimeWorkingDir := ""
+	commandMatched := false
+	configArgFound := false
+	configPath := ""
+	if commandlineErr == nil {
+		runtimeWorkingDir = commandline.WorkingDir
+		commandMatched = matchesCommandline(commandline.Args)
+		if configArg, found := findConfigArg(commandline.Args); found {
+			commandMatched = true
+			configArgFound = true
+			if resolvedPath, resolved := resolveConfigPath(configArg, commandline.WorkingDir); resolved {
+				configPath = resolvedPath
+			}
+		}
+	}
+
+	// If runtime metadata has no resolvable path, inspect live process command
+	// lines. Every discovered path must resolve, and multiple paths must agree.
+	if configPath == "" {
+		for _, commandline := range reader.ReadLiveProcessCommandlines(ctx) {
+			if matchesCommandline(commandline.Args) {
+				commandMatched = true
+			}
+			configArg, found := findConfigArg(commandline.Args)
+			if !found {
+				continue
+			}
+			configArgFound = true
+			resolvedPath, resolved := resolveConfigPath(configArg, commandline.WorkingDir)
+			if !resolved {
+				return configfilesdiscoveryimpl.ConfigFile{}, false, commandlineErr
+			}
+			if configPath != "" && configPath != resolvedPath {
+				return configfilesdiscoveryimpl.ConfigFile{}, false, commandlineErr
+			}
+			configPath = resolvedPath
+		}
+	}
+
+	// Only use the caller-provided fallback when argv did not explicitly name a
+	// config file. An unresolved argv path is authoritative and blocks guessing.
+	if configPath == "" && !configArgFound && fallbackConfigArg != "" {
+		var resolved bool
+		configPath, resolved = resolveConfigPath(fallbackConfigArg, runtimeWorkingDir)
+		if !resolved {
+			return configfilesdiscoveryimpl.ConfigFile{}, false, commandlineErr
+		}
+	}
+
+	// Explicit paths are authoritative. A read failure must not fall through to
+	// conventional defaults that the process might not have loaded.
 	if configPath != "" {
 		file, err := reader.ReadFile(ctx, configPath)
 		if err != nil {
@@ -139,10 +144,15 @@ func readConfigFile(
 		}
 		return file, true, nil
 	}
-	if commandMatched {
-		return configfilesdiscoveryimpl.ConfigFile{}, false, commandlineErr
+
+	// A matching command line or an explicit but unusable source also blocks
+	// defaults, since selecting one would only be a guess.
+	if configArgFound || fallbackConfigArg != "" || commandMatched {
+		return configfilesdiscoveryimpl.ConfigFile{}, false, nil
 	}
 
+	// Default groups are ordered by priority. The first group with readable files
+	// wins, but collection is suppressed when that group is ambiguous.
 	for _, defaultPaths := range defaultPathGroups {
 		files := make([]configfilesdiscoveryimpl.ConfigFile, 0, len(defaultPaths))
 		for _, path := range defaultPaths {

--- a/comp/core/configfilesdiscovery/impl/collectors/helpers_test.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/helpers_test.go
@@ -207,7 +207,7 @@ func TestReadConfigFile(t *testing.T) {
 			if defaultPathGroups == nil {
 				defaultPathGroups = [][]string{defaultPaths}
 			}
-			file, ok, err := readConfigFile(ctx, reader, getTestConfigArg, matchesTestCommandline, defaultPathGroups...)
+			file, ok, err := readConfigFile(ctx, reader, getTestConfigArg, matchesTestCommandline, "", defaultPathGroups...)
 
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)

--- a/comp/core/configfilesdiscovery/impl/collectors/kafka.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/kafka.go
@@ -68,7 +68,7 @@ func (kafkaConfigCollector) CanCollectFromProcess(commandline configfilesdiscove
 }
 
 func (c kafkaConfigCollector) Collect(ctx context.Context, reader configfilesdiscoveryimpl.ConfigReader) (configfilesdiscoveryimpl.CollectedConfig, error) {
-	file, ok, err := readConfigFile(ctx, reader, kafkaGetConfigArgFromCommandline, kafkaMatchesCommandline, kafkaDefaultConfigPathGroups...)
+	file, ok, err := readConfigFile(ctx, reader, kafkaGetConfigArgFromCommandline, kafkaMatchesCommandline, "", kafkaDefaultConfigPathGroups...)
 	if err != nil {
 		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("collect kafka config file: %w", err)
 	}

--- a/comp/core/configfilesdiscovery/impl/collectors/redis.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/redis.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/DataDog/agent-payload/v5/agentdiscovery"
@@ -23,6 +25,17 @@ const (
 
 type redisConfigCollector struct{}
 
+var redisEnvAllow = []*regexp.Regexp{
+	regexp.MustCompile(`^REDIS_[A-Z0-9_]+$`),
+}
+
+var redisEnvDeny = []*regexp.Regexp{
+	// Option bags can contain arbitrary Redis arguments and inline credentials.
+	regexp.MustCompile(`^REDIS(_[A-Z0-9]+)*_(ARGS|OPTS|FLAGS)$`),
+	// Connection strings can contain usernames and passwords.
+	regexp.MustCompile(`^REDIS(_[A-Z0-9]+)*_(URL|URI|DSN|CONNECTION_STRING)$`),
+}
+
 func NewRedis() configfilesdiscoveryimpl.ConfigCollector {
 	return redisConfigCollector{}
 }
@@ -33,10 +46,32 @@ func (c redisConfigCollector) Collect(ctx context.Context, reader configfilesdis
 		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read redis command line: %w", err)
 	}
 
+	env, envErr := reader.ReadEnvVars(ctx, includeRedisEnvVar)
+	if envErr != nil {
+		log.Debugf("config files discovery skipped redis env var collection: %v", envErr)
+		env = nil
+	}
+	envVars := redisBuildEnvVars(env)
+
 	configPath, ok := redisGetConfigPath(commandline)
 	if !ok {
-		log.Debugf("config files discovery skipped redis config collection: no explicit config file path detected")
-		return configfilesdiscoveryimpl.CollectedConfig{}, nil
+		configPath, ok = resolveConfigPath(env["REDIS_CONF_FILE"], commandline.WorkingDir)
+	}
+	if !ok {
+		// Without a config file path, env vars are the only Redis config source.
+		// Return the error so the scheduler retries.
+		if envErr != nil {
+			return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read redis env vars: %w", envErr)
+		}
+		if len(envVars) == 0 {
+			log.Debugf("config files discovery skipped redis config collection: no explicit config file path or selected env vars detected")
+			return configfilesdiscoveryimpl.CollectedConfig{}, nil
+		}
+
+		log.Debugf("config files discovery collected redis env vars without an explicit config file path")
+		return configfilesdiscoveryimpl.CollectedConfig{
+			EnvVars: envVars,
+		}, nil
 	}
 
 	file, err := reader.ReadFile(ctx, configPath)
@@ -47,7 +82,53 @@ func (c redisConfigCollector) Collect(ctx context.Context, reader configfilesdis
 
 	return configfilesdiscoveryimpl.CollectedConfig{
 		ConfigFiles: []configfilesdiscoveryimpl.ConfigFile{file},
+		EnvVars:     envVars,
 	}, nil
+}
+
+func redisBuildEnvVars(env map[string]string) []configfilesdiscoveryimpl.ConfigEnvVar {
+	if len(env) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(env))
+	for name := range env {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	envVars := make([]configfilesdiscoveryimpl.ConfigEnvVar, 0, len(env))
+	for _, name := range names {
+		envVars = append(envVars, configfilesdiscoveryimpl.ConfigEnvVar{
+			Name:  name,
+			Value: env[name],
+		})
+	}
+	return envVars
+}
+
+func includeRedisEnvVar(name string) bool {
+	if configfilesdiscoveryimpl.IsSecretEnvVarName(name) || denyRedisEnvVar(name) {
+		return false
+	}
+	if name == "OPENSSL_FIPS" {
+		return true
+	}
+	for _, re := range redisEnvAllow {
+		if re.MatchString(name) {
+			return true
+		}
+	}
+	return false
+}
+
+func denyRedisEnvVar(name string) bool {
+	for _, re := range redisEnvDeny {
+		if re.MatchString(name) {
+			return true
+		}
+	}
+	return false
 }
 
 // redisGetConfigPath returns the explicit config file path passed to

--- a/comp/core/configfilesdiscovery/impl/collectors/redis.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/redis.go
@@ -36,7 +36,7 @@ var redisEnvAllow = regexp.MustCompile(`^REDIS_[A-Z0-9_]+$`)
 // contain inline credentials.
 var redisEnvDeny = regexp.MustCompile(
 	`^REDIS(_[A-Z0-9]+)*_(` +
-		`REQUIREPASS|MASTERAUTH|` +
+		`AUTH|REQUIREPASS|MASTERAUTH|` +
 		`ARGS|OPTS|FLAGS|` +
 		`URL|URI|DSN|CONNECTION_STRING` +
 		`)$`,

--- a/comp/core/configfilesdiscovery/impl/collectors/redis.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/redis.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"regexp"
 	"strings"
 
 	"github.com/DataDog/agent-payload/v5/agentdiscovery"
@@ -29,6 +30,18 @@ var redisDefaultConfigPaths = []string{
 
 type redisConfigCollector struct{}
 
+var redisEnvAllow = regexp.MustCompile(`^REDIS_[A-Z0-9_]+$`)
+
+// Deny auth directives, arbitrary option bags, and connection strings that can
+// contain inline credentials.
+var redisEnvDeny = regexp.MustCompile(
+	`^REDIS(_[A-Z0-9]+)*_(` +
+		`REQUIREPASS|MASTERAUTH|` +
+		`ARGS|OPTS|FLAGS|` +
+		`URL|URI|DSN|CONNECTION_STRING` +
+		`)$`,
+)
+
 func NewRedis() configfilesdiscoveryimpl.ConfigCollector {
 	return redisConfigCollector{}
 }
@@ -45,20 +58,64 @@ func (redisConfigCollector) CanCollectFromProcess(commandline configfilesdiscove
 }
 
 func (c redisConfigCollector) Collect(ctx context.Context, reader configfilesdiscoveryimpl.ConfigReader) (configfilesdiscoveryimpl.CollectedConfig, error) {
-	file, ok, err := readConfigFile(ctx, reader, redisGetConfigArgFromCommandline, redisMatchesCommandline, redisDefaultConfigPaths)
+	envVars, envErr := readEnvVars(ctx, reader, includeRedisEnvVar)
+	if envErr != nil {
+		log.Debugf("config files discovery skipped redis env var collection: %v", envErr)
+		envVars = nil
+	}
+
+	envConfigPath := ""
+	for _, envVar := range envVars {
+		if envVar.Name == "REDIS_CONF_FILE" {
+			envConfigPath = envVar.Value
+			break
+		}
+	}
+
+	file, ok, err := readConfigFile(
+		ctx,
+		reader,
+		redisGetConfigArgFromCommandline,
+		redisMatchesCommandline,
+		envConfigPath,
+		redisDefaultConfigPaths,
+	)
 	if err != nil {
 		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("collect redis config file: %w", err)
 	}
 	if !ok {
-		log.Debugf("config files discovery skipped redis config collection: no unique config file path detected")
-		return configfilesdiscoveryimpl.CollectedConfig{}, nil
+		// Without a config file, env vars are the only Redis config source.
+		// Return the error so the scheduler retries.
+		if envErr != nil {
+			return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read redis env vars: %w", envErr)
+		}
+		if len(envVars) == 0 {
+			log.Debugf("config files discovery skipped redis config collection: no config file or selected env vars detected")
+			return configfilesdiscoveryimpl.CollectedConfig{}, nil
+		}
+
+		log.Debugf("config files discovery collected redis env vars without a config file")
+		return configfilesdiscoveryimpl.CollectedConfig{
+			EnvVars: envVars,
+		}, nil
 	}
 
 	file.PayloadFormat = redisConfigPayloadFormat
 
 	return configfilesdiscoveryimpl.CollectedConfig{
 		ConfigFiles: []configfilesdiscoveryimpl.ConfigFile{file},
+		EnvVars:     envVars,
 	}, nil
+}
+
+func includeRedisEnvVar(name string) bool {
+	if configfilesdiscoveryimpl.IsSecretEnvVarName(name) || redisEnvDeny.MatchString(name) {
+		return false
+	}
+	if name == "OPENSSL_FIPS" {
+		return true
+	}
+	return redisEnvAllow.MatchString(name)
 }
 
 // redisGetConfigArgFromCommandline returns the explicit config argument passed

--- a/comp/core/configfilesdiscovery/impl/collectors/redis_test.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/redis_test.go
@@ -126,6 +126,46 @@ func TestRedisGetConfigPath(t *testing.T) {
 	}
 }
 
+func TestIncludeRedisEnvVar(t *testing.T) {
+	tests := []struct {
+		name    string
+		envName string
+		want    bool
+	}{
+		{name: "bitnami config", envName: "REDIS_AOF_ENABLED", want: true},
+		{name: "config file", envName: "REDIS_CONF_FILE", want: true},
+		{name: "cluster config", envName: "REDIS_CLUSTER_ANNOUNCE_HOSTNAME", want: true},
+		{name: "read only image config", envName: "REDIS_DEFAULT_CONF_DIR", want: true},
+		{name: "fips config", envName: "OPENSSL_FIPS", want: true},
+		{name: "unrelated", envName: "UNREQUESTED"},
+		{name: "lowercase", envName: "REDIS_port"},
+		{name: "password", envName: "REDIS_PASSWORD"},
+		{name: "password file", envName: "REDIS_MASTER_PASSWORD_FILE"},
+		{name: "allow empty password", envName: "ALLOW_EMPTY_PASSWORD"},
+		{name: "tls key file", envName: "REDIS_TLS_KEY_FILE"},
+		{name: "redis cli auth", envName: "REDISCLI_AUTH"},
+		{name: "redis args", envName: "REDIS_ARGS"},
+		{name: "extra flags", envName: "REDIS_EXTRA_FLAGS"},
+		{name: "custom opts", envName: "REDIS_CUSTOM_OPTS"},
+		{name: "redis search args", envName: "REDISEARCH_ARGS"},
+		{name: "redis json args", envName: "REDISJSON_ARGS"},
+		{name: "redis time series args", envName: "REDISTIMESERIES_ARGS"},
+		{name: "redis bloom args", envName: "REDISBLOOM_ARGS"},
+		{name: "redis url", envName: "REDIS_URL"},
+		{name: "sentinel uri", envName: "REDIS_SENTINEL_URI"},
+		{name: "cluster dsn", envName: "REDIS_CLUSTER_DSN"},
+		{name: "connection string", envName: "REDIS_CONNECTION_STRING"},
+		{name: "valkey", envName: "VALKEY_PORT"},
+		{name: "dragonfly", envName: "DFLY_PORT"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, includeRedisEnvVar(tt.envName))
+		})
+	}
+}
+
 func TestRedisCollectorReadsDetectedConfig(t *testing.T) {
 	reader := &redisCollectorTestReader{
 		commandline: configfilesdiscoveryimpl.TargetCommandline{
@@ -136,12 +176,18 @@ func TestRedisCollectorReadsDetectedConfig(t *testing.T) {
 			Content:   []byte("port 6379\n"),
 			Truncated: true,
 		},
+		env: map[string]string{
+			"REDIS_PORT_NUMBER": "6379",
+			"REDIS_AOF_ENABLED": "yes",
+			"UNREQUESTED":       "value",
+		},
 	}
 	collector := NewRedis()
 
 	collected, err := collector.Collect(context.Background(), reader)
 
 	require.NoError(t, err)
+	requireRedisEnvVarPredicate(t, reader)
 	assert.Equal(t, []string{"/etc/redis/redis.conf"}, reader.readFileCalls)
 	require.Len(t, collected.ConfigFiles, 1)
 	assert.Equal(t, configfilesdiscoveryimpl.ConfigFile{
@@ -150,7 +196,162 @@ func TestRedisCollectorReadsDetectedConfig(t *testing.T) {
 		Truncated:     true,
 		PayloadFormat: redisConfigPayloadFormat,
 	}, collected.ConfigFiles[0])
-	assert.Empty(t, collected.EnvVars)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "REDIS_AOF_ENABLED", Value: "yes"},
+		{Name: "REDIS_PORT_NUMBER", Value: "6379"},
+	}, collected.EnvVars)
+}
+
+func TestRedisCollectorCollectsEnvOnly(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		commandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "--save", "60", "1"},
+		},
+		env: map[string]string{
+			"REDIS_PORT_NUMBER": "6379",
+			"REDIS_AOF_ENABLED": "yes",
+		},
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	requireRedisEnvVarPredicate(t, reader)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Empty(t, collected.ConfigFiles)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "REDIS_AOF_ENABLED", Value: "yes"},
+		{Name: "REDIS_PORT_NUMBER", Value: "6379"},
+	}, collected.EnvVars)
+}
+
+func TestRedisCollectorDoesNotUseMetadataPathsAsConfigFiles(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		commandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "--save", "60", "1"},
+		},
+		env: map[string]string{
+			"REDIS_CONF_DIR":       "/opt/bitnami/redis/etc",
+			"REDIS_OVERRIDES_FILE": "/opt/bitnami/redis/mounted-etc/overrides.conf",
+		},
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Empty(t, collected.ConfigFiles)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "REDIS_CONF_DIR", Value: "/opt/bitnami/redis/etc"},
+		{Name: "REDIS_OVERRIDES_FILE", Value: "/opt/bitnami/redis/mounted-etc/overrides.conf"},
+	}, collected.EnvVars)
+}
+
+func TestRedisCollectorUsesEnvConfigFile(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		commandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/opt/bitnami/scripts/redis/run.sh"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path:    "/opt/bitnami/redis/etc/redis.conf",
+			Content: []byte("port 6379\n"),
+		},
+		env: map[string]string{
+			"REDIS_CONF_FILE":   "/opt/bitnami/redis/etc/redis.conf",
+			"REDIS_AOF_ENABLED": "yes",
+		},
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/opt/bitnami/redis/etc/redis.conf"}, reader.readFileCalls)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "REDIS_AOF_ENABLED", Value: "yes"},
+		{Name: "REDIS_CONF_FILE", Value: "/opt/bitnami/redis/etc/redis.conf"},
+	}, collected.EnvVars)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, redisConfigPayloadFormat, collected.ConfigFiles[0].PayloadFormat)
+}
+
+func TestRedisCollectorResolvesRelativeEnvConfigFile(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		commandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args:       []string{"/opt/bitnami/scripts/redis/run.sh"},
+			WorkingDir: "/opt/bitnami/redis/etc",
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path: "/opt/bitnami/redis/etc/redis.conf",
+		},
+		env: map[string]string{
+			"REDIS_CONF_FILE": "redis.conf",
+		},
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/opt/bitnami/redis/etc/redis.conf"}, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, redisConfigPayloadFormat, collected.ConfigFiles[0].PayloadFormat)
+}
+
+func TestRedisCollectorPrefersCommandlineConfigFile(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		commandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "/etc/redis/redis.conf"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path: "/etc/redis/redis.conf",
+		},
+		env: map[string]string{
+			"REDIS_CONF_FILE": "/opt/bitnami/redis/etc/redis.conf",
+		},
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/redis/redis.conf"}, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, redisConfigPayloadFormat, collected.ConfigFiles[0].PayloadFormat)
+}
+
+func TestRedisCollectorDoesNotCollectSensitiveEnvVars(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		commandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "--save", "60", "1"},
+		},
+		env: map[string]string{
+			"REDIS_AOF_ENABLED":          "yes",
+			"REDIS_PASSWORD":             "secret",
+			"REDIS_MASTER_PASSWORD_FILE": "/run/secrets/master-password",
+			"REDIS_TLS_KEY_FILE":         "/run/secrets/redis.key",
+			"REDIS_ARGS":                 "--requirepass secret",
+			"REDIS_EXTRA_FLAGS":          "--masterauth secret",
+			"REDIS_URL":                  "redis://user:secret@redis:6379",
+			"ALLOW_EMPTY_PASSWORD":       "yes",
+		},
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	predicate := requireRedisEnvVarPredicate(t, reader)
+	assert.False(t, predicate("REDIS_PASSWORD"))
+	assert.False(t, predicate("REDIS_TLS_KEY_FILE"))
+	assert.False(t, predicate("REDIS_ARGS"))
+	assert.False(t, predicate("REDIS_EXTRA_FLAGS"))
+	assert.False(t, predicate("REDIS_URL"))
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "REDIS_AOF_ENABLED", Value: "yes"},
+	}, collected.EnvVars)
 }
 
 func TestRedisCollectorSkipsWhenNoConfigPathIsDetected(t *testing.T) {
@@ -164,6 +365,7 @@ func TestRedisCollectorSkipsWhenNoConfigPathIsDetected(t *testing.T) {
 	collected, err := collector.Collect(context.Background(), reader)
 
 	require.NoError(t, err)
+	requireRedisEnvVarPredicate(t, reader)
 	assert.Empty(t, reader.readFileCalls)
 	assert.Empty(t, collected.ConfigFiles)
 	assert.Empty(t, collected.EnvVars)
@@ -177,6 +379,52 @@ func TestRedisCollectorReturnsCommandlineErrors(t *testing.T) {
 	collected, err := collector.Collect(context.Background(), reader)
 
 	require.ErrorIs(t, err, expectedErr)
+	assert.Empty(t, reader.readEnvVarPredicates)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
+}
+
+func TestRedisCollectorReadsDetectedConfigWhenEnvVarsFail(t *testing.T) {
+	expectedErr := errors.New("env unavailable")
+	reader := &redisCollectorTestReader{
+		commandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "/etc/redis/redis.conf"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path:    "/etc/redis/redis.conf",
+			Content: []byte("port 6379\n"),
+		},
+		readEnvVarsErr: expectedErr,
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/redis/redis.conf"}, reader.readFileCalls)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigFile{
+		{
+			Path:          "/etc/redis/redis.conf",
+			Content:       []byte("port 6379\n"),
+			PayloadFormat: redisConfigPayloadFormat,
+		},
+	}, collected.ConfigFiles)
+	assert.Empty(t, collected.EnvVars)
+}
+
+func TestRedisCollectorReturnsEnvVarErrorsWithoutConfigPath(t *testing.T) {
+	expectedErr := errors.New("env unavailable")
+	reader := &redisCollectorTestReader{
+		commandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "--save", "60", "1"},
+		},
+		readEnvVarsErr: expectedErr,
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Empty(t, reader.readFileCalls)
 	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
 }
 
@@ -198,11 +446,14 @@ func TestRedisCollectorReturnsReadFileErrors(t *testing.T) {
 }
 
 type redisCollectorTestReader struct {
-	commandline    configfilesdiscoveryimpl.TargetCommandline
-	commandlineErr error
-	readFileCalls  []string
-	file           configfilesdiscoveryimpl.ConfigFile
-	readFileErr    error
+	commandline          configfilesdiscoveryimpl.TargetCommandline
+	commandlineErr       error
+	readFileCalls        []string
+	file                 configfilesdiscoveryimpl.ConfigFile
+	readFileErr          error
+	env                  map[string]string
+	readEnvVarPredicates []configfilesdiscoveryimpl.ConfigEnvVarPredicate
+	readEnvVarsErr       error
 }
 
 func (r *redisCollectorTestReader) Runtime() configfilesdiscoveryimpl.RuntimeType {
@@ -219,8 +470,23 @@ func (r *redisCollectorTestReader) ReadFile(_ context.Context, path string) (con
 	return r.file, nil
 }
 
-func (r *redisCollectorTestReader) ReadEnvVars(context.Context, configfilesdiscoveryimpl.ConfigEnvVarPredicate) (map[string]string, error) {
-	return nil, errors.New("not implemented")
+func (r *redisCollectorTestReader) ReadEnvVars(_ context.Context, predicate configfilesdiscoveryimpl.ConfigEnvVarPredicate) (map[string]string, error) {
+	r.readEnvVarPredicates = append(r.readEnvVarPredicates, predicate)
+	if r.readEnvVarsErr != nil {
+		return nil, r.readEnvVarsErr
+	}
+
+	env := make(map[string]string)
+	for name, value := range r.env {
+		if configfilesdiscoveryimpl.IsSecretEnvVarName(name) {
+			continue
+		}
+		if predicate != nil && !predicate(name) {
+			continue
+		}
+		env[name] = value
+	}
+	return env, nil
 }
 
 func (r *redisCollectorTestReader) ReadCommandline(context.Context) (configfilesdiscoveryimpl.TargetCommandline, error) {
@@ -228,4 +494,11 @@ func (r *redisCollectorTestReader) ReadCommandline(context.Context) (configfiles
 		return configfilesdiscoveryimpl.TargetCommandline{}, r.commandlineErr
 	}
 	return r.commandline, nil
+}
+
+func requireRedisEnvVarPredicate(t *testing.T, reader *redisCollectorTestReader) configfilesdiscoveryimpl.ConfigEnvVarPredicate {
+	t.Helper()
+	require.Len(t, reader.readEnvVarPredicates, 1)
+	require.NotNil(t, reader.readEnvVarPredicates[0])
+	return reader.readEnvVarPredicates[0]
 }

--- a/comp/core/configfilesdiscovery/impl/collectors/redis_test.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/redis_test.go
@@ -178,6 +178,7 @@ func TestIncludeRedisEnvVar(t *testing.T) {
 		{name: "password abbreviation", envName: "REDIS_SENTINEL_PWD"},
 		{name: "requirepass directive", envName: "REDIS_REQUIREPASS"},
 		{name: "masterauth directive", envName: "REDIS_MASTERAUTH"},
+		{name: "auth directive", envName: "REDIS_AUTH"},
 		{name: "allow empty password", envName: "ALLOW_EMPTY_PASSWORD"},
 		{name: "tls key file", envName: "REDIS_TLS_KEY_FILE"},
 		{name: "redis cli auth", envName: "REDISCLI_AUTH"},

--- a/comp/core/configfilesdiscovery/impl/collectors/redis_test.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/redis_test.go
@@ -159,6 +159,50 @@ func TestRedisCollectorResolvesAndReadsRelativeProcessConfig(t *testing.T) {
 	require.Len(t, collected.ConfigFiles, 1)
 }
 
+func TestIncludeRedisEnvVar(t *testing.T) {
+	tests := []struct {
+		name    string
+		envName string
+		want    bool
+	}{
+		{name: "bitnami config", envName: "REDIS_AOF_ENABLED", want: true},
+		{name: "config file", envName: "REDIS_CONF_FILE", want: true},
+		{name: "cluster config", envName: "REDIS_CLUSTER_ANNOUNCE_HOSTNAME", want: true},
+		{name: "read only image config", envName: "REDIS_DEFAULT_CONF_DIR", want: true},
+		{name: "tls certificate path", envName: "REDIS_TLS_CERT_FILE", want: true},
+		{name: "fips config", envName: "OPENSSL_FIPS", want: true},
+		{name: "unrelated", envName: "UNREQUESTED"},
+		{name: "lowercase", envName: "REDIS_port"},
+		{name: "password", envName: "REDIS_PASSWORD"},
+		{name: "password file", envName: "REDIS_MASTER_PASSWORD_FILE"},
+		{name: "password abbreviation", envName: "REDIS_SENTINEL_PWD"},
+		{name: "requirepass directive", envName: "REDIS_REQUIREPASS"},
+		{name: "masterauth directive", envName: "REDIS_MASTERAUTH"},
+		{name: "allow empty password", envName: "ALLOW_EMPTY_PASSWORD"},
+		{name: "tls key file", envName: "REDIS_TLS_KEY_FILE"},
+		{name: "redis cli auth", envName: "REDISCLI_AUTH"},
+		{name: "redis args", envName: "REDIS_ARGS"},
+		{name: "extra flags", envName: "REDIS_EXTRA_FLAGS"},
+		{name: "custom opts", envName: "REDIS_CUSTOM_OPTS"},
+		{name: "redis search args", envName: "REDISEARCH_ARGS"},
+		{name: "redis json args", envName: "REDISJSON_ARGS"},
+		{name: "redis time series args", envName: "REDISTIMESERIES_ARGS"},
+		{name: "redis bloom args", envName: "REDISBLOOM_ARGS"},
+		{name: "redis url", envName: "REDIS_URL"},
+		{name: "sentinel uri", envName: "REDIS_SENTINEL_URI"},
+		{name: "cluster dsn", envName: "REDIS_CLUSTER_DSN"},
+		{name: "connection string", envName: "REDIS_CONNECTION_STRING"},
+		{name: "valkey", envName: "VALKEY_PORT"},
+		{name: "dragonfly", envName: "DFLY_PORT"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, includeRedisEnvVar(tt.envName))
+		})
+	}
+}
+
 func TestRedisCollectorReadsDetectedConfig(t *testing.T) {
 	reader := &redisCollectorTestReader{
 		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
@@ -168,6 +212,11 @@ func TestRedisCollectorReadsDetectedConfig(t *testing.T) {
 			Path:      "/etc/redis/redis.conf",
 			Content:   []byte("port 6379\n"),
 			Truncated: true,
+		},
+		env: map[string]string{
+			"REDIS_PORT_NUMBER": "6379",
+			"REDIS_AOF_ENABLED": "yes",
+			"UNREQUESTED":       "value",
 		},
 	}
 	collector := NewRedis()
@@ -183,7 +232,214 @@ func TestRedisCollectorReadsDetectedConfig(t *testing.T) {
 		Truncated:     true,
 		PayloadFormat: redisConfigPayloadFormat,
 	}, collected.ConfigFiles[0])
-	assert.Empty(t, collected.EnvVars)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "REDIS_AOF_ENABLED", Value: "yes"},
+		{Name: "REDIS_PORT_NUMBER", Value: "6379"},
+	}, collected.EnvVars)
+}
+
+func TestRedisCollectorCollectsEnvOnly(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "--save", "60", "1"},
+		},
+		env: map[string]string{
+			"REDIS_PORT_NUMBER": "6379",
+			"REDIS_AOF_ENABLED": "yes",
+		},
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Empty(t, collected.ConfigFiles)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "REDIS_AOF_ENABLED", Value: "yes"},
+		{Name: "REDIS_PORT_NUMBER", Value: "6379"},
+	}, collected.EnvVars)
+}
+
+func TestRedisCollectorDoesNotUseMetadataPathsAsConfigFiles(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "--save", "60", "1"},
+		},
+		env: map[string]string{
+			"REDIS_CONF_DIR":       "/opt/bitnami/redis/etc",
+			"REDIS_OVERRIDES_FILE": "/opt/bitnami/redis/mounted-etc/overrides.conf",
+		},
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Empty(t, collected.ConfigFiles)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "REDIS_CONF_DIR", Value: "/opt/bitnami/redis/etc"},
+		{Name: "REDIS_OVERRIDES_FILE", Value: "/opt/bitnami/redis/mounted-etc/overrides.conf"},
+	}, collected.EnvVars)
+}
+
+func TestRedisCollectorUsesEnvConfigFile(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/opt/bitnami/scripts/redis/run.sh"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path:    "/opt/bitnami/redis/etc/redis.conf",
+			Content: []byte("port 6379\n"),
+		},
+		env: map[string]string{
+			"REDIS_CONF_FILE":   "/opt/bitnami/redis/etc/redis.conf",
+			"REDIS_AOF_ENABLED": "yes",
+		},
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/opt/bitnami/redis/etc/redis.conf"}, reader.readFileCalls)
+	assert.Equal(t, 1, reader.runtimeCommandlineCalls)
+	assert.Equal(t, 1, reader.processCommandlineCalls)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "REDIS_AOF_ENABLED", Value: "yes"},
+		{Name: "REDIS_CONF_FILE", Value: "/opt/bitnami/redis/etc/redis.conf"},
+	}, collected.EnvVars)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, redisConfigPayloadFormat, collected.ConfigFiles[0].PayloadFormat)
+}
+
+func TestRedisCollectorUsesEnvConfigFileWhenCommandlineHasOnlyOptions(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "--save", "60", "1"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path: "/opt/bitnami/redis/etc/redis.conf",
+		},
+		env: map[string]string{
+			"REDIS_CONF_FILE": "/opt/bitnami/redis/etc/redis.conf",
+		},
+	}
+
+	collected, err := NewRedis().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/opt/bitnami/redis/etc/redis.conf"}, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, redisConfigPayloadFormat, collected.ConfigFiles[0].PayloadFormat)
+}
+
+func TestRedisCollectorResolvesRelativeEnvConfigFile(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args:       []string{"/opt/bitnami/scripts/redis/run.sh"},
+			WorkingDir: "/opt/bitnami/redis/etc",
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path: "/opt/bitnami/redis/etc/redis.conf",
+		},
+		env: map[string]string{
+			"REDIS_CONF_FILE": "redis.conf",
+		},
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/opt/bitnami/redis/etc/redis.conf"}, reader.readFileCalls)
+	assert.Equal(t, 1, reader.runtimeCommandlineCalls)
+	assert.Equal(t, 1, reader.processCommandlineCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, redisConfigPayloadFormat, collected.ConfigFiles[0].PayloadFormat)
+}
+
+func TestRedisCollectorDoesNotUseEnvConfigFileWhenProcessConfigIsAmbiguous(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/opt/bitnami/scripts/redis/run.sh"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{
+			{Args: []string{"redis-server", "/etc/redis/one.conf"}},
+			{Args: []string{"redis-server", "/etc/redis/two.conf"}},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path: "/opt/bitnami/redis/etc/redis.conf",
+		},
+		env: map[string]string{
+			"REDIS_CONF_FILE": "/opt/bitnami/redis/etc/redis.conf",
+		},
+	}
+
+	collected, err := NewRedis().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Equal(t, 1, reader.runtimeCommandlineCalls)
+	assert.Equal(t, 1, reader.processCommandlineCalls)
+	assert.Empty(t, collected.ConfigFiles)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "REDIS_CONF_FILE", Value: "/opt/bitnami/redis/etc/redis.conf"},
+	}, collected.EnvVars)
+}
+
+func TestRedisCollectorPrefersCommandlineConfigFile(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "/etc/redis/redis.conf"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path: "/etc/redis/redis.conf",
+		},
+		env: map[string]string{
+			"REDIS_CONF_FILE": "/opt/bitnami/redis/etc/redis.conf",
+		},
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/redis/redis.conf"}, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, redisConfigPayloadFormat, collected.ConfigFiles[0].PayloadFormat)
+}
+
+func TestRedisCollectorDoesNotCollectSensitiveEnvVars(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "--save", "60", "1"},
+		},
+		env: map[string]string{
+			"REDIS_AOF_ENABLED":          "yes",
+			"REDIS_PASSWORD":             "secret",
+			"REDIS_MASTER_PASSWORD_FILE": "/run/secrets/master-password",
+			"REDIS_SENTINEL_PWD":         "secret",
+			"REDIS_REQUIREPASS":          "secret",
+			"REDIS_MASTERAUTH":           "master-secret",
+			"REDIS_TLS_CERT_FILE":        "/etc/redis/tls.crt",
+			"REDIS_TLS_KEY_FILE":         "/run/secrets/redis.key",
+			"REDIS_ARGS":                 "--requirepass secret",
+			"REDIS_EXTRA_FLAGS":          "--masterauth secret",
+			"REDIS_URL":                  "redis://user:secret@redis:6379",
+			"ALLOW_EMPTY_PASSWORD":       "yes",
+		},
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "REDIS_AOF_ENABLED", Value: "yes"},
+		{Name: "REDIS_TLS_CERT_FILE", Value: "/etc/redis/tls.crt"},
+	}, collected.EnvVars)
 }
 
 func TestRedisCollectorSkipsDefaultsWhenCommandlineHasNoConfigFile(t *testing.T) {
@@ -361,6 +617,51 @@ func TestRedisCollectorReturnsCommandlineErrors(t *testing.T) {
 	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
 }
 
+func TestRedisCollectorReadsDetectedConfigWhenEnvVarsFail(t *testing.T) {
+	expectedErr := errors.New("env unavailable")
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "/etc/redis/redis.conf"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path:    "/etc/redis/redis.conf",
+			Content: []byte("port 6379\n"),
+		},
+		readEnvVarsErr: expectedErr,
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/redis/redis.conf"}, reader.readFileCalls)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigFile{
+		{
+			Path:          "/etc/redis/redis.conf",
+			Content:       []byte("port 6379\n"),
+			PayloadFormat: redisConfigPayloadFormat,
+		},
+	}, collected.ConfigFiles)
+	assert.Empty(t, collected.EnvVars)
+}
+
+func TestRedisCollectorReturnsEnvVarErrorsWithoutConfigPath(t *testing.T) {
+	expectedErr := errors.New("env unavailable")
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "--save", "60", "1"},
+		},
+		readEnvVarsErr: expectedErr,
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
+}
+
 func TestRedisCollectorReturnsReadFileErrors(t *testing.T) {
 	expectedErr := errors.New("read failed")
 	reader := &redisCollectorTestReader{
@@ -382,10 +683,13 @@ type redisCollectorTestReader struct {
 	runtimeCommandline      configfilesdiscoveryimpl.TargetCommandline
 	liveProcessCommandlines []configfilesdiscoveryimpl.TargetCommandline
 	commandlineErr          error
+	runtimeCommandlineCalls int
 	processCommandlineCalls int
 	readFileCalls           []string
 	file                    configfilesdiscoveryimpl.ConfigFile
 	readFileErr             error
+	env                     map[string]string
+	readEnvVarsErr          error
 }
 
 func (r *redisCollectorTestReader) Runtime() configfilesdiscoveryimpl.RuntimeType {
@@ -405,11 +709,26 @@ func (r *redisCollectorTestReader) ReadFile(_ context.Context, path string) (con
 	return configfilesdiscoveryimpl.ConfigFile{}, errors.New("file not found")
 }
 
-func (r *redisCollectorTestReader) ReadEnvVars(context.Context, configfilesdiscoveryimpl.ConfigEnvVarPredicate) (map[string]string, error) {
-	return nil, errors.New("not implemented")
+func (r *redisCollectorTestReader) ReadEnvVars(_ context.Context, predicate configfilesdiscoveryimpl.ConfigEnvVarPredicate) (map[string]string, error) {
+	if r.readEnvVarsErr != nil {
+		return nil, r.readEnvVarsErr
+	}
+
+	env := make(map[string]string)
+	for name, value := range r.env {
+		if configfilesdiscoveryimpl.IsSecretEnvVarName(name) {
+			continue
+		}
+		if predicate != nil && !predicate(name) {
+			continue
+		}
+		env[name] = value
+	}
+	return env, nil
 }
 
 func (r *redisCollectorTestReader) ReadRuntimeCommandline(context.Context) (configfilesdiscoveryimpl.TargetCommandline, error) {
+	r.runtimeCommandlineCalls++
 	if r.commandlineErr != nil {
 		return configfilesdiscoveryimpl.TargetCommandline{}, r.commandlineErr
 	}

--- a/test/new-e2e/tests/discovery/configfilesdiscovery_docker_test.go
+++ b/test/new-e2e/tests/discovery/configfilesdiscovery_docker_test.go
@@ -39,6 +39,7 @@ const (
 	redisConfigDir               = "/tmp/configfilesdiscovery-redis"
 	redisExplicitContainerName   = "redis-configfilesdiscovery-explicit"
 	redisDefaultContainerName    = "redis-configfilesdiscovery-default"
+	redisEnvContainerName        = "redis-env-configfilesdiscovery"
 	redisExplicitContainerPath   = "/configfilesdiscovery/redis-explicit.conf"
 	redisDefaultContainerPath    = "/etc/redis/redis.conf"
 	redisExplicitConfigFileName  = "redis-explicit.conf"
@@ -48,6 +49,7 @@ const (
 	redisExplicitConfigSentinel  = "configfilesdiscovery-explicit-e2e-sentinel"
 	redisDefaultConfigSentinel   = "configfilesdiscovery-default-e2e-sentinel"
 	redisIntegrationName         = "redisdb"
+	redisTLSCertFile             = "/etc/redis/tls.crt"
 )
 
 const (
@@ -274,7 +276,7 @@ func (s *configFilesDiscoveryDockerSuite) TestKafkaEnvVarsDiscoveredWithoutConfi
 		if !assert.NoError(c, err) {
 			return
 		}
-		kafkaPayloads := findKafkaEnvPayloads(payloads)
+		kafkaPayloads := findEnvPayloads(payloads, kafkaIntegrationName)
 		if !assert.NotEmpty(c, kafkaPayloads, "no kafka env payloads found in %+v", payloads) {
 			return
 		}
@@ -294,6 +296,48 @@ func (s *configFilesDiscoveryDockerSuite) TestKafkaEnvVarsDiscoveredWithoutConfi
 			assert.NotContains(c, envVars, "KAFKA_CFG_OAUTH_ACCESS_TOKEN")
 		}
 	}, 3*time.Minute, 10*time.Second, "timed out waiting for kafka env var discovery payload")
+}
+
+func (s *configFilesDiscoveryDockerSuite) TestRedisEnvVarsDiscoveredWithoutConfigFile() {
+	t := s.T()
+	s.prepareConfigFilesDiscoveryContainers(t, configFilesDiscoveryContainerFixture{
+		integrationName: redisIntegrationName,
+		configDir:       redisConfigDir,
+		containerNames: []string{
+			redisExplicitContainerName,
+			redisDefaultContainerName,
+			redisEnvContainerName,
+		},
+		startContainerNames: []string{redisEnvContainerName},
+	})
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, isIntegrationScheduled(s.Env().Agent.Client.ConfigCheck(), redisIntegrationName))
+
+		payloads, err := s.Env().FakeIntake.Client().GetAgentDiscoveryPayloads()
+		if !assert.NoError(c, err) {
+			return
+		}
+		redisPayloads := findEnvPayloads(payloads, redisIntegrationName)
+		if !assert.NotEmpty(c, redisPayloads, "no redis env payloads found in %+v", payloads) {
+			return
+		}
+
+		for _, payload := range redisPayloads {
+			assertAgentDiscoveryPayload(c, payload, redisIntegrationName)
+			assert.Empty(c, payload.ConfigFiles)
+
+			envVars := make(map[string]string, len(payload.EnvVars))
+			for _, envVar := range payload.EnvVars {
+				envVars[envVar.Name] = envVar.Value
+			}
+			assert.Equal(c, "yes", envVars["REDIS_AOF_ENABLED"])
+			assert.Equal(c, "6380", envVars["REDIS_PORT_NUMBER"])
+			assert.Equal(c, redisTLSCertFile, envVars["REDIS_TLS_CERT_FILE"])
+			assert.NotContains(c, envVars, "REDIS_PASSWORD")
+			assert.NotContains(c, envVars, "REDIS_REQUIREPASS")
+		}
+	}, 3*time.Minute, 10*time.Second, "timed out waiting for redis env var discovery payload")
 }
 
 func (s *configFilesDiscoveryDockerSuite) TestKafkaDefaultConfigFileDiscovered() {
@@ -369,7 +413,9 @@ func (s *configFilesDiscoveryDockerSuite) TestRedisConfigFilesDiscoveredAndHeart
 		containerNames: []string{
 			redisExplicitContainerName,
 			redisDefaultContainerName,
+			redisEnvContainerName,
 		},
+		startContainerNames: []string{redisExplicitContainerName, redisDefaultContainerName},
 	})
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -495,14 +541,14 @@ func findConfigFilePayloads(payloads []*aggregator.AgentDiscoveryPayload, integr
 	return configFilePayloads
 }
 
-func findKafkaEnvPayloads(payloads []*aggregator.AgentDiscoveryPayload) []*aggregator.AgentDiscoveryPayload {
-	var kafkaPayloads []*aggregator.AgentDiscoveryPayload
+func findEnvPayloads(payloads []*aggregator.AgentDiscoveryPayload, integrationName string) []*aggregator.AgentDiscoveryPayload {
+	var envPayloads []*aggregator.AgentDiscoveryPayload
 	for _, payload := range payloads {
-		if payload.Integration == kafkaIntegrationName && payload.Runtime == dockerRuntime && len(payload.EnvVars) > 0 {
-			kafkaPayloads = append(kafkaPayloads, payload)
+		if payload.Integration == integrationName && payload.Runtime == dockerRuntime && len(payload.EnvVars) > 0 {
+			envPayloads = append(envPayloads, payload)
 		}
 	}
-	return kafkaPayloads
+	return envPayloads
 }
 
 func (s *configFilesDiscoveryDockerSuite) logConfigFilesDiscoveryDebug(t *testing.T) {

--- a/test/new-e2e/tests/discovery/testdata/compose/docker-compose.configfilesdiscovery-redis.yaml
+++ b/test/new-e2e/tests/discovery/testdata/compose/docker-compose.configfilesdiscovery-redis.yaml
@@ -1,4 +1,33 @@
 services:
+  redis-env-configfilesdiscovery:
+    image: ghcr.io/datadog/redis:{APPS_VERSION}
+    container_name: redis-env-configfilesdiscovery
+    # Keep the image running without redis-server or a config path so discovery
+    # has to rely on the container environment.
+    entrypoint:
+      - /bin/sh
+      - -c
+    command:
+      - "trap : TERM INT; sleep 2147483647 & wait"
+    environment:
+      REDIS_AOF_ENABLED: "yes"
+      REDIS_PASSWORD: must-not-be-forwarded
+      REDIS_PORT_NUMBER: "6380"
+      REDIS_REQUIREPASS: must-not-be-forwarded
+      REDIS_TLS_CERT_FILE: /etc/redis/tls.crt
+    labels:
+      com.datadoghq.ad.checks: |
+        {
+          "redisdb": {
+            "instances": [
+              {
+                "host": "%%host%%",
+                "port": 6380
+              }
+            ]
+          }
+        }
+
   redis-configfilesdiscovery-explicit:
     image: ghcr.io/datadog/redis:{APPS_VERSION}
     container_name: redis-configfilesdiscovery-explicit


### PR DESCRIPTION
### What does this PR do?

Collects selected, non-secret Redis environment variables alongside Redis config files in `configfilesdiscovery`. It uses regex-based allow and deny rules plus the shared secret-name filter. Config-file selection follows `redis-server` argv, then `REDIS_CONF_FILE`, then known default paths. The shared reader accepts the optional fallback while Kafka retains its existing behavior by passing none.

### Motivation

DSCVR-619

### Describe how you validated your changes

Unit tests.

### Additional Notes

