### PR TITLE
[OTAGENT-1217] record update-otel-deps pitfalls found during the v0.158.0 bump

### DIFF
--- a/.agents/skills/update-otel-deps/SKILL.md
+++ b/.agents/skills/update-otel-deps/SKILL.md
@@ -79,11 +79,25 @@ Use this only when: the automated workflow has a persistent infrastructure failu
 dda inv collector.update   # bumps go.mod + OCB YAML files to latest OTel version
 dda inv collector.generate # regenerates OTel Agent code from the new manifests
 dda inv components.lint-components --fix
-dda inv modules.add-all-replace
 dda inv tidy               # reconcile transitive dependencies
+dda inv modules.add-all-replace  # must run AFTER tidy (see note below)
 bazel run //:go_mod_tidy_all
 dda inv generate-licenses  # update license inventory
 ```
+
+> **Run `modules.add-all-replace` after `tidy`, not before.** `collector.generate` rewrites
+> `comp/otelcol/collector-contrib/impl/go.mod` with short-form replace paths
+> (`=> ../../../logs-library`) where the repo standard is the canonical form
+> (`=> ../../../../comp/logs-library`). Running `add-all-replace` before `tidy` leaves the short
+> form in place and `check_modules_replace` fails in CI. Verify it converged by re-running it and
+> confirming no `go.mod` changes.
+
+> **`read_old_version` trusts the OCB manifest, which can be stale.** `collector.update`
+> search-replaces the version recorded in `comp/otelcol/collector-contrib/impl/manifest.yaml`.
+> If someone bumped the Go deps directly without running `collector.update` (as #53984 did), the
+> manifest lags and every file referencing the *actual* previous version is silently skipped.
+> Always compare the manifest version against a real dependency before trusting the bump:
+> `grep 'otelcol v' go.mod`.
 
 If a **specific version** was requested, skip `inv collector.update` and do a repo-wide search-and-replace of the old version string (find it in `tasks/collector.py` — the `OCB_VERSION` / `OTEL_CONTRIB_VERSION` constants). Then run the remaining commands above.
 
@@ -106,8 +120,10 @@ This is the **most common failure**. The DD flare extension tests compare OTel r
 Run the test locally to get the actual diff:
 
 ```bash
-dda inv test --targets=./comp/otelcol/ddflareextension/impl/... --build-include=otlp -- -run TestGetConfDump
+dda inv test --targets=./comp/otelcol/ddflareextension/impl/... --build-include=test,otlp -- -run TestGetConfDump
 ```
+
+> **The `test` tag is required.** `--build-include` *replaces* the default build-tag set rather than adding to it. With only `otlp`, the files gated behind `//go:build test` (`configstore_test.go`, `extension_test.go`, `factory_test.go`) never compile, so `-run TestGetConfDump` matches nothing — the run still reports "ALL TESTS PASSED" from the handful of untagged tests. Confirm the test really ran by checking `test_output.json` for `"Test":"TestGetConfDump"`.
 
 The failure output shows exactly which lines differ. Apply the diffs to the golden files in:
 - `comp/otelcol/ddflareextension/impl/testdata/` (unit test golden files)
@@ -169,8 +185,39 @@ Then run `dda inv tidy` again. Use this only when upgrading the Agent code is no
 
 ```bash
 dda inv linter.go --targets=./comp/otelcol/...                                        # lint the changed OTel components
-dda inv test --targets=./comp/otelcol/ddflareextension/impl/... --build-include=otlp  # confirm tests pass
+dda inv test --targets=./comp/otelcol/ddflareextension/impl/... --build-include=test,otlp  # confirm tests pass
 ```
+
+> **`--targets=./comp/otelcol/...` only covers the root module.** Several OTel packages are
+> *separate Go modules* and are invisible to that invocation — it will report "0 issues" while
+> they are silently unlinted. An upstream API change typically breaks exactly these. Lint each one
+> in its own module context:
+>
+> ```bash
+> for m in comp/otelcol/otlp/components/datadogconfig \
+>          comp/otelcol/otlp/components/exporter/serializerexporter \
+>          comp/otelcol/otlp/components/processor/infraattributesprocessor; do
+>   dda inv linter.go --module="$m"
+> done
+> ```
+>
+> Find the full list with `find comp/otelcol -name go.mod`. Note that `comp/host-profiler` also
+> consumes OTel APIs and is gated behind `//go:build linux`, so it cannot be linted from macOS
+> without a `x86_64-linux-gnu-gcc` cross toolchain — rely on CI's `lint_linux-x64` for it.
+
+### Upstream API moves
+
+When a symbol goes `undefined` after the bump, it has usually been *promoted* from an experimental
+`x`-prefixed package into its stable counterpart rather than deleted. Confirm before rewriting call
+sites, then rename:
+
+```bash
+rg -n "^func Validate|^type Validator" "$(go env GOMODCACHE)"/go.opentelemetry.io/collector/confmap@v1.64.0/*.go
+```
+
+Seen in v0.158.0: `xconfmap.Validate` / `xconfmap.Validator` → `confmap.Validate` / `confmap.Validator`
+(identical signatures). This breaks `lint_*`, `bazel:test:*`, and `build_host_profiler_binary_*`
+together, so a large fan-out of failures often has a single upstream cause.
 
 Open a draft PR to let CI catch any remaining failures. The PR title convention is:
 `Update OTel Collector dependencies to v<VERSION>`
