### PR TITLE
[ AGNTLOG-702 ] Restrict TLS log listeners to named client identities

### DIFF
--- a/comp/logs-library/utils/tls/BUILD.bazel
+++ b/comp/logs-library/utils/tls/BUILD.bazel
@@ -3,7 +3,10 @@ load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "tls",
-    srcs = ["server_config.go"],
+    srcs = [
+        "client_names.go",
+        "server_config.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/comp/logs-library/utils/tls",
     visibility = ["//visibility:public"],
     deps = [
@@ -14,7 +17,13 @@ go_library(
 
 dd_agent_go_test(
     name = "tls_test",
-    srcs = ["server_config_test.go"],
+    srcs = [
+        "client_names_test.go",
+        "server_config_test.go",
+    ],
     embed = [":tls"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/comp/logs-library/utils/tls/client_names.go
+++ b/comp/logs-library/utils/tls/client_names.go
@@ -8,6 +8,7 @@ package tlsutil
 import (
 	"crypto/x509"
 	"fmt"
+	"net"
 	"strings"
 )
 
@@ -15,25 +16,43 @@ import (
 // narrowing access from "anyone the CA vouches for" to a named set of clients.
 // A shared or organization-wide CA otherwise admits every certificate it has
 // ever issued, which is rarely the intended trust boundary for a log listener.
+//
+// Each configured entry is indexed under every comparison rule, because the
+// identity type an operator had in mind is not known until a certificate
+// presents one. Comparison then follows the rule for the type actually
+// presented, so no identity is matched more loosely than its own syntax allows.
 type clientNameMatcher struct {
-	// allowed holds the lowercased entries used for lookups.
-	allowed map[string]struct{}
+	// folded holds entries canonicalized for the identity types compared
+	// without regard to case: DNS names, IP addresses and the common name.
+	folded map[string]struct{}
+	// mailbox holds entries with only their domain folded, for email addresses.
+	mailbox map[string]struct{}
+	// exact holds entries verbatim, for URIs.
+	exact map[string]struct{}
 	// configured keeps the original spellings so rejection messages show what
 	// the operator actually wrote.
 	configured []string
 }
 
-// newClientNameMatcher builds a matcher from the configured names. Blank
-// entries are ignored so that a trailing comma in a comma-separated list does
-// not create an unmatchable entry.
+// newClientNameMatcher builds a matcher from the configured names.
+//
+// Blank entries are dropped. Configuration validation already rejects them, so
+// this guards the case where a matcher is built directly: an empty entry would
+// otherwise authorize a certificate carrying an empty subject alternative name.
 func newClientNameMatcher(names []string) *clientNameMatcher {
-	m := &clientNameMatcher{allowed: make(map[string]struct{}, len(names))}
+	m := &clientNameMatcher{
+		folded:  make(map[string]struct{}, len(names)),
+		mailbox: make(map[string]struct{}, len(names)),
+		exact:   make(map[string]struct{}, len(names)),
+	}
 	for _, name := range names {
 		name = strings.TrimSpace(name)
 		if name == "" {
 			continue
 		}
-		m.allowed[strings.ToLower(name)] = struct{}{}
+		m.folded[foldIdentity(name)] = struct{}{}
+		m.mailbox[foldMailboxDomain(name)] = struct{}{}
+		m.exact[name] = struct{}{}
 		m.configured = append(m.configured, name)
 	}
 	return m
@@ -42,23 +61,74 @@ func newClientNameMatcher(names []string) *clientNameMatcher {
 // empty reports whether the matcher would authorize nothing, which means the
 // caller should not install it at all.
 func (m *clientNameMatcher) empty() bool {
-	return len(m.allowed) == 0
+	return len(m.configured) == 0
 }
 
 // verify accepts the certificate when any identity it presents is allowed.
 func (m *clientNameMatcher) verify(cert *x509.Certificate) error {
-	presented := certificateNames(cert)
-	for _, name := range presented {
-		if _, ok := m.allowed[strings.ToLower(name)]; ok {
+	for _, name := range cert.DNSNames {
+		if contains(m.folded, foldIdentity(name)) {
 			return nil
 		}
 	}
+	for _, email := range cert.EmailAddresses {
+		if contains(m.mailbox, foldMailboxDomain(email)) {
+			return nil
+		}
+	}
+	for _, ip := range cert.IPAddresses {
+		if contains(m.folded, foldIdentity(ip.String())) {
+			return nil
+		}
+	}
+	for _, uri := range cert.URIs {
+		if contains(m.exact, uri.String()) {
+			return nil
+		}
+	}
+	if cn := strings.TrimSpace(cert.Subject.CommonName); cn != "" {
+		if contains(m.folded, foldIdentity(cn)) {
+			return nil
+		}
+	}
+
+	presented := certificateNames(cert)
 	return fmt.Errorf("client certificate identities [%s] do not match any entry in allowed_client_names [%s]",
 		strings.Join(presented, ", "), strings.Join(m.configured, ", "))
 }
 
+func contains(set map[string]struct{}, key string) bool {
+	_, ok := set[key]
+	return ok
+}
+
+// foldIdentity canonicalizes an identity whose comparison ignores case: DNS
+// names (RFC 4343), IP addresses, and the common name, for which X.500
+// prescribes caseIgnoreMatch. IP literals are also reduced to their canonical
+// textual form, so an operator who writes an uncompressed IPv6 address still
+// matches the address a certificate presents.
+func foldIdentity(s string) string {
+	if ip := net.ParseIP(s); ip != nil {
+		return ip.String()
+	}
+	return strings.ToLower(s)
+}
+
+// foldMailboxDomain folds only the domain of an email address. RFC 5321 leaves
+// the local part case-sensitive, and Go draws the same line when matching email
+// name constraints.
+func foldMailboxDomain(s string) string {
+	at := strings.LastIndex(s, "@")
+	if at < 0 {
+		return s
+	}
+	return s[:at+1] + strings.ToLower(s[at+1:])
+}
+
 // certificateNames returns the identities a client certificate presents: every
-// subject alternative name, plus the subject common name.
+// subject alternative name, plus the subject common name. It backs the
+// rejection message; authorization itself compares each identity under the rule
+// for its own type.
 //
 // Hostname verification (RFC 6125) ignores the common name whenever any
 // subject alternative name is present. That rule is deliberately not applied

--- a/comp/logs-library/utils/tls/client_names.go
+++ b/comp/logs-library/utils/tls/client_names.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package tlsutil
+
+import (
+	"crypto/x509"
+	"fmt"
+	"strings"
+)
+
+// clientNameMatcher authorizes a client by the identity in its certificate,
+// narrowing access from "anyone the CA vouches for" to a named set of clients.
+// A shared or organization-wide CA otherwise admits every certificate it has
+// ever issued, which is rarely the intended trust boundary for a log listener.
+type clientNameMatcher struct {
+	// allowed holds the lowercased entries used for lookups.
+	allowed map[string]struct{}
+	// configured keeps the original spellings so rejection messages show what
+	// the operator actually wrote.
+	configured []string
+}
+
+// newClientNameMatcher builds a matcher from the configured names. Blank
+// entries are ignored so that a trailing comma in a comma-separated list does
+// not create an unmatchable entry.
+func newClientNameMatcher(names []string) *clientNameMatcher {
+	m := &clientNameMatcher{allowed: make(map[string]struct{}, len(names))}
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		m.allowed[strings.ToLower(name)] = struct{}{}
+		m.configured = append(m.configured, name)
+	}
+	return m
+}
+
+// empty reports whether the matcher would authorize nothing, which means the
+// caller should not install it at all.
+func (m *clientNameMatcher) empty() bool {
+	return len(m.allowed) == 0
+}
+
+// verify accepts the certificate when any identity it presents is allowed.
+func (m *clientNameMatcher) verify(cert *x509.Certificate) error {
+	presented := certificateNames(cert)
+	for _, name := range presented {
+		if _, ok := m.allowed[strings.ToLower(name)]; ok {
+			return nil
+		}
+	}
+	return fmt.Errorf("client certificate identities [%s] do not match any entry in allowed_client_names [%s]",
+		strings.Join(presented, ", "), strings.Join(m.configured, ", "))
+}
+
+// certificateNames returns the identities a client certificate presents: every
+// subject alternative name, plus the subject common name.
+//
+// Hostname verification (RFC 6125) ignores the common name whenever any
+// subject alternative name is present. That rule is deliberately not applied
+// here: this is client authorization rather than server identity checking, and
+// client certificates in the field routinely carry their identity only in the
+// common name. Any name the trusted CA chose to put in the certificate is
+// therefore eligible to match.
+func certificateNames(cert *x509.Certificate) []string {
+	names := make([]string, 0, len(cert.DNSNames)+len(cert.EmailAddresses)+len(cert.IPAddresses)+len(cert.URIs)+1)
+	names = append(names, cert.DNSNames...)
+	names = append(names, cert.EmailAddresses...)
+	for _, ip := range cert.IPAddresses {
+		names = append(names, ip.String())
+	}
+	for _, uri := range cert.URIs {
+		names = append(names, uri.String())
+	}
+	if cn := strings.TrimSpace(cert.Subject.CommonName); cn != "" {
+		names = append(names, cn)
+	}
+	return names
+}

--- a/comp/logs-library/utils/tls/client_names_test.go
+++ b/comp/logs-library/utils/tls/client_names_test.go
@@ -1,0 +1,115 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package tlsutil
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"net"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClientNameMatcher(t *testing.T) {
+	t.Run("no names yields an empty matcher", func(t *testing.T) {
+		assert.True(t, newClientNameMatcher(nil).empty())
+		assert.True(t, newClientNameMatcher([]string{}).empty())
+	})
+
+	// A trailing comma in a comma-separated list produces a blank entry, which
+	// must not become an unmatchable name.
+	t.Run("blank entries are dropped", func(t *testing.T) {
+		assert.True(t, newClientNameMatcher([]string{"", "   "}).empty())
+
+		m := newClientNameMatcher([]string{"relay.example.com", "  "})
+		assert.False(t, m.empty())
+		assert.Equal(t, []string{"relay.example.com"}, m.configured)
+	})
+
+	t.Run("surrounding whitespace is ignored", func(t *testing.T) {
+		m := newClientNameMatcher([]string{" relay.example.com "})
+		cert := &x509.Certificate{DNSNames: []string{"relay.example.com"}}
+		assert.NoError(t, m.verify(cert))
+	})
+}
+
+func TestClientNameMatcherVerify(t *testing.T) {
+	uri, err := url.Parse("spiffe://example.com/relay")
+	require.NoError(t, err)
+
+	cert := &x509.Certificate{
+		Subject:        pkix.Name{CommonName: "relay-1"},
+		DNSNames:       []string{"relay.example.com"},
+		EmailAddresses: []string{"relay@example.com"},
+		IPAddresses:    []net.IP{net.IPv4(10, 0, 0, 5)},
+		URIs:           []*url.URL{uri},
+	}
+
+	allowedBy := []struct {
+		name  string
+		entry string
+	}{
+		{"dns SAN", "relay.example.com"},
+		{"email SAN", "relay@example.com"},
+		{"ip SAN", "10.0.0.5"},
+		{"uri SAN", "spiffe://example.com/relay"},
+		{"common name", "relay-1"},
+	}
+	for _, tc := range allowedBy {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.NoError(t, newClientNameMatcher([]string{"other", tc.entry}).verify(cert))
+		})
+	}
+
+	// DNS names and mail addresses are not case-sensitive, and operators should
+	// not have to match the CA's capitalization exactly.
+	t.Run("matching is case-insensitive", func(t *testing.T) {
+		assert.NoError(t, newClientNameMatcher([]string{"RELAY.EXAMPLE.COM"}).verify(cert))
+		assert.NoError(t, newClientNameMatcher([]string{"Relay-1"}).verify(cert))
+	})
+
+	t.Run("unlisted identity is rejected", func(t *testing.T) {
+		err := newClientNameMatcher([]string{"other.example.com"}).verify(cert)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "allowed_client_names")
+		// The message must name both sides so the mismatch is diagnosable from
+		// the Agent log alone.
+		assert.Contains(t, err.Error(), "relay.example.com")
+		assert.Contains(t, err.Error(), "other.example.com")
+	})
+
+	t.Run("substring of an allowed name is rejected", func(t *testing.T) {
+		assert.Error(t, newClientNameMatcher([]string{"relay.example.com.attacker.test"}).verify(cert))
+		assert.Error(t, newClientNameMatcher([]string{"example.com"}).verify(cert))
+	})
+
+	// Wildcards are not supported; an entry containing one matches literally
+	// rather than silently authorizing a whole domain.
+	t.Run("wildcard entry does not match a subdomain", func(t *testing.T) {
+		assert.Error(t, newClientNameMatcher([]string{"*.example.com"}).verify(cert))
+	})
+
+	t.Run("certificate with no identities is rejected", func(t *testing.T) {
+		assert.Error(t, newClientNameMatcher([]string{"relay-1"}).verify(&x509.Certificate{}))
+	})
+}
+
+func TestCertificateNames(t *testing.T) {
+	t.Run("blank common name is omitted", func(t *testing.T) {
+		names := certificateNames(&x509.Certificate{
+			Subject:  pkix.Name{CommonName: "  "},
+			DNSNames: []string{"relay.example.com"},
+		})
+		assert.Equal(t, []string{"relay.example.com"}, names)
+	})
+
+	t.Run("no identities yields no names", func(t *testing.T) {
+		assert.Empty(t, certificateNames(&x509.Certificate{}))
+	})
+}

--- a/comp/logs-library/utils/tls/client_names_test.go
+++ b/comp/logs-library/utils/tls/client_names_test.go
@@ -22,14 +22,20 @@ func TestNewClientNameMatcher(t *testing.T) {
 		assert.True(t, newClientNameMatcher([]string{}).empty())
 	})
 
-	// A trailing comma in a comma-separated list produces a blank entry, which
-	// must not become an unmatchable name.
 	t.Run("blank entries are dropped", func(t *testing.T) {
 		assert.True(t, newClientNameMatcher([]string{"", "   "}).empty())
 
 		m := newClientNameMatcher([]string{"relay.example.com", "  "})
 		assert.False(t, m.empty())
 		assert.Equal(t, []string{"relay.example.com"}, m.configured)
+	})
+
+	// Certificates may carry an empty subject alternative name. A blank entry
+	// that survived into the matcher would authorize any such certificate.
+	t.Run("blank entry does not authorize an empty subject alternative name", func(t *testing.T) {
+		m := newClientNameMatcher([]string{"relay.example.com", ""})
+		assert.Error(t, m.verify(&x509.Certificate{DNSNames: []string{""}}))
+		assert.Error(t, m.verify(&x509.Certificate{EmailAddresses: []string{""}}))
 	})
 
 	t.Run("surrounding whitespace is ignored", func(t *testing.T) {
@@ -67,11 +73,33 @@ func TestClientNameMatcherVerify(t *testing.T) {
 		})
 	}
 
-	// DNS names and mail addresses are not case-sensitive, and operators should
-	// not have to match the CA's capitalization exactly.
-	t.Run("matching is case-insensitive", func(t *testing.T) {
+	// DNS names and the common name are compared without regard to case, so
+	// operators need not match the CA's capitalization exactly.
+	t.Run("dns and common name matching is case-insensitive", func(t *testing.T) {
 		assert.NoError(t, newClientNameMatcher([]string{"RELAY.EXAMPLE.COM"}).verify(cert))
 		assert.NoError(t, newClientNameMatcher([]string{"Relay-1"}).verify(cert))
+	})
+
+	// Only the scheme and authority of a URI are case-insensitive. Folding the
+	// path would let one SPIFFE workload identity authorize a different one.
+	t.Run("uri paths are case-sensitive", func(t *testing.T) {
+		assert.Error(t, newClientNameMatcher([]string{"spiffe://example.com/Relay"}).verify(cert))
+		assert.NoError(t, newClientNameMatcher([]string{"spiffe://example.com/relay"}).verify(cert))
+	})
+
+	// RFC 5321 leaves the local part case-sensitive while the domain is not.
+	t.Run("only the mail domain is case-insensitive", func(t *testing.T) {
+		mailOnly := &x509.Certificate{EmailAddresses: []string{"relay@example.com"}}
+		assert.NoError(t, newClientNameMatcher([]string{"relay@EXAMPLE.COM"}).verify(mailOnly))
+		assert.Error(t, newClientNameMatcher([]string{"Relay@example.com"}).verify(mailOnly))
+	})
+
+	// A certificate always presents its canonical form, so an operator writing
+	// an uncompressed address should not be silently locked out.
+	t.Run("ip entries are compared in canonical form", func(t *testing.T) {
+		v6 := &x509.Certificate{IPAddresses: []net.IP{net.ParseIP("fe80::1")}}
+		assert.NoError(t, newClientNameMatcher([]string{"FE80:0:0:0:0:0:0:1"}).verify(v6))
+		assert.Error(t, newClientNameMatcher([]string{"fe80::2"}).verify(v6))
 	})
 
 	t.Run("unlisted identity is rejected", func(t *testing.T) {

--- a/comp/logs-library/utils/tls/server_config.go
+++ b/comp/logs-library/utils/tls/server_config.go
@@ -24,11 +24,15 @@ import (
 // calling config layer is responsible for parsing and validating raw input
 // before constructing a ServerConfig.
 type ServerConfig struct {
-	CertFile   string
-	KeyFile    string
-	CAFile     string
-	ClientAuth tls.ClientAuthType
-	MinVersion uint16
+	CertFile string
+	KeyFile  string
+	CAFile   string
+	// AllowedClientNames restricts which client identities may connect once
+	// their certificate chain is trusted. Empty means any client the CA vouches
+	// for is accepted.
+	AllowedClientNames []string
+	ClientAuth         tls.ClientAuthType
+	MinVersion         uint16
 }
 
 // BuildTLSConfig loads certificates from disk and returns a *tls.Config ready
@@ -41,6 +45,9 @@ type ServerConfig struct {
 // and perform CA verification in VerifyConnection against the
 // dynamically-reloaded pool. This follows the pattern recommended by the Go
 // crypto team: https://go.dev/issue/64796
+//
+// When client names are configured, the same callback additionally requires the
+// client certificate to present an allowed identity.
 func (c *ServerConfig) BuildTLSConfig(ctx context.Context) (*tls.Config, error) {
 	if err := c.Validate(); err != nil {
 		return nil, err
@@ -67,8 +74,13 @@ func (c *ServerConfig) BuildTLSConfig(ctx context.Context) (*tls.Config, error) 
 		if _, err := caReloader.GetPool(); err != nil {
 			return nil, fmt.Errorf("failed to load TLS CA: %w", err)
 		}
+		var nameMatcher *clientNameMatcher
+		if matcher := newClientNameMatcher(c.AllowedClientNames); !matcher.empty() {
+			nameMatcher = matcher
+		}
+
 		tlsCfg.ClientAuth = clientAuthNoVerify(c.ClientAuth)
-		tlsCfg.VerifyConnection = buildCAVerifier(caReloader)
+		tlsCfg.VerifyConnection = buildCAVerifier(caReloader, nameMatcher)
 	}
 
 	return tlsCfg, nil
@@ -90,6 +102,12 @@ func (c *ServerConfig) Validate() error {
 	}
 	if ClientAuthRequiresVerification(c.ClientAuth) && c.CAFile == "" {
 		return errors.New("tls client_auth requires ca_file to be set")
+	}
+	// With client_auth "optional" a client that presents no certificate is
+	// accepted and never reaches the name check, so the allowlist would be
+	// trivially bypassable.
+	if len(c.AllowedClientNames) > 0 && c.ClientAuth != tls.RequireAndVerifyClientCert {
+		return errors.New(`tls allowed_client_names requires client_auth to be "required"`)
 	}
 	WarnKeyFilePermissions(c.KeyFile)
 	return nil
@@ -134,8 +152,9 @@ func clientAuthNoVerify(auth tls.ClientAuthType) tls.ClientAuthType {
 }
 
 // buildCAVerifier returns a VerifyConnection callback that verifies client
-// certificates against the CAReloader's current pool.
-func buildCAVerifier(caReloader *certreloader.CAReloader) func(tls.ConnectionState) error {
+// certificates against the CAReloader's current pool. When nameMatcher is
+// non-nil, a trusted certificate must additionally present an allowed identity.
+func buildCAVerifier(caReloader *certreloader.CAReloader, nameMatcher *clientNameMatcher) func(tls.ConnectionState) error {
 	return func(cs tls.ConnectionState) error {
 		if len(cs.PeerCertificates) == 0 {
 			return nil
@@ -155,6 +174,13 @@ func buildCAVerifier(caReloader *certreloader.CAReloader) func(tls.ConnectionSta
 			Intermediates: intermediates,
 			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		})
-		return err
+		if err != nil {
+			return err
+		}
+
+		if nameMatcher == nil {
+			return nil
+		}
+		return nameMatcher.verify(cs.PeerCertificates[0])
 	}
 }

--- a/comp/logs-library/utils/tls/server_config_test.go
+++ b/comp/logs-library/utils/tls/server_config_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClientAuthRequiresVerification(t *testing.T) {
@@ -93,5 +94,32 @@ func TestValidate(t *testing.T) {
 			ClientAuth: tls.VerifyClientCertIfGiven,
 		}
 		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("allowed_client_names with required client auth is OK", func(t *testing.T) {
+		c := &ServerConfig{
+			CertFile:           "/cert",
+			KeyFile:            "/key",
+			CAFile:             "/ca",
+			AllowedClientNames: []string{"relay.example.com"},
+			ClientAuth:         tls.RequireAndVerifyClientCert,
+		}
+		assert.NoError(t, c.Validate())
+	})
+
+	// "optional" lets a client skip its certificate, and the allowlist with it.
+	t.Run("allowed_client_names without required client auth is rejected", func(t *testing.T) {
+		for _, auth := range []tls.ClientAuthType{tls.NoClientCert, tls.RequestClientCert, tls.RequireAnyClientCert, tls.VerifyClientCertIfGiven} {
+			c := &ServerConfig{
+				CertFile:           "/cert",
+				KeyFile:            "/key",
+				CAFile:             "/ca",
+				AllowedClientNames: []string{"relay.example.com"},
+				ClientAuth:         auth,
+			}
+			err := c.Validate()
+			require.Error(t, err, "client auth %d should be rejected", auth)
+			assert.Contains(t, err.Error(), "allowed_client_names requires client_auth")
+		}
 	})
 }

--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -245,11 +245,16 @@ type AutoMultilineSample struct {
 // deserialized directly from YAML/JSON. String fields are validated and
 // converted to typed values when building the TLS configuration.
 type TLSListenerConfig struct {
-	CertFile      string `mapstructure:"cert_file" json:"cert_file" yaml:"cert_file"`
-	KeyFile       string `mapstructure:"key_file" json:"key_file" yaml:"key_file"`
-	CAFile        string `mapstructure:"ca_file" json:"ca_file" yaml:"ca_file"`
-	ClientAuth    string `mapstructure:"client_auth" json:"client_auth" yaml:"client_auth"`
-	MinTLSVersion string `mapstructure:"min_tls_version" json:"min_tls_version" yaml:"min_tls_version"`
+	CertFile string `mapstructure:"cert_file" json:"cert_file" yaml:"cert_file"`
+	KeyFile  string `mapstructure:"key_file" json:"key_file" yaml:"key_file"`
+	CAFile   string `mapstructure:"ca_file" json:"ca_file" yaml:"ca_file"`
+	// AllowedClientNames lists the client identities permitted to connect,
+	// matched against the subject alternative names and common name of the
+	// client certificate. Empty means every client the CA trusts is accepted.
+	// Requires client_auth to be "required".
+	AllowedClientNames StringSliceField `mapstructure:"allowed_client_names" json:"allowed_client_names,omitempty" yaml:"allowed_client_names,omitempty"`
+	ClientAuth         string           `mapstructure:"client_auth" json:"client_auth" yaml:"client_auth"`
+	MinTLSVersion      string           `mapstructure:"min_tls_version" json:"min_tls_version" yaml:"min_tls_version"`
 }
 
 // BuildTLSConfig validates user-facing strings, converts them to typed values,
@@ -264,11 +269,12 @@ func (t *TLSListenerConfig) BuildTLSConfig(ctx context.Context) (*tls.Config, er
 		return nil, err
 	}
 	cfg := &tlsutil.ServerConfig{
-		CertFile:   t.CertFile,
-		KeyFile:    t.KeyFile,
-		CAFile:     t.CAFile,
-		ClientAuth: clientAuth,
-		MinVersion: minVer,
+		CertFile:           t.CertFile,
+		KeyFile:            t.KeyFile,
+		CAFile:             t.CAFile,
+		AllowedClientNames: t.AllowedClientNames,
+		ClientAuth:         clientAuth,
+		MinVersion:         minVer,
 	}
 	return cfg.BuildTLSConfig(ctx)
 }
@@ -350,8 +356,8 @@ func (c *LogsConfig) Dump(multiline bool) string {
 		fmt.Fprintf(&b, ws("Port: %d,"), c.Port)
 		fmt.Fprintf(&b, ws("IdleTimeout: %#v,"), c.IdleTimeout)
 		if c.TLS != nil {
-			fmt.Fprintf(&b, ws("TLS: {CertFile: %#v, KeyFile: %#v, CAFile: %#v, ClientAuth: %#v, MinTLSVersion: %#v},"),
-				c.TLS.CertFile, c.TLS.KeyFile, c.TLS.CAFile, c.TLS.ClientAuth, c.TLS.MinTLSVersion)
+			fmt.Fprintf(&b, ws("TLS: {CertFile: %#v, KeyFile: %#v, CAFile: %#v, AllowedClientNames: %#v, ClientAuth: %#v, MinTLSVersion: %#v},"),
+				c.TLS.CertFile, c.TLS.KeyFile, c.TLS.CAFile, c.TLS.AllowedClientNames, c.TLS.ClientAuth, c.TLS.MinTLSVersion)
 		}
 		if c.Format != "" {
 			fmt.Fprintf(&b, ws("Format: %#v,"), c.Format)
@@ -593,7 +599,27 @@ func (c *LogsConfig) validateTLS() error {
 	if tlsutil.ClientAuthRequiresVerification(auth) && c.TLS.CAFile == "" {
 		return fmt.Errorf("tls client_auth %q requires ca_file to be set", c.TLS.ClientAuth)
 	}
+	if err := c.validateAllowedClientNames(auth); err != nil {
+		return err
+	}
 	tlsutil.WarnKeyFilePermissions(c.TLS.KeyFile)
+	return nil
+}
+
+func (c *LogsConfig) validateAllowedClientNames(auth tls.ClientAuthType) error {
+	if len(c.TLS.AllowedClientNames) == 0 {
+		return nil
+	}
+	// Anything short of "required" lets a client skip the certificate entirely,
+	// which would skip the allowlist with it.
+	if auth != tls.RequireAndVerifyClientCert {
+		return fmt.Errorf("tls allowed_client_names requires client_auth to be \"required\", got %q", c.TLS.ClientAuth)
+	}
+	for _, name := range c.TLS.AllowedClientNames {
+		if strings.TrimSpace(name) == "" {
+			return errors.New("tls allowed_client_names must not contain empty entries")
+		}
+	}
 	return nil
 }
 

--- a/comp/logs/agent/config/integration_config_test.go
+++ b/comp/logs/agent/config/integration_config_test.go
@@ -453,6 +453,59 @@ func TestValidateTLSConfig(t *testing.T) {
 			assert.Contains(t, err.Error(), "unrecognized min_tls_version")
 		}
 	})
+
+	t.Run("allowed_client_names with required client auth is valid", func(t *testing.T) {
+		cfg := &LogsConfig{
+			Type: TCPType,
+			Port: 6514,
+			TLS: &TLSListenerConfig{
+				CertFile:           "/cert",
+				KeyFile:            "/key",
+				CAFile:             "/ca",
+				ClientAuth:         "required",
+				AllowedClientNames: StringSliceField{"relay.example.com"},
+			},
+		}
+		assert.Nil(t, cfg.validateTLS())
+	})
+
+	// Under any weaker mode a client can decline to send a certificate and the
+	// allowlist never applies, so accepting the setting would be misleading.
+	t.Run("allowed_client_names without required client auth is rejected", func(t *testing.T) {
+		for _, auth := range []string{"", "none", "optional"} {
+			cfg := &LogsConfig{
+				Type: TCPType,
+				Port: 6514,
+				TLS: &TLSListenerConfig{
+					CertFile:           "/cert",
+					KeyFile:            "/key",
+					CAFile:             "/ca",
+					ClientAuth:         auth,
+					AllowedClientNames: StringSliceField{"relay.example.com"},
+				},
+			}
+			err := cfg.validateTLS()
+			assert.NotNil(t, err, "allowed_client_names with client_auth %q should be rejected", auth)
+			assert.Contains(t, err.Error(), "allowed_client_names requires client_auth")
+		}
+	})
+
+	t.Run("empty allowed_client_names entry is rejected", func(t *testing.T) {
+		cfg := &LogsConfig{
+			Type: TCPType,
+			Port: 6514,
+			TLS: &TLSListenerConfig{
+				CertFile:           "/cert",
+				KeyFile:            "/key",
+				CAFile:             "/ca",
+				ClientAuth:         "required",
+				AllowedClientNames: StringSliceField{"relay.example.com", " "},
+			},
+		}
+		err := cfg.validateTLS()
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "must not contain empty entries")
+	})
 }
 
 func TestParseTLSVersion(t *testing.T) {

--- a/pkg/logs/launchers/listener/tcp_test.go
+++ b/pkg/logs/launchers/listener/tcp_test.go
@@ -13,6 +13,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -824,4 +825,142 @@ func TestTCPMTLSRejectsExpiredClientCert(t *testing.T) {
 	assert.Equal(t, 0, len(listener.tailers), "no tailer should exist for an expired client cert")
 
 	listener.Stop()
+}
+
+func TestTCPMTLSAcceptsAllowedClientName(t *testing.T) {
+	pki := generateTestPKI(t)
+	serverCert, serverKey := pki.issueServerCert(t)
+	clientCert, clientKey := pki.issueClientCert(t)
+
+	pp := mock.NewMockProvider()
+	msgChan := pp.NextPipelineChan()
+
+	src := sources.NewLogSource("", &config.LogsConfig{
+		Port: tcpTestPort,
+		TLS: &config.TLSListenerConfig{
+			CertFile:   serverCert,
+			KeyFile:    serverKey,
+			CAFile:     pki.caPath,
+			ClientAuth: "required",
+			// The test PKI issues client certificates with common name "client".
+			AllowedClientNames: config.StringSliceField{"other-relay", "client"},
+		},
+	})
+
+	listener, err := NewTCPListener(pp, src, 9000)
+	require.NoError(t, err)
+	listener.Start()
+	defer listener.Stop()
+	require.NotNil(t, listener.listener)
+
+	clientTLSCert, err := tls.LoadX509KeyPair(clientCert, clientKey)
+	require.NoError(t, err)
+
+	conn, err := dialTLSWithRetry(t, listener.listener.Addr().String(), &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec
+		Certificates:       []tls.Certificate{clientTLSCert},
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	fmt.Fprint(conn, "allowed name\n")
+	msg := <-msgChan
+	assert.Equal(t, "allowed name", string(msg.GetContent()))
+}
+
+// A certificate the CA vouches for is still turned away when its identity is
+// not on the list, which is the whole point of the setting.
+func TestTCPMTLSRejectsUnlistedClientName(t *testing.T) {
+	pki := generateTestPKI(t)
+	serverCert, serverKey := pki.issueServerCert(t)
+	clientCert, clientKey := pki.issueClientCert(t)
+
+	pp := mock.NewMockProvider()
+
+	src := sources.NewLogSource("", &config.LogsConfig{
+		Port: tcpTestPort,
+		TLS: &config.TLSListenerConfig{
+			CertFile:           serverCert,
+			KeyFile:            serverKey,
+			CAFile:             pki.caPath,
+			ClientAuth:         "required",
+			AllowedClientNames: config.StringSliceField{"some-other-relay"},
+		},
+	})
+
+	listener, err := NewTCPListener(pp, src, 9000)
+	require.NoError(t, err)
+	listener.Start()
+	defer listener.Stop()
+	require.NotNil(t, listener.listener)
+
+	clientTLSCert, err := tls.LoadX509KeyPair(clientCert, clientKey)
+	require.NoError(t, err)
+
+	conn, dialErr := tls.Dial("tcp", listener.listener.Addr().String(), &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec
+		Certificates:       []tls.Certificate{clientTLSCert},
+	})
+
+	if dialErr == nil {
+		// TLS 1.3: the server rejects after the handshake completes, so the
+		// failure only surfaces on the first I/O. Closing the connection before
+		// the listener stops keeps a regression from hanging Stop().
+		defer conn.Close()
+		conn.SetDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
+		_, writeErr := fmt.Fprint(conn, "should fail\n")
+		if writeErr == nil {
+			buf := make([]byte, 1)
+			_, readErr := conn.Read(buf)
+			require.Error(t, readErr, "server should reject an unlisted client name")
+			// A read deadline would also produce an error, which would let this
+			// assertion pass on a server that quietly accepted the connection.
+			var netErr net.Error
+			if errors.As(readErr, &netErr) {
+				assert.False(t, netErr.Timeout(), "server left the connection open instead of rejecting the unlisted client name")
+			}
+		}
+	}
+
+	assert.Equal(t, 0, len(listener.tailers), "no tailer should exist for an unlisted client name")
+}
+
+// Without the setting, any client the CA trusts is still accepted.
+func TestTCPMTLSAcceptsAnyClientWhenNoNamesConfigured(t *testing.T) {
+	pki := generateTestPKI(t)
+	serverCert, serverKey := pki.issueServerCert(t)
+	clientCert, clientKey := pki.issueClientCert(t)
+
+	pp := mock.NewMockProvider()
+	msgChan := pp.NextPipelineChan()
+
+	src := sources.NewLogSource("", &config.LogsConfig{
+		Port: tcpTestPort,
+		TLS: &config.TLSListenerConfig{
+			CertFile:   serverCert,
+			KeyFile:    serverKey,
+			CAFile:     pki.caPath,
+			ClientAuth: "required",
+		},
+	})
+
+	listener, err := NewTCPListener(pp, src, 9000)
+	require.NoError(t, err)
+	listener.Start()
+	defer listener.Stop()
+	require.NotNil(t, listener.listener)
+
+	clientTLSCert, err := tls.LoadX509KeyPair(clientCert, clientKey)
+	require.NoError(t, err)
+
+	conn, err := dialTLSWithRetry(t, listener.listener.Addr().String(), &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec
+		Certificates:       []tls.Certificate{clientTLSCert},
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	fmt.Fprint(conn, "no allowlist\n")
+	msg := <-msgChan
+	assert.Equal(t, "no allowlist", string(msg.GetContent()))
 }


### PR DESCRIPTION
### What does this PR do?

Adds an `allowed_client_names` setting to the `tls` block of a TCP log listener. When set, a client must not only present a certificate the configured CA trusts, but that certificate must also carry an identity on the list. Entries are matched against every subject alternative name in the certificate — DNS, email, IP and URI — as well as the subject common name.

Each identity is compared under the case rules of its own type, so nothing is matched more loosely than its syntax allows: DNS names, IP addresses and the common name ignore case, an email address folds only its domain and keeps its local part exact, and a URI must match exactly, since folding a URI path would let one SPIFFE workload identity authorize a different one. IP entries are compared in canonical form, so an uncompressed IPv6 address still matches the form a certificate presents. Wildcards are never interpreted: an entry containing one matches literally rather than quietly authorizing a whole domain.

The setting requires `client_auth: required`; under `optional` a client can decline to send a certificate and would bypass the list entirely, so that combination is rejected at config validation time rather than accepted and ignored. When a client is turned away, the handshake failure logged by the listener names both the identities the certificate presented and the configured entries, so the mismatch can be diagnosed without reproducing the connection.

### Motivation

Mutual TLS previously answered only "did the CA vouch for this client". Organizations commonly run one internal CA for a wide range of workloads, so trusting that CA on a log listener also trusts every certificate it has ever issued, including hosts with no business shipping logs. Operators coming from other syslog servers expect to be able to pin the specific senders they intend to accept.

Common name matching is intentionally kept alongside subject alternative names, even though RFC 6125 hostname verification ignores the common name whenever any SAN is present. This is client authorization rather than server identity verification, and client certificates in the field routinely carry their identity only in the common name.

### Describe how you validated your changes

`dda inv test --targets=./comp/logs-library/utils/tls/...`, `dda inv test --targets=./comp/logs/agent/config` and `dda inv test --targets=./pkg/logs/launchers/listener` all pass.

New coverage includes matching on each identity type, the per-type case rules, rejection of substring and wildcard near-misses, certificates carrying no identity at all, blank entries from a trailing comma in a comma-separated list, and the validation rules. End to end, `TestTCPMTLSAcceptsAllowedClientName`, `TestTCPMTLSRejectsUnlistedClientName` and `TestTCPMTLSAcceptsAnyClientWhenNoNamesConfigured` drive real TLS handshakes against the listener.

The rejection test was checked against a deliberately broken build with the name check disabled: it fails there on both assertions, so it is not passing vacuously. It also distinguishes a server-side rejection from a read deadline, which would otherwise satisfy a naive error assertion. The two case-sensitivity rules were verified the same way, against a build that folded URIs and mail local parts.

### Additional Notes

No release note is attached because TLS support on log listeners is not yet generally available.

Wildcard and regular-expression entries were deliberately left out. They can be added later without breaking existing configuration, whereas retrofitting exact-match semantics onto entries that were previously treated as patterns could not be done safely.