### PR TITLE
Fix Windows AWS authentication

### DIFF
--- a/.gitlab/windows/build/source_test/windows.yml
+++ b/.gitlab/windows/build/source_test/windows.yml
@@ -87,6 +87,7 @@ tests_windows-x64:
       -m 16384M
       -v "$(Get-Location):c:\mnt"
       -e AWS_NETWORKING=true
+      -e CI
       -e GITLAB_CI
       -e CI_PIPELINE_ID
       -e CI_PROJECT_NAME
@@ -118,6 +119,7 @@ tests_windows-x64:
       -m 16384M
       -v "$(Get-Location):c:\mnt"
       -e AWS_NETWORKING=true
+      -e CI
       -e GITLAB_CI
       -e CI_PIPELINE_ID
       -e CI_PROJECT_NAME

--- a/.gitlab/windows/build/source_test/windows.yml
+++ b/.gitlab/windows/build/source_test/windows.yml
@@ -97,6 +97,7 @@ tests_windows-x64:
       -e GOPROXY
       -e GONOSUMDB
       -e PIP_INDEX_URL
+      -e CI_IDENTITIES_GITLAB_ID_TOKEN
       ${WINBUILDIMAGE}
       c:\mnt\tasks\winbuildscripts\sysprobe.bat
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
@@ -127,6 +128,7 @@ tests_windows-x64:
       -e GOPROXY
       -e GONOSUMDB
       -e PIP_INDEX_URL
+      -e CI_IDENTITIES_GITLAB_ID_TOKEN
       ${WINBUILDIMAGE}
       c:\mnt\tasks\winbuildscripts\secagent.bat
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }

--- a/tasks/winbuildscripts/secagent.ps1
+++ b/tasks/winbuildscripts/secagent.ps1
@@ -1,3 +1,9 @@
+. "$PSScriptRoot\common.ps1"
+
+if ($env:CI) {
+    Initialize-CIIdentity
+}
+
 $Password = ConvertTo-SecureString "dummyPW_:-gch6Rejae9" -AsPlainText -Force
 New-LocalUser -Name "ddagentuser" -Description "Test user for the secrets feature on windows." -Password $Password
 

--- a/tasks/winbuildscripts/sysprobe.ps1
+++ b/tasks/winbuildscripts/sysprobe.ps1
@@ -1,3 +1,9 @@
+. "$PSScriptRoot\common.ps1"
+
+if ($env:CI) {
+    Initialize-CIIdentity
+}
+
 $Password = ConvertTo-SecureString "dummyPW_:-gch6Rejae9" -AsPlainText -Force
 New-LocalUser -Name "ddagentuser" -Description "Test user for the secrets feature on windows." -Password $Password
 


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Forward the `CI_IDENTITIES_GITLAB_ID_TOKEN` & invoke the `common.ps1` script to setup the auth like it's done for other jobs

### Motivation

Following https://github.com/DataDog/cloud-inventory/pull/66767, we need to rely on CI identities to access S3.
[#incident-58723](https://dd.enterprise.slack.com/archives/C0BMQV32T7V)

### Describe how you validated your changes

CI

### Additional Notes
