### PR TITLE
fix(security): fix data race on process cache entry cgroup/container/SID

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1289,7 +1289,7 @@ func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Ev
 			// If the kernel reports a different SID than the one in our
 			// cache, the process called setsid(). Update the cache entry.
 			if event.PIDContext.SID != 0 {
-				p.Resolvers.ProcessResolver.UpdateSID(entry.Pid, event.PIDContext.SID)
+				p.Resolvers.ProcessResolver.UpdateSID(entry, event.PIDContext.SID)
 			}
 
 			if _, err := entry.HasValidLineage(); err != nil {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1289,7 +1289,7 @@ func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Ev
 			// If the kernel reports a different SID than the one in our
 			// cache, the process called setsid(). Update the cache entry.
 			if event.PIDContext.SID != 0 {
-				entry.SID = event.PIDContext.SID
+				p.Resolvers.ProcessResolver.UpdateSID(entry.Pid, event.PIDContext.SID)
 			}
 
 			if _, err := entry.HasValidLineage(); err != nil {

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -1613,15 +1613,12 @@ func (p *EBPFResolver) UpdateProcessContexts(pce *model.ProcessCacheEntry, cgrou
 	}
 }
 
-// UpdateSID updates the SID of the process matching the provided pid
-func (p *EBPFResolver) UpdateSID(pid uint32, sid uint32) {
+// UpdateSID updates the SID of the given process cache entry
+func (p *EBPFResolver) UpdateSID(pce *model.ProcessCacheEntry, sid uint32) {
 	p.Lock()
 	defer p.Unlock()
 
-	entry := p.entryCache[pid]
-	if entry != nil {
-		entry.SID = sid
-	}
+	pce.SID = sid
 }
 
 const (

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -1615,6 +1615,14 @@ func (p *EBPFResolver) UpdateProcessContexts(pce *model.ProcessCacheEntry, cgrou
 
 // UpdateSID updates the SID of the given process cache entry
 func (p *EBPFResolver) UpdateSID(pce *model.ProcessCacheEntry, sid uint32) {
+	p.RLock()
+	currSID := pce.SID
+	p.RUnlock()
+
+	if currSID == sid {
+		return
+	}
+
 	p.Lock()
 	defer p.Unlock()
 

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -1602,11 +1602,25 @@ func (p *EBPFResolver) Walk(callback func(entry *model.ProcessCacheEntry)) {
 
 // UpdateProcessContexts updates the cgroup context and container ID of the process matching the provided PID
 func (p *EBPFResolver) UpdateProcessContexts(pce *model.ProcessCacheEntry, cgroupContext model.CGroupContext, containerContext model.ContainerContext) {
+	p.Lock()
+	defer p.Unlock()
+
 	if !cgroupContext.IsNull() {
 		pce.Process.CGroup = cgroupContext
 	}
 	if !containerContext.IsNull() {
 		pce.Process.ContainerContext = containerContext
+	}
+}
+
+// UpdateSID updates the SID of the process matching the provided pid
+func (p *EBPFResolver) UpdateSID(pid uint32, sid uint32) {
+	p.Lock()
+	defer p.Unlock()
+
+	entry := p.entryCache[pid]
+	if entry != nil {
+		entry.SID = sid
 	}
 }
 


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Fixes two data races in the CWS process resolver: 
- `EBPFResolver.UpdateProcessContexts()` mutated a shared `*model.ProcessCacheEntry`'s `CGroup`/`ContainerContext` fields without taking the resolver's lock.
- `entry.SID` write in `setProcessContext` had the same issue; moved it behind a new locked `UpdateSID` accessor.

### Motivation

Found via `-race` in a live `system-probe` deployment log (`ActivityDump.MatchesSelector()` racing with `UpdateProcessContexts()` from the eBPF ring-buffer event handler).

### Describe how you validated your changes

CI

### Additional Notes