### PR TITLE
e2e/installer: harden apt against mirror outages

### DIFF
--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -80,6 +80,27 @@ func (h *Host) setSystemdVersion() {
 	h.systemdVersion = version
 }
 
+// ConfigureAptMirrors hardens apt against package-mirror outages on apt-based hosts.
+// It bounds apt's per-request timeout and retries so an unreachable mirror fails within
+// minutes instead of hanging until the CI job's 2h timeout, and on Ubuntu rewrites the apt
+// sources to a "mirror+file" list so apt fails over to the global archive.ubuntu.com /
+// ports.ubuntu.com mirrors when the regional EC2 mirror is down. This mirrors the pattern
+// used in Dockerfiles/agent/Dockerfile. See incident 58780.
+func (h *Host) ConfigureAptMirrors() {
+	if h.pkgManager != "apt" {
+		return
+	}
+	// Fail fast when a mirror is unreachable instead of retrying with long default TCP timeouts.
+	h.remote.MustExecute(`printf 'Acquire::Retries "2";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' | sudo tee /etc/apt/apt.conf.d/99datadog-e2e-fail-fast`)
+	// Ubuntu EC2 AMIs point at a single regional mirror with no fallback; add global mirrors.
+	if h.os.Flavor != e2eos.Ubuntu {
+		return
+	}
+	h.remote.MustExecute(`printf 'http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu\n' | sudo tee /etc/apt/mirrorlist.main`)
+	h.remote.MustExecute(`printf 'http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports\n' | sudo tee /etc/apt/mirrorlist.ports`)
+	h.remote.MustExecute(`for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do if [ -f "$f" ]; then sudo sed -i -e 's#http://[a-z0-9.-]*ec2\.archive\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' -e 's#http://archive\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' -e 's#http://security\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' -e 's#http://[a-z0-9.-]*ec2\.ports\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' -e 's#http://ports\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' "$f"; fi; done`)
+}
+
 // dockerImage returns the ECR pull-through URL for ecrPath when a registry is configured,
 // or publicFallback otherwise.
 func (h *Host) dockerImage(ecrPath, publicFallback string) string {

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -98,7 +98,7 @@ func (h *Host) ConfigureAptMirrors() {
 	}
 	h.remote.MustExecute(`printf 'http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu\n' | sudo tee /etc/apt/mirrorlist.main`)
 	h.remote.MustExecute(`printf 'http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports\n' | sudo tee /etc/apt/mirrorlist.ports`)
-	h.remote.MustExecute(`for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do if [ -f "$f" ]; then sudo sed -i -e 's#http://[a-z0-9.-]*ec2\.archive\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' -e 's#http://archive\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' -e 's#http://security\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' -e 's#http://[a-z0-9.-]*ec2\.ports\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' -e 's#http://ports\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' "$f"; fi; done`)
+	h.remote.MustExecute(`for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do if [ -f "$f" ]; then sudo sed -i -e 's#https\?://[a-z0-9.-]*ec2\.archive\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' -e 's#https\?://archive\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' -e 's#https\?://security\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' -e 's#https\?://[a-z0-9.-]*ec2\.ports\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' -e 's#https\?://ports\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' "$f"; fi; done`)
 }
 
 // dockerImage returns the ECR pull-through URL for ecrPath when a registry is configured,

