### PR TITLE
fix(autoscaling): fix data race on verticalController's in-place-resize cache

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/controller_vertical.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -55,6 +56,7 @@ type verticalController struct {
 	patchClient                *workloadpatcher.Patcher
 	podWatcher                 PodWatcher
 	progressTracker            *rolloutProgressTracker
+	inPlaceResizeMu            sync.Mutex
 	inPlaceResizeSupported     *bool
 	inPlaceResizeSupportedTime time.Time
 }

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
@@ -51,6 +51,9 @@ var removeLimitSentinel = resource.MustParse("-1")
 // subresource, which requires InPlacePodVerticalScaling to be enabled. The result
 // is cached for 15 minutes.
 func (u *verticalController) isInPlaceResizeSupported() bool {
+	u.inPlaceResizeMu.Lock()
+	defer u.inPlaceResizeMu.Unlock()
+
 	if u.inPlaceResizeSupported != nil && u.clock.Since(u.inPlaceResizeSupportedTime) < inPlaceResizeSupportedCacheTTL {
 		return *u.inPlaceResizeSupported
 	}

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers_test.go
@@ -8,6 +8,7 @@
 package workload
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +17,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clock "k8s.io/utils/clock/testing"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
@@ -24,6 +27,27 @@ import (
 
 	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 )
+
+// TestIsInPlaceResizeSupportedConcurrent reproduces the scenario that raced in
+// production: multiple pod-autoscaler reconcile workers sharing one *verticalController
+// calling isInPlaceResizeSupported() concurrently while its cache is unpopulated/expired.
+// Run with -race.
+func TestIsInPlaceResizeSupportedConcurrent(_ *testing.T) {
+	u := &verticalController{
+		clock:  clock.NewFakeClock(time.Now()),
+		client: k8sfake.NewSimpleClientset(),
+	}
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			u.isInPlaceResizeSupported()
+		}()
+	}
+	wg.Wait()
+}
 
 func TestHasLimitIncrease_Detected(t *testing.T) {
 	cpuLimit1 := float64(50) // 500m


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Fixes a data race in `isInPlaceResizeSupported()`, it reads and writes `inPlaceResizeSupported`/`inPlaceResizeSupportedTime` without any synchronization.
The `verticalController` instance is called concurrently by every pod-autoscaler reconcile worker, racing whenever the cache needs to refresh. Added a mutex guarding those fields.

### Motivation
Fix a race.

### Describe how you validated your changes

CI

### Additional Notes
Found via `-race` in a live cluster-agent deployment log.
