### PR TITLE
[CNM-5556] Add diagnostics for TLS traffic reported as tls_encrypted:false

### DIFF
--- a/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
+++ b/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
@@ -1,6 +1,7 @@
 #ifndef __PROTOCOL_DISPATCHER_HELPERS_H
 #define __PROTOCOL_DISPATCHER_HELPERS_H
 
+#include "protocols/classification/tls-misclassification-counters.h"
 #include "ktypes.h"
 
 #include "ip.h"
@@ -107,6 +108,13 @@ static __always_inline void classify_protocol_for_dispatcher(protocol_t *protoco
         *protocol = PROTOCOL_POSTGRES;
     } else if (is_redis_enabled() && is_redis(buf, size)) {
         *protocol = PROTOCOL_REDIS;
+        // TLS-misclassification diagnostics (jmw/tls-misclassification). This is one of the two
+        // is_redis() call sites in usm.c that the socket-filter counters do not cover, and it
+        // writes PROTOCOL_REDIS into the *shared* connection_protocol stack below — which is
+        // enough to trip the app-layer gate on is_tls() and lock TLS out permanently.
+        if (is_tls_diag_enabled()) {
+            tls_diag_count(TLS_DIAG_CTR_USM_DISPATCHER_REDIS);
+        }
     } else {
         *protocol = PROTOCOL_UNKNOWN;
     }

