### PR TITLE
[ACIX-1926] chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/add-dependabot-pr-to-mq.yml
+++ b/.github/workflows/add-dependabot-pr-to-mq.yml
@@ -23,7 +23,7 @@ jobs:
           scope: DataDog/datadog-agent
           policy: self.add-dependabot-pr-to-mq.comment-pr
       - name: Check if the PR is mergeable
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: check-mergeable
         with:
           github-token: ${{ steps.octo-sts.outputs.token }}
@@ -51,7 +51,7 @@ jobs:
           result-encoding: string
       - name: Add Merge Comment to Pull Request
         if: ${{ steps.check-mergeable.outputs.result == 'true' }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.octo-sts.outputs.token }}
           script: |

--- a/.github/workflows/add-label-pr.yml
+++ b/.github/workflows/add-label-pr.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           features: legacy-tasks
       - name: Add the internal label
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.octo-sts.outputs.token }}
           script: |

--- a/.github/workflows/agenttelemetry-metric-reminder.yml
+++ b/.github/workflows/agenttelemetry-metric-reminder.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.triggering_actor != 'dd-devflow[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const marker = '<!-- coat-metric-reminder -->';

--- a/.github/workflows/check-issue-status.yml
+++ b/.github/workflows/check-issue-status.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Check if the latest comment is from a datadog member
         id: datadog-comment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.octo-sts.outputs.token }}
           result-encoding: string
@@ -76,7 +76,7 @@ jobs:
             }
       - name: Remove the pending label when issue is commented
         if: steps.datadog-comment.outputs.result == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
@@ -100,7 +100,7 @@ jobs:
             }
       - name: Remove the "waiting on author" label when issue is commented
         if: steps.datadog-comment.outputs.result == 'false'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
@@ -123,7 +123,7 @@ jobs:
               }
             }
       - name: Remove the team/triage label if another team label exists
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.octo-sts.outputs.token }}
           script: |

--- a/.github/workflows/codex-review-draft.yml
+++ b/.github/workflows/codex-review-draft.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/docs-dev.yml
+++ b/.github/workflows/docs-dev.yml
@@ -42,7 +42,7 @@ jobs:
     # build image pinned in .gitlab-ci.yml, so that file changing is the only reason to fetch again.
     - name: Restore fetched documentation content
       id: docs-content
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: .docs-cache
         key: docs-content-${{ hashFiles('.gitlab-ci.yml', 'docs/public/.hooks/inject_variables.py') }}
@@ -50,7 +50,7 @@ jobs:
     # Restoring the most recent results, which `cache` in .lychee.toml tells the checker to keep,
     # means a host that is briefly unreachable does not fail the run.
     - name: Restore link check results
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: .lycheecache
         key: docs-links-${{ github.run_id }}
@@ -71,7 +71,7 @@ jobs:
     # that fails on an unrelated link is exactly when the next one benefits from not fetching again.
     - name: Save fetched documentation content
       if: always() && steps.docs-content.outputs.cache-hit != 'true'
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: .docs-cache
         key: docs-content-${{ hashFiles('.gitlab-ci.yml', 'docs/public/.hooks/inject_variables.py') }}
@@ -80,7 +80,7 @@ jobs:
     # which is what a re-run of it restores.
     - name: Save link check results
       if: always()
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: .lycheecache
         key: docs-links-${{ github.run_id }}

--- a/.github/workflows/go-update-commenter.yml
+++ b/.github/workflows/go-update-commenter.yml
@@ -63,7 +63,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       # and display it
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           # We need to store the output in an environment variable and not use it directly in the createComment,
           # as it will likely not be a valid JS string (eg. if it contains a quote character)

--- a/.github/workflows/report-merged-pr.yml
+++ b/.github/workflows/report-merged-pr.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Get Datadog credentials
         id: dd-sts
-        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75
+        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
         with:
           policy: datadog-agent-report-pr
 

--- a/.github/workflows/update-kubernetes-versions.yml
+++ b/.github/workflows/update-kubernetes-versions.yml
@@ -47,7 +47,7 @@ jobs:
         run: pip install requests==2.33.1 pyyaml==6.0.3 semver==3.0.4
 
       - name: Install kind
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc #v1.14.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           install_only: true
 


### PR DESCRIPTION
Mechanical rewrite of every `uses:` reference to a full-length commit SHA, produced by [pinact](https://github.com/suzuki-shunsuke/pinact). An unpinned reference resolves to a mutable ref, so a compromise of the upstream action becomes code execution in this repository's CI.

The trailing `# vX.Y.Z` comment is what lets Renovate and Dependabot keep these bumped, so please keep it.

**One thing to check:** references that tracked `@main` or `@master` were resolved to the latest stable tag. If any of them floated deliberately and that behaviour was load-bearing here, say so on the PR and we will revert that line.
