### PR TITLE
[CWS] Release queued SBOM file accesses on every container removal

### DIFF
--- a/pkg/security/resolvers/sbom/BUILD.bazel
+++ b/pkg/security/resolvers/sbom/BUILD.bazel
@@ -71,11 +71,13 @@ dd_agent_go_test(
     deps = select({
         "@rules_go//go/platform:android": [
             "//pkg/security/resolvers/sbom/types",
+            "//pkg/security/secl/containerutils",
             "@com_github_datadog_agent_payload_v5//cyclonedx_v1_4",
             "@com_github_hashicorp_golang_lru_v2//simplelru",
         ],
         "@rules_go//go/platform:linux": [
             "//pkg/security/resolvers/sbom/types",
+            "//pkg/security/secl/containerutils",
             "@com_github_datadog_agent_payload_v5//cyclonedx_v1_4",
             "@com_github_hashicorp_golang_lru_v2//simplelru",
         ],

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -244,11 +244,7 @@ func NewSBOMResolver(c *config.RuntimeSecurityConfig, statsdClient statsd.Client
 		pendingFileEvents:     make(map[containerutils.ContainerID][]pendingFileEvent),
 	}
 
-	sboms, err := simplelru.NewLRU(maxSBOMEntries, func(_ containerutils.ContainerID, sbom *SBOM) {
-		// should be trigger from a function already locking the sbom, see Add, Delete
-		sbom.stop()
-		resolver.removePendingScan(sbom.ContainerID)
-	})
+	sboms, err := simplelru.NewLRU(maxSBOMEntries, resolver.onSBOMEvicted)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create new SBOM resolver: %w", err)
 	}
@@ -950,6 +946,10 @@ func (r *Resolver) Delete(id containerutils.ContainerID) {
 
 	sbom, ok := r.sboms.Peek(id)
 	if !ok {
+		// file accesses are queued as soon as a container ID is resolved, which
+		// happens well before the workload selector that creates the SBOM entry, so
+		// a container that dies in between has accesses to release and nothing else
+		r.deletePendingFileEvents(id)
 		return
 	}
 	sbom.Lock()
@@ -964,12 +964,26 @@ func (r *Resolver) Delete(id containerutils.ContainerID) {
 func (r *Resolver) deleteSBOM(sbom *SBOM) {
 	seclog.Infof("deleting SBOM entry for '%s'", sbom.ContainerID)
 
-	r.pendingFileEventsLock.Lock()
-	delete(r.pendingFileEvents, sbom.ContainerID)
-	r.pendingFileEventsLock.Unlock()
-
 	// should be called under sbom.Lock and sbomsLock.Lock
+	// the eviction callback releases everything else indexed by the container ID
 	r.sboms.Remove(sbom.ContainerID)
+}
+
+// onSBOMEvicted releases everything indexed by the container ID of an SBOM leaving
+// the cache. It runs both on the explicit removal done by deleteSBOM and on the
+// eviction of the least recently used entry, so it is the single release point.
+// Should be triggered from a function already locking the sbom, see Add, Delete.
+func (r *Resolver) onSBOMEvicted(_ containerutils.ContainerID, sbom *SBOM) {
+	sbom.stop()
+	r.removePendingScan(sbom.ContainerID)
+	r.deletePendingFileEvents(sbom.ContainerID)
+}
+
+// deletePendingFileEvents drops the file accesses queued for the provided container ID
+func (r *Resolver) deletePendingFileEvents(containerID containerutils.ContainerID) {
+	r.pendingFileEventsLock.Lock()
+	delete(r.pendingFileEvents, containerID)
+	r.pendingFileEventsLock.Unlock()
 }
 
 // SetPolicyGeneratorCallback sets a callback to be called when an SBOM is computed

--- a/pkg/security/resolvers/sbom/resolver_test.go
+++ b/pkg/security/resolvers/sbom/resolver_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/golang-lru/v2/simplelru"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 )
 
 // TestRefreshScanResetsStateForRescan checks that refreshing a workload clears
@@ -48,5 +50,59 @@ func TestRefreshScanResetsStateForRescan(t *testing.T) {
 		}
 	default:
 		t.Errorf("workload was not re-queued for a scan")
+	}
+}
+
+func newPendingFileEventsResolver() *Resolver {
+	return &Resolver{
+		pendingFileEvents: make(map[containerutils.ContainerID][]pendingFileEvent),
+	}
+}
+
+// TestDeleteReleasesPendingFileEventsWithoutSBOM checks that a container leaving
+// before an SBOM entry was created for it still releases its queued file accesses.
+// Accesses are queued from the moment a container ID resolves, which is well before
+// the workload selector that creates the entry.
+func TestDeleteReleasesPendingFileEventsWithoutSBOM(t *testing.T) {
+	sboms, err := simplelru.NewLRU[containerutils.ContainerID, *SBOM](2, nil)
+	if err != nil {
+		t.Fatalf("NewLRU: %v", err)
+	}
+	r := newPendingFileEventsResolver()
+	r.sboms = sboms
+
+	r.queuePendingFileEvent("container-id", "/usr/bin/su", 04755, 0)
+	r.Delete("container-id")
+
+	if len(r.pendingFileEvents) != 0 {
+		t.Errorf("queued file accesses were not released")
+	}
+}
+
+// TestEvictedSBOMReleasesPendingFileEvents checks that the file accesses queued for
+// a workload are released when its SBOM leaves the cache, whether it is removed
+// explicitly or evicted to make room.
+func TestEvictedSBOMReleasesPendingFileEvents(t *testing.T) {
+	r := newPendingFileEventsResolver()
+	sboms, err := simplelru.NewLRU(1, r.onSBOMEvicted)
+	if err != nil {
+		t.Fatalf("NewLRU: %v", err)
+	}
+	r.sboms = sboms
+
+	sboms.Add("evicted-container-id", NewSBOM("evicted-container-id", nil, "image:tag"))
+	r.queuePendingFileEvent("evicted-container-id", "/usr/bin/su", 04755, 0)
+
+	sboms.Add("container-id", NewSBOM("container-id", nil, "image:tag"))
+	r.queuePendingFileEvent("container-id", "/usr/bin/su", 04755, 0)
+
+	if _, ok := r.pendingFileEvents["evicted-container-id"]; ok {
+		t.Errorf("queued file accesses of the evicted SBOM were not released")
+	}
+
+	r.Delete("container-id")
+
+	if len(r.pendingFileEvents) != 0 {
+		t.Errorf("queued file accesses of the removed SBOM were not released")
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Releases the file accesses queued for a container on the two removal paths that were missing it.

### Motivation

While a workload is waiting for its SBOM, the file accesses observed for it are queued so they can be applied once the scan completes. They were only released along with the SBOM entry of the container, which left two leaks: a container that stops before that entry exists has nothing to remove, and an entry dropped to make room for another never went through the removal path. Each case leaves a set of queued paths behind forever, and per container.

### Describe how you validated your changes

Added unit tests for both removal paths.

### Additional Notes