### PR TITLE
fix(collector): fix data race on collectorErrors loader-error map

### DIFF
--- a/pkg/collector/stats.go
+++ b/pkg/collector/stats.go
@@ -29,6 +29,9 @@ func newCollectorErrors() *collectorErrors {
 
 // setLoaderError will safely set the error for that check and loader to the LoaderErrorStats
 func (ce *collectorErrors) setLoaderError(checkName string, loaderName string, err string) {
+	ce.m.Lock()
+	defer ce.m.Unlock()
+
 	_, found := ce.loader[checkName]
 	if !found {
 		ce.loader[checkName] = make(map[string]string)
@@ -39,6 +42,9 @@ func (ce *collectorErrors) setLoaderError(checkName string, loaderName string, e
 
 // removeLoaderErrors removes the errors for a check (usually when successfully loaded)
 func (ce *collectorErrors) removeLoaderErrors(checkName string) {
+	ce.m.Lock()
+	defer ce.m.Unlock()
+
 	delete(ce.loader, checkName)
 }
 


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Fixes a data race in `pkg/collector/stats.go`: `setLoaderError()` and `removeLoaderErrors()` mutated `collectorErrors.loader` without taking `ce.m.Lock()`.

### Motivation

Found via `-race` in a live deployment log.

### Describe how you validated your changes

CI

### Additional Notes