@@ -183,8 +230,12 @@ Once the PR is open, run `/dd:ci:fix` to automatically fetch, analyze, and fix a
 
 - [ ] Automated workflow checked — succeeded (auto-PR reviewed) or failure diagnosed and fixed
 - [ ] `dda inv collector.update` + `collector.generate` + `tidy` + `generate-licenses` all completed without error (automated or manual)
-- [ ] No remaining references to the old OTel version in tracked files
-- [ ] ddflareextension unit + E2E golden files updated and tests pass
+- [ ] `modules.add-all-replace` run **after** `tidy` and confirmed idempotent (re-run produces no `go.mod` diff)
+- [ ] No remaining references to the old OTel version in tracked files — check the *actual* dep version, not just the manifest's
+- [ ] ddflareextension unit + E2E golden files updated and tests pass (with the `test` build tag)
+- [ ] Separate OTel Go modules linted individually with `--module=` (not just `--targets=./comp/otelcol/...`)
+- [ ] `test/fakeintake/version/VERSION` bumped if `tidy` touched `test/fakeintake/go.mod`
+- [ ] Release note added under `releasenotes/notes/` (or `changelog/no-changelog` applied)
 - [ ] OCB build script succeeds (or known issue tracked)
 - [ ] Static quality gate limits raised if breached (exemption approved)
 - [ ] Draft PR open and CI green (use `/dd:ci:fix` for any remaining failures)


### PR DESCRIPTION
### What does this PR do?

Updates `.agents/skills/update-otel-deps/SKILL.md` with pitfalls found while running the OTel Collector dependency update by hand for v0.158.0.

Documentation only — no code or build changes. Split out of #54442 so the dependency bump there stays reviewable on its own.

### Motivation

Four issues cost real time during that update, and two of them produced a **misleading green result** rather than an error — the failure mode most worth documenting:

1. **`--build-include` replaces the default build-tag set** rather than adding to it. The previously documented `--build-include=otlp` dropped the `test` tag, so the three files gated behind `//go:build test` — including `configstore_test.go`, home of `TestGetConfDump` — never compiled. `-run TestGetConfDump` then matched nothing, and the run still printed `ALL TESTS PASSED` from 5 unrelated untagged tests. The skill now uses `--build-include=test,otlp` and says to confirm via `test_output.json`.

2. **`--targets=./comp/otelcol/...` only covers the root module.** Several OTel packages are separate Go modules, invisible to that invocation — it reports `0 issues` while leaving them unlinted. That is exactly where an upstream API change lands: CI caught `undefined: xconfmap.Validate` in three such modules after a local lint had reported clean. The skill now shows how to lint each with `--module=`.

3. **`modules.add-all-replace` must run after `tidy`.** `collector.generate` writes short-form replace paths (`=> ../../../logs-library`) where the repo standard is canonical (`=> ../../../../comp/logs-library`); running `add-all-replace` first leaves the short form and `check_modules_replace` fails.

4. **`read_old_version` trusts the OCB manifest, which can be stale.** When someone bumps the Go dependencies without running `collector.update` (as #53984 did), the manifest lags and `update_file()` silently skips every file referencing the *actual* previous version.

Also documents the `x`-prefixed package promotion pattern — v0.158.0 moved `xconfmap.Validate`/`Validator` into the stable `confmap` package with identical signatures — and notes that this single upstream change fans out into `lint_*`, `bazel:test:*`, and `build_host_profiler_binary_*` failures together, so a large number of red jobs often has one cause.

### Describe how you validated your changes

Every command and claim documented here was executed during the v0.158.0 update in #54442:

- `--build-include=test,otlp` verified to actually run `TestGetConfDump` (14/14 pass, subtests confirmed in `test_output.json`); the `otlp`-only form confirmed to run 5 unrelated tests instead.
- Per-module linting verified to reach the three separate modules (`0 issues` each once fixed, having previously failed in CI).
- `add-all-replace` after `tidy` verified to produce the canonical replace paths and confirmed idempotent.
- The `confmap` symbol locations verified against the module cache at `confmap@v1.64.0`.

No code changes, so no build or test impact.

### Possible Drawbacks / Trade-offs

The `confmap@v1.64.0` path in the example `rg` command is version-specific and will age; it is illustrative of the technique rather than a command to run verbatim.

### Additional Notes

Per the self-improvement guidance in `AGENTS.md`, these were fixed in the same session they were found. The guidance is written to cover the general class — build-tag replacement, module-scoped tooling, task ordering, stale generated metadata — rather than only the v0.158.0 instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)