### PR TITLE
Bump ebpf-manager to released v0.8.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -209,7 +209,7 @@ require (
 	github.com/DataDog/dd-policy-engine/go v0.0.0-20260730181922-c5e419a4ec7d
 	github.com/DataDog/dd-trace-go/v2 v2.9.0
 	github.com/DataDog/ddtrivy v0.0.0-20260519164847-bf6bcaf2f9b7
-	github.com/DataDog/ebpf-manager v0.8.1-0.20260723114030-df952c39a4e3
+	github.com/DataDog/ebpf-manager v0.8.1
 	github.com/DataDog/go-acl v1.0.1
 	github.com/DataDog/go-sqllexer v0.2.4
 	github.com/DataDog/jsonapi v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -2551,8 +2551,8 @@ github.com/DataDog/dd-trace-go/v2 v2.9.0 h1:J/EsZ7nPqkf3Pa56AAre306ylYMhtzz6oylm
 github.com/DataDog/dd-trace-go/v2 v2.9.0/go.mod h1:SdMkCESSBc2knx56Xol2pO7jhMDPi7MxyNj6vRYMW48=
 github.com/DataDog/ddtrivy v0.0.0-20260519164847-bf6bcaf2f9b7 h1:N9Ufc+tRU6BaVpxw0D60bvhqwsJ90r5ygXNIbx/kucg=
 github.com/DataDog/ddtrivy v0.0.0-20260519164847-bf6bcaf2f9b7/go.mod h1:cy6fMTy/g9yD4GxWUXTTDzKKJE9ZbONxcwiQfpPrv/M=
-github.com/DataDog/ebpf-manager v0.8.1-0.20260723114030-df952c39a4e3 h1:pwNwwUS6pnk73IiEv99zTdtBFUIP+lqpdEtG0EFGgEE=
-github.com/DataDog/ebpf-manager v0.8.1-0.20260723114030-df952c39a4e3/go.mod h1:zlmQH/xpl87sWLv2k0ek5Nw1PsAOEfDYc8+AYd7lYxw=
+github.com/DataDog/ebpf-manager v0.8.1 h1:QtbZds3sK35+m29L4xy//NLCUstdVIdrYEvaZd/2qRA=
+github.com/DataDog/ebpf-manager v0.8.1/go.mod h1:zlmQH/xpl87sWLv2k0ek5Nw1PsAOEfDYc8+AYd7lYxw=
 github.com/DataDog/go-acl v1.0.1 h1:uRbp98YmlVZYqNNyTBFNI3Y6bnziBLyCIR4nRu0bIpU=
 github.com/DataDog/go-acl v1.0.1/go.mod h1:YJx333qSb3GUqCLIbqKeGaZS2pUYh2IYGI7+FsX18CU=
 github.com/DataDog/go-cmp v0.0.0-20250605161605-8f326bf2ab9d h1:ErpIQikDqtpE21afk2ExlJn0wg7gGWyUVu/RY4rBlMI=


### PR DESCRIPTION
### What does this PR do?
Points `github.com/DataDog/ebpf-manager` at the released `v0.8.1` tag instead of the pinned pseudo-version `v0.8.1-0.20260723114030-df952c39a4e3`.

### Motivation
The custom hash was pinned ahead of the release. Now that `v0.8.1` is tagged, reference the release for clarity and easier future bumps.

### Describe how you validated your changes
`dda inv tidy` regenerates only these two lines. The `/go.mod` hash in `go.sum` is unchanged between the pseudo-version and the tag, so the module contents are identical — no behavior change expected. CI covers the eBPF/system-probe builds and tests.

### Possible Drawbacks / Trade-offs
None.

### Additional Notes
No release note: dependency-only change with no user-visible effect.