### PR TITLE
fix(coat): restore discovered_services metric

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -53,6 +53,16 @@ const (
 	componentName     = "workloadmeta-process"
 	cacheValidityNoRT = 2 * time.Second
 
+	// discoveredServicesSubsystem is the telemetry subsystem (metric prefix) for the
+	// discovered_services gauge. It is intentionally "service_discovery" rather than the
+	// collectorID ("process-collector"): through Agent 7.70 this gauge was emitted by the
+	// service_discovery corecheck under that subsystem, so the emitted metric was
+	// "service_discovery.discovered_services", which the cross-org agent telemetry (COAT)
+	// allowlist in comp/core/agenttelemetry/impl/defaultProfiles.yaml matches. Reusing the
+	// same subsystem keeps that metric name stable across agent versions instead of minting
+	// a new "process_collector.discovered_services", so historical COAT data stays continuous.
+	discoveredServicesSubsystem = "service_discovery"
+
 	// Service discovery constants
 	maxPortCheckTries                                = 10
 	serviceCollectionBatchSizeConfigKey              = "discovery.service_collection_batch_size"
@@ -107,7 +117,7 @@ func newProcessCollector(id string, catalog workloadmeta.AgentType, clock clock.
 	var discoveredServicesGauge telemetry.Gauge
 	if serviceDiscoveryEnabled(systemProbeConfig) {
 		discoveredServicesGauge = telemetryimpl.GetCompatComponent().NewGaugeWithOpts(
-			collectorID,
+			discoveredServicesSubsystem,
 			"discovered_services",
 			[]string{},
 			"Number of discovered alive services.",


### PR DESCRIPTION
<!-- dd-meta {"pullId":"7928ff50-48e4-4c62-bbef-3a908f51e2b9","source":"chat","resourceId":"a2ed2a3a-18de-4785-a649-90f3d49aa122","workflowId":"b28f4989-ccfd-4306-90dc-5801e9b3ac18","codeChangeId":"b28f4989-ccfd-4306-90dc-5801e9b3ac18","sourceType":"slack"} -->
### What does this PR do?

Restores the `service_discovery.discovered_services` gauge in cross-org agent telemetry (COAT), which stopped being reported starting with Agent 7.71.

The fix is a single line: the `discovered_services` gauge in the workloadmeta process collector is now registered under the telemetry subsystem `service_discovery` (via a documented `discoveredServicesSubsystem` constant) instead of the collector's dashed id `collectorID` (`"process-collector"`). The COAT allowlist and profile in `comp/core/agenttelemetry/impl/defaultProfiles.yaml` are left unchanged — they already reference `service_discovery.discovered_services`.

### Motivation

Through Agent 7.70, this gauge was created by the `service_discovery` corecheck with subsystem `service_discovery`, producing the metric `service_discovery.discovered_services`, which the COAT allowlist matched.

In 7.71 the gauge moved into the workloadmeta process collector and was registered with subsystem `collectorID = "process-collector"` (a dash). Because this repo's Prometheus client uses `UTF8Validation`, the dash is preserved, so the registry family name became `process-collector__discovered_services`. The COAT matcher only normalizes `__`→`_` (it does not touch dashes), so the `service_discovery.discovered_services` allowlist entry no longer matched anything — COAT went silent for this metric from 7.71 on.

Rather than re-point the allowlist at a new `process_collector.discovered_services` name (which would mint a brand-new metric and break continuity with the ≤7.70 data), this restores the original `service_discovery` subsystem on the emitter. The metric name is then identical across all agent versions, so historical COAT data stays continuous and a "% of orgs" query works over the full window (apart from the 7.71–7.79 gap on already-deployed agents, which only fixed rollouts can fill going forward).

Match after the fix: subsystem `service_discovery` + name `discovered_services` → family `service_discovery__discovered_services` → the matcher normalizes the first `__`→`_` to `service_discovery_discovered_services`, which equals the key derived from the YAML name `service_discovery.discovered_services`. This is the same match that worked through 7.70.

### Describe how you validated your changes

- `go build` of `comp/core/workloadmeta/collectors/internal/process/` and `comp/core/agenttelemetry/impl/` — passes.
- `go test -tags "test systemprobechecks" ./comp/core/workloadmeta/collectors/internal/process/` — passes.
- `go test -tags test ./comp/core/agenttelemetry/impl/ -run TestRun` — passes (COAT `defaultProfiles.yaml` parses; profile count unchanged at 20).
- Traced the registration path (`NewGaugeWithOpts` → `NameWithSeparator` → Prometheus `BuildFQName`) and the COAT matcher (`compileMetric` key build + `transformMetricFamily` `__`→`_` normalization) to confirm the emitted family name matches the existing allowlist key.

### Additional Notes

No release note: COAT emitter/allowlist changes are internal cross-org telemetry and not customer-facing (consistent with recent `defaultProfiles.yaml` changes, which carried none) — expect the `changelog/no-changelog` label.

This supersedes an earlier approach that renamed the metric to `process_collector.discovered_services`; per review feedback, reusing the existing `service_discovery.discovered_services` name preserves historical continuity and touches only the one line that regressed.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/a2ed2a3a-18de-4785-a649-90f3d49aa122)

Comment @datadog to request changes