### PR TITLE
fix(collector): fix data race in GetCheckStats() bypassing per-Stats lock

### DIFF
--- a/pkg/collector/check/stats/BUILD.bazel
+++ b/pkg/collector/check/stats/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/config/utils",
         "//pkg/util/log",
         "@com_github_go_viper_mapstructure_v2//:mapstructure",
+        "@com_github_mohae_deepcopy//:deepcopy",
     ],
 )
 

--- a/pkg/collector/check/stats/stats.go
+++ b/pkg/collector/check/stats/stats.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-viper/mapstructure/v2"
+	"github.com/mohae/deepcopy"
 
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
@@ -99,8 +100,9 @@ func (s SenderStats) Copy() (result SenderStats) {
 	return result
 }
 
-// Stats holds basic runtime statistics about check instances
-type Stats struct {
+// stats holds Stats' fields, split out so Clone() can deep-copy it without ever
+// reflecting over a struct containing Stats.m (see Clone).
+type stats struct {
 	CheckName         string
 	CheckVersion      string
 	CheckConfigSource string
@@ -133,9 +135,14 @@ type Stats struct {
 	LastDelay                float64       // most recent check start time delay relative to the previous check run, in seconds
 	LastWarnings             []string      // warnings that occurred in the last run, if any
 	UpdateTimestamp          time.Time     // latest update to this instance, unix timestamp in seconds
-	m                        sync.Mutex
-	Telemetry                bool // do we want telemetry on this Check
+	Telemetry                bool          // do we want telemetry on this Check
 	HASupported              bool
+}
+
+// Stats holds basic runtime statistics about check instances
+type Stats struct {
+	stats
+	m sync.Mutex
 }
 
 //nolint:revive
@@ -158,27 +165,29 @@ type StatsCheck interface {
 
 // NewStats returns a new check stats instance
 func NewStats(c StatsCheck) *Stats {
-	stats := Stats{
-		CheckID:                  c.ID(),
-		CheckName:                c.String(),
-		CheckLoader:              c.Loader(),
-		CheckVersion:             c.Version(),
-		CheckConfigSource:        c.ConfigSource(),
-		Interval:                 c.Interval(),
-		Telemetry:                utils.IsCheckTelemetryEnabled(c.String(), pkgconfigsetup.Datadog()),
-		EventPlatformEvents:      make(map[string]int64),
-		TotalEventPlatformEvents: make(map[string]int64),
-		HASupported:              c.IsHASupported(),
+	cs := &Stats{
+		stats: stats{
+			CheckID:                  c.ID(),
+			CheckName:                c.String(),
+			CheckLoader:              c.Loader(),
+			CheckVersion:             c.Version(),
+			CheckConfigSource:        c.ConfigSource(),
+			Interval:                 c.Interval(),
+			Telemetry:                utils.IsCheckTelemetryEnabled(c.String(), pkgconfigsetup.Datadog()),
+			EventPlatformEvents:      make(map[string]int64),
+			TotalEventPlatformEvents: make(map[string]int64),
+			HASupported:              c.IsHASupported(),
+		},
 	}
 
 	// We are interested in a check's run state values even when they are 0 so we
 	// initialize them here explicitly
-	if stats.Telemetry && utils.IsTelemetryEnabled(pkgconfigsetup.Datadog()) {
-		tlmRuns.InitializeToZero(stats.CheckName, runCheckFailureTag)
-		tlmRuns.InitializeToZero(stats.CheckName, runCheckSuccessTag)
+	if cs.Telemetry && utils.IsTelemetryEnabled(pkgconfigsetup.Datadog()) {
+		tlmRuns.InitializeToZero(cs.CheckName, runCheckFailureTag)
+		tlmRuns.InitializeToZero(cs.CheckName, runCheckSuccessTag)
 	}
 
-	return &stats
+	return cs
 }
 
 // Add tracks a new execution time
@@ -284,52 +293,12 @@ func (cs *Stats) SetStateCancelling() {
 	cs.Cancelling = true
 }
 
-// Clone returns a copy of the check stats, safe to read after the lock is released. A raw
-// struct copy or a generic deep-copy (e.g. github.com/mohae/deepcopy) would read the fields
-// directly via reflection, bypassing this lock and racing with Add()/SetStateCancelling();
-// Clone() reads them under the lock instead.
+// Clone returns a copy of the check stats, safe to read after the lock is released.
 func (cs *Stats) Clone() *Stats {
 	cs.m.Lock()
 	defer cs.m.Unlock()
 
-	clone := &Stats{
-		CheckName:                cs.CheckName,
-		CheckVersion:             cs.CheckVersion,
-		CheckConfigSource:        cs.CheckConfigSource,
-		CheckLoader:              cs.CheckLoader,
-		CheckID:                  cs.CheckID,
-		Interval:                 cs.Interval,
-		LongRunning:              cs.LongRunning,
-		Cancelling:               cs.Cancelling,
-		TotalRuns:                cs.TotalRuns,
-		TotalErrors:              cs.TotalErrors,
-		TotalWarnings:            cs.TotalWarnings,
-		MetricSamples:            cs.MetricSamples,
-		Events:                   cs.Events,
-		ServiceChecks:            cs.ServiceChecks,
-		HistogramBuckets:         cs.HistogramBuckets,
-		TotalMetricSamples:       cs.TotalMetricSamples,
-		TotalEvents:              cs.TotalEvents,
-		TotalServiceChecks:       cs.TotalServiceChecks,
-		TotalHistogramBuckets:    cs.TotalHistogramBuckets,
-		EventPlatformEvents:      make(map[string]int64, len(cs.EventPlatformEvents)),
-		TotalEventPlatformEvents: make(map[string]int64, len(cs.TotalEventPlatformEvents)),
-		ExecutionTimes:           cs.ExecutionTimes,
-		FirstExecutionTime:       cs.FirstExecutionTime,
-		AverageExecutionTime:     cs.AverageExecutionTime,
-		LastExecutionTime:        cs.LastExecutionTime,
-		LastSuccessDate:          cs.LastSuccessDate,
-		LastError:                cs.LastError,
-		LastDelay:                cs.LastDelay,
-		LastWarnings:             append([]string(nil), cs.LastWarnings...),
-		UpdateTimestamp:          cs.UpdateTimestamp,
-		Telemetry:                cs.Telemetry,
-		HASupported:              cs.HASupported,
-	}
-	maps.Copy(clone.EventPlatformEvents, cs.EventPlatformEvents)
-	maps.Copy(clone.TotalEventPlatformEvents, cs.TotalEventPlatformEvents)
-
-	return clone
+	return &Stats{stats: deepcopy.Copy(cs.stats).(stats)}
 }
 
 type aggStats struct {

--- a/pkg/collector/check/stats/stats.go
+++ b/pkg/collector/check/stats/stats.go
@@ -100,8 +100,7 @@ func (s SenderStats) Copy() (result SenderStats) {
 	return result
 }
 
-// stats holds Stats' fields, split out so Clone() can deep-copy it without ever
-// reflecting over a struct containing Stats.m (see Clone).
+// stats holds Stats' fields, split out to ease deep-copy without touching the mutex
 type stats struct {
 	CheckName         string
 	CheckVersion      string

--- a/pkg/collector/check/stats/stats.go
+++ b/pkg/collector/check/stats/stats.go
@@ -284,6 +284,54 @@ func (cs *Stats) SetStateCancelling() {
 	cs.Cancelling = true
 }
 
+// Clone returns a copy of the check stats, safe to read after the lock is released. A raw
+// struct copy or a generic deep-copy (e.g. github.com/mohae/deepcopy) would read the fields
+// directly via reflection, bypassing this lock and racing with Add()/SetStateCancelling();
+// Clone() reads them under the lock instead.
+func (cs *Stats) Clone() *Stats {
+	cs.m.Lock()
+	defer cs.m.Unlock()
+
+	clone := &Stats{
+		CheckName:                cs.CheckName,
+		CheckVersion:             cs.CheckVersion,
+		CheckConfigSource:        cs.CheckConfigSource,
+		CheckLoader:              cs.CheckLoader,
+		CheckID:                  cs.CheckID,
+		Interval:                 cs.Interval,
+		LongRunning:              cs.LongRunning,
+		Cancelling:               cs.Cancelling,
+		TotalRuns:                cs.TotalRuns,
+		TotalErrors:              cs.TotalErrors,
+		TotalWarnings:            cs.TotalWarnings,
+		MetricSamples:            cs.MetricSamples,
+		Events:                   cs.Events,
+		ServiceChecks:            cs.ServiceChecks,
+		HistogramBuckets:         cs.HistogramBuckets,
+		TotalMetricSamples:       cs.TotalMetricSamples,
+		TotalEvents:              cs.TotalEvents,
+		TotalServiceChecks:       cs.TotalServiceChecks,
+		TotalHistogramBuckets:    cs.TotalHistogramBuckets,
+		EventPlatformEvents:      make(map[string]int64, len(cs.EventPlatformEvents)),
+		TotalEventPlatformEvents: make(map[string]int64, len(cs.TotalEventPlatformEvents)),
+		ExecutionTimes:           cs.ExecutionTimes,
+		FirstExecutionTime:       cs.FirstExecutionTime,
+		AverageExecutionTime:     cs.AverageExecutionTime,
+		LastExecutionTime:        cs.LastExecutionTime,
+		LastSuccessDate:          cs.LastSuccessDate,
+		LastError:                cs.LastError,
+		LastDelay:                cs.LastDelay,
+		LastWarnings:             append([]string(nil), cs.LastWarnings...),
+		UpdateTimestamp:          cs.UpdateTimestamp,
+		Telemetry:                cs.Telemetry,
+		HASupported:              cs.HASupported,
+	}
+	maps.Copy(clone.EventPlatformEvents, cs.EventPlatformEvents)
+	maps.Copy(clone.TotalEventPlatformEvents, cs.TotalEventPlatformEvents)
+
+	return clone
+}
+
 type aggStats struct {
 	EventPlatformEvents       map[string]interface{}
 	EventPlatformEventsErrors map[string]interface{}

--- a/pkg/collector/check/stats/stats_test.go
+++ b/pkg/collector/check/stats/stats_test.go
@@ -181,3 +181,24 @@ func TestTranslateEventPlatformEventTypes(t *testing.T) {
 	assert.True(t, assert.ObjectsAreEqual(expected, result))
 	assert.EqualValues(t, expected, result)
 }
+
+// TestStatsCloneConcurrent reproduces the scenario that raced in production: something
+// reading a *Stats (e.g. via GetCheckStats()) while Add()/SetStateCancelling() run
+// concurrently on the same instance. Run with -race.
+func TestStatsCloneConcurrent(_ *testing.T) {
+	stats := NewStats(newMockCheck())
+	haagent := haagentmock.NewMockHaAgent()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 1000 {
+			stats.Add(time.Millisecond, nil, []error{}, SenderStats{}, haagent)
+			stats.SetStateCancelling()
+		}
+	}()
+	for range 1000 {
+		stats.Clone()
+	}
+	<-done
+}

--- a/pkg/collector/runner/expvars/BUILD.bazel
+++ b/pkg/collector/runner/expvars/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//pkg/collector/check/id",
         "//pkg/collector/check/stats",
         "//pkg/util/log",
-        "@com_github_mohae_deepcopy//:deepcopy",
     ],
 )
 

--- a/pkg/collector/runner/expvars/expvars.go
+++ b/pkg/collector/runner/expvars/expvars.go
@@ -11,8 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mohae/deepcopy"
-
 	haagent "github.com/DataDog/datadog-agent/comp/haagent/def"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
@@ -100,9 +98,19 @@ func GetCheckStats() map[string]map[checkid.ID]*checkstats.Stats {
 	checkStats.statsLock.RLock()
 	defer checkStats.statsLock.RUnlock()
 
-	// Because the returned maps will be used after the lock is released, and
-	// thus when they might be further modified, we must clone them here.
-	return deepcopy.Copy(checkStats.stats).(map[string]map[checkid.ID]*checkstats.Stats)
+	// Because the returned maps will be used after the lock is released, and thus when they
+	// might be further modified, we must clone them here. Each *Stats has its own lock
+	// guarding its fields, so clone it via its own Clone() method rather than a generic
+	// deep-copy, which would reflect over it directly and bypass that lock.
+	result := make(map[string]map[checkid.ID]*checkstats.Stats, len(checkStats.stats))
+	for name, perCheckID := range checkStats.stats {
+		cloned := make(map[checkid.ID]*checkstats.Stats, len(perCheckID))
+		for id, stats := range perCheckID {
+			cloned[id] = stats.Clone()
+		}
+		result[name] = cloned
+	}
+	return result
 }
 
 // AddCheckStats adds runtime stats to the check's expvars

--- a/pkg/collector/runner/expvars/expvars.go
+++ b/pkg/collector/runner/expvars/expvars.go
@@ -98,10 +98,7 @@ func GetCheckStats() map[string]map[checkid.ID]*checkstats.Stats {
 	checkStats.statsLock.RLock()
 	defer checkStats.statsLock.RUnlock()
 
-	// Because the returned maps will be used after the lock is released, and thus when they
-	// might be further modified, we must clone them here. Each *Stats has its own lock
-	// guarding its fields, so clone it via its own Clone() method rather than a generic
-	// deep-copy, which would reflect over it directly and bypass that lock.
+	// Clone to avoid race conditions on the stats later
 	result := make(map[string]map[checkid.ID]*checkstats.Stats, len(checkStats.stats))
 	for name, perCheckID := range checkStats.stats {
 		cloned := make(map[checkid.ID]*checkstats.Stats, len(perCheckID))


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Fixes a data race in `pkg/collector/runner/expvars`: `*Stat` objects are dereferenced and then converted to an interface within `mohae/deepcopy`, which copies the object by value, which in particular reads the raw bytes of the mutex, causing a race with legit uses of the same mutex.
Split the mutex into a separate struct to avoid this issue.

### Motivation
Fix a race.

### Describe how you validated your changes

CI

### Additional Notes
Found via `-race` in a live deployment log (`GetCheckStats()`, reachable via the collector metadata payload, racing with a check being unscheduled).
