### PR TITLE
[OTAGENT-1217] handle empty modules list in upstream versions.yaml

### DIFF
--- a/tasks/collector.py
+++ b/tasks/collector.py
@@ -500,7 +500,7 @@ class CollectorRepo:
 
         for _, details in data.get("module-sets", {}).items():
             version = details.get("version", "unknown")
-            for module in details.get("modules", []):
+            for module in details.get("modules") or []:
                 version_modules[version] = version_modules.get(version, []) + [module]
 
         return version_modules


### PR DESCRIPTION
### What does this PR do?

Makes `CollectorRepo.fetch_module_versions` in `tasks/collector.py` tolerate a `module-sets` entry whose `modules:` list is empty.

### Motivation

The scheduled `collector-generate-and-update` workflow is failing with:

```
File "tasks/collector.py", line 503, in fetch_module_versions
    for module in details.get("modules", []):
TypeError: 'NoneType' object is not iterable
```

`opentelemetry-collector-contrib`'s `versions.yaml` at `v0.158.0` has a `stable-base` module-set whose only entry is commented out:

```yaml
  stable-base:
    version: v1.0.0
    modules:
      # Uncomment once https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49152 is merged
      # - github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
```

YAML parses that as `None`, not `[]`, so the `.get("modules", [])` default never kicks in. This blocks every OTel dependency update until it's fixed.

### Describe how you validated your changes

Reproduced the upstream YAML parse locally and confirmed the `stable-base` module-set yields `None` for `modules`. The `or []` form handles both a missing key and an explicitly-null value.

### Possible Drawbacks / Trade-offs

None — a module-set with no modules contributes nothing to the version map either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)