### PR TITLE
Fix permissions of files created for E2E testing

### DIFF
--- a/tasks/e2e_framework/config.py
+++ b/tasks/e2e_framework/config.py
@@ -8,7 +8,7 @@ from invoke.exceptions import Exit
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from termcolor import colored
 
-from .tool import info
+from .tool import info, write_secret_file
 
 profile_filename = ".test_infra_config.yaml"
 
@@ -152,17 +152,9 @@ You should consider moving to the agent-sandbox account. Please follow https://d
     def save_to_local_config(self, config_path: str | None = None):
         profile_path = get_full_profile_path(config_path)
         try:
-            with open(profile_path, "w") as outfile:
-                yaml.dump(self.dict(), outfile)
+            write_secret_file(profile_path, yaml.dump(self.dict()))
         except Exception as e:
             raise Exit(f"Error saving config file {profile_path}: {e}") from e
-        # The file holds the auto-generated Pulumi passphrase, so tighten perms.
-        # Skip on Windows where chmod has no effect on the ACL model.
-        if os.name == "posix":
-            try:
-                os.chmod(profile_path, 0o600)
-            except OSError:
-                pass
         info(f"Configuration file saved at {profile_path}")
 
 

--- a/tasks/e2e_framework/setup/aws.py
+++ b/tasks/e2e_framework/setup/aws.py
@@ -9,7 +9,7 @@ from invoke.exceptions import Exit, UnexpectedExit
 
 from tasks.e2e_framework.config import Config
 from tasks.e2e_framework.setup.ssh_keys import KeyInfo, add_key_to_ssh_agent, default_key_paths
-from tasks.e2e_framework.tool import ask, ask_yesno, error, get_aws_cmd, info, is_windows, warn
+from tasks.e2e_framework.tool import ask, ask_yesno, error, get_aws_cmd, info, warn, write_secret_file
 
 SUPPORTED_KEY_TYPES = ["rsa", "ed25519"]
 AVAILABLE_AWS_ACCOUNTS = ["agent-sandbox", "sandbox", "tse-playground"]