--- a/test/new-e2e/tests/installer/script/all_scripts_test.go
+++ b/test/new-e2e/tests/installer/script/all_scripts_test.go
@@ -136,6 +136,7 @@ func (s *installerScriptBaseSuite) SetupSuite() {
 	defer s.CleanupOnSetupFailure()
 
 	s.host = host.New(s.T, s.Env().RemoteHost, s.os, s.arch)
+	s.host.ConfigureAptMirrors()
 }
 
 type installerScriptBaseSuite struct {

--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -169,6 +169,7 @@ func (s *packageBaseSuite) SetupSuite() {
 	s.setupFakeIntake()
 	s.host = host.New(s.T, s.Env().RemoteHost, s.os, s.arch)
 	s.configureAptFailFast()
+	s.configureAptMirrorList()
 	s.disableUnattendedUpgrades()
 	s.updateCurlOnUbuntu()
 	s.updatePythonOnSuse()
@@ -182,6 +183,20 @@ func (s *packageBaseSuite) configureAptFailFast() {
 		return
 	}
 	s.Env().RemoteHost.MustExecute(`printf 'Acquire::Retries "2";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' | sudo tee /etc/apt/apt.conf.d/99datadog-e2e-fail-fast`)
+}
+
+func (s *packageBaseSuite) configureAptMirrorList() {
+	// Ubuntu EC2 hosts use a single regional mirror (e.g. us-east-1.ec2.archive.ubuntu.com).
+	// When it is unavailable apt has no fallback and the job hangs until the 2h timeout
+	// (see incident 58780). Mirror the approach used in Dockerfiles/agent/Dockerfile:
+	// rewrite the apt sources to a "mirror+file" list so apt fails over to the global
+	// archive.ubuntu.com/ports.ubuntu.com mirrors when the regional one is down.
+	if s.os.Flavor != e2eos.Ubuntu {
+		return
+	}
+	s.Env().RemoteHost.MustExecute(`printf 'http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu\n' | sudo tee /etc/apt/mirrorlist.main`)
+	s.Env().RemoteHost.MustExecute(`printf 'http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports\n' | sudo tee /etc/apt/mirrorlist.ports`)
+	s.Env().RemoteHost.MustExecute(`for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do if [ -f "$f" ]; then sudo sed -i -e 's#http://[a-z0-9.-]*ec2\.archive\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' -e 's#http://archive\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' -e 's#http://security\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' -e 's#http://[a-z0-9.-]*ec2\.ports\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' -e 's#http://ports\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' "$f"; fi; done`)
 }
 
 func (s *packageBaseSuite) updatePythonOnSuse() {

--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -168,9 +168,20 @@ func (s *packageBaseSuite) SetupSuite() {
 	s.pipelineAgentVersion = PipelineAgentVersion(s.T())
 	s.setupFakeIntake()
 	s.host = host.New(s.T, s.Env().RemoteHost, s.os, s.arch)
+	s.configureAptFailFast()
 	s.disableUnattendedUpgrades()
 	s.updateCurlOnUbuntu()
 	s.updatePythonOnSuse()
+}
+
+func (s *packageBaseSuite) configureAptFailFast() {
+	// Bound apt's per-request timeout and retries on apt-based distributions so that
+	// unreachable package mirrors fail within minutes instead of retrying with long
+	// default TCP timeouts until the CI job's 2h timeout (see incident 58780).
+	if _, err := s.Env().RemoteHost.Execute("which apt-get"); err != nil {
+		return
+	}
+	s.Env().RemoteHost.MustExecute(`printf 'Acquire::Retries "2";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' | sudo tee /etc/apt/apt.conf.d/99datadog-e2e-fail-fast`)
 }
 
 func (s *packageBaseSuite) updatePythonOnSuse() {

--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -168,35 +168,10 @@ func (s *packageBaseSuite) SetupSuite() {
 	s.pipelineAgentVersion = PipelineAgentVersion(s.T())
 	s.setupFakeIntake()
 	s.host = host.New(s.T, s.Env().RemoteHost, s.os, s.arch)
-	s.configureAptFailFast()
-	s.configureAptMirrorList()
+	s.host.ConfigureAptMirrors()
 	s.disableUnattendedUpgrades()
 	s.updateCurlOnUbuntu()
 	s.updatePythonOnSuse()
-}
-
-func (s *packageBaseSuite) configureAptFailFast() {
-	// Bound apt's per-request timeout and retries on apt-based distributions so that
-	// unreachable package mirrors fail within minutes instead of retrying with long
-	// default TCP timeouts until the CI job's 2h timeout (see incident 58780).
-	if _, err := s.Env().RemoteHost.Execute("which apt-get"); err != nil {
-		return
-	}
-	s.Env().RemoteHost.MustExecute(`printf 'Acquire::Retries "2";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' | sudo tee /etc/apt/apt.conf.d/99datadog-e2e-fail-fast`)
-}
-
-func (s *packageBaseSuite) configureAptMirrorList() {
-	// Ubuntu EC2 hosts use a single regional mirror (e.g. us-east-1.ec2.archive.ubuntu.com).
-	// When it is unavailable apt has no fallback and the job hangs until the 2h timeout
-	// (see incident 58780). Mirror the approach used in Dockerfiles/agent/Dockerfile:
-	// rewrite the apt sources to a "mirror+file" list so apt fails over to the global
-	// archive.ubuntu.com/ports.ubuntu.com mirrors when the regional one is down.
-	if s.os.Flavor != e2eos.Ubuntu {
-		return
-	}
-	s.Env().RemoteHost.MustExecute(`printf 'http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu\n' | sudo tee /etc/apt/mirrorlist.main`)
-	s.Env().RemoteHost.MustExecute(`printf 'http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports\n' | sudo tee /etc/apt/mirrorlist.ports`)
-	s.Env().RemoteHost.MustExecute(`for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do if [ -f "$f" ]; then sudo sed -i -e 's#http://[a-z0-9.-]*ec2\.archive\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' -e 's#http://archive\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' -e 's#http://security\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' -e 's#http://[a-z0-9.-]*ec2\.ports\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' -e 's#http://ports\.ubuntu\.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' "$f"; fi; done`)
 }
 
 func (s *packageBaseSuite) updatePythonOnSuse() {


### PR DESCRIPTION
<!-- dd-meta {"pullId":"e095e149-f7db-4999-848a-b4477100c1be","source":"chat","resourceId":"7fbff1a5-7df2-4b60-a947-8aa653813aa6","workflowId":"28a02e98-6764-4caf-b5e0-8213a584c4aa","codeChangeId":"28a02e98-6764-4caf-b5e0-8213a584c4aa","sourceType":"slack"} -->
### What does this PR do?

Hardens the installer E2E suites against Ubuntu package-mirror outages. Extracts the logic into a shared `(*Host).ConfigureAptMirrors()` method in `test/new-e2e/tests/installer/host` that runs on apt-based hosts and is called from both installer suites' `SetupSuite`:

- `test/new-e2e/tests/installer/unix` (`TestPackages`) → jobs `new-e2e-installer` and `new-e2e-installer-ansible`
- `test/new-e2e/tests/installer/script` → job `new-e2e-installer-script`

`ConfigureAptMirrors()` does two things, before any apt operation runs:

1. Writes `/etc/apt/apt.conf.d/99datadog-e2e-fail-fast` on all apt hosts, bounding apt retries/timeouts (`Acquire::Retries "2"`, `Acquire::http::Timeout "30"`, `Acquire::https::Timeout "30"`) so an unreachable mirror fails within minutes instead of hanging until the 2h job timeout.
2. On Ubuntu, writes `/etc/apt/mirrorlist.main` and `/etc/apt/mirrorlist.ports` (regional EC2 mirror at `priority:1`, global `archive.ubuntu.com`/`ports.ubuntu.com` as fallback) and rewrites `/etc/apt/sources.list` and `/etc/apt/sources.list.d/ubuntu.sources` to `mirror+file:`, matching the pattern in `Dockerfiles/agent/Dockerfile`. Unlike the Dockerfiles, the sed also matches the regional `*.ec2.archive.ubuntu.com` / `*.ec2.ports.ubuntu.com` hosts that EC2 AMIs use by default.

### Motivation

The `new-e2e-installer-ansible` job on `main` has been failing (incident 58780). Every failure is a platform/network issue: the test VMs can only reach the single regional Ubuntu mirror (`us-east-1.ec2.archive.ubuntu.com`) while apt fetches OS/kernel packages such as `linux-modules-*-aws`. When that mirror is unreachable, apt has no fallback and retries with long default TCP timeouts until the job burns the full 2h GitLab timeout. The `new-e2e-installer` and `new-e2e-installer-script` jobs run the same install flows and issue `apt-get update` against the same regional mirror, so they are exposed to the identical failure — hence the shared helper.

- The mirrorlist lets apt fail over to a working global mirror, so transient regional-mirror outages no longer break the jobs at all.
- The fail-fast bound ensures that if every mirror is down, jobs fail within minutes instead of ~2h, freeing CI runners and surfacing infra issues faster.

### Describe how you validated your changes

- `go vet` passes for the three affected packages (`installer/host`, `installer/unix`, `installer/script`); `gofmt` is clean; no new imports are introduced (the helper reuses the existing `RemoteHost.MustExecute` API and the `Host.pkgManager`/`os` fields).
- The mirror rewrite is Ubuntu-gated and idempotent (re-running finds no `*.ubuntu.com` hosts left to rewrite); the sed is a no-op when the source files are absent. The whole helper is a no-op on non-apt hosts (RPM distros) and non-Linux hosts, guarded by `pkgManager`/OS flavor.
- The mirrorlist file format and `mirror+file` rewrite match the proven pattern in `Dockerfiles/agent/Dockerfile` and five other Dockerfiles.
- Full functional validation requires the installer CI jobs (they provision AWS VMs); the change only alters apt client/source configuration on the test host and preserves existing install flows.

### Additional Notes

Scope is intentionally apt/Ubuntu, which is the flavor in the incident and the origin of the pattern. Debian (served by the `deb.debian.org` CDN) and the RPM-based flavors (Amazon Linux, RedHat, CentOS, SUSE) use different repo/mirror mechanisms (yum/zypper mirrorlists, RHUI, S3-backed repos) and are not covered here. A follow-up PR can add per-distro fallbacks once a vetted mirror list is available for each.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/7fbff1a5-7df2-4b60-a947-8aa653813aa6)

Comment @datadog to request changes