### PR TITLE
fix(installer): migrate ddagentuser password from SCM during Windows Agent MSI upgrade

### DIFF
--- a/releasenotes/notes/windows-scm-ddagentuser-password-upgrade-11725bac83629bed.yaml
+++ b/releasenotes/notes/windows-scm-ddagentuser-password-upgrade-11725bac83629bed.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Windows: Fixed Agent MSI upgrades where the ``ddagentuser`` password was not
+    recovered when the installer LSA secret was missing but the existing
+    ``datadogagent`` service still had credentials stored in SCM. The installer
+    no longer reuses that SCM password when ``DDAGENTUSER_NAME`` is changed to a
+    different account during upgrade.

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/ProcessUserCustomActionsTestSetup.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/ProcessUserCustomActionsTestSetup.cs
@@ -186,6 +186,40 @@ namespace CustomActions.Tests.ProcessUserCustomActions
             return this;
         }
 
+        public ProcessUserCustomActionsTestSetup WithLookupAccountName(
+            string accountName,
+            string resolvedUser,
+            string resolvedDomain,
+            SecurityIdentifier sid,
+            SID_NAME_USE userType = SID_NAME_USE.SidTypeUser)
+        {
+            NativeMethods.Setup(n => n.IsServiceAccount(sid)).Returns(false);
+            NativeMethods.Setup(n => n.IsDomainAccount(sid)).Returns(true);
+            NativeMethods.Setup(n => n.LookupAccountName(
+                    accountName,
+                    out It.Ref<string>.IsAny,
+                    out It.Ref<string>.IsAny,
+                    out It.Ref<SecurityIdentifier>.IsAny,
+                    out It.Ref<SID_NAME_USE>.IsAny))
+                .Callback(new LookupAccountNameDelegate(
+                    (
+                        string _,
+                        out string user,
+                        out string domain,
+                        out SecurityIdentifier resolvedSid,
+                        out SID_NAME_USE nameUse
+                    ) =>
+                    {
+                        user = resolvedUser;
+                        domain = resolvedDomain;
+                        resolvedSid = sid;
+                        nameUse = userType;
+                    }))
+                .Returns(true);
+
+            return this;
+        }
+
         public ProcessUserCustomActionsTestSetup WithManagedServiceAccount(
             string userName,
             SID_NAME_USE userType = SID_NAME_USE.SidTypeUser)

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
@@ -269,8 +269,11 @@ namespace CustomActions.Tests.ProcessUserCustomActions
                 .Should()
                 .Be(ActionResult.Success);
 
+            // Local accounts with no fetched password get a newly generated one; the assertion
+            // here is that SCM was not consulted when the agent service is absent.
             Test.Properties.Should()
-                .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && string.IsNullOrEmpty(kvp.Value));
+                .Contain("DDAGENTUSER_RESET_PASSWORD", "yes").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && !string.IsNullOrEmpty(kvp.Value));
             Test.NativeMethods.Verify(
                 nativeMethods => nativeMethods.FetchSecret(scmPasswordKey),
                 Times.Never);

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
@@ -336,11 +336,63 @@ namespace CustomActions.Tests.ProcessUserCustomActions
                 Times.Once);
         }
 
