### PR TITLE
[ AGNTLOG-700 ] Honor bind_host on UDP log listeners

### DIFF
--- a/pkg/logs/launchers/listener/udp.go
+++ b/pkg/logs/launchers/listener/udp.go
@@ -8,6 +8,7 @@ package listener
 import (
 	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -110,7 +111,8 @@ func (l *UDPListener) resetTailer() {
 // newUDPConnection returns a new UDP connection,
 // returns an error if the creation failed.
 func (l *UDPListener) newUDPConnection() (*net.UDPConn, error) {
-	udpAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf(":%d", l.source.Config.Port))
+	bindAddr := net.JoinHostPort(l.source.Config.BindHost, strconv.Itoa(l.source.Config.Port))
+	udpAddr, err := net.ResolveUDPAddr("udp", bindAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/logs/launchers/listener/udp_test.go
+++ b/pkg/logs/launchers/listener/udp_test.go
@@ -8,6 +8,7 @@ package listener
 import (
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,6 +44,31 @@ func TestUDPShouldReceiveMessage(t *testing.T) {
 	fmt.Fprint(conn, "hello world\n")
 	msg = <-msgChan
 	assert.Equal(t, "hello world", string(msg.GetContent()))
+
+	listener.Stop()
+}
+
+func TestUDPBindHost(t *testing.T) {
+	pp := mock.NewMockProvider()
+	msgChan := pp.NextPipelineChan()
+	listener, err := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{
+		Port:     udpTestPort,
+		BindHost: "127.0.0.1",
+	}), 9000)
+	require.NoError(t, err)
+	listener.Start()
+	require.NotNil(t, listener.Conn)
+
+	addr := listener.Conn.LocalAddr().String()
+	assert.True(t, strings.HasPrefix(addr, "127.0.0.1:"), "expected 127.0.0.1 bind, got %s", addr)
+
+	conn, err := net.Dial("udp", addr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	fmt.Fprint(conn, "bound msg\n")
+	msg := <-msgChan
+	assert.Equal(t, "bound msg", string(msg.GetContent()))
 
 	listener.Stop()
 }

--- a/releasenotes/notes/logs-udp-listener-bind-host-fc9b109c334a0be6.yaml
+++ b/releasenotes/notes/logs-udp-listener-bind-host-fc9b109c334a0be6.yaml
@@ -1,8 +1,4 @@
 ---
 fixes:
   - |
-    Fix ``bind_host`` being ignored by UDP log listeners. A UDP log source
-    configured with ``bind_host`` previously always listened on all
-    interfaces; it now binds to the configured address, matching the
-    behavior of TCP log listeners. Sources that do not set ``bind_host``
-    keep listening on all interfaces.
+    Add new ``bind_host`` configuration option to TCP and UDP log listeners.

--- a/releasenotes/notes/logs-udp-listener-bind-host-fc9b109c334a0be6.yaml
+++ b/releasenotes/notes/logs-udp-listener-bind-host-fc9b109c334a0be6.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix ``bind_host`` being ignored by UDP log listeners. A UDP log source
+    configured with ``bind_host`` previously always listened on all
+    interfaces; it now binds to the configured address, matching the
+    behavior of TCP log listeners. Sources that do not set ``bind_host``
+    keep listening on all interfaces.


### PR DESCRIPTION
### What does this PR do?

UDP log listeners now bind to the address configured in `bind_host` instead of always listening on the wildcard address. TCP log listeners already honored the setting; the UDP listener built its listen address from the port alone and silently discarded `bind_host`. Sources that leave `bind_host` unset are unaffected and continue to listen on all interfaces.

### Motivation

`bind_host` is documented as applying to both TCP and UDP log sources, so an operator restricting a UDP syslog listener to a specific management interface would reasonably expect the port to be reachable only there. In practice the socket was bound to the IPv6 wildcard address and accepted datagrams on every interface, which makes this a silent exposure rather than merely an ignored option.

The release note is updated as if this was a new feature for TCP AND UDP, because the specific bind host functionality can be separated from the preview feature the option was previously soft-gated behind. 

### Describe how you validated your changes

`TestUDPBindHost` was added, mirroring the existing `TestTCPBindHost`, and confirmed to fail against the previous behavior — the listener reported `[::]:<port>` rather than the configured address. The full package suite passes via `dda inv test --targets=./pkg/logs/launchers/listener` (31 tests), alongside `dda inv linter.go --only-modified-packages`.

### Additional Notes
No configuration migration is required: an empty `bind_host` still resolves to `:<port>`, preserving the all-interfaces default.