### PR TITLE
[AAD-23] Fix RRCF detector

### DIFF
--- a/comp/anomalydetection/observer/AGENTS.md
+++ b/comp/anomalydetection/observer/AGENTS.md
@@ -57,13 +57,19 @@ Registered in `impl/component_catalog.go`. Enabled by default unless noted:
 | Extractor | `log_pattern_extractor` | on |
 | Extractor | `connection_error_extractor` | off |
 | Detector | `bocpd` | on |
-| Detector | `rrcf` | on |
-| Detector | `cusum`, `scanmw`, `scanwelch`, `holt_residual`, `tukey_biweight` | off |
+| Detector | `rrcf`, `cusum`, `scanmw`, `scanwelch`, `holt_residual`, `tukey_biweight` | off |
 | Correlator | `time_cluster` | on |
 | Correlator | `cross_signal`, `passthrough` | off |
 | Correlator | `anomaly_scorer` | off |
 
 Toggle detectors/correlators/extractors via `anomaly_detection.detectors.<name>.enabled` in datadog.yaml.
+
+RRCF has two paths: its original multivariate forest analyzes the fixed
+configured system-metric set, while a separate shared forest analyzes scalar
+count shingles from all built-in log-extractor namespaces. The shared log
+forest avoids allocating one forest per dynamically named log pattern; its
+per-series state is limited to incremental cursors and the current shingle
+prefix.
 
 The `anomaly_scorer` correlator has a **dedicated config namespace** under `anomaly_detection.anomaly_scorer.*` (not `detectors.*`) with an `output` sub-section controlling logs and correlation events:
 