+        [Fact]
+        public void ProcessDdAgentUserCredentials_Skips_Scm_Password_When_Registry_Metadata_Missing_And_Account_Requested()
+        {
+            const string ddAgentUserName = "ddagentuser";
+            const string domain = "EXAMPLE";
+
+            var (agentPasswordKey, scmPasswordKey) = SetupUpgradePasswordFetch(
+                requestedAccountName: $"{domain}\\{ddAgentUserName}",
+                configureDomainClient: () => Test.WithDomainClient(domain).WithDomainUser(ddAgentUserName),
+                lsaFetchError: new Exception("not found"));
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Success);
+
+            Test.Properties.Should()
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && string.IsNullOrEmpty(kvp.Value));
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(scmPasswordKey),
+                Times.Never);
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(agentPasswordKey),
+                Times.Once);
+        }
+
+        [Fact]
+        public void ProcessDdAgentUserCredentials_Reads_Scm_Password_When_Registry_Metadata_And_Account_Name_Missing()
+        {
+            const string ddAgentUserName = "ddagentuser";
+            var machineDomain = Environment.MachineName;
+
+            var (agentPasswordKey, scmPasswordKey) = SetupUpgradePasswordFetch(
+                requestedAccountName: null,
+                configureDomainClient: () => Test.WithLocalUser(machineDomain, ddAgentUserName),
+                lsaFetchError: new Exception("not found"));
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Success);
+
+            Test.Properties.Should()
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && kvp.Value == "scm-password");
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(scmPasswordKey),
+                Times.Once);
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(agentPasswordKey),
+                Times.Once);
+        }
+
         private (string agentPasswordKey, string scmPasswordKey) SetupUpgradePasswordFetch(
             string requestedAccountName,
-            string installedDomain,
-            string installedUser,
             Action configureDomainClient,
+            string installedDomain = null,
+            string installedUser = null,
             string lsaPassword = null,
             Exception lsaFetchError = null,
             bool agentServiceExists = true,
@@ -355,12 +407,23 @@ namespace CustomActions.Tests.ProcessUserCustomActions
                 Test.WithDatadogAgentService();
             }
 
-            Test.Session
-                .Setup(session => session["DDAGENTUSER_NAME"]).Returns(requestedAccountName);
-            Test.Session
-                .Setup(session => session["DDAGENT_installedDomain"]).Returns(installedDomain);
-            Test.Session
-                .Setup(session => session["DDAGENT_installedUser"]).Returns(installedUser);
+            if (requestedAccountName != null)
+            {
+                Test.Session
+                    .Setup(session => session["DDAGENTUSER_NAME"]).Returns(requestedAccountName);
+            }
+
+            if (installedDomain != null)
+            {
+                Test.Session
+                    .Setup(session => session["DDAGENT_installedDomain"]).Returns(installedDomain);
+            }
+
+            if (installedUser != null)
+            {
+                Test.Session
+                    .Setup(session => session["DDAGENT_installedUser"]).Returns(installedUser);
+            }
 
             var lsaSetup = Test.NativeMethods
                 .Setup(nativeMethods => nativeMethods.FetchSecret(agentPasswordKey));

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
@@ -193,5 +193,191 @@ namespace CustomActions.Tests.ProcessUserCustomActions
                 .Should()
                 .Be(ActionResult.Success);
         }
