### PR TITLE
test(agenttelemetry): run error-tracking e2e suites in parallel

### DIFF
--- a/test/new-e2e/tests/agent-telemetry/errortracking_cluster_agent_test.go
+++ b/test/new-e2e/tests/agent-telemetry/errortracking_cluster_agent_test.go
@@ -56,6 +56,7 @@ type errorTrackingClusterAgentSuite struct {
 // TestErrorTrackingClusterAgentSuite is the cluster-agent variant of
 // TestAgentTelemetryErrorTrackingSuite.
 func TestErrorTrackingClusterAgentSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &errorTrackingClusterAgentSuite{},
 		e2e.WithProvisioner(provkind.Provisioner(
 			provkind.WithRunOptions(

--- a/test/new-e2e/tests/agent-telemetry/errortracking_otel_agent_test.go
+++ b/test/new-e2e/tests/agent-telemetry/errortracking_otel_agent_test.go
@@ -109,6 +109,7 @@ type errorTrackingOTelAgentSuite struct {
 // TestAgentTelemetryErrorTrackingSuite, exercised via the OTel collector's
 // own zap-bridged logging rather than the core agent's.
 func TestErrorTrackingOTelAgentSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &errorTrackingOTelAgentSuite{},
 		e2e.WithProvisioner(provkind.Provisioner(
 			provkind.WithRunOptions(

--- a/test/new-e2e/tests/agent-telemetry/errortracking_test.go
+++ b/test/new-e2e/tests/agent-telemetry/errortracking_test.go
@@ -90,6 +90,7 @@ func errorTrackingAgentOptions(agentConfig string) []agentparams.Option {
 // every binary sharing the errortracking pipeline emits a deterministic
 // error, covering all of them with a single VM instead of one per binary.
 func TestAgentTelemetryErrorTrackingSuite(t *testing.T) {
+	t.Parallel()
 	e2e.Run(t, &errorTrackingSuite{},
 		e2e.WithProvisioner(
 			awshost.Provisioner(


### PR DESCRIPTION
### What does this PR do?
Adds `t.Parallel()` to the three top-level error-tracking e2e suite entry points in `test/new-e2e/tests/agent-telemetry`: `TestAgentTelemetryErrorTrackingSuite`, `TestErrorTrackingClusterAgentSuite`, and `TestErrorTrackingOTelAgentSuite`.

### Motivation
Each suite provisions its own independent infrastructure (a separate EC2 host or K8s cluster), so there's no shared-state reason to run them sequentially. Marking them parallel-eligible lets the test runner execute them concurrently and cuts total e2e wall-clock time.

### Describe how you validated your changes
- Reviewed that `t.Parallel()` was only added at the top-level suite functions, not inside the individual `TestPayloadShape`/`TestDisabledByDefault` suite methods, since those share one suite's environment and `TestDisabledByDefault` mutates it via `UpdateEnv`.
- Ran a Claude + Codex (`codex exec review --base main`) review pass; no issues found.

### Additional Notes
Follows the convention documented in `test/e2e-framework/AGENTS.md`.