### PR TITLE
[CONTP-1963] feat(orchestrator): collect DatadogInstrumentation as OOTB custom resource

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -530,6 +530,7 @@ func newBuiltinCRDConfigs() []builtinCRDConfig {
 		newBuiltinCRDConfig(datadogAPIGroup, "datadogpodautoscalers", isOOTBCRDEnabled, "v1alpha2"),
 		newBuiltinCRDConfig(datadogAPIGroup, "datadogpodautoscalerclusterprofiles", isOOTBCRDEnabled, "v1alpha2"),
 		newBuiltinCRDConfig(datadogAPIGroup, "datadogagents", isOOTBCRDEnabled, "v2alpha1"),
+		newBuiltinCRDConfig(datadogAPIGroup, "datadoginstrumentations", isOOTBCRDEnabled, "v1alpha1"),
 
 		// Argo resources
 		newBuiltinCRDConfig(ArgoAPIGroup, "rollouts", isOOTBCRDEnabled, "v1alpha1"),

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
@@ -410,6 +410,7 @@ func TestNewBuiltinCRDConfigs(t *testing.T) {
 		"datadoghq.com/v1alpha1/datadogagentprofiles",
 		"datadoghq.com/v1alpha1/datadogmonitors",
 		"datadoghq.com/v1alpha1/datadogmetrics",
+		"datadoghq.com/v1alpha1/datadoginstrumentations",
 
 		// Argo
 		"argoproj.io/v1alpha1/rollouts",

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
@@ -36,14 +36,15 @@ func createMockAPIClient() *apiserver.APIClient {
 	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(scheme,
 		map[schema.GroupVersionResource]string{
 			// Datadog resources
-			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogmetrics"}:        "DatadogMetricList",
-			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogmonitors"}:       "DatadogMonitorList",
-			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogslos"}:           "DatadogSloList",
-			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogdashboards"}:     "DatadogDashboardList",
-			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogagentprofiles"}:  "DatadogAgentProfileList",
-			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogpodautoscalers"}: "DatadogPodAutoscalerList",
-			{Group: "datadoghq.com", Version: "v1alpha2", Resource: "datadogpodautoscalers"}: "DatadogPodAutoscalerList",
-			{Group: "datadoghq.com", Version: "v2alpha1", Resource: "datadogagents"}:         "DatadogAgentList",
+			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogmetrics"}:          "DatadogMetricList",
+			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogmonitors"}:         "DatadogMonitorList",
+			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogslos"}:             "DatadogSloList",
+			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogdashboards"}:       "DatadogDashboardList",
+			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogagentprofiles"}:    "DatadogAgentProfileList",
+			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadogpodautoscalers"}:   "DatadogPodAutoscalerList",
+			{Group: "datadoghq.com", Version: "v1alpha2", Resource: "datadogpodautoscalers"}:   "DatadogPodAutoscalerList",
+			{Group: "datadoghq.com", Version: "v2alpha1", Resource: "datadogagents"}:           "DatadogAgentList",
+			{Group: "datadoghq.com", Version: "v1alpha1", Resource: "datadoginstrumentations"}: "DatadogInstrumentationList",
 			// Third-party resources
 			{Group: "argoproj.io", Version: "v1alpha1", Resource: "rollouts"}: "RolloutList",
 		})
@@ -63,15 +64,16 @@ func TestImportBuiltinCollectors(t *testing.T) {
 	collectorDiscovery := &discovery.DiscoveryCollector{}
 	collectorDiscovery.SetCache(discovery.DiscoveryCache{
 		CollectorForVersion: map[discovery.CollectorVersion]struct{}{
-			{GroupVersion: "v1", Kind: "pods"}:                                      {},
-			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmetrics"}:        {},
-			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmonitors"}:       {},
-			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogslos"}:           {},
-			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogdashboards"}:     {},
-			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogagentprofiles"}:  {},
-			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogpodautoscalers"}: {},
-			{GroupVersion: "datadoghq.com/v1alpha2", Kind: "datadogpodautoscalers"}: {},
-			{GroupVersion: "datadoghq.com/v2alpha1", Kind: "datadogagents"}:         {},
+			{GroupVersion: "v1", Kind: "pods"}:                                        {},
+			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmetrics"}:          {},
+			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmonitors"}:         {},
+			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogslos"}:             {},
+			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogdashboards"}:       {},
+			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogagentprofiles"}:    {},
+			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogpodautoscalers"}:   {},
+			{GroupVersion: "datadoghq.com/v1alpha2", Kind: "datadogpodautoscalers"}:   {},
+			{GroupVersion: "datadoghq.com/v2alpha1", Kind: "datadogagents"}:           {},
+			{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadoginstrumentations"}: {},
 		},
 		Groups: []*v1.APIGroup{
 			{
@@ -121,6 +123,7 @@ func TestImportBuiltinCollectors(t *testing.T) {
 		"datadoghq.com/v1alpha1/datadogagentprofiles",
 		"datadoghq.com/v1alpha2/datadogpodautoscalers", // preferred version selected
 		"datadoghq.com/v2alpha1/datadogagents",
+		"datadoghq.com/v1alpha1/datadoginstrumentations",
 	}
 	require.ElementsMatch(t, expected, names)
 }

--- a/releasenotes/notes/orchestrator-ootb-datadoginstrumentation-3c6c3b4a1f0d5e27.yaml
+++ b/releasenotes/notes/orchestrator-ootb-datadoginstrumentation-3c6c3b4a1f0d5e27.yaml
@@ -1,0 +1,10 @@
+---
+enhancements:
+  - |
+    The orchestrator check now collects ``DatadogInstrumentation``
+    (``datadoghq.com/v1alpha1``) custom resources as part of the out-of-the-box
+    set indexed by the Kubernetes Explorer, alongside the other
+    ``datadoghq.com`` custom resources. Collection requires
+    ``orchestrator_explorer.custom_resources.ootb.enabled`` (enabled by
+    default) and is skipped when the custom resource definition is absent from
+    the cluster.


### PR DESCRIPTION
### What does this PR do?

Adds `datadoghq.com/v1alpha1` `datadoginstrumentations` to `newBuiltinCRDConfigs()` in the orchestrator check, so Kubernetes Explorer indexes `DatadogInstrumentation` resources out of the box (gated by the existing `orchestrator_explorer.custom_resources.ootb.enabled` flag, like the other `datadoghq.com` CRDs).

### Motivation

Kubernetes Explorer already indexes most `datadoghq.com` CRDs by default; `DatadogInstrumentation` was missing.

### Describe how you validated your changes

Extended `TestImportBuiltinCollectors` fixtures (fake dynamic client + discovery cache + expected collector list) with the new GVR, and ran the orchestrator package tests — they pass. As with the other built-in CRDs, the collector is only created when the resource is actually present in the cluster's API discovery, so clusters without the CRD are unaffected.

### Additional Notes

No new config knob; nothing to change for users other than upgrading.
