### PR TITLE
chore(sqg): compensate PAR under-bump from #53879

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,5 +1,5 @@
 static_quality_gate_agent_deb_amd64:
-  max_on_disk_size: 759.01 MiB
+  max_on_disk_size: 759.22 MiB
   max_on_wire_size: 181.38 MiB
 static_quality_gate_agent_deb_amd64_fips:
   max_on_disk_size: 710.52 MiB
@@ -8,43 +8,43 @@ static_quality_gate_agent_heroku_amd64:
   max_on_disk_size: 315.23 MiB
   max_on_wire_size: 80.56 MiB
 static_quality_gate_agent_msi:
-  max_on_disk_size: 657.0 MiB
+  max_on_disk_size: 657.29 MiB
   max_on_wire_size: 157.89 MiB
 static_quality_gate_agent_rpm_amd64:
-  max_on_disk_size: 758.98 MiB
+  max_on_disk_size: 759.19 MiB
   max_on_wire_size: 184.16 MiB
 static_quality_gate_agent_rpm_amd64_fips:
   max_on_disk_size: 710.52 MiB
   max_on_wire_size: 175.6 MiB
 static_quality_gate_agent_rpm_arm64:
-  max_on_disk_size: 730.38 MiB
+  max_on_disk_size: 730.63 MiB
   max_on_wire_size: 165.03 MiB
 static_quality_gate_agent_rpm_arm64_fips:
   max_on_disk_size: 688.91 MiB
   max_on_wire_size: 158.68 MiB
 static_quality_gate_agent_suse_amd64:
-  max_on_disk_size: 758.98 MiB
+  max_on_disk_size: 759.19 MiB
   max_on_wire_size: 184.13 MiB
 static_quality_gate_agent_suse_amd64_fips:
   max_on_disk_size: 710.52 MiB
   max_on_wire_size: 175.74 MiB
 static_quality_gate_agent_suse_arm64:
-  max_on_disk_size: 730.38 MiB
+  max_on_disk_size: 730.63 MiB
   max_on_wire_size: 164.99 MiB
 static_quality_gate_agent_suse_arm64_fips:
   max_on_disk_size: 688.91 MiB
   max_on_wire_size: 158.67 MiB
 static_quality_gate_docker_agent_amd64:
-  max_on_disk_size: 814.6 MiB
+  max_on_disk_size: 814.81 MiB
   max_on_wire_size: 275.7 MiB
 static_quality_gate_docker_agent_arm64:
-  max_on_disk_size: 815.75 MiB
+  max_on_disk_size: 815.96 MiB
   max_on_wire_size: 263.67 MiB
 static_quality_gate_docker_agent_jmx_amd64:
-  max_on_disk_size: 1005.36 MiB
+  max_on_disk_size: 1005.57 MiB
   max_on_wire_size: 344.32 MiB
 static_quality_gate_docker_agent_jmx_arm64:
-  max_on_disk_size: 995.43 MiB
+  max_on_disk_size: 995.64 MiB
   max_on_wire_size: 328.27 MiB
 static_quality_gate_docker_cluster_agent_amd64:
   max_on_disk_size: 211.25 MiB


### PR DESCRIPTION
## Summary

- Adds the on-disk headroom that #53879 failed to grant when raising static quality gates for PAR rshell system-service policy.
- Bumps **all ten gates** affected by #53879, with gate-specific amounts derived from the SQG CI report on that PR (measured increase minus actual cap bump), not a flat +400 KiB.
- Gives arm64 rpm/suse variants a slightly larger buffer (+0.25 MiB) because they already sit within ~2 KiB of the limit on `main`.

## Context

Slack thread: https://dd.slack.com/archives/C08SK4B0FK8/p1785839242865769

#53879 SQG report measured vs compensated:

| Gate group | Measured Δ | #53879 bump | Gap |
|------------|-----------|-------------|-----|
| deb/rpm/suse amd64, docker amd64/jmx amd64 | ~1021 KiB | 809 KiB | ~212 KiB |
| rpm/suse arm64, docker arm64/jmx arm64 | ~909 KiB | 717 KiB | ~193 KiB |
| msi | 639 KiB | 348 KiB | ~291 KiB |

This PR adds:

| Gate | Old limit | New limit | Delta |
|------|-----------|-----------|-------|
| `static_quality_gate_agent_deb_amd64` | 759.01 MiB | 759.22 MiB | +0.21 MiB |
| `static_quality_gate_agent_msi` | 657.00 MiB | 657.29 MiB | +0.29 MiB |
| `static_quality_gate_agent_rpm_amd64` | 758.98 MiB | 759.19 MiB | +0.21 MiB |
| `static_quality_gate_agent_rpm_arm64` | 730.38 MiB | 730.63 MiB | +0.25 MiB |
| `static_quality_gate_agent_suse_amd64` | 758.98 MiB | 759.19 MiB | +0.21 MiB |
| `static_quality_gate_agent_suse_arm64` | 730.38 MiB | 730.63 MiB | +0.25 MiB |
| `static_quality_gate_docker_agent_amd64` | 814.60 MiB | 814.81 MiB | +0.21 MiB |
| `static_quality_gate_docker_agent_arm64` | 815.75 MiB | 815.96 MiB | +0.21 MiB |
| `static_quality_gate_docker_agent_jmx_amd64` | 1005.36 MiB | 1005.57 MiB | +0.21 MiB |
| `static_quality_gate_docker_agent_jmx_arm64` | 995.43 MiB | 995.64 MiB | +0.21 MiB |

## Test plan

- [ ] SQG approval from @TonyAiuto or @Quentin de Longraye
- [ ] Unblocks failing SQG checks on #52174 and #54378