### PR TITLE
Lower memory usage of the mmaped files snapshot replay

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -37,7 +37,6 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/DataDog/ebpf-manager/tracefs"
-	gopsutilprocess "github.com/shirou/gopsutil/v4/process"
 
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
@@ -924,10 +923,19 @@ func (p *EBPFProbe) ReplayEvents() {
 	}
 }
 
+// replayEntry is a process event to replay, along with the memory-mapped files
+// to replay right after it. The open events are built during the dispatch loop
+// rather than upfront: materializing them all would hold one pooled event per
+// (process, mmaped file) pair, which the pool never gets to recycle.
+type replayEntry struct {
+	event       *model.Event
+	mmapedFiles []model.SnapshottedMmapedFile
+}
+
 func (p *EBPFProbe) replayEvents(notifyConsumers bool) {
 	seclog.Debugf("playing the snapshot")
 
-	var events []*model.Event
+	var entries []replayEntry
 
 	entryToEvent := func(entry *model.ProcessCacheEntry) {
 		event := p.newEBPFPooledEventFromPCE(entry)
@@ -939,38 +947,30 @@ func (p *EBPFProbe) replayEvents(notifyConsumers bool) {
 
 		event.AddToFlags(model.EventFlagsFromReplay)
 
-		events = append(events, event)
+		var mmapedFiles []model.SnapshottedMmapedFile
 
 		// Replay mmaped files (only needed if SBOM resolver is enabled)
 		if p.config.RuntimeSecurity.SBOMResolverEnabled {
-			proc, err := gopsutilprocess.NewProcess(int32(entry.Pid))
-			if err != nil {
-				return
-			}
-
-			mmapedFiles, err := procfs.GetMmapedFiles(proc)
-			if err != nil {
+			var err error
+			if mmapedFiles, err = procfs.GetMmapedFiles(int32(entry.Pid)); err != nil {
 				seclog.Debugf("mmaped files snapshot failed for (pid: %v): %s", entry.Pid, err)
-				return
-			}
-
-			for _, f := range mmapedFiles {
-				openEvent := p.newOpenEventFromReplay(entry, f)
-				openEvent.Source = model.EventSourceReplay
-				events = append(events, openEvent)
 			}
 		}
+
+		entries = append(entries, replayEntry{event: event, mmapedFiles: mmapedFiles})
 	}
 
 	p.Walk(entryToEvent)
 
 	// replay synthetic load_module events for every entry in /proc/modules.
-	events = append(events, p.snapshotLoadedModules()...)
+	for _, event := range p.snapshotLoadedModules() {
+		entries = append(entries, replayEntry{event: event})
+	}
 
 	// order events so that they're dispatched in creation time order
-	sort.Slice(events, func(i, j int) bool {
-		eventA := events[i]
-		eventB := events[j]
+	sort.Slice(entries, func(i, j int) bool {
+		eventA := entries[i].event
+		eventB := entries[j].event
 
 		tsA := eventA.ProcessContext.ExecTime
 		tsB := eventB.ProcessContext.ExecTime
@@ -981,9 +981,17 @@ func (p *EBPFProbe) replayEvents(notifyConsumers bool) {
 		return tsA.Before(tsB)
 	})
 
-	for _, event := range events {
-		p.DispatchEvent(event, notifyConsumers)
-		p.putBackPoolEvent(event)
+	for _, re := range entries {
+		p.DispatchEvent(re.event, notifyConsumers)
+
+		for _, f := range re.mmapedFiles {
+			openEvent := p.newOpenEventFromReplay(re.event.ProcessCacheEntry, f)
+			openEvent.Source = model.EventSourceReplay
+			p.DispatchEvent(openEvent, notifyConsumers)
+			p.putBackPoolEvent(openEvent)
+		}
+
+		p.putBackPoolEvent(re.event)
 	}
 	// send not triggered remediations
 	p.HandleRemediationNotTriggered()

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -929,7 +929,7 @@ func (p *EBPFProbe) ReplayEvents() {
 // (process, mmaped file) pair, which the pool never gets to recycle.
 type replayEntry struct {
 	event       *model.Event
-	mmapedFiles []model.SnapshottedMmapedFile
+	mmapedFiles []procfs.MmapedFile
 }
 
 func (p *EBPFProbe) replayEvents(notifyConsumers bool) {
@@ -947,12 +947,12 @@ func (p *EBPFProbe) replayEvents(notifyConsumers bool) {
 
 		event.AddToFlags(model.EventFlagsFromReplay)
 
-		var mmapedFiles []model.SnapshottedMmapedFile
+		var mmapedFiles []procfs.MmapedFile
 
 		// Replay mmaped files (only needed if SBOM resolver is enabled)
 		if p.config.RuntimeSecurity.SBOMResolverEnabled {
 			var err error
-			if mmapedFiles, err = procfs.GetMmapedFiles(int32(entry.Pid)); err != nil {
+			if mmapedFiles, err = procfs.GetMmapedFiles(entry.Pid); err != nil {
 				seclog.Debugf("mmaped files snapshot failed for (pid: %v): %s", entry.Pid, err)
 			}
 		}
@@ -984,8 +984,8 @@ func (p *EBPFProbe) replayEvents(notifyConsumers bool) {
 	for _, re := range entries {
 		p.DispatchEvent(re.event, notifyConsumers)
 
-		for _, f := range re.mmapedFiles {
-			openEvent := p.newOpenEventFromReplay(re.event.ProcessCacheEntry, f)
+		for _, file := range re.mmapedFiles {
+			openEvent := p.newOpenEventFromReplay(re.event.ProcessCacheEntry, file)
 			openEvent.Source = model.EventSourceReplay
 			p.DispatchEvent(openEvent, notifyConsumers)
 			p.putBackPoolEvent(openEvent)
@@ -3980,7 +3980,7 @@ func (p *EBPFProbe) newLoadModuleEventFromProcFSSnapshot(mod utils.ProcFSModule,
 	event.LoadModule.File.SetPathnameStr(modulePath)
 	event.LoadModule.File.SetBasenameStr(filepath.Base(modulePath))
 
-	// Best-effort file metadata (mirrors newOpenEventFromReplay).
+	// Best-effort file metadata.
 	var fileStats unix.Statx_t
 	if err := unix.Statx(unix.AT_FDCWD, modulePath, 0, unix.STATX_ALL, &fileStats); err == nil {
 		event.LoadModule.File.FileFields.Mode = uint16(fileStats.Mode)
@@ -4000,7 +4000,7 @@ func (p *EBPFProbe) newLoadModuleEventFromProcFSSnapshot(mod utils.ProcFSModule,
 }
 
 // newOpenEventFromReplay returns a new open event for a memory-mapped file with a process context
-func (p *EBPFProbe) newOpenEventFromReplay(entry *model.ProcessCacheEntry, snapshottedFile model.SnapshottedMmapedFile) *model.Event {
+func (p *EBPFProbe) newOpenEventFromReplay(entry *model.ProcessCacheEntry, snapshottedFile procfs.MmapedFile) *model.Event {
 	event := p.getPoolEvent()
 	event.Timestamp = time.Now()
 	event.TimestampRaw = uint64(p.Resolvers.TimeResolver.ComputeMonotonicTimestamp(event.Timestamp))
@@ -4014,24 +4014,7 @@ func (p *EBPFProbe) newOpenEventFromReplay(entry *model.ProcessCacheEntry, snaps
 	event.Open.File.IsPathnameStrResolved = true
 	event.Open.File.BasenameStr = filepath.Base(snapshottedFile.Path)
 	event.Open.File.IsBasenameStrResolved = true
-
-	// Try to stat the file to get basic metadata (best effort)
-	// This helps with file resolution and enrichment
-	var fileStats unix.Statx_t
-	fullPath := utils.ProcRootFilePath(entry.Pid, snapshottedFile.Path)
-	if err := unix.Statx(unix.AT_FDCWD, fullPath, 0, unix.STATX_ALL, &fileStats); err == nil {
-		event.Open.File.FileFields.Mode = uint16(fileStats.Mode)
-		event.Open.File.FileFields.Inode = fileStats.Ino
-		event.Open.File.FileFields.UID = fileStats.Uid
-		event.Open.File.FileFields.GID = fileStats.Gid
-		event.Open.File.CTime = uint64(time.Unix(fileStats.Ctime.Sec, int64(fileStats.Ctime.Nsec)).Nanosecond())
-		event.Open.File.MTime = uint64(time.Unix(fileStats.Mtime.Sec, int64(fileStats.Mtime.Nsec)).Nanosecond())
-		event.Open.File.Mode = fileStats.Mode
-		event.Open.File.Inode = fileStats.Ino
-		event.Open.File.Device = fileStats.Dev_major<<20 | fileStats.Dev_minor
-		event.Open.File.NLink = fileStats.Nlink
-		event.Open.File.MountID = uint32(fileStats.Mnt_id)
-	}
+	event.Open.File.FileFields = snapshottedFile.FileFields
 
 	return event
 }

--- a/pkg/security/probe/procfs/BUILD.bazel
+++ b/pkg/security/probe/procfs/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "@rules_go//go/platform:android": [
             "//pkg/security/secl/model",
             "//pkg/security/seclog",
+            "//pkg/security/utils",
             "//pkg/util/kernel",
             "@com_github_shirou_gopsutil_v4//process",
             "@org_golang_x_sys//unix",
@@ -21,6 +22,7 @@ go_library(
         "@rules_go//go/platform:linux": [
             "//pkg/security/secl/model",
             "//pkg/security/seclog",
+            "//pkg/security/utils",
             "//pkg/util/kernel",
             "@com_github_shirou_gopsutil_v4//process",
             "@org_golang_x_sys//unix",

--- a/pkg/security/probe/procfs/snapshot_mmapped_files.go
+++ b/pkg/security/probe/procfs/snapshot_mmapped_files.go
@@ -9,25 +9,61 @@
 package procfs
 
 import (
+	"time"
+
+	"golang.org/x/sys/unix"
+
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
+
+// MmapedFile represents a snapshotted memory-mapped file
+type MmapedFile struct {
+	Path string
+	model.FileFields
+}
 
 // GetMmapedFiles returns the list of executable memory-mapped files for a given process
 // Uses the shared GetMappedFiles utility with FilterExecutableRegularFiles
-func GetMmapedFiles(pid int32) ([]model.SnapshottedMmapedFile, error) {
+func GetMmapedFiles(pid uint32) ([]MmapedFile, error) {
 	// Use shared parsing utilities to get executable regular files (not [vdso], [stack], etc.)
-	paths, err := GetMappedFiles(pid, MaxMmapedFilesPerProcess, FilterExecutableRegularFiles)
+	paths, err := GetMappedFiles(int32(pid), MaxMmapedFilesPerProcess, FilterExecutableRegularFiles)
 	if err != nil {
 		return nil, err
 	}
 
-	// Convert to SnapshottedMmapedFile format
-	mmapedFiles := make([]model.SnapshottedMmapedFile, 0, len(paths))
+	mmapedFiles := make([]MmapedFile, 0, len(paths))
 	for _, path := range paths {
-		mmapedFiles = append(mmapedFiles, model.SnapshottedMmapedFile{
-			Path: path,
+		mmapedFiles = append(mmapedFiles, MmapedFile{
+			Path:       path,
+			FileFields: statMmapedFile(pid, path),
 		})
 	}
 
 	return mmapedFiles, nil
+}
+
+// statMmapedFile returns the metadata of a memory-mapped file. It has to be
+// collected along with the snapshot: the file is resolved through the root of
+// the mapping process, which is gone as soon as that process exits. Best
+// effort, zero values are returned for a file that cannot be stat'ed.
+func statMmapedFile(pid uint32, path string) model.FileFields {
+	var fileStats unix.Statx_t
+	if err := unix.Statx(unix.AT_FDCWD, utils.ProcRootFilePath(pid, path), 0, unix.STATX_ALL, &fileStats); err != nil {
+		return model.FileFields{}
+	}
+
+	fileFields := model.FileFields{
+		Mode:   fileStats.Mode,
+		UID:    fileStats.Uid,
+		GID:    fileStats.Gid,
+		CTime:  uint64(time.Unix(fileStats.Ctime.Sec, int64(fileStats.Ctime.Nsec)).Nanosecond()),
+		MTime:  uint64(time.Unix(fileStats.Mtime.Sec, int64(fileStats.Mtime.Nsec)).Nanosecond()),
+		Device: fileStats.Dev_major<<20 | fileStats.Dev_minor,
+		NLink:  fileStats.Nlink,
+	}
+	fileFields.Inode = fileStats.Ino
+	fileFields.MountID = uint32(fileStats.Mnt_id)
+
+	return fileFields
 }

--- a/pkg/security/probe/procfs/snapshot_mmapped_files.go
+++ b/pkg/security/probe/procfs/snapshot_mmapped_files.go
@@ -9,16 +9,14 @@
 package procfs
 
 import (
-	"github.com/shirou/gopsutil/v4/process"
-
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
 // GetMmapedFiles returns the list of executable memory-mapped files for a given process
 // Uses the shared GetMappedFiles utility with FilterExecutableRegularFiles
-func GetMmapedFiles(p *process.Process) ([]model.SnapshottedMmapedFile, error) {
+func GetMmapedFiles(pid int32) ([]model.SnapshottedMmapedFile, error) {
 	// Use shared parsing utilities to get executable regular files (not [vdso], [stack], etc.)
-	paths, err := GetMappedFiles(int32(p.Pid), MaxMmapedFilesPerProcess, FilterExecutableRegularFiles)
+	paths, err := GetMappedFiles(pid, MaxMmapedFilesPerProcess, FilterExecutableRegularFiles)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -573,11 +573,6 @@ type SnapshottedBoundSocket struct {
 	Protocol uint16
 }
 
-// SnapshottedMmapedFile represents a snapshotted memory-mapped file
-type SnapshottedMmapedFile struct {
-	Path string
-}
-
 // ProcessCacheEntry this struct holds process context kept in the process tree
 type ProcessCacheEntry struct {
 	ProcessContext

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -573,11 +573,6 @@ type SnapshottedBoundSocket struct {
 	Protocol uint16
 }
 
-// SnapshottedMmapedFile represents a snapshotted memory-mapped file
-type SnapshottedMmapedFile struct {
-	Path string
-}
-
 // ProcessCacheEntry this struct holds process context kept in the process tree
 type ProcessCacheEntry struct {
 	ProcessContext


### PR DESCRIPTION
### What does this PR do?

Makes the replay of snapshotted memory-mapped files, done when the SBOM resolver is enabled, use a constant amount of memory instead of an amount proportional to the number of processes running on the host.
Peak live allocated events during replay goes from `processes * (1 + mapped files)` to `processes + 1`, and the event pool now actually recycles events instead of allocating `processes * (1 + mapped files)` events.

This change also fixes a slice ordering bug: open events used to conflict with their own exec event in the slice (identical ExecTime and Pid), so an open event could be dispatched before the exec event that established its process context. Now they always follow it.

The PR also drops the call to `gopsutil.NewProcess` that would parse `/proc/<pid>/stat` for nothing. 

### Motivation

Every mapped file of every cached process was previously turned into a replay event upfront, and all of them were kept alive until the whole snapshot was dispatched. On a busy host this checks out thousands of events at once, none of which can be recycled, causing a memory spike at startup and on every ruleset reload. Building each replay event only when it is about to be dispatched keeps the pool of events effective.

### Describe how you validated your changes

Existing unit tests and linters pass for the affected packages. The replay is already covered end to end by the functional tests that assert the snapshot is played back on startup and on ruleset reload.

### Additional Notes
