### PR TITLE
Remove unused skip_flakes flag from `inv test`

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -641,7 +641,6 @@ def test(
     junit_tar="",
     only_modified_packages=False,
     only_impacted_packages=False,
-    skip_flakes=False,
     build_stdlib=False,
     test_washer=False,
     extra_args=None,
@@ -748,7 +747,6 @@ def test(
         "nocache": nocache,
         # Used to print failed tests at the end of the go test command
         "rerun_fails": f"--rerun-fails={rerun_fails}" if rerun_fails else "",
-        "skip_flakes": "--skip-flake" if skip_flakes else "",
         "gotestsum_format": "standard-verbose" if verbose else "pkgname",
         "extra_args": extra_args or "",
         "trimpath_opt": trimpath_opt,


### PR DESCRIPTION
### What does this PR do?

It removes the `--skip-flakes` flag from `inv test`.

### Motivation

It is a no-op flag, and as we're close to switching to Bazel as the standard way to run tests, it's not worth repairing it. If we want similar functionality we'll probably want to base it on Bazel functionality.

Particularly since, looking at git history, it seems like it was introduced [here](https://github.com/DataDog/datadog-agent/commit/85ca2cb1ac3dcc58140afc2a34b1732eb73afc20) and (accidentally?) broken three days later [here](https://github.com/DataDog/datadog-agent/commit/0b4261c9c6eb386b02e1133981142dc09a94e256).

### Describe how you validated your changes

### Additional Notes
