### PR TITLE
[DSEC-230] Catch Rust check panics at the FFI boundary to prevent agent aborts

### DIFF
--- a/pkg/collector/sharedlibrary/rustchecks/core/BUILD.bazel
+++ b/pkg/collector/sharedlibrary/rustchecks/core/BUILD.bazel
@@ -24,8 +24,8 @@ rust_library(
 
 # Unit tests embedded in the crate sources (run with `bazel test`).
 rust_test(
-    name = "core_test",
-    crate = ":core",
+    name = "shlib_core_test",
+    crate = ":shlib_core",
     edition = "2024",
     target_compatible_with = _LINUX,
 )

--- a/pkg/collector/sharedlibrary/rustchecks/core/BUILD.bazel
+++ b/pkg/collector/sharedlibrary/rustchecks/core/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 # Rust shared-library checks are Linux-only (see the omnibus/agent.build wiring;
 # the loader only ships them on Linux).
@@ -20,4 +20,12 @@ rust_library(
         "@crates//:serde",
         "@crates//:serde_yaml",
     ],
+)
+
+# Unit tests embedded in the crate sources (run with `bazel test`).
+rust_test(
+    name = "core_test",
+    crate = ":core",
+    edition = "2024",
+    target_compatible_with = _LINUX,
 )

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/ffi.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/ffi.rs
@@ -12,18 +12,40 @@ macro_rules! generate_ffi {
             aggregator_ptr: *const $crate::Aggregator,
             error_handler: *mut *mut std::ffi::c_char,
         ) {
-            if let Err(e) = create_and_run_check(
-                check_id_cstr,
-                init_config_cstr,
-                instance_config_cstr,
-                aggregator_ptr,
-            ) {
-                let error_msg = std::ffi::CString::new(e.to_string()).unwrap_or_default();
-                unsafe {
-                    let ptr = libc::strdup(error_msg.as_ptr());
-                    *error_handler = ptr;
-                };
-            }
+            // Catch panics: unwinding across this `extern "C"` boundary would
+            // abort (SIGABRT) the whole agent.
+            // See https://doc.rust-lang.org/nomicon/ffi.html#catching-panic-preemptively
+            let result = std::panic::catch_unwind(|| {
+                create_and_run_check(
+                    check_id_cstr,
+                    init_config_cstr,
+                    instance_config_cstr,
+                    aggregator_ptr,
+                )
+                .map_err(|e| e.to_string())
+            });
+
+            let error_msg = match result {
+                Ok(Ok(())) => return,
+                Ok(Err(msg)) => msg,
+                Err(payload) => {
+                    let msg = payload
+                        .downcast_ref::<&str>()
+                        .map(|s| s.to_string())
+                        .or_else(|| payload.downcast_ref::<String>().cloned())
+                        .unwrap_or_else(|| "unknown panic".to_string());
+                    // Dropping the payload may itself panic (see catch_unwind
+                    // docs); leak it so a second panic cannot escape here.
+                    std::mem::forget(payload);
+                    format!("check panicked: {msg}")
+                }
+            };
+
+            let error_cstr = std::ffi::CString::new(error_msg).unwrap_or_default();
+            unsafe {
+                let ptr = libc::strdup(error_cstr.as_ptr());
+                *error_handler = ptr;
+            };
         }
 
         /// Build the check structure and execute its custom implementation

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/ffi.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/ffi.rs
@@ -34,9 +34,6 @@ macro_rules! generate_ffi {
                         .map(|s| s.to_string())
                         .or_else(|| payload.downcast_ref::<String>().cloned())
                         .unwrap_or_else(|| "unknown panic".to_string());
-                    // Dropping the payload may itself panic (see catch_unwind
-                    // docs); leak it so a second panic cannot escape here.
-                    std::mem::forget(payload);
                     format!("check panicked: {msg}")
                 }
             };

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/ffi.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/ffi.rs
@@ -80,3 +80,93 @@ macro_rules! generate_ffi {
         }
     };
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{AgentCheck, Aggregator, AggregatorStub};
+
+    use anyhow::{Result, bail};
+
+    use std::cell::Cell;
+    use std::ffi::{CStr, CString, c_char};
+
+    // Per-thread check behavior. A single `generate_ffi!` `Run` (one `#[no_mangle]`
+    // symbol) is driven by each test via this thread-local.
+    #[derive(Clone, Copy)]
+    enum Behavior {
+        Panic,
+        Error,
+        Success,
+    }
+
+    thread_local! {
+        static BEHAVIOR: Cell<Behavior> = const { Cell::new(Behavior::Success) };
+    }
+
+    fn configurable_check(_check: &AgentCheck) -> Result<()> {
+        match BEHAVIOR.with(Cell::get) {
+            Behavior::Panic => panic!("divide by zero"),
+            Behavior::Error => bail!("check failed"),
+            Behavior::Success => Ok(()),
+        }
+    }
+
+    const TEST_VERSION: &CStr = c"test";
+
+    generate_ffi!(configurable_check, TEST_VERSION);
+
+    /// Calls the generated `Run` and returns the reported error message
+    /// (`strdup`-allocated, freed here), or `None` on success.
+    fn run_check() -> Option<String> {
+        let aggregator = AggregatorStub::new().aggregator();
+        let check_id = CString::new("test-check").unwrap();
+        let config = CString::new("{}").unwrap();
+        let mut error_handler: *mut c_char = std::ptr::null_mut();
+
+        Run(
+            check_id.as_ptr(),
+            config.as_ptr(),
+            config.as_ptr(),
+            &aggregator as *const Aggregator,
+            &mut error_handler as *mut *mut c_char,
+        );
+
+        // Null means success: `Run` leaves `error_handler` untouched.
+        if error_handler.is_null() {
+            return None;
+        }
+
+        let msg = unsafe { CStr::from_ptr(error_handler) }
+            .to_str()
+            .unwrap()
+            .to_string();
+        unsafe { libc::free(error_handler as *mut libc::c_void) };
+        Some(msg)
+    }
+
+    #[test]
+    fn run_catches_panic_and_reports_it() {
+        BEHAVIOR.with(|b| b.set(Behavior::Panic));
+
+        let msg = run_check().expect("panicking check should report an error");
+        assert_eq!(msg, "check panicked: divide by zero");
+    }
+
+    #[test]
+    fn run_reports_check_error() {
+        BEHAVIOR.with(|b| b.set(Behavior::Error));
+
+        let msg = run_check().expect("failing check should report an error");
+        assert_eq!(msg, "check failed");
+    }
+
+    #[test]
+    fn run_succeeds_without_error() {
+        BEHAVIOR.with(|b| b.set(Behavior::Success));
+
+        assert!(
+            run_check().is_none(),
+            "successful check should not report an error"
+        );
+    }
+}

