### PR TITLE
[AGENTRUN-1421] corechecks/network: port AIX support to the v2 Go network check

### DIFF
--- a/pkg/collector/corechecks/net/networkv2/BUILD.bazel
+++ b/pkg/collector/corechecks/net/networkv2/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "const_linux.go",
         "network.go",
+        "network_aix.go",
         "network_linux.go",
         "network_windows.go",
         "stub.go",
@@ -14,9 +15,15 @@ go_library(
     visibility = ["//visibility:public"],
     deps = select({
         "@rules_go//go/platform:aix": [
+            "//comp/core/autodiscovery/integration",
             "//comp/core/config",
+            "//pkg/aggregator/sender",
             "//pkg/collector/check",
+            "//pkg/collector/corechecks",
+            "//pkg/util/log",
             "//pkg/util/option",
+            "@com_github_shirou_gopsutil_v4//net",
+            "@in_yaml_go_yaml_v2//:yaml",
         ],
         "@rules_go//go/platform:android": [
             "//comp/core/autodiscovery/integration",

--- a/pkg/collector/corechecks/net/networkv2/BUILD.bazel
+++ b/pkg/collector/corechecks/net/networkv2/BUILD.bazel
@@ -132,11 +132,20 @@ go_library(
 dd_agent_go_test(
     name = "networkv2_test",
     srcs = [
+        "network_aix_test.go",
         "network_test.go",
         "network_windows_test.go",
     ],
     embed = [":networkv2"],
     deps = select({
+        "@rules_go//go/platform:aix": [
+            "//comp/core/autodiscovery/integration",
+            "//pkg/aggregator",
+            "//pkg/aggregator/mocksender",
+            "@com_github_shirou_gopsutil_v4//net",
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//mock",
+        ],
         "@rules_go//go/platform:android": [
             "//comp/core/autodiscovery/integration",
             "//pkg/aggregator",

--- a/pkg/collector/corechecks/net/networkv2/network.go
+++ b/pkg/collector/corechecks/net/networkv2/network.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux || windows
+//go:build linux || windows || aix
 
 // Package networkv2 provides a check for network connection and socket statistics
 package networkv2
@@ -21,7 +21,7 @@ const (
 )
 
 // NetworkCheck represents a network check. networkStats and networkInstanceConfig are
-// declared per-platform (network_linux.go, network_windows.go).
+// declared per-platform (network_linux.go, network_windows.go, network_aix.go).
 type NetworkCheck struct {
 	core.CheckBase
 	net    networkStats

--- a/pkg/collector/corechecks/net/networkv2/network.go
+++ b/pkg/collector/corechecks/net/networkv2/network.go
@@ -21,7 +21,7 @@ const (
 )
 
 // NetworkCheck represents a network check. networkStats and networkInstanceConfig are
-// declared per-platform (network_linux.go, network_windows.go, network_aix.go).
+// declared per-platform.
 type NetworkCheck struct {
 	core.CheckBase
 	net    networkStats

--- a/pkg/collector/corechecks/net/networkv2/network_aix.go
+++ b/pkg/collector/corechecks/net/networkv2/network_aix.go
@@ -1,0 +1,265 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build aix
+
+package networkv2
+
+import (
+	"fmt"
+	"maps"
+	"regexp"
+	"slices"
+
+	"github.com/shirou/gopsutil/v4/net"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	yaml "go.yaml.in/yaml/v2"
+)
+
+var (
+	protocolsMetricsMapping = map[string]map[string]string{
+		"tcp": {
+			"RetransSegs":     "system.net.tcp.retrans_segs",
+			"InSegs":          "system.net.tcp.in_segs",
+			"OutSegs":         "system.net.tcp.out_segs",
+			"ListenOverflows": "system.net.tcp.listen_overflows",
+			"ListenDrops":     "system.net.tcp.listen_drops",
+			"TCPBacklogDrop":  "system.net.tcp.backlog_drops",
+			"TCPRetransFail":  "system.net.tcp.failed_retransmits",
+		},
+		"udp": {
+			"InDatagrams":  "system.net.udp.in_datagrams",
+			"NoPorts":      "system.net.udp.no_ports",
+			"InErrors":     "system.net.udp.in_errors",
+			"OutDatagrams": "system.net.udp.out_datagrams",
+			"RcvbufErrors": "system.net.udp.rcv_buf_errors",
+			"SndbufErrors": "system.net.udp.snd_buf_errors",
+			"InCsumErrors": "system.net.udp.in_csum_errors",
+		},
+	}
+	tcpStateMetricsSuffixMapping = map[string]string{
+		"ESTABLISHED": "established",
+		"SYN_SENT":    "opening",
+		"SYN_RECV":    "opening",
+		"FIN_WAIT1":   "closing",
+		"FIN_WAIT2":   "closing",
+		"TIME_WAIT":   "time_wait",
+		"CLOSE":       "closing",
+		"CLOSE_WAIT":  "closing",
+		"LAST_ACK":    "closing",
+		"LISTEN":      "listening",
+		"CLOSING":     "closing",
+	}
+
+	udpStateMetricsSuffixMapping = map[string]string{
+		"NONE": "connections",
+		// AIX netstat output omits the state column for UDP rows; gopsutil
+		// leaves Status as "" in that case. Map it the same as "NONE".
+		"": "connections",
+	}
+)
+
+type networkInstanceConfig struct {
+	CollectRateMetrics       bool     `yaml:"collect_rate_metrics"`
+	CollectCountMetrics      bool     `yaml:"collect_count_metrics"`
+	CollectConnectionState   bool     `yaml:"collect_connection_state"`
+	ExcludedInterfaces       []string `yaml:"excluded_interfaces"`
+	ExcludedInterfaceRe      string   `yaml:"excluded_interface_re"`
+	ExcludedInterfacePattern *regexp.Regexp
+}
+
+type networkStats interface {
+	IOCounters(pernic bool) ([]net.IOCountersStat, error)
+	ProtoCounters(protocols []string) ([]net.ProtoCountersStat, error)
+	Connections(kind string) ([]net.ConnectionStat, error)
+	NetstatTCPExtCounters() (map[string]int64, error)
+}
+
+type defaultNetworkStats struct{}
+
+func (n defaultNetworkStats) IOCounters(pernic bool) ([]net.IOCountersStat, error) {
+	return net.IOCounters(pernic)
+}
+
+func (n defaultNetworkStats) ProtoCounters(protocols []string) ([]net.ProtoCountersStat, error) {
+	return net.ProtoCounters(protocols)
+}
+
+func (n defaultNetworkStats) Connections(kind string) ([]net.ConnectionStat, error) {
+	return net.Connections(kind)
+}
+
+func (n defaultNetworkStats) NetstatTCPExtCounters() (map[string]int64, error) {
+	// TCPExt counters come from /proc/net/netstat which does not exist on AIX.
+	return nil, nil
+}
+
+// Run executes the check
+func (c *NetworkCheck) Run() error {
+	sender, err := c.GetSender()
+	if err != nil {
+		return err
+	}
+
+	ioByInterface, err := c.net.IOCounters(true)
+	if err != nil {
+		return err
+	}
+	for _, interfaceIO := range ioByInterface {
+		if !c.isDeviceExcluded(interfaceIO.Name) {
+			submitInterfaceMetrics(sender, interfaceIO)
+		}
+	}
+
+	protocols := []string{"tcp", "udp"}
+	protocolsStats, err := c.net.ProtoCounters(protocols)
+	if err != nil {
+		return err
+	}
+	for _, protocolStats := range protocolsStats {
+		// For TCP we want some extra counters coming from /proc/net/netstat if available
+		if protocolStats.Protocol == "tcp" {
+			counters, err := c.net.NetstatTCPExtCounters()
+			if err != nil {
+				log.Debug(err)
+			} else {
+				maps.Copy(protocolStats.Stats, counters)
+			}
+		}
+		c.submitProtocolMetrics(sender, protocolStats)
+	}
+
+	if c.config.instance.CollectConnectionState {
+		connectionsStats, err := c.net.Connections("udp4")
+		if err != nil {
+			return err
+		}
+		submitConnectionsMetrics(sender, "udp4", udpStateMetricsSuffixMapping, connectionsStats)
+
+		connectionsStats, err = c.net.Connections("udp6")
+		if err != nil {
+			return err
+		}
+		submitConnectionsMetrics(sender, "udp6", udpStateMetricsSuffixMapping, connectionsStats)
+
+		connectionsStats, err = c.net.Connections("tcp4")
+		if err != nil {
+			return err
+		}
+		submitConnectionsMetrics(sender, "tcp4", tcpStateMetricsSuffixMapping, connectionsStats)
+
+		connectionsStats, err = c.net.Connections("tcp6")
+		if err != nil {
+			return err
+		}
+		submitConnectionsMetrics(sender, "tcp6", tcpStateMetricsSuffixMapping, connectionsStats)
+	}
+
+	sender.Commit()
+	return nil
+}
+
+func (c *NetworkCheck) isDeviceExcluded(deviceName string) bool {
+	if slices.Contains(c.config.instance.ExcludedInterfaces, deviceName) {
+		return true
+	}
+	if c.config.instance.ExcludedInterfacePattern != nil {
+		return c.config.instance.ExcludedInterfacePattern.MatchString(deviceName)
+	}
+	return false
+}
+
+func submitInterfaceMetrics(sender sender.Sender, interfaceIO net.IOCountersStat) {
+	tags := []string{"device:" + interfaceIO.Name, "device_name:" + interfaceIO.Name}
+	sender.Rate("system.net.bytes_rcvd", float64(interfaceIO.BytesRecv), "", tags)
+	sender.Rate("system.net.bytes_sent", float64(interfaceIO.BytesSent), "", tags)
+	sender.Rate("system.net.packets_in.count", float64(interfaceIO.PacketsRecv), "", tags)
+	sender.Rate("system.net.packets_in.drop", float64(interfaceIO.Dropin), "", tags)
+	sender.Rate("system.net.packets_in.error", float64(interfaceIO.Errin), "", tags)
+	sender.Rate("system.net.packets_out.count", float64(interfaceIO.PacketsSent), "", tags)
+	sender.Rate("system.net.packets_out.drop", float64(interfaceIO.Dropout), "", tags)
+	sender.Rate("system.net.packets_out.error", float64(interfaceIO.Errout), "", tags)
+}
+
+func (c *NetworkCheck) submitProtocolMetrics(sender sender.Sender, protocolStats net.ProtoCountersStat) {
+	if protocolMapping, ok := protocolsMetricsMapping[protocolStats.Protocol]; ok {
+		for rawMetricName, metricName := range protocolMapping {
+			if metricValue, ok := protocolStats.Stats[rawMetricName]; ok {
+				if c.config.instance.CollectRateMetrics {
+					sender.Rate(metricName, float64(metricValue), "", nil)
+				}
+				if c.config.instance.CollectCountMetrics {
+					sender.MonotonicCount(metricName+".count", float64(metricValue), "", nil)
+				}
+			}
+		}
+	}
+}
+
+// submitConnectionsMetrics tallies connectionsStats by status (via stateMetricSuffixMapping)
+// and emits one gauge per resulting suffix.
+func submitConnectionsMetrics(sender sender.Sender, protocolName string, stateMetricSuffixMapping map[string]string, connectionsStats []net.ConnectionStat) {
+	metricCount := map[string]float64{}
+	for _, suffix := range stateMetricSuffixMapping {
+		metricCount[suffix] = 0
+	}
+
+	for _, connectionStats := range connectionsStats {
+		if suffix, ok := stateMetricSuffixMapping[connectionStats.Status]; ok {
+			metricCount[suffix]++
+		} else {
+			log.Debugf("%s state mapping not found for %s", protocolName, connectionStats.Status)
+		}
+	}
+
+	for suffix, count := range metricCount {
+		sender.Gauge(fmt.Sprintf("system.net.%s.%s", protocolName, suffix), count, "", nil)
+	}
+}
+
+// Configure configures the network checks
+func (c *NetworkCheck) Configure(senderManager sender.SenderManager, _ uint64, rawInstance integration.Data, rawInitConfig integration.Data, source string, provider string) error {
+	err := c.CommonConfigure(senderManager, rawInitConfig, rawInstance, source, provider)
+	if err != nil {
+		return err
+	}
+	err = yaml.Unmarshal(rawInitConfig, &c.config.initConf)
+	if err != nil {
+		return err
+	}
+	err = yaml.Unmarshal(rawInstance, &c.config.instance)
+	if err != nil {
+		return err
+	}
+
+	if c.config.instance.ExcludedInterfaceRe != "" {
+		pattern, err := regexp.Compile(c.config.instance.ExcludedInterfaceRe)
+		if err != nil {
+			log.Errorf("Failed to parse network check option excluded_interface_re: %s", err)
+		} else {
+			c.config.instance.ExcludedInterfacePattern = pattern
+		}
+	}
+
+	return nil
+}
+
+func newCheck(_ config.Component) check.Check {
+	return &NetworkCheck{
+		CheckBase: core.NewCheckBase(CheckName),
+		net:       defaultNetworkStats{},
+		config: networkConfig{
+			instance: networkInstanceConfig{
+				CollectRateMetrics: true,
+			},
+		},
+	}
+}

--- a/pkg/collector/corechecks/net/networkv2/network_aix_test.go
+++ b/pkg/collector/corechecks/net/networkv2/network_aix_test.go
@@ -1,0 +1,415 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build aix
+
+package networkv2
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/shirou/gopsutil/v4/net"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+)
+
+type fakeNetworkStats struct {
+	counterStats             []net.IOCountersStat
+	counterStatsError        error
+	protoCountersStats       []net.ProtoCountersStat
+	protoCountersStatsError  error
+	connectionStatsUDP4      []net.ConnectionStat
+	connectionStatsUDP4Error error
+	connectionStatsUDP6      []net.ConnectionStat
+	connectionStatsUDP6Error error
+	connectionStatsTCP4      []net.ConnectionStat
+	connectionStatsTCP4Error error
+	connectionStatsTCP6      []net.ConnectionStat
+	connectionStatsTCP6Error error
+	netstatTCPExtCounters    map[string]int64
+	netstatTCPExtCountersErr error
+}
+
+// IOCounters returns the inner values of counterStats and counterStatsError
+func (n *fakeNetworkStats) IOCounters(_ bool) ([]net.IOCountersStat, error) {
+	return n.counterStats, n.counterStatsError
+}
+
+// ProtoCounters returns the inner values of protoCountersStats and protoCountersStatsError
+func (n *fakeNetworkStats) ProtoCounters(_ []string) ([]net.ProtoCountersStat, error) {
+	return n.protoCountersStats, n.protoCountersStatsError
+}
+
+// Connections returns the inner values of the connectionStats* fields matching kind
+func (n *fakeNetworkStats) Connections(kind string) ([]net.ConnectionStat, error) {
+	switch kind {
+	case "udp4":
+		return n.connectionStatsUDP4, n.connectionStatsUDP4Error
+	case "udp6":
+		return n.connectionStatsUDP6, n.connectionStatsUDP6Error
+	case "tcp4":
+		return n.connectionStatsTCP4, n.connectionStatsTCP4Error
+	case "tcp6":
+		return n.connectionStatsTCP6, n.connectionStatsTCP6Error
+	}
+	return nil, nil
+}
+
+// NetstatTCPExtCounters returns the inner values of netstatTCPExtCounters and netstatTCPExtCountersErr
+func (n *fakeNetworkStats) NetstatTCPExtCounters() (map[string]int64, error) {
+	return n.netstatTCPExtCounters, n.netstatTCPExtCountersErr
+}
+
+func createTestNetworkCheck(mockNetStats networkStats) *NetworkCheck {
+	return &NetworkCheck{
+		net: mockNetStats,
+		config: networkConfig{
+			instance: networkInstanceConfig{
+				CollectRateMetrics: true,
+			},
+		},
+	}
+}
+
+func TestDefaultConfiguration(t *testing.T) {
+	check := createTestNetworkCheck(nil)
+	err := check.Configure(aggregator.NewNoOpSenderManager(), integration.FakeConfigHash, []byte(``), []byte(``), "test", "provider")
+
+	assert.Nil(t, err)
+	assert.Equal(t, false, check.config.instance.CollectConnectionState)
+	assert.Equal(t, []string(nil), check.config.instance.ExcludedInterfaces)
+	assert.Equal(t, "", check.config.instance.ExcludedInterfaceRe)
+}
+
+func TestConfiguration(t *testing.T) {
+	check := createTestNetworkCheck(nil)
+	rawInstanceConfig := []byte(`
+collect_connection_state: true
+collect_count_metrics: true
+excluded_interfaces:
+    - en0
+    - lo0
+excluded_interface_re: "en.*"
+`)
+	err := check.Configure(aggregator.NewNoOpSenderManager(), integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test", "provider")
+
+	assert.Nil(t, err)
+	assert.Equal(t, true, check.config.instance.CollectConnectionState)
+	assert.Equal(t, true, check.config.instance.CollectCountMetrics)
+	assert.ElementsMatch(t, []string{"en0", "lo0"}, check.config.instance.ExcludedInterfaces)
+	assert.Equal(t, "en.*", check.config.instance.ExcludedInterfaceRe)
+	assert.NotNil(t, check.config.instance.ExcludedInterfacePattern)
+}
+
+func TestNetworkCheck(t *testing.T) {
+	netStats := &fakeNetworkStats{
+		counterStats: []net.IOCountersStat{
+			{
+				Name:        "en0",
+				BytesRecv:   10,
+				BytesSent:   11,
+				PacketsRecv: 12,
+				Dropin:      13,
+				Errin:       14,
+				PacketsSent: 15,
+				Dropout:     16,
+				Errout:      17,
+			},
+			{
+				Name:        "lo0",
+				BytesRecv:   18,
+				BytesSent:   19,
+				PacketsRecv: 20,
+				Dropin:      21,
+				Errin:       22,
+				PacketsSent: 23,
+				Dropout:     24,
+				Errout:      25,
+			},
+		},
+		protoCountersStats: []net.ProtoCountersStat{
+			{
+				Protocol: "tcp",
+				Stats: map[string]int64{
+					"RetransSegs":     1,
+					"InSegs":          2,
+					"OutSegs":         3,
+					"ListenOverflows": 4,
+					"ListenDrops":     5,
+					"TCPBacklogDrop":  6,
+					"TCPRetransFail":  7,
+				},
+			},
+			{
+				Protocol: "udp",
+				Stats: map[string]int64{
+					"InDatagrams":  8,
+					"NoPorts":      9,
+					"InErrors":     10,
+					"OutDatagrams": 11,
+					"RcvbufErrors": 12,
+					"SndbufErrors": 13,
+					"InCsumErrors": 14,
+				},
+			},
+		},
+		// gopsutil's AIX backend never populates TCPExt counters (no /proc/net/netstat);
+		// exercise that no-op path explicitly.
+		netstatTCPExtCounters: nil,
+		connectionStatsUDP4: []net.ConnectionStat{
+			// AIX netstat output omits the state column for UDP rows, so gopsutil leaves
+			// Status as "" here.
+			{Status: ""},
+		},
+		connectionStatsUDP6: []net.ConnectionStat{
+			{Status: ""},
+			{Status: ""},
+		},
+		connectionStatsTCP4: []net.ConnectionStat{
+			{Status: "ESTABLISHED"},
+			{Status: "SYN_SENT"},
+			{Status: "SYN_RECV"},
+			{Status: "FIN_WAIT1"},
+			{Status: "FIN_WAIT2"},
+			{Status: "TIME_WAIT"},
+			{Status: "CLOSE"},
+			{Status: "CLOSE_WAIT"},
+			{Status: "LAST_ACK"},
+			{Status: "LISTEN"},
+			{Status: "CLOSING"},
+		},
+		connectionStatsTCP6: []net.ConnectionStat{
+			{Status: "ESTABLISHED"},
+			{Status: "LISTEN"},
+		},
+	}
+
+	networkCheck := createTestNetworkCheck(netStats)
+
+	rawInstanceConfig := []byte(`
+collect_connection_state: true
+collect_count_metrics: true
+`)
+
+	mockSender := mocksender.NewMockSender(t, networkCheck.ID())
+	err := networkCheck.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test", "provider")
+	assert.Nil(t, err)
+
+	mockSender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("Rate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("Commit").Return()
+
+	err = networkCheck.Run()
+	assert.Nil(t, err)
+
+	en0Tags := []string{"device:en0", "device_name:en0"}
+	mockSender.AssertCalled(t, "Rate", "system.net.bytes_rcvd", float64(10), "", en0Tags)
+	mockSender.AssertCalled(t, "Rate", "system.net.bytes_sent", float64(11), "", en0Tags)
+	mockSender.AssertCalled(t, "Rate", "system.net.packets_in.count", float64(12), "", en0Tags)
+	mockSender.AssertCalled(t, "Rate", "system.net.packets_in.drop", float64(13), "", en0Tags)
+	mockSender.AssertCalled(t, "Rate", "system.net.packets_in.error", float64(14), "", en0Tags)
+	mockSender.AssertCalled(t, "Rate", "system.net.packets_out.count", float64(15), "", en0Tags)
+	mockSender.AssertCalled(t, "Rate", "system.net.packets_out.drop", float64(16), "", en0Tags)
+	mockSender.AssertCalled(t, "Rate", "system.net.packets_out.error", float64(17), "", en0Tags)
+
+	lo0Tags := []string{"device:lo0", "device_name:lo0"}
+	mockSender.AssertCalled(t, "Rate", "system.net.bytes_rcvd", float64(18), "", lo0Tags)
+	mockSender.AssertCalled(t, "Rate", "system.net.bytes_sent", float64(19), "", lo0Tags)
+	mockSender.AssertCalled(t, "Rate", "system.net.packets_in.count", float64(20), "", lo0Tags)
+	mockSender.AssertCalled(t, "Rate", "system.net.packets_in.drop", float64(21), "", lo0Tags)
+	mockSender.AssertCalled(t, "Rate", "system.net.packets_in.error", float64(22), "", lo0Tags)
+	mockSender.AssertCalled(t, "Rate", "system.net.packets_out.count", float64(23), "", lo0Tags)
+	mockSender.AssertCalled(t, "Rate", "system.net.packets_out.drop", float64(24), "", lo0Tags)
+	mockSender.AssertCalled(t, "Rate", "system.net.packets_out.error", float64(25), "", lo0Tags)
+
+	var customTags []string
+
+	mockSender.AssertCalled(t, "Rate", "system.net.tcp.retrans_segs", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "MonotonicCount", "system.net.tcp.retrans_segs.count", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Rate", "system.net.tcp.in_segs", float64(2), "", customTags)
+	mockSender.AssertCalled(t, "MonotonicCount", "system.net.tcp.in_segs.count", float64(2), "", customTags)
+	mockSender.AssertCalled(t, "Rate", "system.net.tcp.out_segs", float64(3), "", customTags)
+	mockSender.AssertCalled(t, "MonotonicCount", "system.net.tcp.out_segs.count", float64(3), "", customTags)
+	mockSender.AssertCalled(t, "Rate", "system.net.tcp.listen_overflows", float64(4), "", customTags)
+	mockSender.AssertCalled(t, "MonotonicCount", "system.net.tcp.listen_overflows.count", float64(4), "", customTags)
+	mockSender.AssertCalled(t, "Rate", "system.net.tcp.listen_drops", float64(5), "", customTags)
+	mockSender.AssertCalled(t, "MonotonicCount", "system.net.tcp.listen_drops.count", float64(5), "", customTags)
+	mockSender.AssertCalled(t, "Rate", "system.net.tcp.backlog_drops", float64(6), "", customTags)
+	mockSender.AssertCalled(t, "MonotonicCount", "system.net.tcp.backlog_drops.count", float64(6), "", customTags)
+	mockSender.AssertCalled(t, "Rate", "system.net.tcp.failed_retransmits", float64(7), "", customTags)
+	mockSender.AssertCalled(t, "MonotonicCount", "system.net.tcp.failed_retransmits.count", float64(7), "", customTags)
+
+	mockSender.AssertCalled(t, "Rate", "system.net.udp.in_datagrams", float64(8), "", customTags)
+	mockSender.AssertCalled(t, "MonotonicCount", "system.net.udp.in_datagrams.count", float64(8), "", customTags)
+	mockSender.AssertCalled(t, "Rate", "system.net.udp.no_ports", float64(9), "", customTags)
+	mockSender.AssertCalled(t, "MonotonicCount", "system.net.udp.no_ports.count", float64(9), "", customTags)
+	mockSender.AssertCalled(t, "Rate", "system.net.udp.in_errors", float64(10), "", customTags)
+	mockSender.AssertCalled(t, "MonotonicCount", "system.net.udp.in_errors.count", float64(10), "", customTags)
+	mockSender.AssertCalled(t, "Rate", "system.net.udp.out_datagrams", float64(11), "", customTags)
+	mockSender.AssertCalled(t, "MonotonicCount", "system.net.udp.out_datagrams.count", float64(11), "", customTags)
+	mockSender.AssertCalled(t, "Rate", "system.net.udp.rcv_buf_errors", float64(12), "", customTags)
+	mockSender.AssertCalled(t, "MonotonicCount", "system.net.udp.rcv_buf_errors.count", float64(12), "", customTags)
+	mockSender.AssertCalled(t, "Rate", "system.net.udp.snd_buf_errors", float64(13), "", customTags)
+	mockSender.AssertCalled(t, "MonotonicCount", "system.net.udp.snd_buf_errors.count", float64(13), "", customTags)
+	mockSender.AssertCalled(t, "Rate", "system.net.udp.in_csum_errors", float64(14), "", customTags)
+	mockSender.AssertCalled(t, "MonotonicCount", "system.net.udp.in_csum_errors.count", float64(14), "", customTags)
+
+	// The empty-status UDP rows must still count as "connections" (AIX-specific gopsutil quirk).
+	mockSender.AssertCalled(t, "Gauge", "system.net.udp4.connections", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.udp6.connections", float64(2), "", customTags)
+
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.established", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.opening", float64(2), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.closing", float64(6), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.time_wait", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.listening", float64(1), "", customTags)
+
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.established", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.listening", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.opening", float64(0), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.closing", float64(0), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.time_wait", float64(0), "", customTags)
+
+	mockSender.AssertCalled(t, "Commit")
+}
+
+// TestNetworkCheckNetstatTCPExtCountersMerged verifies that TCPExt counters returned by
+// NetstatTCPExtCounters (a no-op on real AIX, but exercised here to cover the merge path)
+// get merged into the tcp protocol stats before submission.
+func TestNetworkCheckNetstatTCPExtCountersMerged(t *testing.T) {
+	netStats := &fakeNetworkStats{
+		protoCountersStats: []net.ProtoCountersStat{
+			{
+				Protocol: "tcp",
+				Stats: map[string]int64{
+					"InSegs": 100,
+				},
+			},
+		},
+		netstatTCPExtCounters: map[string]int64{
+			"OutSegs": 200,
+		},
+	}
+
+	networkCheck := createTestNetworkCheck(netStats)
+	mockSender := mocksender.NewMockSender(t, networkCheck.ID())
+	err := networkCheck.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, []byte(``), []byte(``), "test", "provider")
+	assert.Nil(t, err)
+
+	mockSender.On("Rate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("Commit").Return()
+
+	err = networkCheck.Run()
+	assert.Nil(t, err)
+
+	mockSender.AssertCalled(t, "Rate", "system.net.tcp.in_segs", float64(100), "", []string(nil))
+	mockSender.AssertCalled(t, "Rate", "system.net.tcp.out_segs", float64(200), "", []string(nil))
+}
+
+// TestNetworkCheckNetstatTCPExtCountersError verifies that an error from
+// NetstatTCPExtCounters is only logged, not propagated by Run.
+func TestNetworkCheckNetstatTCPExtCountersError(t *testing.T) {
+	netStats := &fakeNetworkStats{
+		protoCountersStats: []net.ProtoCountersStat{
+			{
+				Protocol: "tcp",
+				Stats: map[string]int64{
+					"InSegs": 1,
+				},
+			},
+		},
+		netstatTCPExtCountersErr: errors.New("boom"),
+	}
+
+	networkCheck := createTestNetworkCheck(netStats)
+	mockSender := mocksender.NewMockSender(t, networkCheck.ID())
+	err := networkCheck.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, []byte(``), []byte(``), "test", "provider")
+	assert.Nil(t, err)
+
+	mockSender.On("Rate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("Commit").Return()
+
+	err = networkCheck.Run()
+	assert.Nil(t, err)
+
+	mockSender.AssertCalled(t, "Rate", "system.net.tcp.in_segs", float64(1), "", []string(nil))
+}
+
+func TestExcludedInterfaces(t *testing.T) {
+	netStats := &fakeNetworkStats{
+		counterStats: []net.IOCountersStat{
+			{Name: "en0", BytesRecv: 10, BytesSent: 11},
+			{Name: "lo0", BytesRecv: 18, BytesSent: 19},
+		},
+	}
+
+	networkCheck := createTestNetworkCheck(netStats)
+
+	rawInstanceConfig := []byte(`
+excluded_interfaces:
+    - lo0
+`)
+
+	mockSender := mocksender.NewMockSender(t, networkCheck.ID())
+	err := networkCheck.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test", "provider")
+	assert.Nil(t, err)
+
+	mockSender.On("Rate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("Commit").Return()
+
+	err = networkCheck.Run()
+	assert.Nil(t, err)
+
+	en0Tags := []string{"device:en0", "device_name:en0"}
+	mockSender.AssertCalled(t, "Rate", "system.net.bytes_rcvd", float64(10), "", en0Tags)
+	mockSender.AssertCalled(t, "Rate", "system.net.bytes_sent", float64(11), "", en0Tags)
+
+	lo0Tags := []string{"device:lo0", "device_name:lo0"}
+	mockSender.AssertNotCalled(t, "Rate", "system.net.bytes_rcvd", float64(18), "", lo0Tags)
+	mockSender.AssertNotCalled(t, "Rate", "system.net.bytes_sent", float64(19), "", lo0Tags)
+}
+
+func TestExcludedInterfacesRe(t *testing.T) {
+	netStats := &fakeNetworkStats{
+		counterStats: []net.IOCountersStat{
+			{Name: "en0", BytesRecv: 10, BytesSent: 11},
+			{Name: "en1", BytesRecv: 18, BytesSent: 19},
+			{Name: "lo0", BytesRecv: 26, BytesSent: 27},
+		},
+	}
+
+	networkCheck := createTestNetworkCheck(netStats)
+
+	rawInstanceConfig := []byte(`
+excluded_interface_re: "en[0-9]"
+`)
+
+	mockSender := mocksender.NewMockSender(t, networkCheck.ID())
+	err := networkCheck.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test", "provider")
+	assert.Nil(t, err)
+
+	mockSender.On("Rate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("Commit").Return()
+
+	err = networkCheck.Run()
+	assert.Nil(t, err)
+
+	en0Tags := []string{"device:en0", "device_name:en0"}
+	mockSender.AssertNotCalled(t, "Rate", "system.net.bytes_rcvd", float64(10), "", en0Tags)
+
+	en1Tags := []string{"device:en1", "device_name:en1"}
+	mockSender.AssertNotCalled(t, "Rate", "system.net.bytes_rcvd", float64(18), "", en1Tags)
+
+	lo0Tags := []string{"device:lo0", "device_name:lo0"}
+	mockSender.AssertCalled(t, "Rate", "system.net.bytes_rcvd", float64(26), "", lo0Tags)
+	mockSender.AssertCalled(t, "Rate", "system.net.bytes_sent", float64(27), "", lo0Tags)
+}

--- a/pkg/collector/corechecks/net/networkv2/stub.go
+++ b/pkg/collector/corechecks/net/networkv2/stub.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux && !windows
+//go:build !linux && !windows && !aix
 
 // Package networkv2 provides a check for network connection and socket statistics
 package networkv2

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -9566,6 +9566,7 @@ properties:
         platform_default:
           linux: true
           windows: true
+          aix: true
           other: false
     tags:
     - full-agent-only:true
@@ -10533,6 +10534,7 @@ properties:
     platform_default:
       linux: true
       windows: true
+      aix: true
       other: false
     tags:
     - full-agent-only:true

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -85,11 +85,13 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("use_networkv2_check", getPlatformDefault(map[string]interface{}{
 		"linux":   true,
 		"windows": true,
+		"aix":     true,
 		"other":   false,
 	}))
 	config.BindEnvAndSetDefault("network_check.use_core_loader", getPlatformDefault(map[string]interface{}{
 		"linux":   true,
 		"windows": true,
+		"aix":     true,
 		"other":   false,
 	}))
 


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Adds AIX support to the v2 Go network check (`networkv2`), building on top of the common `network.go` / `network_linux.go` / `network_windows.go` split (#54509, merged). Switches AIX to use v2 by default instead of v1.

### Motivation

AIX currently runs the v1 network check. Moving it to v2 lets us eventually drop v1 entirely.

### Describe how you validated your changes

On real AIX hardware: `go build`/`go vet` clean, and a throwaway comparison test confirmed this v2 check emits metrics identical to v1 (46/46 matching name/tags/value).

### Additional Notes

Rebased on top of the now-merged `networkv2` common-file refactor (#54509).