### PR TITLE
[TEST] Try -mminimal-toc for AIX cross trace-agent TOC overflow

### DIFF
--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -461,7 +461,7 @@ def get_build_flags(
         if target_platform == "aix":
             # Set the sysroot flag for the cross compiler
             sysroot = "/opt/aix-cross/sysroot"
-            env["CGO_CFLAGS"] = env.get("CGO_CFLAGS", "") + f" --sysroot={sysroot} -maix64"
+            env["CGO_CFLAGS"] = env.get("CGO_CFLAGS", "") + f" --sysroot={sysroot} -maix64 -mminimal-toc"
             env["CGO_LDFLAGS"] = env.get("CGO_LDFLAGS", "") + f" --sysroot={sysroot} -maix64 -Wl,-brtl -Wl,-bbigtoc"
 
             # Go's DWARF-on-AIX support probes the external linker but fails to parse the output of


### PR DESCRIPTION
Testing whether adding `-mminimal-toc` to CGO_CFLAGS for the AIX cross build fixes the `cross_build_trace_agent-binary_aix_ppc64` TOC overflow (`0x594f8 > 0x10000`) introduced by #54290. CI-only test, not meant to be merged.