--- a/pkg/collector/sharedlibrary/rustchecks/core/src/stubs.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/core/src/stubs.rs
@@ -250,21 +250,25 @@ impl AggregatorStub {
         }
     }
 
-    /// Builds an [`AgentCheck`] wired to this stub. Panics on invalid YAML.
-    pub fn agent_check(&self, init_config: &str, instance_config: &str) -> AgentCheck {
-        let aggregator = Aggregator::new(
+    /// Builds the recording [`Aggregator`] wired to this stub's callbacks.
+    pub fn aggregator(&self) -> Aggregator {
+        Aggregator::new(
             record_metric,
             record_service_check,
             record_event,
             record_histogram_bucket,
             record_event_platform_event,
             log_msg,
-        );
+        )
+    }
+
+    /// Builds an [`AgentCheck`] wired to this stub. Panics on invalid YAML.
+    pub fn agent_check(&self, init_config: &str, instance_config: &str) -> AgentCheck {
         AgentCheck::new(
             self.check_id.clone(),
             Config::from_str(init_config).expect("invalid init_config YAML"),
             Config::from_str(instance_config).expect("invalid instance_config YAML"),
-            aggregator,
+            self.aggregator(),
         )
     }
 

--- a/releasenotes/notes/rust-check-panic-resilience-74fed3bd18fdaf8b.yaml
+++ b/releasenotes/notes/rust-check-panic-resilience-74fed3bd18fdaf8b.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    A panic in a Rust-based shared-library check no longer aborts the whole
+    Agent. The panic is now caught at the check boundary and surfaced as a
+    check error, keeping the rest of the Agent running.


### PR DESCRIPTION
### What does this PR do?

Wraps the Rust check entrypoint (`generate_ffi!`'s `extern "C" fn Run`) in `std::panic::catch_unwind`, converting a panic into the check's error out-param instead of letting it unwind across the FFI boundary.

### Motivation

A panic escaping the `extern "C"` boundary aborts the whole agent (SIGABRT), and Go's `recover()` (`pkg/collector/worker/worker.go:222`) can't catch a foreign abort raised during a cgo call. Catching it in Rust makes a panicking Rust check degrade like Go/Python ones (logged error).

Docs: [Nomicon — FFI and unwinding](https://doc.rust-lang.org/nomicon/ffi.html#catching-panic-preemptively), [`std::panic::catch_unwind`](https://doc.rust-lang.org/std/panic/fn.catch_unwind.html) (note its "dropping the `Err` payload may itself panic" caveat. This is handled via `mem::forget`).

### Describe how you validated your changes

Added a deliberate `panic!` in the `datasecurity` check and ran the agent.

**Before** — the panic aborts the process (`SIGABRT`), taking every goroutine down:

<details><summary>agent crash log</summary>

```
thread '<unnamed>' (15225144) panicked at .../datasecurity/src/check.rs:25:5:
datasecurity: systematic test panic (TODO remove me)
...
panic in a function that cannot unwind
...
  10:        0x16314cd6c - _Run
  11:        0x102ad2fd0 - _run_shared_library
  12:        0x102ad2cf4 - __cgo_74362e09ab08_Cfunc_run_shared_library
thread caused non-unwinding panic. aborting.
SIGABRT: abort
PC=0x18cb725e8 m=11 sigcode=0
signal arrived during cgo execution
...
created by .../runner.(*Runner).newWorker in goroutine 537
	.../pkg/collector/runner/runner.go:175 +0x230
```

</details>

**After** — the panic is caught, surfaced as a check error, and the agent keeps running:

<details><summary>agent log</summary>

```
CORE | INFO  | check:datasecurity | Running check...
CORE | INFO  | datasecurity: about to panic (test only)

thread '<unnamed>' (15347494) panicked at .../datasecurity/src/check.rs:25:5:
datasecurity: systematic test panic (TODO remove me)
CORE | ERROR | check:datasecurity | Error running check: Run failed: Failed to run check: check panicked: datasecurity: systematic test panic (TODO remove me)
CORE | INFO  | check:datasecurity | Done running check
CORE | INFO  | check:datasecurity | Check's one time execution has finished
```

</details>

### Additional Notes

The test-only `panic!` used for validation is not part of this change.
