### PR TITLE
bazel: iot-agent: use dd_agent_go_binary with the correct build tags

### DIFF
--- a/cmd/iot-agent/BUILD.bazel
+++ b/cmd/iot-agent/BUILD.bazel
@@ -1,4 +1,6 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:go_binary.bzl", "dd_agent_go_binary")
+load("//tasks:build_tags.bzl", "IOT_AGENT_TAGS")
 
 go_library(
     name = "iot-agent_lib",
@@ -88,9 +90,10 @@ go_library(
     }),
 )
 
-go_binary(
+dd_agent_go_binary(
     name = "iot-agent",
     embed = [":iot-agent_lib"],
+    gotags = IOT_AGENT_TAGS,  # keep
     target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
### What does this PR do?
Switch `//cmd/iot-agent` from `go_binary` to `dd_agent_go_binary` and provide the expected gotags.

### Motivation

We need `dd_agent_go_binary` for all our end binaries so that version stamping and other linker flags are properly applied.
The gotags ensure we build the iot-agent with the same behavior as the dda based builds.

### Describe how you validated your changes
- `bazel build //cmd/iot-agent` succeeds.
- Verified the compiled binary links in the real `impl-zlib`/`impl-zstd` compression implementation instead of the stub.
- CI

### Additional Notes
