### PR TITLE
[CWS-6580] Count network namespace resolver errors per error class

### DIFF
--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -402,6 +402,11 @@ var (
 	// lonely network namespaces.
 	// Tags: -
 	MetricNamespaceResolverLonelyNetworkNamespace = newRuntimeMetric(".namespace_resolver.lonely_netns")
+	// MetricNamespaceResolverError is the name of the metric used to report the count of errors hit by the
+	// NamespaceResolver, mostly while attaching TC classifiers to network devices.
+	// Tags: error_type ('link_not_found', 'no_such_device', 'classifier_exists', 'queue_full', 'netlink_socket',
+	// 'link_list', 'unknown')
+	MetricNamespaceResolverError = newRuntimeMetric(".namespace_resolver.error")
 
 	// Policies
 

--- a/pkg/security/resolvers/netns/BUILD.bazel
+++ b/pkg/security/resolvers/netns/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "netns",
     srcs = [
         "async.go",
+        "errors.go",
         "graph.go",
         "network_namespace.go",
         "resolver.go",

--- a/pkg/security/resolvers/netns/BUILD.bazel
+++ b/pkg/security/resolvers/netns/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "netns",
@@ -26,6 +27,7 @@ go_library(
             "@com_github_hashicorp_golang_lru_v2//simplelru",
             "@com_github_vishvananda_netlink//:netlink",
             "@org_golang_x_sys//unix",
+            "@org_uber_go_atomic//:atomic",
         ],
         "@rules_go//go/platform:linux": [
             "//pkg/security/metrics",
@@ -39,6 +41,36 @@ go_library(
             "@com_github_datadog_datadog_go_v5//statsd",
             "@com_github_datadog_ebpf_manager//:ebpf-manager",
             "@com_github_hashicorp_golang_lru_v2//simplelru",
+            "@com_github_vishvananda_netlink//:netlink",
+            "@org_golang_x_sys//unix",
+            "@org_uber_go_atomic//:atomic",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+dd_agent_go_test(
+    name = "netns_test",
+    srcs = ["errors_test.go"],
+    embed = [":netns"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "//pkg/security/metrics",
+            "//pkg/security/tests/statsdclient",
+            "@com_github_datadog_ebpf_manager//:ebpf-manager",
+            "@com_github_hashicorp_go_multierror//:go-multierror",
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+            "@com_github_vishvananda_netlink//:netlink",
+            "@org_golang_x_sys//unix",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//pkg/security/metrics",
+            "//pkg/security/tests/statsdclient",
+            "@com_github_datadog_ebpf_manager//:ebpf-manager",
+            "@com_github_hashicorp_go_multierror//:go-multierror",
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
             "@com_github_vishvananda_netlink//:netlink",
             "@org_golang_x_sys//unix",
         ],

--- a/pkg/security/resolvers/netns/async.go
+++ b/pkg/security/resolvers/netns/async.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
-	manager "github.com/DataDog/ebpf-manager"
-	"github.com/vishvananda/netlink"
 )
 
 // QueuedNetworkDeviceError is used to indicate that the new network Device was queued until its namespace handle is
@@ -68,21 +66,12 @@ func (tcr *Resolver) startSetupNewTCClassifierLoop() {
 
 			if err := tcr.setupNewTCClassifier(request.Device); err != nil {
 				var qnde QueuedNetworkDeviceError
-				var linkNotFound netlink.LinkNotFoundError
-
 				if errors.As(err, &qnde) {
 					seclog.Debugf("%v", err)
-				} else if errors.As(err, &linkNotFound) {
-					seclog.Debugf("link not found while setting up new tc classifier: %v", err)
-				} else if errors.Is(err, manager.ErrIdentificationPairInUse) {
-					if request.RequestType != TcDeviceUpdateRequestType {
-						seclog.Errorf("tc classifier already exists: %v", err)
-					} else {
-						seclog.Debugf("tc classifier already exists: %v", err)
-					}
-				} else {
-					seclog.Errorf("error setting up new tc classifier on %+v: %v", request.Device, err)
+					continue
 				}
+
+				tcr.reportTCClassifierError(err, request.Device)
 			}
 		}
 	}

--- a/pkg/security/resolvers/netns/async.go
+++ b/pkg/security/resolvers/netns/async.go
@@ -50,7 +50,8 @@ func (tcr *Resolver) PushNewTCClassifierRequest(request TcClassifierRequest) {
 	case tcr.tcRequests <- request:
 		// do nothing
 	default:
-		seclog.Errorf("failed to slot new tc classifier request: %+v", request)
+		tcr.countError(errorClassQueueFull)
+		seclog.Debugf("failed to slot new tc classifier request: %+v", request)
 	}
 }
 

--- a/pkg/security/resolvers/netns/errors.go
+++ b/pkg/security/resolvers/netns/errors.go
@@ -12,8 +12,10 @@ import (
 
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/vishvananda/netlink"
+	"go.uber.org/atomic"
 	"golang.org/x/sys/unix"
 
+	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 )
@@ -26,9 +28,51 @@ const (
 	errorClassNoSuchDevice = "no_such_device"
 	// errorClassClassifierExists is reported when the eBPF manager already holds a classifier for an interface
 	errorClassClassifierExists = "classifier_exists"
+	// errorClassQueueFull is reported when a classifier request is dropped because the queue is full
+	errorClassQueueFull = "queue_full"
+	// errorClassNetlinkSocket is reported when no netlink socket can be opened in a network namespace
+	errorClassNetlinkSocket = "netlink_socket"
+	// errorClassLinkList is reported when the interfaces of a network namespace can't be listed
+	errorClassLinkList = "link_list"
 	// errorClassUnknown is reported for the failures we can't explain
 	errorClassUnknown = "unknown"
 )
+
+// errorClasses lists every class the resolver reports. The counters are built from it upfront so
+// that the map is only ever read afterwards, which is what makes it safe to count without a lock.
+var errorClasses = []string{
+	errorClassLinkNotFound,
+	errorClassNoSuchDevice,
+	errorClassClassifierExists,
+	errorClassQueueFull,
+	errorClassNetlinkSocket,
+	errorClassLinkList,
+	errorClassUnknown,
+}
+
+func newErrorCounters() map[string]*atomic.Int64 {
+	counters := make(map[string]*atomic.Int64, len(errorClasses))
+	for _, class := range errorClasses {
+		counters[class] = atomic.NewInt64(0)
+	}
+	return counters
+}
+
+// countError counts an error of the provided class. The counters are flushed by SendStats.
+func (nr *Resolver) countError(class string) {
+	if counter, ok := nr.errorCounters[class]; ok {
+		counter.Inc()
+	}
+}
+
+// sendErrorStats flushes the error counters to the statsd client.
+func (nr *Resolver) sendErrorStats() {
+	for class, counter := range nr.errorCounters {
+		if val := counter.Swap(0); val > 0 {
+			_ = nr.client.Count(metrics.MetricNamespaceResolverError, val, []string{"error_type:" + class}, 1.0)
+		}
+	}
+}
 
 // classifyTCClassifierError returns the class of a TC classifier setup failure.
 func classifyTCClassifierError(err error) string {
@@ -50,7 +94,10 @@ func classifyTCClassifierError(err error) string {
 // deleted faster than classifiers can be attached to them, so the failures we expect are only worth
 // a debug line.
 func (nr *Resolver) reportTCClassifierError(err error, device model.NetDevice) {
-	if class := classifyTCClassifierError(err); class != errorClassUnknown {
+	class := classifyTCClassifierError(err)
+	nr.countError(class)
+
+	if class != errorClassUnknown {
 		seclog.Debugf("couldn't set up tc classifier on %+v [%s]: %v", device, class, err)
 		return
 	}

--- a/pkg/security/resolvers/netns/errors.go
+++ b/pkg/security/resolvers/netns/errors.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package netns
+
+import (
+	"errors"
+
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+)
+
+// classes of errors reported by the network namespace resolver
+const (
+	// errorClassLinkNotFound is reported when an interface is gone before its classifier is attached
+	errorClassLinkNotFound = "link_not_found"
+	// errorClassNoSuchDevice is reported when an interface is gone while its classifier is attached
+	errorClassNoSuchDevice = "no_such_device"
+	// errorClassClassifierExists is reported when the eBPF manager already holds a classifier for an interface
+	errorClassClassifierExists = "classifier_exists"
+	// errorClassUnknown is reported for the failures we can't explain
+	errorClassUnknown = "unknown"
+)
+
+// classifyTCClassifierError returns the class of a TC classifier setup failure.
+func classifyTCClassifierError(err error) string {
+	var linkNotFound netlink.LinkNotFoundError
+
+	switch {
+	case errors.As(err, &linkNotFound):
+		return errorClassLinkNotFound
+	case errors.Is(err, unix.ENODEV):
+		return errorClassNoSuchDevice
+	case errors.Is(err, manager.ErrIdentificationPairInUse):
+		return errorClassClassifierExists
+	default:
+		return errorClassUnknown
+	}
+}
+
+// reportTCClassifierError reports a TC classifier setup failure. Interfaces are created, renamed and
+// deleted faster than classifiers can be attached to them, so the failures we expect are only worth
+// a debug line.
+func (nr *Resolver) reportTCClassifierError(err error, device model.NetDevice) {
+	if class := classifyTCClassifierError(err); class != errorClassUnknown {
+		seclog.Debugf("couldn't set up tc classifier on %+v [%s]: %v", device, class, err)
+		return
+	}
+
+	seclog.Errorf("couldn't set up tc classifier on %+v: %v", device, err)
+}

--- a/pkg/security/resolvers/netns/errors_test.go
+++ b/pkg/security/resolvers/netns/errors_test.go
@@ -1,0 +1,107 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package netns
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/hashicorp/go-multierror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"github.com/DataDog/datadog-agent/pkg/security/metrics"
+	"github.com/DataDog/datadog-agent/pkg/security/tests/statsdclient"
+)
+
+// cloneErr rebuilds the error chain that the eBPF manager returns when cloning a TC probe fails.
+func cloneErr(cause error) error {
+	pip := manager.ProbeIdentificationPair{UID: "security", EBPFFuncName: "classifier_egress"}
+	return fmt.Errorf("couldn't clone %s: %w", pip, cause)
+}
+
+// linkNotFoundErr asks netlink for an interface that cannot exist: the error it returns wraps an
+// unexported field, so this is the only way to get one from outside of the netlink package.
+func linkNotFoundErr(t *testing.T) error {
+	_, err := netlink.LinkByName("dd-no-such-link")
+	require.ErrorAs(t, err, &netlink.LinkNotFoundError{})
+	return err
+}
+
+func TestClassifyTCClassifierError(t *testing.T) {
+	pip := manager.ProbeIdentificationPair{UID: "security_classifier_egress_2_4026532420", EBPFFuncName: "classifier_egress"}
+
+	for _, test := range []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name: "identification pair in use",
+			err: multierror.Append(nil,
+				cloneErr(fmt.Errorf("couldn't add probe %v: %w", pip, manager.ErrIdentificationPairInUse)),
+				cloneErr(fmt.Errorf("couldn't add probe %v: %w", pip, manager.ErrIdentificationPairInUse)),
+			).ErrorOrNil(),
+			expected: errorClassClassifierExists,
+		},
+		{
+			name: "link not found",
+			err: fmt.Errorf("failed to attach new probe %v: %w", pip,
+				fmt.Errorf("couldn't start probe %v: %w", pip,
+					fmt.Errorf("couldn't resolve interface with IfIndex %d in namespace %d: %w", 1658, 4026536040,
+						linkNotFoundErr(t)))),
+			expected: errorClassLinkNotFound,
+		},
+		{
+			name: "missing device",
+			err: multierror.Append(nil, cloneErr(
+				fmt.Errorf("failed to attach new probe %v: %w", pip,
+					fmt.Errorf("couldn't start probe %v: %w", pip,
+						fmt.Errorf("couldn't add a %q qdisc to interface %s[%d]: %w", "clsact", "tmp0e9ec", 231, unix.ENODEV))))).ErrorOrNil(),
+			expected: errorClassNoSuchDevice,
+		},
+		{
+			name:     "unknown",
+			err:      multierror.Append(nil, cloneErr(errors.New("something else"))).ErrorOrNil(),
+			expected: errorClassUnknown,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			class := classifyTCClassifierError(test.err)
+			assert.Equal(t, test.expected, class)
+			// a class without a counter would make countError panic
+			assert.Contains(t, errorClasses, class)
+		})
+	}
+}
+
+func TestErrorCounters(t *testing.T) {
+	client := statsdclient.NewStatsdClient()
+	nr := &Resolver{client: client, errorCounters: newErrorCounters()}
+
+	expected := make(map[string]int64, len(errorClasses))
+	for _, class := range errorClasses {
+		nr.countError(class)
+		expected[class] = 1
+	}
+	nr.countError(errorClassLinkNotFound)
+	expected[errorClassLinkNotFound] = 2
+
+	nr.sendErrorStats()
+
+	prefix := metrics.MetricNamespaceResolverError + ":error_type:"
+	assert.Equal(t, expected, client.GetByPrefix(prefix))
+
+	// the flush resets the counters, so nothing is reported until a new error is counted
+	nr.sendErrorStats()
+	assert.Equal(t, expected, client.GetByPrefix(prefix))
+}

--- a/pkg/security/resolvers/netns/network_namespace.go
+++ b/pkg/security/resolvers/netns/network_namespace.go
@@ -15,11 +15,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/security/resolvers/tc"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
-	manager "github.com/DataDog/ebpf-manager"
 	"golang.org/x/sys/unix"
 )
 
@@ -124,8 +122,9 @@ func (nn *NetworkNamespace) getNamespaceHandleDup() (*os.File, error) {
 	return os.NewFile(uintptr(dup), nn.handle.Name()), nil
 }
 
-// dequeueNetworkDevices dequeues the devices in the current network devices queue.
-func (nn *NetworkNamespace) dequeueNetworkDevices(tcResolver *tc.Resolver, manager *manager.Manager) {
+// dequeueNetworkDevices dequeues the devices in the current network devices queue. Never take the
+// resolver lock from here: everywhere else it is acquired before the namespace lock.
+func (nn *NetworkNamespace) dequeueNetworkDevices(nr *Resolver) {
 	nn.Lock()
 	defer nn.Unlock()
 
@@ -147,8 +146,8 @@ func (nn *NetworkNamespace) dequeueNetworkDevices(tcResolver *tc.Resolver, manag
 	}()
 
 	for _, queuedDevice := range nn.networkDevicesQueue {
-		if err = tcResolver.SetupNewTCClassifierWithNetNSHandle(queuedDevice, handle, manager); err != nil {
-			seclog.Errorf("error setting up new tc classifier on queued Device: %v", err)
+		if err = nr.tcResolver.SetupNewTCClassifierWithNetNSHandle(queuedDevice, handle, nr.manager); err != nil {
+			nr.reportTCClassifierError(err, queuedDevice)
 		}
 	}
 	nn.flushNetworkDevicesQueue()

--- a/pkg/security/resolvers/netns/resolver.go
+++ b/pkg/security/resolvers/netns/resolver.go
@@ -114,7 +114,7 @@ func (nr *Resolver) SaveNetworkNamespaceHandle(nsID uint32, nsPath *utils.NSPath
 	nr.Unlock()
 
 	if isNew && netns != nil {
-		netns.dequeueNetworkDevices(nr.tcResolver, nr.manager)
+		netns.dequeueNetworkDevices(nr)
 		nr.snapshotNetworkDevices(netns)
 	}
 
@@ -133,7 +133,7 @@ func (nr *Resolver) SaveNetworkNamespaceHandleLazy(nsID uint32, nsPathFunc func(
 	nr.Unlock()
 
 	if isNew && netns != nil {
-		netns.dequeueNetworkDevices(nr.tcResolver, nr.manager)
+		netns.dequeueNetworkDevices(nr)
 		nr.snapshotNetworkDevices(netns)
 	}
 
@@ -242,7 +242,7 @@ func (nr *Resolver) snapshotNetworkDevices(netns *NetworkNamespace) int {
 				attachedDeviceCountNoLazyDeletion++
 			}
 		} else {
-			seclog.Errorf("error setting up new tc classifier on snapshot: %v", err)
+			nr.reportTCClassifierError(err, device)
 		}
 	}
 
@@ -314,7 +314,7 @@ func (nr *Resolver) SyncCache() bool {
 	nr.Unlock()
 
 	for _, entry := range newEntries {
-		entry.netns.dequeueNetworkDevices(nr.tcResolver, nr.manager)
+		entry.netns.dequeueNetworkDevices(nr)
 		nr.snapshotNetworkDevices(entry.netns)
 	}
 

--- a/pkg/security/resolvers/netns/resolver.go
+++ b/pkg/security/resolvers/netns/resolver.go
@@ -18,6 +18,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
+	"github.com/vishvananda/netlink"
+	"go.uber.org/atomic"
+	"golang.org/x/sys/unix"
+
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
@@ -25,11 +32,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
-	"github.com/DataDog/datadog-go/v5/statsd"
-	manager "github.com/DataDog/ebpf-manager"
-	"github.com/hashicorp/golang-lru/v2/simplelru"
-	"github.com/vishvananda/netlink"
-	"golang.org/x/sys/unix"
 )
 
 var (
@@ -67,6 +69,7 @@ type Resolver struct {
 
 	networkNamespaces *simplelru.LRU[uint32, *NetworkNamespace]
 	tcRequests        chan TcClassifierRequest
+	errorCounters     map[string]*atomic.Int64
 	ctx               context.Context
 	wg                sync.WaitGroup
 }
@@ -80,6 +83,8 @@ func NewResolver(config *config.Config, manager *manager.Manager, statsdClient s
 		tcResolver: tcResolver,
 		tcRequests: make(chan TcClassifierRequest, 16),
 		ctx:        context.Background(),
+
+		errorCounters: newErrorCounters(),
 	}
 
 	lru, err := simplelru.NewLRU(1024, func(_ uint32, value *NetworkNamespace) {
@@ -213,13 +218,15 @@ func (nr *Resolver) snapshotNetworkDevices(netns *NetworkNamespace) int {
 
 	ntl, err := nr.manager.GetNetlinkSocket(uint64(handle.Fd()), netns.nsID)
 	if err != nil {
+		nr.countError(errorClassNetlinkSocket)
 		seclog.Errorf("couldn't open netlink socket: %s", err)
 		return 0
 	}
 
 	links, err := listLinks(ntl.Sock)
 	if err != nil {
-		seclog.Errorf("couldn't list network interfaces in namespace %d: %s", netns.nsID, err)
+		nr.countError(errorClassLinkList)
+		seclog.Debugf("couldn't list network interfaces in namespace %d: %s", netns.nsID, err)
 		return 0
 	}
 
@@ -508,6 +515,8 @@ func (nr *Resolver) SendStats() error {
 	if lonelyNetworkNamespacesCount > 0 {
 		_ = nr.client.Gauge(metrics.MetricNamespaceResolverLonelyNetworkNamespace, lonelyNetworkNamespacesCount, []string{}, 1.0)
 	}
+
+	nr.sendErrorStats()
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Reports the failures of the network namespace resolver as a metric with one tag per class of error, and keeps the log lines for the failures we can't explain.

### Motivation

Attaching a classifier to a network interface races against the lifecycle of that interface: short-lived containers tear theirs down while the classifier is being set up. These failures are expected and can't be acted upon, but every one of them was logged as an error, which drowned the failures that do deserve attention. Counting them keeps their volume visible without a log line for every occurrence.

### Describe how you validated your changes

Unit test on the error classification. The error classes were derived from real-world occurrences.

### Additional Notes

