### PR TITLE
Add critical thermal shutdown/hibernation notable events

### DIFF
--- a/comp/notableevents/impl/collector.go
+++ b/comp/notableevents/impl/collector.go
@@ -167,6 +167,26 @@ func getEventDefinitions() []eventDefinition {
 			Message:       "An application removal (MSI) failed",
 			FormatPayload: formatMsiInstaller1034Payload,
 		},
+		{
+			Provider:      "Microsoft-Windows-Kernel-Power",
+			EventID:       86,
+			Channel:       "System",
+			QueryBody:     `    <Select Path="System">*[System[Provider[@Name='Microsoft-Windows-Kernel-Power'] and EventID=86]]</Select>`,
+			EventType:     "Critical Temperature",
+			Title:         "The system was shut down due to a critical thermal event",
+			Message:       "The system was shut down due to a critical thermal event.",
+			FormatPayload: formatCriticalThermalShutdownPayload,
+		},
+		{
+			Provider:      "Microsoft-Windows-Kernel-Power",
+			EventID:       88,
+			Channel:       "System",
+			QueryBody:     `    <Select Path="System">*[System[Provider[@Name='Microsoft-Windows-Kernel-Power'] and EventID=88]]</Select>`,
+			EventType:     "Critical Temperature",
+			Title:         "The system was hibernated due to a critical thermal event",
+			Message:       "The system was hibernated due to a critical thermal event.",
+			FormatPayload: formatCriticalThermalHibernatePayload,
+		},
 	}
 	return e
 }

--- a/comp/notableevents/impl/format.go
+++ b/comp/notableevents/impl/format.go
@@ -212,3 +212,47 @@ func formatUnexpectedRebootPayload(payload *eventPayload, eventData map[string]i
 	}
 	// If BugcheckCode=0, keep the default "Unexpected reboot" values
 }
+
+// formatCriticalThermalShutdownPayload formats the message for a critical thermal shutdown
+// (Microsoft-Windows-Kernel-Power / Event ID 86), matching the provider's own message template.
+func formatCriticalThermalShutdownPayload(payload *eventPayload, eventData map[string]interface{}) {
+	shutdownTime, zone, crt := getThermalTripPointFields(eventData, "ShutdownTime", "_CRT")
+	if shutdownTime == "" && zone == "" && crt == "" {
+		return
+	}
+	payload.Message = fmt.Sprintf("%s\nShutdown Time = %s\nACPI Thermal Zone = %s\n_CRT = %s", payload.Message, shutdownTime, zone, formatKelvinAsCelsius(crt))
+}
+
+// formatCriticalThermalHibernatePayload formats the message for a critical thermal hibernation
+// (Microsoft-Windows-Kernel-Power / Event ID 88), matching the provider's own message template.
+func formatCriticalThermalHibernatePayload(payload *eventPayload, eventData map[string]interface{}) {
+	hibernateTime, zone, hot := getThermalTripPointFields(eventData, "HibernateTime", "_HOT")
+	if hibernateTime == "" && zone == "" && hot == "" {
+		return
+	}
+	payload.Message = fmt.Sprintf("%s\nHibernate Time = %s\nACPI Thermal Zone = %s\n_HOT = %s", payload.Message, hibernateTime, zone, formatKelvinAsCelsius(hot))
+}
+
+// formatKelvinAsCelsius converts an ACPI temperature threshold from Kelvin to Celsius,
+// falling back to the raw value if it isn't numeric.
+func formatKelvinAsCelsius(kelvinStr string) string {
+	kelvin, err := strconv.ParseFloat(kelvinStr, 64)
+	if err != nil {
+		return kelvinStr + "K"
+	}
+	return fmt.Sprintf("%.1f°C", kelvin-273.15)
+}
+
+// getThermalTripPointFields extracts the zone/time/threshold EventData fields shared by the
+// Kernel-Power critical trip point events (86/88). Like Event ID 41 on this same provider,
+// these always render as named fields, so no positional-list fallback is needed.
+func getThermalTripPointFields(eventData map[string]interface{}, timeField, thresholdField string) (string, string, string) {
+	data := getEventDataMap(eventData)
+	if data == nil {
+		return "", "", ""
+	}
+	timeVal, _ := data[timeField].(string)
+	zoneVal, _ := data["ThermalZoneDeviceInstance"].(string)
+	thresholdVal, _ := data[thresholdField].(string)
+	return timeVal, zoneVal, thresholdVal
+}