--- a/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
+++ b/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
@@ -203,35 +203,37 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint(struct
     if (!encryption_layer_known) {
         tls_record_header_t diag_hdr = {0};
         if (is_tls_record_header_plausible(skb, skb_info.data_off, skb_info.data_end, &diag_hdr)) {
-            // Link 1: is_tls() above requires the whole record to fit inside this packet
-            // (read_tls_record_header's final bounds check). Records run to 16 KB while MSS is
-            // ~1460, so genuine TLS reads as "not TLS" and classification falls through to the
-            // app-layer classifiers. This counter measures how often that door is opened.
-            if (skb_info.data_off + sizeof(tls_record_header_t) + diag_hdr.length > skb_info.data_end) {
-                increment_telemetry_count(tls_reject_record_exceeds_packet);
-                record_tls_misclassification_event(&skb_tup, TLS_DIAG_RECORD_EXCEEDS_PACKET, app_layer_proto, diag_hdr.content_type);
-            } else if (diag_hdr.content_type == TLS_HANDSHAKE &&
-                       !is_valid_tls_handshake(skb, skb_info.data_off, skb_info.data_end, &diag_hdr)) {
-                // Link 1, structural variant. The record fits, so the size check above is not the
-                // reason is_tls() failed; is_valid_tls_handshake() rejected it instead. It accepts
-                // ONLY ClientHello and ServerHello, and requires handshake_length + 4 to equal the
-                // record length exactly — so Certificate/ServerKeyExchange/Finished records,
-                // records carrying several coalesced handshake messages, and handshake messages
-                // fragmented across records all land here. This is how a brand-new connection can
-                // be misclassified, without any missed handshake.
-                //
-                // Note this only fires when is_tls() was actually reachable. If the app layer is
-                // already recorded, the gate above skips is_tls() entirely and the lock-out
-                // counter below is the correct attribution instead.
-                increment_telemetry_count(tls_reject_handshake_invalid);
-                record_tls_misclassification_event(&skb_tup, TLS_DIAG_HANDSHAKE_INVALID, app_layer_proto, diag_hdr.content_type);
-            }
-
-            // Link 3: the is_tls() call above is gated on the app layer being UNKNOWN or POSTGRES,
-            // so once any other protocol is recorded is_tls() can never run again for this
-            // connection — the wrong answer is pinned regardless of FLAG_FULLY_CLASSIFIED.
-            // Purely observational; no classification state is modified here.
-            if (app_layer_proto != PROTOCOL_UNKNOWN && app_layer_proto != PROTOCOL_POSTGRES) {
+            // These two branches are mutually exclusive, and the distinction matters for
+            // attribution. The is_tls() call above is gated on the app layer being UNKNOWN or
+            // POSTGRES, so when any other protocol is already recorded is_tls() never ran at all —
+            // nothing was "rejected", and counting a rejection there would over-attribute to
+            // link 1 and inflate its totals.
+            if (app_layer_proto == PROTOCOL_UNKNOWN || app_layer_proto == PROTOCOL_POSTGRES) {
+                // is_tls() was reachable and, since control reached here, returned false on bytes
+                // that do look like a TLS record. Attribute why.
+                if (skb_info.data_off + sizeof(tls_record_header_t) + diag_hdr.length > skb_info.data_end) {
+                    // Link 1a. read_tls_record_header()'s final bounds check requires the whole
+                    // record to fit inside this packet. Records run to 16 KB while MSS is ~1460,
+                    // so genuine TLS reads as "not TLS" and classification falls through to the
+                    // app-layer classifiers.
+                    increment_telemetry_count(tls_reject_record_exceeds_packet);
+                    record_tls_misclassification_event(&skb_tup, TLS_DIAG_RECORD_EXCEEDS_PACKET, app_layer_proto, diag_hdr.content_type);
+                } else if (diag_hdr.content_type == TLS_HANDSHAKE &&
+                           !is_valid_tls_handshake(skb, skb_info.data_off, skb_info.data_end, &diag_hdr)) {
+                    // Link 1b, structural variant. The record fits, so size is not why is_tls()
+                    // failed; is_valid_tls_handshake() rejected it. That accepts ONLY ClientHello
+                    // and ServerHello and requires handshake_length + 4 == record length, so
+                    // Certificate/ServerKeyExchange/Finished records, records carrying several
+                    // coalesced handshake messages, and fragmented handshake messages all land
+                    // here. This is how a brand-new connection can be misclassified, with no
+                    // missed handshake involved.
+                    increment_telemetry_count(tls_reject_handshake_invalid);
+                    record_tls_misclassification_event(&skb_tup, TLS_DIAG_HANDSHAKE_INVALID, app_layer_proto, diag_hdr.content_type);
+                }
+            } else {
+                // Link 3. The app layer is already recorded, so is_tls() can never run again for
+                // this connection and the wrong answer is pinned regardless of
+                // FLAG_FULLY_CLASSIFIED. Purely observational; no state is modified here.
                 increment_telemetry_count(tls_locked_out_by_applayer);
                 record_tls_misclassification_event(&skb_tup, TLS_DIAG_LOCKED_OUT_BY_APPLAYER, app_layer_proto, diag_hdr.content_type);
             }

--- a/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
+++ b/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
@@ -200,7 +200,7 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint(struct
 
     // TLS/Redis misclassification diagnostics (see jmw/tls-misclassification).
     //
-    if (!encryption_layer_known) {
+    if (is_tls_diag_enabled() && !encryption_layer_known) {
         tls_record_header_t diag_hdr = {0};
         if (is_tls_record_header_plausible(skb, skb_info.data_off, skb_info.data_end, &diag_hdr)) {
             // These two branches are mutually exclusive, and the distinction matters for
@@ -353,7 +353,7 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint_dbs(st
     //      definition rather than a heuristic judgement.
     //
     // Both are observational only — the classification below is left exactly as it was.
-    {
+    if (is_tls_diag_enabled()) {
         tls_record_header_t diag_hdr = {0};
         bool looks_like_tls = is_tls_record_header_plausible(skb, classification_ctx->skb_info.data_off, classification_ctx->skb_info.data_end, &diag_hdr);
         if (looks_like_tls) {

--- a/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
+++ b/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
@@ -24,6 +24,9 @@
 #include "protocols/redis/helpers.h"
 #include "protocols/postgres/helpers.h"
 #include "protocols/tls/tls.h"
+// TLS/Redis misclassification diagnostics: increment_telemetry_count + the diag event map.
+#include "tracer/telemetry.h"
+#include "protocols/classification/tls-misclassification-diag.h"
 
 // Some considerations about multiple protocol classification:
 //
@@ -195,6 +198,46 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint(struct
         return;
     }
 
+    // TLS/Redis misclassification diagnostics (see jmw/tls-misclassification).
+    //
+    if (!encryption_layer_known) {
+        tls_record_header_t diag_hdr = {0};
+        if (is_tls_record_header_plausible(skb, skb_info.data_off, skb_info.data_end, &diag_hdr)) {
+            // Link 1: is_tls() above requires the whole record to fit inside this packet
+            // (read_tls_record_header's final bounds check). Records run to 16 KB while MSS is
+            // ~1460, so genuine TLS reads as "not TLS" and classification falls through to the
+            // app-layer classifiers. This counter measures how often that door is opened.
+            if (skb_info.data_off + sizeof(tls_record_header_t) + diag_hdr.length > skb_info.data_end) {
+                increment_telemetry_count(tls_reject_record_exceeds_packet);
+                record_tls_misclassification_event(&skb_tup, TLS_DIAG_RECORD_EXCEEDS_PACKET, app_layer_proto, diag_hdr.content_type);
+            } else if (diag_hdr.content_type == TLS_HANDSHAKE &&
+                       !is_valid_tls_handshake(skb, skb_info.data_off, skb_info.data_end, &diag_hdr)) {
+                // Link 1, structural variant. The record fits, so the size check above is not the
+                // reason is_tls() failed; is_valid_tls_handshake() rejected it instead. It accepts
+                // ONLY ClientHello and ServerHello, and requires handshake_length + 4 to equal the
+                // record length exactly — so Certificate/ServerKeyExchange/Finished records,
+                // records carrying several coalesced handshake messages, and handshake messages
+                // fragmented across records all land here. This is how a brand-new connection can
+                // be misclassified, without any missed handshake.
+                //
+                // Note this only fires when is_tls() was actually reachable. If the app layer is
+                // already recorded, the gate above skips is_tls() entirely and the lock-out
+                // counter below is the correct attribution instead.
+                increment_telemetry_count(tls_reject_handshake_invalid);
+                record_tls_misclassification_event(&skb_tup, TLS_DIAG_HANDSHAKE_INVALID, app_layer_proto, diag_hdr.content_type);
+            }
+
+            // Link 3: the is_tls() call above is gated on the app layer being UNKNOWN or POSTGRES,
+            // so once any other protocol is recorded is_tls() can never run again for this
+            // connection — the wrong answer is pinned regardless of FLAG_FULLY_CLASSIFIED.
+            // Purely observational; no classification state is modified here.
+            if (app_layer_proto != PROTOCOL_UNKNOWN && app_layer_proto != PROTOCOL_POSTGRES) {
+                increment_telemetry_count(tls_locked_out_by_applayer);
+                record_tls_misclassification_event(&skb_tup, TLS_DIAG_LOCKED_OUT_BY_APPLAYER, app_layer_proto, diag_hdr.content_type);
+            }
+        }
+    }
+
     // If we have already classified the encryption layer, we can skip the rest of the classification
     if (encryption_layer_known) {
         return;
@@ -292,6 +335,34 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint_dbs(st
     protocol_t cur_fragment_protocol = classify_db_protocols(&classification_ctx->tuple, buffer, classification_ctx->buffer.size);
     if (!cur_fragment_protocol) {
         goto next_program;
+    }
+
+    // TLS/Redis misclassification diagnostics (see jmw/tls-misclassification and
+    // protocols/classification/tls-misclassification-diag.h).
+    //
+    // Link 2 of the suspected chain. is_redis() accepts a buffer on the strength of a single byte
+    // matching one of 14 RESP type markers, so it matches arbitrary ciphertext roughly 5.5% of the
+    // time. Two independent signals that a match here is spurious:
+    //
+    //   a) the buffer begins with a plausible TLS record header — near-conclusive, since no real
+    //      RESP frame starts with a valid content_type plus TLS version; and
+    //   b) Redis was matched on a port Redis never serves. Classification is purely content-based
+    //      (there are no port heuristics anywhere in it), so this is a false positive by
+    //      definition rather than a heuristic judgement.
+    //
+    // Both are observational only — the classification below is left exactly as it was.
+    {
+        tls_record_header_t diag_hdr = {0};
+        bool looks_like_tls = is_tls_record_header_plausible(skb, classification_ctx->skb_info.data_off, classification_ctx->skb_info.data_end, &diag_hdr);
+        if (looks_like_tls) {
+            increment_telemetry_count(applayer_match_on_tls_payload);
+            record_tls_misclassification_event(&classification_ctx->tuple, TLS_DIAG_APPLAYER_ON_TLS_PAYLOAD, cur_fragment_protocol, diag_hdr.content_type);
+        }
+        if (cur_fragment_protocol == PROTOCOL_REDIS &&
+            !is_standard_redis_port(classification_ctx->tuple.sport, classification_ctx->tuple.dport)) {
+            increment_telemetry_count(redis_match_on_nonstandard_port);
+            record_tls_misclassification_event(&classification_ctx->tuple, TLS_DIAG_REDIS_NONSTANDARD_PORT, cur_fragment_protocol, looks_like_tls ? diag_hdr.content_type : 0);
+        }
     }
 
     protocol_stack_t *protocol_stack = get_or_create_protocol_stack(&classification_ctx->tuple);

--- a/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
+++ b/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
@@ -100,6 +100,12 @@ static __always_inline protocol_t classify_applayer_protocols(const char *buf, _
 // Checks if a given buffer is redis, mongo, postgres, or mysql.
 static __always_inline protocol_t classify_db_protocols(conn_tuple_t *tup, const char *buf, __u32 size) {
     if (is_redis(buf, size)) {
+        // TLS-misclassification diagnostics: the third of three is_redis() call sites, counted
+        // unconditionally so all three are directly comparable. See
+        // protocols/classification/tls-misclassification-counters.h.
+        if (is_tls_diag_enabled()) {
+            tls_diag_count(TLS_DIAG_CTR_SOCKET_FILTER_REDIS);
+        }
         return PROTOCOL_REDIS;
     }
 

--- a/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
@@ -115,8 +115,14 @@ __maybe_unused static __always_inline void delete_protocol_stack(conn_tuple_t* n
     // event that tcp_close and the socket filter processing the FIN packet
     // execute at the same time, there is a chance that none of the callers
     // of this function will ever see both flags set.
-    // We assume this is rare and OK since we're using an LRU map which will
-    // eventually evict the leaked entry if it ever reaches capacity.
+    // We assume this is rare and OK since leaked entries are reclaimed by the
+    // userspace map cleaner (see setupConnectionProtocolMapCleaner in
+    // pkg/network/tracer/tracer.go), which periodically scans the map and
+    // deletes entries older than the connection-protocol TTL. Note that
+    // `connection_protocol` is a plain hash map, *not* an LRU map: once it is
+    // full, further inserts fail with E2BIG (surfaced via the
+    // bpf_map_update_with_telemetry error counters) rather than silently
+    // evicting the oldest entry.
     //
     // Note that we could instead have a reference count field and increment it
     // attomically using the __sync_fetch_and_add builtin, which produces a
@@ -127,7 +133,7 @@ __maybe_unused static __always_inline void delete_protocol_stack(conn_tuple_t* n
     //
     // In any case, even if we were using atomic operations, there is still a
     // chance of leak we can't avoid in the context of kprobe misses, so it's ok
-    // to rely on the LRU in those cases.
+    // to rely on the userspace map cleaner in those cases.
     stack->flags |= deletion_flag;
     if (!(stack->flags&FLAG_TCP_CLOSE_DELETION) ||
         !(stack->flags&FLAG_SOCKET_FILTER_DELETION)) {

--- a/pkg/network/ebpf/c/protocols/classification/tls-misclassification-counters.h
+++ b/pkg/network/ebpf/c/protocols/classification/tls-misclassification-counters.h
@@ -1,0 +1,62 @@
+#ifndef __TLS_MISCLASSIFICATION_COUNTERS_H
+#define __TLS_MISCLASSIFICATION_COUNTERS_H
+
+#include "ktypes.h"
+#include "map-defs.h"
+#include "compiler.h"
+
+// Counters for the TLS-reported-as-plaintext investigation that must be reachable from usm.c as
+// well as tracer.c. See jmw/tls-misclassification.
+//
+// Why a separate map rather than telemetry_t: telemetry_t lives in tracer/maps.h, and including
+// that from usm.c would declare every tracer map inside usm.o. This header deliberately depends
+// only on ktypes/map-defs/compiler so it can be included from either object.
+//
+// Why this exists at all: staging showed 248k tls_locked_out_by_applayer events on vaporeon-c, all
+// naming PROTOCOL_REDIS (16391), while the two counters at the socket-filter classification site
+// (applayer_match_on_tls_payload, redis_match_on_nonstandard_port) stayed at zero. The lock is
+// observed but never the act of locking, which means the Redis verdict is being written somewhere
+// other than protocol_classifier_entrypoint_dbs. is_redis() has two other callers, both in usm.c:
+// the protocol dispatcher and the decrypted-TLS path. Both call set_protocol() on the *shared*
+// connection_protocol stack, so either can produce the lock. These counters tell us which.
+//
+// USM Redis monitoring is confirmed enabled on the affected cluster (usm.redis.connections = 1223
+// over 24h), so the dispatcher path is live and is the leading suspect.
+
+typedef enum {
+    // is_redis() matched inside classify_protocol_for_dispatcher() (protocol dispatcher, usm.c).
+    TLS_DIAG_CTR_USM_DISPATCHER_REDIS = 0,
+    // is_redis() matched inside classify_decrypted_payload() (TLS uprobe path, usm.c). A match here
+    // is on *decrypted* bytes, so it may be a legitimate Redis-inside-TLS classification.
+    TLS_DIAG_CTR_USM_TLS_REDIS = 1,
+    // is_redis() matched inside classify_db_protocols() (socket filter, tracer.o). Counted
+    // unconditionally so it is directly comparable with the two USM counters above;
+    // redis_match_on_nonstandard_port only fires on a non-Redis port, which makes it useful as an
+    // invariant but useless as a "did this site fire" signal.
+    TLS_DIAG_CTR_SOCKET_FILTER_REDIS = 2,
+    TLS_DIAG_CTR_MAX = 4,
+} tls_diag_counter_t;
+
+BPF_ARRAY_MAP(tls_diag_usm_counters, __u64, TLS_DIAG_CTR_MAX)
+
+// is_tls_diag_enabled reports whether the diagnostics are active. Patched in by userspace before
+// load (see util.TLSDiagnosticsSupported), so at verification time it is a known constant and the
+// verifier prunes every guarded branch when false.
+//
+// NOTE: this constant must be supplied by *every* manager that loads an object containing these
+// branches — the tracer managers and the USM manager. If a manager forgets it, the value stays 0
+// and the counters silently read zero, which is indistinguishable from "the site never fired".
+static __always_inline bool is_tls_diag_enabled() {
+    __u64 val = 0;
+    LOAD_CONSTANT("tls_diag_enabled", val);
+    return val > 0;
+}
+
+static __always_inline void tls_diag_count(__u32 idx) {
+    __u64 *val = bpf_map_lookup_elem(&tls_diag_usm_counters, &idx);
+    if (val) {
+        __sync_fetch_and_add(val, 1);
+    }
+}
+
+#endif // __TLS_MISCLASSIFICATION_COUNTERS_H

--- a/pkg/network/ebpf/c/protocols/classification/tls-misclassification-diag-types.h
+++ b/pkg/network/ebpf/c/protocols/classification/tls-misclassification-diag-types.h
@@ -47,9 +47,7 @@ typedef struct {
     __u8 tls_content_type;
     // A tls_diag_reason_t value.
     __u8 reason;
-    // Whether userspace has already logged this entry, so repeat drains stay quiet.
-    __u8 logged;
-    __u8 _pad[3];
+    __u8 _pad[4];
 } tls_diag_event_t;
 
 #endif // __TLS_MISCLASSIFICATION_DIAG_TYPES_H

--- a/pkg/network/ebpf/c/protocols/classification/tls-misclassification-diag-types.h
+++ b/pkg/network/ebpf/c/protocols/classification/tls-misclassification-diag-types.h
@@ -1,0 +1,55 @@
+#ifndef __TLS_MISCLASSIFICATION_DIAG_TYPES_H
+#define __TLS_MISCLASSIFICATION_DIAG_TYPES_H
+
+#include "ktypes.h"
+
+// Types for the TLS-reported-as-plaintext diagnostics. Kept separate from
+// tls-misclassification-diag.h (which declares the BPF map and helpers) so this file can be
+// included by kprobe_types.go for cgo -godefs, where the BPF map machinery and kernel uapi headers
+// are not available. Same split as tls-certs-types.h vs tls-certs.h.
+
+// Reasons a diagnostic event is recorded. Keep in sync with the tlsDiag* constants in
+// pkg/network/tracer/connection/ebpf_tracer.go.
+typedef enum {
+    // A plausible TLS record header was seen whose record ran past the end of the packet, so
+    // is_tls() returned false on genuine TLS bytes (link 1).
+    TLS_DIAG_RECORD_EXCEEDS_PACKET = 1,
+    // An app-layer/db classifier matched a buffer that begins with a plausible TLS record
+    // header — the classification is almost certainly a false positive on ciphertext (link 2).
+    TLS_DIAG_APPLAYER_ON_TLS_PAYLOAD = 2,
+    // Redis was matched on a port Redis never serves. Classification is purely content-based
+    // (there are no port heuristics in it), so this is a false positive by definition (link 2).
+    TLS_DIAG_REDIS_NONSTANDARD_PORT = 3,
+    // A plausible TLS record header arrived on a connection whose app layer was already
+    // recorded, so is_tls() can never run again for it (link 3).
+    TLS_DIAG_LOCKED_OUT_BY_APPLAYER = 4,
+    // A handshake record fit entirely within the packet, yet is_tls() still rejected it because
+    // is_valid_tls_handshake() failed. That happens when the handshake type is anything other
+    // than ClientHello or ServerHello (Certificate, ServerKeyExchange, Finished, ...), when a
+    // record carries several coalesced handshake messages so handshake_length + 4 != record
+    // length, or when one handshake message is fragmented across records. Distinguishes
+    // "rejected for size" (link 1) from "rejected for structure", which is the path by which a
+    // brand-new connection can be affected.
+    TLS_DIAG_HANDSHAKE_INVALID = 5,
+} tls_diag_reason_t;
+
+typedef struct {
+    // Time the entry was first created, from bpf_ktime_get_ns().
+    __u64 timestamp;
+    // How many times this (tuple, reason) pair has fired since the entry was created. Lets
+    // userspace log once per connection while still reporting magnitude.
+    __u32 hits;
+    __u16 sport;
+    __u16 dport;
+    // The protocol_t already recorded at the application layer, or 0 if none.
+    __u16 app_layer_proto;
+    // TLS record content_type observed, when the reason involves a TLS header.
+    __u8 tls_content_type;
+    // A tls_diag_reason_t value.
+    __u8 reason;
+    // Whether userspace has already logged this entry, so repeat drains stay quiet.
+    __u8 logged;
+    __u8 _pad[3];
+} tls_diag_event_t;
+
+#endif // __TLS_MISCLASSIFICATION_DIAG_TYPES_H

--- a/pkg/network/ebpf/c/protocols/classification/tls-misclassification-diag.h
+++ b/pkg/network/ebpf/c/protocols/classification/tls-misclassification-diag.h
@@ -1,0 +1,85 @@
+#ifndef __TLS_MISCLASSIFICATION_DIAG_H
+#define __TLS_MISCLASSIFICATION_DIAG_H
+
+#include "ktypes.h"
+#include "map-defs.h"
+#include "conn_tuple.h"
+#include "protocols/classification/defs.h"
+#include "protocols/classification/tls-misclassification-diag-types.h"
+
+// Diagnostics for the suspected TLS-reported-as-plaintext root cause.
+// See the investigation notes on branch jmw/tls-misclassification.
+//
+// Suspected chain, on a connection whose TLS handshake was never observed by the socket filter
+// (established before system-probe started, or before its tuple was tracked):
+//
+//   1. is_tls() rejects genuine TLS bytes, because read_tls_record_header() requires the entire
+//      record to fit inside one packet. Records run to 16 KB; MSS is ~1460.
+//   2. Classification falls through to the app-layer classifiers. is_redis() tests a SINGLE byte
+//      against 14 RESP type markers, so it matches arbitrary ciphertext ~5.5% of the time.
+//   3. mark_as_fully_classified() plus the `app_layer_proto == UNKNOWN || POSTGRES` gate on the
+//      is_tls() call mean the wrong answer is pinned for the life of the map entry.
+//
+// Result: encrypted traffic is reported as tls_encrypted:false.
+//
+// The counters in telemetry_t quantify each link. This map carries the per-connection detail
+// (which port, which protocol, which TLS content type) that makes a report actionable, for
+// userspace to drain and log. It is an LRU map so a burst displaces older entries rather than
+// wedging the map once full; losing detail is acceptable because the counters are authoritative.
+
+
+// Standard Redis ports. Redis serves 6379 by convention (6380 for TLS), 26379 for Sentinel and
+// 16379 for the cluster bus. A Redis classification on anything else is not credible.
+#define REDIS_PORT_DEFAULT  6379
+#define REDIS_PORT_TLS      6380
+#define REDIS_PORT_CLUSTER 16379
+#define REDIS_PORT_SENTINEL 26379
+
+
+// Bounded deliberately: this is a diagnostic side channel, not a data path. 1024 entries is enough
+// to characterise a problem without meaningful memory cost.
+BPF_LRU_MAP(tls_diag_events, conn_tuple_t, tls_diag_event_t, 1024)
+
+// is_standard_redis_port reports whether either side of the tuple is a port Redis actually serves.
+static __always_inline bool is_standard_redis_port(__u16 sport, __u16 dport) {
+    return sport == REDIS_PORT_DEFAULT || dport == REDIS_PORT_DEFAULT ||
+           sport == REDIS_PORT_TLS || dport == REDIS_PORT_TLS ||
+           sport == REDIS_PORT_CLUSTER || dport == REDIS_PORT_CLUSTER ||
+           sport == REDIS_PORT_SENTINEL || dport == REDIS_PORT_SENTINEL;
+}
+
+// record_tls_misclassification_event records (or bumps the hit count on) a diagnostic event for
+// this connection. Keyed by the pre-normalization skb tuple with pid/netns zeroed, so repeated
+// observations of the same connection coalesce into one entry instead of flooding the map.
+//
+// Best-effort by design: a failed insert (map full and nothing evictable) is silently ignored,
+// since the telemetry_t counters remain the authoritative signal.
+static __always_inline void record_tls_misclassification_event(conn_tuple_t *tup, tls_diag_reason_t reason, __u16 app_layer_proto, __u8 tls_content_type) {
+    conn_tuple_t key = *tup;
+    key.pid = 0;
+    key.netns = 0;
+
+    tls_diag_event_t *existing = bpf_map_lookup_elem(&tls_diag_events, &key);
+    if (existing) {
+        // Only coalesce when it is the same finding; a different reason on the same connection is
+        // worth surfacing, so overwrite and let userspace log it again.
+        if (existing->reason == reason) {
+            __sync_fetch_and_add(&existing->hits, 1);
+            return;
+        }
+    }
+
+    tls_diag_event_t event = {};
+    event.timestamp = bpf_ktime_get_ns();
+    event.hits = 1;
+    event.sport = tup->sport;
+    event.dport = tup->dport;
+    event.app_layer_proto = app_layer_proto;
+    event.tls_content_type = tls_content_type;
+    event.reason = (__u8)reason;
+    event.logged = 0;
+
+    bpf_map_update_elem(&tls_diag_events, &key, &event, BPF_ANY);
+}
+
+#endif // __TLS_MISCLASSIFICATION_DIAG_H

--- a/pkg/network/ebpf/c/protocols/classification/tls-misclassification-diag.h
+++ b/pkg/network/ebpf/c/protocols/classification/tls-misclassification-diag.h
@@ -6,6 +6,7 @@
 #include "conn_tuple.h"
 #include "protocols/classification/defs.h"
 #include "protocols/classification/tls-misclassification-diag-types.h"
+#include "compiler.h"
 
 // Diagnostics for the suspected TLS-reported-as-plaintext root cause.
 // See the investigation notes on branch jmw/tls-misclassification.
@@ -34,6 +35,19 @@
 // on each drain to keep space available; if the map does fill between drains, further events are
 // dropped, which is acceptable because the telemetry_t counters remain authoritative.
 
+
+// is_tls_diag_enabled reports whether these diagnostics are active. The value is patched in by
+// userspace (see util.TLSDiagnosticsSupported) before the program is loaded, so at verification time
+// it is a known constant and the verifier prunes every guarded branch when it is false. That is what
+// keeps the classifier's complexity at baseline on older kernels, whose verifiers prune far less
+// aggressively and rejected socket__classifier_entry with these branches present.
+//
+// Note this does not reduce program size — the dead instructions still count toward BPF_MAXINSNS.
+static __always_inline bool is_tls_diag_enabled() {
+    __u64 val = 0;
+    LOAD_CONSTANT("tls_diag_enabled", val);
+    return val > 0;
+}
 
 // Standard Redis ports. Redis serves 6379 by convention (6380 for TLS), 26379 for Sentinel and
 // 16379 for the cluster bus. A Redis classification on anything else is not credible.

--- a/pkg/network/ebpf/c/protocols/classification/tls-misclassification-diag.h
+++ b/pkg/network/ebpf/c/protocols/classification/tls-misclassification-diag.h
@@ -6,7 +6,7 @@
 #include "conn_tuple.h"
 #include "protocols/classification/defs.h"
 #include "protocols/classification/tls-misclassification-diag-types.h"
-#include "compiler.h"
+#include "protocols/classification/tls-misclassification-counters.h"
 
 // Diagnostics for the suspected TLS-reported-as-plaintext root cause.
 // See the investigation notes on branch jmw/tls-misclassification.
@@ -35,19 +35,6 @@
 // on each drain to keep space available; if the map does fill between drains, further events are
 // dropped, which is acceptable because the telemetry_t counters remain authoritative.
 
-
-// is_tls_diag_enabled reports whether these diagnostics are active. The value is patched in by
-// userspace (see util.TLSDiagnosticsSupported) before the program is loaded, so at verification time
-// it is a known constant and the verifier prunes every guarded branch when it is false. That is what
-// keeps the classifier's complexity at baseline on older kernels, whose verifiers prune far less
-// aggressively and rejected socket__classifier_entry with these branches present.
-//
-// Note this does not reduce program size — the dead instructions still count toward BPF_MAXINSNS.
-static __always_inline bool is_tls_diag_enabled() {
-    __u64 val = 0;
-    LOAD_CONSTANT("tls_diag_enabled", val);
-    return val > 0;
-}
 
 // Standard Redis ports. Redis serves 6379 by convention (6380 for TLS), 26379 for Sentinel and
 // 16379 for the cluster bus. A Redis classification on anything else is not credible.

--- a/pkg/network/ebpf/c/protocols/classification/tls-misclassification-diag.h
+++ b/pkg/network/ebpf/c/protocols/classification/tls-misclassification-diag.h
@@ -24,8 +24,15 @@
 //
 // The counters in telemetry_t quantify each link. This map carries the per-connection detail
 // (which port, which protocol, which TLS content type) that makes a report actionable, for
-// userspace to drain and log. It is an LRU map so a burst displaces older entries rather than
-// wedging the map once full; losing detail is acceptable because the counters are authoritative.
+// userspace to drain and log.
+//
+// Deliberately a plain hash map, NOT an LRU map: BPF_MAP_TYPE_LRU_HASH was added in kernel 4.10,
+// but classification runs from 4.11 down through runtime compilation on far older kernels
+// (classificationMinimumKernel is 4.11, and KMT covers debian_9 / ubuntu_16.04 on 4.9 / 4.4).
+// Runtime compilation uses the host's kernel headers, so referencing the LRU enum there fails to
+// compile outright. A plain hash map does not evict, so userspace deletes every entry it visits
+// on each drain to keep space available; if the map does fill between drains, further events are
+// dropped, which is acceptable because the telemetry_t counters remain authoritative.
 
 
 // Standard Redis ports. Redis serves 6379 by convention (6380 for TLS), 26379 for Sentinel and
@@ -38,7 +45,7 @@
 
 // Bounded deliberately: this is a diagnostic side channel, not a data path. 1024 entries is enough
 // to characterise a problem without meaningful memory cost.
-BPF_LRU_MAP(tls_diag_events, conn_tuple_t, tls_diag_event_t, 1024)
+BPF_HASH_MAP(tls_diag_events, conn_tuple_t, tls_diag_event_t, 1024)
 
 // is_standard_redis_port reports whether either side of the tuple is a port Redis actually serves.
 static __always_inline bool is_standard_redis_port(__u16 sport, __u16 dport) {
@@ -52,8 +59,8 @@ static __always_inline bool is_standard_redis_port(__u16 sport, __u16 dport) {
 // this connection. Keyed by the pre-normalization skb tuple with pid/netns zeroed, so repeated
 // observations of the same connection coalesce into one entry instead of flooding the map.
 //
-// Best-effort by design: a failed insert (map full and nothing evictable) is silently ignored,
-// since the telemetry_t counters remain the authoritative signal.
+// Best-effort by design: a failed insert (map full, since a plain hash map does not evict) is
+// silently ignored, because the telemetry_t counters remain the authoritative signal.
 static __always_inline void record_tls_misclassification_event(conn_tuple_t *tup, tls_diag_reason_t reason, __u16 app_layer_proto, __u8 tls_content_type) {
     conn_tuple_t key = *tup;
     key.pid = 0;
@@ -77,7 +84,6 @@ static __always_inline void record_tls_misclassification_event(conn_tuple_t *tup
     event.app_layer_proto = app_layer_proto;
     event.tls_content_type = tls_content_type;
     event.reason = (__u8)reason;
-    event.logged = 0;
 
     bpf_map_update_elem(&tls_diag_events, &key, &event, BPF_ANY);
 }

--- a/pkg/network/ebpf/c/protocols/redis/helpers.h
+++ b/pkg/network/ebpf/c/protocols/redis/helpers.h
@@ -4,31 +4,6 @@
 #include "protocols/classification/common.h"
 #include "protocols/redis/defs.h"
 
-// Checks the buffer represent a standard response (OK) or any of redis commands
-// https://redis.io/commands/
-static __always_inline __maybe_unused bool check_supported_ascii_and_crlf(const char* buf, __u32 buf_size, int index_to_start_from) {
-    bool found_cr = false;
-    char current_char;
-    int i = index_to_start_from;
-#pragma unroll(CLASSIFICATION_MAX_BUFFER)
-    for (; i < CLASSIFICATION_MAX_BUFFER; i++) {
-        current_char = buf[i];
-        if (current_char == '\r') {
-            found_cr = true;
-            break;
-        } else if ('A' <= current_char && current_char <= 'Z') {
-            continue;
-        } else if ('a' <= current_char && current_char <= 'z') {
-            continue;
-        } else if (current_char == '.' || current_char == ' ' || current_char == '-' || current_char == '_') {
-            continue;
-        }
-        return false;
-    }
-
-    return found_cr && i + 1 < buf_size && i + 1 < CLASSIFICATION_MAX_BUFFER && buf[i + 1] == '\n';
-}
-
 static __always_inline __maybe_unused void convert_method_to_upper_case(char* method) {
     #pragma unroll (MAX_METHOD_LEN)
     for (int i = 0; i < MAX_METHOD_LEN; i++) {
@@ -39,7 +14,7 @@ static __always_inline __maybe_unused void convert_method_to_upper_case(char* me
 }
 
 // Checks the buffer represents an error according to https://redis.io/docs/reference/protocol-spec/#resp-errors
-static __always_inline __maybe_unused bool check_err_prefix(const char* buf, __u32 buf_size) {
+static __always_inline bool check_err_prefix(const char* buf, __u32 buf_size) {
 #define ERR "-ERR "
 #define WRONGTYPE "-WRONGTYPE "
 
@@ -52,48 +27,140 @@ static __always_inline __maybe_unused bool check_err_prefix(const char* buf, __u
     return match;
 }
 
-static __always_inline __maybe_unused bool check_integer_and_crlf(const char* buf, __u32 buf_size, int index_to_start_from) {
-    bool found_cr = false;
-    char current_char;
-    int i = index_to_start_from;
-#pragma unroll(CLASSIFICATION_MAX_BUFFER)
-    for (; i < CLASSIFICATION_MAX_BUFFER; i++) {
-        current_char = buf[i];
-        if (current_char == '\r') {
-            found_cr = true;
-            break;
-        } else if ('0' <= current_char && current_char <= '9') {
-            continue;
-        }
+// Character classes permitted between a RESP type byte and the CRLF that
+// terminates its first field. Passed as a mask so that every RESP type shares
+// one validator rather than each growing its own.
+#define RESP_CLASS_DIGIT (1 << 0) // 0-9
+#define RESP_CLASS_SIGN  (1 << 1) // '-' or '+', leading position only
+#define RESP_CLASS_DOT   (1 << 2) // '.', for RESP3 doubles
+#define RESP_CLASS_ALPHA (1 << 3) // A-Za-z, for +OK, -ERR, inf/nan
+#define RESP_CLASS_PUNCT (1 << 4) // ' ', '-', '_', for error and status text
 
-        return false;
+// Is c acceptable inside a RESP field of the given classes? `first` marks the
+// byte immediately after the type prefix, the only position a sign may occupy.
+static __always_inline bool resp_char_allowed(char c, __u8 allowed_classes, bool first) {
+    if ((allowed_classes & RESP_CLASS_DIGIT) && '0' <= c && c <= '9') {
+        return true;
     }
-
-    return found_cr && i + 1 < buf_size && i + 1 < CLASSIFICATION_MAX_BUFFER && buf[i + 1] == '\n';
+    if ((allowed_classes & RESP_CLASS_SIGN) && first && (c == '-' || c == '+')) {
+        return true;
+    }
+    if ((allowed_classes & RESP_CLASS_DOT) && c == '.') {
+        return true;
+    }
+    if ((allowed_classes & RESP_CLASS_ALPHA) && (('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z'))) {
+        return true;
+    }
+    if ((allowed_classes & RESP_CLASS_PUNCT) && (c == ' ' || c == '-' || c == '_')) {
+        return true;
+    }
+    return false;
 }
 
+// Examines one fixed position N of the field. If buf[N] is CR the field ends
+// there, and the frame is valid iff at least one payload byte preceded it and
+// LF follows. Otherwise buf[N] must be an allowed character.
+//
+// N is always a literal. That is the whole point: a loop over this buffer gets
+// unrolled into offsets the verifier cannot bound — the runtime-compiled build
+// rejects it with "invalid access to map value" one byte past the end — and
+// masking the index to a power of two does not help, because the optimiser
+// discards the mask it can already prove redundant. Literal indices give the
+// verifier constant offsets with nothing left to prove. Do not convert this
+// back into a loop.
+#define RESP_FIELD_STEP(N)                                                  \
+    do {                                                                    \
+        if ((N) + 1 >= buf_size) {                                          \
+            return false;                                                   \
+        }                                                                   \
+        if (buf[(N)] == RESP_TERMINATOR_1) {                                \
+            return (N) > 1 && buf[(N) + 1] == RESP_TERMINATOR_2;            \
+        }                                                                   \
+        if (!resp_char_allowed(buf[(N)], allowed_classes, (N) == 1)) {      \
+            return false;                                                   \
+        }                                                                   \
+    } while (0)
+
+// Validates the first field of a RESP frame: the bytes between the type prefix
+// at buf[0] and the CRLF that terminates the field.
+//
+// Only the first RESP_FIELD_MAX_LEN bytes are examined. A field longer than
+// that is rejected rather than accepted on faith — a payload we cannot
+// positively identify as RESP must not be classified as Redis. That covers
+// every field we classify on in practice: length and count prefixes, +OK,
+// +PONG, -ERR ....
+#define RESP_FIELD_MAX_LEN 9
+static __always_inline bool check_resp_field_and_crlf(const char* buf, __u32 buf_size, __u8 allowed_classes) {
+    RESP_FIELD_STEP(1);
+    RESP_FIELD_STEP(2);
+    RESP_FIELD_STEP(3);
+    RESP_FIELD_STEP(4);
+    RESP_FIELD_STEP(5);
+    RESP_FIELD_STEP(6);
+    RESP_FIELD_STEP(7);
+    RESP_FIELD_STEP(8);
+    RESP_FIELD_STEP(9);
+    return false;
+}
+
+// Text fields: the character set the previous validator accepted for simple
+// strings and errors (A-Za-z plus '.', ' ', '-', '_'), minus the unbounded scan.
+#define RESP_CLASS_TEXT (RESP_CLASS_ALPHA | RESP_CLASS_DOT | RESP_CLASS_PUNCT)
+
+// is_redis reports whether buf holds the start of a RESP frame.
+//
+// The type byte alone is not sufficient evidence. A bare switch on buf[0]
+// accepts 14 of 256 values, so it matches ~5.5% of arbitrary payloads — enough
+// to claim TLS ciphertext. That is not a cosmetic mis-label: once the app layer
+// is set to Redis, the encryption-layer gate in protocol_classifier_entrypoint
+// stops running is_tls() for the life of the connection, and the connection is
+// reported with tls_encrypted:false. Measured on one staging cluster over one
+// hour: 6.00k connections wrongly tagged redis, of which 16.8GB was Kafka.
+//
+// So every type byte is now followed by a check on the shape of the frame's
+// first field — a decimal length or count, a signed number, or CRLF-terminated
+// text. Frames whose terminator falls outside the classification buffer are
+// rejected; giving up is the safe direction, and the caller retries on later
+// packets.
 static __always_inline bool is_redis(const char* buf, __u32 buf_size) {
     CHECK_PRELIMINARY_BUFFER_CONDITIONS(buf, buf_size, REDIS_MIN_FRAME_LENGTH);
 
-    char first_char = buf[0];
-    switch (first_char) {
-    // RESP2 types
-    case '+':  // Simple String
-    case '-':  // Error
-    case ':':  // Integer
-    case '$':  // Bulk String
-    case '*':  // Array
-    // RESP3 types (Redis 6.0+)
-    case '_':  // Null
-    case '#':  // Boolean
-    case ',':  // Double
-    case '(':  // Big Number
-    case '!':  // Bulk Error
-    case '=':  // Verbatim String
-    case '%':  // Map
-    case '~':  // Set
-    case '>':  // Push
-        return true;
+    switch (buf[0]) {
+    // Length- and count-prefixed types: <type><decimal>\r\n. The sign class also
+    // admits the null forms $-1\r\n and *-1\r\n.
+    case RESP_ARRAY_PREFIX:            // Array
+    case RESP_BULK_PREFIX:             // Bulk String
+    case RESP3_BULK_ERROR_PREFIX:      // Bulk Error
+    case RESP3_VERBATIM_STRING_PREFIX: // Verbatim String
+    case RESP3_MAP_PREFIX:             // Map
+    case RESP3_SET_PREFIX:             // Set
+    case RESP3_PUSH_PREFIX:            // Push
+    // Integers and big numbers are the same shape. A big number longer than the
+    // classification buffer will not find its terminator and is rejected.
+    case RESP_INTEGER_PREFIX:          // Integer
+    case RESP3_BIG_NUMBER_PREFIX:      // Big Number
+        return check_resp_field_and_crlf(buf, buf_size,RESP_CLASS_DIGIT | RESP_CLASS_SIGN);
+
+    // Doubles additionally carry '.' and the literals inf, -inf and nan.
+    case RESP3_DOUBLE_PREFIX:          // Double
+        return check_resp_field_and_crlf(buf, buf_size,RESP_CLASS_DIGIT | RESP_CLASS_SIGN | RESP_CLASS_DOT | RESP_CLASS_ALPHA);
+
+    // Simple strings: +OK\r\n, +PONG\r\n.
+    case RESP_SIMPLE_STRING_PREFIX:    // Simple String
+        return check_resp_field_and_crlf(buf, buf_size,RESP_CLASS_TEXT);
+
+    // Errors: -ERR ..., -WRONGTYPE ..., or other CRLF-terminated text.
+    case RESP_ERROR_PREFIX:            // Error
+        return check_err_prefix(buf, buf_size) || check_resp_field_and_crlf(buf, buf_size,RESP_CLASS_TEXT);
+
+    // RESP3 null is exactly _\r\n. REDIS_MIN_FRAME_LENGTH guarantees 3 bytes.
+    case RESP3_NULL_PREFIX:            // Null
+        return buf[1] == RESP_TERMINATOR_1 && buf[2] == RESP_TERMINATOR_2;
+
+    // RESP3 boolean is exactly #t\r\n or #f\r\n.
+    case RESP3_BOOLEAN_PREFIX:         // Boolean
+        return buf_size > 3 && (buf[1] == 't' || buf[1] == 'f') && buf[2] == RESP_TERMINATOR_1 && buf[3] == RESP_TERMINATOR_2;
+
     default:
         return false;
     }

--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -2,6 +2,7 @@
 #define __HTTPS_H
 
 #ifdef COMPILE_CORE
+#include "protocols/classification/tls-misclassification-counters.h"
 #include "ktypes.h"
 #define MINORBITS	20
 #define MINORMASK	((1U << MINORBITS) - 1)
@@ -55,6 +56,13 @@ static __always_inline void classify_decrypted_payload(protocol_stack_t *stack, 
         proto = PROTOCOL_AMQP;
     } else if (is_redis(buffer, len)) {
         proto = PROTOCOL_REDIS;
+        // TLS-misclassification diagnostics (jmw/tls-misclassification). Second uninstrumented
+        // is_redis() call site. Note this one runs on *decrypted* bytes, so a match here may be a
+        // legitimate Redis-inside-TLS classification rather than a false positive — which is
+        // exactly why it is counted separately from the dispatcher.
+        if (is_tls_diag_enabled()) {
+            tls_diag_count(TLS_DIAG_CTR_USM_TLS_REDIS);
+        }
     } else if (is_mysql(t, buffer, len)) {
         proto = PROTOCOL_MYSQL;
     }

--- a/pkg/network/ebpf/c/protocols/tls/tls.h
+++ b/pkg/network/ebpf/c/protocols/tls/tls.h
@@ -207,6 +207,47 @@ static __always_inline bool is_valid_tls_handshake(struct __sk_buff *skb, __u32 
     return true;
 }
 
+// is_tls_record_header_plausible validates ONLY the content_type and version of a TLS record
+// header. Unlike read_tls_record_header() it deliberately does NOT require the declared record
+// length to fit within the current packet.
+//
+// This exists for diagnostics: a TLS record may be up to TLS_MAX_PAYLOAD_LENGTH (16 KB) while a
+// typical MSS is ~1460 bytes, so a perfectly valid record header whose record spans several TCP
+// segments is rejected by read_tls_record_header()'s final bounds check. Callers that want to know
+// "did these bytes *look* like the start of a TLS record?" — as opposed to "can I safely parse the
+// whole record here?" — should use this instead.
+//
+// Do NOT use this to drive classification decisions; a one-byte content_type plus a two-byte
+// version is far weaker evidence than is_tls() requires, and would raise the false-positive rate.
+__maybe_unused static __always_inline bool is_tls_record_header_plausible(struct __sk_buff *skb, __u32 header_offset, __u32 data_end, tls_record_header_t *tls_hdr) {
+    if (header_offset + sizeof(tls_record_header_t) > data_end) {
+        return false;
+    }
+    if (bpf_skb_load_bytes(skb, header_offset, tls_hdr, sizeof(tls_record_header_t)) < 0) {
+        return false;
+    }
+
+    tls_hdr->version = bpf_ntohs(tls_hdr->version);
+    tls_hdr->length = bpf_ntohs(tls_hdr->length);
+
+    if (!is_valid_tls_version(tls_hdr->version)) {
+        return false;
+    }
+    if (tls_hdr->length > TLS_MAX_PAYLOAD_LENGTH) {
+        return false;
+    }
+
+    switch (tls_hdr->content_type) {
+    case TLS_HANDSHAKE:
+    case TLS_APPLICATION_DATA:
+    case TLS_CHANGE_CIPHER_SPEC:
+    case TLS_ALERT:
+        return true;
+    default:
+        return false;
+    }
+}
+
 // is_tls checks if the packet is a TLS packet by reading and validating the TLS record header
 // Reference: RFC 5246 Section 6.2.1 (Record Layer), https://tools.ietf.org/html/rfc5246#section-6.2.1
 // Validates that content_type matches known TLS types (Handshake, Application Data, etc.).

--- a/pkg/network/ebpf/c/tracer/telemetry.h
+++ b/pkg/network/ebpf/c/tracer/telemetry.h
@@ -26,6 +26,12 @@ enum telemetry_counter {
     tcp_done_connection_flush,
     tcp_close_connection_flush,
     tcp_syn_retransmit,
+    // TLS-vs-Redis misclassification diagnostics (see jmw/tls-misclassification)
+    tls_reject_record_exceeds_packet,
+    tls_reject_handshake_invalid,
+    applayer_match_on_tls_payload,
+    redis_match_on_nonstandard_port,
+    tls_locked_out_by_applayer,
 };
 
 static __always_inline void __increment_telemetry_count(enum telemetry_counter counter_name, int times) {
@@ -69,6 +75,21 @@ static __always_inline void __increment_telemetry_count(enum telemetry_counter c
         break;
     case tcp_syn_retransmit:
         __sync_fetch_and_add(&val->tcp_syn_retransmit, times);
+        break;
+    case tls_reject_record_exceeds_packet:
+        __sync_fetch_and_add(&val->tls_reject_record_exceeds_packet, times);
+        break;
+    case tls_reject_handshake_invalid:
+        __sync_fetch_and_add(&val->tls_reject_handshake_invalid, times);
+        break;
+    case applayer_match_on_tls_payload:
+        __sync_fetch_and_add(&val->applayer_match_on_tls_payload, times);
+        break;
+    case redis_match_on_nonstandard_port:
+        __sync_fetch_and_add(&val->redis_match_on_nonstandard_port, times);
+        break;
+    case tls_locked_out_by_applayer:
+        __sync_fetch_and_add(&val->tls_locked_out_by_applayer, times);
         break;
     }
 }

--- a/pkg/network/ebpf/c/tracer/tracer.h
+++ b/pkg/network/ebpf/c/tracer/tracer.h
@@ -139,6 +139,25 @@ typedef struct {
     __u64 tcp_done_connection_flush;
     __u64 tcp_close_connection_flush;
     __u64 tcp_syn_retransmit;
+    // TLS-vs-Redis misclassification diagnostics (see jmw/tls-misclassification).
+    // These validate a specific suspected root cause: on a connection whose TLS handshake was
+    // never observed, is_tls() rejects large records (they span segments), the loose one-byte
+    // is_redis() check then matches ciphertext, and mark_as_fully_classified() pins that wrong
+    // answer permanently — reporting encrypted traffic as tls_encrypted:false.
+    //
+    // Link 1: is_tls() bailed out solely because the record ran past the end of the packet.
+    __u64 tls_reject_record_exceeds_packet;
+    // Link 1 (variant): a handshake record fit in the packet but is_valid_tls_handshake() rejected
+    // it — handshake type other than Client/ServerHello, coalesced messages, or a fragmented
+    // message. This is the path by which a brand-new connection can be misclassified.
+    __u64 tls_reject_handshake_invalid;
+    // Link 2: a db-layer protocol matched a buffer that begins with a plausible TLS record header.
+    __u64 applayer_match_on_tls_payload;
+    // Link 2: Redis matched on a port Redis never serves — a false positive by definition.
+    __u64 redis_match_on_nonstandard_port;
+    // Link 3: a plausible TLS record header was seen but the app layer was already locked in,
+    // so is_tls() could never run again for this connection.
+    __u64 tls_locked_out_by_applayer;
 } telemetry_t;
 
 typedef struct {

--- a/pkg/network/ebpf/kprobe_types.go
+++ b/pkg/network/ebpf/kprobe_types.go
@@ -14,6 +14,7 @@ package ebpf
 #include "./c/prebuilt/offset-guess.h"
 #include "./c/protocols/classification/defs.h"
 #include "./c/protocols/tls/tls-certs-types.h"
+#include "./c/protocols/classification/tls-misclassification-diag-types.h"
 
 */
 import "C"
@@ -39,6 +40,7 @@ type CertSerial C.cert_serial_t
 type CertDomain C.cert_domain_t
 type CertValidity C.cert_validity_t
 type SSLHandshakeState C.ssl_handshake_state_t
+type TLSDiagEvent C.tls_diag_event_t
 
 // udp_recv_sock_t have *sock and *msghdr struct members, we make them opaque here
 type _Ctype_struct_sock uint64

--- a/pkg/network/ebpf/kprobe_types_linux.go
+++ b/pkg/network/ebpf/kprobe_types_linux.go
@@ -151,8 +151,7 @@ type TLSDiagEvent struct {
 	App_layer_proto  uint16
 	Tls_content_type uint8
 	Reason           uint8
-	Logged           uint8
-	X_pad            [3]uint8
+	X_pad            [4]uint8
 }
 
 type _Ctype_struct_sock uint64

--- a/pkg/network/ebpf/kprobe_types_linux.go
+++ b/pkg/network/ebpf/kprobe_types_linux.go
@@ -62,18 +62,23 @@ type PidTs struct {
 	Timestamp uint64
 }
 type Telemetry struct {
-	Tcp_sent_miscounts              uint64
-	Udp_sends_processed             uint64
-	Udp_sends_missed                uint64
-	Udp_dropped_conns               uint64
-	Tcp_done_missing_pid            uint64
-	Tcp_connect_failed_tuple        uint64
-	Tcp_done_failed_tuple           uint64
-	Tcp_finish_connect_failed_tuple uint64
-	Tcp_close_target_failures       uint64
-	Tcp_done_connection_flush       uint64
-	Tcp_close_connection_flush      uint64
-	Tcp_syn_retransmit              uint64
+	Tcp_sent_miscounts               uint64
+	Udp_sends_processed              uint64
+	Udp_sends_missed                 uint64
+	Udp_dropped_conns                uint64
+	Tcp_done_missing_pid             uint64
+	Tcp_connect_failed_tuple         uint64
+	Tcp_done_failed_tuple            uint64
+	Tcp_finish_connect_failed_tuple  uint64
+	Tcp_close_target_failures        uint64
+	Tcp_done_connection_flush        uint64
+	Tcp_close_connection_flush       uint64
+	Tcp_syn_retransmit               uint64
+	Tls_reject_record_exceeds_packet uint64
+	Tls_reject_handshake_invalid     uint64
+	Applayer_match_on_tls_payload    uint64
+	Redis_match_on_nonstandard_port  uint64
+	Tls_locked_out_by_applayer       uint64
 }
 type PortBinding struct {
 	Netns     uint32
@@ -137,6 +142,17 @@ type SSLHandshakeState struct {
 	Item      CertItem
 	Id        uint32
 	Pad_cgo_0 [4]byte
+}
+type TLSDiagEvent struct {
+	Timestamp        uint64
+	Hits             uint32
+	Sport            uint16
+	Dport            uint16
+	App_layer_proto  uint16
+	Tls_content_type uint8
+	Reason           uint8
+	Logged           uint8
+	X_pad            [3]uint8
 }
 
 type _Ctype_struct_sock uint64

--- a/pkg/network/ebpf/kprobe_types_linux_test.go
+++ b/pkg/network/ebpf/kprobe_types_linux_test.go
@@ -91,3 +91,7 @@ func TestCgoAlignment_CertValidity(t *testing.T) {
 func TestCgoAlignment_SSLHandshakeState(t *testing.T) {
 	ebpftest.TestCgoAlignment[SSLHandshakeState](t)
 }
+
+func TestCgoAlignment_TLSDiagEvent(t *testing.T) {
+	ebpftest.TestCgoAlignment[TLSDiagEvent](t)
+}

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -254,6 +254,10 @@ const (
 	ConnectionTupleToSocketSKBConnMap BPFMapName = "conn_tuple_to_socket_skb_conn_tuple"
 	// EnhancedTLSTagsMap is the map storing additional tags for TLS connections (version, cipher, etc.)
 	EnhancedTLSTagsMap BPFMapName = "tls_enhanced_tags"
+	// TLSDiagEventsMap is the diagnostic side channel for the TLS-reported-as-plaintext
+	// investigation: per-connection detail about suspected protocol misclassifications.
+	// See pkg/network/ebpf/c/protocols/classification/tls-misclassification-diag.h
+	TLSDiagEventsMap BPFMapName = "tls_diag_events"
 	// ClassificationProgsMap is the map storing the programs to run on classification events
 	ClassificationProgsMap BPFMapName = "classification_progs"
 )

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -258,6 +258,10 @@ const (
 	// investigation: per-connection detail about suspected protocol misclassifications.
 	// See pkg/network/ebpf/c/protocols/classification/tls-misclassification-diag.h
 	TLSDiagEventsMap BPFMapName = "tls_diag_events"
+	// TLSDiagUSMCountersMap counts is_redis() matches at the two call sites that live in usm.c
+	// (the protocol dispatcher and the decrypted-TLS path), which the socket-filter counters do
+	// not cover. Shared into the USM manager so both objects increment the same map.
+	TLSDiagUSMCountersMap BPFMapName = "tls_diag_usm_counters"
 	// ClassificationProgsMap is the map storing the programs to run on classification events
 	ClassificationProgsMap BPFMapName = "classification_progs"
 )

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -70,11 +70,17 @@ type EbpfTracerTelemetryData struct {
 	tcpCloseConnectionFlush     *prometheus.Desc
 	tcpFailedConnections        telemetryComponent.Counter
 	tcpSynRetransmit            *prometheus.Desc
-	ongoingConnectPidCleaned    telemetryComponent.Counter
-	PidCollisions               *telemetryComponent.StatCounterWrapper
-	iterationDups               telemetryComponent.Counter
-	iterationAborts             telemetryComponent.Counter
-	sslCertMissed               telemetryComponent.Counter
+	// TLS/Redis misclassification diagnostics (see jmw/tls-misclassification)
+	tlsRejectRecordExceedsPacket *prometheus.Desc
+	tlsRejectHandshakeInvalid    *prometheus.Desc
+	applayerMatchOnTLSPayload    *prometheus.Desc
+	redisMatchOnNonstandardPort  *prometheus.Desc
+	tlsLockedOutByApplayer       *prometheus.Desc
+	ongoingConnectPidCleaned     telemetryComponent.Counter
+	PidCollisions                *telemetryComponent.StatCounterWrapper
+	iterationDups                telemetryComponent.Counter
+	iterationAborts              telemetryComponent.Counter
+	sslCertMissed                telemetryComponent.Counter
 
 	mu sync.Mutex
 
@@ -91,6 +97,12 @@ type EbpfTracerTelemetryData struct {
 	lastTCPDoneConnectionFlush      int64
 	lastTCPCloseConnectionFlush     int64
 	lastTCPSynRetransmit            int64
+	// TLS/Redis misclassification diagnostics (see jmw/tls-misclassification)
+	lastTLSRejectRecordExceedsPacket int64
+	lastTLSRejectHandshakeInvalid    int64
+	lastApplayerMatchOnTLSPayload    int64
+	lastRedisMatchOnNonstandardPort  int64
+	lastTLSLockedOutByApplayer       int64
 }
 
 // EbpfTracerTelemetry holds telemetry from the EBPF tracer
@@ -109,6 +121,11 @@ var EbpfTracerTelemetry = EbpfTracerTelemetryData{
 	prometheus.NewDesc(connTracerModuleName+"__tcp_close_connection_flush", "Counter measuring the number of connection flushes performed in tcp_close", nil, nil),
 	telemetryimpl.GetCompatComponent().NewCounter(connTracerModuleName, "tcp_failed_connections", []string{"errno"}, "Gauge measuring the number of unsupported failed TCP connections"),
 	prometheus.NewDesc(connTracerModuleName+"__tcp_syn_retransmit", "Counter measuring the number of tcp retransmits of syn packets", nil, nil),
+	prometheus.NewDesc(connTracerModuleName+"__tls_reject_record_exceeds_packet", "Counter measuring plausible TLS record headers rejected by is_tls() solely because the record ran past the end of the packet", nil, nil),
+	prometheus.NewDesc(connTracerModuleName+"__tls_reject_handshake_invalid", "Counter measuring TLS handshake records that fit within the packet but were still rejected by is_valid_tls_handshake (non-Hello handshake type, coalesced messages, or a fragmented message)", nil, nil),
+	prometheus.NewDesc(connTracerModuleName+"__applayer_match_on_tls_payload", "Counter measuring db-layer protocol classifications on a buffer that begins with a plausible TLS record header (suspected false positive on ciphertext)", nil, nil),
+	prometheus.NewDesc(connTracerModuleName+"__redis_match_on_nonstandard_port", "Counter measuring Redis classifications on ports Redis does not serve (false positive by definition)", nil, nil),
+	prometheus.NewDesc(connTracerModuleName+"__tls_locked_out_by_applayer", "Counter measuring plausible TLS record headers seen on connections whose application layer was already recorded, preventing is_tls() from ever running again", nil, nil),
 	telemetryimpl.GetCompatComponent().NewCounter(connTracerModuleName, "ongoing_connect_pid_cleaned", []string{}, "Counter measuring the number of tcp_ongoing_connect_pid entries cleaned in userspace"),
 	telemetryComponent.NewStatCounterWrapper(telemetryimpl.GetCompatComponent(), connTracerModuleName, "pid_collisions", []string{}, "Counter measuring number of process collisions"),
 	telemetryimpl.GetCompatComponent().NewCounter(connTracerModuleName, "iteration_dups", []string{}, "Counter measuring the number of connections iterated more than once"),
@@ -122,6 +139,12 @@ var EbpfTracerTelemetry = EbpfTracerTelemetryData{
 	0,
 	0,
 	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	// TLS/Redis misclassification diagnostics
 	0,
 	0,
 	0,
@@ -149,7 +172,10 @@ type ebpfTracer struct {
 	ebpfTelemetryMap        *maps.GenericMap[uint32, netebpf.Telemetry]
 	tcpFailuresTelemetryMap *maps.GenericMap[int32, uint64]
 	sslCertInfoMap          *maps.GenericMap[uint32, netebpf.CertItem]
-	config                  *config.Config
+	// tlsDiagEventsMap is the diagnostic side channel for the TLS-reported-as-plaintext
+	// investigation. See jmw/tls-misclassification.
+	tlsDiagEventsMap *maps.GenericMap[netebpf.ConnTuple, netebpf.TLSDiagEvent]
+	config           *config.Config
 
 	// tcp_close events
 	closeConsumer *tcpCloseConsumer
@@ -363,6 +389,11 @@ func newEbpfTracer(config *config.Config, _ telemetryComponent.Component) (Trace
 		tr.sslCertInfoMap, err = maps.GetMap[uint32, netebpf.CertItem](m.Manager, probes.SSLCertInfoMap)
 		if err != nil {
 			log.Warnf("error retrieving ssl cert info map: %s", err)
+		}
+
+		tr.tlsDiagEventsMap, err = maps.GetMap[netebpf.ConnTuple, netebpf.TLSDiagEvent](m.Manager, probes.TLSDiagEventsMap)
+		if err != nil {
+			log.Warnf("error retrieving TLS diagnostic events map: %s", err)
 		}
 	}
 
@@ -754,6 +785,92 @@ func (t *ebpfTracer) getTCPFailureTelemetry() map[int32]uint64 {
 	return result
 }
 
+// Reasons a TLS-misclassification diagnostic event was recorded. Must stay in sync with
+// tls_diag_reason_t in pkg/network/ebpf/c/protocols/classification/tls-misclassification-diag.h
+const (
+	tlsDiagRecordExceedsPacket  uint8 = 1
+	tlsDiagApplayerOnTLSPayload uint8 = 2
+	tlsDiagRedisNonstandardPort uint8 = 3
+	tlsDiagLockedOutByApplayer  uint8 = 4
+	tlsDiagHandshakeInvalid     uint8 = 5
+)
+
+// tlsDiagMaxLogsPerCollect bounds how many diagnostic lines we emit per telemetry scrape. The
+// counters are the authoritative signal; these logs exist to identify *which* connections are
+// affected, so a handful per scrape is plenty and keeps a broadly-affected host from flooding
+// its own log file.
+const tlsDiagMaxLogsPerCollect = 5
+
+func tlsDiagReasonString(reason uint8) string {
+	switch reason {
+	case tlsDiagRecordExceedsPacket:
+		return "tls_record_exceeds_packet (is_tls rejected a valid header because the record spans segments)"
+	case tlsDiagApplayerOnTLSPayload:
+		return "applayer_match_on_tls_payload (db classifier matched a buffer starting with a TLS record header)"
+	case tlsDiagRedisNonstandardPort:
+		return "redis_match_on_nonstandard_port (Redis classified on a port Redis does not serve)"
+	case tlsDiagLockedOutByApplayer:
+		return "tls_locked_out_by_applayer (TLS header seen but app layer already recorded, is_tls can never run again)"
+	case tlsDiagHandshakeInvalid:
+		return "tls_reject_handshake_invalid (handshake record fit the packet but is_valid_tls_handshake rejected it: non-Hello type, coalesced, or fragmented)"
+	default:
+		return "unknown"
+	}
+}
+
+// logTLSDiagEvents drains the diagnostic side channel populated by the classifier and logs each
+// distinct finding once, at info level, so the data is available on a normal staging build without
+// enabling debug logging fleet-wide.
+//
+// Entries are marked as logged in place rather than deleted, so the hit counter keeps accumulating
+// and a subsequent scrape can show whether a finding is still firing without re-logging it. The map
+// is an LRU, so stale entries age out on their own.
+func (t *ebpfTracer) logTLSDiagEvents() {
+	if t.tlsDiagEventsMap == nil {
+		return
+	}
+
+	var key netebpf.ConnTuple
+	var event netebpf.TLSDiagEvent
+	logged := 0
+	suppressed := 0
+
+	it := t.tlsDiagEventsMap.IterateWithBatchSize(100)
+	for it.Next(&key, &event) {
+		if err := it.Err(); err != nil {
+			log.Warnf("error iterating TLS diagnostic events map: %s", err)
+			return
+		}
+		if event.Logged != 0 {
+			continue
+		}
+		if logged >= tlsDiagMaxLogsPerCollect {
+			suppressed++
+			continue
+		}
+
+		log.Infof("tls-misclassification: %s | %s:%d -> %s:%d | classified_app_proto=%d tls_content_type=0x%02x hits=%d",
+			tlsDiagReasonString(event.Reason),
+			key.SourceAddress(), event.Sport,
+			key.DestAddress(), event.Dport,
+			event.App_layer_proto, event.Tls_content_type, event.Hits)
+		logged++
+
+		event.Logged = 1
+		if err := t.tlsDiagEventsMap.Put(&key, &event); err != nil {
+			// Non-fatal: worst case we log this connection again next scrape.
+			if log.ShouldLog(log.TraceLvl) {
+				log.Tracef("could not mark TLS diagnostic event as logged: %s", err)
+			}
+		}
+	}
+
+	if suppressed > 0 {
+		log.Infof("tls-misclassification: suppressed %d additional diagnostic event(s) this interval (limit %d); see the network_tracer__ebpf counters for totals",
+			suppressed, tlsDiagMaxLogsPerCollect)
+	}
+}
+
 // Describe returns all descriptions of the collector
 func (t *ebpfTracer) Describe(ch chan<- *prometheus.Desc) {
 	ch <- EbpfTracerTelemetry.tcpSentMiscounts
@@ -768,6 +885,11 @@ func (t *ebpfTracer) Describe(ch chan<- *prometheus.Desc) {
 	ch <- EbpfTracerTelemetry.tcpDoneConnectionFlush
 	ch <- EbpfTracerTelemetry.tcpCloseConnectionFlush
 	ch <- EbpfTracerTelemetry.tcpSynRetransmit
+	ch <- EbpfTracerTelemetry.tlsRejectRecordExceedsPacket
+	ch <- EbpfTracerTelemetry.tlsRejectHandshakeInvalid
+	ch <- EbpfTracerTelemetry.applayerMatchOnTLSPayload
+	ch <- EbpfTracerTelemetry.redisMatchOnNonstandardPort
+	ch <- EbpfTracerTelemetry.tlsLockedOutByApplayer
 }
 
 // Collect returns the current state of all metrics of the collector
@@ -826,6 +948,31 @@ func (t *ebpfTracer) Collect(ch chan<- prometheus.Metric) {
 	delta = int64(ebpfTelemetry.Tcp_syn_retransmit) - EbpfTracerTelemetry.lastTCPSynRetransmit
 	EbpfTracerTelemetry.lastTCPSynRetransmit = int64(ebpfTelemetry.Tcp_syn_retransmit)
 	ch <- prometheus.MustNewConstMetric(EbpfTracerTelemetry.tcpSynRetransmit, prometheus.CounterValue, float64(delta))
+
+	// TLS/Redis misclassification diagnostics (see jmw/tls-misclassification)
+	delta = int64(ebpfTelemetry.Tls_reject_record_exceeds_packet) - EbpfTracerTelemetry.lastTLSRejectRecordExceedsPacket
+	EbpfTracerTelemetry.lastTLSRejectRecordExceedsPacket = int64(ebpfTelemetry.Tls_reject_record_exceeds_packet)
+	ch <- prometheus.MustNewConstMetric(EbpfTracerTelemetry.tlsRejectRecordExceedsPacket, prometheus.CounterValue, float64(delta))
+
+	delta = int64(ebpfTelemetry.Tls_reject_handshake_invalid) - EbpfTracerTelemetry.lastTLSRejectHandshakeInvalid
+	EbpfTracerTelemetry.lastTLSRejectHandshakeInvalid = int64(ebpfTelemetry.Tls_reject_handshake_invalid)
+	ch <- prometheus.MustNewConstMetric(EbpfTracerTelemetry.tlsRejectHandshakeInvalid, prometheus.CounterValue, float64(delta))
+
+	delta = int64(ebpfTelemetry.Applayer_match_on_tls_payload) - EbpfTracerTelemetry.lastApplayerMatchOnTLSPayload
+	EbpfTracerTelemetry.lastApplayerMatchOnTLSPayload = int64(ebpfTelemetry.Applayer_match_on_tls_payload)
+	ch <- prometheus.MustNewConstMetric(EbpfTracerTelemetry.applayerMatchOnTLSPayload, prometheus.CounterValue, float64(delta))
+
+	delta = int64(ebpfTelemetry.Redis_match_on_nonstandard_port) - EbpfTracerTelemetry.lastRedisMatchOnNonstandardPort
+	EbpfTracerTelemetry.lastRedisMatchOnNonstandardPort = int64(ebpfTelemetry.Redis_match_on_nonstandard_port)
+	ch <- prometheus.MustNewConstMetric(EbpfTracerTelemetry.redisMatchOnNonstandardPort, prometheus.CounterValue, float64(delta))
+
+	delta = int64(ebpfTelemetry.Tls_locked_out_by_applayer) - EbpfTracerTelemetry.lastTLSLockedOutByApplayer
+	EbpfTracerTelemetry.lastTLSLockedOutByApplayer = int64(ebpfTelemetry.Tls_locked_out_by_applayer)
+	ch <- prometheus.MustNewConstMetric(EbpfTracerTelemetry.tlsLockedOutByApplayer, prometheus.CounterValue, float64(delta))
+
+	// Drain the per-connection diagnostic detail and log it. Rate limited: at most
+	// tlsDiagMaxLogsPerCollect lines per scrape, and each entry is logged only once.
+	t.logTLSDiagEvents()
 
 	// Collect the TCP failure telemetry
 	for k, v := range t.getTCPFailureTelemetry() {

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -818,13 +818,16 @@ func tlsDiagReasonString(reason uint8) string {
 	}
 }
 
-// logTLSDiagEvents drains the diagnostic side channel populated by the classifier and logs each
-// distinct finding once, at info level, so the data is available on a normal staging build without
-// enabling debug logging fleet-wide.
+// logTLSDiagEvents drains the diagnostic side channel populated by the classifier and logs the
+// findings at info level, so the data is available on a normal build without enabling debug
+// logging fleet-wide.
 //
-// Entries are marked as logged in place rather than deleted, so the hit counter keeps accumulating
-// and a subsequent scrape can show whether a finding is still firing without re-logging it. The map
-// is an LRU, so stale entries age out on their own.
+// Every entry visited is deleted, whether or not it was logged. tls_diag_events is a plain hash
+// map (BPF_MAP_TYPE_LRU_HASH does not exist before kernel 4.10, and classification runs well below
+// that via runtime compilation), so it does not evict: if the drain only removed the entries it
+// logged, a busy host would pin the map at capacity and stop recording anything new. Deleting
+// everything visited keeps space available while the per-scrape log cap keeps the log volume
+// bounded; the telemetry_t counters remain authoritative for magnitude.
 func (t *ebpfTracer) logTLSDiagEvents() {
 	if t.tlsDiagEventsMap == nil {
 		return
@@ -834,33 +837,35 @@ func (t *ebpfTracer) logTLSDiagEvents() {
 	var event netebpf.TLSDiagEvent
 	logged := 0
 	suppressed := 0
+	// Collected and deleted after iteration rather than during it, to avoid mutating the map while
+	// the iterator walks it.
+	drained := make([]netebpf.ConnTuple, 0, 64)
 
 	it := t.tlsDiagEventsMap.IterateWithBatchSize(100)
 	for it.Next(&key, &event) {
 		if err := it.Err(); err != nil {
 			log.Warnf("error iterating TLS diagnostic events map: %s", err)
-			return
+			break
 		}
-		if event.Logged != 0 {
-			continue
-		}
+		drained = append(drained, key)
+
 		if logged >= tlsDiagMaxLogsPerCollect {
 			suppressed++
 			continue
 		}
-
 		log.Infof("tls-misclassification: %s | %s:%d -> %s:%d | classified_app_proto=%d tls_content_type=0x%02x hits=%d",
 			tlsDiagReasonString(event.Reason),
 			key.SourceAddress(), event.Sport,
 			key.DestAddress(), event.Dport,
 			event.App_layer_proto, event.Tls_content_type, event.Hits)
 		logged++
+	}
 
-		event.Logged = 1
-		if err := t.tlsDiagEventsMap.Put(&key, &event); err != nil {
-			// Non-fatal: worst case we log this connection again next scrape.
+	for i := range drained {
+		if err := t.tlsDiagEventsMap.Delete(&drained[i]); err != nil {
+			// Non-fatal: the entry may already be gone, or the map may be under concurrent write.
 			if log.ShouldLog(log.TraceLvl) {
-				log.Tracef("could not mark TLS diagnostic event as logged: %s", err)
+				log.Tracef("could not delete TLS diagnostic event: %s", err)
 			}
 		}
 	}

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -73,6 +73,9 @@ type EbpfTracerTelemetryData struct {
 	// TLS/Redis misclassification diagnostics (see jmw/tls-misclassification)
 	tlsRejectRecordExceedsPacket *prometheus.Desc
 	tlsRejectHandshakeInvalid    *prometheus.Desc
+	usmDispatcherRedisMatch      *prometheus.Desc
+	usmTLSRedisMatch             *prometheus.Desc
+	socketFilterRedisMatch       *prometheus.Desc
 	applayerMatchOnTLSPayload    *prometheus.Desc
 	redisMatchOnNonstandardPort  *prometheus.Desc
 	tlsLockedOutByApplayer       *prometheus.Desc
@@ -123,6 +126,9 @@ var EbpfTracerTelemetry = EbpfTracerTelemetryData{
 	prometheus.NewDesc(connTracerModuleName+"__tcp_syn_retransmit", "Counter measuring the number of tcp retransmits of syn packets", nil, nil),
 	prometheus.NewDesc(connTracerModuleName+"__tls_reject_record_exceeds_packet", "Counter measuring plausible TLS record headers rejected by is_tls() solely because the record ran past the end of the packet", nil, nil),
 	prometheus.NewDesc(connTracerModuleName+"__tls_reject_handshake_invalid", "Counter measuring TLS handshake records that fit within the packet but were still rejected by is_valid_tls_handshake (non-Hello handshake type, coalesced messages, or a fragmented message)", nil, nil),
+	prometheus.NewDesc(connTracerModuleName+"__usm_dispatcher_redis_match", "Counter measuring is_redis() matches in the USM protocol dispatcher, a call site the socket-filter counters do not cover", nil, nil),
+	prometheus.NewDesc(connTracerModuleName+"__usm_tls_redis_match", "Counter measuring is_redis() matches on decrypted TLS payloads in USM", nil, nil),
+	prometheus.NewDesc(connTracerModuleName+"__socket_filter_redis_match", "Counter measuring is_redis() matches in the socket-filter db classifier, counted unconditionally so it is comparable with the two USM call-site counters", nil, nil),
 	prometheus.NewDesc(connTracerModuleName+"__applayer_match_on_tls_payload", "Counter measuring db-layer protocol classifications on a buffer that begins with a plausible TLS record header (suspected false positive on ciphertext)", nil, nil),
 	prometheus.NewDesc(connTracerModuleName+"__redis_match_on_nonstandard_port", "Counter measuring Redis classifications on ports Redis does not serve (false positive by definition)", nil, nil),
 	prometheus.NewDesc(connTracerModuleName+"__tls_locked_out_by_applayer", "Counter measuring plausible TLS record headers seen on connections whose application layer was already recorded, preventing is_tls() from ever running again", nil, nil),
@@ -175,7 +181,10 @@ type ebpfTracer struct {
 	// tlsDiagEventsMap is the diagnostic side channel for the TLS-reported-as-plaintext
 	// investigation. See jmw/tls-misclassification.
 	tlsDiagEventsMap *maps.GenericMap[netebpf.ConnTuple, netebpf.TLSDiagEvent]
-	config           *config.Config
+	// tlsDiagUSMCountersMap is shared into the USM manager so the two is_redis() call sites in
+	// usm.c increment the same map the tracer reads. Index is a tls_diag_counter_t.
+	tlsDiagUSMCountersMap *maps.GenericMap[uint32, uint64]
+	config                *config.Config
 
 	// tcp_close events
 	closeConsumer *tcpCloseConsumer
@@ -398,6 +407,10 @@ func newEbpfTracer(config *config.Config, _ telemetryComponent.Component) (Trace
 			tr.tlsDiagEventsMap, err = maps.GetMap[netebpf.ConnTuple, netebpf.TLSDiagEvent](m.Manager, probes.TLSDiagEventsMap)
 			if err != nil {
 				log.Warnf("error retrieving TLS diagnostic events map: %s", err)
+			}
+			tr.tlsDiagUSMCountersMap, err = maps.GetMap[uint32, uint64](m.Manager, probes.TLSDiagUSMCountersMap)
+			if err != nil {
+				log.Warnf("error retrieving TLS diagnostic USM counters map: %s", err)
 			}
 		}
 	}
@@ -897,6 +910,9 @@ func (t *ebpfTracer) Describe(ch chan<- *prometheus.Desc) {
 	ch <- EbpfTracerTelemetry.tcpSynRetransmit
 	ch <- EbpfTracerTelemetry.tlsRejectRecordExceedsPacket
 	ch <- EbpfTracerTelemetry.tlsRejectHandshakeInvalid
+	ch <- EbpfTracerTelemetry.usmDispatcherRedisMatch
+	ch <- EbpfTracerTelemetry.usmTLSRedisMatch
+	ch <- EbpfTracerTelemetry.socketFilterRedisMatch
 	ch <- EbpfTracerTelemetry.applayerMatchOnTLSPayload
 	ch <- EbpfTracerTelemetry.redisMatchOnNonstandardPort
 	ch <- EbpfTracerTelemetry.tlsLockedOutByApplayer
@@ -979,6 +995,25 @@ func (t *ebpfTracer) Collect(ch chan<- prometheus.Metric) {
 	delta = int64(ebpfTelemetry.Tls_locked_out_by_applayer) - EbpfTracerTelemetry.lastTLSLockedOutByApplayer
 	EbpfTracerTelemetry.lastTLSLockedOutByApplayer = int64(ebpfTelemetry.Tls_locked_out_by_applayer)
 	ch <- prometheus.MustNewConstMetric(EbpfTracerTelemetry.tlsLockedOutByApplayer, prometheus.CounterValue, float64(delta))
+
+	// The USM-side counters are absolute totals living in a shared array map, not per-scrape
+	// deltas like the telemetry_t counters above, so they are emitted as-is.
+	if t.tlsDiagUSMCountersMap != nil {
+		for _, c := range []struct {
+			idx  uint32
+			desc *prometheus.Desc
+		}{
+			{0, EbpfTracerTelemetry.usmDispatcherRedisMatch},
+			{1, EbpfTracerTelemetry.usmTLSRedisMatch},
+			{2, EbpfTracerTelemetry.socketFilterRedisMatch},
+		} {
+			var v uint64
+			if err := t.tlsDiagUSMCountersMap.Lookup(&c.idx, &v); err != nil {
+				continue
+			}
+			ch <- prometheus.MustNewConstMetric(c.desc, prometheus.CounterValue, float64(v))
+		}
+	}
 
 	// Drain the per-connection diagnostic detail and log it. Rate limited: at most
 	// tlsDiagMaxLogsPerCollect lines per scrape, and each entry is logged only once.

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -391,9 +391,14 @@ func newEbpfTracer(config *config.Config, _ telemetryComponent.Component) (Trace
 			log.Warnf("error retrieving ssl cert info map: %s", err)
 		}
 
-		tr.tlsDiagEventsMap, err = maps.GetMap[netebpf.ConnTuple, netebpf.TLSDiagEvent](m.Manager, probes.TLSDiagEventsMap)
-		if err != nil {
-			log.Warnf("error retrieving TLS diagnostic events map: %s", err)
+		// Only wire up the diagnostic map when the eBPF side is actually populating it. Leaving the
+		// handle nil makes logTLSDiagEvents() a no-op rather than iterating an always-empty map on
+		// every telemetry scrape.
+		if util.TLSDiagnosticsSupported() {
+			tr.tlsDiagEventsMap, err = maps.GetMap[netebpf.ConnTuple, netebpf.TLSDiagEvent](m.Manager, probes.TLSDiagEventsMap)
+			if err != nil {
+				log.Warnf("error retrieving TLS diagnostic events map: %s", err)
+			}
 		}
 	}
 

--- a/pkg/network/tracer/connection/fentry/manager.go
+++ b/pkg/network/tracer/connection/fentry/manager.go
@@ -28,6 +28,7 @@ func initManager(mgr *ddebpf.Manager) {
 		{Name: "pending_bind"},
 		{Name: probes.TelemetryMap},
 		{Name: probes.ConnectionProtocolMap},
+		{Name: probes.TLSDiagEventsMap},
 		{Name: probes.ClassificationProgsMap},
 		{Name: probes.EnhancedTLSTagsMap},
 		{Name: probes.ConnectionTupleToSocketSKBConnMap},

--- a/pkg/network/tracer/connection/fentry/manager.go
+++ b/pkg/network/tracer/connection/fentry/manager.go
@@ -29,6 +29,7 @@ func initManager(mgr *ddebpf.Manager) {
 		{Name: probes.TelemetryMap},
 		{Name: probes.ConnectionProtocolMap},
 		{Name: probes.TLSDiagEventsMap},
+		{Name: probes.TLSDiagUSMCountersMap},
 		{Name: probes.ClassificationProgsMap},
 		{Name: probes.EnhancedTLSTagsMap},
 		{Name: probes.ConnectionTupleToSocketSKBConnMap},

--- a/pkg/network/tracer/connection/fentry/tracer.go
+++ b/pkg/network/tracer/connection/fentry/tracer.go
@@ -163,6 +163,8 @@ func initFentryTracer(ar bytecode.AssetReader, o manager.Options, config *config
 	// Protocol classification setup
 	var closeProtocolClassifierSocketFilterFn func()
 	util.AddBoolConst(&o, "protocol_classification_enabled", isClassificationSupported)
+	// Gated on kernel version: when false the verifier prunes the diagnostic branches entirely.
+	util.AddBoolConst(&o, "tls_diag_enabled", isClassificationSupported && util.TLSDiagnosticsSupported())
 	var tailCallsIdentifiersSet map[manager.ProbeIdentificationPair]struct{}
 
 	if isClassificationSupported {

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -73,6 +73,7 @@ func initManager(mgr *ddebpf.Manager, runtimeTracer bool) error {
 		{Name: probes.TelemetryMap},
 		{Name: probes.ConnectionProtocolMap},
 		{Name: probes.TLSDiagEventsMap},
+		{Name: probes.TLSDiagUSMCountersMap},
 		{Name: probes.TCPSendMsgArgsMap},
 		{Name: probes.TCPSendPageArgsMap},
 		{Name: probes.UDPSendPageArgsMap},

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -72,6 +72,7 @@ func initManager(mgr *ddebpf.Manager, runtimeTracer bool) error {
 		{Name: "pending_bind"},
 		{Name: probes.TelemetryMap},
 		{Name: probes.ConnectionProtocolMap},
+		{Name: probes.TLSDiagEventsMap},
 		{Name: probes.TCPSendMsgArgsMap},
 		{Name: probes.TCPSendPageArgsMap},
 		{Name: probes.UDPSendPageArgsMap},

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -173,6 +173,8 @@ func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer boo
 	var closeProtocolClassifierSocketFilterFn func()
 	classificationSupported := ClassificationSupported(config)
 	util.AddBoolConst(&mgrOpts, "protocol_classification_enabled", classificationSupported)
+	// Gated on kernel version: when false the verifier prunes the diagnostic branches entirely.
+	util.AddBoolConst(&mgrOpts, "tls_diag_enabled", classificationSupported && util.TLSDiagnosticsSupported())
 	var tailCallsIdentifiersSet map[manager.ProbeIdentificationPair]struct{}
 
 	if classificationSupported {

--- a/pkg/network/tracer/connection/util/conn_tracer.go
+++ b/pkg/network/tracer/connection/util/conn_tracer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 // toPowerOf2 converts a number to its nearest power of 2
@@ -79,4 +80,34 @@ func ConnTupleToEBPFTuple(c *network.ConnectionTuple, tup *netebpf.ConnTuple) {
 	if c.Dest.IsValid() {
 		tup.Daddr_l, tup.Daddr_h = util.ToLowHigh(c.Dest)
 	}
+}
+
+// tlsDiagMinimumKernel is the lowest kernel on which the TLS-misclassification diagnostics are
+// enabled. The threshold is deliberately conservative.
+//
+// The functional boundary is 5.2, where both BPF_MAXINSNS and the verifier's complexity limit jump
+// from 4,096 / 131,072 to 1,000,000. Below that, older verifiers do far less path pruning, and the
+// diagnostics' extra branches were enough to stop socket__classifier_entry loading in the prebuilt
+// object on 4.18 (KMT: ubuntu_18.04, amazon_4.14 — TLS classification silently disabled, while the
+// runtime-compiled tracer passed because host-specific compilation drops the version-gated branches
+// that make the prebuilt object more complex).
+//
+// 6.0 is used rather than 5.2 because these diagnostics are a temporary investigation aid only ever
+// deployed to 6.x staging hosts, so there is no reason to carry any risk on older kernels.
+var tlsDiagMinimumKernel = kernel.VersionCode(6, 0, 0)
+
+// TLSDiagnosticsSupported reports whether the TLS-misclassification diagnostics should be active.
+//
+// Gating matters for more than tidiness: the constant is patched into the program before load, so
+// when it is false the verifier sees a known-zero scalar and prunes the diagnostic branches
+// entirely, returning the classifier programs to their baseline complexity. Note it does NOT reduce
+// program size — the dead instructions still count against BPF_MAXINSNS — so this only helps with
+// complexity, which is what the pre-5.2 failure was.
+func TLSDiagnosticsSupported() bool {
+	kv, err := kernel.HostVersion()
+	if err != nil {
+		// Fail closed: without a version we cannot rule out an old verifier.
+		return false
+	}
+	return kv >= tlsDiagMinimumKernel
 }

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -852,7 +852,14 @@ func newUSMMonitor(c *config.Config, tracer connection.Tracer, statsd statsd.Cli
 		log.Warnf("couldn't get %q map: %s", probes.ConnectionProtocolMap, err)
 	}
 
-	monitor, err := usm.NewMonitor(c, connectionProtocolMap, statsd)
+	// TLS-misclassification diagnostics: usm.c holds two of the three is_redis() call sites, so
+	// share the counter map with USM to make their increments visible to the tracer's telemetry.
+	tlsDiagUSMCounters, err := tracer.GetMap(probes.TLSDiagUSMCountersMap)
+	if err != nil {
+		log.Warnf("couldn't get %q map: %s", probes.TLSDiagUSMCountersMap, err)
+	}
+
+	monitor, err := usm.NewMonitor(c, connectionProtocolMap, tlsDiagUSMCounters, statsd)
 	if err != nil {
 		log.Errorf("usm initialization failed: %s", err)
 		return nil

--- a/pkg/network/usm/BUILD.bazel
+++ b/pkg/network/usm/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//pkg/network/protocols/postgres",
         "//pkg/network/protocols/redis",
         "//pkg/network/protocols/telemetry",
+        "//pkg/network/tracer/connection/util",
         "//pkg/network/tracer/offsetguess",
         "//pkg/network/usm/buildmode",
         "//pkg/network/usm/config",

--- a/pkg/network/usm/debugger/cmd/usm_debugger.go
+++ b/pkg/network/usm/debugger/cmd/usm_debugger.go
@@ -37,7 +37,7 @@ func main() {
 	cleanupFn := setupBytecode()
 	defer cleanupFn()
 
-	monitor, err := usm.NewMonitor(getConfiguration(), nil, nil)
+	monitor, err := usm.NewMonitor(getConfiguration(), nil, nil, nil)
 	checkError(err)
 
 	err = monitor.Start()

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/kafka"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/postgres"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/redis"
+	connutil "github.com/DataDog/datadog-agent/pkg/network/tracer/connection/util"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/offsetguess"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/buildmode"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
@@ -84,6 +85,7 @@ type ebpfProgram struct {
 	cfg                   *config.Config
 	tailCallRouter        []manager.TailCallRoute
 	connectionProtocolMap *ebpf.Map
+	tlsDiagUSMCounters    *ebpf.Map
 
 	enabledProtocols  []*protocols.ProtocolSpec
 	disabledProtocols []*protocols.ProtocolSpec
@@ -91,7 +93,7 @@ type ebpfProgram struct {
 	buildMode buildmode.Type
 }
 
-func newEBPFProgram(c *config.Config, connectionProtocolMap *ebpf.Map) (*ebpfProgram, error) {
+func newEBPFProgram(c *config.Config, connectionProtocolMap, tlsDiagUSMCounters *ebpf.Map) (*ebpfProgram, error) {
 	mgr := &manager.Manager{
 		Maps: []*manager.Map{
 			{Name: protocols.TLSDispatcherProgramsMap},
@@ -143,6 +145,7 @@ func newEBPFProgram(c *config.Config, connectionProtocolMap *ebpf.Map) (*ebpfPro
 		Manager:               ddebpf.NewManager(mgr, "usm", &ebpftelemetry.ErrorsTelemetryModifier{}),
 		cfg:                   c,
 		connectionProtocolMap: connectionProtocolMap,
+		tlsDiagUSMCounters:    tlsDiagUSMCounters,
 	}
 
 	if err := program.initProtocols(c); err != nil {
@@ -426,6 +429,15 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 		options.MapEditors[probes.ConnectionProtocolMap] = e.connectionProtocolMap
 	}
 
+	// Share the TLS-misclassification counter map so the two is_redis() call sites in usm.c
+	// increment the same map the tracer reads, rather than usm.o's private copy.
+	if e.tlsDiagUSMCounters != nil {
+		if options.MapEditors == nil {
+			options.MapEditors = make(map[string]*ebpf.Map)
+		}
+		options.MapEditors[probes.TLSDiagUSMCountersMap] = e.tlsDiagUSMCounters
+	}
+
 	begin, end := network.EphemeralRange()
 	options.ConstantEditors = append(options.ConstantEditors,
 		manager.ConstantEditor{Name: "ephemeral_range_begin", Value: uint64(begin)},
@@ -438,6 +450,14 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 	// Some parts of USM (https capturing, and part of the classification) use `read_conn_tuple`, and has some if
 	// clauses that handled IPV6, for USM we care (ATM) only from TCP connections, so adding the sole config about tcpv6.
 	utils.AddBoolConst(&options, e.cfg.CollectTCPv6Conns, "tcpv6_enabled")
+
+	// TLS-misclassification diagnostics (jmw/tls-misclassification). usm.c contains two of the
+	// three is_redis() call sites, and both write PROTOCOL_REDIS into the shared
+	// connection_protocol stack. This constant MUST be supplied here as well as by the tracer
+	// managers: if it is missing the value stays 0, the verifier prunes the counting branches, and
+	// the counters read zero — indistinguishable from "the site never fired", which is precisely
+	// the ambiguity these counters exist to resolve.
+	utils.AddBoolConst(&options, connutil.TLSDiagnosticsSupported(), "tls_diag_enabled")
 
 	options.DefaultKProbeMaxActive = maxActive
 	options.DefaultKprobeAttachMethod = kprobeAttachMethod

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -59,7 +59,7 @@ type Monitor struct {
 }
 
 // NewMonitor returns a new Monitor instance
-func NewMonitor(c *config.Config, connectionProtocolMap *ebpf.Map, statsd statsd.ClientInterface) (m *Monitor, err error) {
+func NewMonitor(c *config.Config, connectionProtocolMap, tlsDiagUSMCounters *ebpf.Map, statsd statsd.ClientInterface) (m *Monitor, err error) {
 	defer func() {
 		// capture error and wrap it
 		if err != nil {
@@ -69,7 +69,7 @@ func NewMonitor(c *config.Config, connectionProtocolMap *ebpf.Map, statsd statsd
 		}
 	}()
 
-	mgr, err := newEBPFProgram(c, connectionProtocolMap)
+	mgr, err := newEBPFProgram(c, connectionProtocolMap, tlsDiagUSMCounters)
 	if err != nil {
 		return nil, fmt.Errorf("error setting up ebpf program: %w", err)
 	}

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -805,6 +805,120 @@ func testUnclassifiedProtocol(t *testing.T, tr *tracer.Tracer, clientHost, targe
 	}
 }
 
+// testRedisRESPValidation exercises is_redis() over a raw socket, covering both
+// directions of the guarantee it has to provide: valid RESP frames must still be
+// classified as Redis, and payloads that merely begin with a RESP type byte must
+// not be.
+//
+// The second half is the regression test for the TLS-reported-as-plaintext bug.
+// is_redis() used to accept any buffer whose first byte was one of the 14 RESP
+// type bytes, i.e. ~5.5% of arbitrary payloads. TLS ciphertext hit that often
+// enough to lock the application layer to Redis, and once the app layer is set,
+// protocol_classifier_entrypoint stops calling is_tls() for the life of the
+// connection — so encrypted connections were reported with tls_encrypted:false.
+// On one staging cluster that was 6.00k connections in an hour.
+//
+// Deliberately raw-socket rather than Docker-based: this asserts on the byte
+// validation itself, so it must not depend on a Redis server being reachable.
+func testRedisRESPValidation(t *testing.T, tr *tracer.Tracer, clientHost, targetHost, serverHost string) {
+	// Each case gets its own port. Sharing one would make the positive
+	// assertions meaningless: validateProtocolConnection matches *any*
+	// connection between the target and server addresses carrying the expected
+	// stack, so a case expecting Redis can be satisfied by a connection an
+	// earlier case already classified — it passes without the payload under
+	// test ever having been accepted. Observed: with a deliberately crippled
+	// validator that cannot accept "+PONG\r\n", the simple-string case still
+	// passed, matching a leftover connection from a previous case.
+	const respValidationBasePort = 9095
+
+	defaultDialer := &net.Dialer{
+		LocalAddr: &net.TCPAddr{
+			IP: net.ParseIP(clientHost),
+		},
+	}
+
+	// Stand-in for TLS ciphertext. Contains no \r and no \n on purpose: that
+	// makes rejection deterministic rather than dependent on whether the bytes
+	// chosen happen to contain a CRLF.
+	cipherTail := []byte{0x9f, 0x1a, 0x03, 0xc7, 0x5e, 0xb2, 0x41, 0xf8, 0x2d, 0x96, 0x77, 0x08, 0xe4, 0x3b, 0xa1, 0x60}
+	nonRESP := func(prefix byte) []byte {
+		return append([]byte{prefix}, cipherTail...)
+	}
+
+	redisStack := &protocols.Stack{Application: protocols.Redis}
+	unclassified := &protocols.Stack{}
+
+	cases := []struct {
+		name     string
+		payload  []byte
+		expected *protocols.Stack
+	}{
+		// Valid RESP must still be classified as Redis.
+		{"resp array command", []byte("*1\r\n$4\r\nPING\r\n"), redisStack},
+		{"resp bulk string", []byte("$6\r\nfoobar\r\n"), redisStack},
+		{"resp simple string", []byte("+PONG\r\n"), redisStack},
+		{"resp error", []byte("-ERR unknown command\r\n"), redisStack},
+		{"resp integer", []byte(":42\r\n"), redisStack},
+		{"resp negative integer", []byte(":-1\r\n"), redisStack},
+		{"resp null bulk string", []byte("$-1\r\n"), redisStack},
+
+		// A RESP type byte followed by ciphertext must not be classified as
+		// Redis. Every one of these was a false positive before the fix.
+		{"array prefix then ciphertext", nonRESP('*'), unclassified},
+		{"bulk prefix then ciphertext", nonRESP('$'), unclassified},
+		{"simple string prefix then ciphertext", nonRESP('+'), unclassified},
+		{"error prefix then ciphertext", nonRESP('-'), unclassified},
+		{"integer prefix then ciphertext", nonRESP(':'), unclassified},
+		{"map prefix then ciphertext", nonRESP('%'), unclassified},
+		{"push prefix then ciphertext", nonRESP('>'), unclassified},
+		{"verbatim string prefix then ciphertext", nonRESP('='), unclassified},
+	}
+
+	tests := make([]protocolClassificationAttributes, 0, len(cases))
+	for i, tc := range cases {
+		port := strconv.Itoa(respValidationBasePort + i)
+		serverAddress := net.JoinHostPort(serverHost, port)
+		targetAddress := net.JoinHostPort(targetHost, port)
+
+		server := tracertestutil.NewTCPServerOnAddress(serverAddress, func(c net.Conn) {
+			_, _ = io.Copy(c, c)
+		})
+		require.NoError(t, server.Run())
+		t.Cleanup(server.Shutdown)
+
+		tests = append(tests, protocolClassificationAttributes{
+			name: tc.name,
+			context: testContext{
+				serverPort:    port,
+				serverAddress: serverAddress,
+				targetAddress: targetAddress,
+				extras:        make(map[string]interface{}),
+			},
+			postTracerSetup: func(t *testing.T, ctx testContext) {
+				c, err := defaultDialer.Dial("tcp", ctx.targetAddress)
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = c.Close() })
+
+				_, err = c.Write(tc.payload)
+				require.NoError(t, err)
+
+				// Read the echo back, so the server-to-client direction carries
+				// the same bytes and the exchange has completed before the
+				// classification is inspected.
+				_, err = io.ReadFull(c, make([]byte, len(tc.payload)))
+				require.NoError(t, err)
+			},
+			validation: validateProtocolConnection(tc.expected),
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testProtocolClassificationInner(t, tt, tr)
+		})
+	}
+}
+
 func testMySQLProtocolClassification(t *testing.T, tr *tracer.Tracer, clientHost, targetHost, serverHost string) {
 	testMySQLProtocolClassificationInner(t, tr, clientHost, targetHost, serverHost, protocolsUtils.TLSDisabled)
 }
@@ -2232,6 +2346,10 @@ func testProtocolClassificationLinux(t *testing.T, tr *tracer.Tracer, clientHost
 		{
 			name:     "redis",
 			testFunc: testRedisProtocolClassification,
+		},
+		{
+			name:     "redis RESP validation",
+			testFunc: testRedisRESPValidation,
 		},
 		{
 			name:     "amqp",


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Adds **observational-only** eBPF diagnostics to confirm a suspected root cause for encrypted traffic being reported as `tls_encrypted:false` in CNM. **No classification behaviour changes.**

Five counters, one per link in the suspected chain, exposed as `datadog.system_probe.network_tracer.ebpf.*`:

| Counter | Link | What a non-zero value proves |
|---|---|---|
| `tls_reject_record_exceeds_packet` | 1a | `is_tls()` rejected a valid record header solely because the record ran past the end of the packet |
| `tls_reject_handshake_invalid` | 1b | The record fit, but `is_valid_tls_handshake()` rejected it (non-Hello type, coalesced, or fragmented) |
| `applayer_match_on_tls_payload` | 2 | A db-layer classifier matched a buffer that *begins with a plausible TLS record header* |
| `redis_match_on_nonstandard_port` | 2 | Redis matched on a port Redis never serves |
| `tls_locked_out_by_applayer` | 3 | A TLS record header arrived on a connection whose app layer was already recorded, so `is_tls()` can never run again |

Supporting pieces:

- `is_tls_record_header_plausible()` in `tls.h` — validates `content_type` + `version` **without** the fits-in-packet bound. Needed because reusing `is_tls()` for diagnostics would be blind to precisely the case under investigation. Documented as diagnostic-only; deliberately not used for classification.
- `tls_diag_events` — a bounded (1024-entry) hash map carrying per-connection detail, drained from the Prometheus `Collect()` path and logged at **info** level. Because the logging is userspace, a normal non-debug build at default log level is sufficient; eBPF cannot write agent logs at all. Rate limited to 5 lines per scrape, and every entry visited is deleted so the map cannot pin at capacity.
- Everything is gated behind a `tls_diag_enabled` constant (kernel **6.0+**), so on older kernels the verifier prunes the branches entirely — see "Additional Notes".
- Drive-by: corrects a stale comment claiming `connection_protocol` is an LRU map. It is a plain hash map, so it does not evict; leaked entries are reclaimed by the userspace map cleaner.

### Motivation

Encrypted traffic is being reported as unencrypted across a broad slice of staging: **47 aggregate connections on one Kafka port, all classified `redis`**, spanning ~10 client services and ~10 kube clusters plus bare EC2, with Rust, Go and JVM clients all affected. Both endpoints' agents misclassify independently.

The suspected mechanism, from reading the classifier:

1. On a connection whose TLS handshake was never observed, `is_tls()` rejects genuine TLS because `read_tls_record_header()` requires the whole record to fit in one packet. Records run to 16 KB; MSS is ~1460.
2. Classification falls through to the app-layer classifiers. `is_redis()` accepts on a **single byte** matching any of 14 RESP type markers, with no CRLF, length or structure check — so it matches arbitrary ciphertext ~5.5% of the time.
3. `mark_as_fully_classified()`, plus the `app_layer_proto == UNKNOWN || POSTGRES` gate on the `is_tls()` call, pin that wrong answer for the life of the map entry.

Result: emitted protocol stack `[Redis]` → `tls_encrypted:false` on genuinely encrypted traffic.

Note this does **not** mean the gate is wrong. Per the [Harden TLS socket filter classification RFC](https://datadoghq.atlassian.net/wiki/spaces/UT/pages/3954869126), which introduced it in #28198, the reasoning was *"if the socket filter was able to classify the protocol, then it is not TLS"* — sound, **provided classifiers do not false-positive**. This PR measures whether that proviso is being violated in practice.

`redis_match_on_nonstandard_port` is the decisive signal: classification is purely content-based with no port heuristics anywhere, so Redis matched off 6379/6380/16379/26379 is a false positive by definition — no ground truth required. The other four are sampling-dependent (they need a packet to begin at a TLS record boundary), so treat their magnitudes as evidence of *mechanism*, not blast radius.

**Falsification condition:** if all five stay zero while `tls_encrypted:false` persists on the affected port, the theory is wrong and the Redis verdict is arriving via some other path.

### Describe how you validated your changes

- eBPF compiles for prebuilt, runtime and CO-RE; `cgo -godefs` regenerated via `bazel run //pkg/network/ebpf:kprobe_types_godefs{,_test_file}` (both generated files), 46/48 godefs tests pass (2 Windows-only skipped).
- Verifier accepts `tracer.o` and `tracer-fentry.o` with no load failures.
- Measured on 6.8/arm64 with the gate closed, confirming the branches are pruned rather than merely unreached:

  | program | diagnostics active | gated off |
  |---|---|---|
  | `socket__classifier_entry` | 5,245 processed | **2,946** (−44%) |
  | `socket__classifier_dbs` | 2,060 processed | **1,247** (−39%) |

- Program sizes measured against the base commit: `_entry` 1,127 → 1,402, `_dbs` 703 → 922 instructions. `_grpc` and `_tls_handshake_client` are byte-identical to `main`.

### Additional Notes

**This is an investigation aid, not the fix.** It changes no classification behaviour. The likely fix — tightening `is_redis` to require a well-formed RESP frame, using the validators that already exist unused in `redis/helpers.h` — is intentionally not in this PR so the diagnostics can be reviewed independently and so the fix lands with its own regression test.

**Two earlier KMT failures shaped the design, both fixed here:**

1. `BPF_MAP_TYPE_LRU_HASH` was added in kernel **4.10**, but classification runs from 4.11 down through runtime compilation on older kernels, which builds against the *host's* headers — so debian_9 (4.9) and ubuntu_16.04 (4.4) failed to compile outright. No other map reachable from `tracer.c` used `BPF_LRU_MAP`. Now a plain hash map.
2. On ubuntu_18.04 / amazon_4.14 (**kernel 4.18**), the added branches stopped `socket__classifier_entry` loading in the *prebuilt* object while the runtime-compiled tracer passed on the same kernel and commit. Not program size — the diagnostics add 275 instructions to a 4,096 limit — but verifier **complexity**, where pre-5.2 kernels cap processed instructions at 131,072 and prune far less. The runtime object escapes because host-specific compilation drops the version-gated branches that make the prebuilt object more complex. Hence the kernel-6.0 gate.

The threshold is 6.0 rather than the functional boundary of 5.2 (where `BPF_MAXINSNS` and the complexity limit both jump to 1M) because these diagnostics only ever run on 6.x staging hosts, so there is no reason to carry risk on older kernels. `TLSDiagnosticsSupported()` fails closed if the kernel version cannot be determined, and is ANDed with classification support.

Known limitations: the gate reduces complexity but **not** program size (dead instructions still count toward `BPF_MAXINSNS`); `tls_diag_events` is still created on every kernel (~72 KB) because it is declared in the ELF; and KMT distros below 6.0 no longer exercise the diagnostic code, so a regression in it would not be caught there.
