### PR TITLE
[CWS] Host-wide capture window on the V2 security profile manager

### DIFF
--- a/cmd/system-probe/subcommands/runtime/activity_dump.go
+++ b/cmd/system-probe/subcommands/runtime/activity_dump.go
@@ -58,6 +58,7 @@ func activityDumpCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	activityDumpCmd.AddCommand(listCommands(globalParams)...)
 	activityDumpCmd.AddCommand(stopCommands(globalParams)...)
 	activityDumpCmd.AddCommand(diffCommands(globalParams)...)
+	activityDumpCmd.AddCommand(hostCommands(globalParams)...)
 	return []*cobra.Command{activityDumpCmd}
 }
 
@@ -116,6 +117,122 @@ func stopCommands(globalParams *command.GlobalParams) []*cobra.Command {
 		"a cgroup ID can be used to filter the activity dump.",
 	)
 	return []*cobra.Command{activityDumpStopCmd}
+}
+
+func hostCommands(globalParams *command.GlobalParams) []*cobra.Command {
+	hostCmd := &cobra.Command{
+		Use:   "host",
+		Short: "host-wide activity capture commands",
+		Long: "open/close a host-wide capture window on top of the V2 security profile manager. " +
+			"Requires runtime_security_config.security_profile.v2.host_dump.enabled, which also " +
+			"enables the V2 manager and host (systemd) cgroup profiling. Intended to be driven " +
+			"from a CI job's pre/post steps to capture the whole host for the duration of a job.",
+	}
+
+	hostCmd.AddCommand(hostStartCommands(globalParams)...)
+	hostCmd.AddCommand(hostStopCommands(globalParams)...)
+	return []*cobra.Command{hostCmd}
+}
+
+func hostStartCommands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &activityDumpCliParams{
+		GlobalParams: globalParams,
+	}
+
+	hostStartCmd := &cobra.Command{
+		Use:   "start",
+		Short: "open the host-wide capture window",
+		Long: "discards everything recorded so far so that the capture window only contains " +
+			"activity from this point on. Call this at the start of a CI job so the capture " +
+			"lines up with the job rather than agent/VM boot.",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return fxutil.OneShot(hostStartActivityDump,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
+					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
+				core.Bundle(),
+			)
+		},
+	}
+
+	return []*cobra.Command{hostStartCmd}
+}
+
+func hostStopCommands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &activityDumpCliParams{
+		GlobalParams: globalParams,
+	}
+
+	hostStopCmd := &cobra.Command{
+		Use:   "stop",
+		Short: "close the host-wide capture window and persist every profile",
+		Long: "persists every profile recorded during the window to the configured local " +
+			"storage. Call this at the end of a CI job, then collect the output directory.",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return fxutil.OneShot(hostStopActivityDump,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.DatadogConfFilePath()),
+					LogParams:    log.ForOneShot(command.LoggerName, "info", true)}),
+				core.Bundle(),
+			)
+		},
+	}
+
+	return []*cobra.Command{hostStopCmd}
+}
+
+func hostStartActivityDump(_ log.Component, _ config.Component, _ secrets.Component, _ *activityDumpCliParams) error {
+	client, err := secagent.NewRuntimeSecurityCmdClient()
+	if err != nil {
+		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
+	}
+	defer client.Close()
+
+	output, err := client.GenerateActivityDump(&api.ActivityDumpParams{
+		Host: true,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to send request to system-probe: %w", err)
+	}
+	if len(output.Error) > 0 {
+		return fmt.Errorf("host activity capture start request failed: %s", output.Error)
+	}
+
+	// the server reports the outcome (including how much state was discarded) in the metadata name
+	if md := output.GetMetadata(); md != nil && len(md.GetName()) > 0 {
+		fmt.Println(md.GetName())
+	} else {
+		fmt.Println("host-wide capture window started")
+	}
+	return nil
+}
+
+func hostStopActivityDump(_ log.Component, _ config.Component, _ secrets.Component, _ *activityDumpCliParams) error {
+	client, err := secagent.NewRuntimeSecurityCmdClient()
+	if err != nil {
+		return fmt.Errorf("unable to create a runtime security client instance: %w", err)
+	}
+	defer client.Close()
+
+	output, err := client.StopActivityDump(&api.ActivityDumpStopParams{All: true})
+	if err != nil {
+		return fmt.Errorf("unable to send request to system-probe: %w", err)
+	}
+	if len(output.Error) > 0 {
+		return fmt.Errorf("host activity capture stop request failed: %s", output.Error)
+	}
+
+	if len(output.Dumps) > 0 {
+		fmt.Printf("host-wide capture stopped, %d profiles persisted:\n", len(output.Dumps))
+		for _, d := range output.Dumps {
+			printSecurityActivityDumpMessage("\t", d)
+		}
+	} else {
+		fmt.Println("host-wide capture stopped: no profiles were recorded")
+	}
+	return nil
 }
 
 func generateCommands(globalParams *command.GlobalParams) []*cobra.Command {
@@ -616,7 +733,11 @@ func stopActivityDump(_ log.Component, _ config.Component, _ secrets.Component, 
 	}
 	defer client.Close()
 
-	output, err := client.StopActivityDump(activityDumpArgs.name, activityDumpArgs.containerID, activityDumpArgs.cgroupID)
+	output, err := client.StopActivityDump(&api.ActivityDumpStopParams{
+		Name:        activityDumpArgs.name,
+		ContainerID: activityDumpArgs.containerID,
+		CGroupID:    activityDumpArgs.cgroupID,
+	})
 	if err != nil {
 		return fmt.Errorf("unable to send request to system-probe: %w", err)
 	}

--- a/cmd/system-probe/subcommands/runtime/activity_dump_test.go
+++ b/cmd/system-probe/subcommands/runtime/activity_dump_test.go
@@ -53,3 +53,19 @@ func TestDumpActivityDumpCommand(t *testing.T) {
 		generateActivityDump,
 		func() {})
 }
+
+func TestHostStartActivityDumpCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"runtime", "activity-dump", "host", "start"},
+		hostStartActivityDump,
+		func() {})
+}
+
+func TestHostStopActivityDumpCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"runtime", "activity-dump", "host", "stop"},
+		hostStopActivityDump,
+		func() {})
+}

--- a/pkg/config/schema/yaml/system-probe-cws.yaml
+++ b/pkg/config/schema/yaml/system-probe-cws.yaml
@@ -717,6 +717,14 @@ properties:
             default: []
             items:
               type: string
+          host_dump:
+            node_type: section
+            type: object
+            properties:
+              enabled:
+                node_type: setting
+                type: boolean
+                default: false
           max_dump_size:
             node_type: setting
             type: integer

--- a/pkg/config/setup/system_probe_settings.go
+++ b/pkg/config/setup/system_probe_settings.go
@@ -455,6 +455,7 @@ func initCWSSystemProbeConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.sample_refresh_period", "30s")
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.excluded_images", []string{})
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.max_dump_size", 5120)
+	config.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.host_dump.enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.auto_suppression.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.auto_suppression.event_types", []string{"exec", "dns"})
 	config.BindEnvAndSetDefault("runtime_security_config.security_profile.anomaly_detection.event_types", []string{"exec"})

