### PR TITLE
[Backport 7.82.x] [incident-58605] Remove http status code tag from e2e check assertion

### DIFF
--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -249,7 +249,6 @@ func (suite *eksSuite) TestNginxFargate() {
 		Expect: testMetricExpectArgs{
 			Tags: &[]string{
 				`^cluster_name:`,
-				`^http_status_code:200$`,
 				`^instance:My_Nginx$`,
 				`^kube_cluster_name:`,
 				"^kube_distribution:eks$",

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -760,7 +760,6 @@ func (suite *k8sSuite) TestNginx() {
 		Expect: testMetricExpectArgs{
 			Tags: suite.testClusterTags([]string{
 				`^cluster_name:`,
-				`^http_status_code:200$`,
 				`^instance:My_Nginx$`,
 				`^kube_cluster_name:`,
 				`^orch_cluster_id:`,


### PR DESCRIPTION
Backport `a69543d15fb91502f8d41037a96ba89c72e31e7f` from #54313.

### What does this PR do?

Removes the obsolete `http_status_code:200` expectation from the Kubernetes and EKS container E2E tests for `network.http.response_time` while retaining the remaining metric and tag assertions.

### Motivation

Backport the incident-58605 fix to `7.82.x`. The bundled http_check no longer emits `http_status_code` by default, so the old expectation causes the container E2E tests to fail.

### Describe how you validated your changes

- `dda inv test --targets=./test/new-e2e/tests/containers --extra-args='-run=TestAssertTags'`
- `git diff --check origin/7.82.x..HEAD`
- Repository pre-commit and pre-push checks passed.