--- a/comp/notableevents/impl/format_test.go
+++ b/comp/notableevents/impl/format_test.go
@@ -456,3 +456,134 @@ func TestFormatMsiExitCode(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatCriticalThermalShutdownPayload(t *testing.T) {
+	tests := []struct {
+		name            string
+		eventXML        string
+		defaultMessage  string
+		expectedMessage string
+	}{
+		{
+			name: "extracts fields from named EventData",
+			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+				<System>
+					<Provider Name="Microsoft-Windows-Kernel-Power"/>
+					<EventID>86</EventID>
+				</System>
+				<EventData>
+					<Data Name="ThermalZoneDeviceInstanceLength">22</Data>
+					<Data Name="ThermalZoneDeviceInstance">ACPI\ThermalZone\THRM</Data>
+					<Data Name="ShutdownTime">2026-08-03T13:23:45.000000Z</Data>
+					<Data Name="_CRT">373</Data>
+				</EventData>
+			</Event>`,
+			defaultMessage:  "The system was shut down due to a critical thermal event.",
+			expectedMessage: "The system was shut down due to a critical thermal event.\nShutdown Time = 2026-08-03T13:23:45.000000Z\nACPI Thermal Zone = ACPI\\ThermalZone\\THRM\n_CRT = 99.9°C",
+		},
+		{
+			name: "non-numeric _CRT falls back to raw Kelvin value",
+			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+				<System>
+					<Provider Name="Microsoft-Windows-Kernel-Power"/>
+					<EventID>86</EventID>
+				</System>
+				<EventData>
+					<Data Name="ThermalZoneDeviceInstance">ACPI\ThermalZone\THRM</Data>
+					<Data Name="ShutdownTime">2026-08-03T13:23:45.000000Z</Data>
+					<Data Name="_CRT">N/A</Data>
+				</EventData>
+			</Event>`,
+			defaultMessage:  "The system was shut down due to a critical thermal event.",
+			expectedMessage: "The system was shut down due to a critical thermal event.\nShutdown Time = 2026-08-03T13:23:45.000000Z\nACPI Thermal Zone = ACPI\\ThermalZone\\THRM\n_CRT = N/AK",
+		},
+		{
+			name: "empty EventData keeps default message",
+			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+				<System>
+					<Provider Name="Microsoft-Windows-Kernel-Power"/>
+					<EventID>86</EventID>
+				</System>
+				<EventData></EventData>
+			</Event>`,
+			defaultMessage:  "The system was shut down due to a critical thermal event.",
+			expectedMessage: "The system was shut down due to a critical thermal event.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eventMap, err := parseEventXML([]byte(tt.eventXML))
+			require.NoError(t, err)
+
+			payload := &eventPayload{Message: tt.defaultMessage}
+			formatCriticalThermalShutdownPayload(payload, eventMap.Map)
+			assert.Equal(t, tt.expectedMessage, payload.Message)
+		})
+	}
+}
+
+func TestFormatCriticalThermalHibernatePayload(t *testing.T) {
+	tests := []struct {
+		name            string
+		eventXML        string
+		defaultMessage  string
+		expectedMessage string
+	}{
+		{
+			name: "extracts fields from named EventData",
+			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+				<System>
+					<Provider Name="Microsoft-Windows-Kernel-Power"/>
+					<EventID>88</EventID>
+				</System>
+				<EventData>
+					<Data Name="ThermalZoneDeviceInstanceLength">22</Data>
+					<Data Name="ThermalZoneDeviceInstance">ACPI\ThermalZone\THRM</Data>
+					<Data Name="HibernateTime">2026-08-03T13:23:45.000000Z</Data>
+					<Data Name="_HOT">353</Data>
+				</EventData>
+			</Event>`,
+			defaultMessage:  "The system was hibernated due to a critical thermal event.",
+			expectedMessage: "The system was hibernated due to a critical thermal event.\nHibernate Time = 2026-08-03T13:23:45.000000Z\nACPI Thermal Zone = ACPI\\ThermalZone\\THRM\n_HOT = 79.9°C",
+		},
+		{
+			name: "empty EventData keeps default message",
+			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+				<System>
+					<Provider Name="Microsoft-Windows-Kernel-Power"/>
+					<EventID>88</EventID>
+				</System>
+				<EventData></EventData>
+			</Event>`,
+			defaultMessage:  "The system was hibernated due to a critical thermal event.",
+			expectedMessage: "The system was hibernated due to a critical thermal event.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eventMap, err := parseEventXML([]byte(tt.eventXML))
+			require.NoError(t, err)
+
+			payload := &eventPayload{Message: tt.defaultMessage}
+			formatCriticalThermalHibernatePayload(payload, eventMap.Map)
+			assert.Equal(t, tt.expectedMessage, payload.Message)
+		})
+	}
+}
+
+func TestFormatKelvinAsCelsius(t *testing.T) {
+	tests := []struct {
+		name     string
+		kelvin   string
+		expected string
+	}{
+		{name: "typical critical threshold", kelvin: "373", expected: "99.9°C"},
+		{name: "typical hot threshold", kelvin: "353", expected: "79.9°C"},
+		{name: "non-numeric falls back to raw value with K suffix", kelvin: "N/A", expected: "N/AK"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatKelvinAsCelsius(tt.kelvin))
+		})
+	}
+}

--- a/releasenotes/notes/add-critical-temperature-notable-events-fc91ed06ad756a10.yaml
+++ b/releasenotes/notes/add-critical-temperature-notable-events-fc91ed06ad756a10.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Notable Events on Windows now reports critical temperature events: system shutdown or
+    hibernation triggered by a critical thermal condition.


### PR DESCRIPTION
### What does this PR do?

Adds two new Windows notable events to `comp/notableevents`: `Microsoft-Windows-Kernel-Power` Event ID 86 (critical thermal shutdown) and Event ID 88 (critical thermal hibernation), both collected from the default-enabled `System` log channel.

### Motivation

[WINA-3002](https://datadoghq.atlassian.net/browse/WINA-3002)

### Describe how you validated your changes

Added unit tests.

[WINA-3002]: https://datadoghq.atlassian.net/browse/WINA-3002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