### PR TITLE
[CWS] Mark a workload computed when its SBOM comes from the cache

### DIFF
--- a/pkg/security/resolvers/sbom/BUILD.bazel
+++ b/pkg/security/resolvers/sbom/BUILD.bazel
@@ -75,6 +75,7 @@ dd_agent_go_test(
             "//pkg/security/secl/containerutils",
             "@com_github_datadog_agent_payload_v5//cyclonedx_v1_4",
             "@com_github_hashicorp_golang_lru_v2//simplelru",
+            "@org_uber_go_atomic//:atomic",
         ],
         "@rules_go//go/platform:linux": [
             "//pkg/security/config",
@@ -82,6 +83,7 @@ dd_agent_go_test(
             "//pkg/security/secl/containerutils",
             "@com_github_datadog_agent_payload_v5//cyclonedx_v1_4",
             "@com_github_hashicorp_golang_lru_v2//simplelru",
+            "@org_uber_go_atomic//:atomic",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/security/resolvers/sbom/BUILD.bazel
+++ b/pkg/security/resolvers/sbom/BUILD.bazel
@@ -70,12 +70,14 @@ dd_agent_go_test(
     embed = [":sbom"],
     deps = select({
         "@rules_go//go/platform:android": [
+            "//pkg/security/config",
             "//pkg/security/resolvers/sbom/types",
             "//pkg/security/secl/containerutils",
             "@com_github_datadog_agent_payload_v5//cyclonedx_v1_4",
             "@com_github_hashicorp_golang_lru_v2//simplelru",
         ],
         "@rules_go//go/platform:linux": [
+            "//pkg/security/config",
             "//pkg/security/resolvers/sbom/types",
             "//pkg/security/secl/containerutils",
             "@com_github_datadog_agent_payload_v5//cyclonedx_v1_4",

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -659,7 +659,10 @@ func (r *Resolver) analyzeWorkload(sb *SBOM) error {
 		r.dataCacheLock.RUnlock()
 		sb.data = data
 
+		sb.state.Store(computedState)
+
 		r.removePendingScan(sb.ContainerID)
+		r.processPendingFileEvents(sb)
 
 		return nil
 	}

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -664,12 +664,17 @@ func (r *Resolver) analyzeWorkload(sb *SBOM) error {
 
 		sb.state.Store(computedState)
 
+		r.sbomsCacheHit.Inc()
+
 		r.removePendingScan(sb.ContainerID)
 		r.processPendingFileEvents(sb)
 
 		return nil
 	}
 	r.dataCacheLock.Unlock()
+
+	// Only count a cache miss when we actually do the scan
+	r.sbomsCacheMiss.Inc()
 
 	report, scanErr := r.doScan(sb)
 	if scanErr != nil {
@@ -880,7 +885,8 @@ func (r *Resolver) queueWorkload(sbom *SBOM) {
 
 		return
 	}
-	r.sbomsCacheMiss.Inc()
+	// Do not increment sbomsCacheMiss here since the SBOM can still hit
+	// the cache after it has been dequeued.
 
 	r.triggerScan(sbom)
 }

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -649,8 +649,11 @@ func (r *Resolver) analyzeWorkload(sb *SBOM) error {
 		if currentState != stoppedState {
 			// should not append, ignore
 			seclog.Warnf("trying to analyze a sbom not in pending state for '%s': %d", sb.ContainerID, currentState)
-			return nil
 		}
+
+		// a stopped workload is unreachable from the resolver, so not returning here would start a new
+		// forwarding debouncer go routine that we can never stop
+		return nil
 	}
 
 	// bail out if the workload has been analyzed while queued up

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -657,9 +657,9 @@ func (r *Resolver) analyzeWorkload(sb *SBOM) error {
 	}
 
 	// bail out if the workload has been analyzed while queued up
-	r.dataCacheLock.RLock()
+	r.dataCacheLock.Lock()
 	if data, exists := r.dataCache.Get(sb.workloadKey); exists {
-		r.dataCacheLock.RUnlock()
+		r.dataCacheLock.Unlock()
 		sb.data = data
 
 		sb.state.Store(computedState)
@@ -669,7 +669,7 @@ func (r *Resolver) analyzeWorkload(sb *SBOM) error {
 
 		return nil
 	}
-	r.dataCacheLock.RUnlock()
+	r.dataCacheLock.Unlock()
 
 	report, scanErr := r.doScan(sb)
 	if scanErr != nil {

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -864,14 +864,20 @@ func (r *Resolver) queueWorkload(sbom *SBOM) {
 
 	// check if this sbom has been scanned before
 	r.dataCacheLock.Lock()
-	defer r.dataCacheLock.Unlock()
+	data, cached := r.dataCache.Get(sbom.workloadKey)
+	r.dataCacheLock.Unlock()
 
-	if data, ok := r.dataCache.Get(sbom.workloadKey); ok {
+	if cached {
 		sbom.data = data
 
 		sbom.state.Store(computedState)
 
 		r.sbomsCacheHit.Inc()
+
+		// file accesses are queued from the moment a container ID resolves, which
+		// happens before the workload selector that got us here.
+		r.processPendingFileEvents(sbom)
+
 		return
 	}
 	r.sbomsCacheMiss.Inc()

--- a/pkg/security/resolvers/sbom/resolver_test.go
+++ b/pkg/security/resolvers/sbom/resolver_test.go
@@ -150,3 +150,39 @@ func TestAnalyzeWorkloadReusesCachedDataAsComputed(t *testing.T) {
 		t.Errorf("package = %+v, want last access set from the queued accesses", pkg)
 	}
 }
+
+// TestAnalyzeWorkloadSkipsStoppedWorkload checks that a workload stopped while it was
+// queued for a scan is left alone. Reviving it as computed restarts a forwarding
+// debouncer that can never be stopped again, since a stopped workload is no longer
+// reachable from the resolver, and reports an SBOM for a container that is gone.
+func TestAnalyzeWorkloadSkipsStoppedWorkload(t *testing.T) {
+	dataCache, err := simplelru.NewLRU[workloadKey, *Data](10, nil)
+	if err != nil {
+		t.Fatalf("NewLRU: %v", err)
+	}
+	r := &Resolver{
+		cfg:               &config.RuntimeSecurityConfig{SBOMResolverForwardInterval: time.Hour},
+		dataCache:         dataCache,
+		pendingFileEvents: make(map[containerutils.ContainerID][]pendingFileEvent),
+	}
+
+	dataCache.Add("image:tag", newData([]sbomtypes.PackageWithInstalledFiles{{
+		Package:        sbomtypes.Package{Name: "shadow-utils"},
+		InstalledFiles: []string{"/usr/bin/su"},
+	}}, false))
+
+	sbom := NewSBOM("container-id", nil, "image:tag")
+	sbom.stop()
+	t.Cleanup(sbom.stop)
+
+	if err := r.analyzeWorkload(sbom); err != nil {
+		t.Fatalf("analyzeWorkload: %v", err)
+	}
+
+	if got := sbom.state.Load(); got != stoppedState {
+		t.Errorf("state = %d, want stoppedState (%d)", got, stoppedState)
+	}
+	if sbom.forwarder != nil {
+		t.Errorf("a forwarding debouncer was started for a stopped workload")
+	}
+}

--- a/pkg/security/resolvers/sbom/resolver_test.go
+++ b/pkg/security/resolvers/sbom/resolver_test.go
@@ -9,9 +9,12 @@ package sbom
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	sbomtypes "github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom/types"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 )
 
@@ -104,5 +107,46 @@ func TestEvictedSBOMReleasesPendingFileEvents(t *testing.T) {
 
 	if len(r.pendingFileEvents) != 0 {
 		t.Errorf("queued file accesses of the removed SBOM were not released")
+	}
+}
+
+// TestAnalyzeWorkloadReusesCachedDataAsComputed checks that a workload whose data
+// landed in the cache while it was queued for a scan still ends up computed. Left
+// pending, every package lookup for that container queues instead of resolving and
+// its queued accesses are never applied — which is the fate of every replica of an
+// image but the one that gets scanned.
+func TestAnalyzeWorkloadReusesCachedDataAsComputed(t *testing.T) {
+	dataCache, err := simplelru.NewLRU[workloadKey, *Data](10, nil)
+	if err != nil {
+		t.Fatalf("NewLRU: %v", err)
+	}
+	r := &Resolver{
+		// long enough that the forwarding debouncer cannot fire during the test
+		cfg:               &config.RuntimeSecurityConfig{SBOMResolverForwardInterval: time.Hour},
+		dataCache:         dataCache,
+		pendingFileEvents: make(map[containerutils.ContainerID][]pendingFileEvent),
+	}
+
+	dataCache.Add("image:tag", newData([]sbomtypes.PackageWithInstalledFiles{{
+		Package:        sbomtypes.Package{Name: "shadow-utils"},
+		InstalledFiles: []string{"/usr/bin/su"},
+	}}, false))
+
+	sbom := NewSBOM("container-id", nil, "image:tag")
+	t.Cleanup(sbom.stop)
+	r.queuePendingFileEvent("container-id", "/usr/bin/su", 04755, 0)
+
+	if err := r.analyzeWorkload(sbom); err != nil {
+		t.Fatalf("analyzeWorkload: %v", err)
+	}
+
+	if !sbom.IsComputed() {
+		t.Errorf("state = %d, want computedState (%d)", sbom.state.Load(), computedState)
+	}
+	if len(r.pendingFileEvents) != 0 {
+		t.Errorf("queued file accesses were not drained")
+	}
+	if pkg := sbom.data.packages[0]; pkg.LastAccess.IsZero() {
+		t.Errorf("package = %+v, want last access set from the queued accesses", pkg)
 	}
 }

--- a/pkg/security/resolvers/sbom/resolver_test.go
+++ b/pkg/security/resolvers/sbom/resolver_test.go
@@ -126,6 +126,8 @@ func TestAnalyzeWorkloadReusesCachedDataAsComputed(t *testing.T) {
 		cfg:               &config.RuntimeSecurityConfig{SBOMResolverForwardInterval: time.Hour},
 		dataCache:         dataCache,
 		pendingFileEvents: make(map[containerutils.ContainerID][]pendingFileEvent),
+		sbomsCacheHit:     atomic.NewUint64(0),
+		sbomsCacheMiss:    atomic.NewUint64(0),
 	}
 
 	dataCache.Add("image:tag", newData([]sbomtypes.PackageWithInstalledFiles{{
@@ -150,6 +152,12 @@ func TestAnalyzeWorkloadReusesCachedDataAsComputed(t *testing.T) {
 	if pkg := sbom.data.packages[0]; pkg.LastAccess.IsZero() {
 		t.Errorf("package = %+v, want last access set from the queued accesses", pkg)
 	}
+	if got := r.sbomsCacheHit.Load(); got != 1 {
+		t.Errorf("cache hits = %d, want 1: the scan avoided while queued was not counted", got)
+	}
+	if got := r.sbomsCacheMiss.Load(); got != 0 {
+		t.Errorf("cache misses = %d, want 0: the workload did not scan", got)
+	}
 }
 
 // TestAnalyzeWorkloadSkipsStoppedWorkload checks that a workload stopped while it was
@@ -165,6 +173,8 @@ func TestAnalyzeWorkloadSkipsStoppedWorkload(t *testing.T) {
 		cfg:               &config.RuntimeSecurityConfig{SBOMResolverForwardInterval: time.Hour},
 		dataCache:         dataCache,
 		pendingFileEvents: make(map[containerutils.ContainerID][]pendingFileEvent),
+		sbomsCacheHit:     atomic.NewUint64(0),
+		sbomsCacheMiss:    atomic.NewUint64(0),
 	}
 
 	dataCache.Add("image:tag", newData([]sbomtypes.PackageWithInstalledFiles{{

--- a/pkg/security/resolvers/sbom/resolver_test.go
+++ b/pkg/security/resolvers/sbom/resolver_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/golang-lru/v2/simplelru"
+	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	sbomtypes "github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom/types"
@@ -184,5 +185,45 @@ func TestAnalyzeWorkloadSkipsStoppedWorkload(t *testing.T) {
 	}
 	if sbom.forwarder != nil {
 		t.Errorf("a forwarding debouncer was started for a stopped workload")
+	}
+}
+
+// TestQueueWorkloadAppliesQueuedAccessesOnCacheHit checks that a workload admitted
+// with data already in the cache applies the accesses queued for it. They are queued
+// from the moment its container ID resolves, which precedes the workload selector
+// that admits it, so a workload going idle right after would otherwise never have
+// them applied.
+func TestQueueWorkloadAppliesQueuedAccessesOnCacheHit(t *testing.T) {
+	dataCache, err := simplelru.NewLRU[workloadKey, *Data](10, nil)
+	if err != nil {
+		t.Fatalf("NewLRU: %v", err)
+	}
+	r := &Resolver{
+		dataCache:         dataCache,
+		scanChan:          make(chan *SBOM, 1),
+		pendingFileEvents: make(map[containerutils.ContainerID][]pendingFileEvent),
+		sbomsCacheHit:     atomic.NewUint64(0),
+		sbomsCacheMiss:    atomic.NewUint64(0),
+	}
+
+	dataCache.Add("image:tag", newData([]sbomtypes.PackageWithInstalledFiles{{
+		Package:        sbomtypes.Package{Name: "shadow-utils"},
+		InstalledFiles: []string{"/usr/bin/su"},
+	}}, false))
+
+	sbom := NewSBOM("container-id", nil, "image:tag")
+	t.Cleanup(sbom.stop)
+	r.queuePendingFileEvent("container-id", "/usr/bin/su", 04755, 0)
+
+	r.queueWorkload(sbom)
+
+	if !sbom.IsComputed() {
+		t.Errorf("state = %d, want computedState (%d)", sbom.state.Load(), computedState)
+	}
+	if len(r.pendingFileEvents) != 0 {
+		t.Errorf("queued file accesses were not applied")
+	}
+	if pkg := sbom.data.packages[0]; pkg.LastAccess.IsZero() || !pkg.SuidBit || !pkg.AccessedByRoot {
+		t.Errorf("package = %+v, want last access and both sticky properties set", pkg)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Marks a workload as scanned when it reuses the SBOM of another container of the same image, instead of leaving it in the pending state.

### Motivation

A workload queued for a scan bails out if another container of the same image was scanned in the meantime, and reuses the result. That path never marked the workload as scanned, and package lookups treat an unscanned workload as not ready: they queue the access and resolve nothing. The container therefore never resolved a single package, and the accesses it queued were never applied.

### Describe how you validated your changes

Added a unit test covering the cache reuse path.

### Additional Notes