### PR TITLE
Fix `TestStopDrainsBeforeFlush` flakiness

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -800,6 +800,7 @@ func (agg *BufferedAggregator) run() {
 		select {
 		case <-agg.stopChan:
 			log.Info("Stopping aggregator")
+			agg.health.Deregister() //nolint:errcheck
 			return
 		case trigger := <-agg.flushChan:
 			agg.Flush(trigger)

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -107,6 +108,10 @@ func (f *countingForwarder) SubmitSketchSeries(_ transaction.BytesPayloads, _ ht
 // flush before the sample is incorporated — a race that drops ~50% of samples
 // in practice. 100 iterations exercise that race.
 func TestStopDrainsBeforeFlush(t *testing.T) {
+	synctest.Test(t, testStopDrainsBeforeFlush)
+}
+
+func testStopDrainsBeforeFlush(t *testing.T) {
 	mockConfig := configmock.New(t)
 	pkgconfigsetup.LoadDatadog(mockConfig, secretsmock.New(t), delegatedauthmock.New(t), nil)
 	// Gate Stop()'s per-worker sample drain (and the incomplete-bucket flush),


### PR DESCRIPTION
### What does this PR do?
Scope `TestStopDrainsBeforeFlush`'s whole 100-iteration loop to a single `synctest.Test` "bubble".

Deregister `BufferedAggregator`'s health check handle when its run loop stops.

### Motivation
Running `gotestsum` through `bazel` (tighter scheduling) strengthens the following flake:
```
   FAIL   pkg/serverless/metrics :: TestStopDrainsBeforeFlush
         Not equal: expected: 100, actual: 99
         every AddEnhancedMetric followed by Stop() must produce
         exactly one sketch flush
```
It turns out Datadog's flaky test tracker classifies it as [active](https://app.datadoghq.com/ci/test/flaky?query=fingerprint_fqn%3A60e9b51ef57d69be).

The test indeed calls `AgentDemultiplexer.Stop()` 100 times back to back, each gated by a single `aggregator_stop_timeout` (2s default) shared across draining every worker's `samplesChan` and sending the `flush` trigger.

Under CI contention (`-race`, parallel jobs) that budget can occasionally run out mid-drain, silently skipping the flush and undercounting the expected sketch count by one.

`synctest` scopes that timeout's context to a fake clock instead of the wall clock, so it can only expire from a genuine deadlock, never from real scheduling delays.

That surfaced a separate, dormant bug: `BufferedAggregator` registers a liveness health check but never deregisters it on `Stop()`, so its handle, and `catalog.run()`'s goroutine, never exit.

In production this only leaks for the brief window between `Stop()` (called once, from the demultiplexer's `OnStop` hook) and process exit, misreporting the aggregator as unhealthy instead of gone.

In the test, creating and stopping 100 demuxes in one process turned that one-shot gap into a goroutine `synctest` refuses to leave running, so it had to be fixed for the bubble to close cleanly.

### Describe how you validated your changes
With the drain barrier temporarily disabled, the `synctest` version fails reliably (94-99 out of 100 sketches across several runs).

Restored,
`dda inv test --targets=./pkg/serverless/metrics,./pkg/aggregator --race` passes all 236 tests, and 20 repeated runs of `TestStopDrainsBeforeFlush` alone pass cleanly.

Wall-clock under `-race`, isolated by swapping just these two files against the pre-fix baseline, steady state over several runs: ~11.5s before and after moving the whole test in one bubble.

### Additional Notes
The `nolint:errcheck` on `Deregister()` matches existing precedent in `jmxfetch.go` and `admission/server.go`, where the same shutdown-time deregister error is intentionally ignored (best-effort).