### PR TITLE
[DSEC-212] [No-Static-Quality-Bump] Enable data security rust check 

### DIFF
--- a/pkg/collector/sharedlibrary/rustchecks/BUILD.bazel
+++ b/pkg/collector/sharedlibrary/rustchecks/BUILD.bazel
@@ -4,8 +4,8 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 # Rust shared-library checks are Linux-only.
 _LINUX = ["@platforms//os:linux"]
 
-# Rust checks are disabled by default; add a check name -> cdylib target entry
-# here to ship it. Uncomment the datasecurity entry below to ship the check.
+# Map of check name -> cdylib target for each Rust check we ship. Add an entry
+# here to ship a new check.
 ENABLED_CHECKS = {
     "datasecurity": "//pkg/collector/sharedlibrary/rustchecks/checks/datasecurity:datasecurity",
 }

--- a/pkg/collector/sharedlibrary/rustchecks/BUILD.bazel
+++ b/pkg/collector/sharedlibrary/rustchecks/BUILD.bazel
@@ -7,7 +7,7 @@ _LINUX = ["@platforms//os:linux"]
 # Rust checks are disabled by default; add a check name -> cdylib target entry
 # here to ship it. Uncomment the datasecurity entry below to ship the check.
 ENABLED_CHECKS = {
-    # "datasecurity": "//pkg/collector/sharedlibrary/rustchecks/checks/datasecurity:datasecurity",
+    "datasecurity": "//pkg/collector/sharedlibrary/rustchecks/checks/datasecurity:datasecurity",
 }
 
 # Stage every enabled cdylib into checks.d with the loader naming convention

--- a/releasenotes/notes/ship-data-security-shared-library-9c1f4a7d2be835a0.yaml
+++ b/releasenotes/notes/ship-data-security-shared-library-9c1f4a7d2be835a0.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add the Data Security feature to scan monitored PostgreSQL databases for
+    sensitive data, driven remotely through Remote Configuration
+    (``DATA_SECURITY_DB_SCAN_TASKS``). Enabled with ``data_security.enabled`` and
+    ``shared_library_check.enabled``.


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Ships the `datasecurity` Rust shared-library check by enabling it in `ENABLED_CHECKS`, so its cdylib is bundled with the Agent build.

### Motivation

Enable the Data Security feature (RC-driven PostgreSQL scanning via the `DATA_SECURITY_DB_SCAN_TASKS` product) so it can be turned on with `data_security.enabled` + `shared_library_check.enabled`.

### Describe how you validated your changes

The feature was already validated end-to-end in previous PRs. This PR only flips the check on for shipping.

### Decision Record
https://datadoghq.atlassian.net/wiki/spaces/ABLD/pages/7034209304/Data+Security+-+Quality+Gates+Decision+Records