--- a/comp/anomalydetection/observer/impl/BUILD.bazel
+++ b/comp/anomalydetection/observer/impl/BUILD.bazel
@@ -94,6 +94,7 @@ dd_agent_go_test(
         "metrics_detector_bocpd_test.go",
         "metrics_detector_cusum_test.go",
         "metrics_detector_holt_residual_test.go",
+        "metrics_detector_rrcf_test.go",
         "metrics_detector_scanmw_test.go",
         "metrics_detector_scanwelch_test.go",
         "metrics_detector_tukey_biweight_test.go",

--- a/comp/anomalydetection/observer/impl/component_catalog.go
+++ b/comp/anomalydetection/observer/impl/component_catalog.go
@@ -186,7 +186,7 @@ func defaultCatalog() *componentCatalog {
 				kind:           componentDetector,
 				defaultConfig:  DefaultRRCFConfig(),
 				factory:        func(cfg any) any { return NewRRCFDetector(cfg.(RRCFConfig)) },
-				defaultEnabled: true,
+				defaultEnabled: false,
 				parseJSON: func(defaults any, raw []byte) (any, error) {
 					cfg := defaults.(RRCFConfig)
 					if err := json.Unmarshal(raw, &cfg); err != nil {
@@ -473,16 +473,6 @@ var statelessDetectorAllowlist = map[string]struct{}{
 	//
 	// Truly-stateless catalog Detectors are listed below.
 
-	// RRCF tracks a FIXED set of metric definitions configured at construction
-	// (RRCFConfig.Metrics, with DefaultRRCFMetrics() as the fallback). Its
-	// resolvedKeys / cursors maps are keyed by cursorKey (a metric definition
-	// identifier), not by ingested SeriesRef — so the map size is bounded by
-	// the configured metrics, not by storage cardinality. Adding storage-eviction
-	// fan-out would not free anything because RRCF state isn't keyed by SeriesRef.
-	// If RRCF is ever extended to track per-tag-combination state keyed by
-	// SeriesRef, this entry must be removed and RRCF must implement
-	// SeriesRemover.
-	"rrcf": {},
 }
 
 // validateDetectorTeardownContract checks that every detector entry in the

--- a/comp/anomalydetection/observer/impl/component_catalog_test.go
+++ b/comp/anomalydetection/observer/impl/component_catalog_test.go
@@ -25,16 +25,6 @@ func TestDefaultCatalog_DetectorTeardownContract(t *testing.T) {
 		"every catalog detector must implement SeriesRemover or be added to statelessDetectorAllowlist with a justification comment")
 }
 
-func TestDefaultCatalogRRCFIsDisabled(t *testing.T) {
-	for _, entry := range defaultCatalog().entries {
-		if entry.name == "rrcf" {
-			require.False(t, entry.defaultEnabled)
-			return
-		}
-	}
-	t.Fatal("rrcf is not registered in the production catalog")
-}
-
 // TestValidateDetectorTeardownContract_FlagsBareDetector confirms the
 // validator rejects a Detector that doesn't implement SeriesRemover and isn't
 // allowlisted — i.e. the check actually fails when it should.

--- a/comp/anomalydetection/observer/impl/component_catalog_test.go
+++ b/comp/anomalydetection/observer/impl/component_catalog_test.go
@@ -25,6 +25,16 @@ func TestDefaultCatalog_DetectorTeardownContract(t *testing.T) {
 		"every catalog detector must implement SeriesRemover or be added to statelessDetectorAllowlist with a justification comment")
 }
 
+func TestDefaultCatalogRRCFIsDisabled(t *testing.T) {
+	for _, entry := range defaultCatalog().entries {
+		if entry.name == "rrcf" {
+			require.False(t, entry.defaultEnabled)
+			return
+		}
+	}
+	t.Fatal("rrcf is not registered in the production catalog")
+}
+
 // TestValidateDetectorTeardownContract_FlagsBareDetector confirms the
 // validator rejects a Detector that doesn't implement SeriesRemover and isn't
 // allowlisted — i.e. the check actually fails when it should.

--- a/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
@@ -15,13 +15,16 @@ import (
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
 
+const maxRRCFLogScoreHistory = 100_000
+
 // RRCFScoredPoint records a CoDisp score at a specific timestamp.
 type RRCFScoredPoint struct {
 	Timestamp int64   `json:"timestamp"`
 	Score     float64 `json:"score"`
 }
 
-// RRCFScoreStats contains distribution statistics and full score history for threshold analysis.
+// RRCFScoreStats contains distribution statistics and retained score history
+// for threshold analysis. Log score history is capped to bound live-agent memory.
 type RRCFScoreStats struct {
 	Enabled       bool              `json:"enabled"`
 	SampleCount   int               `json:"sampleCount"`
@@ -47,6 +50,7 @@ type RRCFConfigSummary struct {
 	TreeSize       int     `json:"treeSize"`
 	ShingleSize    int     `json:"shingleSize"`
 	ShingleDim     int     `json:"shingleDim"`
+	LogShingleDim  int     `json:"logShingleDim"`
 	ThresholdSigma float64 `json:"thresholdSigma"`
 }
 
@@ -102,8 +106,9 @@ func DefaultRRCFMetrics() []RRCFMetricDef {
 	}
 }
 
-// RRCFDetector implements multivariate anomaly detection using Robust Random Cut Forest.
-// It queries multiple system metrics and detects unusual combinations/trajectories.
+// RRCFDetector implements anomaly detection using Robust Random Cut Forest.
+// It uses a multivariate forest for configured system metrics and a separate,
+// bounded forest of scalar count shingles for dynamically named log series.
 type RRCFDetector struct {
 	config RRCFConfig
 	// telemetry is optional and wired by the observer component.
@@ -116,6 +121,10 @@ type RRCFDetector struct {
 	// resolvedKeys caches the numeric series ID for each metric.
 	// Populated lazily on first Detect call via ListSeries discovery.
 	resolvedKeys map[string]observer.SeriesRef
+	// resolveGeneration prevents rescanning the fixed metric set until storage
+	// gains another series. Partial matches are never committed.
+	resolveGeneration uint64
+	resolveAttempted  bool
 
 	// cursors tracks read position per metric for incremental reads.
 	cursors map[string]int64
@@ -136,10 +145,57 @@ type RRCFDetector struct {
 	// alignedCount and shingleCount track pipeline throughput for diagnostics.
 	alignedCount int
 	shingleCount int
+	anomalous    bool
+	// alignedPrefix carries the final ShingleSize-1 aligned vectors across
+	// Detect calls. Without it, one-point streaming advances never build a
+	// shingle even though batch replay does.
+	alignedPrefix []timestampedVector
+
+	// Log-derived series have dynamic names, so they cannot participate in the
+	// fixed metric allowlist above. They share one bounded forest of scalar
+	// temporal shingles. Per-series state only retains the shingle prefix and
+	// incremental read cursor.
+	logForest       *rcForest
+	logSeries       map[observer.SeriesRef]*rrcfLogSeriesState
+	logRefs         []observer.SeriesRef
+	logSeriesGen    uint64
+	logSeriesCached bool
+	logRecentScores []float64
+	logTotalScored  int
+	logScores       []RRCFScoredPoint
+	logScoreStart   int
+	logAlignedCount int
+	logShingleCount int
+}
+
+type rrcfLogSeriesState struct {
+	lastProcessedTime  int64
+	lastProcessedCount int
+	lastWriteGen       int64
+	shinglePrefix      []float64
+	source             observer.SeriesDescriptor
+	anomalous          bool
+}
+
+type rrcfLogShingle struct {
+	shingle
+	ref    observer.SeriesRef
+	source observer.SeriesDescriptor
 }
 
 // NewRRCFDetector creates an RRCF detector with the given config.
 func NewRRCFDetector(config RRCFConfig) *RRCFDetector {
+	defaults := DefaultRRCFConfig()
+	if config.NumTrees <= 0 {
+		config.NumTrees = defaults.NumTrees
+	}
+	if config.TreeSize <= 0 {
+		config.TreeSize = defaults.TreeSize
+	}
+	if config.ShingleSize <= 0 {
+		config.ShingleSize = defaults.ShingleSize
+	}
+
 	metrics := config.Metrics
 	if len(metrics) == 0 {
 		metrics = DefaultRRCFMetrics()
@@ -160,6 +216,9 @@ func NewRRCFDetector(config RRCFConfig) *RRCFDetector {
 		forest:       forest,
 		recentScores: make([]float64, 0, 100),
 		allScores:    make([]RRCFScoredPoint, 0, 1024),
+		logForest:    newRCForest(config.NumTrees, config.TreeSize, config.ShingleSize, 43),
+		logSeries:    make(map[observer.SeriesRef]*rrcfLogSeriesState),
+		logScores:    make([]RRCFScoredPoint, 0, 1024),
 	}
 }
 
@@ -173,14 +232,22 @@ func (r *RRCFDetector) SetObserverTelemetry(t *observerTelemetry) {
 	r.telemetry = t
 }
 
-// Detect implements Detector. It queries storage for system metrics,
-// builds multivariate shingles, and detects anomalies using RRCF.
+// Detect implements Detector. It analyzes both configured system metrics and
+// dynamically named count series emitted by log extractors.
 func (r *RRCFDetector) Detect(storage observer.StorageReader, dataTime int64) observer.DetectionResult {
+	var result observer.DetectionResult
+
 	// Step 0: Resolve all metric keys to the same tag set (on first call)
-	if !r.resolveAllKeys(storage) {
-		return observer.DetectionResult{}
+	if r.resolveAllKeys(storage) {
+		result = r.detectConfiguredMetrics(storage, dataTime)
 	}
 
+	logResult := r.detectLogSeries(storage, dataTime)
+	result.Anomalies = append(result.Anomalies, logResult.Anomalies...)
+	return result
+}
+
+func (r *RRCFDetector) detectConfiguredMetrics(storage observer.StorageReader, dataTime int64) observer.DetectionResult {
 	// Step 1: Read new points for each metric since last cursor
 	newPointsByMetric := r.readNewPoints(storage, dataTime)
 	if len(newPointsByMetric) == 0 {
@@ -224,16 +291,29 @@ func (r *RRCFDetector) resolveAllKeys(storage observer.StorageReader) bool {
 		return true // already resolved
 	}
 
-	// For each metric, collect all matching series grouped by tag string
+	generation := storage.SeriesGeneration()
+	if r.resolveAttempted && r.resolveGeneration == generation {
+		return false
+	}
+	r.resolveAttempted = true
+	r.resolveGeneration = generation
+
+	// Collect all configured metrics with one catalog scan per namespace.
+	// The default seven-metric set shares a namespace, so this avoids seven
+	// large ListSeries result allocations whenever resolution is retried.
 	seriesByMetric := make(map[string][]observer.SeriesMeta) // cursorKey -> all matching series
+	metricKeysByNamespace := make(map[string]map[string]string)
 	for _, m := range r.metrics {
 		cursorKey := m.Namespace + "|" + m.Name
-		matches := storage.ListSeries(observer.SeriesFilter{
-			Namespace:   m.Namespace,
-			NamePattern: m.Name,
-		})
+		if metricKeysByNamespace[m.Namespace] == nil {
+			metricKeysByNamespace[m.Namespace] = make(map[string]string)
+		}
+		metricKeysByNamespace[m.Namespace][m.Name] = cursorKey
+	}
+	for namespace, metricKeys := range metricKeysByNamespace {
+		matches := storage.ListSeries(observer.SeriesFilter{Namespace: namespace})
 		for _, meta := range matches {
-			if meta.Name == m.Name {
+			if cursorKey, ok := metricKeys[meta.Name]; ok {
 				seriesByMetric[cursorKey] = append(seriesByMetric[cursorKey], meta)
 			}
 		}
@@ -287,6 +367,7 @@ func (r *RRCFDetector) resolveAllKeys(storage observer.StorageReader) bool {
 
 	if bestMetricCount < numMetrics {
 		log.Printf("  RRCF WARNING: only %d/%d configured metrics found (tags=%s); alignment requires all metrics so no vectors will be produced until the missing metrics appear\n", bestMetricCount, numMetrics, bestSig)
+		return false
 	}
 	log.Printf("  RRCF: resolved %d metrics to tag set with %d total points\n", bestMetricCount, bestPointCount)
 
@@ -321,6 +402,205 @@ func (r *RRCFDetector) readNewPoints(storage observer.StorageReader, dataTime in
 	}
 
 	return result
+}
+
+func (r *RRCFDetector) detectLogSeries(storage observer.StorageReader, dataTime int64) observer.DetectionResult {
+	r.refreshLogSeries(storage)
+	if len(r.logRefs) == 0 {
+		return observer.DetectionResult{}
+	}
+
+	shingles, rebuild := r.collectLogShingles(storage, dataTime, false)
+	if rebuild {
+		r.resetLogDetection()
+		shingles, _ = r.collectLogShingles(storage, dataTime, true)
+	}
+	if len(shingles) == 0 {
+		return observer.DetectionResult{}
+	}
+
+	sort.Slice(shingles, func(i, j int) bool {
+		if shingles[i].endTimestamp != shingles[j].endTimestamp {
+			return shingles[i].endTimestamp < shingles[j].endTimestamp
+		}
+		return shingles[i].ref < shingles[j].ref
+	})
+
+	var anomalies []observer.Anomaly
+	for _, item := range shingles {
+		_, score := r.logForest.insertPoint(item.vector)
+		r.logTotalScored++
+		r.appendLogScore(RRCFScoredPoint{
+			Timestamp: item.endTimestamp,
+			Score:     score,
+		})
+		if r.telemetry != nil {
+			r.telemetry.recordRRCFScore(r.Name(), score)
+		}
+
+		if r.logTotalScored <= r.config.TreeSize {
+			continue
+		}
+
+		threshold, ready := rrcfDynamicThreshold(r.logRecentScores, r.config.ThresholdSigma)
+		baselineMean := rrcfMean(r.logRecentScores)
+		baselineStddev := rrcfStddev(r.logRecentScores, baselineMean)
+		if ready && r.telemetry != nil {
+			r.telemetry.recordRRCFThreshold(r.Name(), threshold)
+		}
+
+		r.logRecentScores = appendRRCFScore(r.logRecentScores, score)
+		state := r.logSeries[item.ref]
+		if !rrcfShouldEmitAnomaly(&state.anomalous, r.config.ThresholdSigma > 0, ready, score, threshold) {
+			continue
+		}
+
+		anomalyScore := score
+		anomalies = append(anomalies, observer.Anomaly{
+			Source:       item.source,
+			SourceRef:    &observer.QueryHandle{Ref: item.ref, Aggregate: observer.AggregateCount},
+			DetectorName: r.Name(),
+			Title:        "RRCF log-count anomaly",
+			Description:  fmt.Sprintf("Unusual log count trajectory (CoDisp=%.1f, threshold=%.1f)", score, threshold),
+			Timestamp:    item.endTimestamp,
+			Score:        &anomalyScore,
+			DebugInfo: &observer.AnomalyDebugInfo{
+				CurrentValue:   score,
+				Threshold:      threshold,
+				DeviationSigma: (score - baselineMean) / math.Max(baselineStddev, 1),
+			},
+		})
+	}
+
+	return observer.DetectionResult{Anomalies: anomalies}
+}
+
+func (r *RRCFDetector) appendLogScore(score RRCFScoredPoint) {
+	if len(r.logScores) < maxRRCFLogScoreHistory {
+		r.logScores = append(r.logScores, score)
+		return
+	}
+	r.logScores[r.logScoreStart] = score
+	r.logScoreStart = (r.logScoreStart + 1) % len(r.logScores)
+}
+
+func (r *RRCFDetector) orderedLogScores() []RRCFScoredPoint {
+	if len(r.logScores) < maxRRCFLogScoreHistory || r.logScoreStart == 0 {
+		return r.logScores
+	}
+	scores := make([]RRCFScoredPoint, 0, len(r.logScores))
+	scores = append(scores, r.logScores[r.logScoreStart:]...)
+	scores = append(scores, r.logScores[:r.logScoreStart]...)
+	return scores
+}
+
+func (r *RRCFDetector) refreshLogSeries(storage observer.StorageReader) {
+	generation := storage.SeriesGeneration()
+	if r.logSeriesCached && r.logSeriesGen == generation {
+		return
+	}
+
+	r.logRefs = r.logRefs[:0]
+	for _, meta := range storage.ListSeries(observer.WorkloadSeriesFilter()) {
+		if isLogDerivedNamespace(meta.Namespace) {
+			r.logRefs = append(r.logRefs, meta.Ref)
+		}
+	}
+	sort.Slice(r.logRefs, func(i, j int) bool { return r.logRefs[i] < r.logRefs[j] })
+	r.logSeriesGen = generation
+	r.logSeriesCached = true
+}
+
+func isLogDerivedNamespace(namespace string) bool {
+	switch namespace {
+	case LogMetricsExtractorName, LogPatternExtractorName, "connection_error_extractor":
+		return true
+	default:
+		return false
+	}
+}
+
+// collectLogShingles incrementally builds scalar temporal shingles for every
+// log-derived series. The forest is shared across series to keep memory bounded:
+// each shingle still carries its source identity for anomaly attribution.
+//
+// A same-bucket merge or out-of-order backfill invalidates an incremental
+// prefix. The caller then resets the shared log forest and rebuilds all visible
+// log series, preserving batch/replay equivalence.
+func (r *RRCFDetector) collectLogShingles(storage observer.StorageReader, dataTime int64, forceRebuild bool) ([]rrcfLogShingle, bool) {
+	var result []rrcfLogShingle
+
+	for _, ref := range r.logRefs {
+		visibleCount := storage.PointCountUpTo(ref, dataTime)
+		writeGen := storage.WriteGeneration(ref)
+		state := r.logSeries[ref]
+
+		var start int64
+		if state != nil && !forceRebuild {
+			if state.lastProcessedCount == visibleCount && state.lastWriteGen == writeGen {
+				continue
+			}
+			start = state.lastProcessedTime
+		}
+
+		series := storage.GetSeriesRange(ref, start, dataTime, observer.AggregateCount)
+		if series == nil {
+			continue
+		}
+
+		if state != nil && !forceRebuild {
+			expectedNewPoints := visibleCount - state.lastProcessedCount
+			sameBucketChanged := expectedNewPoints == 0 && state.lastWriteGen != writeGen
+			if expectedNewPoints < 0 || sameBucketChanged || len(series.Points) != expectedNewPoints {
+				return nil, true
+			}
+		}
+
+		if state == nil || forceRebuild {
+			state = &rrcfLogSeriesState{
+				shinglePrefix: make([]float64, 0, r.config.ShingleSize),
+			}
+			r.logSeries[ref] = state
+		}
+		state.source = observer.SeriesDescriptor{
+			Namespace: series.Namespace,
+			Name:      series.Name,
+			Tags:      series.Tags,
+			Aggregate: observer.AggregateCount,
+		}
+
+		for _, point := range series.Points {
+			state.shinglePrefix = append(state.shinglePrefix, point.Value)
+			if len(state.shinglePrefix) > r.config.ShingleSize {
+				copy(state.shinglePrefix, state.shinglePrefix[1:])
+				state.shinglePrefix = state.shinglePrefix[:r.config.ShingleSize]
+			}
+			if len(state.shinglePrefix) < r.config.ShingleSize {
+				continue
+			}
+
+			vector := make([]float64, len(state.shinglePrefix))
+			copy(vector, state.shinglePrefix)
+			result = append(result, rrcfLogShingle{
+				shingle: shingle{
+					endTimestamp: point.Timestamp,
+					vector:       vector,
+				},
+				ref:    ref,
+				source: state.source,
+			})
+		}
+
+		r.logAlignedCount += len(series.Points)
+		state.lastProcessedCount = visibleCount
+		state.lastWriteGen = writeGen
+		if len(series.Points) > 0 {
+			state.lastProcessedTime = series.Points[len(series.Points)-1].Timestamp
+		}
+	}
+
+	r.logShingleCount += len(result)
+	return result, false
 }
 
 // timestampedVector represents a multivariate point at a specific timestamp.
@@ -397,7 +677,18 @@ type shingle struct {
 // buildShingles creates shingles by combining consecutive aligned points.
 // A shingle of size 4 with 7 metrics produces a 28-dimensional vector.
 func (r *RRCFDetector) buildShingles(aligned []timestampedVector) []shingle {
-	if len(aligned) < r.config.ShingleSize {
+	combined := make([]timestampedVector, 0, len(r.alignedPrefix)+len(aligned))
+	combined = append(combined, r.alignedPrefix...)
+	combined = append(combined, aligned...)
+
+	prefixLen := len(r.alignedPrefix)
+	keep := r.config.ShingleSize - 1
+	if keep > len(combined) {
+		keep = len(combined)
+	}
+	r.alignedPrefix = append(r.alignedPrefix[:0], combined[len(combined)-keep:]...)
+
+	if len(combined) < r.config.ShingleSize {
 		return nil
 	}
 
@@ -406,17 +697,22 @@ func (r *RRCFDetector) buildShingles(aligned []timestampedVector) []shingle {
 
 	var result []shingle
 
-	// Sliding window over aligned points
-	for i := r.config.ShingleSize - 1; i < len(aligned); i++ {
+	// Sliding window over aligned points. Only emit shingles whose final point
+	// came from this Detect call; prefix-only shingles were already scored.
+	firstEnd := r.config.ShingleSize - 1
+	if prefixLen > firstEnd {
+		firstEnd = prefixLen
+	}
+	for i := firstEnd; i < len(combined); i++ {
 		vec := make([]float64, 0, shingleDim)
 
 		// Concatenate values from ShingleSize consecutive points
 		for j := i - r.config.ShingleSize + 1; j <= i; j++ {
-			vec = append(vec, aligned[j].values...)
+			vec = append(vec, combined[j].values...)
 		}
 
 		result = append(result, shingle{
-			endTimestamp: aligned[i].timestamp,
+			endTimestamp: combined[i].timestamp,
 			vector:       vec,
 		})
 	}
@@ -450,29 +746,30 @@ func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.Dete
 		}
 
 		// Compute dynamic threshold from recent scores
-		threshold := r.dynamicThreshold()
-		if threshold > 0 && r.telemetry != nil {
+		threshold, ready := rrcfDynamicThreshold(r.recentScores, r.config.ThresholdSigma)
+		baselineMean := r.rollingMean()
+		baselineStddev := r.rollingStddev()
+		if ready && r.telemetry != nil {
 			r.telemetry.recordRRCFThreshold(r.Name(), threshold)
 		}
 
 		// Update rolling window (after computing threshold, so current score
 		// doesn't influence its own threshold)
-		r.recentScores = append(r.recentScores, score)
-		if len(r.recentScores) > 100 {
-			r.recentScores = r.recentScores[1:]
-		}
+		r.recentScores = appendRRCFScore(r.recentScores, score)
 
-		if r.config.ThresholdSigma > 0 && threshold > 0 && score > threshold {
+		if rrcfShouldEmitAnomaly(&r.anomalous, r.config.ThresholdSigma > 0, ready, score, threshold) {
+			anomalyScore := score
 			anomaly := observer.Anomaly{
 				Source:       observer.SeriesDescriptor{Namespace: "rrcf", Name: "score"},
 				DetectorName: r.Name(),
 				Title:        "RRCF multivariate anomaly",
 				Description:  fmt.Sprintf("Unusual system metric combination (CoDisp=%.1f, threshold=%.1f)", score, threshold),
 				Timestamp:    s.endTimestamp,
+				Score:        &anomalyScore,
 				DebugInfo: &observer.AnomalyDebugInfo{
 					CurrentValue:   score,
 					Threshold:      threshold,
-					DeviationSigma: (score - r.rollingMean()) / math.Max(r.rollingStddev(), 1),
+					DeviationSigma: (score - baselineMean) / math.Max(baselineStddev, 1),
 				},
 			}
 			anomalies = append(anomalies, anomaly)
@@ -484,37 +781,68 @@ func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.Dete
 	}
 }
 
-// dynamicThreshold returns mean + ThresholdSigma*stddev of the recent score window.
-func (r *RRCFDetector) dynamicThreshold() float64 {
-	if len(r.recentScores) < 10 {
-		return 0 // not enough data yet
-	}
-	return r.rollingMean() + r.config.ThresholdSigma*r.rollingStddev()
+func (r *RRCFDetector) rollingMean() float64 {
+	return rrcfMean(r.recentScores)
 }
 
-func (r *RRCFDetector) rollingMean() float64 {
-	if len(r.recentScores) == 0 {
-		return 0
-	}
+func rrcfMean(scores []float64) float64 {
 	sum := 0.0
-	for _, v := range r.recentScores {
+	for _, v := range scores {
 		sum += v
 	}
-	return sum / float64(len(r.recentScores))
+	if len(scores) == 0 {
+		return 0
+	}
+	return sum / float64(len(scores))
 }
 
 func (r *RRCFDetector) rollingStddev() float64 {
-	n := len(r.recentScores)
+	return rrcfStddev(r.recentScores, r.rollingMean())
+}
+
+func rrcfStddev(scores []float64, mean float64) float64 {
+	n := len(scores)
 	if n < 2 {
 		return 0
 	}
-	mean := r.rollingMean()
 	sumSq := 0.0
-	for _, v := range r.recentScores {
+	for _, v := range scores {
 		d := v - mean
 		sumSq += d * d
 	}
 	return math.Sqrt(sumSq / float64(n))
+}
+
+func rrcfDynamicThreshold(scores []float64, thresholdSigma float64) (float64, bool) {
+	if len(scores) < 10 {
+		return 0, false
+	}
+	mean := rrcfMean(scores)
+	return mean + thresholdSigma*rrcfStddev(scores, mean), true
+}
+
+func appendRRCFScore(scores []float64, score float64) []float64 {
+	scores = append(scores, score)
+	if len(scores) > 100 {
+		copy(scores, scores[len(scores)-100:])
+		scores = scores[:100]
+	}
+	return scores
+}
+
+// rrcfShouldEmitAnomaly reports only the transition into an anomalous state.
+// Continued above-threshold scores belong to the same episode and are
+// suppressed until a normal score resets the state.
+func rrcfShouldEmitAnomaly(anomalous *bool, enabled, ready bool, score, threshold float64) bool {
+	if !enabled || !ready || score <= threshold {
+		*anomalous = false
+		return false
+	}
+	if *anomalous {
+		return false
+	}
+	*anomalous = true
+	return true
 }
 
 // scoreShingle computes the CoDisp (collusive displacement) score for a shingle.
@@ -527,14 +855,63 @@ func (r *RRCFDetector) scoreShingle(s shingle) float64 {
 
 // Reset clears all state, useful for testing or after major regime changes.
 func (r *RRCFDetector) Reset() {
+	r.resetConfiguredMetricDetection()
+	r.logRefs = nil
+	r.logSeriesGen = 0
+	r.logSeriesCached = false
+	r.resetLogDetection()
+}
+
+func (r *RRCFDetector) resetConfiguredMetricDetection() {
 	r.resolvedKeys = make(map[string]observer.SeriesRef)
+	r.resolveAttempted = false
+	r.resolveGeneration = 0
 	r.cursors = make(map[string]int64)
 	r.recentScores = r.recentScores[:0]
 	r.allScores = r.allScores[:0]
 	r.totalScored = 0
 	r.alignedCount = 0
 	r.shingleCount = 0
+	r.anomalous = false
+	r.alignedPrefix = nil
 	r.forest.reset()
+}
+
+func (r *RRCFDetector) resetLogDetection() {
+	r.logSeries = make(map[observer.SeriesRef]*rrcfLogSeriesState)
+	r.logRecentScores = r.logRecentScores[:0]
+	r.logScores = r.logScores[:0]
+	r.logScoreStart = 0
+	r.logTotalScored = 0
+	r.logAlignedCount = 0
+	r.logShingleCount = 0
+	r.logForest.reset()
+}
+
+// RemoveSeries drops state for series evicted from storage. Removing any
+// configured metric invalidates the whole multivariate pipeline because its
+// forest and shingles combine every configured input. Log-series state is
+// independent; only states for the removed refs are discarded, while their
+// historical shingles remain in the bounded shared forest until FIFO eviction.
+func (r *RRCFDetector) RemoveSeries(refs []observer.SeriesRef) {
+	configuredMetricRemoved := false
+	for _, ref := range refs {
+		delete(r.logSeries, ref)
+		if configuredMetricRemoved {
+			continue
+		}
+		for _, resolvedRef := range r.resolvedKeys {
+			if ref == resolvedRef {
+				configuredMetricRemoved = true
+				break
+			}
+		}
+	}
+	if configuredMetricRemoved {
+		r.resetConfiguredMetricDetection()
+	}
+	r.logRefs = nil
+	r.logSeriesCached = false
 }
 
 // GetExtraData implements ComponentDataProvider, exposing score stats via /api/components/rrcf/data.
@@ -542,35 +919,52 @@ func (r *RRCFDetector) GetExtraData() interface{} {
 	return r.GetScoreStats()
 }
 
-// GetScoreStats returns distribution statistics and full score history.
+// GetScoreStats returns distribution statistics and retained score history.
 func (r *RRCFDetector) GetScoreStats() RRCFScoreStats {
+	logScores := r.orderedLogScores()
+	scores := make([]RRCFScoredPoint, 0, len(r.allScores)+len(logScores))
+	scores = append(scores, r.allScores...)
+	scores = append(scores, logScores...)
+	sort.Slice(scores, func(i, j int) bool {
+		if scores[i].Timestamp != scores[j].Timestamp {
+			return scores[i].Timestamp < scores[j].Timestamp
+		}
+		return scores[i].Score < scores[j].Score
+	})
+
 	stats := RRCFScoreStats{
 		Enabled:       true,
-		SampleCount:   len(r.allScores),
-		AlignedPoints: r.alignedCount,
-		ShinglesBuilt: r.shingleCount,
+		SampleCount:   len(scores),
+		AlignedPoints: r.alignedCount + r.logAlignedCount,
+		ShinglesBuilt: r.shingleCount + r.logShingleCount,
 		Config: RRCFConfigSummary{
 			NumTrees:       r.config.NumTrees,
 			TreeSize:       r.config.TreeSize,
 			ShingleSize:    r.config.ShingleSize,
 			ShingleDim:     r.config.ShingleSize * len(r.metrics),
+			LogShingleDim:  r.config.ShingleSize,
 			ThresholdSigma: r.config.ThresholdSigma,
 		},
-		Scores: r.allScores,
+		Scores: scores,
 	}
 
 	for _, m := range r.metrics {
 		stats.Metrics = append(stats.Metrics, m.Namespace+"|"+m.Name)
 	}
+	for _, ref := range r.logRefs {
+		if state := r.logSeries[ref]; state != nil && state.source.Name != "" {
+			stats.Metrics = append(stats.Metrics, state.source.Key())
+		}
+	}
 
-	if len(r.allScores) == 0 {
+	if len(scores) == 0 {
 		return stats
 	}
 
 	// Compute distribution stats
-	sorted := make([]float64, len(r.allScores))
+	sorted := make([]float64, len(scores))
 	sum := 0.0
-	for i, sp := range r.allScores {
+	for i, sp := range scores {
 		sorted[i] = sp.Score
 		sum += sp.Score
 	}

--- a/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
@@ -171,6 +171,7 @@ type RRCFDetector struct {
 type rrcfLogSeriesState struct {
 	lastProcessedTime  int64
 	lastProcessedCount int
+	lastVisibleSamples float64
 	lastWriteGen       int64
 	shinglePrefix      []float64
 	source             observer.SeriesDescriptor
@@ -540,6 +541,15 @@ func (r *RRCFDetector) collectLogShingles(storage observer.StorageReader, dataTi
 			if state.lastProcessedCount == visibleCount && state.lastWriteGen == writeGen {
 				continue
 			}
+			if state.lastProcessedCount == visibleCount {
+				visibleSamples := storage.SumRange(ref, 0, dataTime, observer.AggregateCount)
+				if state.lastVisibleSamples == visibleSamples {
+					// WriteGeneration includes points newer than dataTime. Record the
+					// generation without rebuilding when the visible prefix is unchanged.
+					state.lastWriteGen = writeGen
+					continue
+				}
+			}
 			start = state.lastProcessedTime
 		}
 
@@ -575,6 +585,7 @@ func (r *RRCFDetector) collectLogShingles(storage observer.StorageReader, dataTi
 				copy(state.shinglePrefix, state.shinglePrefix[1:])
 				state.shinglePrefix = state.shinglePrefix[:r.config.ShingleSize]
 			}
+			state.lastVisibleSamples += point.Value
 			if len(state.shinglePrefix) < r.config.ShingleSize {
 				continue
 			}

--- a/comp/anomalydetection/observer/impl/metrics_detector_rrcf_test.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_rrcf_test.go
@@ -6,6 +6,7 @@
 package observerimpl
 
 import (
+	"strconv"
 	"testing"
 
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
@@ -197,6 +198,65 @@ func TestRRCFDetector_RemoveSeriesPreservesUnrelatedLogState(t *testing.T) {
 	assert.False(t, detector.logSeriesCached)
 }
 
+func TestRRCFDetector_FutureLogWriteDoesNotReset(t *testing.T) {
+	cfg := DefaultRRCFConfig()
+	cfg.NumTrees = 5
+	cfg.TreeSize = 8
+	cfg.ShingleSize = 2
+	detector := NewRRCFDetector(cfg)
+	storage := newDetectorTestStorage()
+
+	for ts := int64(1); ts <= 8; ts++ {
+		storage.Add(LogPatternExtractorName, "log.pattern.one", 1, ts, nil)
+		storage.Add(LogPatternExtractorName, "log.pattern.two", 1, ts, nil)
+	}
+	detector.Detect(storage, 8)
+	metas := storage.ListSeries(observer.SeriesFilter{Namespace: LogPatternExtractorName})
+	require.Len(t, metas, 2)
+	states := map[observer.SeriesRef]*rrcfLogSeriesState{
+		metas[0].Ref: detector.logSeries[metas[0].Ref],
+		metas[1].Ref: detector.logSeries[metas[1].Ref],
+	}
+	scored := detector.logTotalScored
+
+	storage.Add(LogPatternExtractorName, "log.pattern.one", 1, 10, nil)
+	detector.Detect(storage, 9)
+
+	assert.Same(t, states[metas[0].Ref], detector.logSeries[metas[0].Ref])
+	assert.Same(t, states[metas[1].Ref], detector.logSeries[metas[1].Ref])
+	assert.Equal(t, scored, detector.logTotalScored)
+
+	detector.Detect(storage, 10)
+	assert.Same(t, states[metas[0].Ref], detector.logSeries[metas[0].Ref])
+	assert.Same(t, states[metas[1].Ref], detector.logSeries[metas[1].Ref])
+	assert.Equal(t, scored+1, detector.logTotalScored)
+}
+
+func TestRRCFDetector_VisibleSameBucketMergeStillResets(t *testing.T) {
+	cfg := DefaultRRCFConfig()
+	cfg.NumTrees = 5
+	cfg.TreeSize = 8
+	cfg.ShingleSize = 2
+	detector := NewRRCFDetector(cfg)
+	storage := newDetectorTestStorage()
+
+	for ts := int64(1); ts <= 8; ts++ {
+		storage.Add(LogPatternExtractorName, "log.pattern.count", 1, ts, nil)
+	}
+	detector.Detect(storage, 8)
+	meta := storage.ListSeries(observer.SeriesFilter{Namespace: LogPatternExtractorName})
+	require.Len(t, meta, 1)
+	previousState := detector.logSeries[meta[0].Ref]
+	require.NotNil(t, previousState)
+
+	storage.Add(LogPatternExtractorName, "log.pattern.count", 1, 8, nil)
+	detector.Detect(storage, 8)
+
+	state := detector.logSeries[meta[0].Ref]
+	assert.NotSame(t, previousState, state)
+	assert.Equal(t, float64(9), state.lastVisibleSamples)
+}
+
 func TestRRCFShouldEmitAnomalyOnlyOnRisingEdge(t *testing.T) {
 	anomalous := false
 
@@ -219,4 +279,31 @@ func TestRRCFDetector_LogScoreHistoryIsBoundedAndOrdered(t *testing.T) {
 	require.Len(t, scores, maxRRCFLogScoreHistory)
 	assert.Equal(t, int64(1), scores[0].Timestamp)
 	assert.Equal(t, int64(maxRRCFLogScoreHistory), scores[len(scores)-1].Timestamp)
+}
+
+func BenchmarkRRCFDetector_SparseFutureLogWrite(b *testing.B) {
+	cfg := DefaultRRCFConfig()
+	cfg.NumTrees = 10
+	cfg.TreeSize = 32
+	cfg.ShingleSize = 4
+	cfg.ThresholdSigma = 0
+	cfg.Metrics = []RRCFMetricDef{{Namespace: "unused", Name: "unused", Agg: observer.AggregateAverage}}
+	detector := NewRRCFDetector(cfg)
+	storage := newDetectorTestStorage()
+
+	const seriesCount = 500
+	for i := 0; i < seriesCount; i++ {
+		name := "log.pattern." + strconv.Itoa(i)
+		for ts := int64(1); ts <= 8; ts++ {
+			storage.Add(LogPatternExtractorName, name, 1, ts, nil)
+		}
+	}
+	detector.Detect(storage, 8)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		storage.Add(LogPatternExtractorName, "log.pattern.0", 1, 10, nil)
+		detector.Detect(storage, 9)
+	}
 }

--- a/comp/anomalydetection/observer/impl/metrics_detector_rrcf_test.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_rrcf_test.go
@@ -1,0 +1,222 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"testing"
+
+	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRCForest_DuplicateBaselinePreservesOutlierContrast(t *testing.T) {
+	forest := newRCForest(20, 16, 1, 42)
+
+	for i := 0; i < 16; i++ {
+		_, score := forest.insertPoint([]float64{1})
+		assert.Zero(t, score, "identical baseline points must have zero CoDisp")
+	}
+
+	_, score := forest.insertPoint([]float64{10})
+	assert.Greater(t, score, 0.0, "an outlier after a constant baseline must have positive CoDisp")
+}
+
+func TestRRCFDetector_DetectsLogCountSpike(t *testing.T) {
+	cfg := DefaultRRCFConfig()
+	cfg.NumTrees = 20
+	cfg.TreeSize = 8
+	cfg.ShingleSize = 2
+	detector := NewRRCFDetector(cfg)
+	storage := newDetectorTestStorage()
+
+	for ts := int64(1); ts <= 24; ts++ {
+		storage.Add(LogPatternExtractorName, "log.pattern.count", 1, ts, []string{"service:test"})
+	}
+	for i := 0; i < 20; i++ {
+		storage.Add(LogPatternExtractorName, "log.pattern.count", 1, 25, []string{"service:test"})
+	}
+
+	result := detector.Detect(storage, 25)
+
+	require.NotEmpty(t, result.Anomalies)
+	anomaly := result.Anomalies[len(result.Anomalies)-1]
+	assert.Equal(t, int64(25), anomaly.Timestamp)
+	assert.Equal(t, LogPatternExtractorName, anomaly.Source.Namespace)
+	assert.Equal(t, observer.AggregateCount, anomaly.Source.Aggregate)
+	assert.NotNil(t, anomaly.SourceRef)
+	assert.NotNil(t, anomaly.Score)
+	assert.Greater(t, *anomaly.Score, 0.0)
+}
+
+func TestRRCFDetector_RetriesPartialMetricResolution(t *testing.T) {
+	cfg := DefaultRRCFConfig()
+	cfg.NumTrees = 5
+	cfg.TreeSize = 8
+	cfg.ShingleSize = 1
+	cfg.Metrics = []RRCFMetricDef{
+		{Namespace: "test", Name: "one", Agg: observer.AggregateAverage},
+		{Namespace: "test", Name: "two", Agg: observer.AggregateAverage},
+	}
+	detector := NewRRCFDetector(cfg)
+	storage := newDetectorTestStorage()
+
+	for ts := int64(1); ts <= 4; ts++ {
+		storage.Add("test", "one", float64(ts), ts, nil)
+	}
+	detector.Detect(storage, 4)
+	assert.Empty(t, detector.resolvedKeys)
+
+	for ts := int64(1); ts <= 4; ts++ {
+		storage.Add("test", "two", float64(ts), ts, nil)
+	}
+	detector.Detect(storage, 4)
+
+	assert.Len(t, detector.resolvedKeys, 2)
+	assert.Equal(t, 4, detector.GetScoreStats().SampleCount)
+}
+
+func TestRRCFDetector_IncrementalMatchesBatch(t *testing.T) {
+	cfg := DefaultRRCFConfig()
+	cfg.NumTrees = 10
+	cfg.TreeSize = 8
+	cfg.ShingleSize = 3
+	cfg.ThresholdSigma = 0
+	cfg.Metrics = []RRCFMetricDef{
+		{Namespace: "test", Name: "one", Agg: observer.AggregateAverage},
+		{Namespace: "test", Name: "two", Agg: observer.AggregateAverage},
+	}
+
+	batch := NewRRCFDetector(cfg)
+	incremental := NewRRCFDetector(cfg)
+	batchStorage := newDetectorTestStorage()
+	incrementalStorage := newDetectorTestStorage()
+
+	for ts := int64(1); ts <= 20; ts++ {
+		batchStorage.Add("test", "one", float64(ts), ts, nil)
+		batchStorage.Add("test", "two", float64(ts*2), ts, nil)
+	}
+	batch.Detect(batchStorage, 20)
+
+	for ts := int64(1); ts <= 20; ts++ {
+		incrementalStorage.Add("test", "one", float64(ts), ts, nil)
+		incrementalStorage.Add("test", "two", float64(ts*2), ts, nil)
+		incremental.Detect(incrementalStorage, ts)
+	}
+
+	batchStats := batch.GetScoreStats()
+	incrementalStats := incremental.GetScoreStats()
+	require.Equal(t, 18, batchStats.SampleCount)
+	assert.Equal(t, batchStats.Scores, incrementalStats.Scores)
+}
+
+func TestRRCFDetector_ResetReplaysDeterministically(t *testing.T) {
+	cfg := DefaultRRCFConfig()
+	cfg.NumTrees = 10
+	cfg.TreeSize = 8
+	cfg.ShingleSize = 2
+	detector := NewRRCFDetector(cfg)
+	storage := newDetectorTestStorage()
+
+	for ts := int64(1); ts <= 24; ts++ {
+		storage.Add(LogMetricsExtractorName, "log.pattern.count", 1, ts, nil)
+	}
+	for i := 0; i < 10; i++ {
+		storage.Add(LogMetricsExtractorName, "log.pattern.count", 1, 25, nil)
+	}
+
+	first := detector.Detect(storage, 25)
+	firstStats := detector.GetScoreStats()
+	detector.Reset()
+	second := detector.Detect(storage, 25)
+	secondStats := detector.GetScoreStats()
+
+	assert.Equal(t, firstStats.Scores, secondStats.Scores)
+	assert.Equal(t, first.Anomalies, second.Anomalies)
+}
+
+func TestRRCFDetector_RemoveSeriesReresolvesConfiguredMetrics(t *testing.T) {
+	cfg := DefaultRRCFConfig()
+	cfg.NumTrees = 5
+	cfg.TreeSize = 8
+	cfg.ShingleSize = 1
+	cfg.Metrics = []RRCFMetricDef{
+		{Namespace: "test", Name: "one", Agg: observer.AggregateAverage},
+		{Namespace: "test", Name: "two", Agg: observer.AggregateAverage},
+	}
+	detector := NewRRCFDetector(cfg)
+	storage := newDetectorTestStorage()
+
+	for ts := int64(1); ts <= 4; ts++ {
+		storage.Add("test", "one", float64(ts), ts, []string{"host:test"})
+		storage.Add("test", "two", float64(ts*2), ts, []string{"host:test"})
+	}
+	detector.Detect(storage, 4)
+	replacedRef := detector.resolvedKeys["test|two"]
+	require.NotZero(t, replacedRef)
+	require.Equal(t, []observer.SeriesRef{replacedRef}, storage.RemoveSeriesByRefs([]observer.SeriesRef{replacedRef}))
+
+	detector.RemoveSeries([]observer.SeriesRef{replacedRef})
+	assert.Empty(t, detector.resolvedKeys)
+	assert.Zero(t, detector.GetScoreStats().SampleCount)
+
+	for ts := int64(1); ts <= 4; ts++ {
+		storage.Add("test", "two", float64(ts*3), ts, []string{"host:test"})
+	}
+	detector.Detect(storage, 4)
+
+	require.Len(t, detector.resolvedKeys, 2)
+	assert.NotEqual(t, replacedRef, detector.resolvedKeys["test|two"])
+	assert.Equal(t, 4, detector.GetScoreStats().SampleCount)
+}
+
+func TestRRCFDetector_RemoveSeriesPreservesUnrelatedLogState(t *testing.T) {
+	detector := NewRRCFDetector(DefaultRRCFConfig())
+	storage := newDetectorTestStorage()
+
+	for ts := int64(1); ts <= 4; ts++ {
+		storage.Add(LogPatternExtractorName, "log.pattern.one", 1, ts, nil)
+		storage.Add(LogPatternExtractorName, "log.pattern.two", 1, ts, nil)
+	}
+	detector.Detect(storage, 4)
+	metas := storage.ListSeries(observer.SeriesFilter{Namespace: LogPatternExtractorName})
+	require.Len(t, metas, 2)
+	removedRef := metas[0].Ref
+	retainedRef := metas[1].Ref
+	retainedState := detector.logSeries[retainedRef]
+	require.NotNil(t, retainedState)
+	require.Equal(t, []observer.SeriesRef{removedRef}, storage.RemoveSeriesByRefs([]observer.SeriesRef{removedRef}))
+
+	detector.RemoveSeries([]observer.SeriesRef{removedRef})
+
+	assert.NotContains(t, detector.logSeries, removedRef)
+	assert.Same(t, retainedState, detector.logSeries[retainedRef])
+	assert.False(t, detector.logSeriesCached)
+}
+
+func TestRRCFShouldEmitAnomalyOnlyOnRisingEdge(t *testing.T) {
+	anomalous := false
+
+	assert.True(t, rrcfShouldEmitAnomaly(&anomalous, true, true, 11, 10))
+	assert.True(t, anomalous)
+	assert.False(t, rrcfShouldEmitAnomaly(&anomalous, true, true, 12, 10))
+	assert.True(t, anomalous)
+	assert.False(t, rrcfShouldEmitAnomaly(&anomalous, true, true, 9, 10))
+	assert.False(t, anomalous)
+	assert.True(t, rrcfShouldEmitAnomaly(&anomalous, true, true, 11, 10))
+}
+
+func TestRRCFDetector_LogScoreHistoryIsBoundedAndOrdered(t *testing.T) {
+	detector := NewRRCFDetector(DefaultRRCFConfig())
+	for i := 0; i <= maxRRCFLogScoreHistory; i++ {
+		detector.appendLogScore(RRCFScoredPoint{Timestamp: int64(i), Score: float64(i)})
+	}
+
+	scores := detector.orderedLogScores()
+	require.Len(t, scores, maxRRCFLogScoreHistory)
+	assert.Equal(t, int64(1), scores[0].Timestamp)
+	assert.Equal(t, int64(maxRRCFLogScoreHistory), scores[len(scores)-1].Timestamp)
+}

--- a/comp/anomalydetection/observer/impl/rrcf.go
+++ b/comp/anomalydetection/observer/impl/rrcf.go
@@ -17,10 +17,6 @@ type node interface {
 	setParent(node)
 	leafCount() int
 	setLeafCount(int)
-	// boundingBox returns the bounding box as a flat slice:
-	// [min_d0, min_d1, ..., min_{ndim-1}, max_d0, max_d1, ..., max_{ndim-1}]
-	boundingBox() []float64
-	setBoundingBox([]float64)
 }
 
 // branch is an internal node in a random cut tree.
@@ -34,13 +30,11 @@ type branch struct {
 	b []float64 // bounding box: [min_d0, ..., min_{ndim-1}, max_d0, ..., max_{ndim-1}]
 }
 
-func (b *branch) isNode()                     {}
-func (b *branch) getParent() node             { return b.u }
-func (b *branch) setParent(p node)            { b.u = p }
-func (b *branch) leafCount() int              { return b.n }
-func (b *branch) setLeafCount(n int)          { b.n = n }
-func (b *branch) boundingBox() []float64      { return b.b }
-func (b *branch) setBoundingBox(bb []float64) { b.b = bb }
+func (b *branch) isNode()            {}
+func (b *branch) getParent() node    { return b.u }
+func (b *branch) setParent(p node)   { b.u = p }
+func (b *branch) leafCount() int     { return b.n }
+func (b *branch) setLeafCount(n int) { b.n = n }
 
 // leaf is a terminal node in a random cut tree.
 type leaf struct {
@@ -56,19 +50,6 @@ func (l *leaf) getParent() node    { return l.u }
 func (l *leaf) setParent(p node)   { l.u = p }
 func (l *leaf) leafCount() int     { return l.n }
 func (l *leaf) setLeafCount(n int) { l.n = n }
-
-// boundingBox for a leaf returns the point as both min and max.
-func (l *leaf) boundingBox() []float64 {
-	ndim := len(l.x)
-	bb := make([]float64, 2*ndim)
-	copy(bb[:ndim], l.x)
-	copy(bb[ndim:], l.x)
-	return bb
-}
-
-func (l *leaf) setBoundingBox(_ []float64) {
-	// Leaf bounding box is always just its point, so this is a no-op.
-}
 
 // rcTree is a single random cut tree.
 type rcTree struct {
@@ -123,11 +104,19 @@ func (t *rcTree) insertPoint(point []float64, index int) *leaf {
 
 	// Walk down tree, at each step decide if we create a cut above the current node
 	for {
-		nodeBbox := currentNode.boundingBox()
-		cutDim, cutVal := t.insertPointCut(point, nodeBbox)
+		// RRCF represents identical points as one leaf with multiplicity. Log
+		// count series commonly produce long runs of identical shingles; making
+		// a zero-width branch for every duplicate gives those normal shingles
+		// the same large CoDisp score as a real outlier.
+		if leafNode, ok := currentNode.(*leaf); ok && equalPoint(leafNode.x, point) {
+			leafNode.n++
+			t.updateLeafCountUpwards(leafNode.u, 1)
+			t.leaves[index] = leafNode
+			return leafNode
+		}
 
-		minVal := nodeBbox[cutDim]        // min in cut dimension
-		maxVal := nodeBbox[t.ndim+cutDim] // max in cut dimension
+		cutDim, cutVal := t.insertPointCutNode(point, currentNode)
+		minVal, maxVal := nodeBoundsAt(currentNode, cutDim, t.ndim)
 
 		// If cut separates point from current subtree (cut <= min or cut >= max),
 		// create a new branch here
@@ -207,6 +196,18 @@ func (t *rcTree) insertPoint(point []float64, index int) *leaf {
 	}
 }
 
+func equalPoint(a, b []float64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // linkBranchToParent links a new branch to its parent (or sets it as root).
 func (t *rcTree) linkBranchToParent(newBranch *branch, parent node, side byte) {
 	if parent == nil {
@@ -224,23 +225,18 @@ func (t *rcTree) linkBranchToParent(newBranch *branch, parent node, side byte) {
 // insertPointCut generates cut dimension and value for inserting a new point.
 // bbox is the bounding box of the current subtree in flat format.
 func (t *rcTree) insertPointCut(point []float64, bbox []float64) (cutDim int, cutVal float64) {
-	ndim := t.ndim
+	return t.insertPointCutFromBounds(point, bbox, nil)
+}
 
-	// Compute expanded bounding box including the new point
-	bboxHatMin := make([]float64, ndim)
-	bboxHatMax := make([]float64, ndim)
+func (t *rcTree) insertPointCutNode(point []float64, current node) (cutDim int, cutVal float64) {
+	return t.insertPointCutFromBounds(point, nil, current)
+}
 
-	for d := 0; d < ndim; d++ {
-		bboxHatMin[d] = math.Min(bbox[d], point[d])
-		bboxHatMax[d] = math.Max(bbox[ndim+d], point[d])
-	}
-
-	// Compute span in each dimension and total range
-	spans := make([]float64, ndim)
+func (t *rcTree) insertPointCutFromBounds(point, bbox []float64, current node) (cutDim int, cutVal float64) {
 	totalRange := 0.0
-	for d := 0; d < ndim; d++ {
-		spans[d] = bboxHatMax[d] - bboxHatMin[d]
-		totalRange += spans[d]
+	for d := 0; d < t.ndim; d++ {
+		minVal, maxVal := t.boundsAt(bbox, current, d)
+		totalRange += math.Max(maxVal, point[d]) - math.Min(minVal, point[d])
 	}
 
 	// If all spans are zero (all points identical), pick dimension 0 arbitrarily
@@ -253,9 +249,10 @@ func (t *rcTree) insertPointCut(point []float64, bbox []float64) (cutDim int, cu
 
 	// Find which dimension the cut falls in
 	cumSum := 0.0
-	cutDim = ndim - 1 // default to last dimension
-	for d := 0; d < ndim; d++ {
-		cumSum += spans[d]
+	cutDim = t.ndim - 1 // default to last dimension
+	for d := 0; d < t.ndim; d++ {
+		minVal, maxVal := t.boundsAt(bbox, current, d)
+		cumSum += math.Max(maxVal, point[d]) - math.Min(minVal, point[d])
 		if cumSum >= r {
 			cutDim = d
 			break
@@ -263,9 +260,28 @@ func (t *rcTree) insertPointCut(point []float64, bbox []float64) (cutDim int, cu
 	}
 
 	// Cut value within that dimension
-	cutVal = bboxHatMin[cutDim] + cumSum - r
+	minVal, _ := t.boundsAt(bbox, current, cutDim)
+	cutVal = math.Min(minVal, point[cutDim]) + cumSum - r
 
 	return cutDim, cutVal
+}
+
+func (t *rcTree) boundsAt(bbox []float64, current node, d int) (float64, float64) {
+	if current != nil {
+		return nodeBoundsAt(current, d, t.ndim)
+	}
+	return bbox[d], bbox[t.ndim+d]
+}
+
+func nodeBoundsAt(n node, d, ndim int) (float64, float64) {
+	switch current := n.(type) {
+	case *leaf:
+		return current.x[d], current.x[d]
+	case *branch:
+		return current.b[d], current.b[ndim+d]
+	default:
+		panic("unknown RRCF node type")
+	}
 }
 
 // forgetPoint removes a point from the tree by its index.
@@ -420,19 +436,21 @@ func (t *rcTree) incrementDepthsBelow(n node, inc int) {
 
 // computeBranchBbox computes bounding box of a branch from its children.
 func (t *rcTree) computeBranchBbox(br *branch) []float64 {
-	lbox := br.l.boundingBox()
-	rbox := br.r.boundingBox()
+	return t.computeBranchBboxInto(br, nil)
+}
 
-	ndim := t.ndim
-	bbox := make([]float64, 2*ndim)
-
-	// Min values
-	for d := 0; d < ndim; d++ {
-		bbox[d] = math.Min(lbox[d], rbox[d])
+func (t *rcTree) computeBranchBboxInto(br *branch, bbox []float64) []float64 {
+	if cap(bbox) < 2*t.ndim {
+		bbox = make([]float64, 2*t.ndim)
+	} else {
+		bbox = bbox[:2*t.ndim]
 	}
-	// Max values
-	for d := 0; d < ndim; d++ {
-		bbox[ndim+d] = math.Max(lbox[ndim+d], rbox[ndim+d])
+
+	for d := 0; d < t.ndim; d++ {
+		leftMin, leftMax := nodeBoundsAt(br.l, d, t.ndim)
+		rightMin, rightMax := nodeBoundsAt(br.r, d, t.ndim)
+		bbox[d] = math.Min(leftMin, rightMin)
+		bbox[t.ndim+d] = math.Max(leftMax, rightMax)
 	}
 
 	return bbox
@@ -502,7 +520,7 @@ func (t *rcTree) relaxBboxUpwards(n node, deletedPoint []float64) {
 		}
 
 		// Recompute bbox from children
-		br.b = t.computeBranchBbox(br)
+		br.b = t.computeBranchBboxInto(br, br.b)
 		n = n.getParent()
 	}
 }
@@ -514,6 +532,7 @@ type rcForest struct {
 	treeSize   int // max points per tree
 	ndim       int
 	rng        *rand.Rand
+	seed       int64
 	indexQueue []int // FIFO queue of point indices for sliding window
 	nextIndex  int   // next index to assign to new points
 }
@@ -536,6 +555,7 @@ func newRCForest(numTrees, treeSize, ndim int, seed int64) *rcForest {
 		treeSize:   treeSize,
 		ndim:       ndim,
 		rng:        rng,
+		seed:       seed,
 		indexQueue: make([]int, 0, treeSize),
 		nextIndex:  0,
 	}
@@ -610,6 +630,9 @@ func (f *rcForest) score(point []float64) float64 {
 
 // reset clears all trees in the forest.
 func (f *rcForest) reset() {
+	// Recreate the seed stream as well as the trees so Reset and a fresh
+	// detector produce identical scores for the same replay.
+	f.rng = rand.New(rand.NewSource(f.seed))
 	for i := range f.trees {
 		treeSeed := f.rng.Int63()
 		treeRng := rand.New(rand.NewSource(treeSeed))

--- a/internal/qbranch/anomalydetection-testbench/main.go
+++ b/internal/qbranch/anomalydetection-testbench/main.go
@@ -129,6 +129,7 @@ func main() {
 		}
 		componentSettings = observerimpl.ComponentSettings{Enabled: overrides}
 	}
+	componentSettings = applyTestbenchComponentDefaults(componentSettings)
 
 	if *baselineDuration == "0" || *baselineDuration == "disabled" {
 		componentSettings.Baseline = observerimpl.BaselineConfig{Enabled: false}
@@ -215,6 +216,16 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Failed to run observer test bench: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func applyTestbenchComponentDefaults(settings observerimpl.ComponentSettings) observerimpl.ComponentSettings {
+	if settings.Enabled == nil {
+		settings.Enabled = make(map[string]bool)
+	}
+	if _, explicitlySet := settings.Enabled["rrcf"]; !explicitlySet {
+		settings.Enabled["rrcf"] = true
+	}
+	return settings
 }
 
 func run(

--- a/internal/qbranch/anomalydetection-testbench/main_test.go
+++ b/internal/qbranch/anomalydetection-testbench/main_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/fx"
 
 	observerfx "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/fx"
+	observerimpl "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/impl"
 	recordernoop "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/fx-noop"
 	reportertestbenchfx "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/fx-testbench"
 	"github.com/DataDog/datadog-agent/comp/core"
@@ -76,5 +77,19 @@ func TestValidateCLIParams(t *testing.T) {
 	t.Run("retain override is accepted in headless mode", func(t *testing.T) {
 		err := validateCLIParams(CLIParams{RetainParquet: true, Headless: "scenario"})
 		require.NoError(t, err)
+	})
+}
+
+func TestApplyTestbenchComponentDefaults(t *testing.T) {
+	t.Run("enables RRCF by default", func(t *testing.T) {
+		settings := applyTestbenchComponentDefaults(observerimpl.ComponentSettings{})
+		require.True(t, settings.Enabled["rrcf"])
+	})
+
+	t.Run("preserves an explicit RRCF override", func(t *testing.T) {
+		settings := applyTestbenchComponentDefaults(observerimpl.ComponentSettings{
+			Enabled: map[string]bool{"rrcf": false},
+		})
+		require.False(t, settings.Enabled["rrcf"])
 	})
 }

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -6219,7 +6219,7 @@ properties:
               enabled:
                 node_type: setting
                 type: boolean
-                default: true
+                default: false
           scanmw:
             node_type: section
             type: object

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -2302,7 +2302,7 @@ func anomalyDetection(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("anomaly_detection.detectors.log_pattern_extractor.enabled", true)
 	config.BindEnvAndSetDefault("anomaly_detection.detectors.cusum.enabled", false)
 	config.BindEnvAndSetDefault("anomaly_detection.detectors.bocpd.enabled", true)
-	config.BindEnvAndSetDefault("anomaly_detection.detectors.rrcf.enabled", true)
+	config.BindEnvAndSetDefault("anomaly_detection.detectors.rrcf.enabled", false)
 	config.BindEnvAndSetDefault("anomaly_detection.detectors.scanmw.enabled", false)
 	config.BindEnvAndSetDefault("anomaly_detection.detectors.scanwelch.enabled", false)
 	config.BindEnvAndSetDefault("anomaly_detection.detectors.holt_residual.enabled", false)

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -63,6 +63,7 @@ func TestDefaults(t *testing.T) {
 	assert.False(t, config.IsConfigured("dd_url"))
 	assert.Equal(t, constants.DefaultSite, config.GetString("site"))
 	assert.Equal(t, "https://app.datadoghq.com", config.GetString("dd_url"))
+	assert.False(t, config.GetBool("anomaly_detection.detectors.rrcf.enabled"))
 	assert.Equal(t, []string{"aws", "gcp", "azure", "alibaba", "oracle", "ibm"}, config.GetStringSlice("cloud_provider_metadata"))
 
 	// Testing process-agent defaults


### PR DESCRIPTION
### What does this PR do?

This PR fixes RRCF so it can run correctly in Observer's incremental pipeline while keeping it disabled by default.

- carries shingle state across detector advances and retries incomplete metric resolution
- adds bounded RRCF detection for log-derived count series
- handles duplicate points and series eviction
- emits on anomaly onset and removes avoidable tree and catalog allocations

### Motivation

RRCF was effectively inert in both live and testbench streaming. Each detector advance usually exposed one new point, but RRCF advanced its cursor while discarding partial four-point shingles. It therefore never formed a shingle or reached warmup during steady-state ingestion. It also cached incomplete fixed-metric matches and did not consume dynamic log-count series.

Across the 12 local scenarios with TimeCluster:

| | Before | After |
|---|---:|---:|
| Mean F1 | 0.0000 | 0.1872 |
| Raw RRCF anomalies | 0 | 3,429 |

Compared with BOCPD + TimeCluster:

| | BOCPD | RRCF |
|---|---:|---:|
| Mean F1 (12 scenarios) | 0.1289 | 0.1872 |
| Live heap (`dns-upstream-outage`) | 1.46 GiB | 1.50 GiB |
| Cumulative allocations (`dns-upstream-outage`) | 10.68 GiB | 20.09 GiB |

The heap profiles cover the whole testbench process over the same 4,982-second scenario. RRCF used 42 MiB (+2.8%) more live heap and 1.88x cumulative allocations.

RRCF remains disabled by default.

### Describe how you validated your changes

- `dda inv test --targets=./comp/anomalydetection/observer/impl`
- 12-scenario RRCF + TimeCluster evaluation
- BOCPD/RRCF heap profiles on `dns-upstream-outage`

### Additional Notes
