### PR TITLE
[ AGNTLOG-701 ] Support certificate revocation lists on TLS log listeners

### DIFF
--- a/comp/logs-library/utils/tls/BUILD.bazel
+++ b/comp/logs-library/utils/tls/BUILD.bazel
@@ -3,7 +3,10 @@ load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "tls",
-    srcs = ["server_config.go"],
+    srcs = [
+        "revocation.go",
+        "server_config.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/comp/logs-library/utils/tls",
     visibility = ["//visibility:public"],
     deps = [
@@ -14,7 +17,13 @@ go_library(
 
 dd_agent_go_test(
     name = "tls_test",
-    srcs = ["server_config_test.go"],
+    srcs = [
+        "revocation_test.go",
+        "server_config_test.go",
+    ],
     embed = [":tls"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/comp/logs-library/utils/tls/certreloader/BUILD.bazel
+++ b/comp/logs-library/utils/tls/certreloader/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "ca_reloader.go",
         "cert_reloader.go",
+        "crl_reloader.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/comp/logs-library/utils/tls/certreloader",
     visibility = ["//visibility:public"],
@@ -14,7 +15,10 @@ go_library(
 
 dd_agent_go_test(
     name = "certreloader_test",
-    srcs = ["cert_reloader_test.go"],
+    srcs = [
+        "cert_reloader_test.go",
+        "crl_reloader_test.go",
+    ],
     embed = [":certreloader"],
     deps = [
         "@com_github_stretchr_testify//assert",

--- a/comp/logs-library/utils/tls/certreloader/crl_reloader.go
+++ b/comp/logs-library/utils/tls/certreloader/crl_reloader.go
@@ -1,0 +1,163 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package certreloader
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// crlPEMTypes are the PEM block types that hold a certificate revocation list.
+// "X509 CRL" is what RFC 7468 and OpenSSL emit; "CRL" is accepted because some
+// PKI tooling writes the shorter label.
+var crlPEMTypes = map[string]struct{}{
+	"X509 CRL": {},
+	"CRL":      {},
+}
+
+// CRLReloader manages a set of certificate revocation lists with automatic
+// periodic reloading from disk. It is safe for concurrent use.
+//
+// On reload failure, the last successfully loaded lists are preserved and
+// continue to be used. A revocation list that cannot be re-read is more useful
+// than no revocation list at all: dropping it would silently re-admit every
+// revoked certificate.
+type CRLReloader struct {
+	mu         sync.RWMutex
+	clock      Clock
+	crlFile    string
+	crls       []*x509.RevocationList
+	err        error
+	loadErr    error
+	lastUpdate time.Time
+	crlFileMod time.Time
+}
+
+// NewCRLReloader creates a CRLReloader that immediately loads the revocation
+// lists from disk and starts a background goroutine to periodically reload
+// them. The background goroutine exits when ctx is cancelled.
+func NewCRLReloader(ctx context.Context, crlFile string, clock Clock) *CRLReloader {
+	r := &CRLReloader{
+		crlFile: crlFile,
+		clock:   clock,
+	}
+	r.reloadCRLs()
+	go r.run(ctx)
+	return r
+}
+
+// GetCRLs returns the currently loaded revocation lists.
+func (r *CRLReloader) GetCRLs() ([]*x509.RevocationList, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.crls, r.err
+}
+
+func (r *CRLReloader) run(ctx context.Context) {
+	ticker := time.NewTicker(tickInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if r.shouldReload() {
+				r.reloadCRLs()
+			}
+		}
+	}
+}
+
+func (r *CRLReloader) shouldReload() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	now := r.clock.Now()
+	if r.loadErr != nil {
+		return now.After(r.lastUpdate.Add(errorCacheTimeout))
+	}
+	if !now.After(r.lastUpdate.Add(cacheTimeout)) {
+		return false
+	}
+	return fileModified(r.crlFile, r.crlFileMod)
+}
+
+func (r *CRLReloader) reloadCRLs() {
+	crls, err := LoadCRLs(r.crlFile)
+
+	r.mu.Lock()
+	r.loadErr = err
+	if err == nil {
+		r.crls = crls
+		r.err = nil
+		r.crlFileMod = fileMtime(r.crlFile)
+		warnExpiredCRLs(r.crlFile, crls, r.clock.Now())
+	} else if r.crls != nil {
+		log.Warnf("Failed to reload CRLs from %s, continuing with previously loaded revocation lists: %v", r.crlFile, err)
+	} else {
+		r.err = err
+	}
+	r.lastUpdate = r.clock.Now()
+	r.mu.Unlock()
+}
+
+// LoadCRLs reads a file containing one or more certificate revocation lists.
+// Both PEM (possibly concatenated) and raw DER encodings are accepted, since
+// CAs and PKI tooling emit either.
+func LoadCRLs(crlFile string) ([]*x509.RevocationList, error) {
+	data, err := os.ReadFile(crlFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CRL file: %w", err)
+	}
+
+	var crls []*x509.RevocationList
+	for rest := data; len(rest) > 0; {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if _, ok := crlPEMTypes[block.Type]; !ok {
+			continue
+		}
+		crl, parseErr := x509.ParseRevocationList(block.Bytes)
+		if parseErr != nil {
+			return nil, fmt.Errorf("failed to parse CRL in %q: %w", crlFile, parseErr)
+		}
+		crls = append(crls, crl)
+	}
+
+	if len(crls) == 0 {
+		crl, derErr := x509.ParseRevocationList(data)
+		if derErr != nil {
+			return nil, fmt.Errorf("CRL file %q contains no valid PEM or DER revocation list: %w", crlFile, derErr)
+		}
+		crls = append(crls, crl)
+	}
+
+	return crls, nil
+}
+
+// warnExpiredCRLs flags revocation lists whose nextUpdate has passed. An
+// expired list is still enforced — refusing to enforce it would re-admit
+// revoked certificates — but it may be missing recent revocations, so the
+// operator needs to know their CRL distribution has stalled.
+func warnExpiredCRLs(crlFile string, crls []*x509.RevocationList, now time.Time) {
+	for _, crl := range crls {
+		if !crl.NextUpdate.IsZero() && now.After(crl.NextUpdate) {
+			log.Warnf("CRL for issuer %s in %s expired at %s; its entries are still enforced but the list may be missing recent revocations",
+				crl.Issuer, crlFile, crl.NextUpdate.UTC().Format(time.RFC3339))
+		}
+	}
+}

--- a/comp/logs-library/utils/tls/certreloader/crl_reloader_test.go
+++ b/comp/logs-library/utils/tls/certreloader/crl_reloader_test.go
@@ -1,0 +1,276 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package certreloader
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testCA is a self-signed CA able to sign revocation lists.
+type testCA struct {
+	key  crypto.Signer
+	cert *x509.Certificate
+}
+
+func newTestCA(t *testing.T, cn string) *testCA {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, key.Public(), key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return &testCA{key: key, cert: cert}
+}
+
+// crlDER creates a revocation list covering the given serial numbers.
+func (ca *testCA) crlDER(t *testing.T, nextUpdate time.Time, serials ...int64) []byte {
+	t.Helper()
+
+	entries := make([]x509.RevocationListEntry, 0, len(serials))
+	for _, serial := range serials {
+		entries = append(entries, x509.RevocationListEntry{
+			SerialNumber:   big.NewInt(serial),
+			RevocationTime: time.Now().Add(-time.Minute),
+		})
+	}
+
+	der, err := x509.CreateRevocationList(rand.Reader, &x509.RevocationList{
+		Number:                    big.NewInt(1),
+		ThisUpdate:                time.Now().Add(-time.Hour),
+		NextUpdate:                nextUpdate,
+		RevokedCertificateEntries: entries,
+	}, ca.cert, ca.key)
+	require.NoError(t, err)
+	return der
+}
+
+func writeFile(t *testing.T, dir, name string, contents []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, contents, 0644))
+	return path
+}
+
+func TestLoadCRLs_PEM(t *testing.T) {
+	dir := t.TempDir()
+	ca := newTestCA(t, "crl-pem-ca")
+	der := ca.crlDER(t, time.Now().Add(time.Hour), 42)
+	path := writeFile(t, dir, "crl.pem", pem.EncodeToMemory(&pem.Block{Type: "X509 CRL", Bytes: der}))
+
+	crls, err := LoadCRLs(path)
+	require.NoError(t, err)
+	require.Len(t, crls, 1)
+	require.Len(t, crls[0].RevokedCertificateEntries, 1)
+	assert.Equal(t, int64(42), crls[0].RevokedCertificateEntries[0].SerialNumber.Int64())
+}
+
+func TestLoadCRLs_DER(t *testing.T) {
+	dir := t.TempDir()
+	ca := newTestCA(t, "crl-der-ca")
+	path := writeFile(t, dir, "crl.der", ca.crlDER(t, time.Now().Add(time.Hour), 7))
+
+	crls, err := LoadCRLs(path)
+	require.NoError(t, err)
+	require.Len(t, crls, 1)
+	assert.Equal(t, int64(7), crls[0].RevokedCertificateEntries[0].SerialNumber.Int64())
+}
+
+func TestLoadCRLs_ConcatenatedPEMFromMultipleIssuers(t *testing.T) {
+	dir := t.TempDir()
+	first := newTestCA(t, "crl-ca-one")
+	second := newTestCA(t, "crl-ca-two")
+
+	var contents []byte
+	contents = append(contents, pem.EncodeToMemory(&pem.Block{Type: "X509 CRL", Bytes: first.crlDER(t, time.Now().Add(time.Hour), 1)})...)
+	contents = append(contents, pem.EncodeToMemory(&pem.Block{Type: "CRL", Bytes: second.crlDER(t, time.Now().Add(time.Hour), 2)})...)
+	path := writeFile(t, dir, "crls.pem", contents)
+
+	crls, err := LoadCRLs(path)
+	require.NoError(t, err)
+	require.Len(t, crls, 2)
+	assert.Contains(t, crls[0].Issuer.String(), "crl-ca-one")
+	assert.Contains(t, crls[1].Issuer.String(), "crl-ca-two")
+}
+
+func TestLoadCRLs_IgnoresUnrelatedPEMBlocks(t *testing.T) {
+	dir := t.TempDir()
+	ca := newTestCA(t, "crl-mixed-ca")
+
+	var contents []byte
+	contents = append(contents, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.cert.Raw})...)
+	contents = append(contents, pem.EncodeToMemory(&pem.Block{Type: "X509 CRL", Bytes: ca.crlDER(t, time.Now().Add(time.Hour), 3)})...)
+	path := writeFile(t, dir, "bundle.pem", contents)
+
+	crls, err := LoadCRLs(path)
+	require.NoError(t, err)
+	require.Len(t, crls, 1)
+}
+
+func TestLoadCRLs_RejectsFileWithNoCRL(t *testing.T) {
+	dir := t.TempDir()
+	ca := newTestCA(t, "cert-only-ca")
+	path := writeFile(t, dir, "cert.pem", pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.cert.Raw}))
+
+	_, err := LoadCRLs(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no valid PEM or DER revocation list")
+}
+
+func TestLoadCRLs_RejectsMissingFile(t *testing.T) {
+	_, err := LoadCRLs("/nonexistent/crl.pem")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read CRL file")
+}
+
+func TestCRLReloader_LoadsAtConstruction(t *testing.T) {
+	dir := t.TempDir()
+	ca := newTestCA(t, "reloader-ca")
+	path := writeFile(t, dir, "crl.pem", pem.EncodeToMemory(&pem.Block{Type: "X509 CRL", Bytes: ca.crlDER(t, time.Now().Add(time.Hour), 5)}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := NewCRLReloader(ctx, path, RealClock())
+	crls, err := r.GetCRLs()
+	require.NoError(t, err)
+	require.Len(t, crls, 1)
+}
+
+func TestCRLReloader_InitialLoadFailureReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := NewCRLReloader(ctx, "/nonexistent/crl.pem", RealClock())
+	crls, err := r.GetCRLs()
+	assert.Nil(t, crls)
+	assert.Error(t, err)
+}
+
+func TestCRLReloader_ReloadPicksUpNewRevocations(t *testing.T) {
+	dir := t.TempDir()
+	ca := newTestCA(t, "rotating-ca")
+	path := writeFile(t, dir, "crl.pem", pem.EncodeToMemory(&pem.Block{Type: "X509 CRL", Bytes: ca.crlDER(t, time.Now().Add(time.Hour), 1)}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := NewCRLReloader(ctx, path, RealClock())
+	crls, err := r.GetCRLs()
+	require.NoError(t, err)
+	require.Len(t, crls[0].RevokedCertificateEntries, 1)
+
+	writeFile(t, dir, "crl.pem", pem.EncodeToMemory(&pem.Block{Type: "X509 CRL", Bytes: ca.crlDER(t, time.Now().Add(time.Hour), 1, 2)}))
+	r.reloadCRLs()
+
+	crls, err = r.GetCRLs()
+	require.NoError(t, err)
+	assert.Len(t, crls[0].RevokedCertificateEntries, 2, "reload should pick up newly revoked serials")
+}
+
+// A revocation list that can no longer be read must stay in effect: discarding
+// it would silently re-admit every certificate it revoked.
+func TestCRLReloader_ReloadFailurePreservesLastKnownGoodCRLs(t *testing.T) {
+	dir := t.TempDir()
+	ca := newTestCA(t, "preserve-ca")
+	path := writeFile(t, dir, "crl.pem", pem.EncodeToMemory(&pem.Block{Type: "X509 CRL", Bytes: ca.crlDER(t, time.Now().Add(time.Hour), 9)}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := NewCRLReloader(ctx, path, RealClock())
+	require.NoError(t, os.Remove(path))
+	r.reloadCRLs()
+
+	crls, err := r.GetCRLs()
+	require.NoError(t, err, "should not return an error while last known good CRLs are available")
+	require.Len(t, crls, 1)
+	assert.Equal(t, int64(9), crls[0].RevokedCertificateEntries[0].SerialNumber.Int64())
+}
+
+func TestCRLReloader_ShouldReloadUsesErrorCadenceAfterFailure(t *testing.T) {
+	dir := t.TempDir()
+	ca := newTestCA(t, "cadence-ca")
+	path := writeFile(t, dir, "crl.pem", pem.EncodeToMemory(&pem.Block{Type: "X509 CRL", Bytes: ca.crlDER(t, time.Now().Add(time.Hour), 1)}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := NewCRLReloader(ctx, path, RealClock())
+	assert.False(t, r.shouldReload(), "should not reload immediately after construction")
+
+	require.NoError(t, os.Remove(path))
+	r.reloadCRLs()
+
+	r.mu.Lock()
+	r.lastUpdate = time.Now().Add(-errorCacheTimeout - time.Minute)
+	r.mu.Unlock()
+
+	assert.True(t, r.shouldReload(), "should retry on the error cadence after a failed reload")
+}
+
+func TestCRLReloader_ShouldReloadOnFileChange(t *testing.T) {
+	dir := t.TempDir()
+	ca := newTestCA(t, "mtime-ca")
+	path := writeFile(t, dir, "crl.pem", pem.EncodeToMemory(&pem.Block{Type: "X509 CRL", Bytes: ca.crlDER(t, time.Now().Add(time.Hour), 1)}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := NewCRLReloader(ctx, path, RealClock())
+
+	r.mu.Lock()
+	r.lastUpdate = time.Now().Add(-cacheTimeout - time.Minute)
+	r.mu.Unlock()
+	assert.False(t, r.shouldReload(), "should not reload when the file is unchanged")
+
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(path, future, future))
+	assert.True(t, r.shouldReload(), "should reload once the file changes")
+}
+
+// An expired list is still honored; only a warning distinguishes it.
+func TestCRLReloader_ExpiredCRLIsStillLoaded(t *testing.T) {
+	dir := t.TempDir()
+	ca := newTestCA(t, "expired-ca")
+	path := writeFile(t, dir, "crl.pem", pem.EncodeToMemory(&pem.Block{Type: "X509 CRL", Bytes: ca.crlDER(t, time.Now().Add(-time.Minute), 4)}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := NewCRLReloader(ctx, path, RealClock())
+	crls, err := r.GetCRLs()
+	require.NoError(t, err)
+	require.Len(t, crls, 1)
+	assert.Equal(t, int64(4), crls[0].RevokedCertificateEntries[0].SerialNumber.Int64())
+}

--- a/comp/logs-library/utils/tls/revocation.go
+++ b/comp/logs-library/utils/tls/revocation.go
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package tlsutil
+
+import (
+	"bytes"
+	"crypto/x509"
+	"fmt"
+)
+
+// checkChainsRevocation rejects a client certificate when every chain that
+// verified against the trust store contains a revoked certificate. A single
+// clean chain is enough to accept: cross-signed PKIs can produce several valid
+// chains, and revoking one intermediate should not invalidate a path that does
+// not go through it.
+func checkChainsRevocation(chains [][]*x509.Certificate, crls []*x509.RevocationList) error {
+	if len(crls) == 0 {
+		return nil
+	}
+	var firstErr error
+	for _, chain := range chains {
+		err := checkChainRevocation(chain, crls)
+		if err == nil {
+			return nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// checkChainRevocation reports an error if any certificate in chain is listed in
+// a revocation list published by that certificate's issuer. chain is ordered
+// leaf-first, so each certificate's issuer is its successor; the final
+// certificate is the trust anchor and has no issuer in the chain to attest for
+// it, so it is not checked.
+//
+// A revocation list is only consulted for a certificate it could plausibly
+// cover: its issuer name must match the candidate issuer and its signature must
+// verify against that issuer's key. An unrelated or tampered list therefore
+// cannot cause a spurious rejection.
+func checkChainRevocation(chain []*x509.Certificate, crls []*x509.RevocationList) error {
+	for i := 0; i+1 < len(chain); i++ {
+		cert, issuer := chain[i], chain[i+1]
+		for _, crl := range crls {
+			if !bytes.Equal(crl.RawIssuer, issuer.RawSubject) {
+				continue
+			}
+			if err := crl.CheckSignatureFrom(issuer); err != nil {
+				continue
+			}
+			for _, entry := range crl.RevokedCertificateEntries {
+				if entry.SerialNumber.Cmp(cert.SerialNumber) == 0 {
+					return &RevokedCertificateError{Certificate: cert, Entry: entry}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// RevokedCertificateError reports that a presented certificate appears in a
+// certificate revocation list.
+type RevokedCertificateError struct {
+	Certificate *x509.Certificate
+	Entry       x509.RevocationListEntry
+}
+
+func (e *RevokedCertificateError) Error() string {
+	return fmt.Sprintf("certificate %q (serial %s, issuer %q) was revoked at %s with reason code %d",
+		e.Certificate.Subject.CommonName, e.Certificate.SerialNumber,
+		e.Certificate.Issuer.CommonName, e.Entry.RevocationTime.UTC(), e.Entry.ReasonCode)
+}

--- a/comp/logs-library/utils/tls/revocation_test.go
+++ b/comp/logs-library/utils/tls/revocation_test.go
@@ -1,0 +1,195 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package tlsutil
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// revocationTestCA issues certificates and revocation lists for the tests below.
+type revocationTestCA struct {
+	key    crypto.Signer
+	cert   *x509.Certificate
+	serial int64
+}
+
+func newRevocationTestCA(t *testing.T, cn string, parent *revocationTestCA) *revocationTestCA {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+
+	signerCert, signerKey := tmpl, crypto.Signer(key)
+	if parent != nil {
+		tmpl.SerialNumber = big.NewInt(parent.nextSerial())
+		signerCert, signerKey = parent.cert, parent.key
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, signerCert, key.Public(), signerKey)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return &revocationTestCA{key: key, cert: cert, serial: 100}
+}
+
+func (ca *revocationTestCA) nextSerial() int64 {
+	ca.serial++
+	return ca.serial
+}
+
+func (ca *revocationTestCA) issueLeaf(t *testing.T, cn string) *x509.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(ca.nextSerial()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, key.Public(), ca.key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert
+}
+
+func (ca *revocationTestCA) issueCRL(t *testing.T, certs ...*x509.Certificate) *x509.RevocationList {
+	t.Helper()
+
+	entries := make([]x509.RevocationListEntry, 0, len(certs))
+	for _, cert := range certs {
+		entries = append(entries, x509.RevocationListEntry{
+			SerialNumber:   cert.SerialNumber,
+			RevocationTime: time.Now().Add(-time.Minute),
+			ReasonCode:     1, // keyCompromise
+		})
+	}
+
+	der, err := x509.CreateRevocationList(rand.Reader, &x509.RevocationList{
+		Number:                    big.NewInt(1),
+		ThisUpdate:                time.Now().Add(-time.Hour),
+		NextUpdate:                time.Now().Add(time.Hour),
+		RevokedCertificateEntries: entries,
+	}, ca.cert, ca.key)
+	require.NoError(t, err)
+
+	crl, err := x509.ParseRevocationList(der)
+	require.NoError(t, err)
+	return crl
+}
+
+func TestCheckChainRevocation(t *testing.T) {
+	ca := newRevocationTestCA(t, "revocation-ca", nil)
+	leaf := ca.issueLeaf(t, "client")
+	other := ca.issueLeaf(t, "other-client")
+	chain := []*x509.Certificate{leaf, ca.cert}
+
+	t.Run("no lists accepts", func(t *testing.T) {
+		assert.NoError(t, checkChainRevocation(chain, nil))
+	})
+
+	t.Run("list without the leaf accepts", func(t *testing.T) {
+		assert.NoError(t, checkChainRevocation(chain, []*x509.RevocationList{ca.issueCRL(t, other)}))
+	})
+
+	t.Run("revoked leaf is rejected", func(t *testing.T) {
+		err := checkChainRevocation(chain, []*x509.RevocationList{ca.issueCRL(t, leaf)})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "was revoked")
+		assert.Contains(t, err.Error(), leaf.SerialNumber.String())
+
+		var revoked *RevokedCertificateError
+		require.ErrorAs(t, err, &revoked)
+		assert.Equal(t, leaf.SerialNumber, revoked.Certificate.SerialNumber)
+	})
+
+	t.Run("revoked intermediate is rejected", func(t *testing.T) {
+		root := newRevocationTestCA(t, "revocation-root", nil)
+		intermediate := newRevocationTestCA(t, "revocation-intermediate", root)
+		intermediateLeaf := intermediate.issueLeaf(t, "deep-client")
+
+		deepChain := []*x509.Certificate{intermediateLeaf, intermediate.cert, root.cert}
+		crl := root.issueCRL(t, intermediate.cert)
+
+		err := checkChainRevocation(deepChain, []*x509.RevocationList{crl})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "revocation-intermediate")
+	})
+
+	// A list signed by a different key must never be trusted, even when its
+	// issuer name matches: otherwise anyone able to write the CRL file could
+	// revoke arbitrary certificates, or an operator copying the wrong file
+	// would lock out valid clients.
+	t.Run("list from an impostor issuer is ignored", func(t *testing.T) {
+		impostor := newRevocationTestCA(t, "revocation-ca", nil)
+		impostorCRL := impostor.issueCRL(t, leaf)
+		require.Equal(t, ca.cert.RawSubject, impostor.cert.RawSubject, "test requires matching issuer names")
+
+		assert.NoError(t, checkChainRevocation(chain, []*x509.RevocationList{impostorCRL}))
+	})
+
+	// The trust anchor has no issuer inside the chain, so nothing in the chain
+	// can attest to a list revoking it.
+	t.Run("self-signed root in the chain is not checked", func(t *testing.T) {
+		assert.NoError(t, checkChainRevocation([]*x509.Certificate{ca.cert}, []*x509.RevocationList{ca.issueCRL(t, ca.cert)}))
+	})
+}
+
+func TestCheckChainsRevocation(t *testing.T) {
+	ca := newRevocationTestCA(t, "chains-ca", nil)
+	leaf := ca.issueLeaf(t, "client")
+	revokedCRL := ca.issueCRL(t, leaf)
+
+	t.Run("empty list set accepts", func(t *testing.T) {
+		chains := [][]*x509.Certificate{{leaf, ca.cert}}
+		assert.NoError(t, checkChainsRevocation(chains, nil))
+	})
+
+	t.Run("all chains revoked is rejected", func(t *testing.T) {
+		chains := [][]*x509.Certificate{{leaf, ca.cert}}
+		require.Error(t, checkChainsRevocation(chains, []*x509.RevocationList{revokedCRL}))
+	})
+
+	// Cross-signed PKIs yield several valid chains. Revoking an intermediate on
+	// one path must not invalidate a path that does not traverse it.
+	t.Run("one clean chain accepts", func(t *testing.T) {
+		altCA := newRevocationTestCA(t, "alternate-ca", nil)
+		altLeaf := altCA.issueLeaf(t, "client")
+
+		chains := [][]*x509.Certificate{
+			{leaf, ca.cert},
+			{altLeaf, altCA.cert},
+		}
+		assert.NoError(t, checkChainsRevocation(chains, []*x509.RevocationList{revokedCRL}))
+	})
+}

--- a/comp/logs-library/utils/tls/server_config.go
+++ b/comp/logs-library/utils/tls/server_config.go
@@ -27,6 +27,7 @@ type ServerConfig struct {
 	CertFile   string
 	KeyFile    string
 	CAFile     string
+	CRLFile    string
 	ClientAuth tls.ClientAuthType
 	MinVersion uint16
 }
@@ -41,6 +42,11 @@ type ServerConfig struct {
 // and perform CA verification in VerifyConnection against the
 // dynamically-reloaded pool. This follows the pattern recommended by the Go
 // crypto team: https://go.dev/issue/64796
+//
+// When a CRL file is configured, the same VerifyConnection callback also
+// rejects clients whose certificate chain contains a revoked certificate. The
+// revocation lists are reloaded from disk on the same schedule as the CA
+// certificates, so publishing a new CRL takes effect without a restart.
 func (c *ServerConfig) BuildTLSConfig(ctx context.Context) (*tls.Config, error) {
 	if err := c.Validate(); err != nil {
 		return nil, err
@@ -67,8 +73,17 @@ func (c *ServerConfig) BuildTLSConfig(ctx context.Context) (*tls.Config, error) 
 		if _, err := caReloader.GetPool(); err != nil {
 			return nil, fmt.Errorf("failed to load TLS CA: %w", err)
 		}
+
+		var crlReloader *certreloader.CRLReloader
+		if c.CRLFile != "" {
+			crlReloader = certreloader.NewCRLReloader(ctx, c.CRLFile, certreloader.RealClock())
+			if _, err := crlReloader.GetCRLs(); err != nil {
+				return nil, fmt.Errorf("failed to load TLS CRL: %w", err)
+			}
+		}
+
 		tlsCfg.ClientAuth = clientAuthNoVerify(c.ClientAuth)
-		tlsCfg.VerifyConnection = buildCAVerifier(caReloader)
+		tlsCfg.VerifyConnection = buildCAVerifier(caReloader, crlReloader)
 	}
 
 	return tlsCfg, nil
@@ -90,6 +105,9 @@ func (c *ServerConfig) Validate() error {
 	}
 	if ClientAuthRequiresVerification(c.ClientAuth) && c.CAFile == "" {
 		return errors.New("tls client_auth requires ca_file to be set")
+	}
+	if c.CRLFile != "" && !ClientAuthRequiresVerification(c.ClientAuth) {
+		return errors.New("tls crl_file requires client_auth to be optional or required")
 	}
 	WarnKeyFilePermissions(c.KeyFile)
 	return nil
@@ -134,8 +152,10 @@ func clientAuthNoVerify(auth tls.ClientAuthType) tls.ClientAuthType {
 }
 
 // buildCAVerifier returns a VerifyConnection callback that verifies client
-// certificates against the CAReloader's current pool.
-func buildCAVerifier(caReloader *certreloader.CAReloader) func(tls.ConnectionState) error {
+// certificates against the CAReloader's current pool. When crlReloader is
+// non-nil, chains that verified against the trust store are additionally
+// checked against the current revocation lists.
+func buildCAVerifier(caReloader *certreloader.CAReloader, crlReloader *certreloader.CRLReloader) func(tls.ConnectionState) error {
 	return func(cs tls.ConnectionState) error {
 		if len(cs.PeerCertificates) == 0 {
 			return nil
@@ -150,11 +170,22 @@ func buildCAVerifier(caReloader *certreloader.CAReloader) func(tls.ConnectionSta
 			intermediates.AddCert(cert)
 		}
 
-		_, err = cs.PeerCertificates[0].Verify(x509.VerifyOptions{
+		chains, err := cs.PeerCertificates[0].Verify(x509.VerifyOptions{
 			Roots:         pool,
 			Intermediates: intermediates,
 			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		})
-		return err
+		if err != nil {
+			return err
+		}
+
+		if crlReloader == nil {
+			return nil
+		}
+		crls, err := crlReloader.GetCRLs()
+		if err != nil {
+			return fmt.Errorf("CRL unavailable: %w", err)
+		}
+		return checkChainsRevocation(chains, crls)
 	}
 }

--- a/comp/logs-library/utils/tls/server_config_test.go
+++ b/comp/logs-library/utils/tls/server_config_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClientAuthRequiresVerification(t *testing.T) {
@@ -93,5 +94,30 @@ func TestValidate(t *testing.T) {
 			ClientAuth: tls.VerifyClientCertIfGiven,
 		}
 		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("crl_file with client verification is OK", func(t *testing.T) {
+		c := &ServerConfig{
+			CertFile:   "/cert",
+			KeyFile:    "/key",
+			CAFile:     "/ca",
+			CRLFile:    "/crl",
+			ClientAuth: tls.RequireAndVerifyClientCert,
+		}
+		assert.NoError(t, c.Validate())
+	})
+
+	// Without client certificate verification there is nothing to revoke, so a
+	// configured CRL would be silently ignored.
+	t.Run("crl_file without client verification is rejected", func(t *testing.T) {
+		c := &ServerConfig{
+			CertFile:   "/cert",
+			KeyFile:    "/key",
+			CRLFile:    "/crl",
+			ClientAuth: tls.NoClientCert,
+		}
+		err := c.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "crl_file requires client_auth")
 	})
 }

--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -245,9 +245,13 @@ type AutoMultilineSample struct {
 // deserialized directly from YAML/JSON. String fields are validated and
 // converted to typed values when building the TLS configuration.
 type TLSListenerConfig struct {
-	CertFile      string `mapstructure:"cert_file" json:"cert_file" yaml:"cert_file"`
-	KeyFile       string `mapstructure:"key_file" json:"key_file" yaml:"key_file"`
-	CAFile        string `mapstructure:"ca_file" json:"ca_file" yaml:"ca_file"`
+	CertFile string `mapstructure:"cert_file" json:"cert_file" yaml:"cert_file"`
+	KeyFile  string `mapstructure:"key_file" json:"key_file" yaml:"key_file"`
+	CAFile   string `mapstructure:"ca_file" json:"ca_file" yaml:"ca_file"`
+	// CRLFile points at one or more PEM or DER certificate revocation lists.
+	// Clients whose certificate chain contains a revoked certificate are
+	// rejected. Only meaningful when client_auth is optional or required.
+	CRLFile       string `mapstructure:"crl_file" json:"crl_file" yaml:"crl_file"`
 	ClientAuth    string `mapstructure:"client_auth" json:"client_auth" yaml:"client_auth"`
 	MinTLSVersion string `mapstructure:"min_tls_version" json:"min_tls_version" yaml:"min_tls_version"`
 }
@@ -267,6 +271,7 @@ func (t *TLSListenerConfig) BuildTLSConfig(ctx context.Context) (*tls.Config, er
 		CertFile:   t.CertFile,
 		KeyFile:    t.KeyFile,
 		CAFile:     t.CAFile,
+		CRLFile:    t.CRLFile,
 		ClientAuth: clientAuth,
 		MinVersion: minVer,
 	}
@@ -350,8 +355,8 @@ func (c *LogsConfig) Dump(multiline bool) string {
 		fmt.Fprintf(&b, ws("Port: %d,"), c.Port)
 		fmt.Fprintf(&b, ws("IdleTimeout: %#v,"), c.IdleTimeout)
 		if c.TLS != nil {
-			fmt.Fprintf(&b, ws("TLS: {CertFile: %#v, KeyFile: %#v, CAFile: %#v, ClientAuth: %#v, MinTLSVersion: %#v},"),
-				c.TLS.CertFile, c.TLS.KeyFile, c.TLS.CAFile, c.TLS.ClientAuth, c.TLS.MinTLSVersion)
+			fmt.Fprintf(&b, ws("TLS: {CertFile: %#v, KeyFile: %#v, CAFile: %#v, CRLFile: %#v, ClientAuth: %#v, MinTLSVersion: %#v},"),
+				c.TLS.CertFile, c.TLS.KeyFile, c.TLS.CAFile, c.TLS.CRLFile, c.TLS.ClientAuth, c.TLS.MinTLSVersion)
 		}
 		if c.Format != "" {
 			fmt.Fprintf(&b, ws("Format: %#v,"), c.Format)
@@ -592,6 +597,9 @@ func (c *LogsConfig) validateTLS() error {
 	}
 	if tlsutil.ClientAuthRequiresVerification(auth) && c.TLS.CAFile == "" {
 		return fmt.Errorf("tls client_auth %q requires ca_file to be set", c.TLS.ClientAuth)
+	}
+	if c.TLS.CRLFile != "" && !tlsutil.ClientAuthRequiresVerification(auth) {
+		return fmt.Errorf("tls crl_file requires client_auth to be optional or required, got %q", c.TLS.ClientAuth)
 	}
 	tlsutil.WarnKeyFilePermissions(c.TLS.KeyFile)
 	return nil

--- a/comp/logs/agent/config/integration_config_test.go
+++ b/comp/logs/agent/config/integration_config_test.go
@@ -453,6 +453,33 @@ func TestValidateTLSConfig(t *testing.T) {
 			assert.Contains(t, err.Error(), "unrecognized min_tls_version")
 		}
 	})
+
+	t.Run("crl_file with client verification is valid", func(t *testing.T) {
+		for _, auth := range []string{"optional", "required"} {
+			cfg := &LogsConfig{
+				Type: TCPType,
+				Port: 6514,
+				TLS:  &TLSListenerConfig{CertFile: "/cert", KeyFile: "/key", CAFile: "/ca", CRLFile: "/crl", ClientAuth: auth},
+			}
+			assert.Nil(t, cfg.validateTLS(), "crl_file with client_auth %q should be valid", auth)
+		}
+	})
+
+	// A CRL only has an effect when client certificates are verified. Accepting
+	// the setting without verification would leave the operator believing
+	// revoked clients are being turned away.
+	t.Run("crl_file without client verification is rejected", func(t *testing.T) {
+		for _, auth := range []string{"", "none"} {
+			cfg := &LogsConfig{
+				Type: TCPType,
+				Port: 6514,
+				TLS:  &TLSListenerConfig{CertFile: "/cert", KeyFile: "/key", CRLFile: "/crl", ClientAuth: auth},
+			}
+			err := cfg.validateTLS()
+			assert.NotNil(t, err, "crl_file with client_auth %q should be rejected", auth)
+			assert.Contains(t, err.Error(), "crl_file requires client_auth")
+		}
+	})
 }
 
 func TestParseTLSVersion(t *testing.T) {

--- a/pkg/logs/launchers/listener/tcp_test.go
+++ b/pkg/logs/launchers/listener/tcp_test.go
@@ -13,6 +13,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -213,6 +214,13 @@ func (p *testPKI) issueClientCert(t *testing.T) (certPath, keyPath string) {
 	return p.issueCert(t, "client", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
 }
 
+// issueNamedClientCert creates a client certificate under a caller-chosen file
+// prefix, so that a test can hold several distinct client identities at once.
+func (p *testPKI) issueNamedClientCert(t *testing.T, prefix string) (certPath, keyPath string) {
+	t.Helper()
+	return p.issueCert(t, prefix, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+}
+
 // issueExpiredClientCert creates an already-expired client certificate signed
 // by the CA. The cert's NotAfter is in the past.
 func (p *testPKI) issueExpiredClientCert(t *testing.T) (certPath, keyPath string) {
@@ -225,6 +233,42 @@ func (p *testPKI) issueCert(t *testing.T, prefix string, extKeyUsage []x509.ExtK
 	t.Helper()
 	return p.issueCertWithValidity(t, prefix, extKeyUsage,
 		time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+}
+
+// writeCRL publishes a revocation list, signed by the CA, covering the client
+// certificates at the given cert paths. Returns the CRL file path.
+func (p *testPKI) writeCRL(t *testing.T, name string, revokedCertPaths ...string) string {
+	t.Helper()
+
+	entries := make([]x509.RevocationListEntry, 0, len(revokedCertPaths))
+	for _, path := range revokedCertPaths {
+		pemBytes, err := os.ReadFile(path)
+		require.NoError(t, err)
+		block, _ := pem.Decode(pemBytes)
+		require.NotNil(t, block)
+		cert, err := x509.ParseCertificate(block.Bytes)
+		require.NoError(t, err)
+		entries = append(entries, x509.RevocationListEntry{
+			SerialNumber:   cert.SerialNumber,
+			RevocationTime: time.Now().Add(-time.Minute),
+		})
+	}
+
+	crlDER, err := x509.CreateRevocationList(rand.Reader, &x509.RevocationList{
+		Number:                    big.NewInt(1),
+		ThisUpdate:                time.Now().Add(-time.Hour),
+		NextUpdate:                time.Now().Add(time.Hour),
+		RevokedCertificateEntries: entries,
+	}, p.caCert, p.caKey)
+	require.NoError(t, err)
+
+	crlPath := filepath.Join(p.dir, name)
+	out, err := os.Create(crlPath)
+	require.NoError(t, err)
+	require.NoError(t, pem.Encode(out, &pem.Block{Type: "X509 CRL", Bytes: crlDER}))
+	out.Close()
+
+	return crlPath
 }
 
 func (p *testPKI) issueCertWithValidity(t *testing.T, prefix string, extKeyUsage []x509.ExtKeyUsage, notBefore, notAfter time.Time) (certPath, keyPath string) {
@@ -824,4 +868,124 @@ func TestTCPMTLSRejectsExpiredClientCert(t *testing.T) {
 	assert.Equal(t, 0, len(listener.tailers), "no tailer should exist for an expired client cert")
 
 	listener.Stop()
+}
+
+func TestTCPMTLSRejectsRevokedClientCert(t *testing.T) {
+	pki := generateTestPKI(t)
+	serverCert, serverKey := pki.issueServerCert(t)
+	clientCert, clientKey := pki.issueClientCert(t)
+	crlPath := pki.writeCRL(t, "revoked.crl", clientCert)
+
+	pp := mock.NewMockProvider()
+
+	src := sources.NewLogSource("", &config.LogsConfig{
+		Port: tcpTestPort,
+		TLS: &config.TLSListenerConfig{
+			CertFile:   serverCert,
+			KeyFile:    serverKey,
+			CAFile:     pki.caPath,
+			CRLFile:    crlPath,
+			ClientAuth: "required",
+		},
+	})
+
+	listener, err := NewTCPListener(pp, src, 9000)
+	require.NoError(t, err)
+	listener.Start()
+	defer listener.Stop()
+	require.NotNil(t, listener.listener)
+
+	clientTLSCert, err := tls.LoadX509KeyPair(clientCert, clientKey)
+	require.NoError(t, err)
+
+	conn, dialErr := tls.Dial("tcp", listener.listener.Addr().String(), &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec
+		Certificates:       []tls.Certificate{clientTLSCert},
+	})
+
+	if dialErr == nil {
+		// TLS 1.3: the server rejects after the handshake completes, so the
+		// failure only surfaces on the first I/O. Closing the connection before
+		// the listener stops keeps a regression from hanging Stop().
+		defer conn.Close()
+		conn.SetDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
+		_, writeErr := fmt.Fprint(conn, "should fail\n")
+		if writeErr == nil {
+			buf := make([]byte, 1)
+			_, readErr := conn.Read(buf)
+			require.Error(t, readErr, "server should reject a revoked client certificate")
+			// A read deadline would also produce an error, which would let this
+			// assertion pass on a server that quietly accepted the connection.
+			var netErr net.Error
+			if errors.As(readErr, &netErr) {
+				assert.False(t, netErr.Timeout(), "server left the connection open instead of rejecting the revoked certificate")
+			}
+		}
+	}
+
+	assert.Equal(t, 0, len(listener.tailers), "no tailer should exist for a revoked client cert")
+}
+
+func TestTCPMTLSAcceptsClientCertAbsentFromCRL(t *testing.T) {
+	pki := generateTestPKI(t)
+	serverCert, serverKey := pki.issueServerCert(t)
+	revokedCert, _ := pki.issueNamedClientCert(t, "revoked-client")
+	goodCert, goodKey := pki.issueNamedClientCert(t, "good-client")
+	crlPath := pki.writeCRL(t, "revoked.crl", revokedCert)
+
+	pp := mock.NewMockProvider()
+	msgChan := pp.NextPipelineChan()
+
+	src := sources.NewLogSource("", &config.LogsConfig{
+		Port: tcpTestPort,
+		TLS: &config.TLSListenerConfig{
+			CertFile:   serverCert,
+			KeyFile:    serverKey,
+			CAFile:     pki.caPath,
+			CRLFile:    crlPath,
+			ClientAuth: "required",
+		},
+	})
+
+	listener, err := NewTCPListener(pp, src, 9000)
+	require.NoError(t, err)
+	listener.Start()
+	require.NotNil(t, listener.listener)
+
+	clientTLSCert, err := tls.LoadX509KeyPair(goodCert, goodKey)
+	require.NoError(t, err)
+
+	conn, err := dialTLSWithRetry(t, listener.listener.Addr().String(), &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec
+		Certificates:       []tls.Certificate{clientTLSCert},
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	fmt.Fprint(conn, "not revoked\n")
+	msg := <-msgChan
+	assert.Equal(t, "not revoked", string(msg.GetContent()))
+
+	listener.Stop()
+}
+
+func TestTCPTLSRefusesToStartOnUnreadableCRL(t *testing.T) {
+	pki := generateTestPKI(t)
+	serverCert, serverKey := pki.issueServerCert(t)
+
+	pp := mock.NewMockProvider()
+
+	src := sources.NewLogSource("", &config.LogsConfig{
+		Port: tcpTestPort,
+		TLS: &config.TLSListenerConfig{
+			CertFile:   serverCert,
+			KeyFile:    serverKey,
+			CAFile:     pki.caPath,
+			CRLFile:    "/nonexistent/revoked.crl",
+			ClientAuth: "required",
+		},
+	})
+
+	_, err := NewTCPListener(pp, src, 9000)
+	require.Error(t, err, "a configured but unusable CRL must not silently degrade to no revocation checking")
 }


### PR DESCRIPTION
### What does this PR do?

Adds a `crl_file` setting to the `tls` block of a TCP log listener. When client certificate verification is enabled, any client whose verified certificate chain contains a revoked certificate is turned away during the TLS handshake. The file may hold one or more certificate revocation lists in either PEM or DER form, and it is reloaded from disk on the same cadence as the CA bundle, so publishing an updated list takes effect without restarting the Agent.

A revocation list is only applied to certificates issued by the CA that signed it: the list's issuer name must match the candidate issuer in the chain and its signature must verify against that issuer's key. An unrelated list left in the file, or one copied from the wrong PKI, therefore cannot lock out valid clients. Configuring `crl_file` without `client_auth` set to `optional` or `required` is rejected at config validation time rather than silently ignored, and a listener whose CRL file cannot be read refuses to start instead of degrading to no revocation checking.

### Motivation

Client certificate verification previously had no way to turn away a certificate before its natural expiry. An operator whose client key was compromised had to either rotate the CA and reissue every client certificate, or wait out the remaining validity window. Revocation lists are the standard answer to that problem and are what a PKI team expects a TLS server to honor.

Expired lists are still enforced rather than ignored, since refusing to apply a stale list would re-admit every certificate it revokes. A warning is logged when a loaded list is past its `nextUpdate` so a stalled CRL distribution is visible to the operator.

### Describe how you validated your changes

`dda inv test --targets=./comp/logs-library/utils/tls/...`, `dda inv test --targets=./comp/logs/agent/config` and `dda inv test --targets=./pkg/logs/launchers/listener` all pass.

New coverage spans the three layers: revocation matching (revoked leaf, revoked intermediate, list signed by an impostor CA with a colliding subject name, cross-signed chains where only one path is revoked), list loading and hot reload (PEM, DER, concatenated lists from several issuers, reload failure preserving the previous lists), and config validation. End to end, `TestTCPMTLSRejectsRevokedClientCert` and `TestTCPMTLSAcceptsClientCertAbsentFromCRL` drive a real TLS handshake against the listener.

The rejection test was checked against a deliberately broken build with revocation enforcement disabled: it fails there on both assertions, so it is not passing vacuously. It also distinguishes a server-side rejection from a read deadline, which would otherwise satisfy a naive error assertion.

### Additional Notes

No release note is attached because TLS support on log listeners is not yet generally available.