### PR TITLE
fix(security): Improve codeql chainguard

### DIFF
--- a/.github/chainguard/self.gitlab.security-events-write.sts.yaml
+++ b/.github/chainguard/self.gitlab.security-events-write.sts.yaml
@@ -3,8 +3,7 @@ subject_pattern: "project_path:DataDog/datadog-agent:ref_type:branch:ref:.*"
 claim_pattern:
   project_path: "DataDog/datadog-agent"
   ref_type: "branch"
-  ref: ".+"
-  ref_path: "refs/heads/.+"
-  ref_protected: "true"
+  ref: "main"
+  ref_path: "refs/heads/main"
 permissions:
   security_events: write


### PR DESCRIPTION
### Motivation + What does this PR do?
Codeql only runs daily on main, according to job definition https://github.com/DataDog/datadog-agent/blob/daf42da470291f772ff22accfc509f547cbcbb2c/.gitlab/build/source_test/codeql_scan.yml#L14 and rule definition https://github.com/DataDog/datadog-agent/blob/daf42da470291f772ff22accfc509f547cbcbb2c/.gitlab-ci.yml#L466. As a consequence we can restrict its execution to main only


### Describe how you validated your changes
Configuration only

### Additional Notes
