### PR TITLE
[pkg/opentelemetry-mapping-go] Map UCUM "{datapoint}" to the "item" unit

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/attributes/units.go
+++ b/pkg/opentelemetry-mapping-go/otlp/attributes/units.go
@@ -24,7 +24,8 @@ func NewUnitMapper() *UnitMapper {
 //
 // The mapping works as follows:
 //  1. Rate units are split and each component is mapped separately.
-//  2. Annotations are mapped verbatim if they are recognized by Datadog.
+//  2. Annotations are mapped verbatim if Datadog recognizes them, or to their
+//     Datadog name if they are a known alias.
 //  3. For non-annotations, prefixes are stripped and the base unit is mapped.
 //     We validate if the prefix-unit combination is a valid Datadog unit.
 func (*UnitMapper) Map(unit string) (string, bool) {
@@ -173,11 +174,19 @@ var allowedAnnotations = map[string]struct{}{
 	"write":             {},
 }
 
+// annotationAliases maps UCUM annotations to the different name Datadog uses for them.
+var annotationAliases = map[string]string{
+	"datapoint": "item",
+}
+
 // mapUCUMComponent to its Datadog equivalent.
 func mapUCUMComponent(component string) (string, bool) {
-	// Map annotation "{x}" to "x" if it is an allowed annotation.
+	// Map annotation "{x}" to its Datadog unit name.
 	if strings.HasPrefix(component, "{") && strings.HasSuffix(component, "}") {
 		annotation := component[1 : len(component)-1]
+		if datadogUnit, aliased := annotationAliases[annotation]; aliased {
+			return datadogUnit, true
+		}
 		if _, allowed := allowedAnnotations[annotation]; allowed {
 			return annotation, true
 		}

--- a/pkg/opentelemetry-mapping-go/otlp/attributes/units_fuzz_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/attributes/units_fuzz_test.go
@@ -74,7 +74,7 @@ func FuzzUnitMapperMap(f *testing.F) {
 		"%", "Cel", "Hz", "MHz", "W", "V", "J",
 		"By/s", "GiBy/h", "{cpu}", "{connection}", "kBy", "EiBy",
 		"dBy", "ps", "dW", "dCel", "furlong", "By/furlong",
-		"{}", "By//s", "By/s/s", "W.h", "By{transmitted}", "{pod}",
+		"{}", "By//s", "By/s/s", "W.h", "By{transmitted}", "{pod}", "{datapoint}",
 	}
 	for _, seed := range seeds {
 		f.Add(seed)

--- a/pkg/opentelemetry-mapping-go/otlp/attributes/units_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/attributes/units_test.go
@@ -40,6 +40,10 @@ func TestUnitMapperMap(t *testing.T) {
 		{"{cpu}", "cpu", true},
 		{"{connection}", "connection", true},
 		{"{pod}", "", false},
+		// Annotation aliases.
+		{"{datapoint}", "item", true},
+		{"{datapoint}/s", "item/second", true},
+		{"{item}", "item", true},
 		// Prefix/base decomposition that resolves to units.
 		{"kBy", "kilobyte", true},
 		{"EBy", "exabyte", true},


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Maps `{datapoint}` to `item`.

### Motivation

The OpenTelemetry Collector internal metrics use the `{datapoint}` annotation to count metric data points. Datadog has no such unit, the closest would be item, so I am mapping it to that.

### Describe how you validated your changes

End to end validation against personal org.

### Additional Notes

This does not have a changelog note yet since it is an experimental feature.

Relates to https://datadoghq.atlassian.net/browse/OTEL-3175