### PR TITLE
Update CODEOWNERS for delegatedauth component

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -380,6 +380,7 @@
 /comp/checks @DataDog/agent-runtimes
 /comp/collector @DataDog/agent-runtimes
 /comp/core @DataDog/agent-runtimes
+/comp/core/delegatedauth @DataDog/credential-management
 /comp/dogstatsd @DataDog/agent-metric-pipelines
 /comp/forwarder @DataDog/agent-metric-pipelines
 /comp/healthplatform @DataDog/fleet-remediation
@@ -686,6 +687,7 @@
 /pkg/system-probe/config/adjust_security.go  @DataDog/ebpf-platform @DataDog/agent-security
 /pkg/tagset/                            @DataDog/agent-runtimes
 /pkg/util/                              @DataDog/agent-runtimes
+/pkg/util/aws/creds                     @DataDog/credential-management
 /pkg/util/aggregatingqueue              @DataDog/container-integrations @DataDog/container-platform
 /pkg/util/cloudproviders/cloudfoundry/  @DataDog/agent-integrations
 /pkg/util/clusteragent/                 @DataDog/container-platform

--- a/comp/core/delegatedauth/def/delegatedauth.go
+++ b/comp/core/delegatedauth/def/delegatedauth.go
@@ -16,7 +16,7 @@ import (
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
-// team: core-authn
+// team: credential-management
 
 // InstanceParams configures a single API key instance.
 type InstanceParams struct {


### PR DESCRIPTION
### What does this PR do?
For CODEOWNERS, assign `credential-management` team (which includes `delegated-auth-login` subteam) to the delegatedauth component of the Datadog agent.

Public docs: https://docs.datadoghq.com/account_management/workload_identity_federation/

### Motivation
CODEOWNERS is out of sync with the `// team: ...` comment, and the team comment refers to a team that doesn't exist anymore.

### Describe how you validated your changes
n/a 🚀 
