### PR TITLE
fix(apm): gate auto CSI by registry

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -51,6 +51,10 @@ type staticConfig struct {
 	// An empty list allows all registries (default).
 	registryAllowList []string
 
+	// defaultDDRegistries contains the Datadog-owned registries that the automatic
+	// injection mode can safely use through the CSI driver without extra credentials.
+	defaultDDRegistries []string
+
 	// mutateUnlabelled is used to control if we require workloads to have a label when using Local Lib Injection.
 	mutateUnlabelled bool
 
@@ -132,6 +136,7 @@ func NewConfig(datadogConfig config.Component) (*Config, error) {
 
 	containerRegistry := mutatecommon.ContainerRegistry(datadogConfig, "admission_controller.auto_instrumentation.container_registry")
 	registryAllowList := datadogConfig.GetStringSlice("admission_controller.auto_instrumentation.container_registry_allow_list")
+	defaultDDRegistries := datadogConfig.GetStringSlice("admission_controller.auto_instrumentation.default_dd_registries")
 	mutateUnlabelled := datadogConfig.GetBool("admission_controller.mutate_unlabelled")
 
 	return &Config{
@@ -141,6 +146,7 @@ func NewConfig(datadogConfig config.Component) (*Config, error) {
 			Instrumentation:               instrumentationConfig,
 			containerRegistry:             containerRegistry,
 			registryAllowList:             registryAllowList,
+			defaultDDRegistries:           defaultDDRegistries,
 			mutateUnlabelled:              mutateUnlabelled,
 			initResources:                 initResources,
 			initSecurityContext:           initSecurityContext,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/auto.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/auto.go
@@ -8,6 +8,8 @@
 package libraryinjection
 
 import (
+	"slices"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -17,7 +19,7 @@ import (
 // It picks the best concrete provider for a pod based on the runtime
 // environment, currently:
 //   - CSIProvider when the Datadog CSI driver is registered in the cluster
-//     with APM SSI advertised (state cached by CSIDriverWatcher);
+//     with APM SSI advertised and all images use supported registries;
 //   - InitContainerProvider otherwise.
 type AutoProvider struct {
 	realProvider LibraryInjectionProvider
@@ -44,15 +46,28 @@ func NewAutoProvider(cfg LibraryInjectionConfig) *AutoProvider {
 // the provider behaves exactly as before this feature existed and always
 // returns the init-container provider.
 func pickAutoProvider(cfg LibraryInjectionConfig) LibraryInjectionProvider {
-	if cfg.CSIDriverWatcher == nil {
+	if cfg.CSIDriverWatcher == nil || !cfg.CSIDriverWatcher.IsAPMEnabled() {
+		log.Debugf("library injection auto provider: Datadog CSI driver %q is unavailable for APM injection, using InitContainerProvider", csiDriverName)
 		return NewInitContainerProvider(cfg)
 	}
-	if cfg.CSIDriverWatcher.IsAPMEnabled() {
-		log.Debugf("library injection auto provider: Datadog CSI driver %q is registered with APM enabled, using CSIProvider", csiDriverName)
-		return NewCSIProvider(cfg)
+	if registry, found := firstUnsupportedCSIRegistry(cfg); found {
+		log.Debugf("library injection auto provider: registry %q requires workload image pull credentials, using InitContainerProvider", registry)
+		return NewInitContainerProvider(cfg)
 	}
-	log.Debugf("library injection auto provider: Datadog CSI driver %q is not registered (or APM not advertised), using InitContainerProvider", csiDriverName)
-	return NewInitContainerProvider(cfg)
+	log.Debugf("library injection auto provider: Datadog CSI driver %q is registered with APM enabled, using CSIProvider", csiDriverName)
+	return NewCSIProvider(cfg)
+}
+
+func firstUnsupportedCSIRegistry(cfg LibraryInjectionConfig) (string, bool) {
+	if !slices.Contains(cfg.CSIAutoRegistries, cfg.Injector.Package.Registry) {
+		return cfg.Injector.Package.Registry, true
+	}
+	for _, library := range cfg.Libraries {
+		if !slices.Contains(cfg.CSIAutoRegistries, library.Package.Registry) {
+			return library.Package.Registry, true
+		}
+	}
+	return "", false
 }
 
 // GetName returns the effective injection mode of the resolved concrete provider,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/auto_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/auto_test.go
@@ -20,6 +20,8 @@ import (
 
 const datadogCSIDriverName = "k8s.csi.datadoghq.com"
 
+var defaultCSIAutoRegistries = []string{"gcr.io/datadoghq", "public.ecr.aws/datadog"}
+
 // fakeCSIDriverWatcher is a deterministic CSIDriverWatcher implementation
 // used in unit tests so we can drive the AutoProvider decision tree without
 // spinning up a workloadmeta subscription.
@@ -63,7 +65,9 @@ func TestAutoProvider_PicksCSIWhenWatcherReportsAPMEnabled(t *testing.T) {
 	pod := newPod()
 
 	provider := libraryinjection.NewAutoProvider(libraryinjection.LibraryInjectionConfig{
-		CSIDriverWatcher: fakeCSIDriverWatcher{registered: true, apmEnabled: true},
+		Injector:          injectorConfig(),
+		CSIAutoRegistries: defaultCSIAutoRegistries,
+		CSIDriverWatcher:  fakeCSIDriverWatcher{registered: true, apmEnabled: true},
 	})
 
 	result := provider.InjectInjector(pod, injectorConfig())
@@ -76,6 +80,61 @@ func TestAutoProvider_PicksCSIWhenWatcherReportsAPMEnabled(t *testing.T) {
 	vol := findInstrumentationVolume(t, pod)
 	r.NotNil(vol.CSI, "instrumentation volume should be a CSI volume")
 	r.Equal(datadogCSIDriverName, vol.CSI.Driver)
+}
+
+func TestAutoProvider_RegistrySelection(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      libraryinjection.LibraryInjectionConfig
+		wantMode string
+	}{
+		{
+			name: "selects csi when every image uses an allowed registry",
+			cfg: libraryinjection.LibraryInjectionConfig{
+				Injector: injectorConfig(),
+				Libraries: []libraryinjection.LibraryConfig{
+					{Package: libraryinjection.LibraryImage{Registry: "public.ecr.aws/datadog"}},
+				},
+				CSIAutoRegistries: []string{"gcr.io/datadoghq", "public.ecr.aws/datadog"},
+			},
+			wantMode: "csi (auto)",
+		},
+		{
+			name: "falls back when the injector uses another registry",
+			cfg: libraryinjection.LibraryInjectionConfig{
+				Injector: libraryinjection.InjectorConfig{
+					Package: libraryinjection.LibraryImage{Registry: "registry.example.com/datadog"},
+				},
+				CSIAutoRegistries: []string{"gcr.io/datadoghq"},
+			},
+			wantMode: "init_container (auto)",
+		},
+		{
+			name: "falls back when a library uses another registry",
+			cfg: libraryinjection.LibraryInjectionConfig{
+				Injector: injectorConfig(),
+				Libraries: []libraryinjection.LibraryConfig{
+					{Package: libraryinjection.LibraryImage{Registry: "registry.example.com/datadog"}},
+				},
+				CSIAutoRegistries: []string{"gcr.io/datadoghq"},
+			},
+			wantMode: "init_container (auto)",
+		},
+		{
+			name: "falls back when no csi registry is configured",
+			cfg: libraryinjection.LibraryInjectionConfig{
+				Injector: injectorConfig(),
+			},
+			wantMode: "init_container (auto)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.cfg.CSIDriverWatcher = fakeCSIDriverWatcher{registered: true, apmEnabled: true}
+			require.Equal(t, tt.wantMode, libraryinjection.NewAutoProvider(tt.cfg).GetName())
+		})
+	}
 }
 
 func TestAutoProvider_FallsBackToInitContainerWhenWatcherReportsAPMDisabled(t *testing.T) {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator_test.go
@@ -70,7 +70,9 @@ func TestGetName(t *testing.T) {
 		{
 			name: "AutoProvider resolves to CSI when driver is available",
 			provider: libraryinjection.NewAutoProvider(libraryinjection.LibraryInjectionConfig{
-				CSIDriverWatcher: fakeCSIDriverWatcher{registered: true, apmEnabled: true},
+				Injector:          injectorConfig(),
+				CSIAutoRegistries: defaultCSIAutoRegistries,
+				CSIDriverWatcher:  fakeCSIDriverWatcher{registered: true, apmEnabled: true},
 			}),
 			expected: "csi (auto)",
 		},
@@ -164,10 +166,11 @@ func TestInjectAPMLibraries_Annotations_Auto_CSI(t *testing.T) {
 	pod := newPod()
 
 	err := libraryinjection.InjectAPMLibraries(pod, libraryinjection.LibraryInjectionConfig{
-		InjectionMode:    string(libraryinjection.InjectionModeAuto),
-		CSIDriverWatcher: fakeCSIDriverWatcher{registered: true, apmEnabled: true},
-		Injector:         injectorConfig(),
-		Libraries:        []libraryinjection.LibraryConfig{javaLib()},
+		InjectionMode:     string(libraryinjection.InjectionModeAuto),
+		CSIAutoRegistries: defaultCSIAutoRegistries,
+		CSIDriverWatcher:  fakeCSIDriverWatcher{registered: true, apmEnabled: true},
+		Injector:          injectorConfig(),
+		Libraries:         []libraryinjection.LibraryConfig{javaLib()},
 	})
 	require.NoError(t, err)
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/provider.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/provider.go
@@ -116,6 +116,11 @@ type LibraryInjectionConfig struct {
 	// An empty list allows all registries (default).
 	RegistryAllowList []string
 
+	// CSIAutoRegistries contains registries that auto mode can use through CSI.
+	// Images from other registries fall back to init containers, which use the
+	// workload's image pull credentials.
+	CSIAutoRegistries []string
+
 	// CSIDriverWatcher caches the Datadog CSI driver state observed via
 	// workloadmeta. AutoProvider consults it to decide between CSI and
 	// init-container injection without hitting workloadmeta on every

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
@@ -145,6 +145,7 @@ func (m *mutatorCore) buildLibraryInjectionConfig(pod *corev1.Pod, config extrac
 		Debug:                       m.isDebugEnabled(pod),
 		AutoDetected:                autoDetected,
 		InjectionType:               injectionType,
+		CSIAutoRegistries:           m.config.staticConfig.defaultDDRegistries,
 		CSIDriverWatcher:            m.csiDriverWatcher,
 		Injector: libraryinjection.InjectorConfig{
 			Package: injectorImage,

--- a/releasenotes/notes/csi-auto-registry-fallback-9e4b7c1a6d2f8035.yaml
+++ b/releasenotes/notes/csi-auto-registry-fallback-9e4b7c1a6d2f8035.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    APM: Make the automatic library injection mode use the CSI driver only when
+    the injector and library images come from configured Datadog registries.
+    Images from other registries now fall back to init containers so Kubernetes
+    can use the workload's image pull credentials.


### PR DESCRIPTION
### What does this PR do?

Restricts CSI selection in automatic APM library injection mode to cases where the injector and every library image use a registry from `default_dd_registries`. Other registries fall back to init-container injection.

### Motivation

The CSI driver does not receive the workload's image pull credentials. Selecting it for custom or private registries can therefore make library downloads fail, while init containers can rely on Kubernetes image pull secrets.

### Describe how you validated your changes

Ran the auto-instrumentation unit test suite:

`dda inv test --targets=./pkg/clusteragent/admission/mutate/autoinstrumentation/...`

All 548 targeted tests passed, including new injector and library registry-selection cases.

### Additional Notes

Explicit `csi` injection mode remains unchanged. Supporting private registries through CSI requires a separate authentication mechanism.