### PR TITLE
perf(test): move default test log level from `debug` to `info`

### DIFF
--- a/comp/core/log/mock/BUILD.bazel
+++ b/comp/core/log/mock/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "mock",
@@ -11,5 +12,16 @@ go_library(
     deps = [
         "//comp/core/log/def",
         "//pkg/util/log",
+    ],
+)
+
+dd_agent_go_test(
+    name = "mock_test",
+    srcs = ["mock_test.go"],
+    embed = [":mock"],
+    deps = [
+        "//pkg/util/log",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/comp/core/log/mock/go.mod
+++ b/comp/core/log/mock/go.mod
@@ -5,15 +5,19 @@ go 1.25.0
 require (
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.64.0-devel
 	github.com/DataDog/datadog-agent/pkg/util/log v0.64.1
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/DataDog/datadog-agent/pkg/template v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/version v0.64.1 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/time v0.15.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually

--- a/comp/core/log/mock/mock.go
+++ b/comp/core/log/mock/mock.go
@@ -37,13 +37,19 @@ func New(t testing.TB) log.Component {
 		t.Fatal(err.Error())
 	}
 
+	// The level in effect may not be the default, ebpftest.LogLevel being one way to change it.
+	restore := pkglog.TestLogLevel()
+	if previous, err := pkglog.GetLogLevel(); err == nil {
+		restore = previous.String()
+	}
+
 	t.Cleanup(func() {
-		pkglog.SetupLogger(pkglog.Default(), pkglog.DebugStr)
+		pkglog.SetupLogger(pkglog.Default(), restore)
 		iface.Close()
 	})
 
 	// install the logger into pkg/util/log
-	pkglog.SetupLogger(iface, pkglog.DebugStr)
+	pkglog.SetupLogger(iface, pkglog.TestLogLevel())
 
 	return pkglog.NewWrapper(2)
 }

--- a/comp/core/log/mock/mock_test.go
+++ b/comp/core/log/mock/mock_test.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package mock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// TestNewRestoresPreviousLogLevel asserts New's cleanup puts back the level that was in effect,
+// rather than assuming the default one.
+func TestNewRestoresPreviousLogLevel(t *testing.T) {
+	pkglog.SetupLogger(pkglog.Default(), pkglog.WarnStr)
+	before, err := pkglog.GetLogLevel()
+	require.NoError(t, err)
+	require.Equal(t, pkglog.WarnStr, before.String())
+
+	t.Run("inner", func(t *testing.T) { New(t) })
+
+	after, err := pkglog.GetLogLevel()
+	require.NoError(t, err)
+	assert.Equal(t, before.String(), after.String())
+}

--- a/pkg/util/log/log_test_init.go
+++ b/pkg/util/log/log_test_init.go
@@ -11,10 +11,15 @@ import (
 	"os"
 )
 
-func init() {
-	level := os.Getenv("DD_LOG_LEVEL")
-	if level == "" {
-		level = "debug"
+// TestLogLevel returns the level test binaries log at. It defaults to info, debug costing every
+// emitted line a scrub and burying a failure's own output in unrelated noise.
+func TestLogLevel() string {
+	if level := os.Getenv("DD_LOG_LEVEL"); level != "" {
+		return level
 	}
-	SetupLogger(Default(), level)
+	return InfoStr
+}
+
+func init() {
+	SetupLogger(Default(), TestLogLevel())
 }


### PR DESCRIPTION
### What does this PR do?
Default test binaries to the `info` level rather than `debug`, in the test-only `init` of `pkg/util/log` that installs their logger.

Make `comp/core/log/mock` follow that default instead of hardcoding it a second time, and have it restore the level that was actually in effect when a test ends, rather than assuming the default one.

### Motivation
Every Go test binary in this repository logs at `debug`: the test-only `init` in `pkg/util/log` sets it, and `comp/core/log/mock` hardcoded it again for the 139 packages importing that mock.

Once the level admits a line, it gets formatted, run through dozens of replacers of `pkg/util/scrubber` to redact credentials, then written out, through `t.Log` for the mock or stdout for the default logger. Tests that pass pay that too, `gotestsum` running `go test -json`, so none of it is dropped.

Scrubbing one such line costs 15 allocations and about 7KiB. A run of `pkg/collector/corechecks/system/disk/diskv2` emits 9985 debug lines and one of `pkg/serverless/metrics` 4925, none of which survive this change.

Both packages fail the 180s per-binary timeout of `tests_windows-x64`, at times ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1915978075)).

### Describe how you validated your changes
Medians of 5 interleaved runs under CI's `-race` and `-covermode=atomic`:
| package | before | after | |
|---|---|---|---|
| `pkg/collector/corechecks/system/disk/diskv2` | 23.13s | 15.50s | -33% |
| `pkg/serverless/metrics` | 7.68s | 2.67s | -65% |

Neither pair of distributions overlaps.
The gain is ~4 times smaller on an uninstrumented build, -8% and -25%: the race detector and atomic coverage counters weigh more on an allocation-bound path than on a compute-bound one.

`TestNewRestoresPreviousLogLevel` covers the restore, and fails against the assumed default.

419 tests pass across `comp/core/log` and `pkg/util/log`.

### Additional Notes
`DD_LOG_LEVEL` keeps overriding the level, unchanged.

A mock can put back the level but not the logger it replaced: `SetupLogger` closes whatever logger it supersedes.