--- a/pkg/security/agent/client.go
+++ b/pkg/security/agent/client.go
@@ -47,7 +47,7 @@ type SecurityModuleCmdClientWrapper interface {
 	DumpProcessCache(withArgs bool, format string) (string, error)
 	GenerateActivityDump(request *api.ActivityDumpParams) (*api.ActivityDumpMessage, error)
 	ListActivityDumps() (*api.ActivityDumpListMessage, error)
-	StopActivityDump(name, container, cgroup string) (*api.ActivityDumpStopMessage, error)
+	StopActivityDump(request *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error)
 	GenerateEncoding(request *api.TranscodingRequestParams) (*api.TranscodingRequestMessage, error)
 	DumpNetworkNamespace(snapshotInterfaces bool) (*api.DumpNetworkNamespaceMessage, error)
 	GetConfig() (*api.SecurityConfigMessage, error)
@@ -92,12 +92,8 @@ func (c *RuntimeSecurityCmdClient) GenerateActivityDump(request *api.ActivityDum
 }
 
 // StopActivityDump stops an active dump if it exists
-func (c *RuntimeSecurityCmdClient) StopActivityDump(name, container, cgroup string) (*api.ActivityDumpStopMessage, error) {
-	return c.apiClient.StopActivityDump(context.Background(), &api.ActivityDumpStopParams{
-		Name:        name,
-		ContainerID: container,
-		CGroupID:    cgroup,
-	})
+func (c *RuntimeSecurityCmdClient) StopActivityDump(request *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error) {
+	return c.apiClient.StopActivityDump(context.Background(), request)
 }
 
 // GenerateEncoding sends a transcoding request

--- a/pkg/security/agent/mocks/security_module_cmd_client_wrapper.go
+++ b/pkg/security/agent/mocks/security_module_cmd_client_wrapper.go
@@ -897,8 +897,8 @@ func (_c *SecurityModuleCmdClientWrapper_SaveSecurityProfile_Call) RunAndReturn(
 }
 
 // StopActivityDump provides a mock function for the type SecurityModuleCmdClientWrapper
-func (_mock *SecurityModuleCmdClientWrapper) StopActivityDump(name string, container string, cgroup string) (*api.ActivityDumpStopMessage, error) {
-	ret := _mock.Called(name, container, cgroup)
+func (_mock *SecurityModuleCmdClientWrapper) StopActivityDump(request *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error) {
+	ret := _mock.Called(request)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StopActivityDump")
@@ -906,18 +906,18 @@ func (_mock *SecurityModuleCmdClientWrapper) StopActivityDump(name string, conta
 
 	var r0 *api.ActivityDumpStopMessage
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, string) (*api.ActivityDumpStopMessage, error)); ok {
-		return returnFunc(name, container, cgroup)
+	if returnFunc, ok := ret.Get(0).(func(*api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error)); ok {
+		return returnFunc(request)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, string) *api.ActivityDumpStopMessage); ok {
-		r0 = returnFunc(name, container, cgroup)
+	if returnFunc, ok := ret.Get(0).(func(*api.ActivityDumpStopParams) *api.ActivityDumpStopMessage); ok {
+		r0 = returnFunc(request)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*api.ActivityDumpStopMessage)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, string) error); ok {
-		r1 = returnFunc(name, container, cgroup)
+	if returnFunc, ok := ret.Get(1).(func(*api.ActivityDumpStopParams) error); ok {
+		r1 = returnFunc(request)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -930,31 +930,19 @@ type SecurityModuleCmdClientWrapper_StopActivityDump_Call struct {
 }
 
 // StopActivityDump is a helper method to define mock.On call
-//   - name string
-//   - container string
-//   - cgroup string
-func (_e *SecurityModuleCmdClientWrapper_Expecter) StopActivityDump(name any, container any, cgroup any) *SecurityModuleCmdClientWrapper_StopActivityDump_Call {
-	return &SecurityModuleCmdClientWrapper_StopActivityDump_Call{Call: _e.mock.On("StopActivityDump", name, container, cgroup)}
+//   - request *api.ActivityDumpStopParams
+func (_e *SecurityModuleCmdClientWrapper_Expecter) StopActivityDump(request any) *SecurityModuleCmdClientWrapper_StopActivityDump_Call {
+	return &SecurityModuleCmdClientWrapper_StopActivityDump_Call{Call: _e.mock.On("StopActivityDump", request)}
 }
 
-func (_c *SecurityModuleCmdClientWrapper_StopActivityDump_Call) Run(run func(name string, container string, cgroup string)) *SecurityModuleCmdClientWrapper_StopActivityDump_Call {
+func (_c *SecurityModuleCmdClientWrapper_StopActivityDump_Call) Run(run func(request *api.ActivityDumpStopParams)) *SecurityModuleCmdClientWrapper_StopActivityDump_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 *api.ActivityDumpStopParams
 		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg0 = args[0].(*api.ActivityDumpStopParams)
 		}
 		run(
 			arg0,
-			arg1,
-			arg2,
 		)
 	})
 	return _c
@@ -965,7 +953,7 @@ func (_c *SecurityModuleCmdClientWrapper_StopActivityDump_Call) Return(activityD
 	return _c
 }
 
-func (_c *SecurityModuleCmdClientWrapper_StopActivityDump_Call) RunAndReturn(run func(name string, container string, cgroup string) (*api.ActivityDumpStopMessage, error)) *SecurityModuleCmdClientWrapper_StopActivityDump_Call {
+func (_c *SecurityModuleCmdClientWrapper_StopActivityDump_Call) RunAndReturn(run func(request *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error)) *SecurityModuleCmdClientWrapper_StopActivityDump_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/security/config/BUILD.bazel
+++ b/pkg/security/config/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 load("//bazel/rules/go_stringer:defs.bzl", "go_stringer")
 
 go_library(
@@ -35,4 +36,11 @@ go_stringer(
         "StorageFormat",
         "StorageType",
     ],
+)
+
+dd_agent_go_test(
+    name = "config_test",
+    srcs = ["config_test.go"],
+    embed = [":config"],
+    deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -297,6 +297,11 @@ type RuntimeSecurityConfig struct {
 	SecurityProfileEnabled bool
 	// SecurityProfileManagerV2Enabled defines if the v2 Security Profile manager should be used
 	SecurityProfileV2Enabled bool
+	// SecurityProfileV2HostDumpEnabled enables the host-wide capture window commands
+	// (`activity-dump host start`/`host stop`) on top of the V2 security profile manager. When
+	// enabled, V2 also profiles host (non-container) workloads and persists profiles to local
+	// storage only, never to the remote backend. Intended for local/CI use and off by default.
+	SecurityProfileV2HostDumpEnabled bool
 	// SecurityProfileMaxImageTags defines the maximum number of profile versions to maintain
 	SecurityProfileMaxImageTags int
 	// SecurityProfileDir defines the directory in which Security Profiles are stored
@@ -639,6 +644,7 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		// security profiles
 		SecurityProfileEnabled:             pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.security_profile.enabled"),
 		SecurityProfileV2Enabled:           pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.security_profile.v2.enabled"),
+		SecurityProfileV2HostDumpEnabled:   pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.security_profile.v2.host_dump.enabled"),
 		SecurityProfileMaxImageTags:        pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.security_profile.max_image_tags"),
 		SecurityProfileDir:                 pkgconfigsetup.SystemProbe().GetString("runtime_security_config.security_profile.dir"),
 		SecurityProfileWatchDir:            pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.security_profile.watch_dir"),
@@ -719,6 +725,8 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 	}
 	rsConfig.ActivityDumpRateLimiter = uint16(activityDumpRateLimiter)
 
+	applyHostDumpPrerequisites(rsConfig)
+
 	if rsConfig.SecurityProfileV2Enabled {
 		rsConfig.EventSamplingOpenEnabled = true
 		rsConfig.EventSamplingConnectEnabled = true
@@ -731,6 +739,42 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 	}
 
 	return rsConfig, nil
+}
+
+// applyHostDumpPrerequisites enables what the host-wide capture window needs. The window is
+// implemented on the V2 profile manager, so enabling host_dump turns on the V2 manager and the
+// security profile manager. Changes are upward-only (an operator's explicit enable is never
+// undone) and logged, so the coupling stays visible. Without this, the host_dump commands would
+// be rejected by the V1 manager or capture nothing.
+func applyHostDumpPrerequisites(c *RuntimeSecurityConfig) {
+	if !c.SecurityProfileV2HostDumpEnabled {
+		return
+	}
+
+	// Runtime security as a whole has to be on: when it is off, UpdateEventMonitorOpts calls
+	// DisableRuntimeSecurity, which turns the security profile manager back off and prevents the
+	// CWS command server (and therefore the host capture commands) from ever starting.
+	if !c.RuntimeEnabled {
+		seclog.Infof("security_profile.v2.host_dump.enabled=true: enabling runtime_security_config.enabled")
+		c.RuntimeEnabled = true
+	}
+	if !c.SecurityProfileEnabled {
+		seclog.Infof("security_profile.v2.host_dump.enabled=true: enabling security_profile.enabled")
+		c.SecurityProfileEnabled = true
+	}
+	if !c.SecurityProfileV2Enabled {
+		seclog.Infof("security_profile.v2.host_dump.enabled=true: enabling security_profile.v2.enabled")
+		c.SecurityProfileV2Enabled = true
+	}
+
+	// Captured profiles are written to the activity dump local storage directory, but enabling
+	// security profiles brings in the constraint that both directories must match. Align them so
+	// that pointing host_dump at a custom output directory does not make the runtime security
+	// module fail to start.
+	if c.ActivityDumpLocalStorageDirectory != c.SecurityProfileDir {
+		seclog.Infof("security_profile.v2.host_dump.enabled=true: aligning security_profile.dir with activity_dump.local_storage.output_directory (%s)", c.ActivityDumpLocalStorageDirectory)
+		c.SecurityProfileDir = c.ActivityDumpLocalStorageDirectory
+	}
 }
 
 // IsRuntimeEnabled returns true if any feature is enabled. Has to be applied in config package too

--- a/pkg/security/config/config_test.go
+++ b/pkg/security/config/config_test.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package config holds config related files
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// the host capture window is a V2 feature: enabling it must pull up the V2 manager and the
+// security profile manager, upward-only.
+func TestHostDumpPullsUpV2Prerequisites(t *testing.T) {
+	c := &RuntimeSecurityConfig{
+		SecurityProfileV2HostDumpEnabled:  true,
+		RuntimeEnabled:                    false,
+		SecurityProfileEnabled:            false,
+		SecurityProfileV2Enabled:          false,
+		ActivityDumpLocalStorageDirectory: "/tmp/captures",
+		SecurityProfileDir:                "/opt/datadog-agent/run/runtime-security/profiles",
+	}
+
+	applyHostDumpPrerequisites(c)
+	// without this, UpdateEventMonitorOpts would call DisableRuntimeSecurity and turn the
+	// security profile manager back off, so the capture commands would never work
+	assert.True(t, c.RuntimeEnabled, "runtime security should be force-enabled")
+	assert.True(t, c.IsRuntimeEnabled(), "the CWS command server gate should be satisfied")
+	assert.True(t, c.SecurityProfileEnabled, "security profiles should be force-enabled")
+	assert.True(t, c.SecurityProfileV2Enabled, "the V2 manager should be force-enabled")
+	assert.Equal(t, "/tmp/captures", c.SecurityProfileDir, "profile dir should be aligned with the dump output directory")
+}
+
+func TestHostDumpDisabledIsNoop(t *testing.T) {
+	c := &RuntimeSecurityConfig{
+		SecurityProfileV2HostDumpEnabled:  false,
+		RuntimeEnabled:                    false,
+		SecurityProfileEnabled:            false,
+		SecurityProfileV2Enabled:          false,
+		ActivityDumpLocalStorageDirectory: "/tmp/captures",
+		SecurityProfileDir:                "/opt/datadog-agent/run/runtime-security/profiles",
+	}
+
+	applyHostDumpPrerequisites(c)
+	assert.False(t, c.RuntimeEnabled)
+	assert.False(t, c.SecurityProfileEnabled)
+	assert.False(t, c.SecurityProfileV2Enabled)
+	assert.Equal(t, "/opt/datadog-agent/run/runtime-security/profiles", c.SecurityProfileDir)
+}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -577,7 +577,7 @@ func (p *EBPFProbe) Init() error {
 	}
 
 	if p.config.RuntimeSecurity.SecurityProfileV2Enabled {
-		p.profileManager, err = securityprofile.NewManagerV2(p.config, p.statsdClient, p.Resolvers, p.kernelVersion, p.activityDumpHandler, p.sendAnomalyDetection, p.hostname, p.opts.FilterStore)
+		p.profileManager, err = securityprofile.NewManagerV2(p.config, p.statsdClient, p.Manager, p.Resolvers, p.kernelVersion, p.activityDumpHandler, p.sendAnomalyDetection, p.hostname, p.opts.FilterStore)
 		if err != nil {
 			return err
 		}

--- a/pkg/security/proto/api/api.pb.go
+++ b/pkg/security/proto/api/api.pb.go
@@ -1919,6 +1919,7 @@ type ActivityDumpParams struct {
 	Storage           *StorageRequestParams  `protobuf:"bytes,3,opt,name=Storage,proto3" json:"Storage,omitempty"`
 	ContainerID       string                 `protobuf:"bytes,4,opt,name=ContainerID,proto3" json:"ContainerID,omitempty"`
 	CGroupID          string                 `protobuf:"bytes,5,opt,name=CGroupID,proto3" json:"CGroupID,omitempty"`
+	Host              bool                   `protobuf:"varint,6,opt,name=Host,proto3" json:"Host,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -1986,6 +1987,13 @@ func (x *ActivityDumpParams) GetCGroupID() string {
 		return x.CGroupID
 	}
 	return ""
+}
+
+func (x *ActivityDumpParams) GetHost() bool {
+	if x != nil {
+		return x.Host
+	}
+	return false
 }
 
 type MetadataMessage struct {
@@ -2425,6 +2433,7 @@ type ActivityDumpStopParams struct {
 	Name          string                 `protobuf:"bytes,1,opt,name=Name,proto3" json:"Name,omitempty"`
 	ContainerID   string                 `protobuf:"bytes,2,opt,name=ContainerID,proto3" json:"ContainerID,omitempty"`
 	CGroupID      string                 `protobuf:"bytes,3,opt,name=CGroupID,proto3" json:"CGroupID,omitempty"`
+	All           bool                   `protobuf:"varint,4,opt,name=All,proto3" json:"All,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2480,9 +2489,17 @@ func (x *ActivityDumpStopParams) GetCGroupID() string {
 	return ""
 }
 
+func (x *ActivityDumpStopParams) GetAll() bool {
+	if x != nil {
+		return x.All
+	}
+	return false
+}
+
 type ActivityDumpStopMessage struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Error         string                 `protobuf:"bytes,1,opt,name=Error,proto3" json:"Error,omitempty"`
+	Dumps         []*ActivityDumpMessage `protobuf:"bytes,2,rep,name=Dumps,proto3" json:"Dumps,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2522,6 +2539,13 @@ func (x *ActivityDumpStopMessage) GetError() string {
 		return x.Error
 	}
 	return ""
+}
+
+func (x *ActivityDumpStopMessage) GetDumps() []*ActivityDumpMessage {
+	if x != nil {
+		return x.Dumps
+	}
+	return nil
 }
 
 type TranscodingRequestParams struct {
@@ -3559,13 +3583,14 @@ const file_pkg_security_proto_api_api_proto_rawDesc = "" +
 	"\x13LocalStorageFormats\x18\x02 \x03(\tR\x13LocalStorageFormats\x128\n" +
 	"\x17LocalStorageCompression\x18\x03 \x01(\bR\x17LocalStorageCompression\x122\n" +
 	"\x14RemoteStorageFormats\x18\x04 \x03(\tR\x14RemoteStorageFormats\x12:\n" +
-	"\x18RemoteStorageCompression\x18\x05 \x01(\bR\x18RemoteStorageCompression\"\xcf\x01\n" +
+	"\x18RemoteStorageCompression\x18\x05 \x01(\bR\x18RemoteStorageCompression\"\xe3\x01\n" +
 	"\x12ActivityDumpParams\x12\x18\n" +
 	"\aTimeout\x18\x01 \x01(\tR\aTimeout\x12,\n" +
 	"\x11DifferentiateArgs\x18\x02 \x01(\bR\x11DifferentiateArgs\x123\n" +
 	"\aStorage\x18\x03 \x01(\v2\x19.api.StorageRequestParamsR\aStorage\x12 \n" +
 	"\vContainerID\x18\x04 \x01(\tR\vContainerID\x12\x1a\n" +
-	"\bCGroupID\x18\x05 \x01(\tR\bCGroupID\"\x95\x04\n" +
+	"\bCGroupID\x18\x05 \x01(\tR\bCGroupID\x12\x12\n" +
+	"\x04Host\x18\x06 \x01(\bR\x04Host\"\x95\x04\n" +
 	"\x0fMetadataMessage\x12\"\n" +
 	"\fAgentVersion\x18\x01 \x01(\tR\fAgentVersion\x12 \n" +
 	"\vAgentCommit\x18\x02 \x01(\tR\vAgentCommit\x12$\n" +
@@ -3602,13 +3627,15 @@ const file_pkg_security_proto_api_api_proto_rawDesc = "" +
 	"\x16ActivityDumpListParams\"_\n" +
 	"\x17ActivityDumpListMessage\x12.\n" +
 	"\x05Dumps\x18\x01 \x03(\v2\x18.api.ActivityDumpMessageR\x05Dumps\x12\x14\n" +
-	"\x05Error\x18\x02 \x01(\tR\x05Error\"j\n" +
+	"\x05Error\x18\x02 \x01(\tR\x05Error\"|\n" +
 	"\x16ActivityDumpStopParams\x12\x12\n" +
 	"\x04Name\x18\x01 \x01(\tR\x04Name\x12 \n" +
 	"\vContainerID\x18\x02 \x01(\tR\vContainerID\x12\x1a\n" +
-	"\bCGroupID\x18\x03 \x01(\tR\bCGroupID\"/\n" +
+	"\bCGroupID\x18\x03 \x01(\tR\bCGroupID\x12\x10\n" +
+	"\x03All\x18\x04 \x01(\bR\x03All\"_\n" +
 	"\x17ActivityDumpStopMessage\x12\x14\n" +
-	"\x05Error\x18\x01 \x01(\tR\x05Error\"{\n" +
+	"\x05Error\x18\x01 \x01(\tR\x05Error\x12.\n" +
+	"\x05Dumps\x18\x02 \x03(\v2\x18.api.ActivityDumpMessageR\x05Dumps\"{\n" +
 	"\x18TranscodingRequestParams\x12*\n" +
 	"\x10ActivityDumpFile\x18\x01 \x01(\tR\x10ActivityDumpFile\x123\n" +
 	"\aStorage\x18\x02 \x01(\v2\x19.api.StorageRequestParamsR\aStorage\"g\n" +
@@ -3809,65 +3836,66 @@ var file_pkg_security_proto_api_api_proto_depIdxs = []int32{
 	37, // 20: api.ActivityDumpMessage.Metadata:type_name -> api.MetadataMessage
 	50, // 21: api.ActivityDumpMessage.Stats:type_name -> api.ActivityTreeStatsMessage
 	39, // 22: api.ActivityDumpListMessage.Dumps:type_name -> api.ActivityDumpMessage
-	35, // 23: api.TranscodingRequestParams.Storage:type_name -> api.StorageRequestParams
-	38, // 24: api.TranscodingRequestMessage.Storage:type_name -> api.StorageRequestMessage
-	47, // 25: api.ActivityDumpStreamMessage.Selector:type_name -> api.WorkloadSelectorMessage
-	60, // 26: api.ProfileContextMessage.event_type_state:type_name -> api.ProfileContextMessage.EventTypeStateEntry
-	47, // 27: api.SecurityProfileMessage.Selector:type_name -> api.WorkloadSelectorMessage
-	48, // 28: api.SecurityProfileMessage.LastAnomalies:type_name -> api.LastAnomalyTimestampMessage
-	49, // 29: api.SecurityProfileMessage.Instances:type_name -> api.InstanceMessage
-	37, // 30: api.SecurityProfileMessage.Metadata:type_name -> api.MetadataMessage
-	50, // 31: api.SecurityProfileMessage.Stats:type_name -> api.ActivityTreeStatsMessage
-	61, // 32: api.SecurityProfileMessage.profile_contexts:type_name -> api.SecurityProfileMessage.ProfileContextsEntry
-	53, // 33: api.SecurityProfileListMessage.Profiles:type_name -> api.SecurityProfileMessage
-	47, // 34: api.SecurityProfileSaveParams.Selector:type_name -> api.WorkloadSelectorMessage
-	27, // 35: api.ScopedVariableStore.KeyValuesEntry.value:type_name -> api.SECLVariableStateList
-	28, // 36: api.Status.ScopedVariablesEntry.value:type_name -> api.ScopedVariableStore
-	51, // 37: api.ProfileContextMessage.EventTypeStateEntry.value:type_name -> api.event_type_state
-	52, // 38: api.SecurityProfileMessage.ProfileContextsEntry.value:type_name -> api.ProfileContextMessage
-	63, // 39: api.SecurityModuleEvent.GetEventStream:input_type -> google.protobuf.Empty
-	63, // 40: api.SecurityModuleEvent.GetActivityDumpStream:input_type -> google.protobuf.Empty
-	1,  // 41: api.SecurityModuleCmd.DumpProcessCache:input_type -> api.DumpProcessCacheParams
-	5,  // 42: api.SecurityModuleCmd.GetConfig:input_type -> api.GetConfigParams
-	21, // 43: api.SecurityModuleCmd.GetStatus:input_type -> api.GetStatusParams
-	19, // 44: api.SecurityModuleCmd.RunSelfTest:input_type -> api.RunSelfTestParams
-	13, // 45: api.SecurityModuleCmd.GetRuleSetReport:input_type -> api.GetRuleSetReportParams
-	15, // 46: api.SecurityModuleCmd.ReloadPolicies:input_type -> api.ReloadPoliciesParams
-	17, // 47: api.SecurityModuleCmd.GetLoadedPolicies:input_type -> api.GetLoadedPoliciesParams
-	3,  // 48: api.SecurityModuleCmd.DumpNetworkNamespace:input_type -> api.DumpNetworkNamespaceParams
-	33, // 49: api.SecurityModuleCmd.DumpDiscarders:input_type -> api.DumpDiscardersParams
-	36, // 50: api.SecurityModuleCmd.DumpActivity:input_type -> api.ActivityDumpParams
-	40, // 51: api.SecurityModuleCmd.ListActivityDumps:input_type -> api.ActivityDumpListParams
-	42, // 52: api.SecurityModuleCmd.StopActivityDump:input_type -> api.ActivityDumpStopParams
-	44, // 53: api.SecurityModuleCmd.TranscodingRequest:input_type -> api.TranscodingRequestParams
-	54, // 54: api.SecurityModuleCmd.ListSecurityProfiles:input_type -> api.SecurityProfileListParams
-	56, // 55: api.SecurityModuleCmd.SaveSecurityProfile:input_type -> api.SecurityProfileSaveParams
-	0,  // 56: api.SecurityAgentAPI.SendEvent:input_type -> api.SecurityEventMessage
-	46, // 57: api.SecurityAgentAPI.SendActivityDumpStream:input_type -> api.ActivityDumpStreamMessage
-	0,  // 58: api.SecurityModuleEvent.GetEventStream:output_type -> api.SecurityEventMessage
-	46, // 59: api.SecurityModuleEvent.GetActivityDumpStream:output_type -> api.ActivityDumpStreamMessage
-	2,  // 60: api.SecurityModuleCmd.DumpProcessCache:output_type -> api.SecurityDumpProcessCacheMessage
-	6,  // 61: api.SecurityModuleCmd.GetConfig:output_type -> api.SecurityConfigMessage
-	29, // 62: api.SecurityModuleCmd.GetStatus:output_type -> api.Status
-	20, // 63: api.SecurityModuleCmd.RunSelfTest:output_type -> api.SecuritySelfTestResultMessage
-	14, // 64: api.SecurityModuleCmd.GetRuleSetReport:output_type -> api.GetRuleSetReportMessage
-	16, // 65: api.SecurityModuleCmd.ReloadPolicies:output_type -> api.ReloadPoliciesResultMessage
-	18, // 66: api.SecurityModuleCmd.GetLoadedPolicies:output_type -> api.GetLoadedPoliciesMessage
-	4,  // 67: api.SecurityModuleCmd.DumpNetworkNamespace:output_type -> api.DumpNetworkNamespaceMessage
-	34, // 68: api.SecurityModuleCmd.DumpDiscarders:output_type -> api.DumpDiscardersMessage
-	39, // 69: api.SecurityModuleCmd.DumpActivity:output_type -> api.ActivityDumpMessage
-	41, // 70: api.SecurityModuleCmd.ListActivityDumps:output_type -> api.ActivityDumpListMessage
-	43, // 71: api.SecurityModuleCmd.StopActivityDump:output_type -> api.ActivityDumpStopMessage
-	45, // 72: api.SecurityModuleCmd.TranscodingRequest:output_type -> api.TranscodingRequestMessage
-	55, // 73: api.SecurityModuleCmd.ListSecurityProfiles:output_type -> api.SecurityProfileListMessage
-	57, // 74: api.SecurityModuleCmd.SaveSecurityProfile:output_type -> api.SecurityProfileSaveMessage
-	63, // 75: api.SecurityAgentAPI.SendEvent:output_type -> google.protobuf.Empty
-	63, // 76: api.SecurityAgentAPI.SendActivityDumpStream:output_type -> google.protobuf.Empty
-	58, // [58:77] is the sub-list for method output_type
-	39, // [39:58] is the sub-list for method input_type
-	39, // [39:39] is the sub-list for extension type_name
-	39, // [39:39] is the sub-list for extension extendee
-	0,  // [0:39] is the sub-list for field type_name
+	39, // 23: api.ActivityDumpStopMessage.Dumps:type_name -> api.ActivityDumpMessage
+	35, // 24: api.TranscodingRequestParams.Storage:type_name -> api.StorageRequestParams
+	38, // 25: api.TranscodingRequestMessage.Storage:type_name -> api.StorageRequestMessage
+	47, // 26: api.ActivityDumpStreamMessage.Selector:type_name -> api.WorkloadSelectorMessage
+	60, // 27: api.ProfileContextMessage.event_type_state:type_name -> api.ProfileContextMessage.EventTypeStateEntry
+	47, // 28: api.SecurityProfileMessage.Selector:type_name -> api.WorkloadSelectorMessage
+	48, // 29: api.SecurityProfileMessage.LastAnomalies:type_name -> api.LastAnomalyTimestampMessage
+	49, // 30: api.SecurityProfileMessage.Instances:type_name -> api.InstanceMessage
+	37, // 31: api.SecurityProfileMessage.Metadata:type_name -> api.MetadataMessage
+	50, // 32: api.SecurityProfileMessage.Stats:type_name -> api.ActivityTreeStatsMessage
+	61, // 33: api.SecurityProfileMessage.profile_contexts:type_name -> api.SecurityProfileMessage.ProfileContextsEntry
+	53, // 34: api.SecurityProfileListMessage.Profiles:type_name -> api.SecurityProfileMessage
+	47, // 35: api.SecurityProfileSaveParams.Selector:type_name -> api.WorkloadSelectorMessage
+	27, // 36: api.ScopedVariableStore.KeyValuesEntry.value:type_name -> api.SECLVariableStateList
+	28, // 37: api.Status.ScopedVariablesEntry.value:type_name -> api.ScopedVariableStore
+	51, // 38: api.ProfileContextMessage.EventTypeStateEntry.value:type_name -> api.event_type_state
+	52, // 39: api.SecurityProfileMessage.ProfileContextsEntry.value:type_name -> api.ProfileContextMessage
+	63, // 40: api.SecurityModuleEvent.GetEventStream:input_type -> google.protobuf.Empty
+	63, // 41: api.SecurityModuleEvent.GetActivityDumpStream:input_type -> google.protobuf.Empty
+	1,  // 42: api.SecurityModuleCmd.DumpProcessCache:input_type -> api.DumpProcessCacheParams
+	5,  // 43: api.SecurityModuleCmd.GetConfig:input_type -> api.GetConfigParams
+	21, // 44: api.SecurityModuleCmd.GetStatus:input_type -> api.GetStatusParams
+	19, // 45: api.SecurityModuleCmd.RunSelfTest:input_type -> api.RunSelfTestParams
+	13, // 46: api.SecurityModuleCmd.GetRuleSetReport:input_type -> api.GetRuleSetReportParams
+	15, // 47: api.SecurityModuleCmd.ReloadPolicies:input_type -> api.ReloadPoliciesParams
+	17, // 48: api.SecurityModuleCmd.GetLoadedPolicies:input_type -> api.GetLoadedPoliciesParams
+	3,  // 49: api.SecurityModuleCmd.DumpNetworkNamespace:input_type -> api.DumpNetworkNamespaceParams
+	33, // 50: api.SecurityModuleCmd.DumpDiscarders:input_type -> api.DumpDiscardersParams
+	36, // 51: api.SecurityModuleCmd.DumpActivity:input_type -> api.ActivityDumpParams
+	40, // 52: api.SecurityModuleCmd.ListActivityDumps:input_type -> api.ActivityDumpListParams
+	42, // 53: api.SecurityModuleCmd.StopActivityDump:input_type -> api.ActivityDumpStopParams
+	44, // 54: api.SecurityModuleCmd.TranscodingRequest:input_type -> api.TranscodingRequestParams
+	54, // 55: api.SecurityModuleCmd.ListSecurityProfiles:input_type -> api.SecurityProfileListParams
+	56, // 56: api.SecurityModuleCmd.SaveSecurityProfile:input_type -> api.SecurityProfileSaveParams
+	0,  // 57: api.SecurityAgentAPI.SendEvent:input_type -> api.SecurityEventMessage
+	46, // 58: api.SecurityAgentAPI.SendActivityDumpStream:input_type -> api.ActivityDumpStreamMessage
+	0,  // 59: api.SecurityModuleEvent.GetEventStream:output_type -> api.SecurityEventMessage
+	46, // 60: api.SecurityModuleEvent.GetActivityDumpStream:output_type -> api.ActivityDumpStreamMessage
+	2,  // 61: api.SecurityModuleCmd.DumpProcessCache:output_type -> api.SecurityDumpProcessCacheMessage
+	6,  // 62: api.SecurityModuleCmd.GetConfig:output_type -> api.SecurityConfigMessage
+	29, // 63: api.SecurityModuleCmd.GetStatus:output_type -> api.Status
+	20, // 64: api.SecurityModuleCmd.RunSelfTest:output_type -> api.SecuritySelfTestResultMessage
+	14, // 65: api.SecurityModuleCmd.GetRuleSetReport:output_type -> api.GetRuleSetReportMessage
+	16, // 66: api.SecurityModuleCmd.ReloadPolicies:output_type -> api.ReloadPoliciesResultMessage
+	18, // 67: api.SecurityModuleCmd.GetLoadedPolicies:output_type -> api.GetLoadedPoliciesMessage
+	4,  // 68: api.SecurityModuleCmd.DumpNetworkNamespace:output_type -> api.DumpNetworkNamespaceMessage
+	34, // 69: api.SecurityModuleCmd.DumpDiscarders:output_type -> api.DumpDiscardersMessage
+	39, // 70: api.SecurityModuleCmd.DumpActivity:output_type -> api.ActivityDumpMessage
+	41, // 71: api.SecurityModuleCmd.ListActivityDumps:output_type -> api.ActivityDumpListMessage
+	43, // 72: api.SecurityModuleCmd.StopActivityDump:output_type -> api.ActivityDumpStopMessage
+	45, // 73: api.SecurityModuleCmd.TranscodingRequest:output_type -> api.TranscodingRequestMessage
+	55, // 74: api.SecurityModuleCmd.ListSecurityProfiles:output_type -> api.SecurityProfileListMessage
+	57, // 75: api.SecurityModuleCmd.SaveSecurityProfile:output_type -> api.SecurityProfileSaveMessage
+	63, // 76: api.SecurityAgentAPI.SendEvent:output_type -> google.protobuf.Empty
+	63, // 77: api.SecurityAgentAPI.SendActivityDumpStream:output_type -> google.protobuf.Empty
+	59, // [59:78] is the sub-list for method output_type
+	40, // [40:59] is the sub-list for method input_type
+	40, // [40:40] is the sub-list for extension type_name
+	40, // [40:40] is the sub-list for extension extendee
+	0,  // [0:40] is the sub-list for field type_name
 }
 
 func init() { file_pkg_security_proto_api_api_proto_init() }

--- a/pkg/security/proto/api/api.proto
+++ b/pkg/security/proto/api/api.proto
@@ -191,6 +191,7 @@ message ActivityDumpParams {
     StorageRequestParams Storage = 3;
     string ContainerID = 4;
     string CGroupID = 5;
+    bool Host = 6;
 }
 
 message MetadataMessage {
@@ -243,10 +244,12 @@ message ActivityDumpStopParams {
     string Name = 1;
     string ContainerID = 2;
     string CGroupID = 3;
+    bool All = 4;
 }
 
 message ActivityDumpStopMessage {
     string Error = 1;
+    repeated ActivityDumpMessage Dumps = 2;
 }
 
 message TranscodingRequestParams {

--- a/pkg/security/proto/api/api_vtproto.pb.go
+++ b/pkg/security/proto/api/api_vtproto.pb.go
@@ -1895,6 +1895,16 @@ func (m *ActivityDumpParams) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Host {
+		i--
+		if m.Host {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x30
+	}
 	if len(m.CGroupID) > 0 {
 		i -= len(m.CGroupID)
 		copy(dAtA[i:], m.CGroupID)
@@ -2377,6 +2387,16 @@ func (m *ActivityDumpStopParams) MarshalToSizedBufferVT(dAtA []byte) (int, error
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.All {
+		i--
+		if m.All {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
+	}
 	if len(m.CGroupID) > 0 {
 		i -= len(m.CGroupID)
 		copy(dAtA[i:], m.CGroupID)
@@ -2430,6 +2450,18 @@ func (m *ActivityDumpStopMessage) MarshalToSizedBufferVT(dAtA []byte) (int, erro
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Dumps) > 0 {
+		for iNdEx := len(m.Dumps) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Dumps[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+		}
 	}
 	if len(m.Error) > 0 {
 		i -= len(m.Error)
@@ -4028,6 +4060,9 @@ func (m *ActivityDumpParams) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if m.Host {
+		n += 2
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -4229,6 +4264,9 @@ func (m *ActivityDumpStopParams) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if m.All {
+		n += 2
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -4242,6 +4280,12 @@ func (m *ActivityDumpStopMessage) SizeVT() (n int) {
 	l = len(m.Error)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.Dumps) > 0 {
+		for _, e := range m.Dumps {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -9051,6 +9095,26 @@ func (m *ActivityDumpParams) UnmarshalVT(dAtA []byte) error {
 			}
 			m.CGroupID = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Host", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Host = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -10420,6 +10484,26 @@ func (m *ActivityDumpStopParams) UnmarshalVT(dAtA []byte) error {
 			}
 			m.CGroupID = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field All", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.All = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -10502,6 +10586,40 @@ func (m *ActivityDumpStopMessage) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Error = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Dumps", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Dumps = append(m.Dumps, &ActivityDumpMessage{})
+			if err := m.Dumps[len(m.Dumps)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/security/security_profile/errors.go
+++ b/pkg/security/security_profile/errors.go
@@ -15,3 +15,10 @@ var ErrActivityDumpManagerDisabled = errors.New("ActivityDumpManager is disabled
 
 // ErrSecurityProfileManagerDisabled is returned when the security profile manager is disabled
 var ErrSecurityProfileManagerDisabled = errors.New("SecurityProfileManager is disabled")
+
+// ErrHostDumpDisabled is returned when a host-wide capture is requested but the feature is not enabled
+var ErrHostDumpDisabled = errors.New("host activity dump is disabled: set runtime_security_config.security_profile.v2.host_dump.enabled to true")
+
+// ErrHostDumpV1Unsupported is returned when a host-wide capture is requested while the V1 profile
+// manager is active. The host capture window is implemented on the V2 manager.
+var ErrHostDumpV1Unsupported = errors.New("host activity dump requires the V2 security profile manager (set runtime_security_config.security_profile.v2.host_dump.enabled, which enables it)")

--- a/pkg/security/security_profile/grpc.go
+++ b/pkg/security/security_profile/grpc.go
@@ -57,6 +57,11 @@ func (m *Manager) DumpActivity(params *api.ActivityDumpParams) (*api.ActivityDum
 		}, ErrActivityDumpManagerDisabled
 	}
 
+	// the host-wide capture window is implemented on the V2 profile manager
+	if params.GetHost() {
+		return &api.ActivityDumpMessage{Error: ErrHostDumpV1Unsupported.Error()}, ErrHostDumpV1Unsupported
+	}
+
 	if params.GetContainerID() == "" && params.GetCGroupID() == "" {
 		err := errors.New("you must specify one selector between containerID and cgroupID")
 		return &api.ActivityDumpMessage{Error: err.Error()}, err
@@ -126,6 +131,11 @@ func (m *Manager) StopActivityDump(params *api.ActivityDumpStopParams) (*api.Act
 
 	m.m.Lock()
 	defer m.m.Unlock()
+
+	// the host-wide capture window is implemented on the V2 profile manager
+	if params.GetAll() {
+		return &api.ActivityDumpStopMessage{Error: ErrHostDumpV1Unsupported.Error()}, ErrHostDumpV1Unsupported
+	}
 
 	if params.GetName() == "" && params.GetContainerID() == "" && params.GetCGroupID() == "" {
 		err := errors.New("you must specify one selector between name, containerID and cgroupID")

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
+	ebpfmanager "github.com/DataDog/ebpf-manager"
+	"github.com/cilium/ebpf"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"go.uber.org/atomic"
 
@@ -27,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/managerhelper"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup"
@@ -125,6 +128,10 @@ type ManagerV2 struct {
 	pendingProfileRemovalsLock sync.Mutex
 
 	// Sample refresh: maps kernel dedup cookie → (process node, event node, imageTag)
+	// kernel dedup sample maps, only resolved in host-dump mode so that opening a capture
+	// window can flush them and let already-seen activity be delivered again
+	sampleDedupMaps []*ebpf.Map
+
 	sampleCookieMap       *lru.Cache[uint32, sampleCookieEntry]
 	sampleRefreshReceived *atomic.Uint64
 	sampleRefreshHits     *atomic.Uint64
@@ -134,7 +141,7 @@ type ManagerV2 struct {
 	imageExcluder    *imageExcluder
 }
 
-func NewManagerV2(cfg *config.Config, statsdClient statsd.ClientInterface, resolvers *resolvers.EBPFResolvers, kernelVersion *kernel.Version, dumpHandler backend.ActivityDumpHandler, sendAnomalyDetection func(*model.Event), hostname string, filterStore workloadfilter.Component) (*ManagerV2, error) {
+func NewManagerV2(cfg *config.Config, statsdClient statsd.ClientInterface, ebpfManager *ebpfmanager.Manager, resolvers *resolvers.EBPFResolvers, kernelVersion *kernel.Version, dumpHandler backend.ActivityDumpHandler, sendAnomalyDetection func(*model.Event), hostname string, filterStore workloadfilter.Component) (*ManagerV2, error) {
 
 	localStorage, err := storage.NewDirectory(cfg.RuntimeSecurity.ActivityDumpLocalStorageDirectory, cfg.RuntimeSecurity.ActivityDumpLocalStorageMaxDumpsCount)
 	if err != nil {
@@ -156,12 +163,33 @@ func NewManagerV2(cfg *config.Config, statsdClient statsd.ClientInterface, resol
 		))
 	}
 
-	configuredStorageRequests = append(configuredStorageRequests, config.NewStorageRequest(
-		config.RemoteStorage,
-		config.Protobuf,
-		true, // force remote compression
-		"",
-	))
+	// host_dump is a local-only capture mode: skip the remote storage request entirely so no
+	// profile is ever forwarded to the backend and the intake endpoints are not even set up.
+	if !cfg.RuntimeSecurity.SecurityProfileV2HostDumpEnabled {
+		configuredStorageRequests = append(configuredStorageRequests, config.NewStorageRequest(
+			config.RemoteStorage,
+			config.Protobuf,
+			true, // force remote compression
+			"",
+		))
+	}
+
+	// In host-dump mode, resolve the kernel dedup sample maps so that opening a capture window
+	// can flush them. They are global LRUs keyed by (process, target), so without flushing, an
+	// open/bind/connect already seen before the window would never be re-delivered during it.
+	var sampleDedupMaps []*ebpf.Map
+	if cfg.RuntimeSecurity.SecurityProfileV2HostDumpEnabled && ebpfManager != nil {
+		for _, name := range []string{"open_samples", "bind_samples", "connect_samples", "pid_path_keys"} {
+			sampleMap, err := managerhelper.Map(ebpfManager, name)
+			if err != nil {
+				// not fatal: the capture window still works, it just cannot replay activity
+				// that was already deduplicated before the window was opened
+				seclog.Warnf("host dump: couldn't resolve the %s map, dedup entries will not be flushed on host start: %v", name, err)
+				continue
+			}
+			sampleDedupMaps = append(sampleDedupMaps, sampleMap)
+		}
+	}
 
 	cookieMap, _ := lru.New[uint32, sampleCookieEntry](sampleCookieMapSize)
 
@@ -197,6 +225,7 @@ func NewManagerV2(cfg *config.Config, statsdClient statsd.ClientInterface, resol
 		insertionErrors:           make(map[insertionErrorKey]*atomic.Uint64),
 		resolvedCgroups:           make(map[containerutils.CGroupID]struct{}),
 		pendingProfileRemovals:    make(map[cgroupModel.WorkloadSelector]time.Time),
+		sampleDedupMaps:           sampleDedupMaps,
 		sampleCookieMap:           cookieMap,
 		sampleRefreshReceived:     atomic.NewUint64(0),
 		sampleRefreshHits:         atomic.NewUint64(0),
@@ -493,8 +522,10 @@ func (m *ManagerV2) sendPersistenceMetrics(request config.StorageRequest, dataSi
 }
 
 func (m *ManagerV2) ProcessEvent(event *model.Event) {
-	// Filter out systemd cgroups for now, we will add support for them later
-	if event.ProcessContext.Process.ContainerContext.IsNull() {
+	// Host (systemd) cgroups are only profiled in host-dump mode, the dedicated local/CI
+	// capture mode. Outside of it, V2 profiles containers only.
+	isHostWorkload := event.ProcessContext.Process.ContainerContext.IsNull()
+	if isHostWorkload && !m.config.RuntimeSecurity.SecurityProfileV2HostDumpEnabled {
 		return
 	}
 
@@ -516,9 +547,15 @@ func (m *ManagerV2) ProcessEvent(event *model.Event) {
 		em.eventsReceived.Inc()
 	}
 
-	// Try to resolve tags for this workload
+	// Try to resolve tags for this workload. Host cgroups are tagged service/version rather
+	// than image_name/image_tag, so the readiness check differs.
 	workloadTags, err := m.resolvers.TagsResolver.ResolveWithErr(workloadID)
-	tagsResolved := err == nil && len(workloadTags) != 0 && utils.GetTagValue("image_tag", workloadTags) != ""
+	tagsResolved := err == nil && len(workloadTags) != 0
+	if isHostWorkload {
+		tagsResolved = tagsResolved && utils.GetTagValue("service", workloadTags) != ""
+	} else {
+		tagsResolved = tagsResolved && utils.GetTagValue("image_tag", workloadTags) != ""
+	}
 
 	if tagsResolved {
 		// Set resolved tags on the event for downstream processing
@@ -860,8 +897,17 @@ func (m *ManagerV2) insertEventIntoProfile(event *model.Event) (*profile.Profile
 	// Ensure version context exists for this selector
 	m.ensureVersionContext(secprof, selector.Tag)
 
-	// Insert the event into the profile's activity tree
+	// Insert the event into the profile's activity tree. Host workloads are tagged
+	// service/version rather than image_name/image_tag: without this fallback their image tag
+	// would be empty, which resolves to tag ID 0 and makes AppendImageTagID skip the node, so
+	// the persisted profile would carry no first/last seen timestamps for host activity.
 	imageTag := secprof.GetTagValue("image_tag")
+	if imageTag == "" {
+		imageTag = secprof.GetTagValue("version")
+	}
+	if imageTag == "" {
+		imageTag = "latest"
+	}
 	inserted, processNode, eventNodeBase, err := secprof.Insert(event, true, imageTag, activity_tree.Runtime, m.resolvers)
 	if err != nil {
 		if !activity_tree.IsExpectedFilterError(err) {
@@ -897,7 +943,13 @@ func (m *ManagerV2) insertEventIntoProfile(event *model.Event) (*profile.Profile
 
 // buildWorkloadSelector creates a workload selector from the event's container tags
 func (m *ManagerV2) buildWorkloadSelector(event *model.Event) (cgroupModel.WorkloadSelector, error) {
-	imageName := utils.GetTagValue("image_name", event.ProcessContext.Process.ContainerContext.Tags)
+	workloadTags := event.ProcessContext.Process.ContainerContext.Tags
+	if event.ProcessContext.Process.ContainerContext.IsNull() {
+		// Host workload: key the profile on the cgroup's service tag (the systemd unit) so each
+		// unit gets its own profile, matching the granularity of the V1 host activity dumps.
+		return cgroupModel.NewWorkloadSelector(utils.GetTagValue("service", workloadTags), "*")
+	}
+	imageName := utils.GetTagValue("image_name", workloadTags)
 	return cgroupModel.NewWorkloadSelector(imageName, "*")
 }
 
@@ -1001,8 +1053,13 @@ func (m *ManagerV2) getOrCreateProfile(selector cgroupModel.WorkloadSelector, ev
 		return nil, errors.New("workload excluded")
 	}
 
-	// Try to load from local storage first
-	secprof, loaded := m.loadProfileFromStorage(selector, event)
+	// Try to load from local storage first. In host-dump mode this is skipped on purpose: a
+	// capture window must only contain activity recorded during the window, and loading a
+	// previously persisted profile from disk would resurrect a stale tree into it.
+	var loaded bool
+	if !m.config.RuntimeSecurity.SecurityProfileV2HostDumpEnabled {
+		secprof, loaded = m.loadProfileFromStorage(selector, event)
+	}
 	if !loaded {
 		// Create a new profile if not found in storage
 		var err error
@@ -1469,22 +1526,154 @@ func (m *ManagerV2) HandleCGroupTracingEvent(_ *model.CgroupTracingEvent) {}
 // NO-OP in V2: V2 doesn't manage kernel-space traced cgroups maps.
 func (m *ManagerV2) SyncTracedCgroups() {}
 
-// ListActivityDumps lists the activity dumps.
-// NO-OP in V2: V2 doesn't expose individual activity dumps through this API.
+// flushSampleDedupMaps empties the kernel dedup sample maps. Those maps are global LRUs keyed by
+// (process, target): the first open/bind/connect for a key is delivered and every later one is
+// discarded in kernel space. They know nothing about capture windows, so without this a file or
+// destination already touched before the window would stay invisible for its whole duration.
+// Flushing them makes the window self-contained. Returns the number of entries removed.
+func (m *ManagerV2) flushSampleDedupMaps() int {
+	var flushed int
+
+	for _, sampleMap := range m.sampleDedupMaps {
+		// collect first, delete after: removing entries while iterating a hash map can make the
+		// iterator skip over other entries
+		keys := make([][]byte, 0, 128)
+		key := make([]byte, sampleMap.KeySize())
+		value := make([]byte, sampleMap.ValueSize())
+
+		iterator := sampleMap.Iterate()
+		for iterator.Next(&key, &value) {
+			keys = append(keys, bytes.Clone(key))
+		}
+		if err := iterator.Err(); err != nil {
+			seclog.Warnf("host dump: couldn't iterate a dedup sample map: %v", err)
+		}
+
+		for _, k := range keys {
+			if err := sampleMap.Delete(k); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+				seclog.Debugf("host dump: couldn't delete a dedup sample entry: %v", err)
+				continue
+			}
+			flushed++
+		}
+	}
+
+	return flushed
+}
+
+// hostCaptureReset discards everything recorded so far so that a new capture window only
+// contains activity that happens from now on. V2 has no dump lifecycle, so the window is
+// expressed as a reset of the in-memory profile state: profiles are dropped (they are recreated
+// lazily on the next event), the tag-resolution queues are emptied and the sample cookie LRU is
+// purged since its entries point into the trees being discarded. The kernel dedup sample maps are
+// flushed as well, so activity that was already deduplicated before the window is delivered again
+// and the window is a self-contained record. Returns the number of profiles that were discarded
+// and the number of kernel dedup entries that were flushed.
+func (m *ManagerV2) hostCaptureReset() (int, int) {
+	// each lock is taken and released independently to stay clear of the
+	// profilePendingEventsLock -> profilesLock ordering used by the ingestion path
+	m.profilePendingEventsLock.Lock()
+	clear(m.profilePendingEvents)
+	m.queueSize.Store(0)
+	m.pendingProfiles.Store(0)
+	m.profilePendingEventsLock.Unlock()
+
+	m.pendingProfileRemovalsLock.Lock()
+	clear(m.pendingProfileRemovals)
+	m.pendingProfileRemovalsLock.Unlock()
+
+	m.profilesLock.Lock()
+	discarded := len(m.profiles)
+	clear(m.profiles)
+	m.profilesLock.Unlock()
+
+	// the cookies reference process/event nodes of the trees that were just dropped
+	m.sampleCookieMap.Purge()
+
+	// let the kernel deliver activity it had already deduplicated, so the window is complete
+	flushed := m.flushSampleDedupMaps()
+
+	m.sampleRefreshReceived.Store(0)
+	m.sampleRefreshHits.Store(0)
+	m.sampleRefreshMisses.Store(0)
+
+	return discarded, flushed
+}
+
+// hostCaptureFlush persists every profile recorded during the capture window and returns a
+// message per profile. The profile set is snapshotted under the lock and the encoding and disk
+// writes happen after releasing it, so a slow disk cannot stall event ingestion (which needs
+// profilesLock to look up or create profiles).
+func (m *ManagerV2) hostCaptureFlush() []*api.ActivityDumpMessage {
+	m.profilesLock.Lock()
+	snapshot := make([]*profile.Profile, 0, len(m.profiles))
+	for _, p := range m.profiles {
+		snapshot = append(snapshot, p)
+	}
+	m.profilesLock.Unlock()
+
+	msgs := make([]*api.ActivityDumpMessage, 0, len(snapshot))
+	for _, p := range snapshot {
+		p.Metadata.End = time.Now()
+		m.persistProfile(p)
+		msgs = append(msgs, p.ToSecurityActivityDumpMessage(0, m.configuredStorageRequests))
+	}
+	return msgs
+}
+
+// ListActivityDumps lists the profiles currently being recorded. In V2 there is no activity dump
+// lifecycle, so this reports the in-memory profiles instead.
 func (m *ManagerV2) ListActivityDumps(_ *api.ActivityDumpListParams) (*api.ActivityDumpListMessage, error) {
-	return nil, nil
+	m.profilesLock.Lock()
+	snapshot := make([]*profile.Profile, 0, len(m.profiles))
+	for _, p := range m.profiles {
+		snapshot = append(snapshot, p)
+	}
+	m.profilesLock.Unlock()
+
+	msgs := make([]*api.ActivityDumpMessage, 0, len(snapshot))
+	for _, p := range snapshot {
+		msgs = append(msgs, p.ToSecurityActivityDumpMessage(0, m.configuredStorageRequests))
+	}
+	return &api.ActivityDumpListMessage{Dumps: msgs}, nil
 }
 
 // StopActivityDump stops an active activity dump.
-// NO-OP in V2: V2 doesn't manage activity dumps the traditional way.
-func (m *ManagerV2) StopActivityDump(_ *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error) {
-	return nil, nil
+// In V2 only the host-wide form (All=true) is supported: it closes the capture window by
+// persisting every recorded profile to local storage.
+func (m *ManagerV2) StopActivityDump(params *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error) {
+	if !params.GetAll() {
+		return nil, nil
+	}
+
+	if !m.config.RuntimeSecurity.SecurityProfileV2HostDumpEnabled {
+		return &api.ActivityDumpStopMessage{Error: ErrHostDumpDisabled.Error()}, ErrHostDumpDisabled
+	}
+
+	dumps := m.hostCaptureFlush()
+	seclog.Infof("host-wide capture window stopped, %d profiles persisted", len(dumps))
+	return &api.ActivityDumpStopMessage{Dumps: dumps}, nil
 }
 
 // DumpActivity dumps the activity.
-// NO-OP in V2: V2 doesn't support on-demand activity dumping through this API.
-func (m *ManagerV2) DumpActivity(_ *api.ActivityDumpParams) (*api.ActivityDumpMessage, error) {
-	return nil, nil
+// In V2 only the host-wide form (Host=true) is supported: it opens a capture window by discarding
+// everything recorded so far, so that the window contains only activity from this point on.
+func (m *ManagerV2) DumpActivity(params *api.ActivityDumpParams) (*api.ActivityDumpMessage, error) {
+	if !params.GetHost() {
+		return nil, nil
+	}
+
+	if !m.config.RuntimeSecurity.SecurityProfileV2HostDumpEnabled {
+		return &api.ActivityDumpMessage{Error: ErrHostDumpDisabled.Error()}, ErrHostDumpDisabled
+	}
+
+	discarded, flushed := m.hostCaptureReset()
+	seclog.Infof("host-wide capture window started, %d previously recorded profiles discarded, %d kernel dedup entries flushed", discarded, flushed)
+	return &api.ActivityDumpMessage{
+		Metadata: &api.MetadataMessage{
+			Name: fmt.Sprintf("host-wide capture window started (%d profiles discarded, %d kernel dedup entries flushed)", discarded, flushed),
+		},
+	}, nil
 }
 
 // GenerateTranscoding generates a transcoding request for the given activity dump.

--- a/pkg/system-probe/config/adjust_security.go
+++ b/pkg/system-probe/config/adjust_security.go
@@ -29,6 +29,17 @@ func adjustSecurity(cfg model.Config) {
 		},
 	)
 
+	// The host-wide capture window is built on CWS and the V2 security profile manager, so the
+	// single host_dump switch has to bring both up. This has to happen here, on the raw
+	// configuration and before the checks below: module enablement (event_monitor) reads
+	// runtime_security_config.enabled directly, and the branch below would otherwise force
+	// security_profile.enabled back off.
+	if cfg.GetBool(secNS("security_profile.v2.host_dump.enabled")) {
+		cfg.Set(secNS("enabled"), true, model.SourceAgentRuntime)
+		cfg.Set(secNS("security_profile.enabled"), true, model.SourceAgentRuntime)
+		cfg.Set(secNS("security_profile.v2.enabled"), true, model.SourceAgentRuntime)
+	}
+
 	if cfg.GetBool(secNS("enabled")) {
 		// if runtime is enabled then we enable fim as well (except if force disabled)
 		if runtime.GOOS != "windows" || !cfg.IsConfigured(secNS("fim_enabled")) {

--- a/pkg/system-probe/config/config_test.go
+++ b/pkg/system-probe/config/config_test.go
@@ -155,3 +155,24 @@ func TestEnableDiscovery(t *testing.T) {
 		assert.False(t, cfg.ModuleIsEnabled(DiscoveryModule))
 	})
 }
+
+// The host-wide capture window is advertised as a single switch: enabling it must be enough to
+// bring up the event monitor module (and therefore the CWS command server), without the operator
+// also having to set runtime_security_config.enabled. The other event monitor sources are
+// explicitly turned off so that this asserts the host_dump path specifically.
+func TestHostDumpEnablesEventMonitor(t *testing.T) {
+	mock.NewSystemProbe(t)
+	t.Setenv("DD_RUNTIME_SECURITY_CONFIG_ENABLED", "false")
+	t.Setenv("DD_RUNTIME_SECURITY_CONFIG_FIM_ENABLED", "false")
+	t.Setenv("DD_SYSTEM_PROBE_EVENT_MONITORING_NETWORK_PROCESS_ENABLED", "false")
+	t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLED", "false")
+	t.Setenv("DD_GPU_MONITORING_ENABLED", "false")
+	t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "false")
+	t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_EVENT_STREAM", "false")
+	t.Setenv("DD_RUNTIME_SECURITY_CONFIG_SECURITY_PROFILE_V2_HOST_DUMP_ENABLED", "true")
+
+	cfg, err := New("/doesnotexist", "")
+	require.NoError(t, err)
+
+	assert.True(t, cfg.ModuleIsEnabled(EventMonitorModule), "event monitor module should be enabled by host_dump alone")
+}

--- a/releasenotes/notes/cws-host-capture-window-v2-3f1c6b9a4d2e8071.yaml
+++ b/releasenotes/notes/cws-host-capture-window-v2-3f1c6b9a4d2e8071.yaml
@@ -1,0 +1,20 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    CWS: added a host-wide activity capture window, driven by the new
+    ``system-probe runtime activity-dump host start`` and ``host stop``
+    commands and gated behind
+    ``runtime_security_config.security_profile.v2.host_dump.enabled``
+    (disabled by default). Enabling it also enables the V2 security profile
+    manager and the profiling of host (systemd) cgroups, so that a single
+    setting captures the activity of the whole host between the two commands.
+    Profiles recorded during a window are written to local storage only and
+    are never forwarded to the backend, which makes the feature suitable for
+    local and CI investigations.


### PR DESCRIPTION
### What does this PR do?

V2 alternative to #53808. Same feature — a host-wide "start → run job → stop → collect local profiles" capture button for CI — but built on the **V2 security profile manager** instead of the V1 activity dump machinery, since V1 is being deprecated.

- New CLI: `system-probe runtime activity-dump host start` / `host stop` (same surface as the V1 PR).
- New config switch `runtime_security_config.security_profile.v2.host_dump.enabled` (default **false**), which also enables the V2 manager and host cgroup profiling (upward-only, logged) so a single switch works.
- **Host coverage:** V2 currently drops every non-container event at the top of `ProcessEvent` ("Filter out systemd cgroups for now"). Under `host_dump` that filter is lifted, and `buildWorkloadSelector` keys host workloads on their cgroup `service` tag — one profile per systemd unit, matching the granularity of V1's host dumps. Tag-resolution readiness uses `service`/`version` for host workloads instead of `image_name`/`image_tag`.
- **Local-only:** the remote storage request isn't registered when `host_dump` is on, so nothing is forwarded to the backend and the intake endpoints aren't set up. Loading previously persisted profiles from disk is also skipped, since it would resurrect a stale tree into a fresh window.
- `ListActivityDumps` now reports the in-memory profiles under V2 (it was a no-op), giving the CLI a readiness/inspection view.
- **Self-contained windows:** opening a window also flushes the kernel dedup sample maps (`open_samples`, `bind_samples`, `connect_samples`, `pid_path_keys`). Those are global LRUs keyed by `(process, target)` that know nothing about capture windows — the first open/connect for a key is delivered and later ones are discarded in kernel space, so without flushing, activity already touched before the window would stay invisible for its whole duration. This is userspace-only: the manager now receives the ebpf manager and deletes the entries; no eBPF C changes. If the maps can't be resolved the window still works, it just can't replay already-deduplicated activity.

### How the window maps onto V2

V1's button worked because a "dump" is a discrete object with a start/stop lifecycle. V2 has no such object: profiles are built continuously from the event stream, keyed by workload selector, and flushed on a ticker. So the window is re-expressed as:

| | V1 | V2 (this PR) |
|---|---|---|
| `host start` | reset each dump's tree + snapshot all cgroups | discard all in-memory profiles, empty the tag-resolution queues, purge the sample-cookie LRU |
| `host stop` | finalize + persist each dump | persist every profile recorded during the window |
| scope | per-cgroup kernel gating (`traced_cgroups`) | no kernel gating at all; V2 consumes every event, so scope is a userspace filter |

Concurrency: the profile set is snapshotted under `profilesLock` and encoding/disk writes happen after releasing it, so a slow disk cannot stall event ingestion (which needs the same lock to look up or create profiles).

### Motivation

Spotting anomalous behaviour in CI jobs (ephemeral VM runners): a GitHub Action opens the window at job start and collects the per-workload profiles at job end. Keeping it local-only keeps the captured data on the box. V1 will be deprecated, so the capability needs to exist on V2.

### Describe how you validated your changes

Built and validated end to end on a Linux dev VM running `system-probe` standalone, with a
minimal config that sets **only** `security_profile.v2.host_dump.enabled: true` (plus a custom
local output directory) so the run also exercises the prerequisite pull-up.

**Auto-coupling** — startup logs from the single switch:
```
security_profile.v2.host_dump.enabled=true: enabling security_profile.v2.enabled
security_profile.v2.host_dump.enabled=true: aligning security_profile.dir with activity_dump.local_storage.output_directory (...)
```
(the dir alignment is needed because `activity_dump.enabled` defaults to true, and enabling
security profiles brings in the "both directories must match" constraint — without it the runtime
security module refuses to start with a custom output directory)

**Capture window**, running the activity directly on the host (not in a container):
```
$ activity-dump host start
host-wide capture window started (25 previously recorded profiles discarded)
$ id; whoami; cat /etc/passwd; nslookup google.com; wget example.com
$ activity-dump host stop
host-wide capture stopped, 2 profiles persisted:
  - cgroup ID: /user.slice/user-1000.slice/session-4.scope   tags: service:session-4.scope
  - cgroup ID: /system.slice/systemd-resolved.service        tags: service:systemd-resolved.service
```
Both `storage type: local_storage`. The 25 discarded profiles confirm host workloads are being
profiled; the 2 persisted are exactly the cgroups active during the window (my shell session, and
systemd-resolved which served the DNS) — per-systemd-unit granularity as intended.

**Content of the host session profile** — every requested category is present:

| Category | Captured |
|---|---|
| processes | `/usr/bin/id`, `/usr/bin/whoami`, `/usr/bin/cat`, `/usr/bin/nslookup`, `/usr/bin/wget`, `/usr/bin/zsh` |
| files | `/etc/passwd` |
| DNS | `google.com`, `example.com` |
| connections | `AF_INET` socket nodes, bind address `0.0.0.0` |

**Repeated cycles and dedup flushing** — the decisive test: run *identical* commands from the
*same* parent shell in two consecutive windows, so the kernel dedup key `(ppid, exe, file)` is the
same both times. Without the flush the second window would miss the repeated file open.
```
parent shell pid=28926 (identical for both windows)
WINDOW A: host-wide capture window started (25 profiles discarded, 440 kernel dedup entries flushed)
          cat /etc/passwd; wget example.com   -> 2 profiles persisted
WINDOW B: host-wide capture window started (2 profiles discarded, 602 kernel dedup entries flushed)
          cat /etc/passwd; wget example.com   -> 2 profiles persisted
```
Both windows contain `/etc/passwd`, `example.com` and the `cat`/`wget` execs, so a window is a
complete record of what happened during it, not just of what was novel since boot.

**Local-only** — `grep -c remote_storage` over the stop output returns `0`, and no cws-intake
endpoint is set up at startup.

**Unit tests** — 921/921 pass across `pkg/security/security_profile`, `pkg/security/config` and
`cmd/system-probe/subcommands/runtime`, including new coverage for the prerequisite pull-up
(enable + dir alignment), the off-is-noop case, and the `host start`/`host stop` CLI wiring.

### Additional Notes

- **Draft.** Opening for early review of the approach.
- Flushing the dedup maps on `host start` means the first events after a window opens are re-delivered rather than suppressed, so there is a brief cost in event volume at the start of each window. That is the intended trade for a self-contained capture.
- Exceeding `security_profile.v2.max_dump_size` calls `Profile.Disable()`, which discards the whole tree — so an oversized host profile yields nothing rather than a truncated capture. Worth revisiting for host-wide use.
- `host_dump` makes V2 fully local, so it cannot be combined with normal backend-forwarded profiling.
- Supersedes #53808 in intent; that PR is left open for comparison.
