### PR TITLE
fix(flare): retry post-unzip file existence checks in TestSave

### DIFF
--- a/comp/core/flare/helpers/builder_test.go
+++ b/comp/core/flare/helpers/builder_test.go
@@ -110,8 +110,16 @@ func TestSave(t *testing.T) {
 
 	err = archive.Unzip(archivePath, tmpDir)
 	assert.Nil(t, err)
-	assert.FileExists(t, filepath.Join(tmpDir, hostname, "test.data"))
-	assert.FileExists(t, filepath.Join(tmpDir, hostname, "test/depth1/depth2/test4"))
+
+	for _, extracted := range []string{
+		filepath.Join(tmpDir, hostname, "test.data"),
+		filepath.Join(tmpDir, hostname, "test/depth1/depth2/test4"),
+	} {
+		assert.Eventually(t, func() bool {
+			info, err := os.Lstat(extracted)
+			return err == nil && !info.IsDir()
+		}, 3*time.Second, 10*time.Millisecond, "unable to find file %q", extracted)
+	}
 }
 
 func TestAddFileFromFunc(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?
Wraps the two `assert.FileExists` checks on files extracted from the flare archive in `TestSave` (`comp/core/flare/helpers/builder_test.go`) with the same `assert.Eventually` retry already used for the archive file itself.

### Motivation
`TestSave` flakes intermittently on Windows CI with `unable to find file ... test.data` / `... test4` right after `archive.Unzip` returns successfully (e.g. https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1918185879).

PR #54098 already fixed this exact filesystem-visibility race (a Windows delay between a file being written and being stat-able, most likely AV/Defender scanning) for the top-level archive file by wrapping its existence check in `Eventually`. It did not extend the same fix to the two files extracted from that archive, so the identical race simply resurfaced one step later, in extraction instead of archiving.

### Describe how you validated your changes
Ran `dda inv test --targets=./comp/core/flare/helpers/...` locally — all 48 tests pass.

### Additional Notes
Test-only change; no production code touched.