### PR TITLE
bazel: use the new CI built toolchains from gcc_toolchains setup

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -245,6 +245,7 @@ archive_override(
         "//bazel/patches:gcc-toolchain/0002-fix-c-x86_64-header-locations-with-our-ctng-toolchai.patch",
         "//bazel/patches:gcc-toolchain/0003-add-nostdinc-to-asmflags.patch",
         "//bazel/patches:gcc-toolchain/0005-fix-bazel-9-compat.patch",
+        "//bazel/patches:gcc-toolchain/0006-independent-exec-target-arch.patch",
     ],
     sha256 = "c7a6674abbf309d2ed5fb2cf6a03aca1e4f357a6f287de2cf21ace856a08f6c2",
     strip_prefix = "gcc-toolchain-cd3e7ee1027a3ecc8b89dc61eb485299ed833399",
@@ -254,7 +255,7 @@ archive_override(
 gcc_toolchains = use_extension("@gcc_toolchain//toolchain:module_extensions.bzl", "gcc_toolchains", dev_dependency = True)
 gcc_toolchains.toolchain(
     name = "gcc_toolchain_x86_64",
-    binary_prefix = "x86_64-unknown-linux-gnu-",
+    binary_prefix = "x86_64-linux-gnu-",
     enable_fortran = False,
     extra_ldflags = ["-Wl,--build-id=sha1"],
     gcc_version = "11.4.0",
@@ -262,14 +263,33 @@ gcc_toolchains.toolchain(
 )
 gcc_toolchains.toolchain(
     name = "gcc_toolchain_aarch64",
-    binary_prefix = "aarch64-unknown-linux-gnu-",
+    binary_prefix = "aarch64-linux-gnu-",
     enable_fortran = False,
     extra_ldflags = ["-Wl,--build-id=sha1"],
     gcc_version = "12.3.0",
     target_arch = "aarch64",
 )
+
+# Cross toolchain: runs on aarch64, targets armv7 (armhf). No native armv7 CI
+# runners exist, so unlike the other two entries this always cross-compiles.
+gcc_toolchains.toolchain(
+    name = "gcc_toolchain_armv7",
+    binary_prefix = "arm-linux-gnueabihf-",
+    enable_fortran = False,
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+    gcc_version = "13.2.0",
+    gcc_versions = """{"13.2.0": {"armv7": {
+        "url": "https://dd-agent-build-artifacts.s3.amazonaws.com/toolchains/main/0cd6ae2749998d738188f10abfbdeb186d76a16d4c3f5c814d69bbc3c1757fea/aarch64/arm-linux-gnueabihf-gcc.tar.xz",
+        "sha256": "2f6171e4411c51626ecc857d85dcb25c1b886807272d5b951fac128d31e858d3"
+    }}}""",
+    target_arch = "armv7",
+)
 use_repo(gcc_toolchains, "gcc_toolchain_x86_64")
 use_repo(gcc_toolchains, "gcc_toolchain_aarch64")
+use_repo(gcc_toolchains, "gcc_toolchain_armv7")
 
 sysroot = use_repo_rule("@toolchains_llvm//toolchain:sysroot.bzl", "sysroot")
 
@@ -321,6 +341,7 @@ winlibs_mingw_repository(
 register_toolchains(
     "@gcc_toolchain_x86_64//:cc_toolchain",
     "@gcc_toolchain_aarch64//:cc_toolchain",
+    "@gcc_toolchain_armv7//:cc_toolchain",
     "@winlibs_mingw64//:mingw_cc_toolchain",
     "@llvm_toolchain//:all",  # last to avoid taking precedence over GCC toolchains
 )

--- a/bazel/patches/gcc-toolchain/0001-adapt-to-our-ctng-toolchain.patch
+++ b/bazel/patches/gcc-toolchain/0001-adapt-to-our-ctng-toolchain.patch
@@ -17,12 +17,12 @@ index 0e55fd7..7c8787f 100644
      include_prefix = None
      if target_arch == ARCHS.aarch64:
 -        include_prefix = "aarch64-linux/"
-+        include_prefix = "aarch64-unknown-linux-gnu/"
++        include_prefix = "aarch64-linux-gnu/"
      elif target_arch == ARCHS.armv7:
          include_prefix = "arm-linux-gnueabihf/"
      elif target_arch == ARCHS.x86_64:
 -        include_prefix = "x86_64-linux/"
-+        include_prefix = "x86_64-unknown-linux-gnu/"
++        include_prefix = "x86_64-linux-gnu/"
  
      c_builtin_includes = [
          include.format(
@@ -79,8 +79,8 @@ index 0e55fd7..7c8787f 100644
          "x86_64": {
 -            "url": "https://github.com/f0rmiga/gcc-builds/releases/download/18082025/gcc-toolchain-12.5.0-x86_64.tar.xz",
 -            "sha256": "51076e175839b434bb2dc0006c0096916df585e8c44666d35b0e3ce821d535db",
-+            "url": "https://dd-agent-omnibus.s3.amazonaws.com/bazel/datadog_agent_cc_toolchain_ubuntu_22_gcc_11.4.0_x86_64.tar.gz",
-+            "sha256": "5d6d23c2ac58b4843b5b5cc2de76d655a4da71656627b1ab7160d8e96996b080",
++            "url": "https://dd-agent-build-artifacts.s3.amazonaws.com/toolchains/main/98b584a9d5921dfe1262878d9d7fc322288f919c6e24763401f7cf29194de9c7/x86_64/x86_64-linux-gnu-gcc.tar.xz",
++            "sha256": "3e842665eecc8ebe8ebf8e6f391809a2124c362e97f3d7dfb2df78225c719342",
          },
      },
 -    "13.4.0": {
@@ -124,8 +124,8 @@ index 0e55fd7..7c8787f 100644
 -        "x86_64": {
 -            "url": "https://github.com/f0rmiga/gcc-builds/releases/download/18082025/gcc-toolchain-15.2.0-x86_64.tar.xz",
 -            "sha256": "50dd28021365e7443853d5e77bc94ab1d1c947ad48fd91cbec44dbdfa61412c9",
-+            "url": "https://dd-agent-omnibus.s3.amazonaws.com/bazel/datadog_agent_cc_toolchain_ubuntu_22_gcc_12.3.0_aarch64.tar.gz",
-+            "sha256": "a599fdb7c5985db5bed1bfa06a6fa5aef73f0dba81c6ce12328d176738ec0d09",
++            "url": "https://dd-agent-build-artifacts.s3.amazonaws.com/toolchains/main/3857f6dd078bb69ceb53e37536fa0e90eb7f3c2eefa1454f5f43376f02d8c9cc/aarch64/aarch64-linux-gnu-gcc.tar.xz",
++            "sha256": "26b924f31f21c2d84a3f78954d295ff6eaeaa758dca39cb3c25178c2cfd00692",
          },
      },
  }

--- a/bazel/patches/gcc-toolchain/0006-independent-exec-target-arch.patch
+++ b/bazel/patches/gcc-toolchain/0006-independent-exec-target-arch.patch
@@ -1,0 +1,89 @@
+From 25e9f409b39cc7d858ecfd7f85489e36ea71fbd8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Hugo=20Beauz=C3=A9e-Luyssen?= <hugo.beauzee@datadoghq.com>
+Date: Tue, 4 Aug 2026 15:40:02 +0200
+Subject: [PATCH] support independent exec/target arch
+
+Cross toolchains (e.g. an aarch64-hosted compiler targeting armv7)
+need exec_compatible_with independent from target_arch.
+---
+ toolchain/defs.bzl              | 23 +++++++++++++++++++----
+ toolchain/module_extensions.bzl |  1 +
+ 2 files changed, 20 insertions(+), 4 deletions(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 4e46f7d..bb031de 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -107,6 +107,11 @@ def _gcc_toolchain_impl(rctx):
+         for v in rctx.attr.target_settings
+     ]
+
++    exec_compatible_with = [
++        v.format(target_arch = target_arch)
++        for v in rctx.attr.exec_compatible_with
++    ]
++
+     builtin_include_directories = []
+     builtin_include_directories.extend(c_builtin_includes)
+     builtin_include_directories.extend(cxx_builtin_includes)
+@@ -212,6 +217,7 @@ def _gcc_toolchain_impl(rctx):
+         enable_fortran = str(rctx.attr.enable_fortran),
+         target_compatible_with = target_compatible_with,
+         target_settings = target_settings,
++        exec_compatible_with = exec_compatible_with,
+         binary_prefix = binary_prefix,
+         include_prefix = include_prefix,
+
+@@ -370,6 +376,17 @@ _FEATURE_ATTRS = {
+         doc = "contraint_values passed to target_compatible_with of the toolchain. {target_arch} is rendered to the target_arch attribute value.",
+         mandatory = False,
+     ),
++    "exec_compatible_with": attr.string_list(
++        default = [
++            "@platforms//os:linux",
++            "@platforms//cpu:{target_arch}",
++        ],
++        doc = "contraint_values passed to exec_compatible_with of the toolchain. {target_arch} is rendered to the" +
++              " target_arch attribute value. Defaults to matching target_arch (i.e. a native compiler), but must" +
++              " be overridden for genuine cross toolchains whose execution platform differs from target_arch" +
++              " (e.g. an aarch64-hosted compiler targeting armv7).",
++        mandatory = False,
++    ),
+     "target_settings": attr.string_list(
+         default = [],
+         doc = "config_settings passed to target_compatible_with of the toolchain. {target_arch} is rendered to the target_arch attribute value.",
+@@ -393,7 +410,7 @@ gcc_toolchain = repository_rule(
+
+ ATTRS_SHARED_WITH_MODULE_EXTENSION = {
+     attr_name: _FEATURE_ATTRS[attr_name]
+-    for attr_name in ["gcc_version", "gcc_versions", "enable_fortran", "extra_cflags", "extra_cxxflags", "extra_ldflags", "extra_fflags", "extra_asmflags", "binary_prefix"]
++    for attr_name in ["gcc_version", "gcc_versions", "enable_fortran", "extra_cflags", "extra_cxxflags", "extra_ldflags", "extra_fflags", "extra_asmflags", "binary_prefix", "exec_compatible_with"]
+ }
+
+ def _render_tool_paths(rctx, path_prefix, binary_prefix):
+@@ -549,10 +566,7 @@ package(default_visibility = ["//visibility:public"])
+
+ toolchain(
+     name = "cc_toolchain",
+-    exec_compatible_with = [
+-        "@platforms//os:linux",
+-        "@platforms//cpu:{target_arch}",
+-    ],
++    exec_compatible_with = {exec_compatible_with},
+     target_compatible_with = {target_compatible_with},
+     target_settings = {target_settings},
+     toolchain = ":_cc_toolchain",
+diff --git a/toolchain/module_extensions.bzl b/toolchain/module_extensions.bzl
+index 82e133d..7b30fa3 100644
+--- a/toolchain/module_extensions.bzl
++++ b/toolchain/module_extensions.bzl
+@@ -21,6 +21,7 @@ def _gcc_register_toolchain_module_extension(mctx):
+                 extra_ldflags = declare.extra_ldflags,
+                 extra_fflags = declare.extra_fflags,
+                 binary_prefix = declare.binary_prefix,
++                exec_compatible_with = declare.exec_compatible_with,
+             )
+
+     # Since we know that for each gcc toolchain repository we'll generate the same files, we mark the rule as reproducible.
+--
+2.43.0


### PR DESCRIPTION
### What does this PR do?

Point our gcc_toolchains to the new `dd-agent-build-artifacts` bucket.
These toolchains are build from CI, as opposed to the current one that were built on an invididual contributor's machine and pushed to the bucket manually.

### Motivation

Relying on manually built toolchain wasn't acceptable in the long term from an SDLC security perspective.
We can also expose a new armhf toolchain that will be useful to build the IOT agent with bazel.

### Describe how you validated your changes
- `bazel build //rtloader/...` locally to ensure we can still build C/C++ code
- CI for the whole build

### Additional Notes
The new toolchains aim at using a more standard triplet and are dropping the `-unknown-` section.
The armhf toolchain is only available as a aarch64 -> armhf cross compiler, but we could also publish an x86_64 -> armhf cross compiler. Hovewer, with the armhf IOT agent being the only usecase, it was deemed unnecessary