@@ -272,29 +272,41 @@ def _aws_create_keypair(
     if out is None:
         raise Exit(f"Failed to create key pair {keypair_name}")
     key_material = out.stdout.strip()
-    # write private key to disk
-    os.makedirs(Path(private_key_path).parent, exist_ok=True)
-    with open(private_key_path, "w") as f:
-        f.write(key_material)
-    if not is_windows():
-        os.chmod(private_key_path, 0o600)
-        # Windows permissions should be fine as is via inheritance
 
-    # generate public key from private key
-    cmd = f'ssh-keygen -f "{private_key_path}" -y'
-    out = ctx.run(cmd, hide=True)
-    if out is None:
-        raise Exit(f"Failed to generate public key from private key {private_key_path}")
-    public_key = out.stdout.strip()
-    # write public key to disk
-    with open(public_key_path, "w") as f:
-        f.write(public_key)
+    # The remote keypair is useless without the local files built below, and every step that
+    # builds them can fail. A remote half left behind cannot be repaired by a later run, which
+    # can only refuse to continue and print a manual delete command. Files that already
+    # existed are not ours to remove.
+    ours = [p for p in (private_key_path, public_key_path) if not Path(p).exists()]
+    try:
+        os.makedirs(Path(private_key_path).parent, exist_ok=True)
+        write_secret_file(private_key_path, key_material)
 
-    # encrypt the private key with a random passphrase (matches token_urlsafe length used for Pulumi)
-    passphrase = secrets.token_urlsafe(32)
-    ctx.run(f'ssh-keygen -p -P "" -N "{passphrase}" -f "{private_key_path}"', hide=True)
-    info("✓ Private key encrypted with passphrase (stored in ~/.test_infra_config.yaml, chmod 0600)")
-    add_key_to_ssh_agent(ctx, private_key_path, passphrase)
+        # generate public key from private key
+        cmd = f'ssh-keygen -f "{private_key_path}" -y'
+        out = ctx.run(cmd, hide=True)
+        if out is None:
+            raise Exit(f"Failed to generate public key from private key {private_key_path}")
+        public_key = out.stdout.strip()
+        # write public key to disk
+        with open(public_key_path, "w") as f:
+            f.write(public_key)
+
+        # encrypt the private key with a random passphrase (matches token_urlsafe length used for Pulumi)
+        passphrase = secrets.token_urlsafe(32)
+        ctx.run(f'ssh-keygen -p -P "" -N "{passphrase}" -f "{private_key_path}"', hide=True)
+        info("✓ Private key encrypted with passphrase (stored in ~/.test_infra_config.yaml, chmod 0600)")
+        add_key_to_ssh_agent(ctx, private_key_path, passphrase)
+    except BaseException:
+        # BaseException is caught so that interrupting a prompt also rolls back.
+        _rollback_created_keypair(
+            ctx,
+            keypair_name,
+            ours,
+            use_aws_vault=use_aws_vault,
+            aws_account_name=aws_account_name,
+        )
+        raise
 
     # update config object
     awsConf = config.configParams.aws
@@ -305,6 +317,49 @@ def _aws_create_keypair(
     if private_key_path:
         awsConf.privateKeyPath = private_key_path
     awsConf.privateKeyPassword = passphrase
+
+
+def _rollback_created_keypair(
+    ctx: Context,
+    keypair_name: str,
+    local_paths: list[str],
+    use_aws_vault: bool | None = False,
+    aws_account_name: str | None = None,
+) -> None:
+    """
+    Drop a keypair that was created remotely but never finished setting up locally.
+
+    Nothing here raises, because the caller is already unwinding the failure that matters
+    and replacing it with a cleanup error would hide the real diagnosis.
+    """
+    delete_cmd = get_aws_cmd(
+        f'ec2 delete-key-pair --key-name "{keypair_name}"',
+        use_aws_vault=use_aws_vault,
+        aws_account=aws_account_name,
+    )
+    try:
+        out = ctx.run(delete_cmd, hide=True, warn=True)
+        deleted = out is not None and out.exited == 0
+    except BaseException:
+        deleted = False
+
+    if not deleted:
+        # The remote key outlived the failure, so the local files are still its counterpart
+        # and are left in place for the user to salvage.
+        warn(
+            f"Setup failed after creating AWS keypair '{keypair_name}', and it could not be "
+            f"deleted automatically. Remove it before retrying:\n  {delete_cmd}"
+        )
+        return
+
+    for path in local_paths:
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            warn(f"Could not remove {path} left behind by the failed keypair setup: {e}")
+    info(f"↩ Rolled back partially created keypair '{keypair_name}'")
 
 
 def aws_resolve_keypair_opts(

--- a/tasks/e2e_framework/setup/azure.py
+++ b/tasks/e2e_framework/setup/azure.py
@@ -4,7 +4,12 @@ from pathlib import Path
 from invoke.context import Context
 
 from tasks.e2e_framework.config import Config
-from tasks.e2e_framework.setup.ssh_keys import add_key_to_ssh_agent, default_key_paths, generate_keypair_with_passphrase
+from tasks.e2e_framework.setup.ssh_keys import (
+    add_key_to_ssh_agent,
+    default_key_paths,
+    discard_key_without_passphrase,
+    generate_keypair_with_passphrase,
+)
 from tasks.e2e_framework.tool import info
 
 
@@ -28,6 +33,8 @@ def setup_azure_config(ctx: Context, config: Config):
 
     private_path = Path(azure.privateKeyPath).expanduser()
     public_path = Path(azure.publicKeyPath).expanduser()
+
+    discard_key_without_passphrase(ctx, private_path, public_path, default_priv, azure.privateKeyPassword)
 
     if not private_path.is_file():
         info(f"🔑 Generating Azure SSH keypair → {private_path}")

--- a/tasks/e2e_framework/setup/azure.py
+++ b/tasks/e2e_framework/setup/azure.py
@@ -34,7 +34,7 @@ def setup_azure_config(ctx: Context, config: Config):
     private_path = Path(azure.privateKeyPath).expanduser()
     public_path = Path(azure.publicKeyPath).expanduser()
 
-    discard_key_without_passphrase(ctx, private_path, public_path, default_priv, azure.privateKeyPassword)
+    discard_key_without_passphrase(ctx, private_path, public_path, azure.privateKeyPassword)
 
     if not private_path.is_file():
         info(f"🔑 Generating Azure SSH keypair → {private_path}")

--- a/tasks/e2e_framework/setup/gcp.py
+++ b/tasks/e2e_framework/setup/gcp.py
@@ -6,7 +6,12 @@ from invoke.context import Context
 from invoke.exceptions import Exit
 
 from tasks.e2e_framework.config import Config
-from tasks.e2e_framework.setup.ssh_keys import add_key_to_ssh_agent, default_key_paths, generate_keypair_with_passphrase
+from tasks.e2e_framework.setup.ssh_keys import (
+    add_key_to_ssh_agent,
+    default_key_paths,
+    discard_key_without_passphrase,
+    generate_keypair_with_passphrase,
+)
 from tasks.e2e_framework.tool import info
 
 
@@ -30,6 +35,8 @@ def setup_gcp_config(ctx: Context, config: Config):
 
     private_path = Path(gcp.privateKeyPath).expanduser()
     public_path = Path(gcp.publicKeyPath).expanduser()
+
+    discard_key_without_passphrase(ctx, private_path, public_path, default_priv, gcp.privateKeyPassword)
 
     if not private_path.is_file():
         info(f"🔑 Generating GCP SSH keypair → {private_path}")

--- a/tasks/e2e_framework/setup/gcp.py
+++ b/tasks/e2e_framework/setup/gcp.py
@@ -36,7 +36,7 @@ def setup_gcp_config(ctx: Context, config: Config):
     private_path = Path(gcp.privateKeyPath).expanduser()
     public_path = Path(gcp.publicKeyPath).expanduser()
 
-    discard_key_without_passphrase(ctx, private_path, public_path, default_priv, gcp.privateKeyPassword)
+    discard_key_without_passphrase(ctx, private_path, public_path, gcp.privateKeyPassword)
 
     if not private_path.is_file():
         info(f"🔑 Generating GCP SSH keypair → {private_path}")

--- a/tasks/e2e_framework/setup/ssh_keys.py
+++ b/tasks/e2e_framework/setup/ssh_keys.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 from invoke.context import Context
-from invoke.exceptions import UnexpectedExit
+from invoke.exceptions import Exit, UnexpectedExit
 
 from tasks.e2e_framework.tool import info, is_windows, restrict_file_to_owner, warn
 
@@ -207,6 +207,39 @@ def default_key_paths(
     private_path = Path.home() / ".ssh" / f"id_{key_type}_e2e_{provider_part}{account_part}_{user}.pem"
     public_path = private_path.with_name(f"{private_path.stem}.pub")
     return private_path, public_path
+
+
+def discard_key_without_passphrase(
+    ctx: Context,
+    private_key_path: Path,
+    public_key_path: Path,
+    generated_key_path: Path,
+    recorded_passphrase: str | None,
+) -> None:
+    """
+    Remove a generated key whose passphrase never made it into the local config.
+
+    A run interrupted between generating a key and saving that config leaves an encrypted
+    file nobody holds the passphrase for. Callers read the file's presence as proof of setup,
+    so left alone it would be reported as usable by every later run.
+
+    A key the user supplied is never deleted: an unencrypted one needs no passphrase, and one
+    at a path they chose is theirs to replace.
+    """
+    if recorded_passphrase or not private_key_path.is_file():
+        return
+    if not is_key_encrypted(ctx, str(private_key_path)):
+        return
+    if private_key_path != generated_key_path:
+        raise Exit(
+            f"{private_key_path} is encrypted but no passphrase is recorded in the local config, "
+            f"so it cannot be used. Record the passphrase, or delete the key to have setup "
+            f"generate a replacement."
+        )
+    warn(f"Discarding {private_key_path}, which is encrypted with a passphrase that was never recorded")
+    for stale in (private_key_path, public_key_path):
+        with contextlib.suppress(OSError):
+            os.remove(stale)
 
 
 def generate_keypair_with_passphrase(

--- a/tasks/e2e_framework/setup/ssh_keys.py
+++ b/tasks/e2e_framework/setup/ssh_keys.py
@@ -1,4 +1,5 @@
 import base64
+import contextlib
 import os
 import secrets
 from pathlib import Path
@@ -7,7 +8,7 @@ from typing import NamedTuple
 from invoke.context import Context
 from invoke.exceptions import UnexpectedExit
 
-from tasks.e2e_framework.tool import info, is_windows, warn
+from tasks.e2e_framework.tool import info, is_windows, restrict_file_to_owner, warn
 
 
 def ssh_fingerprint_to_bytes(fingerprint: str) -> bytes:
@@ -165,9 +166,10 @@ def add_key_to_ssh_agent(ctx: Context, private_key_path: str, passphrase: str) -
     with tempfile.NamedTemporaryFile(mode='w', suffix='.sh', delete=False) as f:
         f.write(f'#!/bin/sh\nprintf "%s" "{passphrase}"\n')
         askpass_path = f.name
-    os.chmod(askpass_path, stat.S_IRWXU)
 
     try:
+        # ssh-add executes the script, so it needs the owner execute bit that mkstemp omits.
+        os.chmod(askpass_path, stat.S_IRWXU)
         # On macOS, --apple-use-keychain persists the passphrase across reboots
         extra = "--apple-use-keychain " if platform.system() == "Darwin" else ""
         ctx.run(
@@ -175,10 +177,16 @@ def add_key_to_ssh_agent(ctx: Context, private_key_path: str, passphrase: str) -
             hide=True,
         )
         info(f"✓ SSH key added to ssh-agent: {private_key_path}")
-    except UnexpectedExit as e:
+    except Exception as e:
+        # Loading the agent is a convenience, and the caller has a freshly generated key
+        # whose passphrase is not yet persisted. Aborting setup here would leave that key
+        # on disk with no record of its passphrase.
         warn(f"Could not add key to ssh-agent (is it running?): {e}")
     finally:
-        os.unlink(askpass_path)
+        try:
+            os.unlink(askpass_path)
+        except OSError as e:
+            warn(f"Could not remove {askpass_path}, which holds the key passphrase in cleartext: {e}")
 
 
 def default_key_paths(
@@ -215,10 +223,18 @@ def generate_keypair_with_passphrase(
     passphrase = secrets.token_urlsafe(32)
     os.makedirs(Path(private_key_path).parent, exist_ok=True)
     ctx.run(f'ssh-keygen -t {key_type} -f "{private_key_path}" -N "{passphrase}" -C ""', hide=True)
-    if not is_windows():
-        os.chmod(private_key_path, 0o600)
     # ssh-keygen appends .pub to the private key path; rename to the desired public key path
     generated_pub = f"{private_key_path}.pub"
-    if generated_pub != public_key_path:
-        os.rename(generated_pub, public_key_path)
+    try:
+        restrict_file_to_owner(private_key_path)
+        if generated_pub != public_key_path:
+            os.rename(generated_pub, public_key_path)
+    except BaseException:
+        # The passphrase exists only in this frame until it is returned, so a key that
+        # outlives the failure can never be decrypted. Callers read the private key's
+        # presence as proof of setup and would skip regenerating it.
+        for path in (private_key_path, generated_pub):
+            with contextlib.suppress(OSError):
+                os.remove(path)
+        raise
     return passphrase

--- a/tasks/e2e_framework/setup/ssh_keys.py
+++ b/tasks/e2e_framework/setup/ssh_keys.py
@@ -8,7 +8,7 @@ from typing import NamedTuple
 from invoke.context import Context
 from invoke.exceptions import Exit, UnexpectedExit
 
-from tasks.e2e_framework.tool import info, is_windows, restrict_file_to_owner, warn
+from tasks.e2e_framework.tool import ask_yesno, info, is_windows, restrict_file_to_owner, warn
 
 
 def ssh_fingerprint_to_bytes(fingerprint: str) -> bytes:
@@ -213,30 +213,32 @@ def discard_key_without_passphrase(
     ctx: Context,
     private_key_path: Path,
     public_key_path: Path,
-    generated_key_path: Path,
     recorded_passphrase: str | None,
 ) -> None:
     """
-    Remove a generated key whose passphrase never made it into the local config.
+    Offer to replace a key whose passphrase is not recorded in the local config.
 
-    A run interrupted between generating a key and saving that config leaves an encrypted
-    file nobody holds the passphrase for. Callers read the file's presence as proof of setup,
-    so left alone it would be reported as usable by every later run.
+    A run interrupted between generating a key and saving that config leaves a key nobody
+    holds the passphrase for, and callers read the file's presence as proof of setup, so
+    every later run would otherwise report it as usable.
 
-    A key the user supplied is never deleted: an unencrypted one needs no passphrase, and one
-    at a path they chose is theirs to replace.
+    The passphrase can outlive the config file, however: it may be restorable from a backup,
+    and on macOS add_key_to_ssh_agent keeps a copy in the Keychain. Any host already
+    provisioned with the public half also still trusts it. Deleting the key is therefore
+    offered rather than inferred.
     """
     if recorded_passphrase or not private_key_path.is_file():
         return
     if not is_key_encrypted(ctx, str(private_key_path)):
         return
-    if private_key_path != generated_key_path:
+
+    warn(f"{private_key_path} is encrypted, but no passphrase for it is recorded in the local config.")
+    if not ask_yesno("Delete it and generate a replacement? Hosts that trust the current key will reject the new one"):
         raise Exit(
-            f"{private_key_path} is encrypted but no passphrase is recorded in the local config, "
-            f"so it cannot be used. Record the passphrase, or delete the key to have setup "
-            f"generate a replacement."
+            f"Cannot use {private_key_path} without its passphrase. Restore the local config from a "
+            f"backup, set privateKeyPassword for this provider by hand, or delete the key to have "
+            f"setup generate a replacement."
         )
-    warn(f"Discarding {private_key_path}, which is encrypted with a passphrase that was never recorded")
     for stale in (private_key_path, public_key_path):
         with contextlib.suppress(OSError):
             os.remove(stale)

--- a/tasks/e2e_framework/tool.py
+++ b/tasks/e2e_framework/tool.py
@@ -1,9 +1,11 @@
+import contextlib
 import getpass
 import json
 import os
 import pathlib
 import platform
 import subprocess
+import tempfile
 from io import StringIO
 from typing import Any
 
@@ -75,18 +77,21 @@ def write_secret_file(path: str | pathlib.Path, content: str) -> None:
     change then fail. These files hold the only copy of the Pulumi and SSH key passphrases.
     """
     path = pathlib.Path(path)
-    # The staging file is a sibling of the target because os.replace is only atomic within
-    # a single filesystem, and a temp directory is shared with other users.
-    staging = path.with_name(f".{path.name}.tmp")
+    # mkstemp creates the file with O_EXCL under an unpredictable name, so a symlink planted
+    # at a guessable staging path cannot redirect the write and concurrent saves cannot land
+    # on the same file. It shares a directory with the target because os.replace is only
+    # atomic within a single filesystem.
+    fd, staging = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
     try:
-        # The opener applies the mode at creation, which suffices on POSIX. Windows ignores
-        # it, so the ACL is rewritten separately before any content is written.
-        with open(staging, "w", opener=lambda p, flags: os.open(p, flags, 0o600)) as f:
+        # mkstemp applies mode 0600, which suffices on POSIX. Windows ignores it, so the ACL
+        # is rewritten separately before any content is written.
+        with os.fdopen(fd, "w") as f:
             restrict_file_to_owner(staging)
             f.write(content)
         os.replace(staging, path)
     except BaseException:
-        staging.unlink(missing_ok=True)
+        with contextlib.suppress(OSError):
+            os.remove(staging)
         raise
 
 

--- a/tasks/e2e_framework/tool.py
+++ b/tasks/e2e_framework/tool.py
@@ -3,6 +3,7 @@ import json
 import os
 import pathlib
 import platform
+import subprocess
 from io import StringIO
 from typing import Any
 
@@ -32,6 +33,61 @@ if is_windows():
         print(
             "colorama is not up to date, terminal colors may not work properly. Please run 'dda self dep sync' to fix this."
         )
+
+
+def restrict_file_to_owner(path: str | pathlib.Path) -> None:
+    """
+    Restrict a file holding secrets so that only its owner can read it.
+
+    On Windows os.chmod only toggles the read-only attribute, so the ACL has to be replaced
+    outright. Sandboxing and management tools grant themselves an ACE on the user profile,
+    and a single inherited ACE of that kind leaves the file readable by another principal,
+    which is enough for OpenSSH to reject a private key.
+    """
+    if not is_windows():
+        os.chmod(path, 0o600)
+        return
+    user = os.environ.get("USERNAME") or getpass.getuser()
+    # SYSTEM (S-1-5-18) and Administrators (S-1-5-32-544) are named by SID because their
+    # names are localized, and granting them full control matches what ssh-keygen writes.
+    subprocess.run(
+        [
+            "icacls",
+            str(path),
+            "/inheritance:r",
+            "/grant:r",
+            f"{user}:(F)",
+            "*S-1-5-18:(F)",
+            "*S-1-5-32-544:(F)",
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+
+def write_secret_file(path: str | pathlib.Path, content: str) -> None:
+    """
+    Write text to a file that only its owner can read.
+
+    The content is staged in a file that is locked down while still empty, then moved into
+    place. Writing to the target directly would expose the secret for the duration of the
+    write, and truncating it would destroy the previous contents should the permission
+    change then fail. These files hold the only copy of the Pulumi and SSH key passphrases.
+    """
+    path = pathlib.Path(path)
+    # The staging file is a sibling of the target because os.replace is only atomic within
+    # a single filesystem, and a temp directory is shared with other users.
+    staging = path.with_name(f".{path.name}.tmp")
+    try:
+        # The opener applies the mode at creation, which suffices on POSIX. Windows ignores
+        # it, so the ACL is rewritten separately before any content is written.
+        with open(staging, "w", opener=lambda p, flags: os.open(p, flags, 0o600)) as f:
+            restrict_file_to_owner(staging)
+            f.write(content)
+        os.replace(staging, path)
+    except BaseException:
+        staging.unlink(missing_ok=True)
+        raise
 
 
 def ask(question: str, color: str = "blue") -> str:


### PR DESCRIPTION
### Motivation

There were no equivalent guardrails for Windows.

```
❯ dda inv -- e2e.setup
✓ Pulumi is up to date: v3.256.0
✓ Pulumi plugins installed; local backend configured
🤖 Configuring E2E environment...
✓ AWS account: agent-sandbox
🔍 Checking AWS keypair 'e2e-agent-sandbox-ofek' (this may prompt for aws-vault auth)...

aws: [ERROR]: An error occurred (InvalidKeyPair.NotFound) when calling the DescribeKeyPairs operation: The key pair 'e2e-agent-sandbox-ofek' does not exist
🔑 Creating AWS keypair 'e2e-agent-sandbox-ofek' → C:\Users\ofek\.ssh\id_rsa_e2e_agent_sandbox_ofek.pem
Encountered a bad command exit code!

Command: 'ssh-keygen -f "C:\\Users\\ofek\\.ssh\\id_rsa_e2e_agent_sandbox_ofek.pem" -y'

Exit code: 255

Stdout:

Stderr:

Bad permissions. Try removing permissions for user: OZONE\\CodexSandboxUsers (S-1-5-21-3649501681-3884000529-175642771-1032) on file C:/Users/ofek/.ssh/id_rsa_e2e_agent_sandbox_ofek.pem.
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Permissions for 'C:\\Users\\ofek\\.ssh\\id_rsa_e2e_agent_sandbox_ofek.pem' are too open.
It is required that your private key files are NOT accessible by others.
This private key will be ignored.
Load key "C:\\Users\\ofek\\.ssh\\id_rsa_e2e_agent_sandbox_ofek.pem": bad permissions
```

### Additional Notes

I also made the setup atomic in the presence of errors. When I immediately reran the command above, I got:

```
[ERROR] ✘  dda inv -- e2e.setup
✓ Pulumi is up to date: v3.256.0
✓ Pulumi plugins installed; local backend configured
🤖 Configuring E2E environment...
✓ AWS account: agent-sandbox
🔍 Checking AWS keypair 'e2e-agent-sandbox-ofek' (this may prompt for aws-vault auth)...
AWS already has keypair 'e2e-agent-sandbox-ofek' but the local private/public key files (C:\Users\ofek\.ssh\id_rsa_e2e_agent_sandbox_ofek.pem, C:\Users\ofek\.ssh\id_rsa_e2e_agent_sandbox_ofek.pub) are missing. Either restore the files from a backup, or delete the remote keypair and recreate with `dda inv e2e.setup.aws-create-keypair`:
  aws-vault exec sso-agent-sandbox-account-admin-8h -- aws.exe ec2 delete-key-pair --key-name "e2e-agent-sandbox-ofek"
```