+
+        [Fact]
+        public void ProcessDdAgentUserCredentials_Reads_Scm_Password_When_Lsa_Missing_And_Account_Unchanged()
+        {
+            const string ddAgentUserName = "ddagentuser";
+            const string domain = "EXAMPLE";
+
+            var (agentPasswordKey, scmPasswordKey) = SetupUpgradePasswordFetch(
+                requestedAccountName: $"{domain}\\{ddAgentUserName}",
+                installedDomain: domain,
+                installedUser: ddAgentUserName,
+                configureDomainClient: () => Test.WithDomainClient(domain).WithDomainUser(ddAgentUserName),
+                lsaFetchError: new Exception("not found"));
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Success);
+
+            Test.Properties.Should()
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && kvp.Value == "scm-password");
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(scmPasswordKey),
+                Times.Once);
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(agentPasswordKey),
+                Times.Once);
+        }
+
+        [Fact]
+        public void ProcessDdAgentUserCredentials_Prefers_Lsa_Password_Over_Scm_On_Upgrade()
+        {
+            const string ddAgentUserName = "ddagentuser";
+            const string domain = "EXAMPLE";
+
+            var (agentPasswordKey, scmPasswordKey) = SetupUpgradePasswordFetch(
+                requestedAccountName: $"{domain}\\{ddAgentUserName}",
+                installedDomain: domain,
+                installedUser: ddAgentUserName,
+                configureDomainClient: () => Test.WithDomainClient(domain).WithDomainUser(ddAgentUserName),
+                lsaPassword: "lsa-password");
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Success);
+
+            Test.Properties.Should()
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && kvp.Value == "lsa-password");
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(agentPasswordKey),
+                Times.Once);
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(scmPasswordKey),
+                Times.Never);
+        }
+
+        [Fact]
+        public void ProcessDdAgentUserCredentials_Skips_Scm_Password_When_Agent_Service_Missing()
+        {
+            const string ddAgentUserName = "ddagentuser";
+            var machineDomain = Environment.MachineName;
+
+            var (agentPasswordKey, scmPasswordKey) = SetupUpgradePasswordFetch(
+                requestedAccountName: $"{machineDomain}\\{ddAgentUserName}",
+                installedDomain: machineDomain,
+                installedUser: ddAgentUserName,
+                configureDomainClient: () => Test.WithLocalUser(machineDomain, ddAgentUserName),
+                lsaFetchError: new Exception("not found"),
+                agentServiceExists: false);
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Success);
+
+            Test.Properties.Should()
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && string.IsNullOrEmpty(kvp.Value));
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(scmPasswordKey),
+                Times.Never);
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(agentPasswordKey),
+                Times.Once);
+        }
+
+        [Fact]
+        public void ProcessDdAgentUserCredentials_Reads_Scm_Password_When_Domain_Alias_Matches_Installed_Account()
+        {
+            const string ddAgentUserName = "ddagentuser";
+            var machineDomain = Environment.MachineName;
+
+            var (agentPasswordKey, scmPasswordKey) = SetupUpgradePasswordFetch(
+                requestedAccountName: $".\\{ddAgentUserName}",
+                installedDomain: machineDomain,
+                installedUser: ddAgentUserName,
+                configureDomainClient: () => Test.WithLocalUser(machineDomain, ddAgentUserName),
+                lsaFetchError: new Exception("not found"));
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Success);
+
+            Test.Properties.Should()
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && kvp.Value == "scm-password");
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(scmPasswordKey),
+                Times.Once);
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(agentPasswordKey),
+                Times.Once);
+        }
+
+        [Fact]
+        public void ProcessDdAgentUserCredentials_Skips_Scm_Password_When_Installed_Account_Differs()
+        {
+            const string ddAgentUserName = "newuser";
+            const string oldAgentUserName = "olduser";
+            const string domain = "EXAMPLE";
+
+            var (agentPasswordKey, scmPasswordKey) = SetupUpgradePasswordFetch(
+                requestedAccountName: $"{domain}\\{ddAgentUserName}",
+                installedDomain: domain,
+                installedUser: oldAgentUserName,
+                configureDomainClient: () => Test.WithDomainClient(domain).WithDomainUser(ddAgentUserName),
+                lsaFetchError: new Exception("not found"));
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Success);
+
+            Test.Properties.Should()
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && string.IsNullOrEmpty(kvp.Value));
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(scmPasswordKey),
+                Times.Never);
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(agentPasswordKey),
+                Times.Once);
+        }
+
+        private (string agentPasswordKey, string scmPasswordKey) SetupUpgradePasswordFetch(
+            string requestedAccountName,
+            string installedDomain,
+            string installedUser,
+            Action configureDomainClient,
+            string lsaPassword = null,
+            Exception lsaFetchError = null,
+            bool agentServiceExists = true,
+            string scmPassword = "scm-password")
+        {
+            var agentPasswordKey = Datadog.CustomActions.ConfigureUserCustomActions.AgentPasswordPrivateDataKey();
+            var scmPasswordKey = $"_SC_{Datadog.CustomActions.Constants.AgentServiceName}";
+
+            configureDomainClient();
+            if (agentServiceExists)
+            {
+                Test.WithDatadogAgentService();
+            }
+
+            Test.Session
+                .Setup(session => session["DDAGENTUSER_NAME"]).Returns(requestedAccountName);
+            Test.Session
+                .Setup(session => session["DDAGENT_installedDomain"]).Returns(installedDomain);
+            Test.Session
+                .Setup(session => session["DDAGENT_installedUser"]).Returns(installedUser);
+
+            var lsaSetup = Test.NativeMethods
+                .Setup(nativeMethods => nativeMethods.FetchSecret(agentPasswordKey));
+            if (lsaFetchError != null)
+            {
+                lsaSetup.Throws(lsaFetchError);
+            }
+            else
+            {
+                lsaSetup.Returns(lsaPassword);
+            }
+
+            Test.NativeMethods
+                .Setup(nativeMethods => nativeMethods.FetchSecret(scmPasswordKey))
+                .Returns(scmPassword);
+
+            return (agentPasswordKey, scmPasswordKey);
+        }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
@@ -401,6 +401,36 @@ namespace CustomActions.Tests.ProcessUserCustomActions
         }
 
         [Fact]
