### PR TITLE
[CWS] Deduplicate the file accesses waiting for an SBOM

### DIFF
--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -60,11 +60,12 @@ const (
 )
 
 // pendingFileEvent holds the minimal information needed to re-process a file
-// access once the SBOM for its container becomes available.
+// access once the SBOM for its container becomes available. Accesses are indexed
+// by file path, and the drain stamps every entry with the same timestamp, so only
+// the sticky properties have to be kept.
 type pendingFileEvent struct {
-	filePath string
-	fileMode uint16
-	uid      uint32
+	suidBit        bool
+	accessedByRoot bool
 }
 
 var errNoProcessForContainerID = errors.New("found no running process matching the given container ID")
@@ -189,9 +190,9 @@ type Resolver struct {
 	pendingScanLock sync.Mutex
 	pendingScan     []containerutils.ContainerID
 
-	// pending file events: file accesses received before the SBOM was ready
+	// pending file events: file accesses received before the SBOM was ready, deduplicated per file path
 	pendingFileEventsLock sync.Mutex
-	pendingFileEvents     map[containerutils.ContainerID][]pendingFileEvent
+	pendingFileEvents     *simplelru.LRU[containerutils.ContainerID, map[string]pendingFileEvent]
 
 	statsdClient   statsd.ClientInterface
 	sbomCollector  sbomCollector
@@ -222,6 +223,12 @@ func NewSBOMResolver(c *config.RuntimeSecurityConfig, statsdClient statsd.Client
 		return nil, fmt.Errorf("couldn't create new SBOMResolver: %w", err)
 	}
 
+	// one entry per workload waiting for its scan, so the same bound as the sboms cache
+	pendingFileEvents, err := simplelru.NewLRU[containerutils.ContainerID, map[string]pendingFileEvent](maxSBOMEntries, nil)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create new SBOMResolver: %w", err)
+	}
+
 	hostProcRootPath := utils.ProcRootPath(1)
 	stat, err := utils.UnixStat(hostProcRootPath)
 	if err != nil {
@@ -241,7 +248,7 @@ func NewSBOMResolver(c *config.RuntimeSecurityConfig, statsdClient statsd.Client
 		sbomsCacheMiss:        atomic.NewUint64(0),
 		failedSBOMGenerations: atomic.NewUint64(0),
 		wmeta:                 wmeta,
-		pendingFileEvents:     make(map[containerutils.ContainerID][]pendingFileEvent),
+		pendingFileEvents:     pendingFileEvents,
 	}
 
 	sboms, err := simplelru.NewLRU(maxSBOMEntries, resolver.onSBOMEvicted)
@@ -796,25 +803,40 @@ func (r *Resolver) ResolvePackage(pc *model.ProcessContext, file *model.FileEven
 	return pkg
 }
 
-// queuePendingFileEvent stores a file access that arrived before the SBOM for
-// the given container was ready. The queue keeps the last maxPendingFileEvents
-// entries per container, dropping the oldest when full.
+// queuePendingFileEvent stores a file access that arrived before the SBOM for the
+// given container was ready, keeping up to maxPendingFileEvents distinct paths per
+// container. Accesses are merged per path: the snapshot replay emits one open event
+// per (process, mapped file) pair and runs again on every ruleset reload, so without
+// deduplication the shared libraries mapped by every process of a workload crowd out
+// the distinct paths worth keeping.
 func (r *Resolver) queuePendingFileEvent(containerID containerutils.ContainerID, filePath string, fileMode uint16, uid uint32) {
 	if containerID == "" {
 		return
 	}
+
+	event := pendingFileEvent{
+		suidBit:        fs.FileMode(fileMode)&04000 != 0,
+		accessedByRoot: uid == 0,
+	}
+
 	r.pendingFileEventsLock.Lock()
 	defer r.pendingFileEventsLock.Unlock()
 
-	events := r.pendingFileEvents[containerID]
-	event := pendingFileEvent{filePath: filePath, fileMode: fileMode, uid: uid}
-	if len(events) >= maxPendingFileEvents {
-		// drop the oldest entry to keep the last N
-		events = append(events[1:], event)
-	} else {
-		events = append(events, event)
+	events, ok := r.pendingFileEvents.Get(containerID)
+	if !ok {
+		events = make(map[string]pendingFileEvent)
+		r.pendingFileEvents.Add(containerID, events)
 	}
-	r.pendingFileEvents[containerID] = events
+
+	if previous, ok := events[filePath]; ok {
+		event.suidBit = event.suidBit || previous.suidBit
+		event.accessedByRoot = event.accessedByRoot || previous.accessedByRoot
+	} else if len(events) >= maxPendingFileEvents {
+		seclog.Debugf("dropping pending file event '%s' for container '%s': too many pending events", filePath, containerID)
+		return
+	}
+
+	events[filePath] = event
 }
 
 // processPendingFileEvents drains the pending file-event queue for the given
@@ -822,10 +844,8 @@ func (r *Resolver) queuePendingFileEvent(containerID containerutils.ContainerID,
 // Must be called with sbom.Lock() already held.
 func (r *Resolver) processPendingFileEvents(sbom *SBOM) {
 	r.pendingFileEventsLock.Lock()
-	events, ok := r.pendingFileEvents[sbom.ContainerID]
-	if ok {
-		delete(r.pendingFileEvents, sbom.ContainerID)
-	}
+	events, ok := r.pendingFileEvents.Peek(sbom.ContainerID)
+	r.pendingFileEvents.Remove(sbom.ContainerID)
 	r.pendingFileEventsLock.Unlock()
 
 	if !ok || len(events) == 0 {
@@ -835,14 +855,14 @@ func (r *Resolver) processPendingFileEvents(sbom *SBOM) {
 	seclog.Debugf("processing %d pending file events for container '%s'", len(events), sbom.ContainerID)
 
 	now := time.Now()
-	for _, event := range events {
-		pkg := sbom.data.files.queryFile(event.filePath)
+	for filePath, event := range events {
+		pkg := sbom.data.files.queryFile(filePath)
 		if pkg == nil {
 			continue
 		}
 		pkg.LastAccess = now
-		pkg.SuidBit = pkg.SuidBit || fs.FileMode(event.fileMode)&04000 != 0
-		pkg.AccessedByRoot = pkg.AccessedByRoot || event.uid == 0
+		pkg.SuidBit = pkg.SuidBit || event.suidBit
+		pkg.AccessedByRoot = pkg.AccessedByRoot || event.accessedByRoot
 
 		sbom.invalidated = true
 	}
@@ -999,7 +1019,7 @@ func (r *Resolver) onSBOMEvicted(_ containerutils.ContainerID, sbom *SBOM) {
 // deletePendingFileEvents drops the file accesses queued for the provided container ID
 func (r *Resolver) deletePendingFileEvents(containerID containerutils.ContainerID) {
 	r.pendingFileEventsLock.Lock()
-	delete(r.pendingFileEvents, containerID)
+	r.pendingFileEvents.Remove(containerID)
 	r.pendingFileEventsLock.Unlock()
 }
 

--- a/pkg/security/resolvers/sbom/resolver_test.go
+++ b/pkg/security/resolvers/sbom/resolver_test.go
@@ -8,6 +8,7 @@
 package sbom
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -57,10 +58,16 @@ func TestRefreshScanResetsStateForRescan(t *testing.T) {
 	}
 }
 
-func newPendingFileEventsResolver() *Resolver {
-	return &Resolver{
-		pendingFileEvents: make(map[containerutils.ContainerID][]pendingFileEvent),
+func newPendingFileEvents(t *testing.T) *simplelru.LRU[containerutils.ContainerID, map[string]pendingFileEvent] {
+	events, err := simplelru.NewLRU[containerutils.ContainerID, map[string]pendingFileEvent](maxSBOMEntries, nil)
+	if err != nil {
+		t.Fatalf("NewLRU: %v", err)
 	}
+	return events
+}
+
+func newPendingFileEventsResolver(t *testing.T) *Resolver {
+	return &Resolver{pendingFileEvents: newPendingFileEvents(t)}
 }
 
 // TestDeleteReleasesPendingFileEventsWithoutSBOM checks that a container leaving
@@ -72,13 +79,13 @@ func TestDeleteReleasesPendingFileEventsWithoutSBOM(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewLRU: %v", err)
 	}
-	r := newPendingFileEventsResolver()
+	r := newPendingFileEventsResolver(t)
 	r.sboms = sboms
 
 	r.queuePendingFileEvent("container-id", "/usr/bin/su", 04755, 0)
 	r.Delete("container-id")
 
-	if len(r.pendingFileEvents) != 0 {
+	if r.pendingFileEvents.Len() != 0 {
 		t.Errorf("queued file accesses were not released")
 	}
 }
@@ -87,7 +94,7 @@ func TestDeleteReleasesPendingFileEventsWithoutSBOM(t *testing.T) {
 // a workload are released when its SBOM leaves the cache, whether it is removed
 // explicitly or evicted to make room.
 func TestEvictedSBOMReleasesPendingFileEvents(t *testing.T) {
-	r := newPendingFileEventsResolver()
+	r := newPendingFileEventsResolver(t)
 	sboms, err := simplelru.NewLRU(1, r.onSBOMEvicted)
 	if err != nil {
 		t.Fatalf("NewLRU: %v", err)
@@ -100,13 +107,13 @@ func TestEvictedSBOMReleasesPendingFileEvents(t *testing.T) {
 	sboms.Add("container-id", NewSBOM("container-id", nil, "image:tag"))
 	r.queuePendingFileEvent("container-id", "/usr/bin/su", 04755, 0)
 
-	if _, ok := r.pendingFileEvents["evicted-container-id"]; ok {
+	if _, ok := r.pendingFileEvents.Get("evicted-container-id"); ok {
 		t.Errorf("queued file accesses of the evicted SBOM were not released")
 	}
 
 	r.Delete("container-id")
 
-	if len(r.pendingFileEvents) != 0 {
+	if r.pendingFileEvents.Len() != 0 {
 		t.Errorf("queued file accesses of the removed SBOM were not released")
 	}
 }
@@ -125,7 +132,7 @@ func TestAnalyzeWorkloadReusesCachedDataAsComputed(t *testing.T) {
 		// long enough that the forwarding debouncer cannot fire during the test
 		cfg:               &config.RuntimeSecurityConfig{SBOMResolverForwardInterval: time.Hour},
 		dataCache:         dataCache,
-		pendingFileEvents: make(map[containerutils.ContainerID][]pendingFileEvent),
+		pendingFileEvents: newPendingFileEvents(t),
 		sbomsCacheHit:     atomic.NewUint64(0),
 		sbomsCacheMiss:    atomic.NewUint64(0),
 	}
@@ -146,7 +153,7 @@ func TestAnalyzeWorkloadReusesCachedDataAsComputed(t *testing.T) {
 	if !sbom.IsComputed() {
 		t.Errorf("state = %d, want computedState (%d)", sbom.state.Load(), computedState)
 	}
-	if len(r.pendingFileEvents) != 0 {
+	if r.pendingFileEvents.Len() != 0 {
 		t.Errorf("queued file accesses were not drained")
 	}
 	if pkg := sbom.data.packages[0]; pkg.LastAccess.IsZero() {
@@ -172,7 +179,7 @@ func TestAnalyzeWorkloadSkipsStoppedWorkload(t *testing.T) {
 	r := &Resolver{
 		cfg:               &config.RuntimeSecurityConfig{SBOMResolverForwardInterval: time.Hour},
 		dataCache:         dataCache,
-		pendingFileEvents: make(map[containerutils.ContainerID][]pendingFileEvent),
+		pendingFileEvents: newPendingFileEvents(t),
 		sbomsCacheHit:     atomic.NewUint64(0),
 		sbomsCacheMiss:    atomic.NewUint64(0),
 	}
@@ -211,7 +218,7 @@ func TestQueueWorkloadAppliesQueuedAccessesOnCacheHit(t *testing.T) {
 	r := &Resolver{
 		dataCache:         dataCache,
 		scanChan:          make(chan *SBOM, 1),
-		pendingFileEvents: make(map[containerutils.ContainerID][]pendingFileEvent),
+		pendingFileEvents: newPendingFileEvents(t),
 		sbomsCacheHit:     atomic.NewUint64(0),
 		sbomsCacheMiss:    atomic.NewUint64(0),
 	}
@@ -230,10 +237,88 @@ func TestQueueWorkloadAppliesQueuedAccessesOnCacheHit(t *testing.T) {
 	if !sbom.IsComputed() {
 		t.Errorf("state = %d, want computedState (%d)", sbom.state.Load(), computedState)
 	}
-	if len(r.pendingFileEvents) != 0 {
+	if r.pendingFileEvents.Len() != 0 {
 		t.Errorf("queued file accesses were not applied")
 	}
 	if pkg := sbom.data.packages[0]; pkg.LastAccess.IsZero() || !pkg.SuidBit || !pkg.AccessedByRoot {
 		t.Errorf("package = %+v, want last access and both sticky properties set", pkg)
+	}
+}
+
+// TestPendingFileEventsAreDeduplicatedPerPath checks that repeated accesses to the
+// same file collapse into a single entry with the sticky properties merged. The
+// snapshot replay emits one open event per (process, mapped file) pair and runs again
+// on every ruleset reload, so the shared libraries mapped by every process of a
+// workload would otherwise crowd out the distinct paths worth keeping.
+func TestPendingFileEventsAreDeduplicatedPerPath(t *testing.T) {
+	r := newPendingFileEventsResolver(t)
+
+	for range 3 {
+		r.queuePendingFileEvent("container-id", "/usr/lib/libc.so.6", 0644, 1000)
+	}
+	r.queuePendingFileEvent("container-id", "/usr/bin/su", 04755, 1000)
+	r.queuePendingFileEvent("container-id", "/usr/bin/su", 0755, 0)
+
+	events, _ := r.pendingFileEvents.Get("container-id")
+	if len(events) != 2 {
+		t.Fatalf("queued %d distinct events, want 2", len(events))
+	}
+	if event := events["/usr/lib/libc.so.6"]; event.suidBit || event.accessedByRoot {
+		t.Errorf("libc event = %+v, want no sticky property set", event)
+	}
+	if event := events["/usr/bin/su"]; !event.suidBit || !event.accessedByRoot {
+		t.Errorf("su event = %+v, want both sticky properties merged", event)
+	}
+}
+
+// TestPendingFileEventsBoundDistinctPathsPerContainer checks that a container holds
+// at most maxPendingFileEvents distinct paths, and that an access to an already
+// queued path is still merged once that bound is reached.
+func TestPendingFileEventsBoundDistinctPathsPerContainer(t *testing.T) {
+	r := newPendingFileEventsResolver(t)
+
+	for i := range maxPendingFileEvents {
+		r.queuePendingFileEvent("container-id", fmt.Sprintf("/usr/lib/lib%d.so", i), 0644, 1000)
+	}
+	r.queuePendingFileEvent("container-id", "/usr/lib/overflow.so", 0644, 1000)
+	r.queuePendingFileEvent("container-id", "/usr/lib/lib0.so", 0644, 0)
+
+	events, _ := r.pendingFileEvents.Get("container-id")
+	if len(events) != maxPendingFileEvents {
+		t.Fatalf("queued %d distinct events, want %d", len(events), maxPendingFileEvents)
+	}
+	if _, ok := events["/usr/lib/overflow.so"]; ok {
+		t.Errorf("path queued past the maximum number of pending events")
+	}
+	if !events["/usr/lib/lib0.so"].accessedByRoot {
+		t.Errorf("access to an already queued path was not merged")
+	}
+}
+
+// TestProcessPendingFileEventsEnrichesPackages checks that draining the queue applies
+// the queued accesses to the packages owning the files and marks the SBOM for
+// forwarding.
+func TestProcessPendingFileEventsEnrichesPackages(t *testing.T) {
+	r := newPendingFileEventsResolver(t)
+
+	sbom := NewSBOM("container-id", nil, "image:tag")
+	sbom.data = newData([]sbomtypes.PackageWithInstalledFiles{{
+		Package:        sbomtypes.Package{Name: "shadow-utils"},
+		InstalledFiles: []string{"/usr/bin/su"},
+	}}, false)
+
+	r.queuePendingFileEvent("container-id", "/usr/bin/su", 04755, 0)
+	r.queuePendingFileEvent("container-id", "/usr/bin/not-in-any-package", 0644, 1000)
+
+	r.processPendingFileEvents(sbom)
+
+	if r.pendingFileEvents.Len() != 0 {
+		t.Errorf("pending events were not drained")
+	}
+	if pkg := sbom.data.packages[0]; pkg.LastAccess.IsZero() || !pkg.SuidBit || !pkg.AccessedByRoot {
+		t.Errorf("package = %+v, want last access and both sticky properties set", pkg)
+	}
+	if !sbom.invalidated {
+		t.Errorf("sbom was not marked for forwarding")
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Deduplicates the file accesses queued while a workload is being scanned, and bounds how many containers can hold such accesses.

### Motivation

The snapshot replay emits one open event per process and mapped file, and runs again on every ruleset reload, so the libraries mapped by every process of a workload were queued over and over. They crowded out the distinct paths of a queue bounded to 256 entries, and the packages a workload actually used ended up dropped from the runtime enrichment. Accesses are now indexed by path.

Accesses are queued as soon as a container ID resolves, well before the entry that ties them to a workload exists, so a container that stops in between kept its accesses forever, leaking memory. They now live in an LRU keyed by container, so containers that never get an SBOM cannot accumulate.

### Describe how you validated your changes

Added unit tests for the deduplication, the bound and the enrichment applied when draining.

### Additional Notes