+        public void ProcessDdAgentUserCredentials_Reads_Scm_Password_When_Session_Installed_Metadata_Missing_But_Registry_Has_Account()
+        {
+            const string ddAgentUserName = "ddagentuser";
+            const string domain = "EXAMPLE";
+
+            var (agentPasswordKey, scmPasswordKey) = SetupUpgradePasswordFetch(
+                requestedAccountName: $"{domain}\\{ddAgentUserName}",
+                configureDomainClient: () =>
+                {
+                    Test.WithDomainClient(domain).WithDomainUser(ddAgentUserName);
+                    Test.WithPreviousAgentUser(domain, ddAgentUserName);
+                },
+                lsaFetchError: new Exception("not found"));
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Success);
+
+            Test.Properties.Should()
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && kvp.Value == "scm-password");
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(scmPasswordKey),
+                Times.Once);
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(agentPasswordKey),
+                Times.Once);
+        }
+
+        [Fact]
         public void ProcessDdAgentUserCredentials_Reads_Scm_Password_When_Registry_Metadata_And_Account_Name_Missing()
         {
             const string ddAgentUserName = "ddagentuser";

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
@@ -311,6 +311,41 @@ namespace CustomActions.Tests.ProcessUserCustomActions
         }
 
         [Fact]
+        public void ProcessDdAgentUserCredentials_Reads_Scm_Password_When_Requested_Account_Alias_Matches_Installed_Sid()
+        {
+            const string ddAgentUserName = "ddagentuser";
+            const string netBiosDomain = "EXAMPLE";
+            const string dnsDomain = "example.com";
+            var userSid = new SecurityIdentifier("S-1-5-21-0000000000-0000000000-0000000000-1001");
+
+            var (agentPasswordKey, scmPasswordKey) = SetupUpgradePasswordFetch(
+                requestedAccountName: $"{dnsDomain}\\{ddAgentUserName}",
+                installedDomain: netBiosDomain,
+                installedUser: ddAgentUserName,
+                configureDomainClient: () =>
+                {
+                    Test.WithDomainClient(netBiosDomain);
+                    Test.WithLookupAccountName($"{dnsDomain}\\{ddAgentUserName}", ddAgentUserName, dnsDomain, userSid);
+                    Test.WithLookupAccountName($"{netBiosDomain}\\{ddAgentUserName}", ddAgentUserName, netBiosDomain, userSid);
+                },
+                lsaFetchError: new Exception("not found"));
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Success);
+
+            Test.Properties.Should()
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && kvp.Value == "scm-password");
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(scmPasswordKey),
+                Times.Once);
+            Test.NativeMethods.Verify(
+                nativeMethods => nativeMethods.FetchSecret(agentPasswordKey),
+                Times.Once);
+        }
+
+        [Fact]
         public void ProcessDdAgentUserCredentials_Skips_Scm_Password_When_Installed_Account_Differs()
         {
             const string ddAgentUserName = "newuser";

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
@@ -416,19 +416,22 @@ namespace Datadog.CustomActions
         /// stored from the previous install.
         /// </summary>
         /// <remarks>
-        /// Returns false when registry metadata is missing, so SCM migration is still attempted on
-        /// upgrades that predate stored installedDomain/installedUser values.
+        /// When registry metadata is missing and DDAGENTUSER_NAME is set, returns true so SCM
+        /// migration is skipped because the requested account cannot be verified as unchanged.
+        /// When both registry metadata and DDAGENTUSER_NAME are empty, returns false so SCM
+        /// migration can still run on upgrades that predate stored installedDomain/installedUser.
         /// </remarks>
         private bool IsChangingAgentAccountOnUpgrade()
         {
             var installedDomain = _session.Property("DDAGENT_installedDomain");
             var installedUser = _session.Property("DDAGENT_installedUser");
+            var requestedName = _session.Property("DDAGENTUSER_NAME");
+
             if (string.IsNullOrEmpty(installedDomain) || string.IsNullOrEmpty(installedUser))
             {
-                return false;
+                return !string.IsNullOrEmpty(requestedName);
             }
 
-            var requestedName = _session.Property("DDAGENTUSER_NAME");
             if (string.IsNullOrEmpty(requestedName))
             {
                 return false;

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
@@ -412,21 +412,67 @@ namespace Datadog.CustomActions
         }
 
         /// <summary>
+        /// Returns the installed agent account stored from a previous install.
+        /// </summary>
+        /// <remarks>
+        /// Prefer session properties set by <c>ReadInstallState</c>, but reload from registry when
+        /// they are absent. Private session properties are not persisted from InstallUISequence to
+        /// InstallExecuteSequence, so UI upgrades must read the registry here.
+        /// </remarks>
+        private void GetInstalledAgentAccount(out string installedDomain, out string installedUser)
+        {
+            installedDomain = _session.Property("DDAGENT_installedDomain");
+            installedUser = _session.Property("DDAGENT_installedUser");
+
+            if (!string.IsNullOrEmpty(installedDomain) && !string.IsNullOrEmpty(installedUser))
+            {
+                return;
+            }
+
+            try
+            {
+                using var subkey = _registryServices.OpenRegistryKey(
+                    Registries.LocalMachine,
+                    Constants.DatadogAgentRegistryKey);
+                if (subkey == null)
+                {
+                    return;
+                }
+
+                if (string.IsNullOrEmpty(installedDomain))
+                {
+                    installedDomain = subkey.GetValue("installedDomain")?.ToString();
+                }
+
+                if (string.IsNullOrEmpty(installedUser))
+                {
+                    installedUser = subkey.GetValue("installedUser")?.ToString();
+                }
+            }
+            catch (Exception e)
+            {
+                _session.Log($"Failed to read installed agent account from registry: {e}");
+            }
+        }
+
+        /// <summary>
         /// Returns true when the upgrade explicitly requests a different Agent account than the one
         /// stored from the previous install.
         /// </summary>
         /// <remarks>
-        /// When registry metadata is missing and DDAGENTUSER_NAME is set, returns true so SCM
-        /// migration is skipped because the requested account cannot be verified as unchanged.
-        /// When both registry metadata and DDAGENTUSER_NAME are empty, returns false so SCM
-        /// migration can still run on upgrades that predate stored installedDomain/installedUser.
+        /// When installed-account metadata is missing from both the session and registry and
+        /// DDAGENTUSER_NAME is set, returns true so SCM migration is skipped because the
+        /// requested account cannot be verified as unchanged.
+        /// When both installed-account metadata and DDAGENTUSER_NAME are empty, returns false so
+        /// SCM migration can still run on upgrades that predate stored installedDomain/installedUser.
+        /// Session metadata may be absent during InstallExecuteSequence after a UI upgrade because
+        /// DDAGENT_installedDomain/User are private properties; registry is consulted as a fallback.
         /// When both accounts resolve via LookupAccountName, compares SIDs so alternate AD name
         /// forms (for example DNS vs NetBIOS domain) still count as the same account.
         /// </remarks>
         private bool IsChangingAgentAccountOnUpgrade()
         {
-            var installedDomain = _session.Property("DDAGENT_installedDomain");
-            var installedUser = _session.Property("DDAGENT_installedUser");
+            GetInstalledAgentAccount(out var installedDomain, out var installedUser);
             var requestedName = _session.Property("DDAGENTUSER_NAME");
 
             if (string.IsNullOrEmpty(installedDomain) || string.IsNullOrEmpty(installedUser))

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
@@ -420,6 +420,8 @@ namespace Datadog.CustomActions
         /// migration is skipped because the requested account cannot be verified as unchanged.
         /// When both registry metadata and DDAGENTUSER_NAME are empty, returns false so SCM
         /// migration can still run on upgrades that predate stored installedDomain/installedUser.
+        /// When both accounts resolve via LookupAccountName, compares SIDs so alternate AD name
+        /// forms (for example DNS vs NetBIOS domain) still count as the same account.
         /// </remarks>
         private bool IsChangingAgentAccountOnUpgrade()
         {
@@ -437,14 +439,46 @@ namespace Datadog.CustomActions
                 return false;
             }
 
+            return !AgentAccountsMatch(requestedName, installedDomain, installedUser);
+        }
+
+        /// <summary>
+        /// Returns true when <paramref name="requestedName"/> resolves to the same account as the
+        /// registry-stored <paramref name="installedDomain"/>/<paramref name="installedUser"/>.
+        /// </summary>
+        /// <remarks>
+        /// Compares SIDs via <see cref="LookupAccountWithExtendedDomainSyntax"/> when both accounts
+        /// resolve; falls back to parsed domain/user string comparison otherwise.
+        /// </remarks>
+        private bool AgentAccountsMatch(string requestedName, string installedDomain, string installedUser)
+        {
+            if (LookupAccountWithExtendedDomainSyntax(
+                    requestedName,
+                    out _,
+                    out _,
+                    out var requestedSid,
+                    out _))
+            {
+                var installedAccount = $"{installedDomain}\\{installedUser}";
+                if (_nativeMethods.LookupAccountName(
+                        installedAccount,
+                        out _,
+                        out _,
+                        out var installedSid,
+                        out _))
+                {
+                    return requestedSid.Equals(installedSid);
+                }
+            }
+
             ParseUserName(requestedName, out var user, out var domain);
             if (string.IsNullOrEmpty(domain))
             {
                 domain = GetDefaultDomainPart();
             }
 
-            return !string.Equals(user, installedUser, StringComparison.OrdinalIgnoreCase) ||
-                   !string.Equals(domain, installedDomain, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(user, installedUser, StringComparison.OrdinalIgnoreCase) &&
+                   string.Equals(domain, installedDomain, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
@@ -357,7 +357,8 @@ namespace Datadog.CustomActions
         }
 
         /// <summary>
-        /// Returns the Agent user password from the command line, or the LSA secret store
+        /// Returns the Agent user password from the command line, the installer LSA secret store,
+        /// or the SCM LSA secret for an existing Agent service during upgrade.
         /// </summary>
         private string FetchAgentPassword()
         {
@@ -367,11 +368,12 @@ namespace Datadog.CustomActions
                 return ddAgentUserPassword;
             }
 
+            var agentPasswordKey = ConfigureUserCustomActions.AgentPasswordPrivateDataKey();
+
             // If the password is not provided on the command line, try to fetch it from the LSA secret store
             try
             {
-                var keyName = ConfigureUserCustomActions.AgentPasswordPrivateDataKey();
-                ddAgentUserPassword = _nativeMethods.FetchSecret(keyName);
+                ddAgentUserPassword = _nativeMethods.FetchSecret(agentPasswordKey);
             }
             catch (Exception e)
             {
@@ -379,7 +381,67 @@ namespace Datadog.CustomActions
                 _session.Log($"Failed to read Agent password from LSA, using empty string, this is unexpected only during upgrades: {e}");
             }
 
+            if (string.IsNullOrEmpty(ddAgentUserPassword) &&
+                _serviceController.ServiceExists(Constants.AgentServiceName))
+            {
+                if (IsChangingAgentAccountOnUpgrade())
+                {
+                    _session.Log(
+                        "Skipping SCM password fallback: DDAGENTUSER_NAME differs from installed account");
+                }
+                else
+                {
+                    var scmPasswordKey = $"_SC_{Constants.AgentServiceName}";
+                    try
+                    {
+                        ddAgentUserPassword = _nativeMethods.FetchSecret(scmPasswordKey);
+                        if (!string.IsNullOrEmpty(ddAgentUserPassword))
+                        {
+                            _session.Log(
+                                $"Read Agent password from SCM LSA secret {scmPasswordKey} for upgrade migration");
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        _session.Log($"Failed to read Agent password from SCM LSA secret {scmPasswordKey}: {e}");
+                    }
+                }
+            }
+
             return ddAgentUserPassword;
+        }
+
+        /// <summary>
+        /// Returns true when the upgrade explicitly requests a different Agent account than the one
+        /// stored from the previous install.
+        /// </summary>
+        /// <remarks>
+        /// Returns false when registry metadata is missing, so SCM migration is still attempted on
+        /// upgrades that predate stored installedDomain/installedUser values.
+        /// </remarks>
+        private bool IsChangingAgentAccountOnUpgrade()
+        {
+            var installedDomain = _session.Property("DDAGENT_installedDomain");
+            var installedUser = _session.Property("DDAGENT_installedUser");
+            if (string.IsNullOrEmpty(installedDomain) || string.IsNullOrEmpty(installedUser))
+            {
+                return false;
+            }
+
+            var requestedName = _session.Property("DDAGENTUSER_NAME");
+            if (string.IsNullOrEmpty(requestedName))
+            {
+                return false;
+            }
+
+            ParseUserName(requestedName, out var user, out var domain);
+            if (string.IsNullOrEmpty(domain))
+            {
+                domain = GetDefaultDomainPart();
+            }
+
+            return !string.Equals(user, installedUser, StringComparison.OrdinalIgnoreCase) ||
+                   !string.Equals(domain, installedDomain, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>


### PR DESCRIPTION
### What does this PR do?

On Windows MSI upgrade, `FetchAgentPassword()` now falls back to the `datadogagent` SCM LSA secret (`_SC_datadogagent`) when the installer password secret (`L$datadog_ddagentuser_password`) is missing.

The fallback is skipped when `DDAGENTUSER_NAME` differs from the registry-stored account (`DDAGENT_installedDomain` / `DDAGENT_installedUser`), so switching the agent user during upgrade does not reuse the previous account's password.

### Motivation

Older installs may only have the agent user password in SCM, not in the Datadog LSA secret. Without this fallback, upgrades can leave `DDAGENTUSER_PROCESSED_PASSWORD` empty and break downstream installer steps that persist credentials.

### Describe how you validated your changes

- Added unit tests in `UserCustomActionsTests.cs`:
  - SCM used when LSA is missing and account unchanged
  - LSA preferred over SCM
  - SCM skipped when `datadogagent` service is absent
  - SCM used when `.\ddagentuser` matches registry `MACHINE\ddagentuser`
  - SCM skipped when installed account differs
- CI: Windows `CustomActions.Tests` (via existing installer test job)

### Additional Notes