### PR TITLE
[ AGNTLOG-703 ] Fix syslog TCP frame misclassification and recognize appliance timestamp layouts

### DIFF
--- a/pkg/logs/internal/framer/BUILD.bazel
+++ b/pkg/logs/internal/framer/BUILD.bazel
@@ -39,6 +39,7 @@ dd_agent_go_test(
         "framer_proptest_test.go",
         "framer_test.go",
         "matcher_test.go",
+        "syslog_octet_prefix_test.go",
         "syslog_test.go",
     ],
     embed = [":framer"],

--- a/pkg/logs/internal/framer/BUILD.bazel
+++ b/pkg/logs/internal/framer/BUILD.bazel
@@ -38,6 +38,7 @@ dd_agent_go_test(
         "docker_stream_test.go",
         "framer_test.go",
         "matcher_test.go",
+        "syslog_octet_prefix_test.go",
         "syslog_test.go",
     ],
     embed = [":framer"],

--- a/pkg/logs/internal/framer/syslog.go
+++ b/pkg/logs/internal/framer/syslog.go
@@ -94,9 +94,11 @@ func (m *syslogFrameMatcher) FindFrame(buf []byte, seen int) ([]byte, int, bool)
 	switch {
 	case b >= '1' && b <= '9':
 		// A leading digit alone does not mean octet counting: plenty of log
-		// lines simply start with a number followed by a space (a Cisco NX-OS
-		// year-first header "2024 Apr 04 ...", an epoch prefix, "54 [main] INFO
-		// ..."). Require the full MSG-LEN SP PRI signature before committing,
+		// lines simply start with a number followed by a space. A sender that
+		// omits the PRI produces them routinely — rsyslog's file templates drop
+		// it, so anything relaying such a rendering arrives as a bare timestamp
+		// — as do epoch prefixes and thread ids ("54 [main] INFO ...").
+		// Require the full MSG-LEN SP PRI signature before committing,
 		// otherwise the digits would be consumed as a length and the declared
 		// body would swallow every following frame.
 		switch classifyOctetPrefix(buf) {

--- a/pkg/logs/internal/framer/syslog.go
+++ b/pkg/logs/internal/framer/syslog.go
@@ -93,7 +93,20 @@ func (m *syslogFrameMatcher) FindFrame(buf []byte, seen int) ([]byte, int, bool)
 	b := buf[0]
 	switch {
 	case b >= '1' && b <= '9':
-		return m.findOctetCounted(buf, seen)
+		// A leading digit alone does not mean octet counting: plenty of log
+		// lines simply start with a number followed by a space (a Cisco NX-OS
+		// year-first header "2024 Apr 04 ...", an epoch prefix, "54 [main] INFO
+		// ..."). Require the full MSG-LEN SP PRI signature before committing,
+		// otherwise the digits would be consumed as a length and the declared
+		// body would swallow every following frame.
+		switch classifyOctetPrefix(buf) {
+		case octetPrefixYes:
+			return m.findOctetCounted(buf, seen)
+		case octetPrefixNo:
+			return m.scanMalformed(buf, seen, false /* continuation */)
+		default: // octetPrefixNeedMore
+			return nil, 0, false
+		}
 
 	case b == '<':
 		return m.findNonTransparent(buf, seen)
@@ -214,6 +227,65 @@ func isSyslogFrameStart(buf []byte, i int) bool {
 	return false
 }
 
+// maxOctetLenDigits caps how many digits a MSG-LEN may have. A longer run is
+// not a plausible length, so the leading bytes are not an octet-counting header.
+const maxOctetLenDigits = 10
+
+// octetPrefixVerdict is the result of testing whether buf begins an RFC 6587
+// octet-counted frame. It is three-way rather than boolean: a TCP read can split
+// anywhere, so when the signature is still incomplete at the end of buf neither
+// answer is safe and the caller must wait for more bytes. Treating an incomplete
+// signature as "no" would misclassify a valid frame whose length prefix straddles
+// a read boundary (e.g. "93" arriving before "7 <134>...").
+type octetPrefixVerdict int
+
+const (
+	octetPrefixNeedMore octetPrefixVerdict = iota
+	octetPrefixYes
+	octetPrefixNo
+)
+
+// classifyOctetPrefix reports whether buf starts an octet-counted frame:
+// MSG-LEN SP SYSLOG-MSG, where SYSLOG-MSG begins with a PRI ("<" digit) because
+// RFC 6587 §3.4.1 carries RFC 5424 messages. buf[0] is known to be '1'-'9'.
+//
+// This is the same signature isSyslogFrameStart requires when resynchronizing,
+// so frame detection now agrees on entry and on resync. Without the full
+// signature a line that merely starts with digits and a space would have its
+// digits consumed as a length, and the declared body would then swallow every
+// following frame (MSG-LEN being the authoritative boundary, the body is never
+// re-scanned for frame starts).
+func classifyOctetPrefix(buf []byte) octetPrefixVerdict {
+	i := 0
+	for i < len(buf) && buf[i] >= '0' && buf[i] <= '9' {
+		i++
+		if i > maxOctetLenDigits {
+			return octetPrefixNo
+		}
+	}
+	if i == len(buf) {
+		// The digit run may continue in the next read.
+		return octetPrefixNeedMore
+	}
+	if buf[i] != ' ' {
+		return octetPrefixNo
+	}
+	// The two bytes after the SP must be "<" followed by a digit.
+	if i+1 >= len(buf) {
+		return octetPrefixNeedMore
+	}
+	if buf[i+1] != '<' {
+		return octetPrefixNo
+	}
+	if i+2 >= len(buf) {
+		return octetPrefixNeedMore
+	}
+	if buf[i+2] < '0' || buf[i+2] > '9' {
+		return octetPrefixNo
+	}
+	return octetPrefixYes
+}
+
 // findOctetCounted parses MSG-LEN SP SYSLOG-MSG from the beginning of buf.
 // Returns nil if the buffer does not yet contain enough data.
 //
@@ -246,7 +318,7 @@ func (m *syslogFrameMatcher) findOctetCounted(buf []byte, seen int) ([]byte, int
 			return m.scanMalformed(buf, seen, false /* continuation */)
 		}
 		i++
-		if i > 10 {
+		if i > maxOctetLenDigits {
 			return m.scanMalformed(buf, seen, false /* continuation */)
 		}
 		msgLen = msgLen*10 + int(b-'0')

--- a/pkg/logs/internal/framer/syslog.go
+++ b/pkg/logs/internal/framer/syslog.go
@@ -252,7 +252,7 @@ const (
 // RFC 6587 §3.4.1 carries RFC 5424 messages. buf[0] is known to be '1'-'9'.
 //
 // This is the same signature isSyslogFrameStart requires when resynchronizing,
-// so frame detection now agrees on entry and on resync. Without the full
+// so frame detection agrees on entry and on resync. Without the full
 // signature a line that merely starts with digits and a space would have its
 // digits consumed as a length, and the declared body would then swallow every
 // following frame (MSG-LEN being the authoritative boundary, the body is never

--- a/pkg/logs/internal/framer/syslog.go
+++ b/pkg/logs/internal/framer/syslog.go
@@ -62,7 +62,7 @@ type syslogFrameMatcher struct {
 //
 // When the leading byte is not a valid syslog frame start ('<' or digit),
 // the matcher scans forward for the next probable frame start — either a
-// PRI header (<[0-9]) or an octet-counting prefix (digit+ SP <digit).
+// PRI header (<[0-9]{1,3}>) or an octet-counting prefix (digit+ SP PRI).
 // Everything before that sync point is emitted as a single malformed frame
 // so the downstream parser can log it coherently rather than producing one
 // empty message per byte.
@@ -98,9 +98,8 @@ func (m *syslogFrameMatcher) FindFrame(buf []byte, seen int) ([]byte, int, bool)
 		// omits the PRI produces them routinely — rsyslog's file templates drop
 		// it, so anything relaying such a rendering arrives as a bare timestamp
 		// — as do epoch prefixes and thread ids ("54 [main] INFO ...").
-		// Require the full MSG-LEN SP PRI signature before committing,
-		// otherwise the digits would be consumed as a length and the declared
-		// body would swallow every following frame.
+		// classifyOctetPrefix demands the full MSG-LEN SP PRI signature before
+		// any of those bytes are read as a length.
 		switch classifyOctetPrefix(buf) {
 		case octetPrefixYes:
 			return m.findOctetCounted(buf, seen)
@@ -124,13 +123,10 @@ func (m *syslogFrameMatcher) FindFrame(buf []byte, seen int) ([]byte, int, bool)
 
 // maxFrameStartLookbehind bounds how far scanMalformed rewinds behind the
 // already-scanned prefix (seen) before resuming its search for the next frame
-// start. It must cover the longest frame-start signature isSyslogFrameStart can
-// match across a read boundary so a signature whose tail only arrives in the
-// current read is still detected: up to 10 length digits (the cap enforced by
-// findOctetCounted) + SP + "<" + digit, i.e. ~13 bytes. 16 adds margin. Any
-// "octet header" longer than this is rejected as malformed anyway, so there is
-// no valid frame start beyond the look-behind to miss.
-const maxFrameStartLookbehind = 16
+// start, so a signature whose tail only arrives in the current read is still
+// found. It is the longest such signature: MSG-LEN SP PRI. Anything beginning
+// further back fitted entirely within the previous read and was decided then.
+const maxFrameStartLookbehind = maxOctetLenDigits + 1 + maxPRIDigits + 2
 
 // scanMalformed consumes bytes that do not start a valid syslog frame. buf[0]
 // is known malformed (the FindFrame dispatch handles frame starts and stray
@@ -202,29 +198,23 @@ func (m *syslogFrameMatcher) scanMalformed(buf []byte, seen int, continuation bo
 // isSyslogFrameStart returns true if buf[i] looks like the start of a valid
 // syslog frame. Two patterns are recognized:
 //
-//   - Non-transparent PRI header: <[0-9] (e.g. "<134>...")
-//   - Octet-counting prefix: [1-9][0-9]* SP <[0-9] (e.g. "62 <134>...")
+//   - Non-transparent PRI header: <[0-9]{1,3}> (e.g. "<134>...")
+//   - Octet-counting prefix: [1-9][0-9]* SP <[0-9]{1,3}> (e.g. "62 <134>...")
 //
-// The octet-counting check requires the full "digits SP <digit" signature
-// to avoid false positives on bare digits in non-syslog content (e.g.,
-// timestamps like "2026-04-20T12:00:00Z" or JSON values). Previously, any
-// digit 1-9 was treated as a sync point, which caused a single JSON line
-// to fragment into 13+ entries.
+// Both are delegated — to priLen and classifyOctetPrefix — so that
+// resynchronizing applies exactly the tests that admit a frame in the first
+// place, and a malformed run cannot be cut short at something the reader would
+// then reject. An incomplete signature is not a sync point: unlike the caller
+// that reads frames, a resync can wait for the scan to reach a later candidate
+// instead of having to decide on the bytes in hand.
 func isSyslogFrameStart(buf []byte, i int) bool {
 	b := buf[i]
-	if b == '<' && i+1 < len(buf) && buf[i+1] >= '0' && buf[i+1] <= '9' {
-		return true
+	if b == '<' {
+		n, _ := priLen(buf[i:])
+		return n > 0
 	}
 	if b >= '1' && b <= '9' {
-		j := i
-		for j < len(buf) && buf[j] >= '0' && buf[j] <= '9' {
-			j++
-		}
-		if j < len(buf) && buf[j] == ' ' &&
-			j+1 < len(buf) && buf[j+1] == '<' &&
-			j+2 < len(buf) && buf[j+2] >= '0' && buf[j+2] <= '9' {
-			return true
-		}
+		return classifyOctetPrefix(buf[i:]) == octetPrefixYes
 	}
 	return false
 }
@@ -232,6 +222,10 @@ func isSyslogFrameStart(buf []byte, i int) bool {
 // maxOctetLenDigits caps how many digits a MSG-LEN may have. A longer run is
 // not a plausible length, so the leading bytes are not an octet-counting header.
 const maxOctetLenDigits = 10
+
+// maxPRIDigits is the widest PRIVAL RFC 5424 §6.2.1 allows, "<191>" being the
+// largest valid PRI.
+const maxPRIDigits = 3
 
 // octetPrefixVerdict is the result of testing whether buf begins an RFC 6587
 // octet-counted frame. It is three-way rather than boolean: a TCP read can split
@@ -248,15 +242,10 @@ const (
 )
 
 // classifyOctetPrefix reports whether buf starts an octet-counted frame:
-// MSG-LEN SP SYSLOG-MSG, where SYSLOG-MSG begins with a PRI ("<" digit) because
+// MSG-LEN SP SYSLOG-MSG, where SYSLOG-MSG begins with a whole PRI because
 // RFC 6587 §3.4.1 carries RFC 5424 messages. buf[0] is known to be '1'-'9'.
 //
-// This is the same signature isSyslogFrameStart requires when resynchronizing,
-// so frame detection agrees on entry and on resync. Without the full
-// signature a line that merely starts with digits and a space would have its
-// digits consumed as a length, and the declared body would then swallow every
-// following frame (MSG-LEN being the authoritative boundary, the body is never
-// re-scanned for frame starts).
+// Nothing less than the whole signature will do; see priLen.
 func classifyOctetPrefix(buf []byte) octetPrefixVerdict {
 	i := 0
 	for i < len(buf) && buf[i] >= '0' && buf[i] <= '9' {
@@ -272,20 +261,47 @@ func classifyOctetPrefix(buf []byte) octetPrefixVerdict {
 	if buf[i] != ' ' {
 		return octetPrefixNo
 	}
-	// The two bytes after the SP must be "<" followed by a digit.
-	if i+1 >= len(buf) {
+	// What follows the SP must be a whole PRI.
+	n, needMore := priLen(buf[i+1:])
+	switch {
+	case needMore:
 		return octetPrefixNeedMore
-	}
-	if buf[i+1] != '<' {
-		return octetPrefixNo
-	}
-	if i+2 >= len(buf) {
-		return octetPrefixNeedMore
-	}
-	if buf[i+2] < '0' || buf[i+2] > '9' {
+	case n == 0:
 		return octetPrefixNo
 	}
 	return octetPrefixYes
+}
+
+// priLen returns the length of a complete PRI — "<", a 1-3 digit PRIVAL, ">" —
+// at the start of buf, or 0 if buf does not begin with one. needMore reports
+// that buf ended before the PRI could be decided, which only the caller knows
+// how to handle: a reader that must commit now has to wait, while a scan
+// looking for the next frame start can carry on and pick it up next read.
+//
+// The closing ">" is what makes this worth checking in full. "<" and a digit
+// alone also open ordinary prose ("54 <1 minute elapsed"), and accepting that
+// is enough for the digits ahead of it to be read as a MSG-LEN. Because
+// MSG-LEN is the authoritative frame boundary and the body it declares is
+// never re-scanned, that body then runs past the newline and swallows the
+// frames behind it.
+func priLen(buf []byte) (n int, needMore bool) {
+	if len(buf) == 0 {
+		return 0, true
+	}
+	if buf[0] != '<' {
+		return 0, false
+	}
+	i := 1
+	for i < len(buf) && i-1 < maxPRIDigits && buf[i] >= '0' && buf[i] <= '9' {
+		i++
+	}
+	if i == len(buf) {
+		return 0, true
+	}
+	if i == 1 || buf[i] != '>' {
+		return 0, false
+	}
+	return i + 1, false
 }
 
 // findOctetCounted parses MSG-LEN SP SYSLOG-MSG from the beginning of buf.

--- a/pkg/logs/internal/framer/syslog_octet_prefix_test.go
+++ b/pkg/logs/internal/framer/syslog_octet_prefix_test.go
@@ -76,6 +76,70 @@ func TestSyslogDigitPrefixIsNotAlwaysOctetCount(t *testing.T) {
 	})
 }
 
+// Digits and a space followed by "<" and a digit are still not an octet count
+// unless the PRI is complete. Prose supplies that shape readily — "<1 minute",
+// "<2 sec" — and without the closing ">" the digits ahead of it are read as a
+// MSG-LEN whose body runs past the newline and tears apart the frames behind
+// it, which is the corruption the length prefix is supposed to prevent.
+func TestSyslogPartialPRIIsNotOctetCount(t *testing.T) {
+	good := "<134>Feb 10 12:00:00 flushhost FLUSHTAG[1]: well_formed_message"
+
+	cases := []struct {
+		name string
+		line string
+	}{
+		{
+			// "54 " would be read as MSG-LEN=54, long enough to reach well
+			// into the frame that follows.
+			name: "elapsed time in angle brackets",
+			line: "54 <1 minute elapsed",
+		},
+		{
+			name: "countdown in angle brackets",
+			line: "100 <2 sec remaining until timeout occurs and the job is retried",
+		},
+		{
+			// A closing ">" is present but too far along to form a PRI.
+			name: "bracketed item count",
+			line: "12 <3 items> pending",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stream := tc.line + "\n" + good + "\n" + good + "\n"
+			got, _ := processSyslog(t, 262144, [][]byte{[]byte(stream)})
+
+			require.Len(t, got, 3, "each line is framed on its LF delimiter")
+			assert.Equal(t, tc.line, got[0], "emitted whole, not split at the '<'")
+			assert.Equal(t, good, got[1], "the following frame is neither swallowed nor truncated")
+			assert.Equal(t, good, got[2])
+		})
+	}
+}
+
+// Resynchronizing must accept exactly what the frame reader accepts, otherwise
+// a malformed run is cut short at a candidate that would then be rejected.
+func TestIsSyslogFrameStartRequiresCompletePRI(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"<134>x", true},
+		{"<0>", true},
+		{"<191>x", true},
+		{"62 <134>x", true},
+		{"<1 minute", false},
+		{"<1234>x", false}, // PRIVAL is at most 3 digits
+		{"<>", false},
+		{"<13", false}, // undecidable here; the look-behind re-examines it
+		{"54 <1 min", false},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, isSyslogFrameStart([]byte(tc.in), 0), "input %q", tc.in)
+	}
+}
+
 // Genuine octet-counted frames must keep working, including when the length
 // prefix is split across reads: an incomplete signature has to wait for more
 // bytes rather than be declared malformed.
@@ -122,10 +186,15 @@ func TestClassifyOctetPrefix(t *testing.T) {
 		{"2024-04-04T08:05:06", octetPrefixNo},
 		{"71 x134>", octetPrefixNo},
 		{"71 <x", octetPrefixNo},
+		{"71 <>", octetPrefixNo},
 		{"12345678901 <134>", octetPrefixNo}, // more digits than any plausible length
-		{"71", octetPrefixNeedMore},          // digit run may continue
-		{"71 ", octetPrefixNeedMore},         // need the byte after SP
-		{"71 <", octetPrefixNeedMore},        // need the digit after '<'
+		{"71 <1234>", octetPrefixNo},         // PRIVAL is at most 3 digits
+		{"54 <1 minute elapsed", octetPrefixNo},
+		{"71", octetPrefixNeedMore},    // digit run may continue
+		{"71 ", octetPrefixNeedMore},   // need the byte after SP
+		{"71 <", octetPrefixNeedMore},  // need the digit after '<'
+		{"71 <1", octetPrefixNeedMore}, // PRIVAL may continue
+		{"71 <134", octetPrefixNeedMore},
 	}
 	for _, tc := range cases {
 		assert.Equal(t, tc.want, classifyOctetPrefix([]byte(tc.in)), "input %q", tc.in)

--- a/pkg/logs/internal/framer/syslog_octet_prefix_test.go
+++ b/pkg/logs/internal/framer/syslog_octet_prefix_test.go
@@ -1,0 +1,131 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package framer
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A line that merely begins with digits and a space must not be taken for an
+// RFC 6587 octet-counted frame. Before the signature check, the digit run was
+// consumed as a MSG-LEN and the declared body swallowed every following frame,
+// because MSG-LEN is the authoritative boundary and the body is never re-scanned.
+func TestSyslogDigitPrefixIsNotAlwaysOctetCount(t *testing.T) {
+	good := "<134>Feb 10 12:00:00 flushhost FLUSHTAG[1]: well_formed_message"
+
+	cases := []struct {
+		name string
+		line string
+	}{
+		{
+			// Cisco NX-OS year-first header; "2024 " would be read as MSG-LEN=2024.
+			name: "cisco nx-os year first",
+			line: "2024 Apr 04 08:05:06 MDS9148S-S4 %MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active",
+		},
+		{
+			name: "barracuda secure edge year first",
+			line: "2025 09 26 22:28:00 +05:30 Info     : pam_unix(sudo:session): session opened",
+		},
+		{
+			name: "mysql error log",
+			line: "171113 14:14:20  InnoDB: Shutdown completed; log sequence number 1595675",
+		},
+		{
+			name: "java thread prefix",
+			line: "54 [main] INFO MyApp.foo.bar - Entering application.",
+		},
+		{
+			name: "epoch prefix",
+			line: "1726124251      0 10.10.10.10 TCP_DENIED/403 3920 CONNECT example.com:443 -",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stream := tc.line + "\n" + good + "\n"
+			got, _ := processSyslog(t, 262144, [][]byte{[]byte(stream)})
+
+			require.Len(t, got, 2, "each line is framed on its LF delimiter")
+			assert.Equal(t, tc.line, got[0], "content preserved, no length prefix stripped")
+			assert.Equal(t, good, got[1], "the following frame is not swallowed")
+		})
+	}
+
+	t.Run("many following frames survive", func(t *testing.T) {
+		// The old misread declared a 2024-byte body, absorbing dozens of frames.
+		nxos := "2024 Apr 04 08:05:06 MDS9148S-S4 %MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active"
+		stream := nxos + "\n" + strings.Repeat(good+"\n", 40)
+		got, _ := processSyslog(t, 262144, [][]byte{[]byte(stream)})
+
+		require.Len(t, got, 41)
+		assert.Equal(t, nxos, got[0])
+		for _, frame := range got[1:] {
+			assert.Equal(t, good, frame)
+		}
+	})
+}
+
+// Genuine octet-counted frames must keep working, including when the length
+// prefix is split across reads: an incomplete signature has to wait for more
+// bytes rather than be declared malformed.
+func TestSyslogOctetCountedStillDetected(t *testing.T) {
+	body := "<134>1 2024-12-04T01:18:01-05:00 test.com app - - - octet counted body"
+	frame := fmt.Sprintf("%d %s", len(body), body)
+
+	t.Run("single read", func(t *testing.T) {
+		got, _ := processSyslog(t, 4096, [][]byte{[]byte(frame)})
+		require.Len(t, got, 1)
+		assert.Equal(t, body, got[0], "MSG-LEN SP header is stripped as framing")
+	})
+
+	// Split at every position inside the "70 <1" signature, plus a later offset,
+	// so no read boundary can turn a valid frame into malformed bytes.
+	for _, at := range []int{1, 2, 3, 4, 5, 10} {
+		t.Run("split_after_"+strconv.Itoa(at)+"_bytes", func(t *testing.T) {
+			chunks := [][]byte{[]byte(frame[:at]), []byte(frame[at:])}
+			got, _ := processSyslog(t, 4096, chunks)
+			require.Len(t, got, 1, "frame split at %d bytes should still be one frame", at)
+			assert.Equal(t, body, got[0])
+		})
+	}
+
+	t.Run("length prefix arrives one byte at a time", func(t *testing.T) {
+		// The digits arrive with no SP yet: the matcher must wait, not reject.
+		chunks := [][]byte{[]byte(frame[:1]), []byte(frame[1:2]), []byte(frame[2:3]), []byte(body)}
+		got, _ := processSyslog(t, 4096, chunks)
+		require.Len(t, got, 1)
+		assert.Equal(t, body, got[0])
+	})
+}
+
+func TestClassifyOctetPrefix(t *testing.T) {
+	cases := []struct {
+		in   string
+		want octetPrefixVerdict
+	}{
+		{"71 <134>1 x", octetPrefixYes},
+		{"9 <0>", octetPrefixYes},
+		{"2024 Apr 04", octetPrefixNo},
+		{"54 [main] INFO", octetPrefixNo},
+		{"171113 14:14:20", octetPrefixNo},
+		{"2024-04-04T08:05:06", octetPrefixNo},
+		{"71 x134>", octetPrefixNo},
+		{"71 <x", octetPrefixNo},
+		{"12345678901 <134>", octetPrefixNo}, // more digits than any plausible length
+		{"71", octetPrefixNeedMore},          // digit run may continue
+		{"71 ", octetPrefixNeedMore},         // need the byte after SP
+		{"71 <", octetPrefixNeedMore},        // need the digit after '<'
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, classifyOctetPrefix([]byte(tc.in)), "input %q", tc.in)
+	}
+}

--- a/pkg/logs/internal/framer/syslog_octet_prefix_test.go
+++ b/pkg/logs/internal/framer/syslog_octet_prefix_test.go
@@ -27,8 +27,9 @@ func TestSyslogDigitPrefixIsNotAlwaysOctetCount(t *testing.T) {
 		line string
 	}{
 		{
-			// Cisco NX-OS year-first header; "2024 " would be read as MSG-LEN=2024.
-			name: "cisco nx-os year first",
+			// Cisco NX-OS year-first header as rendered without a PRI, the form a
+			// file template produces; "2024 " would be read as MSG-LEN=2024.
+			name: "cisco nx-os year first, no pri",
 			line: "2024 Apr 04 08:05:06 MDS9148S-S4 %MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active",
 		},
 		{

--- a/pkg/logs/internal/framer/syslog_octet_prefix_test.go
+++ b/pkg/logs/internal/framer/syslog_octet_prefix_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 // A line that merely begins with digits and a space must not be taken for an
-// RFC 6587 octet-counted frame. Before the signature check, the digit run was
-// consumed as a MSG-LEN and the declared body swallowed every following frame,
-// because MSG-LEN is the authoritative boundary and the body is never re-scanned.
+// RFC 6587 octet-counted frame. Consuming the digit run as a MSG-LEN would let
+// the declared body swallow every following frame, because MSG-LEN is the
+// authoritative boundary and the body is never re-scanned for frame starts.
 func TestSyslogDigitPrefixIsNotAlwaysOctetCount(t *testing.T) {
 	good := "<134>Feb 10 12:00:00 flushhost FLUSHTAG[1]: well_formed_message"
 
@@ -28,9 +28,9 @@ func TestSyslogDigitPrefixIsNotAlwaysOctetCount(t *testing.T) {
 	}{
 		{
 			// Cisco NX-OS year-first header as rendered without a PRI, the form a
-			// file template produces; "2024 " would be read as MSG-LEN=2024.
+			// file template produces; "2019 " would be read as MSG-LEN=2019.
 			name: "cisco nx-os year first, no pri",
-			line: "2024 Apr 04 08:05:06 MDS9148S-S4 %MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active",
+			line: "2019 Mar 11 13:42:44 Cisco-customer %ETHPORT-5-IF_DOWN_ADMIN_DOWN: Interface Ethernet3/1 is down",
 		},
 		{
 			name: "barracuda secure edge year first",
@@ -62,8 +62,9 @@ func TestSyslogDigitPrefixIsNotAlwaysOctetCount(t *testing.T) {
 	}
 
 	t.Run("many following frames survive", func(t *testing.T) {
-		// The old misread declared a 2024-byte body, absorbing dozens of frames.
-		nxos := "2024 Apr 04 08:05:06 MDS9148S-S4 %MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active"
+		// Read as a MSG-LEN, "2019" declares a body long enough to absorb dozens
+		// of frames, so the count here is what proves none were absorbed.
+		nxos := "2019 Mar 11 13:42:44 Cisco-customer %ETHPORT-5-IF_DOWN_ADMIN_DOWN: Interface Ethernet3/1 is down"
 		stream := nxos + "\n" + strings.Repeat(good+"\n", 40)
 		got, _ := processSyslog(t, 262144, [][]byte{[]byte(stream)})
 

--- a/pkg/logs/internal/framer/syslog_test.go
+++ b/pkg/logs/internal/framer/syslog_test.go
@@ -305,7 +305,9 @@ func TestSyslogNeverEmitsEmptyFrames(t *testing.T) {
 // split chunks must still reconstruct the body with no data loss.
 func TestSyslogOctetCountedStraddlesLimit(t *testing.T) {
 	limit := 20
-	body := strings.Repeat("x", 20) // msgLen == limit; header pushes total to 23
+	// Octet counting carries RFC 5424 messages, so the body starts with a PRI;
+	// frame detection requires that signature after the MSG-LEN SP.
+	body := "<134>1 " + strings.Repeat("x", 13) // 20 bytes: msgLen == limit; header pushes total to 23
 
 	// "20 " + first 17 body bytes = 20 bytes (== limit) with the body still
 	// incomplete; the remaining 3 body bytes then arrive in a second chunk so a

--- a/pkg/logs/internal/parsers/syslog/BUILD.bazel
+++ b/pkg/logs/internal/parsers/syslog/BUILD.bazel
@@ -36,6 +36,7 @@ dd_agent_go_test(
         "structured_content_test.go",
         "syslog_fuzz_test.go",
         "syslog_test.go",
+        "timestamp_variants_test.go",
     ],
     embed = [":syslog"],
     deps = [

--- a/pkg/logs/internal/parsers/syslog/BUILD.bazel
+++ b/pkg/logs/internal/parsers/syslog/BUILD.bazel
@@ -32,12 +32,14 @@ dd_agent_go_test(
     name = "syslog_test",
     srcs = [
         "cef_leef_test.go",
+        "corpus_golden_test.go",
         "parser_test.go",
         "structured_content_test.go",
         "syslog_fuzz_test.go",
         "syslog_test.go",
         "timestamp_variants_test.go",
     ],
+    data = glob(["testdata/**"]),
     embed = [":syslog"],
     deps = [
         "//comp/logs/agent/config",

--- a/pkg/logs/internal/parsers/syslog/corpus_golden_test.go
+++ b/pkg/logs/internal/parsers/syslog/corpus_golden_test.go
@@ -7,7 +7,6 @@ package syslog
 
 import (
 	"encoding/json"
-	"flag"
 	"os"
 	"path/filepath"
 	"testing"
@@ -48,13 +47,24 @@ import (
 //
 // To adopt new output after an intentional parser change:
 //
-//	go test ./pkg/logs/internal/parsers/syslog -run TestCorpusGolden -update-golden
+//	UPDATE_SYSLOG_CORPUS=1 dda inv test \
+//	  --targets=./pkg/logs/internal/parsers/syslog -e TestCorpusGolden
 //
 // Review the resulting diff message by message. A field moving from a real
 // value to the nilvalue, or CONTENT shifting into a header field, is a
 // regression even when the test would otherwise pass once regenerated.
-var updateGolden = flag.Bool("update-golden", false,
-	"rewrite testdata/corpus.json with the parser's current output")
+//
+// The trigger is an environment variable rather than a -update-golden flag
+// because go test only accepts test-binary flags after the package list, while
+// the dda inv wrapper always emits flags ahead of it. A flag would therefore be
+// reachable only by invoking go test directly, which the repository forbids.
+//
+// Should regenerating ever grow past a single command — more golden files in
+// this package, or work to do either side of the rewrite — the idiom to reach
+// for is an invoke task running go test from the package directory, the way
+// host-profiler.update-golden-tests does. That is not worth a task module and a
+// collection registration while one environment variable covers it.
+var updateGolden = os.Getenv("UPDATE_SYSLOG_CORPUS") != ""
 
 const goldenPath = "testdata/corpus.json"
 
@@ -160,7 +170,7 @@ func loadCorpus(t *testing.T) corpusFile {
 func TestCorpusGolden(t *testing.T) {
 	corpus := loadCorpus(t)
 
-	if *updateGolden {
+	if updateGolden {
 		// Only Want is regenerated; the origin pins and the provenance recorded
 		// with each message are hand-maintained and must survive the rewrite.
 		for i := range corpus.Messages {
@@ -177,7 +187,7 @@ func TestCorpusGolden(t *testing.T) {
 		t.Run(tc.Integration+"/"+tc.Source, func(t *testing.T) {
 			got := parseCorpusLine(tc.Line)
 			assert.Equal(t, tc.Want, got,
-				"parse of %s changed\nline: %q\nrerun with -update-golden to adopt",
+				"parse of %s changed\nline: %q\nset UPDATE_SYSLOG_CORPUS=1 to adopt",
 				tc.Source, tc.Line)
 		})
 	}

--- a/pkg/logs/internal/parsers/syslog/corpus_golden_test.go
+++ b/pkg/logs/internal/parsers/syslog/corpus_golden_test.go
@@ -1,0 +1,243 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package syslog
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testdata/corpus.json holds one message for every syslog-capable integration,
+// each copied verbatim from that integration's log-pipeline fixtures, together
+// with the fields the parser is expected to produce.
+//
+// The hand-written tests elsewhere in this package pin one sample per parsing
+// decision. This file exists for the opposite reason: to notice changes nobody
+// thought to assert on. A message that parses without error into the wrong
+// fields is invisible to a targeted test, since nobody writes an assertion for
+// a value they never expected, but it shows up here as a diff, because every
+// field of every message is compared.
+//
+// # Where the messages come from
+//
+// Every message names an origin, described in the "origins" object at the top of
+// corpus.json, so that "source" can be resolved without guessing. An origin is
+// one of three kinds:
+//
+//	repository      a public Datadog integrations repo, pinned to a commit;
+//	                "source" is a path from its root plus a line number
+//	documentation   a published vendor format example; "source" cites the section
+//	synthesized     constructed here to model a documented shape, not copied
+//
+// A format with no sample available from those repositories is covered from the
+// vendor's published documentation instead.
+//
+// Pinning a commit keeps a repository "source" resolvable after upstream edits
+// the file. The pins record when the samples were taken and are not a dependency:
+// nothing here fetches them, so they only need refreshing when messages are added
+// or rechecked.
+//
+// Two mechanical differences from the upstream fixture are worth knowing when
+// comparing. Pipeline YAML folds long samples over several physical lines, and
+// "source" points at the first of them while "line" holds the joined result.
+// Octet-counted samples appear upstream with their RFC 6587 MSG-LEN prefix, which
+// is stored stripped here because the framer removes it before the parser runs.
+//
+// To adopt new output after an intentional parser change:
+//
+//	go test ./pkg/logs/internal/parsers/syslog -run TestCorpusGolden -update-golden
+//
+// Review the resulting diff message by message. A field moving from a real
+// value to the nilvalue, or CONTENT shifting into a header field, is a
+// regression even when the test would otherwise pass once regenerated.
+var updateGolden = flag.Bool("update-golden", false,
+	"rewrite testdata/corpus.json with the parser's current output")
+
+const goldenPath = "testdata/corpus.json"
+
+// corpusFields is the parse result recorded for each message. Fields are
+// compared exactly, including the nilvalue "-", so a header field silently
+// losing its value fails the test.
+type corpusFields struct {
+	Err       string `json:"err,omitempty"`
+	Pri       int    `json:"pri"`
+	Version   string `json:"version,omitempty"`
+	Timestamp string `json:"timestamp"`
+	Hostname  string `json:"hostname"`
+	AppName   string `json:"appname"`
+	ProcID    string `json:"procid"`
+	MsgID     string `json:"msgid"`
+	Msg       string `json:"msg"`
+	Partial   bool   `json:"partial,omitempty"`
+}
+
+// Origin kinds. A repository origin is pinned to a commit so line numbers stay
+// resolvable; documentation cites a published vendor format; synthesized covers
+// messages written here rather than copied from anywhere.
+const (
+	originRepository    = "repository"
+	originDocumentation = "documentation"
+	originSynthesized   = "synthesized"
+)
+
+// corpusOrigin describes where a group of messages came from.
+type corpusOrigin struct {
+	Kind string `json:"kind"`
+	URL  string `json:"url,omitempty"`
+	// Commit the fixtures were read at. Repository origins only.
+	Commit string `json:"commit,omitempty"`
+}
+
+// corpusFile is the on-disk shape of corpus.json: where the messages came from,
+// then the messages themselves.
+type corpusFile struct {
+	Origins  map[string]corpusOrigin `json:"origins"`
+	Messages []corpusCase            `json:"messages"`
+}
+
+type corpusCase struct {
+	// Integration owning the fixture the message was copied from.
+	Integration string `json:"integration"`
+	// Source locates the message within Origin: a path and line number for a
+	// repository, a cited section for documentation.
+	Source string `json:"source"`
+	// Origin names the entry in corpusFile.Origins that Source resolves against.
+	Origin string `json:"origin"`
+	// Transport is "wire" for messages captured with a PRI, "file" for the
+	// PRI-less rendering a tailed file carries.
+	Transport string `json:"transport"`
+	// Framing is the wire layout, as classified when the corpus was built.
+	// Octet-counted messages are stored without their RFC 6587 MSG-LEN prefix
+	// because the framer strips it before the parser runs.
+	Framing string       `json:"framing"`
+	Line    string       `json:"line"`
+	Want    corpusFields `json:"want"`
+}
+
+// parseCorpusLine mirrors the dispatch in parser.Parse: a leading '<' means the
+// message arrived with a PRI, anything else is a PRI-less file rendering.
+func parseCorpusLine(line string) corpusFields {
+	content := []byte(line)
+	var parsed SyslogMessage
+	var err error
+	if len(content) > 0 && content[0] == '<' {
+		parsed, err = Parse(content)
+	} else {
+		parsed, err = ParseBSDLine(content)
+	}
+
+	got := corpusFields{
+		Pri:       parsed.Pri,
+		Version:   parsed.Version,
+		Timestamp: parsed.Timestamp,
+		Hostname:  parsed.Hostname,
+		AppName:   parsed.AppName,
+		ProcID:    parsed.ProcID,
+		MsgID:     parsed.MsgID,
+		Msg:       string(parsed.Msg),
+		Partial:   parsed.Partial,
+	}
+	if err != nil {
+		got.Err = err.Error()
+	}
+	return got
+}
+
+func loadCorpus(t *testing.T) corpusFile {
+	t.Helper()
+	raw, err := os.ReadFile(goldenPath)
+	require.NoError(t, err, "read %s", goldenPath)
+
+	var corpus corpusFile
+	require.NoError(t, json.Unmarshal(raw, &corpus), "parse %s", goldenPath)
+	require.NotEmpty(t, corpus.Messages, "corpus is empty")
+	return corpus
+}
+
+func TestCorpusGolden(t *testing.T) {
+	corpus := loadCorpus(t)
+
+	if *updateGolden {
+		// Only Want is regenerated; the origin pins and the provenance recorded
+		// with each message are hand-maintained and must survive the rewrite.
+		for i := range corpus.Messages {
+			corpus.Messages[i].Want = parseCorpusLine(corpus.Messages[i].Line)
+		}
+		out, err := json.MarshalIndent(corpus, "", "  ")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Clean(goldenPath), append(out, '\n'), 0o644))
+		t.Logf("rewrote %s with %d messages", goldenPath, len(corpus.Messages))
+		return
+	}
+
+	for _, tc := range corpus.Messages {
+		t.Run(tc.Integration+"/"+tc.Source, func(t *testing.T) {
+			got := parseCorpusLine(tc.Line)
+			assert.Equal(t, tc.Want, got,
+				"parse of %s changed\nline: %q\nrerun with -update-golden to adopt",
+				tc.Source, tc.Line)
+		})
+	}
+}
+
+// The corpus is only useful as a safety net while it still spans the formats
+// the agent claims to handle. These bounds fail if messages are deleted
+// wholesale or a framing class disappears.
+func TestCorpusGoldenCoverage(t *testing.T) {
+	corpus := loadCorpus(t)
+
+	integrations := make(map[string]struct{})
+	framings := make(map[string]struct{})
+	transports := make(map[string]struct{})
+	for _, tc := range corpus.Messages {
+		integrations[tc.Integration] = struct{}{}
+		framings[tc.Framing] = struct{}{}
+		transports[tc.Transport] = struct{}{}
+		assert.NotEmpty(t, tc.Line, "%s has no message", tc.Source)
+		assert.NotEmpty(t, tc.Source, "%s has no provenance", tc.Integration)
+		assert.Contains(t, corpus.Origins, tc.Origin,
+			"%s names origin %q, which is not described in the origins object",
+			tc.Source, tc.Origin)
+	}
+
+	// Provenance is only worth recording if it can be followed back: a
+	// repository needs a commit to make its line numbers resolvable, and
+	// documentation needs somewhere to read it.
+	for name, origin := range corpus.Origins {
+		switch origin.Kind {
+		case originRepository:
+			assert.NotEmpty(t, origin.URL, "origin %s has no url", name)
+			assert.Len(t, origin.Commit, 40, "origin %s needs a full commit sha", name)
+		case originDocumentation:
+			assert.NotEmpty(t, origin.URL, "origin %s has no url", name)
+		case originSynthesized:
+		default:
+			t.Errorf("origin %s has unknown kind %q", name, origin.Kind)
+		}
+	}
+
+	assert.GreaterOrEqual(t, len(integrations), 22, "integrations covered")
+	assert.Subset(t,
+		keysOf(framings),
+		[]string{"rfc3164_pri", "bsd_nopri", "iso_pri", "iso_nopri",
+			"rfc5424", "yearfirst_nopri", "octet_counted"},
+		"every framing class the parser handles must stay represented")
+	assert.Subset(t, keysOf(transports), []string{"wire", "file"})
+}
+
+func keysOf(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/pkg/logs/internal/parsers/syslog/corpus_golden_test.go
+++ b/pkg/logs/internal/parsers/syslog/corpus_golden_test.go
@@ -38,19 +38,13 @@ import (
 //	documentation   a published vendor format example; "source" cites the section
 //	synthesized     constructed here to model a documented shape, not copied
 //
-// A format with no sample available from those repositories is covered from the
-// vendor's published documentation instead.
+// The pins are not a dependency — nothing here fetches them — so they only need
+// refreshing when messages are added or rechecked.
 //
-// Pinning a commit keeps a repository "source" resolvable after upstream edits
-// the file. The pins record when the samples were taken and are not a dependency:
-// nothing here fetches them, so they only need refreshing when messages are added
-// or rechecked.
-//
-// Two mechanical differences from the upstream fixture are worth knowing when
-// comparing. Pipeline YAML folds long samples over several physical lines, and
-// "source" points at the first of them while "line" holds the joined result.
-// Octet-counted samples appear upstream with their RFC 6587 MSG-LEN prefix, which
-// is stored stripped here because the framer removes it before the parser runs.
+// A message will not always match its upstream fixture byte for byte. Pipeline
+// YAML folds long samples across physical lines, so "source" points at the first
+// and "line" holds the joined result; octet-counted samples are stored without
+// the RFC 6587 MSG-LEN prefix the framer strips before the parser runs.
 //
 // To adopt new output after an intentional parser change:
 //

--- a/pkg/logs/internal/parsers/syslog/syslog.go
+++ b/pkg/logs/internal/parsers/syslog/syslog.go
@@ -77,6 +77,10 @@ const (
 	maxSDNameLen    = 32  // max length for SD-ID and PARAM-NAME
 )
 
+// maxCiscoTokenLen bounds the FACILITY and MNEMONIC halves of a Cisco message
+// identifier so the scan cannot run away over arbitrary CONTENT.
+const maxCiscoTokenLen = 32
+
 // SyslogMessage is a parsed syslog message (RFC 5424 or RFC 3164/BSD).
 //
 // String fields are independent copies of the input. The Msg field aliases
@@ -298,23 +302,40 @@ func parseRFC5424(line []byte, pri int, pos int) (SyslogMessage, error) {
 		}
 	}
 
-	// --- Find SPs after VERSION to delimit header fields ---
+	// --- Split the 5 HEADER fields that follow VERSION ---
 	// Fields: TIMESTAMP SP HOSTNAME SP APP-NAME SP PROCID SP MSGID SP ...
 	//
-	// NOTE: This uses a simple space-counting heuristic. It works because
-	// RFC 5424 HEADER fields are single tokens (no embedded spaces), but it
-	// will mis-parse non-conformant TIMESTAMP values that contain extra spaces.
-	// This is an intentional performance trade-off vs. regex or field-by-field parsing.
-	var spPos [5]int
+	// RFC 5424 §6 mandates exactly one SP between fields, but emitters pad:
+	// Claroty CTD sends "<134>1  2025-05-13T04:57:18Z EMC ...". No HEADER
+	// field may contain a space, so collapsing a run of them can never merge
+	// two fields — whereas counting single spaces shifts every field along by
+	// one and leaves TIMESTAMP empty.
+	//
+	// A field only counts as found once it is terminated by a space, which is
+	// what keeps the best-effort recovery below aligned with a truncated
+	// header. nextStart tracks where the next field begins, so an incomplete
+	// header hands everything from that offset to MSG.
+	var fields [5][]byte
 	found := 0
-	for i := sp + 1; i < len(line); i++ {
-		if line[i] == ' ' {
-			spPos[found] = i
-			found++
-			if found == 5 {
-				break
-			}
+	i := sp
+	for i < len(line) && line[i] == ' ' {
+		i++
+	}
+	nextStart := i
+	for found < 5 && i < len(line) {
+		start := i
+		for i < len(line) && line[i] != ' ' {
+			i++
 		}
+		if i >= len(line) {
+			break // no terminating SP: the header is truncated here
+		}
+		fields[found] = line[start:i]
+		for i < len(line) && line[i] == ' ' {
+			i++
+		}
+		found++
+		nextStart = i
 	}
 
 	// Build message with defaults for all fields.
@@ -332,52 +353,52 @@ func parseRFC5424(line []byte, pri int, pos int) (SyslogMessage, error) {
 
 	if found < 1 {
 		// Only VERSION; remainder is MSG.
-		if sp+1 < len(line) {
-			msg.Msg = line[sp+1:]
+		if nextStart < len(line) {
+			msg.Msg = line[nextStart:]
 		}
 		msg.Partial = true
 		return msg, errHeaderTooShort
 	}
-	msg.Timestamp = toHeaderString(line[sp+1 : spPos[0]])
+	msg.Timestamp = toHeaderString(fields[0])
 
 	if found < 2 {
-		if spPos[0]+1 < len(line) {
-			msg.Msg = line[spPos[0]+1:]
+		if nextStart < len(line) {
+			msg.Msg = line[nextStart:]
 		}
 		msg.Partial = true
 		return msg, errHeaderTooShort
 	}
-	msg.Hostname = toHeaderString(line[spPos[0]+1 : spPos[1]])
+	msg.Hostname = toHeaderString(fields[1])
 
 	if found < 3 {
-		if spPos[1]+1 < len(line) {
-			msg.Msg = line[spPos[1]+1:]
+		if nextStart < len(line) {
+			msg.Msg = line[nextStart:]
 		}
 		msg.Partial = true
 		return msg, errHeaderTooShort
 	}
-	msg.AppName = toHeaderString(line[spPos[1]+1 : spPos[2]])
+	msg.AppName = toHeaderString(fields[2])
 
 	if found < 4 {
-		if spPos[2]+1 < len(line) {
-			msg.Msg = line[spPos[2]+1:]
+		if nextStart < len(line) {
+			msg.Msg = line[nextStart:]
 		}
 		msg.Partial = true
 		return msg, errHeaderTooShort
 	}
-	msg.ProcID = toHeaderString(line[spPos[2]+1 : spPos[3]])
+	msg.ProcID = toHeaderString(fields[3])
 
 	if found < 5 {
-		if spPos[3]+1 < len(line) {
-			msg.Msg = line[spPos[3]+1:]
+		if nextStart < len(line) {
+			msg.Msg = line[nextStart:]
 		}
 		msg.Partial = true
 		return msg, errHeaderTooShort
 	}
-	msg.MsgID = toHeaderString(line[spPos[3]+1 : spPos[4]])
+	msg.MsgID = toHeaderString(fields[4])
 
 	// --- Parse STRUCTURED-DATA ---
-	rest := line[spPos[4]+1:]
+	rest := line[nextStart:]
 	if len(rest) == 0 {
 		msg.Partial = true
 		return msg, errMissingSD
@@ -483,6 +504,22 @@ func parseBSD(line []byte, pri int, pos int) (SyslogMessage, error) {
 		return msg, nil
 	}
 
+	// Cisco devices omit the Device-ID when "logging device-id" is disabled,
+	// leaving only a separator between the TIMESTAMP and the message mnemonic.
+	// Its shape varies by platform and release:
+	//
+	//	2024-01-05T05:45:16Z   %FTD-1-430003: EventPriority: Low, ...
+	//	May 17 2023 03:04:28: %ASA-6-302013: Built outbound TCP connection ...
+	//
+	// Cisco's syslog guide tells collectors to expect an optional colon
+	// "followed by zero or more spaces" at this position, so neither the gap
+	// width nor the colon carries meaning. There is no HOSTNAME to read: the
+	// mnemonic begins the CONTENT.
+	if sep := skipCiscoSeparator(line, pos); sep > pos && startsWithCiscoMnemonic(line[sep:]) {
+		msg.Msg = line[sep:]
+		return msg, nil
+	}
+
 	// --- SP + HOSTNAME ---
 	if pos >= len(line) || line[pos] != ' ' {
 		msg.Partial = true
@@ -498,6 +535,18 @@ func parseBSD(line []byte, pri int, pos int) (SyslogMessage, error) {
 		msg.Partial = true
 		return msg, errBSDHostname
 	}
+
+	// Many emitters drop the HOSTNAME and put the TAG straight after the
+	// TIMESTAMP — BIND writes "2024-09-20T10:20:26.751Z network: info: ..."
+	// under print-category, and yum writes "Aug 20 12:51:21 Erased: pkg".
+	// A trailing colon tells the two apart, since a hostname or IP address
+	// never ends in one. Hand the whole remainder to the TAG parser, which
+	// applies its own plausibility checks before committing an APP-NAME.
+	if isTagShapedToken(line[pos:hostEnd]) {
+		parseBSDTag(&msg, line[pos:])
+		return msg, nil
+	}
+
 	msg.Hostname = string(line[pos:hostEnd])
 
 	if hostEnd >= len(line) {
@@ -512,10 +561,15 @@ func parseBSD(line []byte, pri int, pos int) (SyslogMessage, error) {
 	// --- TAG + CONTENT ---
 	rest := line[pos:]
 
-	// Detect "double-header" formats where an ISO 8601 timestamp appears in
-	// the TAG position (e.g. Cisco FTD: "YYYY-MM-DDThh:mm:ssZ hostname ...").
+	// Detect "double-header" formats where a second timestamp appears in the
+	// TAG position. A relay that prepends its own header leaves the original
+	// device header in place, so what follows the relay's HOSTNAME is another
+	// TIMESTAMP rather than a TAG — in ISO form (Cisco FTD:
+	// "YYYY-MM-DDThh:mm:ssZ hostname ...") or in BSD form (Cisco ISE:
+	// "May 31 08:36:58 ISELAB CISE_..."). Without this the TAG scan latches
+	// onto the month abbreviation and reports an APP-NAME of "May".
 	// No real TAG is present; treat the entire remainder as MSG.
-	if looksLikeISOTimestamp(rest) {
+	if looksLikeISOTimestamp(rest) || bsdTimestampLen(rest) > 0 {
 		msg.Msg = rest
 		return msg, nil
 	}
@@ -562,13 +616,11 @@ func parseBSDTag(msg *SyslogMessage, rest []byte) {
 	}
 
 	if delimIdx < 0 {
-		// No delimiter — entire rest is APP-NAME with no MSG.
-		candidate := string(rest)
-		if !isPlausibleAppName(candidate) {
-			msg.Msg = rest
-			return
-		}
-		msg.AppName = candidate
+		// No delimiter, so nothing marks where a TAG would end. RFC 3164
+		// §4.3.3 only recognizes a TAG by its terminator; without one the
+		// remainder is CONTENT. Claiming it as APP-NAME instead would leave
+		// MSG empty and silently discard the body.
+		msg.Msg = rest
 		return
 	}
 
@@ -913,6 +965,26 @@ func isPlausibleAppName(s string) bool {
 	return !allDigit
 }
 
+// isTagShapedToken reports whether the token sitting in the HOSTNAME position
+// is really a TAG. The discriminator is a single trailing colon: RFC 3164
+// §4.1.2 defines HOSTNAME as a hostname or IP address, neither of which ends
+// in a colon, while RFC 3164 §4.1.3 terminates the TAG with one.
+//
+// Tokens holding more than one colon are deliberately left as HOSTNAME so an
+// IPv6 address that ends in "::" is not mistaken for a TAG.
+func isTagShapedToken(tok []byte) bool {
+	if len(tok) < 2 || tok[len(tok)-1] != ':' {
+		return false
+	}
+	colons := 0
+	for _, c := range tok {
+		if c == ':' {
+			colons++
+		}
+	}
+	return colons == 1
+}
+
 // looksLikeISOTimestamp returns true if b starts with an ISO 8601 date prefix
 // (YYYY-MM or YYYY-). This detects the "double-header" pattern used by devices
 // like Cisco FTD, which embed a second timestamp after the BSD hostname:
@@ -930,6 +1002,67 @@ func looksLikeISOTimestamp(b []byte) bool {
 		b[2] >= '0' && b[2] <= '9' &&
 		b[3] >= '0' && b[3] <= '9' &&
 		b[4] == '-'
+}
+
+// skipCiscoSeparator advances past the spaces and at most one colon that Cisco
+// devices place between the TIMESTAMP (or Device-ID) and the message mnemonic.
+// Both parts are optional: FTD pads with spaces when the Device-ID is
+// disabled, while ASA under "logging timestamp" writes the colon straight
+// after the timestamp. It returns pos unchanged when neither is present, so
+// callers can tell whether a separator was consumed at all.
+func skipCiscoSeparator(line []byte, pos int) int {
+	i := pos
+	for i < len(line) && line[i] == ' ' {
+		i++
+	}
+	if i < len(line) && line[i] == ':' {
+		i++
+		for i < len(line) && line[i] == ' ' {
+			i++
+		}
+	}
+	return i
+}
+
+// startsWithCiscoMnemonic reports whether b opens with a Cisco message
+// identifier — "%FACILITY-SEVERITY-MNEMONIC" — as emitted by ASA, FTD, NGIPS
+// and NX-OS (e.g. "%FTD-1-430003:", "%ASA-6-302013:",
+// "%ETHPORT-5-IF_DOWN_CFG_CHANGE:"). SEVERITY is the single syslog severity
+// digit, which is what keeps the token unambiguous: RFC 3164 §4.1.2 defines
+// HOSTNAME as a hostname or IP address, so neither the leading '%' nor the
+// interior severity digit can occur in a well-formed value here.
+func startsWithCiscoMnemonic(b []byte) bool {
+	if len(b) < 2 || b[0] != '%' {
+		return false
+	}
+	i := 1
+
+	facility := i
+	for i < len(b) && (isAlphaNumeric(b[i]) || b[i] == '_') {
+		i++
+	}
+	if i == facility || i-facility > maxCiscoTokenLen {
+		return false
+	}
+	if i >= len(b) || b[i] != '-' {
+		return false
+	}
+	i++
+
+	if i >= len(b) || b[i] < '0' || b[i] > '7' {
+		return false
+	}
+	i++
+	if i >= len(b) || b[i] != '-' {
+		return false
+	}
+	i++
+
+	mnemonic := i
+	for i < len(b) && (isAlphaNumeric(b[i]) || b[i] == '_') {
+		i++
+	}
+	return i > mnemonic && i-mnemonic <= maxCiscoTokenLen
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/logs/internal/parsers/syslog/syslog.go
+++ b/pkg/logs/internal/parsers/syslog/syslog.go
@@ -173,6 +173,17 @@ func Parse(line []byte) (SyslogMessage, error) {
 	var msg SyslogMessage
 	var err error
 
+	// Cisco's EMBLEM dialect terminates the PRI with a colon rather than going
+	// straight into the header: the default remote-logging format on NX-OS is
+	// "<189>:2025 Mar 27 16:22:24 switch %SYSLOG-...", and ASA emits the same
+	// shape when EMBLEM is enabled. The colon carries nothing, so step over it —
+	// but only when a timestamp follows, so that CONTENT which merely begins
+	// with a colon is still treated as MSG per RFC 3164 §4.3.2.
+	if line[pos] == ':' && pos+1 < len(line) &&
+		(bsdTimestampLen(line[pos+1:]) > 0 || isoTimestampLen(line[pos+1:]) > 0) {
+		pos++
+	}
+
 	b := line[pos]
 	switch {
 	case b >= '0' && b <= '9':
@@ -184,13 +195,15 @@ func Parse(line []byte) (SyslogMessage, error) {
 		// remainder as MSG CONTENT per RFC 3164 §4.3.2.
 		switch {
 		case isValidBSDTimestampYearFirst(line[pos:]):
-			// Cisco NX-OS: "<PRI>YYYY Mmm DD HH:MM:SS host %FAC-SEV-MNEMONIC:".
-			// The leading year also matches the RFC 5424 VERSION-SP shape, so
-			// this must be tested first or the year is read as a VERSION.
+			// Cisco NX-OS: "YYYY Mmm DD HH:MM:SS host %FAC-SEV-MNEMONIC:", which
+			// is the platform default. The leading year also matches the RFC 5424
+			// VERSION-SP shape, so this must be tested first or the year is read
+			// as a VERSION.
 			msg, err = parseBSD(line, pri, pos)
 		case isoTimestampLen(line[pos:]) > 0:
-			// Cisco ASA/FTD and Picus put an ISO 8601 timestamp straight after
-			// the PRI, with no RFC 5424 VERSION.
+			// Cisco ASA and FTD emit an ISO 8601 timestamp straight after the
+			// PRI, with no RFC 5424 VERSION, under "logging timestamp rfc5424";
+			// Picus does the same.
 			msg, err = parseBSD(line, pri, pos)
 		case isRFC5424Header(line, pos):
 			msg, err = parseRFC5424(line, pri, pos)
@@ -292,19 +305,9 @@ func parseRFC5424(line []byte, pri int, pos int) (SyslogMessage, error) {
 	// RFC 5424 HEADER fields are single tokens (no embedded spaces), but it
 	// will mis-parse non-conformant TIMESTAMP values that contain extra spaces.
 	// This is an intentional performance trade-off vs. regex or field-by-field parsing.
-	//
-	// Some appliances (e.g. Claroty CTD) emit more than one SP between VERSION
-	// and TIMESTAMP. RFC 5424 allows exactly one, but skipping the extra spaces
-	// costs nothing and avoids yielding an empty TIMESTAMP and shifting every
-	// later field by one position.
-	tsStart := sp + 1
-	for tsStart < len(line) && line[tsStart] == ' ' {
-		tsStart++
-	}
-
 	var spPos [5]int
 	found := 0
-	for i := tsStart; i < len(line); i++ {
+	for i := sp + 1; i < len(line); i++ {
 		if line[i] == ' ' {
 			spPos[found] = i
 			found++
@@ -329,13 +332,13 @@ func parseRFC5424(line []byte, pri int, pos int) (SyslogMessage, error) {
 
 	if found < 1 {
 		// Only VERSION; remainder is MSG.
-		if tsStart < len(line) {
-			msg.Msg = line[tsStart:]
+		if sp+1 < len(line) {
+			msg.Msg = line[sp+1:]
 		}
 		msg.Partial = true
 		return msg, errHeaderTooShort
 	}
-	msg.Timestamp = toHeaderString(line[tsStart:spPos[0]])
+	msg.Timestamp = toHeaderString(line[sp+1 : spPos[0]])
 
 	if found < 2 {
 		if spPos[0]+1 < len(line) {
@@ -509,10 +512,13 @@ func parseBSD(line []byte, pri int, pos int) (SyslogMessage, error) {
 
 	// Detect "double-header" formats where a second timestamp appears in the TAG
 	// position — an ISO 8601 one (e.g. Cisco FTD: "YYYY-MM-DDThh:mm:ssZ hostname
-	// ...") or a repeated BSD one (e.g. Cisco ISE: "<PRI>Mmm dd hh:mm:ss MGMT_IP
-	// Mmm dd hh:mm:ss hostname CISE_... "). No real TAG is present; treat the
-	// entire remainder as MSG. Without the BSD case the month abbreviation of the
-	// second timestamp is extracted as the APP-NAME.
+	// ...") or a repeated BSD one ("Mmm dd hh:mm:ss MGMT_IP Mmm dd hh:mm:ss
+	// hostname CISE_..."). The repeated BSD form is generally not a device
+	// behavior but a relay artifact: an aggregator that fails to recognize a line
+	// as already-formatted syslog prepends its own TIMESTAMP HOSTNAME to the
+	// whole thing, so any source behind a misconfigured relay can produce it.
+	// No real TAG is present; treat the entire remainder as MSG. Without the BSD
+	// case the month abbreviation of the second timestamp becomes the APP-NAME.
 	if looksLikeISOTimestamp(rest) || bsdTimestampLen(rest) > 0 {
 		msg.Msg = rest
 		return msg, nil
@@ -710,9 +716,11 @@ func isValidBSDTimestampWithYear(b []byte) bool {
 //	RFC 3164:      "Jan  9 03:47:40" (15 bytes, day space-padded)
 //	Non-padded:    "Jan 9 03:47:40"  (14 bytes)
 //
-// Several appliances emit the non-padded form (BeyondTrust Privileged Remote
-// Access, Cisco ISE, Infoblox DDI). Structural checks: valid month at [0:3],
-// space at [3], a digit day at [4], space at [5], colons at [8] and [11].
+// The non-padded form is common enough in the field that syslog-ng carries a
+// dedicated detector for it and grok, Fluentd, and Vector all accept one or two
+// spaces; it shows up here in Infoblox, Cisco ISE, and NX-OS samples.
+// Structural checks: valid month at [0:3], space at [3], a digit day at [4],
+// space at [5], colons at [8] and [11].
 func isValidBSDTimestampSingleSpaceDay(b []byte) bool {
 	if len(b) < 14 {
 		return false

--- a/pkg/logs/internal/parsers/syslog/syslog.go
+++ b/pkg/logs/internal/parsers/syslog/syslog.go
@@ -183,9 +183,10 @@ func Parse(line []byte) (SyslogMessage, error) {
 	// shape when EMBLEM is enabled. The colon carries nothing, so step over it —
 	// but only when a timestamp follows, so that CONTENT which merely begins
 	// with a colon is still treated as MSG per RFC 3164 §4.3.2.
-	if line[pos] == ':' && pos+1 < len(line) &&
-		(bsdTimestampLen(line[pos+1:]) > 0 || isoTimestampLen(line[pos+1:]) > 0) {
-		pos++
+	if pos+1 < len(line) && line[pos] == ':' {
+		if n, _ := timestampLen(line[pos+1:]); n > 0 {
+			pos++
+		}
 	}
 
 	b := line[pos]
@@ -197,17 +198,15 @@ func Parse(line []byte) (SyslogMessage, error) {
 		// Only dispatch to the RFC 5424 parser when the bytes actually form a
 		// VERSION token (1-3 digits) followed by SP; otherwise treat the
 		// remainder as MSG CONTENT per RFC 3164 §4.3.2.
+		digitTS, _ := timestampLen(line[pos:])
 		switch {
-		case isValidBSDTimestampYearFirst(line[pos:]):
-			// Cisco NX-OS: "YYYY Mmm DD HH:MM:SS host %FAC-SEV-MNEMONIC:", which
-			// is the platform default. The leading year also matches the RFC 5424
-			// VERSION-SP shape, so this must be tested first or the year is read
-			// as a VERSION.
-			msg, err = parseBSD(line, pri, pos)
-		case isoTimestampLen(line[pos:]) > 0:
-			// Cisco ASA and FTD emit an ISO 8601 timestamp straight after the
-			// PRI, with no RFC 5424 VERSION, under "logging timestamp rfc5424";
-			// Picus does the same.
+		case digitTS > 0:
+			// Two layouts lead with a digit, and both must be tested before
+			// isRFC5424Header or their leading digits are read as a VERSION:
+			// the year-first BSD form "YYYY Mmm DD HH:MM:SS host
+			// %FAC-SEV-MNEMONIC:" that is the NX-OS default, and the bare ISO
+			// 8601 timestamp that Cisco ASA and FTD send under "logging
+			// timestamp rfc5424" (as does Picus) with no VERSION at all.
 			msg, err = parseBSD(line, pri, pos)
 		case isRFC5424Header(line, pos):
 			msg, err = parseRFC5424(line, pri, pos)
@@ -350,43 +349,24 @@ func parseRFC5424(line []byte, pri int, pos int) (SyslogMessage, error) {
 
 	// --- Best-effort: extract available header fields in order ---
 
-	if found < 1 {
-		// Only VERSION; remainder is MSG.
-		if nextStart < len(line) {
-			msg.Msg = line[nextStart:]
-		}
-		msg.Partial = true
-		return msg, errHeaderTooShort
+	// Take whichever fields the header actually carried; the rest keep the
+	// nilvalue default. A header that ran out early is Partial, and everything
+	// from the first unparsed byte becomes MSG.
+	if found > 0 {
+		msg.Timestamp = toHeaderString(fields[0])
 	}
-	msg.Timestamp = toHeaderString(fields[0])
-
-	if found < 2 {
-		if nextStart < len(line) {
-			msg.Msg = line[nextStart:]
-		}
-		msg.Partial = true
-		return msg, errHeaderTooShort
+	if found > 1 {
+		msg.Hostname = toHeaderString(fields[1])
 	}
-	msg.Hostname = toHeaderString(fields[1])
-
-	if found < 3 {
-		if nextStart < len(line) {
-			msg.Msg = line[nextStart:]
-		}
-		msg.Partial = true
-		return msg, errHeaderTooShort
+	if found > 2 {
+		msg.AppName = toHeaderString(fields[2])
 	}
-	msg.AppName = toHeaderString(fields[2])
-
-	if found < 4 {
-		if nextStart < len(line) {
-			msg.Msg = line[nextStart:]
-		}
-		msg.Partial = true
-		return msg, errHeaderTooShort
+	if found > 3 {
+		msg.ProcID = toHeaderString(fields[3])
 	}
-	msg.ProcID = toHeaderString(fields[3])
-
+	if found > 4 {
+		msg.MsgID = toHeaderString(fields[4])
+	}
 	if found < 5 {
 		if nextStart < len(line) {
 			msg.Msg = line[nextStart:]
@@ -394,7 +374,6 @@ func parseRFC5424(line []byte, pri int, pos int) (SyslogMessage, error) {
 		msg.Partial = true
 		return msg, errHeaderTooShort
 	}
-	msg.MsgID = toHeaderString(fields[4])
 
 	// --- Parse STRUCTURED-DATA ---
 	rest := line[nextStart:]
@@ -465,15 +444,7 @@ func parseBSD(line []byte, pri int, pos int) (SyslogMessage, error) {
 	// Cisco ASA/FTD and Picus send in place of the BSD form. The ISO layout also
 	// turns up in tailed files regardless of sender, because rsyslog's default
 	// file template renders the timestamp as RFC 3339 and drops the PRI.
-	tsLen := bsdTimestampLen(line[pos:])
-	isISOTimestamp := false
-	if tsLen == 0 {
-		if n := isoTimestampLen(line[pos:]); n > 0 {
-			tsLen = n
-			isISOTimestamp = true
-		}
-	}
-
+	tsLen, isISOTimestamp := timestampLen(line[pos:])
 	if tsLen == 0 {
 		if pos < len(line) && pri >= 0 {
 			// RFC 3164 §4.3.2: valid PRI, content present but no valid
@@ -764,8 +735,6 @@ func isValidBSDTimestampWithYear(b []byte) bool {
 // The non-padded form is common enough in the field that syslog-ng carries a
 // dedicated detector for it and grok, Fluentd, and Vector all accept one or two
 // spaces; it shows up here in Infoblox, Cisco ISE, and NX-OS samples.
-// Structural checks: valid month at [0:3], space at [3], a digit day at [4],
-// space at [5], colons at [8] and [11].
 func isValidBSDTimestampSingleSpaceDay(b []byte) bool {
 	if len(b) < 14 {
 		return false
@@ -786,10 +755,6 @@ func isValidBSDTimestampSingleSpaceDay(b []byte) bool {
 //	RFC 3164:    "Apr  4 08:05:06"      (15 bytes)
 //	With year:   "Apr 04 2024 08:05:06" (20 bytes)
 //	Year first:  "2024 Apr 04 08:05:06" (20 bytes)
-//
-// Structural checks: four digits at [0:4], space at [4], valid month at [5:8],
-// space at [8], a two-character day at [9:11], space at [11], and colons at
-// [14] and [17].
 func isValidBSDTimestampYearFirst(b []byte) bool {
 	if len(b) < 20 {
 		return false
@@ -814,6 +779,23 @@ func isValidBSDTimestampYearFirst(b []byte) bool {
 // RFC 3164 form is tested before the 14-byte non-padded form so a conformant
 // timestamp is never matched by the looser pattern.
 func bsdTimestampLen(b []byte) int {
+	// 14 bytes is the shortest accepted layout.
+	if len(b) < 14 {
+		return 0
+	}
+	// Year-first is the only layout that opens with a digit; every other one
+	// opens with a month abbreviation. One look at the first byte therefore
+	// picks the family, and the abbreviation is validated once rather than
+	// once per layout.
+	if isDigit(b[0]) {
+		if isValidBSDTimestampYearFirst(b) {
+			return 20
+		}
+		return 0
+	}
+	if !isValidMonthAbbrev(b) {
+		return 0
+	}
 	switch {
 	case isValidBSDTimestamp(b):
 		return 15
@@ -821,10 +803,24 @@ func bsdTimestampLen(b []byte) int {
 		return 14
 	case isValidBSDTimestampWithYear(b):
 		return 20
-	case isValidBSDTimestampYearFirst(b):
-		return 20
 	}
 	return 0
+}
+
+// timestampLen returns the length of the TIMESTAMP at the start of b and
+// whether it is the ISO 8601 form rather than one of the BSD layouts, or 0 if
+// b does not begin with a timestamp at all. Callers that only need to know
+// whether a timestamp is present should use this rather than consulting the
+// two detectors separately, so that dispatch and parsing cannot disagree about
+// where a header starts.
+func timestampLen(b []byte) (int, bool) {
+	if n := bsdTimestampLen(b); n > 0 {
+		return n, false
+	}
+	if n := isoTimestampLen(b); n > 0 {
+		return n, true
+	}
+	return 0, false
 }
 
 // isoTimestampLen returns the length of an ISO 8601 / RFC 3339 timestamp at the
@@ -990,6 +986,12 @@ func isTagShapedToken(tok []byte) bool {
 //
 // When this pattern appears in the TAG position, no real TAG is present and the
 // entire remainder should be treated as MSG.
+//
+// The four-digit-and-dash prefix is all this checks, which is deliberately
+// weaker than isoTimestampLen: the embedded timestamp is never consumed, only
+// recognized, so a relay writing a date-only or otherwise non-conformant second
+// header still keeps its remainder out of APP-NAME. Use isoTimestampLen instead
+// wherever the match decides how many bytes to advance.
 func looksLikeISOTimestamp(b []byte) bool {
 	if len(b) < 5 {
 		return false

--- a/pkg/logs/internal/parsers/syslog/syslog.go
+++ b/pkg/logs/internal/parsers/syslog/syslog.go
@@ -215,6 +215,11 @@ func Parse(line []byte) (SyslogMessage, error) {
 		}
 	case (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z'):
 		msg, err = parseBSD(line, pri, pos)
+	case b == '*':
+		// Cisco IOS marks an unsynchronized clock with '*' before the
+		// TIMESTAMP. parseBSD steps over it; if no timestamp follows it falls
+		// back to treating the remainder as MSG.
+		msg, err = parseBSD(line, pri, pos)
 	default:
 		// RFC 3164 §4.3.2: valid PRI, but what follows is neither a digit
 		// (RFC 5424 VERSION) nor a letter (BSD TIMESTAMP month). Treat the
@@ -444,7 +449,29 @@ func parseBSD(line []byte, pri int, pos int) (SyslogMessage, error) {
 	// Cisco ASA/FTD and Picus send in place of the BSD form. The ISO layout also
 	// turns up in tailed files regardless of sender, because rsyslog's default
 	// file template renders the timestamp as RFC 3339 and drops the PRI.
+	// Cisco IOS writes '*' ahead of the TIMESTAMP when the system clock has
+	// never synchronized to a reliable source. It is a marker rather than part
+	// of the time, so step over it and record the timestamp itself; the '*'
+	// stays visible in the content, which is transmitted verbatim. Only skip it
+	// when a timestamp actually follows, so a body opening with '*' is left as
+	// MSG.
+	if pos < len(line) && line[pos] == '*' {
+		if n, _ := timestampLen(line[pos+1:]); n > 0 {
+			pos++
+		}
+	}
+
 	tsLen, isISOTimestamp := timestampLen(line[pos:])
+	if !isISOTimestamp && tsLen > 0 {
+		// "show-timezone" appends the zone name to the BSD layouts. It belongs
+		// to the timestamp, not to the TAG position it occupies. A zone opens
+		// with an uppercase letter and an ordinary HOSTNAME almost never does,
+		// so that byte is tested before the call rather than inside it.
+		if end := pos + tsLen; end+1 < len(line) &&
+			line[end] == ' ' && line[end+1] >= 'A' && line[end+1] <= 'Z' {
+			tsLen += bsdZoneSuffixLen(line[end:])
+		}
+	}
 	if tsLen == 0 {
 		if pos < len(line) && pri >= 0 {
 			// RFC 3164 §4.3.2: valid PRI, content present but no valid
@@ -787,24 +814,90 @@ func bsdTimestampLen(b []byte) int {
 	// opens with a month abbreviation. One look at the first byte therefore
 	// picks the family, and the abbreviation is validated once rather than
 	// once per layout.
+	n := 0
 	if isDigit(b[0]) {
-		if isValidBSDTimestampYearFirst(b) {
-			return 20
+		if !isValidBSDTimestampYearFirst(b) {
+			return 0
 		}
+		n = 20
+	} else {
+		if !isValidMonthAbbrev(b) {
+			return 0
+		}
+		switch {
+		case isValidBSDTimestamp(b):
+			n = 15
+		case isValidBSDTimestampSingleSpaceDay(b):
+			n = 14
+		case isValidBSDTimestampWithYear(b):
+			n = 20
+		default:
+			return 0
+		}
+	}
+	// Every layout ends in seconds, so an optional fraction attaches the same
+	// way to all of them. The '.' is tested here so the common case of a
+	// timestamp without one costs a single comparison.
+	if len(b) > n && b[n] == '.' {
+		n += bsdFractionLen(b[n:])
+	}
+	return n
+}
+
+// bsdFractionLen returns the length of a fractional-seconds suffix — '.' and at
+// least one digit — at the start of b, or 0 if there is none. Cisco IOS appends
+// one under "service timestamps log datetime msec" ("Mar 18 14:52:10.039"),
+// which its own documentation uses throughout. Every BSD layout ends in seconds,
+// so the suffix attaches the same way to all of them, and isoTimestampLen
+// already accepts the equivalent on the ISO layouts.
+func bsdFractionLen(b []byte) int {
+	if len(b) < 2 || b[0] != '.' || !isDigit(b[1]) {
 		return 0
 	}
-	if !isValidMonthAbbrev(b) {
+	i := 2
+	for i < len(b) && isDigit(b[i]) {
+		i++
+	}
+	return i
+}
+
+// maxZoneAbbrevLen bounds a timezone abbreviation. Four letters covers the
+// longest in common use ("AEDT", "CEST"); five leaves room to spare.
+const maxZoneAbbrevLen = 5
+
+// bsdZoneSuffixLen returns the length of a " ZONE" suffix following a BSD
+// TIMESTAMP, or 0 if there is none. Cisco IOS appends the zone name under
+// "service timestamps log datetime show-timezone", putting it exactly where a
+// TAG would sit:
+//
+//	Mar  1 18:46:11 UTC: %LINK-3-UPDOWN: Interface Serial0 up
+//
+// Read as a TAG it becomes the APP-NAME, which then drives service routing from
+// a timezone. A bare uppercase token is far too weak a signal to act on, so the
+// suffix only counts when a Cisco mnemonic follows the colon that ends it —
+// leaving a genuine uppercase TAG ("GW: session opened") alone. The colon itself
+// is left in place for skipCiscoSeparator.
+func bsdZoneSuffixLen(b []byte) int {
+	// A lowercase byte here is the overwhelmingly common case — an ordinary
+	// HOSTNAME — so it is rejected before anything else runs.
+	if len(b) < 2 || b[0] != ' ' || b[1] < 'A' || b[1] > 'Z' {
 		return 0
 	}
-	switch {
-	case isValidBSDTimestamp(b):
-		return 15
-	case isValidBSDTimestampSingleSpaceDay(b):
-		return 14
-	case isValidBSDTimestampWithYear(b):
-		return 20
+	i := 1
+	for i < len(b) && i-1 < maxZoneAbbrevLen && b[i] >= 'A' && b[i] <= 'Z' {
+		i++
 	}
-	return 0
+	if i-1 < 2 || i >= len(b) || b[i] != ':' {
+		return 0
+	}
+	rest := b[i+1:]
+	for len(rest) > 0 && rest[0] == ' ' {
+		rest = rest[1:]
+	}
+	if !startsWithCiscoMnemonic(rest) {
+		return 0
+	}
+	return i
 }
 
 // timestampLen returns the length of the TIMESTAMP at the start of b and

--- a/pkg/logs/internal/parsers/syslog/syslog.go
+++ b/pkg/logs/internal/parsers/syslog/syslog.go
@@ -512,16 +512,10 @@ func parseBSD(line []byte, pri int, pos int) (SyslogMessage, error) {
 	// --- TAG + CONTENT ---
 	rest := line[pos:]
 
-	// Detect "double-header" formats where a second timestamp appears in the TAG
-	// position — an ISO 8601 one (e.g. Cisco FTD: "YYYY-MM-DDThh:mm:ssZ hostname
-	// ...") or a repeated BSD one ("Mmm dd hh:mm:ss MGMT_IP Mmm dd hh:mm:ss
-	// hostname CISE_..."). The repeated BSD form is generally not a device
-	// behavior but a relay artifact: an aggregator that fails to recognize a line
-	// as already-formatted syslog prepends its own TIMESTAMP HOSTNAME to the
-	// whole thing, so any source behind a misconfigured relay can produce it.
-	// No real TAG is present; treat the entire remainder as MSG. Without the BSD
-	// case the month abbreviation of the second timestamp becomes the APP-NAME.
-	if looksLikeISOTimestamp(rest) || bsdTimestampLen(rest) > 0 {
+	// Detect "double-header" formats where an ISO 8601 timestamp appears in
+	// the TAG position (e.g. Cisco FTD: "YYYY-MM-DDThh:mm:ssZ hostname ...").
+	// No real TAG is present; treat the entire remainder as MSG.
+	if looksLikeISOTimestamp(rest) {
 		msg.Msg = rest
 		return msg, nil
 	}

--- a/pkg/logs/internal/parsers/syslog/syslog.go
+++ b/pkg/logs/internal/parsers/syslog/syslog.go
@@ -442,7 +442,9 @@ func parseBSD(line []byte, pri int, pos int) (SyslogMessage, error) {
 	// Accepted layouts, in order: the RFC 3164 15-byte form "Mmm dd hh:mm:ss",
 	// the 14-byte non-padded-day and 20-byte with-year and year-first variants
 	// emitted by various appliances, and finally an ISO 8601 timestamp, which
-	// Cisco ASA/FTD, Delinea, and Picus use in place of the BSD form.
+	// Cisco ASA/FTD and Picus send in place of the BSD form. The ISO layout also
+	// turns up in tailed files regardless of sender, because rsyslog's default
+	// file template renders the timestamp as RFC 3339 and drops the PRI.
 	tsLen := bsdTimestampLen(line[pos:])
 	isISOTimestamp := false
 	if tsLen == 0 {

--- a/pkg/logs/internal/parsers/syslog/syslog.go
+++ b/pkg/logs/internal/parsers/syslog/syslog.go
@@ -182,9 +182,19 @@ func Parse(line []byte) (SyslogMessage, error) {
 		// Only dispatch to the RFC 5424 parser when the bytes actually form a
 		// VERSION token (1-3 digits) followed by SP; otherwise treat the
 		// remainder as MSG CONTENT per RFC 3164 §4.3.2.
-		if isRFC5424Header(line, pos) {
+		switch {
+		case isValidBSDTimestampYearFirst(line[pos:]):
+			// Cisco NX-OS: "<PRI>YYYY Mmm DD HH:MM:SS host %FAC-SEV-MNEMONIC:".
+			// The leading year also matches the RFC 5424 VERSION-SP shape, so
+			// this must be tested first or the year is read as a VERSION.
+			msg, err = parseBSD(line, pri, pos)
+		case isoTimestampLen(line[pos:]) > 0:
+			// Cisco ASA/FTD and Picus put an ISO 8601 timestamp straight after
+			// the PRI, with no RFC 5424 VERSION.
+			msg, err = parseBSD(line, pri, pos)
+		case isRFC5424Header(line, pos):
 			msg, err = parseRFC5424(line, pri, pos)
-		} else {
+		default:
 			msg = parseBSDNoTimestamp(line, pri, pos)
 		}
 	case (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z'):
@@ -282,9 +292,19 @@ func parseRFC5424(line []byte, pri int, pos int) (SyslogMessage, error) {
 	// RFC 5424 HEADER fields are single tokens (no embedded spaces), but it
 	// will mis-parse non-conformant TIMESTAMP values that contain extra spaces.
 	// This is an intentional performance trade-off vs. regex or field-by-field parsing.
+	//
+	// Some appliances (e.g. Claroty CTD) emit more than one SP between VERSION
+	// and TIMESTAMP. RFC 5424 allows exactly one, but skipping the extra spaces
+	// costs nothing and avoids yielding an empty TIMESTAMP and shifting every
+	// later field by one position.
+	tsStart := sp + 1
+	for tsStart < len(line) && line[tsStart] == ' ' {
+		tsStart++
+	}
+
 	var spPos [5]int
 	found := 0
-	for i := sp + 1; i < len(line); i++ {
+	for i := tsStart; i < len(line); i++ {
 		if line[i] == ' ' {
 			spPos[found] = i
 			found++
@@ -309,13 +329,13 @@ func parseRFC5424(line []byte, pri int, pos int) (SyslogMessage, error) {
 
 	if found < 1 {
 		// Only VERSION; remainder is MSG.
-		if sp+1 < len(line) {
-			msg.Msg = line[sp+1:]
+		if tsStart < len(line) {
+			msg.Msg = line[tsStart:]
 		}
 		msg.Partial = true
 		return msg, errHeaderTooShort
 	}
-	msg.Timestamp = toHeaderString(line[sp+1 : spPos[0]])
+	msg.Timestamp = toHeaderString(line[tsStart:spPos[0]])
 
 	if found < 2 {
 		if spPos[0]+1 < len(line) {
@@ -416,14 +436,17 @@ func parseBSD(line []byte, pri int, pos int) (SyslogMessage, error) {
 	}
 
 	// --- TIMESTAMP ---
-	// Try standard 15-byte BSD format first: "Mmm dd hh:mm:ss"
-	// Then try 20-byte variant with year: "Mmm DD YYYY HH:MM:SS"
-	// (used by some network appliances that deviate from RFC 3164).
-	tsLen := 0
-	if pos+15 <= len(line) && isValidBSDTimestamp(line[pos:pos+15]) {
-		tsLen = 15
-	} else if pos+20 <= len(line) && isValidBSDTimestampWithYear(line[pos:pos+20]) {
-		tsLen = 20
+	// Accepted layouts, in order: the RFC 3164 15-byte form "Mmm dd hh:mm:ss",
+	// the 14-byte non-padded-day and 20-byte with-year and year-first variants
+	// emitted by various appliances, and finally an ISO 8601 timestamp, which
+	// Cisco ASA/FTD, Delinea, and Picus use in place of the BSD form.
+	tsLen := bsdTimestampLen(line[pos:])
+	isISOTimestamp := false
+	if tsLen == 0 {
+		if n := isoTimestampLen(line[pos:]); n > 0 {
+			tsLen = n
+			isISOTimestamp = true
+		}
 	}
 
 	if tsLen == 0 {
@@ -440,6 +463,20 @@ func parseBSD(line []byte, pri int, pos int) (SyslogMessage, error) {
 	}
 	msg.Timestamp = string(line[pos : pos+tsLen])
 	pos += tsLen
+
+	// Cisco ASA/FTD terminate the timestamp with a colon and omit both HOSTNAME
+	// and TAG: "<PRI>2025-11-25T07:19:40Z: %ASA-4-733100: ...". There is no
+	// hostname to read, so the remainder after the colon is CONTENT.
+	if isISOTimestamp && pos < len(line) && line[pos] == ':' {
+		pos++
+		if pos < len(line) && line[pos] == ' ' {
+			pos++
+		}
+		if pos < len(line) {
+			msg.Msg = line[pos:]
+		}
+		return msg, nil
+	}
 
 	// --- SP + HOSTNAME ---
 	if pos >= len(line) || line[pos] != ' ' {
@@ -470,10 +507,13 @@ func parseBSD(line []byte, pri int, pos int) (SyslogMessage, error) {
 	// --- TAG + CONTENT ---
 	rest := line[pos:]
 
-	// Detect "double-header" formats where an ISO 8601 timestamp appears in
-	// the TAG position (e.g. Cisco FTD: "YYYY-MM-DDThh:mm:ssZ hostname ...").
-	// No real TAG is present; treat the entire remainder as MSG.
-	if looksLikeISOTimestamp(rest) {
+	// Detect "double-header" formats where a second timestamp appears in the TAG
+	// position — an ISO 8601 one (e.g. Cisco FTD: "YYYY-MM-DDThh:mm:ssZ hostname
+	// ...") or a repeated BSD one (e.g. Cisco ISE: "<PRI>Mmm dd hh:mm:ss MGMT_IP
+	// Mmm dd hh:mm:ss hostname CISE_... "). No real TAG is present; treat the
+	// entire remainder as MSG. Without the BSD case the month abbreviation of the
+	// second timestamp is extracted as the APP-NAME.
+	if looksLikeISOTimestamp(rest) || bsdTimestampLen(rest) > 0 {
 		msg.Msg = rest
 		return msg, nil
 	}
@@ -661,6 +701,135 @@ func isValidBSDTimestampWithYear(b []byte) bool {
 		}
 	}
 	return isValidMonthAbbrev(b)
+}
+
+// isValidBSDTimestampSingleSpaceDay checks the 14-byte variant "Mmm d hh:mm:ss",
+// where a single-digit day is written with one space instead of the space-padded
+// "Mmm  d" that RFC 3164 requires:
+//
+//	RFC 3164:      "Jan  9 03:47:40" (15 bytes, day space-padded)
+//	Non-padded:    "Jan 9 03:47:40"  (14 bytes)
+//
+// Several appliances emit the non-padded form (BeyondTrust Privileged Remote
+// Access, Cisco ISE, Infoblox DDI). Structural checks: valid month at [0:3],
+// space at [3], a digit day at [4], space at [5], colons at [8] and [11].
+func isValidBSDTimestampSingleSpaceDay(b []byte) bool {
+	if len(b) < 14 {
+		return false
+	}
+	if b[3] != ' ' || b[5] != ' ' || b[8] != ':' || b[11] != ':' {
+		return false
+	}
+	if !isDigit(b[4]) {
+		return false
+	}
+	return isValidMonthAbbrev(b)
+}
+
+// isValidBSDTimestampYearFirst checks the 20-byte variant "YYYY Mmm DD HH:MM:SS"
+// emitted by Cisco NX-OS platforms, which place the year before the month
+// instead of after the day:
+//
+//	RFC 3164:    "Apr  4 08:05:06"      (15 bytes)
+//	With year:   "Apr 04 2024 08:05:06" (20 bytes)
+//	Year first:  "2024 Apr 04 08:05:06" (20 bytes)
+//
+// Structural checks: four digits at [0:4], space at [4], valid month at [5:8],
+// space at [8], a two-character day at [9:11], space at [11], and colons at
+// [14] and [17].
+func isValidBSDTimestampYearFirst(b []byte) bool {
+	if len(b) < 20 {
+		return false
+	}
+	if b[4] != ' ' || b[8] != ' ' || b[11] != ' ' || b[14] != ':' || b[17] != ':' {
+		return false
+	}
+	for _, i := range []int{0, 1, 2, 3} {
+		if !isDigit(b[i]) {
+			return false
+		}
+	}
+	// The day may be space-padded ("Apr  4") or zero-padded ("Apr 04").
+	if !(isDigit(b[9]) || b[9] == ' ') || !isDigit(b[10]) {
+		return false
+	}
+	return isValidMonthAbbrev(b[5:])
+}
+
+// bsdTimestampLen returns the length of a BSD-style timestamp at the start of b,
+// trying every accepted layout, or 0 if b does not start with one. The 15-byte
+// RFC 3164 form is tested before the 14-byte non-padded form so a conformant
+// timestamp is never matched by the looser pattern.
+func bsdTimestampLen(b []byte) int {
+	switch {
+	case isValidBSDTimestamp(b):
+		return 15
+	case isValidBSDTimestampSingleSpaceDay(b):
+		return 14
+	case isValidBSDTimestampWithYear(b):
+		return 20
+	case isValidBSDTimestampYearFirst(b):
+		return 20
+	}
+	return 0
+}
+
+// isoTimestampLen returns the length of an ISO 8601 / RFC 3339 timestamp at the
+// start of b, or 0 if b does not start with one. The recognized shape is
+//
+//	YYYY-MM-DDThh:mm:ss[.frac][Z|(+|-)hh:mm|(+|-)hhmm]
+//
+// Only 'T' is accepted as the date/time separator: a space separator cannot be
+// told apart from a date followed by an unrelated field, and accepting it would
+// let the parser consume a neighbouring token.
+func isoTimestampLen(b []byte) int {
+	const base = 19 // YYYY-MM-DDThh:mm:ss
+	if len(b) < base {
+		return 0
+	}
+	if b[4] != '-' || b[7] != '-' || b[10] != 'T' || b[13] != ':' || b[16] != ':' {
+		return 0
+	}
+	for _, i := range []int{0, 1, 2, 3, 5, 6, 8, 9, 11, 12, 14, 15, 17, 18} {
+		if !isDigit(b[i]) {
+			return 0
+		}
+	}
+	n := base
+
+	// Optional fractional seconds: '.' followed by at least one digit.
+	if n < len(b) && b[n] == '.' {
+		f := n + 1
+		for f < len(b) && isDigit(b[f]) {
+			f++
+		}
+		if f > n+1 {
+			n = f
+		}
+	}
+
+	// Optional zone: 'Z', "+hh:mm"/"-hh:mm", or "+hhmm"/"-hhmm".
+	if n < len(b) {
+		switch b[n] {
+		case 'Z', 'z':
+			n++
+		case '+', '-':
+			switch {
+			case n+6 <= len(b) && isDigit(b[n+1]) && isDigit(b[n+2]) &&
+				b[n+3] == ':' && isDigit(b[n+4]) && isDigit(b[n+5]):
+				n += 6
+			case n+5 <= len(b) && isDigit(b[n+1]) && isDigit(b[n+2]) &&
+				isDigit(b[n+3]) && isDigit(b[n+4]):
+				n += 5
+			}
+		}
+	}
+	return n
+}
+
+// isDigit reports whether b is an ASCII decimal digit.
+func isDigit(b byte) bool {
+	return b >= '0' && b <= '9'
 }
 
 // isValidMonthAbbrev returns true if b[0:3] is a valid three-letter English

--- a/pkg/logs/internal/parsers/syslog/syslog.go
+++ b/pkg/logs/internal/parsers/syslog/syslog.go
@@ -305,11 +305,10 @@ func parseRFC5424(line []byte, pri int, pos int) (SyslogMessage, error) {
 	// --- Split the 5 HEADER fields that follow VERSION ---
 	// Fields: TIMESTAMP SP HOSTNAME SP APP-NAME SP PROCID SP MSGID SP ...
 	//
-	// RFC 5424 §6 mandates exactly one SP between fields, but emitters pad:
-	// Claroty CTD sends "<134>1  2025-05-13T04:57:18Z EMC ...". No HEADER
-	// field may contain a space, so collapsing a run of them can never merge
-	// two fields — whereas counting single spaces shifts every field along by
-	// one and leaves TIMESTAMP empty.
+	// RFC 5424 §6 mandates exactly one SP between fields, but emitters pad,
+	// most often between VERSION and TIMESTAMP ("<134>1  2025-05-13T04:57:18Z
+	// host ..."). No HEADER field may contain a space, so a run of them can be
+	// collapsed without ever merging two fields.
 	//
 	// A field only counts as found once it is terminated by a space, which is
 	// what keeps the best-effort recovery below aligned with a truncated
@@ -566,9 +565,8 @@ func parseBSD(line []byte, pri int, pos int) (SyslogMessage, error) {
 	// device header in place, so what follows the relay's HOSTNAME is another
 	// TIMESTAMP rather than a TAG — in ISO form (Cisco FTD:
 	// "YYYY-MM-DDThh:mm:ssZ hostname ...") or in BSD form (Cisco ISE:
-	// "May 31 08:36:58 ISELAB CISE_..."). Without this the TAG scan latches
-	// onto the month abbreviation and reports an APP-NAME of "May".
-	// No real TAG is present; treat the entire remainder as MSG.
+	// "Mmm dd hh:mm:ss hostname CISE_..."). No real TAG is present, so the
+	// entire remainder is MSG and the month abbreviation is not an APP-NAME.
 	if looksLikeISOTimestamp(rest) || bsdTimestampLen(rest) > 0 {
 		msg.Msg = rest
 		return msg, nil
@@ -618,8 +616,7 @@ func parseBSDTag(msg *SyslogMessage, rest []byte) {
 	if delimIdx < 0 {
 		// No delimiter, so nothing marks where a TAG would end. RFC 3164
 		// §4.3.3 only recognizes a TAG by its terminator; without one the
-		// remainder is CONTENT. Claiming it as APP-NAME instead would leave
-		// MSG empty and silently discard the body.
+		// remainder is CONTENT.
 		msg.Msg = rest
 		return
 	}

--- a/pkg/logs/internal/parsers/syslog/testdata/corpus.json
+++ b/pkg/logs/internal/parsers/syslog/testdata/corpus.json
@@ -1,0 +1,1304 @@
+{
+  "origins": {
+    "cisco-nx-os-docs": {
+      "kind": "documentation",
+      "url": "https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/106x/config-guides/sys-mgmt/cisco-nexus-9000-series-nx-os-system-management-configuration-guide-release-106x/m-configuring-system-message-logging-10x.html"
+    },
+    "integrations-core": {
+      "kind": "repository",
+      "url": "https://github.com/DataDog/integrations-core",
+      "commit": "5c206d587e49acfcab604c994e3fe33abc0d088a"
+    },
+    "integrations-extras": {
+      "kind": "repository",
+      "url": "https://github.com/DataDog/integrations-extras",
+      "commit": "9c197fe2c9ff8864d1fe84274298818aac67853f"
+    },
+    "synthesized": {
+      "kind": "synthesized"
+    }
+  },
+  "messages": [
+    {
+      "integration": "beyondtrust_privileged_remote_access",
+      "source": "beyondtrust_privileged_remote_access/assets/logs/beyondtrust-privileged-remote-access.yaml:67",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c133\u003eDec 24 00:14:20 pf60fc91 BG[51036] 1427:01:02:site=pf60fc91.beyondtrustcloud.com;when=1766556860;who=John Carter (john.carter@test.com);who_ip=64.252.100.129;event=jump_policy_added;authorization:allowed_approvers=0;authorization:allowed_to=1;authorization:approver_name=;authorization:email_addresses=;authorization:enabled=0",
+      "want": {
+        "pri": 133,
+        "timestamp": "Dec 24 00:14:20",
+        "hostname": "pf60fc91",
+        "appname": "BG",
+        "procid": "51036",
+        "msgid": "-",
+        "msg": "1427:01:02:site=pf60fc91.beyondtrustcloud.com;when=1766556860;who=John Carter (john.carter@test.com);who_ip=64.252.100.129;event=jump_policy_added;authorization:allowed_approvers=0;authorization:allowed_to=1;authorization:approver_name=;authorization:email_addresses=;authorization:enabled=0"
+      }
+    },
+    {
+      "integration": "beyondtrust_privileged_remote_access",
+      "source": "beyondtrust_privileged_remote_access/assets/logs/beyondtrust-privileged-remote-access_tests.yaml:5",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c133\u003eJan 9 03:47:40 pf60fc91 BG[81869] 1427:01:01:event=fido2_credential_added;credential_owner_id=123;name=credential_name;roaming=1;registration_date=09-01-2026;last_used_date=09-01-2026;last_signature_count=1;when=1767953860;who=Sam5 Carter5 (sam.carter@test.ai) using oidc;who_ip=64.252.101.204;site=pf60fc91.beyondtrustcloud.com",
+      "want": {
+        "pri": 133,
+        "timestamp": "Jan 9 03:47:40",
+        "hostname": "pf60fc91",
+        "appname": "BG",
+        "procid": "81869",
+        "msgid": "-",
+        "msg": "1427:01:01:event=fido2_credential_added;credential_owner_id=123;name=credential_name;roaming=1;registration_date=09-01-2026;last_used_date=09-01-2026;last_signature_count=1;when=1767953860;who=Sam5 Carter5 (sam.carter@test.ai) using oidc;who_ip=64.252.101.204;site=pf60fc91.beyondtrustcloud.com"
+      }
+    },
+    {
+      "integration": "beyondtrust_privileged_remote_access",
+      "source": "beyondtrust_privileged_remote_access/assets/logs/beyondtrust-privileged-remote-access_tests.yaml:99",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c133\u003eJan 9 03:47:40 pf60fc91 BG[81869] 1427:01:01:event=session_policy_added;when=1767953860;who=Sam5 Carter5 (sam.carter@test.ai) using oidc;who_ip=64.252.101.204;site=pf60fc91.beyondtrustcloud.com;automatic_privacy_screen=1;code_name=code_name;description=description;id=1;name=test",
+      "want": {
+        "pri": 133,
+        "timestamp": "Jan 9 03:47:40",
+        "hostname": "pf60fc91",
+        "appname": "BG",
+        "procid": "81869",
+        "msgid": "-",
+        "msg": "1427:01:01:event=session_policy_added;when=1767953860;who=Sam5 Carter5 (sam.carter@test.ai) using oidc;who_ip=64.252.101.204;site=pf60fc91.beyondtrustcloud.com;automatic_privacy_screen=1;code_name=code_name;description=description;id=1;name=test"
+      }
+    },
+    {
+      "integration": "beyondtrust_privileged_remote_access",
+      "source": "beyondtrust_privileged_remote_access/assets/logs/beyondtrust-privileged-remote-access.yaml:70",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "bsd_nopri",
+      "line": "Jan  5 01:17:57 pf60fc91 BG[70499] 1427:01:02:site=pf60fc91.beyondtrustcloud.com;when=1767597477;who=Sam Carter (sam.carter@test.com);who_ip=64.252.100.129;event=jump_policy_changed;old_authorization:allowed_approvers=0;old_authorization:allowed_to=1;old_authorization:approver_name=;old_authorization:email_addresses=;old_authorization:enabled=0;old_authorization:locale_code=en-us;old_authorization:max_duration=28800;old_authorization:approver_teams=;old_authorization:approvers=;old_code_name=jump_policy_3;old_description=;old_display_name=test73;new_display_name=test75;old_external_tools_rdp_allowed=0;old_external_tools_shell_allowed=0;old_id=8;old_notification:email_addresses=;old_notification:locale_code=en-us;old_notification:recipient_name=;old_notify_on_customer_leave=0;old_notify_on_session_start=0;old_schedule:enabled=1;old_schedule:force_end=1;old_session_recordings_disabled=0;old_simultaneous_jump_behavior_applies_to_copies=0;old_simultaneous_jumps=0;old_simultaneous_rdp_jumps=0;old_authorization:ticket_system_enabled=0;old_two_factor_challenge_required=0",
+      "want": {
+        "pri": -1,
+        "timestamp": "Jan  5 01:17:57",
+        "hostname": "pf60fc91",
+        "appname": "BG",
+        "procid": "70499",
+        "msgid": "-",
+        "msg": "1427:01:02:site=pf60fc91.beyondtrustcloud.com;when=1767597477;who=Sam Carter (sam.carter@test.com);who_ip=64.252.100.129;event=jump_policy_changed;old_authorization:allowed_approvers=0;old_authorization:allowed_to=1;old_authorization:approver_name=;old_authorization:email_addresses=;old_authorization:enabled=0;old_authorization:locale_code=en-us;old_authorization:max_duration=28800;old_authorization:approver_teams=;old_authorization:approvers=;old_code_name=jump_policy_3;old_description=;old_display_name=test73;new_display_name=test75;old_external_tools_rdp_allowed=0;old_external_tools_shell_allowed=0;old_id=8;old_notification:email_addresses=;old_notification:locale_code=en-us;old_notification:recipient_name=;old_notify_on_customer_leave=0;old_notify_on_session_start=0;old_schedule:enabled=1;old_schedule:force_end=1;old_session_recordings_disabled=0;old_simultaneous_jump_behavior_applies_to_copies=0;old_simultaneous_jumps=0;old_simultaneous_rdp_jumps=0;old_authorization:ticket_system_enabled=0;old_two_factor_challenge_required=0"
+      }
+    },
+    {
+      "integration": "beyondtrust_privileged_remote_access",
+      "source": "beyondtrust_privileged_remote_access/assets/logs/beyondtrust-privileged-remote-access_tests.yaml:38",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "bsd_nopri",
+      "line": "Dec 28 23:45:21 pf60fc91 BG[65890] 1427:01:09:site=pf60fc91.beyondtrustcloud.com;when=1766987121;who=John Carter IT (john.carter@test.ai);who_ip=64.252.101.204;event=group_policy_added;account:disabled=0;allow_override=0;login_code:enabled=1",
+      "want": {
+        "pri": -1,
+        "timestamp": "Dec 28 23:45:21",
+        "hostname": "pf60fc91",
+        "appname": "BG",
+        "procid": "65890",
+        "msgid": "-",
+        "msg": "1427:01:09:site=pf60fc91.beyondtrustcloud.com;when=1766987121;who=John Carter IT (john.carter@test.ai);who_ip=64.252.101.204;event=group_policy_added;account:disabled=0;allow_override=0;login_code:enabled=1"
+      }
+    },
+    {
+      "integration": "beyondtrust_privileged_remote_access",
+      "source": "beyondtrust_privileged_remote_access/assets/logs/beyondtrust-privileged-remote-access_tests.yaml:70",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "bsd_nopri",
+      "line": "Jan  7 03:39:48 pf60fc91 BG[58918] 1427:01:04:site=pf60fc91.beyondtrustcloud.com;when=1767778788;who=John Carter IT (john.carter@test.ai);who_ip=64.252.100.19;event=user_added;account:disabled=0;login_code:enabled=0",
+      "want": {
+        "pri": -1,
+        "timestamp": "Jan  7 03:39:48",
+        "hostname": "pf60fc91",
+        "appname": "BG",
+        "procid": "58918",
+        "msgid": "-",
+        "msg": "1427:01:04:site=pf60fc91.beyondtrustcloud.com;when=1767778788;who=John Carter IT (john.carter@test.ai);who_ip=64.252.100.19;event=user_added;account:disabled=0;login_code:enabled=0"
+      }
+    },
+    {
+      "integration": "bind9",
+      "source": "bind9/assets/logs/bind9.yaml:93",
+      "origin": "integrations-extras",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c158\u003eSep 20 15:50:26 bindserver named[1630972]: 2024-09-20T10:20:26.751Z queries: info: client @0x7f264c465b08 10.10.10.10#56256 (google.com): query: google.com IN A + (10.10.10.10)",
+      "want": {
+        "pri": 158,
+        "timestamp": "Sep 20 15:50:26",
+        "hostname": "bindserver",
+        "appname": "named",
+        "procid": "1630972",
+        "msgid": "-",
+        "msg": "2024-09-20T10:20:26.751Z queries: info: client @0x7f264c465b08 10.10.10.10#56256 (google.com): query: google.com IN A + (10.10.10.10)"
+      }
+    },
+    {
+      "integration": "bind9",
+      "source": "bind9/assets/logs/bind9.yaml:90",
+      "origin": "integrations-extras",
+      "transport": "file",
+      "framing": "iso_nopri",
+      "line": "2024-09-20T10:20:26.751Z network: info: no longer listening on 10.10.10.10#50",
+      "want": {
+        "pri": -1,
+        "timestamp": "2024-09-20T10:20:26.751Z",
+        "hostname": "-",
+        "appname": "network",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "info: no longer listening on 10.10.10.10#50"
+      }
+    },
+    {
+      "integration": "cisco_asa",
+      "source": "cisco_asa/assets/logs/cisco-asa.yaml:119",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "iso_pri",
+      "line": "\u003c190\u003e2025-11-20T07:37:58Z: %ASA-6-302014: Teardown TCP connection 134712 for inside:10.10.10.10/5014 to identity:10.10.10.10/45544 duration 0:00:21 bytes 0 No valid adjacency",
+      "want": {
+        "pri": 190,
+        "timestamp": "2025-11-20T07:37:58Z",
+        "hostname": "-",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "%ASA-6-302014: Teardown TCP connection 134712 for inside:10.10.10.10/5014 to identity:10.10.10.10/45544 duration 0:00:21 bytes 0 No valid adjacency"
+      }
+    },
+    {
+      "integration": "cisco_asa",
+      "source": "cisco_asa/assets/logs/cisco-asa_tests.yaml:3",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "iso_pri",
+      "line": "\u003c190\u003e2025-11-25T07:19:40Z: %ASA-4-733100: [ Scanning] drop rate-1 exceeded. Current burst rate is 19 per second, max configured rate is 33; Current average rate is 50 per second, max configured rate is 33; Cumulative total count is 44",
+      "want": {
+        "pri": 190,
+        "timestamp": "2025-11-25T07:19:40Z",
+        "hostname": "-",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "%ASA-4-733100: [ Scanning] drop rate-1 exceeded. Current burst rate is 19 per second, max configured rate is 33; Current average rate is 50 per second, max configured rate is 33; Cumulative total count is 44"
+      }
+    },
+    {
+      "integration": "cisco_asa",
+      "source": "cisco_asa/assets/logs/cisco-asa_tests.yaml:23",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "iso_pri",
+      "line": "\u003c190\u003e2025-11-25T07:17:18Z: %ASA-4-733102: Threat-detection adds host 192.0.2.3 to shun list",
+      "want": {
+        "pri": 190,
+        "timestamp": "2025-11-25T07:17:18Z",
+        "hostname": "-",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "%ASA-4-733102: Threat-detection adds host 192.0.2.3 to shun list"
+      }
+    },
+    {
+      "integration": "cisco_secure_client",
+      "source": "cisco_secure_client/assets/logs/cisco-secure-client.yaml:157",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "iso_pri",
+      "line": "\u003c190\u003e2025-11-20T07:37:58Z: %FTD-6-113039: Group group User test-user IP 10.10.10.10 AnyConnect_parent session started.",
+      "want": {
+        "pri": 190,
+        "timestamp": "2025-11-20T07:37:58Z",
+        "hostname": "-",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "%FTD-6-113039: Group group User test-user IP 10.10.10.10 AnyConnect_parent session started."
+      }
+    },
+    {
+      "integration": "cisco_secure_client",
+      "source": "cisco_secure_client/assets/logs/cisco-secure-client_tests.yaml:5",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "iso_pri",
+      "line": "\u003c190\u003e2025-12-05T10:51:16Z: %FTD-4-113035: Group Employee-Access User evelyn.baker IP 4.2.2.1 Session terminated: AnyConnect not enabled or invalid AnyConnect image on the device_123",
+      "want": {
+        "pri": 190,
+        "timestamp": "2025-12-05T10:51:16Z",
+        "hostname": "-",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "%FTD-4-113035: Group Employee-Access User evelyn.baker IP 4.2.2.1 Session terminated: AnyConnect not enabled or invalid AnyConnect image on the device_123"
+      }
+    },
+    {
+      "integration": "cisco_secure_client",
+      "source": "cisco_secure_client/assets/logs/cisco-secure-client_tests.yaml:26",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "iso_pri",
+      "line": "\u003c190\u003e2025-12-05T10:53:52Z: %FTD-4-113038: Group Mobility-Users User ava.clark IP 8.8.8.8 Unable to create AnyConnect_parent session.",
+      "want": {
+        "pri": 190,
+        "timestamp": "2025-12-05T10:53:52Z",
+        "hostname": "-",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "%FTD-4-113038: Group Mobility-Users User ava.clark IP 8.8.8.8 Unable to create AnyConnect_parent session."
+      }
+    },
+    {
+      "integration": "cisco_secure_firewall",
+      "source": "cisco_secure_firewall/assets/logs/cisco-secure-firewall.yaml:141",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "iso_pri",
+      "line": "\u003c190\u003e2024-01-17T09:07:34Z: %FTD-6-110002: Failed to locate egress interface for UDP from diagnostic:10.50.5.157/137 to 10.50.15.255/137",
+      "want": {
+        "pri": 190,
+        "timestamp": "2024-01-17T09:07:34Z",
+        "hostname": "-",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "%FTD-6-110002: Failed to locate egress interface for UDP from diagnostic:10.50.5.157/137 to 10.50.15.255/137"
+      }
+    },
+    {
+      "integration": "cisco_secure_firewall",
+      "source": "cisco_secure_firewall/assets/logs/cisco-secure-firewall.yaml:159",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "iso_pri",
+      "line": "\u003c190\u003e2024-01-23T07:00:00Z: %FTD-1-735002: Cooling Fan DS-X97-SF1-K9 : Failure Detected",
+      "want": {
+        "pri": 190,
+        "timestamp": "2024-01-23T07:00:00Z",
+        "hostname": "-",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "%FTD-1-735002: Cooling Fan DS-X97-SF1-K9 : Failure Detected"
+      }
+    },
+    {
+      "integration": "cisco_secure_firewall",
+      "source": "cisco_secure_firewall/assets/logs/cisco-secure-firewall.yaml:161",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "iso_pri",
+      "line": "\u003c181\u003e2024-01-05T05:45:16Z %FTD-1-111111 system or infrastructure error message",
+      "want": {
+        "pri": 181,
+        "timestamp": "2024-01-05T05:45:16Z",
+        "hostname": "-",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "%FTD-1-111111 system or infrastructure error message"
+      }
+    },
+    {
+      "integration": "cisco_secure_firewall",
+      "source": "cisco_secure_firewall/assets/logs/cisco-secure-firewall.yaml:143",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "iso_nopri",
+      "line": "2024-01-05T05:45:16Z   %FTD-1-430003: EventPriority: Low, DeviceUUID: fbf9ef28-9b2a-11ee-805f-e9384ce3a258, InstanceID: 1, FirstPacketSecond: 2024-01-05T05:43:14Z, ConnectionID: 38902, AccessControlRuleAction: Allow, SrcIP: 10.40.1.16, DstIP: 142.250.182.194, SrcPort: 50689, DstPort: 443, Protocol: tcp, IngressInterface: LAN, EgressInterface: WAN, IngressZone: LAN, EgressZone: WAN, IngressVRF: Global, EgressVRF: Global, ACPolicy: default, AccessControlRuleName: New-rule, Prefilter Policy: Default Prefilter Policy, User: TEST-AD\\\\nilay.modi, Client: SSL client, ApplicationProtocol: HTTPS, WebApplication: Google, ConnectionDuration: 122, InitiatorPackets: 14, ResponderPackets: 15, InitiatorBytes: 636, ResponderBytes: 4167, NAPPolicy: Balanced Security and Connectivity, URLCategory: Advertisements, URLReputation: Trusted, URL: https://adservice.google.com, NAT_InitiatorPort: 50689, NAT_ResponderPort: 443, NAT_InitiatorIP: 10.50.9.175, NAT_ResponderIP: 142.250.182.194",
+      "want": {
+        "pri": -1,
+        "timestamp": "2024-01-05T05:45:16Z",
+        "hostname": "-",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "%FTD-1-430003: EventPriority: Low, DeviceUUID: fbf9ef28-9b2a-11ee-805f-e9384ce3a258, InstanceID: 1, FirstPacketSecond: 2024-01-05T05:43:14Z, ConnectionID: 38902, AccessControlRuleAction: Allow, SrcIP: 10.40.1.16, DstIP: 142.250.182.194, SrcPort: 50689, DstPort: 443, Protocol: tcp, IngressInterface: LAN, EgressInterface: WAN, IngressZone: LAN, EgressZone: WAN, IngressVRF: Global, EgressVRF: Global, ACPolicy: default, AccessControlRuleName: New-rule, Prefilter Policy: Default Prefilter Policy, User: TEST-AD\\\\nilay.modi, Client: SSL client, ApplicationProtocol: HTTPS, WebApplication: Google, ConnectionDuration: 122, InitiatorPackets: 14, ResponderPackets: 15, InitiatorBytes: 636, ResponderBytes: 4167, NAPPolicy: Balanced Security and Connectivity, URLCategory: Advertisements, URLReputation: Trusted, URL: https://adservice.google.com, NAT_InitiatorPort: 50689, NAT_ResponderPort: 443, NAT_InitiatorIP: 10.50.9.175, NAT_ResponderIP: 142.250.182.194"
+      }
+    },
+    {
+      "integration": "cisco_secure_firewall",
+      "source": "cisco_secure_firewall/assets/logs/cisco-secure-firewall_tests.yaml:18",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "iso_nopri",
+      "line": "2024-01-04T05:49:44Z   %FTD-1-430001: DeviceUUID: fbf9ef28-9b2a-51ur-495e-e9384ce3a258, InstanceID: 1, FirstPacketSecond: 2024-01-04T05:49:44Z, ConnectionID: 39298, SrcIP: 185.64.148.0, DstIP: 185.64.148.0, SrcPort: 53, DstPort: 61550, Protocol: udp, IngressInterface: WAN, EgressInterface: LAN, IngressZone: WAN, EgressZone: LAN, Priority: 2, GID: 1, SID: 254, Revision: 17, Message: PROTOCOL-DNS SPOOF query response with TTL of 1 min. and no authority, Classification: Potentially Bad Traffic, Client: DNS, ApplicationProtocol: DNS, IntrusionPolicy: ABC-IPS, ACPolicy: default, AccessControlRuleName: New-rule, NAPPolicy: Balanced Security and Connectivity, InlineResult: Dropped, IngressVRF: Global, EgressVRF: Global",
+      "want": {
+        "pri": -1,
+        "timestamp": "2024-01-04T05:49:44Z",
+        "hostname": "-",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "%FTD-1-430001: DeviceUUID: fbf9ef28-9b2a-51ur-495e-e9384ce3a258, InstanceID: 1, FirstPacketSecond: 2024-01-04T05:49:44Z, ConnectionID: 39298, SrcIP: 185.64.148.0, DstIP: 185.64.148.0, SrcPort: 53, DstPort: 61550, Protocol: udp, IngressInterface: WAN, EgressInterface: LAN, IngressZone: WAN, EgressZone: LAN, Priority: 2, GID: 1, SID: 254, Revision: 17, Message: PROTOCOL-DNS SPOOF query response with TTL of 1 min. and no authority, Classification: Potentially Bad Traffic, Client: DNS, ApplicationProtocol: DNS, IntrusionPolicy: ABC-IPS, ACPolicy: default, AccessControlRuleName: New-rule, NAPPolicy: Balanced Security and Connectivity, InlineResult: Dropped, IngressVRF: Global, EgressVRF: Global"
+      }
+    },
+    {
+      "integration": "cisco_secure_web_appliance",
+      "source": "cisco_secure_web_appliance/assets/logs/cisco-secure-web-appliance.yaml:144",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c38\u003eSep 23 11:14:10 Crest.CSWA accesslogs: Info: 1727070241.436 866 10.10.10.10 TCP_MISS/200 4394 CONNECT tunnel://v10.events.data.microsoft.com:443/ - DIRECT/v10.events.data.microsoft.com application/octet-stream DEFAULT_CASE_12-DefaultGroup-match_network-NONE-NONE-NONE-DefaultGroup-NONE \u003c\"IW_comp\",9.0,1,\"-\",-,-,-,1,\"-\",-,-,-,\"-\",1,-,\"-\",\"-\",-,-,\"IW_comp\",-,\"-\",\"Computers and Internet\",\"-\",\"Microsoft Dynamics CRM\",\"Enterprise Applications\",\"Encrypted\",\"-\",40.59,0,-,\"-\",\"-\",1,\"-\",-,-,\"-\",\"-\",-,1,\"-\",-,-\u003e - -",
+      "want": {
+        "pri": 38,
+        "timestamp": "Sep 23 11:14:10",
+        "hostname": "Crest.CSWA",
+        "appname": "accesslogs",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "Info: 1727070241.436 866 10.10.10.10 TCP_MISS/200 4394 CONNECT tunnel://v10.events.data.microsoft.com:443/ - DIRECT/v10.events.data.microsoft.com application/octet-stream DEFAULT_CASE_12-DefaultGroup-match_network-NONE-NONE-NONE-DefaultGroup-NONE \u003c\"IW_comp\",9.0,1,\"-\",-,-,-,1,\"-\",-,-,-,\"-\",1,-,\"-\",\"-\",-,-,\"IW_comp\",-,\"-\",\"Computers and Internet\",\"-\",\"Microsoft Dynamics CRM\",\"Enterprise Applications\",\"Encrypted\",\"-\",40.59,0,-,\"-\",\"-\",1,\"-\",-,-,\"-\",\"-\",-,1,\"-\",-,-\u003e - -"
+      }
+    },
+    {
+      "integration": "cisco_secure_web_appliance",
+      "source": "cisco_secure_web_appliance/assets/logs/cisco-secure-web-appliance.yaml:158",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c38\u003eSep 24 16:22:24 Crest.CSWA accesslogs: Info: 1727175142.338 98 10.10.10.10 TCP_DENIED_SSL/403 0 GET https://www.virustotal.com:443/favicon.ico - NONE/- - BLOCK_CUSTOMCAT_12-DefaultGroup-10.50.6.5-NONE-NONE-NONE-NONE-NONE \u003c\"C_viru\",-,-,\"-\",-,-,-,-,\"-\",-,-,-,\"-\",-,-,\"-\",\"-\",-,-,\"-\",-,\"-\",\"-\",\"-\",\"-\",\"-\",\"-\",\"-\",0.00,0,-,\"-\",\"-\",-,\"-\",-,-,\"-\",\"-\",-,-,\"-\",-,-\u003e - -",
+      "want": {
+        "pri": 38,
+        "timestamp": "Sep 24 16:22:24",
+        "hostname": "Crest.CSWA",
+        "appname": "accesslogs",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "Info: 1727175142.338 98 10.10.10.10 TCP_DENIED_SSL/403 0 GET https://www.virustotal.com:443/favicon.ico - NONE/- - BLOCK_CUSTOMCAT_12-DefaultGroup-10.50.6.5-NONE-NONE-NONE-NONE-NONE \u003c\"C_viru\",-,-,\"-\",-,-,-,-,\"-\",-,-,-,\"-\",-,-,\"-\",\"-\",-,-,\"-\",-,\"-\",\"-\",\"-\",\"-\",\"-\",\"-\",\"-\",0.00,0,-,\"-\",\"-\",-,\"-\",-,-,\"-\",\"-\",-,-,\"-\",-,-\u003e - -"
+      }
+    },
+    {
+      "integration": "cisco_secure_web_appliance",
+      "source": "cisco_secure_web_appliance/assets/logs/cisco-secure-web-appliance.yaml:164",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c38\u003eSep 25 12:13:55 Crest.CSWA accesslogs: Info: 1727246631.866 93971 10.xx.xx.xx TCP_MISS/200 8560 CONNECT tunnel://csp.withgoogle.com:443/ - DIRECT/csp.withgoogle.com application/octet-stream DEFAULT_CASE_12-DefaultGroup-match_network-NONE-NONE-NONE-DefaultGroup-NONE \u003c\"IW_comp\",3.0,1,\"-\",-,-,-,1,\"-\",-,-,-,\"-\",1,-,\"-\",\"-\",-,-,\"IW_comp,IW_csec\",-,\"-\",\"Computers and Internet\",\"-\",\"Unknown\",\"Unknown\",\"-\",\"-\",0.73,0,-,\"-\",\"-\",1,\"-\",-,-,\"-\",\"-\",-,1,\"-\",-,-\u003e - -",
+      "want": {
+        "pri": 38,
+        "timestamp": "Sep 25 12:13:55",
+        "hostname": "Crest.CSWA",
+        "appname": "accesslogs",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "Info: 1727246631.866 93971 10.xx.xx.xx TCP_MISS/200 8560 CONNECT tunnel://csp.withgoogle.com:443/ - DIRECT/csp.withgoogle.com application/octet-stream DEFAULT_CASE_12-DefaultGroup-match_network-NONE-NONE-NONE-DefaultGroup-NONE \u003c\"IW_comp\",3.0,1,\"-\",-,-,-,1,\"-\",-,-,-,\"-\",1,-,\"-\",\"-\",-,-,\"IW_comp,IW_csec\",-,\"-\",\"Computers and Internet\",\"-\",\"Unknown\",\"Unknown\",\"-\",\"-\",0.73,0,-,\"-\",\"-\",1,\"-\",-,-,\"-\",\"-\",-,1,\"-\",-,-\u003e - -"
+      }
+    },
+    {
+      "integration": "delinea_privilege_manager",
+      "source": "delinea_privilege_manager/assets/logs/delinea-privilege-manager.yaml:85",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc5424",
+      "line": "\u003c5\u003e1 2024-11-20T10:28:08.736000+00:00 demo 1 demo 1 - 4eb4ec69d7a94797972a41855d3e7799 - CEF:0|Thycotic|Application Control Solution|8|4eb4ec69d7a94797972a41855d3e7799|Application Control Policy Feedback|5|externalId=191 PolicyName=MAC OS Monitor Policy UserName=root FileName=wall FilePath=/usr/bin/wall EventReceivedByServer=11/20/2024 10:33:37 AM _FileId=d25f2fe0-7f22-5046-a6b1-78c8b5f51cd6 _ComputerId=2386a2ac-807a-5682-a261-d0f4e85baa7c ComputerName=demo 1",
+      "want": {
+        "pri": 5,
+        "version": "1",
+        "timestamp": "2024-11-20T10:28:08.736000+00:00",
+        "hostname": "demo",
+        "appname": "1",
+        "procid": "demo",
+        "msgid": "1",
+        "msg": "4eb4ec69d7a94797972a41855d3e7799 - CEF:0|Thycotic|Application Control Solution|8|4eb4ec69d7a94797972a41855d3e7799|Application Control Policy Feedback|5|externalId=191 PolicyName=MAC OS Monitor Policy UserName=root FileName=wall FilePath=/usr/bin/wall EventReceivedByServer=11/20/2024 10:33:37 AM _FileId=d25f2fe0-7f22-5046-a6b1-78c8b5f51cd6 _ComputerId=2386a2ac-807a-5682-a261-d0f4e85baa7c ComputerName=demo 1"
+      }
+    },
+    {
+      "integration": "delinea_privilege_manager",
+      "source": "delinea_privilege_manager/assets/logs/delinea-privilege-manager_tests.yaml:34",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc5424",
+      "line": "\u003c5\u003e1 2020-02-28T22:25:56.567000+00:00 demo user demo user - 67aa593adaf942b0933e24f60239bcc9 - CEF:0|Thycotic|Local Security Solution|8|67aa593adaf942b0933e24f60239bcc9|Password Disclosure Events|5|externalId=1 EventOccuredOnServer=2/28/2020 10:25:56 PM _DisclosedByUserId=fc580694-32fd-4dc1-ae8b-80eae7553109 Requesting User=No name for disclosed by user id 2DB8D3F9-E11E-4924-A19F-AB4FE5AB34EB RemoteIpAddress=10.10.10.10 _ManagedUserId=2db8d3f9-e11e-4924-a19f-ab4fe5ab34eb ManagedUserName=demo user ComputerDomain=No computer domain for user 2DB8D3F9-E11E-4924-A19F-AB4FE5AB34EB ComputerName=No computer name for user 2DB8D3F9-E11E-4924-A19F-AB4FE5AB34EB",
+      "want": {
+        "pri": 5,
+        "version": "1",
+        "timestamp": "2020-02-28T22:25:56.567000+00:00",
+        "hostname": "demo",
+        "appname": "user",
+        "procid": "demo",
+        "msgid": "user",
+        "msg": "67aa593adaf942b0933e24f60239bcc9 - CEF:0|Thycotic|Local Security Solution|8|67aa593adaf942b0933e24f60239bcc9|Password Disclosure Events|5|externalId=1 EventOccuredOnServer=2/28/2020 10:25:56 PM _DisclosedByUserId=fc580694-32fd-4dc1-ae8b-80eae7553109 Requesting User=No name for disclosed by user id 2DB8D3F9-E11E-4924-A19F-AB4FE5AB34EB RemoteIpAddress=10.10.10.10 _ManagedUserId=2db8d3f9-e11e-4924-a19f-ab4fe5ab34eb ManagedUserName=demo user ComputerDomain=No computer domain for user 2DB8D3F9-E11E-4924-A19F-AB4FE5AB34EB ComputerName=No computer name for user 2DB8D3F9-E11E-4924-A19F-AB4FE5AB34EB"
+      }
+    },
+    {
+      "integration": "delinea_privilege_manager",
+      "source": "delinea_privilege_manager/assets/logs/delinea-privilege-manager_tests.yaml:64",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc5424",
+      "line": "\u003c5\u003e1 2020-02-28T22:25:56.567000+00:00 demo demo - 67aa593adaf942b0933e24f60239bcc9 - CEF:0|Thycotic|Local Security Solution|8|67aa593adaf942b0933e24f60239bcc9|Password Disclosure Events|5|externalId=1 EventOccuredOnServer=2/28/2020 10:25:56 PM _DisclosedByUserId=fc580694-32fd-4dc1-ae8b-80eae7553109 Requesting User=No name for disclosed by user id 2DB8D3F9-E11E-4924-A19F-AB4FE5AB34EB RemoteIpAddress=10.10.10.10 _ManagedUserId=2db8d3f9-e11e-4924-a19f-ab4fe5ab34eb ManagedUserName=demo user ComputerDomain=No computer domain for user 2DB8D3F9-E11E-4924-A19F-AB4FE5AB34EB ComputerName=No computer name for user 2DB8D3F9-E11E-4924-A19F-AB4FE5AB34EB",
+      "want": {
+        "pri": 5,
+        "version": "1",
+        "timestamp": "2020-02-28T22:25:56.567000+00:00",
+        "hostname": "demo",
+        "appname": "demo",
+        "procid": "-",
+        "msgid": "67aa593adaf942b0933e24f60239bcc9",
+        "msg": "CEF:0|Thycotic|Local Security Solution|8|67aa593adaf942b0933e24f60239bcc9|Password Disclosure Events|5|externalId=1 EventOccuredOnServer=2/28/2020 10:25:56 PM _DisclosedByUserId=fc580694-32fd-4dc1-ae8b-80eae7553109 Requesting User=No name for disclosed by user id 2DB8D3F9-E11E-4924-A19F-AB4FE5AB34EB RemoteIpAddress=10.10.10.10 _ManagedUserId=2db8d3f9-e11e-4924-a19f-ab4fe5ab34eb ManagedUserName=demo user ComputerDomain=No computer domain for user 2DB8D3F9-E11E-4924-A19F-AB4FE5AB34EB ComputerName=No computer name for user 2DB8D3F9-E11E-4924-A19F-AB4FE5AB34EB"
+      }
+    },
+    {
+      "integration": "delinea_secret_server",
+      "source": "delinea_secret_server/assets/logs/delinea-secret-server.yaml:68",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "iso_nopri",
+      "line": "2025-02-27T10:00:27.461Z DSS-01 CEF:0|Thycotic Software|Secret Server|11.7.000061|10004|SECRET - VIEW|2|msg=[[SecretServer]] Event: [Secret] Action: [View] By User: admin Item name: Test SSH KeyTemplate (Item Id: 9) Container name: admin (Container Id: 2)  suid=2 suser=admin cs4=admin cs4Label=suser Display Name src=10.10.10.10 rt=Feb 27 2025 10:00:26 fname=Test SSH KeyTemplate fileType=Secret fileId=9 cs3Label=Folder cs3=admin",
+      "want": {
+        "pri": -1,
+        "timestamp": "2025-02-27T10:00:27.461Z",
+        "hostname": "DSS-01",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "CEF:0|Thycotic Software|Secret Server|11.7.000061|10004|SECRET - VIEW|2|msg=[[SecretServer]] Event: [Secret] Action: [View] By User: admin Item name: Test SSH KeyTemplate (Item Id: 9) Container name: admin (Container Id: 2)  suid=2 suser=admin cs4=admin cs4Label=suser Display Name src=10.10.10.10 rt=Feb 27 2025 10:00:26 fname=Test SSH KeyTemplate fileType=Secret fileId=9 cs3Label=Folder cs3=admin"
+      }
+    },
+    {
+      "integration": "delinea_secret_server",
+      "source": "delinea_secret_server/assets/logs/delinea-secret-server.yaml:75",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "iso_nopri",
+      "line": "2025-02-25T07:19:03.058Z DSS-01 CEF:0|Thycotic Software|Secret Server|11.7.000061|10140|GROUP - CREATE|2|msg=[[SecretServer]] Event: [Group] Action: [Create] By User: admin Item name: Dev-Team (Item Id: 5)  suid=2 suser=admin cs4=admin cs4Label=suser Display Name src=10.10.10.10 rt=Feb 25 2025 07:19:01",
+      "want": {
+        "pri": -1,
+        "timestamp": "2025-02-25T07:19:03.058Z",
+        "hostname": "DSS-01",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "CEF:0|Thycotic Software|Secret Server|11.7.000061|10140|GROUP - CREATE|2|msg=[[SecretServer]] Event: [Group] Action: [Create] By User: admin Item name: Dev-Team (Item Id: 5)  suid=2 suser=admin cs4=admin cs4Label=suser Display Name src=10.10.10.10 rt=Feb 25 2025 07:19:01"
+      }
+    },
+    {
+      "integration": "delinea_secret_server",
+      "source": "delinea_secret_server/assets/logs/delinea-secret-server.yaml:80",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "iso_nopri",
+      "line": "2025-02-26T06:46:47.420Z DSS-01 CEF:0|Thycotic Software|Secret Server|11.7.000061|19|USER - PASSWORDCHANGE|2|msg=[[SecretServer]] Event: [User] Action: [Password change] By User: john Item name: john (Item Id: 4)  suid=4 suser=john cs4=john cs4Label=suser Display Name duser=john duid=4 fname=john fileType=User fileId=4 src=10.10.10.10 rt=Feb 26 2025 06:46:37",
+      "want": {
+        "pri": -1,
+        "timestamp": "2025-02-26T06:46:47.420Z",
+        "hostname": "DSS-01",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "CEF:0|Thycotic Software|Secret Server|11.7.000061|19|USER - PASSWORDCHANGE|2|msg=[[SecretServer]] Event: [User] Action: [Password change] By User: john Item name: john (Item Id: 4)  suid=4 suser=john cs4=john cs4Label=suser Display Name duser=john duid=4 fname=john fileType=User fileId=4 src=10.10.10.10 rt=Feb 26 2025 06:46:37"
+      }
+    },
+    {
+      "integration": "forescout",
+      "source": "forescout/assets/logs/forescout.yaml:103",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c165\u003eSep 2 11:44:01 ddsfs forescout-syslog[2895]: NAC Policy Log: Source: 10.50.15.114, Rule: Policy \"Primary Classification\" , Match: \"Windows:Match\", Category: Classifier, Details: Host evaluation changed from \"CounterACT Devices:Pending\" to \"Windows:Match\" due to condition . Reason: Property update: Operating System \"Windows\" learned (first time), Function \"Workstation\" learned (first time), Vendor and Model \"VMware\" learned (first time). Duration: less than a second",
+      "want": {
+        "pri": 165,
+        "timestamp": "Sep 2 11:44:01",
+        "hostname": "ddsfs",
+        "appname": "forescout-syslog",
+        "procid": "2895",
+        "msgid": "-",
+        "msg": "NAC Policy Log: Source: 10.50.15.114, Rule: Policy \"Primary Classification\" , Match: \"Windows:Match\", Category: Classifier, Details: Host evaluation changed from \"CounterACT Devices:Pending\" to \"Windows:Match\" due to condition . Reason: Property update: Operating System \"Windows\" learned (first time), Function \"Workstation\" learned (first time), Vendor and Model \"VMware\" learned (first time). Duration: less than a second"
+      }
+    },
+    {
+      "integration": "forescout",
+      "source": "forescout/assets/logs/forescout.yaml:111",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c165\u003eSep 23 17:53:27 ddsfs forescout-syslog[2992]: Log: Login success by admin@10.50.13.83. Details: User admin logged in from 10.50.13.83. Severity: 6",
+      "want": {
+        "pri": 165,
+        "timestamp": "Sep 23 17:53:27",
+        "hostname": "ddsfs",
+        "appname": "forescout-syslog",
+        "procid": "2992",
+        "msgid": "-",
+        "msg": "Log: Login success by admin@10.50.13.83. Details: User admin logged in from 10.50.13.83. Severity: 6"
+      }
+    },
+    {
+      "integration": "forescout",
+      "source": "forescout/assets/logs/forescout_tests.yaml:5",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c165\u003eSep 22 11:44:01 ddsfs forescout-syslog[2895]: Port bite. Source: 10.10.10.10. Destination: 20.20.20.20:139",
+      "want": {
+        "pri": 165,
+        "timestamp": "Sep 22 11:44:01",
+        "hostname": "ddsfs",
+        "appname": "forescout-syslog",
+        "procid": "2895",
+        "msgid": "-",
+        "msg": "Port bite. Source: 10.10.10.10. Destination: 20.20.20.20:139"
+      }
+    },
+    {
+      "integration": "haproxy",
+      "source": "haproxy/assets/logs/haproxy_tests.yaml:203",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "bsd_nopri",
+      "line": "Feb  1 18:34:10 localhost haproxy[42471]: 73.18.215.121:50886 [01/Feb/2018:18:34:10.200] fr_proxy.lirn.net-HTTP bk_UnivOfThePeople-9797/bk_mp01-UnivOfThePeople-9797 0/0/0/121/122 200 938 - - --VN 4/4/3/3/0 0/0 \"GET /MuseProxyID=mp01/MuseSessionID=0000fx7/MuseProtocol=http/MuseHost=go.galegroup.com/MusePath/ps/browseIndex?inPS=true\u0026prodId=PPCA\u0026userGroupName=lirn17237\u0026tabID=T003\u0026topicId=\u0026searchId=R3\u0026searchType=AdvancedSearchForm\u0026searchResultsType=SingleTab\u0026sort=\u0026browseIndex=TY\u0026browsePagination=50\u0026displayFormat=LIST\u0026isMultiSelect=false\u0026initPageSize=3\u0026buildLimiterValues=true\u0026userGroupName=lirn17237\u0026prodId=PPCA HTTP/1.1\"",
+      "want": {
+        "pri": -1,
+        "timestamp": "Feb  1 18:34:10",
+        "hostname": "localhost",
+        "appname": "haproxy",
+        "procid": "42471",
+        "msgid": "-",
+        "msg": "73.18.215.121:50886 [01/Feb/2018:18:34:10.200] fr_proxy.lirn.net-HTTP bk_UnivOfThePeople-9797/bk_mp01-UnivOfThePeople-9797 0/0/0/121/122 200 938 - - --VN 4/4/3/3/0 0/0 \"GET /MuseProxyID=mp01/MuseSessionID=0000fx7/MuseProtocol=http/MuseHost=go.galegroup.com/MusePath/ps/browseIndex?inPS=true\u0026prodId=PPCA\u0026userGroupName=lirn17237\u0026tabID=T003\u0026topicId=\u0026searchId=R3\u0026searchType=AdvancedSearchForm\u0026searchResultsType=SingleTab\u0026sort=\u0026browseIndex=TY\u0026browsePagination=50\u0026displayFormat=LIST\u0026isMultiSelect=false\u0026initPageSize=3\u0026buildLimiterValues=true\u0026userGroupName=lirn17237\u0026prodId=PPCA HTTP/1.1\""
+      }
+    },
+    {
+      "integration": "haproxy",
+      "source": "haproxy/assets/logs/haproxy_tests.yaml:313",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "bsd_nopri",
+      "line": "Feb 01 18:34:10 - haproxy[42471]: 73.18.215.121:50886 [01/Feb/2018:18:34:10.200] fr_proxy.lirn.net-HTTP bk_UnivOfThePeople-9797/bk_mp01-UnivOfThePeople-9797 0/0/0/121/122 200 938 - - --VN 4/4/3/3/0 0/0 \"GET /MuseProxyID=mp01/MuseSessionID=0000fx7/MuseProtocol=http/MuseHost=go.galegroup.com/MusePath/ps/browseIndex?inPS=true\u0026prodId=PPCA\u0026userGroupName=lirn17237\u0026tabID=T003\u0026topicId=\u0026searchId=R3\u0026searchType=AdvancedSearchForm\u0026searchResultsType=SingleTab\u0026sort=\u0026browseIndex=TY\u0026browsePagination=50\u0026displayFormat=LIST\u0026isMultiSelect=false\u0026initPageSize=3\u0026buildLimiterValues=true\u0026userGroupName=lirn17237\u0026prodId=PPCA HTTP/1.1\"",
+      "want": {
+        "pri": -1,
+        "timestamp": "Feb 01 18:34:10",
+        "hostname": "-",
+        "appname": "haproxy",
+        "procid": "42471",
+        "msgid": "-",
+        "msg": "73.18.215.121:50886 [01/Feb/2018:18:34:10.200] fr_proxy.lirn.net-HTTP bk_UnivOfThePeople-9797/bk_mp01-UnivOfThePeople-9797 0/0/0/121/122 200 938 - - --VN 4/4/3/3/0 0/0 \"GET /MuseProxyID=mp01/MuseSessionID=0000fx7/MuseProtocol=http/MuseHost=go.galegroup.com/MusePath/ps/browseIndex?inPS=true\u0026prodId=PPCA\u0026userGroupName=lirn17237\u0026tabID=T003\u0026topicId=\u0026searchId=R3\u0026searchType=AdvancedSearchForm\u0026searchResultsType=SingleTab\u0026sort=\u0026browseIndex=TY\u0026browsePagination=50\u0026displayFormat=LIST\u0026isMultiSelect=false\u0026initPageSize=3\u0026buildLimiterValues=true\u0026userGroupName=lirn17237\u0026prodId=PPCA HTTP/1.1\""
+      }
+    },
+    {
+      "integration": "haproxy",
+      "source": "haproxy/assets/logs/haproxy_tests.yaml:423",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "bsd_nopri",
+      "line": "Apr 16 13:37:08 haproxy-test-fri4 haproxy[4720]: 127.0.0.1:34902 [16/Apr/2018:13:37:08.576] stats stats/\u003cSTATS\u003e 0/0/0/0/0 200 1316 - - LR-- 1/1/0/0/0 0/0 \"GET /haproxy_stats/;csv;norefresh HTTP/1.1\"",
+      "want": {
+        "pri": -1,
+        "timestamp": "Apr 16 13:37:08",
+        "hostname": "haproxy-test-fri4",
+        "appname": "haproxy",
+        "procid": "4720",
+        "msgid": "-",
+        "msg": "127.0.0.1:34902 [16/Apr/2018:13:37:08.576] stats stats/\u003cSTATS\u003e 0/0/0/0/0 200 1316 - - LR-- 1/1/0/0/0 0/0 \"GET /haproxy_stats/;csv;norefresh HTTP/1.1\""
+      }
+    },
+    {
+      "integration": "iboss",
+      "source": "iboss/assets/logs/iboss_tests.yaml:4",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c46\u003eMay  6 06:14:53 test.ibosscloud.com {\"exception\":\"-\",\"totalByteUsage\":\"2903\",\"policyLayers\":\"Bitdefender|DLP Test|Gmail|Github|dd-test-resource|Non Enterprise Owned|Microsoft CASB Unsanctioned Applications\",\"sourcePort\":\"4890\",\"resourceId\":\"-\",\"contentTypeHeader\":\"-\",\"callout\":\"0\",\"privateIp\":\"10.20.10.20\",\"sAction\":\"Soft-blocked\",\"sourceIpAddress\":\"10.20.10.20\",\"subjectId\":\"example\",\"responseCode\":\"302\",\"proxyTimeSinceEpoch\":\"41\",\"authStepUp\":\"false\",\"productVersion\":\"10.3.3.125\",\"ztScore\":\"0\",\"proxyRule\":\"DLP Rule Settings\",\"clientPeerTime\":\"41\",\"totalByteCount\":\"2903\",\"host\":\"example.com\",\"stealth\":\"0\",\"action\":\"Soft-blocked\",\"uriPath\":\"/search\",\"computerMacAddress\":\"00:00:00:00:00:00\",\"iboss\":\"example.ibosscloud.com\",\"ztPolicyName\":\"Non Enterprise Owned\",\"proxyPeerResponseTime\":\"-\",\"tlsVersion\":\"-\",\"ipAddress\":\"10.20.10.30\",\"resourceName\":\"-\",\"localProxyPort\":\"80\",\"logSubType\":\"-\",\"ibossIpAddress\":\"10.20.20.20\",\"mde\":\"-\",\"lastname\":\"-\",\"macAddress\":\"00:00:00:00:00:00\",\"ztPolicyId\":\"test-id-1\",\"filename\":\"-\",\"filteringGroupName\":\"Default\",\"cncFlag\":\"0\",\"proxyDnsLookupTime\":\"-\",\"identityProviderName\":\"-\",\"proxyTotalTime\":\"-\",\"destinationPort\":\"443\",\"logType\":\"WEB_LOG\",\"extension\":\"com\",\"firstname\":\"-\",\"scheme\":\"https\",\"reportingGroup\":\"0\",\"requestMethod\":\"GET\",\"description\":\"Website is part of Microsoft CASB Unsanctioned Applications blocklist. ZeroTrust Policy: Non Enterprise Owned\",\"policyTrace\":\"-\",\"categoryName\":\"Search Engines;Social Media\",\"directionName\":\"outbound\",\"sandBoxDecoded\":\"-\",\"urlLogId\":\"4028\",\"computerName\":\"TEST-COMPUTER\",\"assetId\":\"test-asset-id\",\"audit\":\"0\",\"useTime\":\"6\",\"identityProviderUUID\":\"auto-login\",\"upstreamByteUsage\":\"1250\",\"proxyResponseTime\":\"6\",\"applicationName\":\"C\\\\\\\\chrome.exe\",\"direction\":\"2\",\"malware\":\"0\",\"chatGPTMessage\":\"-\",\"proxyTransactionStartTime\":\"1748240093.321\",\"userAgent\":\"Edg/136.0.0.0\",\"publicIp\":\"10.20.30.20\",\"url\":\"https://example.com/search?locale=en-US\u0026q=test\",\"logTime\":\"2025-05-26\",\"referrerUrl\":\"test.com\",\"sha256Sum\":\"-\",\"uriQuery\":\"locale=en-US\u0026q=test\",\"serverPeerTime\":\"-\",\"downstreamByteUsage\":\"1653\",\"dlpKeywords\":\"-\",\"location\":\"us-central\",\"time\":\"06:14:53\",\"vendorAccountId\":\"313117\",\"username\":\"test-user\",\"heuristicScore\":\"0\"}",
+      "want": {
+        "pri": 46,
+        "timestamp": "May  6 06:14:53",
+        "hostname": "test.ibosscloud.com",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "{\"exception\":\"-\",\"totalByteUsage\":\"2903\",\"policyLayers\":\"Bitdefender|DLP Test|Gmail|Github|dd-test-resource|Non Enterprise Owned|Microsoft CASB Unsanctioned Applications\",\"sourcePort\":\"4890\",\"resourceId\":\"-\",\"contentTypeHeader\":\"-\",\"callout\":\"0\",\"privateIp\":\"10.20.10.20\",\"sAction\":\"Soft-blocked\",\"sourceIpAddress\":\"10.20.10.20\",\"subjectId\":\"example\",\"responseCode\":\"302\",\"proxyTimeSinceEpoch\":\"41\",\"authStepUp\":\"false\",\"productVersion\":\"10.3.3.125\",\"ztScore\":\"0\",\"proxyRule\":\"DLP Rule Settings\",\"clientPeerTime\":\"41\",\"totalByteCount\":\"2903\",\"host\":\"example.com\",\"stealth\":\"0\",\"action\":\"Soft-blocked\",\"uriPath\":\"/search\",\"computerMacAddress\":\"00:00:00:00:00:00\",\"iboss\":\"example.ibosscloud.com\",\"ztPolicyName\":\"Non Enterprise Owned\",\"proxyPeerResponseTime\":\"-\",\"tlsVersion\":\"-\",\"ipAddress\":\"10.20.10.30\",\"resourceName\":\"-\",\"localProxyPort\":\"80\",\"logSubType\":\"-\",\"ibossIpAddress\":\"10.20.20.20\",\"mde\":\"-\",\"lastname\":\"-\",\"macAddress\":\"00:00:00:00:00:00\",\"ztPolicyId\":\"test-id-1\",\"filename\":\"-\",\"filteringGroupName\":\"Default\",\"cncFlag\":\"0\",\"proxyDnsLookupTime\":\"-\",\"identityProviderName\":\"-\",\"proxyTotalTime\":\"-\",\"destinationPort\":\"443\",\"logType\":\"WEB_LOG\",\"extension\":\"com\",\"firstname\":\"-\",\"scheme\":\"https\",\"reportingGroup\":\"0\",\"requestMethod\":\"GET\",\"description\":\"Website is part of Microsoft CASB Unsanctioned Applications blocklist. ZeroTrust Policy: Non Enterprise Owned\",\"policyTrace\":\"-\",\"categoryName\":\"Search Engines;Social Media\",\"directionName\":\"outbound\",\"sandBoxDecoded\":\"-\",\"urlLogId\":\"4028\",\"computerName\":\"TEST-COMPUTER\",\"assetId\":\"test-asset-id\",\"audit\":\"0\",\"useTime\":\"6\",\"identityProviderUUID\":\"auto-login\",\"upstreamByteUsage\":\"1250\",\"proxyResponseTime\":\"6\",\"applicationName\":\"C\\\\\\\\chrome.exe\",\"direction\":\"2\",\"malware\":\"0\",\"chatGPTMessage\":\"-\",\"proxyTransactionStartTime\":\"1748240093.321\",\"userAgent\":\"Edg/136.0.0.0\",\"publicIp\":\"10.20.30.20\",\"url\":\"https://example.com/search?locale=en-US\u0026q=test\",\"logTime\":\"2025-05-26\",\"referrerUrl\":\"test.com\",\"sha256Sum\":\"-\",\"uriQuery\":\"locale=en-US\u0026q=test\",\"serverPeerTime\":\"-\",\"downstreamByteUsage\":\"1653\",\"dlpKeywords\":\"-\",\"location\":\"us-central\",\"time\":\"06:14:53\",\"vendorAccountId\":\"313117\",\"username\":\"test-user\",\"heuristicScore\":\"0\"}"
+      }
+    },
+    {
+      "integration": "iboss",
+      "source": "iboss/assets/logs/iboss_tests.yaml:123",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c46\u003eMay 29 11:58:19 test.ibosscloud.com {\"exception\":\"-\",\"totalByteUsage\":\"17179\",\"policyLayers\":\"-\",\"sourcePort\":\"4890\",\"resourceId\":\"resource-id\",\"contentTypeHeader\":\"application\\/vnd.openxmlformats-officedocument\",\"callout\":\"0\",\"privateIp\":\"10.20.10.20\",\"sAction\":\"Blocked\",\"sourceIpAddress\":\"10.20.20.20\",\"subjectId\":\"example\",\"responseCode\":\"0\",\"proxyTimeSinceEpoch\":\"-\",\"authStepUp\":\"false\",\"productVersion\":\"10.3.3.125\",\"ztScore\":\"0\",\"proxyRule\":\"DLP Test\",\"clientPeerTime\":\"-\",\"totalByteCount\":\"17179\",\"host\":\"dlptest.com\",\"stealth\":\"0\",\"action\":\"Blocked\",\"uriPath\":\"\\/example-path\",\"computerMacAddress\":\"00:00:00:00:00:00\",\"iboss\":\"test.ibosscloud.com\",\"ztPolicyName\":\"DLP Test\",\"proxyPeerResponseTime\":\"-\",\"tlsVersion\":\"-\",\"ipAddress\":\"35.209.95.242\",\"resourceName\":\"DLP Test\",\"localProxyPort\":\"80\",\"logSubType\":\"DLP\",\"ibossIpAddress\":\"10.20.20.20\",\"mde\":\"-\",\"lastname\":\"-\",\"macAddress\":\"00:00:00:00:00:00\",\"ztPolicyId\":\"zt-policy-id\",\"filename\":\"sample-data_2024_test_file_2.xlsx\",\"filteringGroupName\":\"Default\",\"cncFlag\":\"0\",\"proxyDnsLookupTime\":\"-\",\"identityProviderName\":\"-\",\"proxyTotalTime\":\"-\",\"destinationPort\":\"443\",\"logType\":\"DLP\",\"extension\":\"com\",\"firstname\":\"-\",\"scheme\":\"https\",\"reportingGroup\":\"0\",\"requestMethod\":\"POST\",\"description\":\"DLP\",\"policyTrace\":\"-\",\"categoryName\":\"Technology\",\"directionName\":\"outbound\",\"sandBoxDecoded\":\"DLP Content Analysis Rule\",\"urlLogId\":\"17223\",\"computerName\":\"TEST-COMPUTER\",\"assetId\":\"asset-id\",\"audit\":\"0\",\"useTime\":\"0\",\"identityProviderUUID\":\"auto-login\",\"upstreamByteUsage\":\"32918\",\"proxyResponseTime\":\"-\",\"applicationName\":\"C:\\\\\\\\chrome.exe\",\"direction\":\"2\",\"malware\":\"0\",\"chatGPTMessage\":\"-\",\"proxyTransactionStartTime\":\"-\",\"userAgent\":\"Safari\\/537.36\",\"publicIp\":\"42.105.34.8\",\"url\":\"https:\\/\\/dlptest.com\\/example-path\",\"logTime\":\"2025-05-29\",\"referrerUrl\":\"dlptest.com\",\"sha256Sum\":\"123456789\",\"uriQuery\":\"-\",\"serverPeerTime\":\"-\",\"downstreamByteUsage\":\"0\",\"dlpKeywords\":\"-\",\"location\":\"us-central\",\"time\":\"11:58:18\",\"vendorAccountId\":\"313117\",\"username\":\"test-user\",\"heuristicScore\":\"0\"}",
+      "want": {
+        "pri": 46,
+        "timestamp": "May 29 11:58:19",
+        "hostname": "test.ibosscloud.com",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "{\"exception\":\"-\",\"totalByteUsage\":\"17179\",\"policyLayers\":\"-\",\"sourcePort\":\"4890\",\"resourceId\":\"resource-id\",\"contentTypeHeader\":\"application\\/vnd.openxmlformats-officedocument\",\"callout\":\"0\",\"privateIp\":\"10.20.10.20\",\"sAction\":\"Blocked\",\"sourceIpAddress\":\"10.20.20.20\",\"subjectId\":\"example\",\"responseCode\":\"0\",\"proxyTimeSinceEpoch\":\"-\",\"authStepUp\":\"false\",\"productVersion\":\"10.3.3.125\",\"ztScore\":\"0\",\"proxyRule\":\"DLP Test\",\"clientPeerTime\":\"-\",\"totalByteCount\":\"17179\",\"host\":\"dlptest.com\",\"stealth\":\"0\",\"action\":\"Blocked\",\"uriPath\":\"\\/example-path\",\"computerMacAddress\":\"00:00:00:00:00:00\",\"iboss\":\"test.ibosscloud.com\",\"ztPolicyName\":\"DLP Test\",\"proxyPeerResponseTime\":\"-\",\"tlsVersion\":\"-\",\"ipAddress\":\"35.209.95.242\",\"resourceName\":\"DLP Test\",\"localProxyPort\":\"80\",\"logSubType\":\"DLP\",\"ibossIpAddress\":\"10.20.20.20\",\"mde\":\"-\",\"lastname\":\"-\",\"macAddress\":\"00:00:00:00:00:00\",\"ztPolicyId\":\"zt-policy-id\",\"filename\":\"sample-data_2024_test_file_2.xlsx\",\"filteringGroupName\":\"Default\",\"cncFlag\":\"0\",\"proxyDnsLookupTime\":\"-\",\"identityProviderName\":\"-\",\"proxyTotalTime\":\"-\",\"destinationPort\":\"443\",\"logType\":\"DLP\",\"extension\":\"com\",\"firstname\":\"-\",\"scheme\":\"https\",\"reportingGroup\":\"0\",\"requestMethod\":\"POST\",\"description\":\"DLP\",\"policyTrace\":\"-\",\"categoryName\":\"Technology\",\"directionName\":\"outbound\",\"sandBoxDecoded\":\"DLP Content Analysis Rule\",\"urlLogId\":\"17223\",\"computerName\":\"TEST-COMPUTER\",\"assetId\":\"asset-id\",\"audit\":\"0\",\"useTime\":\"0\",\"identityProviderUUID\":\"auto-login\",\"upstreamByteUsage\":\"32918\",\"proxyResponseTime\":\"-\",\"applicationName\":\"C:\\\\\\\\chrome.exe\",\"direction\":\"2\",\"malware\":\"0\",\"chatGPTMessage\":\"-\",\"proxyTransactionStartTime\":\"-\",\"userAgent\":\"Safari\\/537.36\",\"publicIp\":\"42.105.34.8\",\"url\":\"https:\\/\\/dlptest.com\\/example-path\",\"logTime\":\"2025-05-29\",\"referrerUrl\":\"dlptest.com\",\"sha256Sum\":\"123456789\",\"uriQuery\":\"-\",\"serverPeerTime\":\"-\",\"downstreamByteUsage\":\"0\",\"dlpKeywords\":\"-\",\"location\":\"us-central\",\"time\":\"11:58:18\",\"vendorAccountId\":\"313117\",\"username\":\"test-user\",\"heuristicScore\":\"0\"}"
+      }
+    },
+    {
+      "integration": "ivanti_connect_secure",
+      "source": "ivanti_connect_secure/assets/logs/ivanti-connect-secure.yaml:158",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "octet_counted",
+      "line": "\u003c134\u003e1 2024-11-22T00:20:11-05:00 test.com PulseSecure: - - - {\"message_id\":\"WEB20174\",\"date\":\"2024-11-22\",\"timestamp\":\"1732252811\",\"us_timestamp\":\"1732252811.910431\",\"opaque_id\":\"640\",\"gateway_id\":\"\",\"gateway_name\":\"\",\"unique_id\":\"uid__1732252811_4979_82\",\"sev_num\":\"1\",\"sev_string\":\"info\",\"source_ip\":\"10.10.10.10\", \"macaddr\":\"\", \"user\":\"user1@test.com\",\"realm_name\":\"test-realm\",\"roles\":\"kit-common, kit-desktops, kit-automation\",\"session_id\":\"12ab34cd56\",\"useragent\":\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36\",\"device_id\":\"\",\"browser_id\":\"12ab34cd565533110bd94b7d656715d7\",\"tenant_id\":\"\",\"cert_hash\":\"\",\"additional_details\":[],\"raw_message\":\"WebRequest completed, GET to [http://10.0.0.0:8080//api/session/data/noauth/users/1a1a1a1a-1111-11aa-1a11-1111111111a111?token=ABC] from [10.0.0.0] result=[200] sent=[151] received=[67] in [0] seconds\"}",
+      "want": {
+        "pri": 134,
+        "version": "1",
+        "timestamp": "2024-11-22T00:20:11-05:00",
+        "hostname": "test.com",
+        "appname": "PulseSecure:",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "{\"message_id\":\"WEB20174\",\"date\":\"2024-11-22\",\"timestamp\":\"1732252811\",\"us_timestamp\":\"1732252811.910431\",\"opaque_id\":\"640\",\"gateway_id\":\"\",\"gateway_name\":\"\",\"unique_id\":\"uid__1732252811_4979_82\",\"sev_num\":\"1\",\"sev_string\":\"info\",\"source_ip\":\"10.10.10.10\", \"macaddr\":\"\", \"user\":\"user1@test.com\",\"realm_name\":\"test-realm\",\"roles\":\"kit-common, kit-desktops, kit-automation\",\"session_id\":\"12ab34cd56\",\"useragent\":\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36\",\"device_id\":\"\",\"browser_id\":\"12ab34cd565533110bd94b7d656715d7\",\"tenant_id\":\"\",\"cert_hash\":\"\",\"additional_details\":[],\"raw_message\":\"WebRequest completed, GET to [http://10.0.0.0:8080//api/session/data/noauth/users/1a1a1a1a-1111-11aa-1a11-1111111111a111?token=ABC] from [10.0.0.0] result=[200] sent=[151] received=[67] in [0] seconds\"}"
+      }
+    },
+    {
+      "integration": "ivanti_connect_secure",
+      "source": "ivanti_connect_secure/assets/logs/ivanti-connect-secure_tests.yaml:193",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "octet_counted",
+      "line": "\u003c134\u003e1 2024-12-04T01:18:24-05:00 test.com PulseSecure: - - - {\"message_id\":\"AUT31556\",\"date\":\"2024-12-04\",\"timestamp\":\"1733293104\",\"us_timestamp\":\"1733293104.48858\",\"opaque_id\":\"2304\",\"gateway_id\":\"\",\"gateway_name\":\"\",\"unique_id\":\"uid_1234\",\"sev_num\":\"5\",\"sev_string\":\"minor\",\"source_ip\":\"10.10.10.10\", \"macaddr\":\"\", \"user\":\"user@test.com\",\"realm_name\":\"\",\"roles\":\"\",\"session_id\":\"\",\"useragent\":\"\",\"device_id\":\"\",\"browser_id\":\"\",\"tenant_id\":\"\",\"cert_hash\":\"\",\"additional_details\":[],\"raw_message\":\"Unauthenticated request url /test came from IP 10.10.10.10.\"}",
+      "want": {
+        "pri": 134,
+        "version": "1",
+        "timestamp": "2024-12-04T01:18:24-05:00",
+        "hostname": "test.com",
+        "appname": "PulseSecure:",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "{\"message_id\":\"AUT31556\",\"date\":\"2024-12-04\",\"timestamp\":\"1733293104\",\"us_timestamp\":\"1733293104.48858\",\"opaque_id\":\"2304\",\"gateway_id\":\"\",\"gateway_name\":\"\",\"unique_id\":\"uid_1234\",\"sev_num\":\"5\",\"sev_string\":\"minor\",\"source_ip\":\"10.10.10.10\", \"macaddr\":\"\", \"user\":\"user@test.com\",\"realm_name\":\"\",\"roles\":\"\",\"session_id\":\"\",\"useragent\":\"\",\"device_id\":\"\",\"browser_id\":\"\",\"tenant_id\":\"\",\"cert_hash\":\"\",\"additional_details\":[],\"raw_message\":\"Unauthenticated request url /test came from IP 10.10.10.10.\"}"
+      }
+    },
+    {
+      "integration": "ivanti_connect_secure",
+      "source": "ivanti_connect_secure/assets/logs/ivanti-connect-secure_tests.yaml:429",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "octet_counted",
+      "line": "\u003c134\u003e1 2024-12-04T01:18:24-05:00 test.com PulseSecure: - - - {\"message_id\":\"JAV20023\",\"date\":\"2024-12-04\",\"timestamp\":\"1733293104\",\"us_timestamp\":\"1733293104.48858\",\"opaque_id\":\"2304\",\"gateway_id\":\"\",\"gateway_name\":\"\",\"unique_id\":\"uid_1234\",\"sev_num\":\"9\",\"sev_string\":\"major\",\"source_ip\":\"10.10.10.10\", \"macaddr\":\"\", \"user\":\"user@test.com\",\"realm_name\":\"\",\"roles\":\"\",\"session_id\":\"\",\"useragent\":\"\",\"device_id\":\"\",\"browser_id\":\"\",\"tenant_id\":\"\",\"cert_hash\":\"\",\"additional_details\":[],\"raw_message\":\"Closed connection to test.com port 3389 after 7 seconds, with 1286 bytes read (in 5 chunks) and 1364 bytes written (in 5 chunks)\"}",
+      "want": {
+        "pri": 134,
+        "version": "1",
+        "timestamp": "2024-12-04T01:18:24-05:00",
+        "hostname": "test.com",
+        "appname": "PulseSecure:",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "{\"message_id\":\"JAV20023\",\"date\":\"2024-12-04\",\"timestamp\":\"1733293104\",\"us_timestamp\":\"1733293104.48858\",\"opaque_id\":\"2304\",\"gateway_id\":\"\",\"gateway_name\":\"\",\"unique_id\":\"uid_1234\",\"sev_num\":\"9\",\"sev_string\":\"major\",\"source_ip\":\"10.10.10.10\", \"macaddr\":\"\", \"user\":\"user@test.com\",\"realm_name\":\"\",\"roles\":\"\",\"session_id\":\"\",\"useragent\":\"\",\"device_id\":\"\",\"browser_id\":\"\",\"tenant_id\":\"\",\"cert_hash\":\"\",\"additional_details\":[],\"raw_message\":\"Closed connection to test.com port 3389 after 7 seconds, with 1286 bytes read (in 5 chunks) and 1364 bytes written (in 5 chunks)\"}"
+      }
+    },
+    {
+      "integration": "openvpn",
+      "source": "openvpn/assets/logs/openvpn.yaml:69",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c14\u003eFeb 20 12:15:47 openvpnas2 openvpnas: [-] VPN Auth Failed: 'local auth failed: password verification failed' [None]",
+      "want": {
+        "pri": 14,
+        "timestamp": "Feb 20 12:15:47",
+        "hostname": "openvpnas2",
+        "appname": "openvpnas",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "[-] VPN Auth Failed: 'local auth failed: password verification failed' [None]"
+      }
+    },
+    {
+      "integration": "openvpn",
+      "source": "openvpn/assets/logs/openvpn.yaml:80",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c14\u003eFeb 20 12:48:43 openvpnas2 openvpnas:[-] AUTH ERROR: DENY: user in deny list. user=test",
+      "want": {
+        "pri": 14,
+        "timestamp": "Feb 20 12:48:43",
+        "hostname": "openvpnas2",
+        "appname": "openvpnas",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "[-] AUTH ERROR: DENY: user in deny list. user=test"
+      }
+    },
+    {
+      "integration": "openvpn",
+      "source": "openvpn/assets/logs/openvpn_tests.yaml:4",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c14\u003eFeb 24 05:11:20 openvpnas2 openvpnas: [-] [OVPN 2] OUT: '2025-02-24 05:11:20 10.10.10.10:50540 [openvpn] Peer Connection Initiated with [AF_INET]10.10.10.10:50546 (via [AF_INET]198.51.100.20%ens32)'",
+      "want": {
+        "pri": 14,
+        "timestamp": "Feb 24 05:11:20",
+        "hostname": "openvpnas2",
+        "appname": "openvpnas",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "[-] [OVPN 2] OUT: '2025-02-24 05:11:20 10.10.10.10:50540 [openvpn] Peer Connection Initiated with [AF_INET]10.10.10.10:50546 (via [AF_INET]198.51.100.20%ens32)'"
+      }
+    },
+    {
+      "integration": "ossec_security",
+      "source": "ossec_security/assets/logs/ossec-security.yaml:153",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c132\u003eJun  4 09:52:29 10.10.10.10 ossec: {\"crit\":2,\"id\":1002,\"component\":\"ub20-\u003e/var/log/syslog\",\"classification\":\" syslog,errors,\",\"description\":\"Unknown problem somewhere in the system.\",\"message\":\"Jun  4 09:52:29 ub20 multipathd[740]: sda: failed to get sgio uid: No such file or directory\"}",
+      "want": {
+        "pri": 132,
+        "timestamp": "Jun  4 09:52:29",
+        "hostname": "10.10.10.10",
+        "appname": "ossec",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "{\"crit\":2,\"id\":1002,\"component\":\"ub20-\u003e/var/log/syslog\",\"classification\":\" syslog,errors,\",\"description\":\"Unknown problem somewhere in the system.\",\"message\":\"Jun  4 09:52:29 ub20 multipathd[740]: sda: failed to get sgio uid: No such file or directory\"}"
+      }
+    },
+    {
+      "integration": "ossec_security",
+      "source": "ossec_security/assets/logs/ossec-security.yaml:158",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c132\u003eJun 11 14:59:35 ub20 ossec: {\"crit\":5,\"id\":4101,\"component\":\"ub20-\u003e/root/test.log\",\"classification\":\" firewall,firewall_drop,\",\"description\":\"Firewall drop event.\",\"message\":\"2006-09-19 03:31:15 DROP UDP 10.10.10.10 10.10.10.10 1000 1000 310 - - - - - - - RECEIVE\",\"src_ip\":\"10.10.10.10\",\"src_port\":1000,\"dst_ip\":\"10.10.10.10\",\"dst_port\":1000}",
+      "want": {
+        "pri": 132,
+        "timestamp": "Jun 11 14:59:35",
+        "hostname": "ub20",
+        "appname": "ossec",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "{\"crit\":5,\"id\":4101,\"component\":\"ub20-\u003e/root/test.log\",\"classification\":\" firewall,firewall_drop,\",\"description\":\"Firewall drop event.\",\"message\":\"2006-09-19 03:31:15 DROP UDP 10.10.10.10 10.10.10.10 1000 1000 310 - - - - - - - RECEIVE\",\"src_ip\":\"10.10.10.10\",\"src_port\":1000,\"dst_ip\":\"10.10.10.10\",\"dst_port\":1000}"
+      }
+    },
+    {
+      "integration": "ossec_security",
+      "source": "ossec_security/assets/logs/ossec-security_tests.yaml:5",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c132\u003eJun 19 11:56:43 ub20 ossec: {\"crit\":2,\"id\":1002,\"component\":\"ub20-\u003e/var/log/syslog\",\"classification\":\" syslog,errors,\",\"description\":\"Unknown problem somewhere in the system.\",\"message\":\"Jun 19 11:56:42 ub20 multipathd[740]: sda: failed to get sysfs uid: Invalid argument\"}",
+      "want": {
+        "pri": 132,
+        "timestamp": "Jun 19 11:56:43",
+        "hostname": "ub20",
+        "appname": "ossec",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "{\"crit\":2,\"id\":1002,\"component\":\"ub20-\u003e/var/log/syslog\",\"classification\":\" syslog,errors,\",\"description\":\"Unknown problem somewhere in the system.\",\"message\":\"Jun 19 11:56:42 ub20 multipathd[740]: sda: failed to get sysfs uid: Invalid argument\"}"
+      }
+    },
+    {
+      "integration": "ossec_security",
+      "source": "ossec_security/assets/logs/ossec-security.yaml:164",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "bsd_nopri",
+      "line": "Jun 11 14:59:35 10.10.10.10 ossec: {\"crit\":5,\"id\":4101,\"component\":\"ub20-\u003e/root/test.log\",\"classification\":\" firewall,firewall_drop,\",\"description\":\"Firewall drop event.\",\"message\":\"2006-09-19 03:31:15 DROP UDP 10.10.10.10 10.10.10.10 1000 1000 310 - - - - - - - RECEIVE\",\"src_ip\":\"10.10.10.10\",\"src_port\":1000,\"dst_ip\":\"10.10.10.10\",\"dst_port\":1000}",
+      "want": {
+        "pri": -1,
+        "timestamp": "Jun 11 14:59:35",
+        "hostname": "10.10.10.10",
+        "appname": "ossec",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "{\"crit\":5,\"id\":4101,\"component\":\"ub20-\u003e/root/test.log\",\"classification\":\" firewall,firewall_drop,\",\"description\":\"Firewall drop event.\",\"message\":\"2006-09-19 03:31:15 DROP UDP 10.10.10.10 10.10.10.10 1000 1000 310 - - - - - - - RECEIVE\",\"src_ip\":\"10.10.10.10\",\"src_port\":1000,\"dst_ip\":\"10.10.10.10\",\"dst_port\":1000}"
+      }
+    },
+    {
+      "integration": "ossec_security",
+      "source": "ossec_security/assets/logs/ossec-security.yaml:379",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "bsd_nopri",
+      "line": "May 31 10:44:02 ub20 useradd[669813]: new user: name=dummy_ossec_user, UID=1002, GID=1007, home=/home/dummy_ossec_user, shell=/bin/sh, from=/dev/pts/0",
+      "want": {
+        "pri": -1,
+        "timestamp": "May 31 10:44:02",
+        "hostname": "ub20",
+        "appname": "useradd",
+        "procid": "669813",
+        "msgid": "-",
+        "msg": "new user: name=dummy_ossec_user, UID=1002, GID=1007, home=/home/dummy_ossec_user, shell=/bin/sh, from=/dev/pts/0"
+      }
+    },
+    {
+      "integration": "ossec_security",
+      "source": "ossec_security/assets/logs/ossec-security.yaml:382",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "bsd_nopri",
+      "line": "May 27 12:08:23 ub20 groupadd[6134]: new group: name=dd-agent, GID=120",
+      "want": {
+        "pri": -1,
+        "timestamp": "May 27 12:08:23",
+        "hostname": "ub20",
+        "appname": "groupadd",
+        "procid": "6134",
+        "msgid": "-",
+        "msg": "new group: name=dd-agent, GID=120"
+      }
+    },
+    {
+      "integration": "palo_alto_panorama",
+      "source": "palo_alto_panorama/assets/logs/palo-alto-panorama.yaml:351",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c190\u003eJan 16 14:15:24 PA-VM receive_time=2023/11/24 15:38:21|serial=42808DUMMY733|type=CONFIG|subtype=1|time_generated=Jan 25 2024 11:02:57 GMT|host=8.8.8.8|vsys=test1|cmd=audit-commit|admin=admin|client=Web|result=Succeeded|path=vsys vsys1 rulebase nat rules LAN-WAN|before-change-detail=d3669n472-xxyy-4d21-bf0f-ed099ecfbaad|after-change-detail=d3669472-xxyy-4d21-bf0f-ed099ecfbaad|seqno=7304913645853474846|actionflags=0x0|dg_hier_level_1=0|dg_hier_level_2=0|dg_hier_level_3=0|dg_hier_level_4=0|vsys_name=|device_name=PA-VM|dg_id=0|comment=LAN-WAN|high_res_timestamp=2024-01-16T14:15:34.518+05:30",
+      "want": {
+        "pri": 190,
+        "timestamp": "Jan 16 14:15:24",
+        "hostname": "PA-VM",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "receive_time=2023/11/24 15:38:21|serial=42808DUMMY733|type=CONFIG|subtype=1|time_generated=Jan 25 2024 11:02:57 GMT|host=8.8.8.8|vsys=test1|cmd=audit-commit|admin=admin|client=Web|result=Succeeded|path=vsys vsys1 rulebase nat rules LAN-WAN|before-change-detail=d3669n472-xxyy-4d21-bf0f-ed099ecfbaad|after-change-detail=d3669472-xxyy-4d21-bf0f-ed099ecfbaad|seqno=7304913645853474846|actionflags=0x0|dg_hier_level_1=0|dg_hier_level_2=0|dg_hier_level_3=0|dg_hier_level_4=0|vsys_name=|device_name=PA-VM|dg_id=0|comment=LAN-WAN|high_res_timestamp=2024-01-16T14:15:34.518+05:30"
+      }
+    },
+    {
+      "integration": "palo_alto_panorama",
+      "source": "palo_alto_panorama/assets/logs/palo-alto-panorama.yaml:357",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c190\u003eJan 16 14:15:24 PA-VM receive_time=2024/01/16 14:15:34|serial=42808DUMMY733|type=START|subtype=Start|time_generated=Jan 25 2024 11:02:57 GMT|src=10.4.0.1|dst=8.8.8.8|natsrc=10.5.0.1|natdst=8.8.8.8|rule=RuleName|srcuser=DASH12|dstuser=SMT25|app=ssl|vsys=vsys2|from=LAN|to=WAN|inbound_if=ethernet1/2|outbound_if=ethernet1/1|logset=POC-Dash-DD-204-9099|sessionid=2298|repeatcnt=1|sport=53342|dport=443|natsport=53397|natdport=443|flags=0x02000000|proto=tcp|act=Allow|severity=informational|seqno=7324580429950879745|actionflags=0x0|srcloc=10.0.0.0-10.255.255.255|dstloc=United States|dg_hier_level_1=0|dg_hier_level_2=0|dg_hier_level_3=0|dg_hier_level_4=0|vsys_name=vsys2|device_name=PA-VM|tunnelid=0|monitortag=420420123|parent_session_id=0|parent_start_time=2024/01/01 12:15:30|tunnel=IPsec|bytes=847|bytes_sent=781|bytes_received=66|pkt=4|pkts_sent=3|pkts_received=1|max_encap=1|unknown_proto=2|strict_check=2|tunnel_fragment=3|sessions_created=2|sessions_closed=3|session_end_reason=threat|action_source=allow|start=2024/01/01 12:30:15|elapsed=0|tunnel_insp_rule=insepction_rule_1|remote_user_ip=10.1.2.3|remote_user_id=40201234567|rule_uuid=731925f6-8e55-xxyy-b82f-910b26004dfd|pcap_id=1223xa155545|dynusergroup_name=agnet145|src_edl=10.0.1.2|dst_edl=10.0.3.4|high_res_timestamp=2024-01-16T14:15:34.518+05:30|nssai_sd=|nssai_sst=|pdu_session_id=1234758662|subcategory_of_app=encrypted-tunnel|category_of_app=business-systems|technology_of_app=browser-based|risk_of_app=1|characteristic_of_app=used-by-malware,able-to-transfer-file|container_of_app=google|is_saas_of_app=1|sanctioned_state_of_app=0|cluster_name=test-nw-cluster",
+      "want": {
+        "pri": 190,
+        "timestamp": "Jan 16 14:15:24",
+        "hostname": "PA-VM",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "receive_time=2024/01/16 14:15:34|serial=42808DUMMY733|type=START|subtype=Start|time_generated=Jan 25 2024 11:02:57 GMT|src=10.4.0.1|dst=8.8.8.8|natsrc=10.5.0.1|natdst=8.8.8.8|rule=RuleName|srcuser=DASH12|dstuser=SMT25|app=ssl|vsys=vsys2|from=LAN|to=WAN|inbound_if=ethernet1/2|outbound_if=ethernet1/1|logset=POC-Dash-DD-204-9099|sessionid=2298|repeatcnt=1|sport=53342|dport=443|natsport=53397|natdport=443|flags=0x02000000|proto=tcp|act=Allow|severity=informational|seqno=7324580429950879745|actionflags=0x0|srcloc=10.0.0.0-10.255.255.255|dstloc=United States|dg_hier_level_1=0|dg_hier_level_2=0|dg_hier_level_3=0|dg_hier_level_4=0|vsys_name=vsys2|device_name=PA-VM|tunnelid=0|monitortag=420420123|parent_session_id=0|parent_start_time=2024/01/01 12:15:30|tunnel=IPsec|bytes=847|bytes_sent=781|bytes_received=66|pkt=4|pkts_sent=3|pkts_received=1|max_encap=1|unknown_proto=2|strict_check=2|tunnel_fragment=3|sessions_created=2|sessions_closed=3|session_end_reason=threat|action_source=allow|start=2024/01/01 12:30:15|elapsed=0|tunnel_insp_rule=insepction_rule_1|remote_user_ip=10.1.2.3|remote_user_id=40201234567|rule_uuid=731925f6-8e55-xxyy-b82f-910b26004dfd|pcap_id=1223xa155545|dynusergroup_name=agnet145|src_edl=10.0.1.2|dst_edl=10.0.3.4|high_res_timestamp=2024-01-16T14:15:34.518+05:30|nssai_sd=|nssai_sst=|pdu_session_id=1234758662|subcategory_of_app=encrypted-tunnel|category_of_app=business-systems|technology_of_app=browser-based|risk_of_app=1|characteristic_of_app=used-by-malware,able-to-transfer-file|container_of_app=google|is_saas_of_app=1|sanctioned_state_of_app=0|cluster_name=test-nw-cluster"
+      }
+    },
+    {
+      "integration": "palo_alto_panorama",
+      "source": "palo_alto_panorama/assets/logs/palo-alto-panorama_tests.yaml:4",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c190\u003eJan 18 12:46:54 PA-VM serial=42808DUMMY733|type=TRAFFIC|subtype=end|time_generated=Jan 25 2024 11:02:57 GMT|src=185.64.148.0|dst=185.64.148.0|natsrc=185.64.148.0|natdst=185.64.148.0|rule=LAN-WAN|suser=|duser=|app=incomplete|vsys=vsys1|from=LAN|to=WAN|inboundif=ethernet1/1|outboundif=ethernet1/2|logset=POC-Dash-DD-204-9099|sessionid=15281|repeatcnt=1|sport=42071|dport=233|natsport=46973|natdport=233|flags=0x40001b|proto=tcp|act=allow|bytes=134|bytes_sent=74|bytes_received=60|pkt=2|start=2024/01/18 12:46:45|elapsed=0|cat=any|seq=7288183648727243213|actflag=0x0|sloc=10.0.0.0-10.255.255.255|dloc=10.0.0.0-10.255.255.255|pktsent=1|pktrcvd=1|sessionendreason=tcp-rst-from-server|vsysname=|dvc=PA-VM|actsrc=from-policy|suuid=|duuid=|tunnelid=0|monitortag=|parentid=0|parentst=|tunnel=N/A|associd=0|chunk=0|chunksent=0|chunkrcvd=0|ruleuuid=9d526565-xxyy-4e35-9c2e-6f54430132ec|http2conn=0|appflap=0|policyid=|link=|dynusrgrp=|xffip=|scat=|sprofile=|smodel=|sven=|sosfam=|sosver=|shost=|smac=|dcat=|dprofile=|dmodel=|dven=|dosfam=|dosver=|dhost=|dmac=|contid=|podnamespace=|podname=|sedl=|dedl=|hostid=|srnum=|sdag=|ddag=|sessionown=|subcatapp=unknown|appcat=unknown|apptech=unknown|apprisk=1|appchar=|appcont=|tunneledapp=incomplete|appsaas=no|appstate=no|offloaded=0|flowtype=|cluster=",
+      "want": {
+        "pri": 190,
+        "timestamp": "Jan 18 12:46:54",
+        "hostname": "PA-VM",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "serial=42808DUMMY733|type=TRAFFIC|subtype=end|time_generated=Jan 25 2024 11:02:57 GMT|src=185.64.148.0|dst=185.64.148.0|natsrc=185.64.148.0|natdst=185.64.148.0|rule=LAN-WAN|suser=|duser=|app=incomplete|vsys=vsys1|from=LAN|to=WAN|inboundif=ethernet1/1|outboundif=ethernet1/2|logset=POC-Dash-DD-204-9099|sessionid=15281|repeatcnt=1|sport=42071|dport=233|natsport=46973|natdport=233|flags=0x40001b|proto=tcp|act=allow|bytes=134|bytes_sent=74|bytes_received=60|pkt=2|start=2024/01/18 12:46:45|elapsed=0|cat=any|seq=7288183648727243213|actflag=0x0|sloc=10.0.0.0-10.255.255.255|dloc=10.0.0.0-10.255.255.255|pktsent=1|pktrcvd=1|sessionendreason=tcp-rst-from-server|vsysname=|dvc=PA-VM|actsrc=from-policy|suuid=|duuid=|tunnelid=0|monitortag=|parentid=0|parentst=|tunnel=N/A|associd=0|chunk=0|chunksent=0|chunkrcvd=0|ruleuuid=9d526565-xxyy-4e35-9c2e-6f54430132ec|http2conn=0|appflap=0|policyid=|link=|dynusrgrp=|xffip=|scat=|sprofile=|smodel=|sven=|sosfam=|sosver=|shost=|smac=|dcat=|dprofile=|dmodel=|dven=|dosfam=|dosver=|dhost=|dmac=|contid=|podnamespace=|podname=|sedl=|dedl=|hostid=|srnum=|sdag=|ddag=|sessionown=|subcatapp=unknown|appcat=unknown|apptech=unknown|apprisk=1|appchar=|appcont=|tunneledapp=incomplete|appsaas=no|appstate=no|offloaded=0|flowtype=|cluster="
+      }
+    },
+    {
+      "integration": "pan_firewall",
+      "source": "pan_firewall/assets/logs/pan.firewall_tests.yaml:5",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c14\u003eMay  4 04:24:38 PPCMOCK-PA820-A.corp.nuskin.net timestamp=2021/05/04 04:24:37, serial=012001018742, type=TRAFFIC, subtype=end, time_generated=2021/05/04 04:24:37, network.client.ip=10.70.255.70, network.destination.ip=35.184.126.116, natsrc=67.214.229.252, natdst=35.184.126.116, rule=Permit all outbound, usr.id=, dstuser=, app=paloalto-shared-services, vsys=vsys1, from=Management, to=Outside, inbound_if=ethernet1/1.16, outbound_if=ethernet1/1.1101, logset=Panorama, sessionid=92244, repeatcnt=1, network.client.port=42799, network.destination.port=443, natsport=24855 natdport=443, flags=0x40447a, proto=tcp, evt.name=allow, bytes=16680918, network.bytes_read=16415457, network.bytes_written=265461, start=2021/05/04 04:20:10, elapsed=250, category=low-risk, seqno=977161987, actionflags=0x8000000000000000, network.client.geoip.country.name=10.0.0.0-10.255.255.255, dstloc=United States, pkts_sent=11911, pkts_received=3644, session_end_reason=tcp-rst-from-client, device_name=PPCMOCK-PA820-A, action_source=from-policy, src_uuid=, dst_uuid=, tunnelid=0, imsi= 0, monitortag=, imei=0, parent_session_id=0, parent_start_time=, tunnel=N/A, assoc_id=0, chunks=0 chunks_sent=0 chunks_received=0",
+      "want": {
+        "pri": 14,
+        "timestamp": "May  4 04:24:38",
+        "hostname": "PPCMOCK-PA820-A.corp.nuskin.net",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "timestamp=2021/05/04 04:24:37, serial=012001018742, type=TRAFFIC, subtype=end, time_generated=2021/05/04 04:24:37, network.client.ip=10.70.255.70, network.destination.ip=35.184.126.116, natsrc=67.214.229.252, natdst=35.184.126.116, rule=Permit all outbound, usr.id=, dstuser=, app=paloalto-shared-services, vsys=vsys1, from=Management, to=Outside, inbound_if=ethernet1/1.16, outbound_if=ethernet1/1.1101, logset=Panorama, sessionid=92244, repeatcnt=1, network.client.port=42799, network.destination.port=443, natsport=24855 natdport=443, flags=0x40447a, proto=tcp, evt.name=allow, bytes=16680918, network.bytes_read=16415457, network.bytes_written=265461, start=2021/05/04 04:20:10, elapsed=250, category=low-risk, seqno=977161987, actionflags=0x8000000000000000, network.client.geoip.country.name=10.0.0.0-10.255.255.255, dstloc=United States, pkts_sent=11911, pkts_received=3644, session_end_reason=tcp-rst-from-client, device_name=PPCMOCK-PA820-A, action_source=from-policy, src_uuid=, dst_uuid=, tunnelid=0, imsi= 0, monitortag=, imei=0, parent_session_id=0, parent_start_time=, tunnel=N/A, assoc_id=0, chunks=0 chunks_sent=0 chunks_received=0"
+      }
+    },
+    {
+      "integration": "sonicwall_firewall",
+      "source": "sonicwall_firewall/assets/logs/sonicwall-firewall.yaml:132",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c134\u003e  id=firewall sn=0040103D66B5 time=\"2024-09-23 05:38:11 UTC\" fw=10.10.10.10 pri=6 c=16 gcat=4 m=1334 usr=\"admin\" msg=\"User \"kavan\" is added into Group \"SonicWALL Administrators\"\" n=30 fw_action=\"NA\"",
+      "want": {
+        "pri": 134,
+        "timestamp": "-",
+        "hostname": "-",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "  id=firewall sn=0040103D66B5 time=\"2024-09-23 05:38:11 UTC\" fw=10.10.10.10 pri=6 c=16 gcat=4 m=1334 usr=\"admin\" msg=\"User \"kavan\" is added into Group \"SonicWALL Administrators\"\" n=30 fw_action=\"NA\""
+      }
+    },
+    {
+      "integration": "sonicwall_firewall",
+      "source": "sonicwall_firewall/assets/logs/sonicwall-firewall_tests.yaml:5",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c134\u003e  id=firewall sn=0040103060B5 time=\"2024-09-02 13:11:35 UTC\" fw=10.10.10.10 pri=6 c=16 gcat=2 m=1382 src=10.10.10.10:51692 dst=10.10.10.10:443:X1 usr=\"admin\" sess=\"API\" msg=\"Configuration succeeded:  'peActObjLogCustomRPObj' , User_Test, changed to [Global]\" n=207 fw_action=\"NA\" uuid=\"00000000-0000-0002-3200-0040103d66b5\" auditId=185 tranxId=29 userMode=\"Full\" auditTime=\"06:11:35 Sep 02 2024\" grpName=\"groupPeActionObject\" grpIndex=\"User_Test\" oldValue=\"\" newValue=\"Global\"",
+      "want": {
+        "pri": 134,
+        "timestamp": "-",
+        "hostname": "-",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "  id=firewall sn=0040103060B5 time=\"2024-09-02 13:11:35 UTC\" fw=10.10.10.10 pri=6 c=16 gcat=2 m=1382 src=10.10.10.10:51692 dst=10.10.10.10:443:X1 usr=\"admin\" sess=\"API\" msg=\"Configuration succeeded:  'peActObjLogCustomRPObj' , User_Test, changed to [Global]\" n=207 fw_action=\"NA\" uuid=\"00000000-0000-0002-3200-0040103d66b5\" auditId=185 tranxId=29 userMode=\"Full\" auditTime=\"06:11:35 Sep 02 2024\" grpName=\"groupPeActionObject\" grpIndex=\"User_Test\" oldValue=\"\" newValue=\"Global\""
+      }
+    },
+    {
+      "integration": "sonicwall_firewall",
+      "source": "sonicwall_firewall/assets/logs/sonicwall-firewall_tests.yaml:61",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c133\u003e  id=firewall sn=0019206645 time=\"2024-09-03 10:42:36 UTC\" fw=10.10.10.10 pri=5 c=4 gcat=3 m=16 srcMac=00:50:56:81:3c:9e src=10.40.1.245:65025:X0 natSrc=10.10.10.10:62448 dstMac=a8:46:9d:23:d2:7a dst=10.10.10.10:443:X1 natDst=10.10.10.10:443 proto=tcp/https sent=354 rcvd=52 rule=\"User_Securtiy_Profile\" app=11 dstname=settings-win.data.microsoft.com arg=/ code=15 Category=\"Business and Economy\" msg=\"Web site access allowed\" note=\"Host: settings-win.data.microsoft.com, Command: Other HTTP Command Policy: N/A, Info: 6404 \" n=40199 fw_action=\"forward\" dpi=0",
+      "want": {
+        "pri": 133,
+        "timestamp": "-",
+        "hostname": "-",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "  id=firewall sn=0019206645 time=\"2024-09-03 10:42:36 UTC\" fw=10.10.10.10 pri=5 c=4 gcat=3 m=16 srcMac=00:50:56:81:3c:9e src=10.40.1.245:65025:X0 natSrc=10.10.10.10:62448 dstMac=a8:46:9d:23:d2:7a dst=10.10.10.10:443:X1 natDst=10.10.10.10:443 proto=tcp/https sent=354 rcvd=52 rule=\"User_Securtiy_Profile\" app=11 dstname=settings-win.data.microsoft.com arg=/ code=15 Category=\"Business and Economy\" msg=\"Web site access allowed\" note=\"Host: settings-win.data.microsoft.com, Command: Other HTTP Command Policy: N/A, Info: 6404 \" n=40199 fw_action=\"forward\" dpi=0"
+      }
+    },
+    {
+      "integration": "sonicwall_firewall",
+      "source": "sonicwall_firewall/assets/logs/sonicwall-firewall.yaml:103",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "bsd_nopri",
+      "line": "Apr 27 19:29:07 10.10.10.10 id=firewall sn=0000A0AAAA00 time=\"2022-04-27 19:29:40\" fw=10.10.10.10 pri=1 c=32 m=267 msg=\"TCP Xmas Tree dropped\" n=56 src=10.10.10.10:16345:X1 dst=10.10.10.10:81 srcMac=00:53:2a:7d:1d:35 dstMac=00:53:c5:ca:be:01 proto=tcp/81",
+      "want": {
+        "pri": -1,
+        "timestamp": "Apr 27 19:29:07",
+        "hostname": "10.10.10.10",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "id=firewall sn=0000A0AAAA00 time=\"2022-04-27 19:29:40\" fw=10.10.10.10 pri=1 c=32 m=267 msg=\"TCP Xmas Tree dropped\" n=56 src=10.10.10.10:16345:X1 dst=10.10.10.10:81 srcMac=00:53:2a:7d:1d:35 dstMac=00:53:c5:ca:be:01 proto=tcp/81"
+      }
+    },
+    {
+      "integration": "sonicwall_firewall",
+      "source": "sonicwall_firewall/assets/logs/sonicwall-firewall_tests.yaml:273",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "bsd_nopri",
+      "line": "Jan  3 13:45:51 10.10.10.10 id=firewall sn=000SERIAL time=\"2007-01-03 14:48:22\" fw=10.10.10.10 pri=6 c=262144 m=98 msg=\"Connection Opened\" n=23427 src=:28503:WAN:SOURCEHOST srcV6=2a52:cf50:add:4002:91f2:a9b2:e09a:6fc6 dst=::LAN:DSTHOST proto=tcp/dns dstV6=::1",
+      "want": {
+        "pri": -1,
+        "timestamp": "Jan  3 13:45:51",
+        "hostname": "10.10.10.10",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "id=firewall sn=000SERIAL time=\"2007-01-03 14:48:22\" fw=10.10.10.10 pri=6 c=262144 m=98 msg=\"Connection Opened\" n=23427 src=:28503:WAN:SOURCEHOST srcV6=2a52:cf50:add:4002:91f2:a9b2:e09a:6fc6 dst=::LAN:DSTHOST proto=tcp/dns dstV6=::1"
+      }
+    },
+    {
+      "integration": "sonicwall_firewall",
+      "source": "sonicwall_firewall/assets/logs/sonicwall-firewall_tests.yaml:311",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "bsd_nopri",
+      "line": "Apr 27 10:32:18 10.10.10.10 id=firewall sn=0000TSAA00 time=\"2022-04-27 10:32:51\" fw=10.10.10.10 pri=6 c=16 m=998 msg=\"GUI administration session ended\" sess=\"Web\" dur=510 n=11 usr=\"admin\" src=10.10.10.10::X0 dst=10.10.10.10:4444:X0 proto=tcp/4444 note=\"admin\"",
+      "want": {
+        "pri": -1,
+        "timestamp": "Apr 27 10:32:18",
+        "hostname": "10.10.10.10",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "id=firewall sn=0000TSAA00 time=\"2022-04-27 10:32:51\" fw=10.10.10.10 pri=6 c=16 m=998 msg=\"GUI administration session ended\" sess=\"Web\" dur=510 n=11 usr=\"admin\" src=10.10.10.10::X0 dst=10.10.10.10:4444:X0 proto=tcp/4444 note=\"admin\""
+      }
+    },
+    {
+      "integration": "symantec_endpoint_protection",
+      "source": "symantec_endpoint_protection/assets/logs/symantec-endpoint-protection.yaml:59",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c54\u003eSep 13 08:21:26 WIN-RQBT7BNE363 SymantecServer: DESKTOP-CIK30CC,172.50.12.208,Continue,Application and Device Control is ready,System,Begin: 2024-09-13 08:20:13,End Time: 2024-09-13 08:20:13,Rule: Built-in rule,0,SysPlant,0,SysPlant,None,User Name: None,Domain Name: None,Action Type: ,File size (bytes): 0,Device ID:",
+      "want": {
+        "pri": 54,
+        "timestamp": "Sep 13 08:21:26",
+        "hostname": "WIN-RQBT7BNE363",
+        "appname": "SymantecServer",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "DESKTOP-CIK30CC,172.50.12.208,Continue,Application and Device Control is ready,System,Begin: 2024-09-13 08:20:13,End Time: 2024-09-13 08:20:13,Rule: Built-in rule,0,SysPlant,0,SysPlant,None,User Name: None,Domain Name: None,Action Type: ,File size (bytes): 0,Device ID:"
+      }
+    },
+    {
+      "integration": "symantec_endpoint_protection",
+      "source": "symantec_endpoint_protection/assets/logs/symantec-endpoint-protection.yaml:123",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c54\u003eSep 16 23:59:55 WIN-RQBT7BNE363 SymantecServer: WIN-4K914H0NBUP,Event Description: Host Integrity check passed ,Event Type: ,Local Host IP: 172.50.12.216,Local Host MAC: 0050569214AF,Remote Host Name: ,Remote Host IP: 172.50.12.216,Remote Host MAC: 000000000000,Unknown,OTHERS,,Begin: 2024-09-16 23:58:20,End Time: 2024-09-16 23:58:20,Occurrences: 1,Application: ,Location: Default,User Name: none,Domain Name: ,Local Port: 0,Remote Port: 0,CIDS Signature ID: 0,CIDS Signature string: ,CIDS Signature SubID: 0,Intrusion URL: ,Intrusion Payload URL: ,SHA-256: ,MD-5: ,Intensive Protection Level: N/A,URL Risk: N/A,URL Category: N/A,Correlation ID:",
+      "want": {
+        "pri": 54,
+        "timestamp": "Sep 16 23:59:55",
+        "hostname": "WIN-RQBT7BNE363",
+        "appname": "SymantecServer",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "WIN-4K914H0NBUP,Event Description: Host Integrity check passed ,Event Type: ,Local Host IP: 172.50.12.216,Local Host MAC: 0050569214AF,Remote Host Name: ,Remote Host IP: 172.50.12.216,Remote Host MAC: 000000000000,Unknown,OTHERS,,Begin: 2024-09-16 23:58:20,End Time: 2024-09-16 23:58:20,Occurrences: 1,Application: ,Location: Default,User Name: none,Domain Name: ,Local Port: 0,Remote Port: 0,CIDS Signature ID: 0,CIDS Signature string: ,CIDS Signature SubID: 0,Intrusion URL: ,Intrusion Payload URL: ,SHA-256: ,MD-5: ,Intensive Protection Level: N/A,URL Risk: N/A,URL Category: N/A,Correlation ID:"
+      }
+    },
+    {
+      "integration": "symantec_endpoint_protection",
+      "source": "symantec_endpoint_protection/assets/logs/symantec-endpoint-protection.yaml:134",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c51\u003eSep 12 00:11:39 WIN-RQBT7BNE363 SymantecServer: DESKTOP-CIK30CC,Event Description: Device Manager Message Disabled the device. [name]:VMware USB Pointing Device [class]:Mice and other pointing devices [guid]:4d36e96f-e325-11ce-bfc1-08002be10318 [deviceID]:HID\\VID_0E0F\u0026PID_0003\u0026MI_01\\8\u002695BC71C\u00260\u00260000,Event Type: ,Local Host IP: 172.50.12.208,Local Host MAC: 00505681213E,Remote Host Name: ,Remote Host IP: 0.0.0.0,Remote Host MAC: 000000000000,Unknown,Unknown,,Begin: 2024-09-12 00:10:39,End Time: 2024-09-12 00:10:39,Occurrences: 1,Application:  ,Location: Default,User Name: admin,Domain Name: DESKTOP-CIK30CC,Local Port: 0,Remote Port: 0,CIDS Signature ID: 0,CIDS Signature string: ,CIDS Signature SubID: 0,Intrusion URL: ,Intrusion Payload URL: ,SHA-256: ,MD-5: ,Intensive Protection Level: N/A,URL Risk: N/A,URL Category: N/A,Correlation ID:",
+      "want": {
+        "pri": 51,
+        "timestamp": "Sep 12 00:11:39",
+        "hostname": "WIN-RQBT7BNE363",
+        "appname": "SymantecServer",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "DESKTOP-CIK30CC,Event Description: Device Manager Message Disabled the device. [name]:VMware USB Pointing Device [class]:Mice and other pointing devices [guid]:4d36e96f-e325-11ce-bfc1-08002be10318 [deviceID]:HID\\VID_0E0F\u0026PID_0003\u0026MI_01\\8\u002695BC71C\u00260\u00260000,Event Type: ,Local Host IP: 172.50.12.208,Local Host MAC: 00505681213E,Remote Host Name: ,Remote Host IP: 0.0.0.0,Remote Host MAC: 000000000000,Unknown,Unknown,,Begin: 2024-09-12 00:10:39,End Time: 2024-09-12 00:10:39,Occurrences: 1,Application:  ,Location: Default,User Name: admin,Domain Name: DESKTOP-CIK30CC,Local Port: 0,Remote Port: 0,CIDS Signature ID: 0,CIDS Signature string: ,CIDS Signature SubID: 0,Intrusion URL: ,Intrusion Payload URL: ,SHA-256: ,MD-5: ,Intensive Protection Level: N/A,URL Risk: N/A,URL Category: N/A,Correlation ID:"
+      }
+    },
+    {
+      "integration": "watchguard_firebox",
+      "source": "watchguard_firebox/assets/logs/watchguard-firebox.yaml:99",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c142\u003eMar 28 11:21:56 WatchGuard-Firebox FVM (2025-03-28T05:51:56) firewall: msg_id=\"3000-0148\" Allow Trusted Firebox 60 icmp 20 128 10.10.10.10 10.10.10.10 8 0 id=1 seq=59033  (Ping-00)",
+      "want": {
+        "pri": 142,
+        "timestamp": "Mar 28 11:21:56",
+        "hostname": "WatchGuard-Firebox",
+        "appname": "FVM",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "(2025-03-28T05:51:56) firewall: msg_id=\"3000-0148\" Allow Trusted Firebox 60 icmp 20 128 10.10.10.10 10.10.10.10 8 0 id=1 seq=59033  (Ping-00)"
+      }
+    },
+    {
+      "integration": "watchguard_firebox",
+      "source": "watchguard_firebox/assets/logs/watchguard-firebox.yaml:102",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c142\u003eApr  4 10:35:35 WatchGuard-Firebox (2025-04-04T05:05:35) firewall: msg_id=\"3000-0151\" Allow Firebox Firebox tcp 10.10.10.10 127.0.0.1 57576 705 flags=\"SR\" duration=\"0\" sent_pkts=\"1\" rcvd_pkts=\"1\" sent_bytes=\"52\" rcvd_bytes=\"40\"  (Any From Firebox-00)",
+      "want": {
+        "pri": 142,
+        "timestamp": "Apr  4 10:35:35",
+        "hostname": "WatchGuard-Firebox",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "(2025-04-04T05:05:35) firewall: msg_id=\"3000-0151\" Allow Firebox Firebox tcp 10.10.10.10 127.0.0.1 57576 705 flags=\"SR\" duration=\"0\" sent_pkts=\"1\" rcvd_pkts=\"1\" sent_bytes=\"52\" rcvd_bytes=\"40\"  (Any From Firebox-00)"
+      }
+    },
+    {
+      "integration": "watchguard_firebox",
+      "source": "watchguard_firebox/assets/logs/watchguard-firebox.yaml:106",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c142\u003eApr  1 10:57:19 WatchGuard-Firebox FVM (2025-04-01T05:27:19) firewall: msg_id=\"3000-0151\" Allow Trusted Firebox icmp 10.10.10.10 10.10.10.10 echo-request duration=\"32\" sent_pkts=\"1\" rcvd_pkts=\"1\" sent_bytes=\"60\" rcvd_bytes=\"60\"  (Ping-00)",
+      "want": {
+        "pri": 142,
+        "timestamp": "Apr  1 10:57:19",
+        "hostname": "WatchGuard-Firebox",
+        "appname": "FVM",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "(2025-04-01T05:27:19) firewall: msg_id=\"3000-0151\" Allow Trusted Firebox icmp 10.10.10.10 10.10.10.10 echo-request duration=\"32\" sent_pkts=\"1\" rcvd_pkts=\"1\" sent_bytes=\"60\" rcvd_bytes=\"60\"  (Ping-00)"
+      }
+    },
+    {
+      "integration": "wazuh",
+      "source": "wazuh/assets/logs/wazuh.yaml:148",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c132\u003eSep 13 13:21:06 ub20-host ossec: {\"timestamp\":\"2024-09-13T13:21:06.262+0530\",\"rule\":{\"level\":3,\"description\":\"Successful sudo to ROOT executed.\",\"id\":\"5402\",\"mitre\":{\"id\":[\"T1548.003\"],\"tactic\":[\"Privilege Escalation\",\"Defense Evasion\"],\"technique\":[\"Sudo and Sudo Caching\"]},\"firedtimes\":3,\"mail\":false,\"groups\":[\"syslog\",\"sudo\"],\"pci_dss\":[\"10.2.5\",\"10.2.2\"],\"gpg13\":[\"7.6\",\"7.8\",\"7.13\"],\"gdpr\":[\"IV_32.2\"],\"hipaa\":[\"164.312.b\"],\"nist_800_53\":[\"AU.14\",\"AC.7\",\"AC.6\"],\"tsc\":[\"CC6.8\",\"CC7.2\",\"CC7.3\"]},\"agent\":{\"id\":\"000\",\"name\":\"ub20-host\"},\"manager\":{\"name\":\"ub20-host\"},\"id\":\"1726213866.2869025\",\"full_log\":\"Sep 13 13:21:04 ub20-host sudo:     root : TTY=pts/13 ; PWD=/home/devuser ; USER=root ; COMMAND=/usr/bin/nano /var/ossec/etc/ossec.conf\",\"predecoder\":{\"program_name\":\"sudo\",\"timestamp\":\"Sep 13 13:21:04\",\"hostname\":\"ub20-host\"},\"decoder\":{\"parent\":\"sudo\",\"name\":\"sudo\",\"ftscomment\":\"First time user executed the sudo command\"},\"data\":{\"srcuser\":\"root\",\"dstuser\":\"root\",\"tty\":\"pts/13\",\"pwd\":\"/home/devuser\",\"command\":\"/usr/bin/nano /var/ossec/etc/ossec.conf\"},\"location\":\"/var/log/auth.log\"}",
+      "want": {
+        "pri": 132,
+        "timestamp": "Sep 13 13:21:06",
+        "hostname": "ub20-host",
+        "appname": "ossec",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "{\"timestamp\":\"2024-09-13T13:21:06.262+0530\",\"rule\":{\"level\":3,\"description\":\"Successful sudo to ROOT executed.\",\"id\":\"5402\",\"mitre\":{\"id\":[\"T1548.003\"],\"tactic\":[\"Privilege Escalation\",\"Defense Evasion\"],\"technique\":[\"Sudo and Sudo Caching\"]},\"firedtimes\":3,\"mail\":false,\"groups\":[\"syslog\",\"sudo\"],\"pci_dss\":[\"10.2.5\",\"10.2.2\"],\"gpg13\":[\"7.6\",\"7.8\",\"7.13\"],\"gdpr\":[\"IV_32.2\"],\"hipaa\":[\"164.312.b\"],\"nist_800_53\":[\"AU.14\",\"AC.7\",\"AC.6\"],\"tsc\":[\"CC6.8\",\"CC7.2\",\"CC7.3\"]},\"agent\":{\"id\":\"000\",\"name\":\"ub20-host\"},\"manager\":{\"name\":\"ub20-host\"},\"id\":\"1726213866.2869025\",\"full_log\":\"Sep 13 13:21:04 ub20-host sudo:     root : TTY=pts/13 ; PWD=/home/devuser ; USER=root ; COMMAND=/usr/bin/nano /var/ossec/etc/ossec.conf\",\"predecoder\":{\"program_name\":\"sudo\",\"timestamp\":\"Sep 13 13:21:04\",\"hostname\":\"ub20-host\"},\"decoder\":{\"parent\":\"sudo\",\"name\":\"sudo\",\"ftscomment\":\"First time user executed the sudo command\"},\"data\":{\"srcuser\":\"root\",\"dstuser\":\"root\",\"tty\":\"pts/13\",\"pwd\":\"/home/devuser\",\"command\":\"/usr/bin/nano /var/ossec/etc/ossec.conf\"},\"location\":\"/var/log/auth.log\"}"
+      }
+    },
+    {
+      "integration": "wazuh",
+      "source": "wazuh/assets/logs/wazuh_tests.yaml:118",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c132\u003eSep 19 08:25:04 ub20 ossec: {\"timestamp\":\"2024-09-19T08:25:04.210+0530\",\"rule\":{\"level\":7,\"description\":\"Dpkg (Debian Package) half configured.\",\"id\":\"2904\",\"firedtimes\":7,\"mail\":false,\"groups\":[\"syslog\",\"dpkg\",\"config_changed\"],\"pci_dss\":[\"10.6.1\",\"10.2.7\"],\"gpg13\":[\"4.10\"],\"gdpr\":[\"IV_35.7.d\"],\"hipaa\":[\"164.312.b\"],\"nist_800_53\":[\"AU.6\",\"AU.14\"],\"tsc\":[\"CC7.2\",\"CC7.3\",\"CC6.8\",\"CC8.1\"]},\"agent\":{\"id\":\"000\",\"name\":\"ub20\"},\"manager\":{\"name\":\"ub20\"},\"id\":\"1726714504.1044193\",\"full_log\":\"2024-09-19 08:25:02 status half-configured linux-headers-5.15.0-119:all 5.15.0-119.129\",\"decoder\":{\"name\":\"dpkg-decoder\"},\"data\":{\"dpkg_status\":\"status half-configured\",\"package\":\"linux-headers-5.15.0-119\",\"arch\":\"all\",\"version\":\"5.15.0-119.129\"},\"location\":\"/var/log/dpkg.log\"}",
+      "want": {
+        "pri": 132,
+        "timestamp": "Sep 19 08:25:04",
+        "hostname": "ub20",
+        "appname": "ossec",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "{\"timestamp\":\"2024-09-19T08:25:04.210+0530\",\"rule\":{\"level\":7,\"description\":\"Dpkg (Debian Package) half configured.\",\"id\":\"2904\",\"firedtimes\":7,\"mail\":false,\"groups\":[\"syslog\",\"dpkg\",\"config_changed\"],\"pci_dss\":[\"10.6.1\",\"10.2.7\"],\"gpg13\":[\"4.10\"],\"gdpr\":[\"IV_35.7.d\"],\"hipaa\":[\"164.312.b\"],\"nist_800_53\":[\"AU.6\",\"AU.14\"],\"tsc\":[\"CC7.2\",\"CC7.3\",\"CC6.8\",\"CC8.1\"]},\"agent\":{\"id\":\"000\",\"name\":\"ub20\"},\"manager\":{\"name\":\"ub20\"},\"id\":\"1726714504.1044193\",\"full_log\":\"2024-09-19 08:25:02 status half-configured linux-headers-5.15.0-119:all 5.15.0-119.129\",\"decoder\":{\"name\":\"dpkg-decoder\"},\"data\":{\"dpkg_status\":\"status half-configured\",\"package\":\"linux-headers-5.15.0-119\",\"arch\":\"all\",\"version\":\"5.15.0-119.129\"},\"location\":\"/var/log/dpkg.log\"}"
+      }
+    },
+    {
+      "integration": "wazuh",
+      "source": "wazuh/assets/logs/wazuh_tests.yaml:346",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c132\u003eSep 16 16:58:16 Debian ossec: {\"@sampledata\": true, \"timestamp\": \"2024-09-16T16:58:16.015398+05:30\", \"rule\": {\"firedtimes\": 27, \"mail\": false, \"level\": 3, \"description\": \"AWS GuardDuty: PORT_PROBE - Unprotected port on EC2 instance i-0b0b8b34a48c8f1c4 is being probed. [IP: 10.10.10.10] [Port: 80]\", \"groups\": [\"amazon\", \"aws\", \"aws_guardduty\"], \"id\": \"80305\"}, \"agent\": {\"id\": \"007\", \"name\": \"Debian\", \"ip\": \"10.10.10.10\"}, \"manager\": {\"name\": \"ub20\"}, \"cluster\": {\"name\": \"wazuh\"}, \"id\": \"1580123327.49031\", \"predecoder\": {}, \"decoder\": {\"name\": \"json\"}, \"data\": {\"aws\": {\"severity\": \"2\", \"schemaVersion\": \"2.0\", \"resource\": {\"resourceType\": \"Instance\", \"instanceDetails\": {\"launchTime\": \"2019-03-22T14:15:41Z\", \"instanceId\": \"i-0cab4a083d57dc400\", \"networkInterfaces\": {\"networkInterfaceId\": \"eni-0bb465b2d939dbda6\", \"subnetId\": \"subnet-6b1d6203\", \"vpcId\": \"vpc-921e61fa\", \"privateDnsName\": \"ip-10-0-0-1.ec2.internal\", \"publicIp\": \"10.10.10.10\", \"publicDnsName\": \"ec2-10.10.10.10.compute-1.amazonaws.com\", \"privateIpAddress\": \"10.0.0.1\"}, \"instanceState\": \"running\", \"imageId\": \"ami-09ae67bbfcd740875\", \"instanceType\": \"a1.medium\", \"imageDescription\": \"Canonical, Ubuntu, 18.04 LTS, UNSUPPORTED daily arm64 bionic image build on 2019-02-12\", \"productCodes\": {\"productCodeId\": \"zud1u4kjmxu2j2jf0n36bqa\", \"productCodeType\": \"marketplace\"}, \"iamInstanceProfile\": {\"id\": \"AIPAJGAZMFPZHKIBOUFGA\", \"arn\": \"arn:aws:iam::150447125201:instance-profile/opsworks-web-production\"}, \"availabilityZone\": \"us-east-1e\"}}, \"description\": \"EC2 instance has an unprotected port which is being probed by a known malicious host.\", \"source\": \"guardduty\", \"type\": \"Recon:EC2/PortProbeUnprotectedPort\", \"title\": \"Unprotected port on EC2 instance i-0cab4a083d57dc400 is being probed.\", \"partition\": \"aws\", \"service\": {\"archived\": \"false\", \"resourceRole\": \"TARGET\", \"detectorId\": \"cab38390b400c06fb2897dfcebffb80d\", \"additionalInfo\": {\"threatListName\": \"ProofPoint\", \"threatName\": \"Scanner\"}, \"count\": \"2115\", \"action\": {\"actionType\": \"PORT_PROBE\", \"portProbeAction\": {\"blocked\": \"false\", \"portProbeDetails\": {\"localPortDetails\": {\"port\": \"80\", \"portName\": \"HTTP\"}, \"remoteIpDetails\": {\"country\": {\"countryName\": \"Mexico\"}, \"city\": {\"cityName\": \"M\\u00e9rida\"}, \"geoLocation\": {\"lon\": \"-89.616700\", \"lat\": \"20.950000\"}, \"organization\": {\"asnOrg\": \"Internet Mexico Company\", \"org\": \"Internet Mexico Company\", \"isp\": \"Internet Mexico Company\", \"asn\": \"4257\"}, \"ipAddressV4\": \"10.10.10.10\"}}}}, \"serviceName\": \"guardduty\", \"eventFirstSeen\": \"2024-08-28T05:41:44.820Z\", \"eventLastSeen\": \"2024-08-31T05:41:44.820Z\"}, \"region\": \"eu-west-1\", \"accountId\": \"18773455640\", \"log_info\": {\"s3bucket\": \"aws-sample-bucket-2\", \"log_file\": \"guardduty/2024/08/31/05/firehose_guardduty-1-2024-08-31-05-41-44-820b5b9b-ec62-4a07-85d7-b1699b9c031e.zip\"}, \"createdAt\": \"2024-08-28T05:41:44.820Z\"}, \"integration\": \"aws\"}, \"location\": \"Wazuh-AWS\", \"input\": {\"type\": \"log\"}, \"GeoLocation\": {\"country_name\": \"Germany\", \"location\": {\"lat\": 52.524, \"lon\": 13.411}, \"region_name\": \"Berlin\", \"city_name\": \"Berlin\"}}",
+      "want": {
+        "pri": 132,
+        "timestamp": "Sep 16 16:58:16",
+        "hostname": "Debian",
+        "appname": "ossec",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "{\"@sampledata\": true, \"timestamp\": \"2024-09-16T16:58:16.015398+05:30\", \"rule\": {\"firedtimes\": 27, \"mail\": false, \"level\": 3, \"description\": \"AWS GuardDuty: PORT_PROBE - Unprotected port on EC2 instance i-0b0b8b34a48c8f1c4 is being probed. [IP: 10.10.10.10] [Port: 80]\", \"groups\": [\"amazon\", \"aws\", \"aws_guardduty\"], \"id\": \"80305\"}, \"agent\": {\"id\": \"007\", \"name\": \"Debian\", \"ip\": \"10.10.10.10\"}, \"manager\": {\"name\": \"ub20\"}, \"cluster\": {\"name\": \"wazuh\"}, \"id\": \"1580123327.49031\", \"predecoder\": {}, \"decoder\": {\"name\": \"json\"}, \"data\": {\"aws\": {\"severity\": \"2\", \"schemaVersion\": \"2.0\", \"resource\": {\"resourceType\": \"Instance\", \"instanceDetails\": {\"launchTime\": \"2019-03-22T14:15:41Z\", \"instanceId\": \"i-0cab4a083d57dc400\", \"networkInterfaces\": {\"networkInterfaceId\": \"eni-0bb465b2d939dbda6\", \"subnetId\": \"subnet-6b1d6203\", \"vpcId\": \"vpc-921e61fa\", \"privateDnsName\": \"ip-10-0-0-1.ec2.internal\", \"publicIp\": \"10.10.10.10\", \"publicDnsName\": \"ec2-10.10.10.10.compute-1.amazonaws.com\", \"privateIpAddress\": \"10.0.0.1\"}, \"instanceState\": \"running\", \"imageId\": \"ami-09ae67bbfcd740875\", \"instanceType\": \"a1.medium\", \"imageDescription\": \"Canonical, Ubuntu, 18.04 LTS, UNSUPPORTED daily arm64 bionic image build on 2019-02-12\", \"productCodes\": {\"productCodeId\": \"zud1u4kjmxu2j2jf0n36bqa\", \"productCodeType\": \"marketplace\"}, \"iamInstanceProfile\": {\"id\": \"AIPAJGAZMFPZHKIBOUFGA\", \"arn\": \"arn:aws:iam::150447125201:instance-profile/opsworks-web-production\"}, \"availabilityZone\": \"us-east-1e\"}}, \"description\": \"EC2 instance has an unprotected port which is being probed by a known malicious host.\", \"source\": \"guardduty\", \"type\": \"Recon:EC2/PortProbeUnprotectedPort\", \"title\": \"Unprotected port on EC2 instance i-0cab4a083d57dc400 is being probed.\", \"partition\": \"aws\", \"service\": {\"archived\": \"false\", \"resourceRole\": \"TARGET\", \"detectorId\": \"cab38390b400c06fb2897dfcebffb80d\", \"additionalInfo\": {\"threatListName\": \"ProofPoint\", \"threatName\": \"Scanner\"}, \"count\": \"2115\", \"action\": {\"actionType\": \"PORT_PROBE\", \"portProbeAction\": {\"blocked\": \"false\", \"portProbeDetails\": {\"localPortDetails\": {\"port\": \"80\", \"portName\": \"HTTP\"}, \"remoteIpDetails\": {\"country\": {\"countryName\": \"Mexico\"}, \"city\": {\"cityName\": \"M\\u00e9rida\"}, \"geoLocation\": {\"lon\": \"-89.616700\", \"lat\": \"20.950000\"}, \"organization\": {\"asnOrg\": \"Internet Mexico Company\", \"org\": \"Internet Mexico Company\", \"isp\": \"Internet Mexico Company\", \"asn\": \"4257\"}, \"ipAddressV4\": \"10.10.10.10\"}}}}, \"serviceName\": \"guardduty\", \"eventFirstSeen\": \"2024-08-28T05:41:44.820Z\", \"eventLastSeen\": \"2024-08-31T05:41:44.820Z\"}, \"region\": \"eu-west-1\", \"accountId\": \"18773455640\", \"log_info\": {\"s3bucket\": \"aws-sample-bucket-2\", \"log_file\": \"guardduty/2024/08/31/05/firehose_guardduty-1-2024-08-31-05-41-44-820b5b9b-ec62-4a07-85d7-b1699b9c031e.zip\"}, \"createdAt\": \"2024-08-28T05:41:44.820Z\"}, \"integration\": \"aws\"}, \"location\": \"Wazuh-AWS\", \"input\": {\"type\": \"log\"}, \"GeoLocation\": {\"country_name\": \"Germany\", \"location\": {\"lat\": 52.524, \"lon\": 13.411}, \"region_name\": \"Berlin\", \"city_name\": \"Berlin\"}}"
+      }
+    },
+    {
+      "integration": "wazuh",
+      "source": "wazuh/assets/logs/wazuh.yaml:454",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "bsd_nopri",
+      "line": "Dec 17 07:05:06 ax yum: Installed: libX11-devel - 1.0.3-9.el5.i386",
+      "want": {
+        "pri": -1,
+        "timestamp": "Dec 17 07:05:06",
+        "hostname": "ax",
+        "appname": "yum",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "Installed: libX11-devel - 1.0.3-9.el5.i386"
+      }
+    },
+    {
+      "integration": "wazuh",
+      "source": "wazuh/assets/logs/wazuh.yaml:456",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "bsd_nopri",
+      "line": "Oct  8 07:17:27 ax yum[61038]: Erased: file-roller-3.28.1-2.el7.x86_64",
+      "want": {
+        "pri": -1,
+        "timestamp": "Oct  8 07:17:27",
+        "hostname": "ax",
+        "appname": "yum",
+        "procid": "61038",
+        "msgid": "-",
+        "msg": "Erased: file-roller-3.28.1-2.el7.x86_64"
+      }
+    },
+    {
+      "integration": "wazuh",
+      "source": "wazuh/assets/logs/wazuh.yaml:460",
+      "origin": "integrations-core",
+      "transport": "file",
+      "framing": "bsd_nopri",
+      "line": "Aug 20 12:51:21 Erased: libhugetlbfs-lib",
+      "want": {
+        "pri": -1,
+        "timestamp": "Aug 20 12:51:21",
+        "hostname": "-",
+        "appname": "Erased",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "libhugetlbfs-lib"
+      }
+    },
+    {
+      "integration": "zeek",
+      "source": "zeek/assets/logs/zeek.yaml:837",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c134\u003eDec 26 01:35:11 machine-name {\"_path\":\"capture_loss\",\"_write_ts\":\"2023-12-12T05:52:50.756358Z\",\"ts\":\"2023-12-12T05:52:32.763303Z\",\"ts_delta\":15.235642194747925,\"peer\":\"zeek\",\"gaps\":3,\"acks\":316,\"percent_lost\":0.9493670886075949}",
+      "want": {
+        "pri": 134,
+        "timestamp": "Dec 26 01:35:11",
+        "hostname": "machine-name",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "{\"_path\":\"capture_loss\",\"_write_ts\":\"2023-12-12T05:52:50.756358Z\",\"ts\":\"2023-12-12T05:52:32.763303Z\",\"ts_delta\":15.235642194747925,\"peer\":\"zeek\",\"gaps\":3,\"acks\":316,\"percent_lost\":0.9493670886075949}"
+      }
+    },
+    {
+      "integration": "zeek",
+      "source": "zeek/assets/logs/zeek_tests.yaml:489",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c134\u003eJan 12 18:13:46 machine-name {\"_path\":\"datared\",\"_write_ts\":\"2024-01-13T00:13:42.817478Z\",\"ts\":\"2024-01-13T00:13:42.817478Z\",\"conn_red\":1310,\"conn_total\":18460,\"dns_red\":1141,\"dns_total\":1604,\"files_red\":313,\"files_total\":796,\"http_red\":140,\"http_total\":140,\"ssl_red\":215,\"ssl_total\":227,\"weird_red\":20,\"weird_total\":20}",
+      "want": {
+        "pri": 134,
+        "timestamp": "Jan 12 18:13:46",
+        "hostname": "machine-name",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "{\"_path\":\"datared\",\"_write_ts\":\"2024-01-13T00:13:42.817478Z\",\"ts\":\"2024-01-13T00:13:42.817478Z\",\"conn_red\":1310,\"conn_total\":18460,\"dns_red\":1141,\"dns_total\":1604,\"files_red\":313,\"files_total\":796,\"http_red\":140,\"http_total\":140,\"ssl_red\":215,\"ssl_total\":227,\"weird_red\":20,\"weird_total\":20}"
+      }
+    },
+    {
+      "integration": "zeek",
+      "source": "zeek/assets/logs/zeek_tests.yaml:515",
+      "origin": "integrations-core",
+      "transport": "wire",
+      "framing": "rfc3164_pri",
+      "line": "\u003c134\u003eMar  6 22:39:30 machine-name {\"_path\":\"dns_red\",\"_write_ts\":\"2024-03-07T04:39:28.580374Z\",\"ts\":\"2024-03-07T04:38:40.085451Z\",\"uid\":\"CyArTY2KEgcygwMLi1\",\"id.orig_h\":\"10.10.10.10\",\"id.orig_p\":123,\"id.resp_h\":\"20.20.20.20\",\"id.resp_p\":321,\"query\":\"time.missouri.edu\",\"qtype_name\":\"A\",\"num\":4}",
+      "want": {
+        "pri": 134,
+        "timestamp": "Mar  6 22:39:30",
+        "hostname": "machine-name",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "{\"_path\":\"dns_red\",\"_write_ts\":\"2024-03-07T04:39:28.580374Z\",\"ts\":\"2024-03-07T04:38:40.085451Z\",\"uid\":\"CyArTY2KEgcygwMLi1\",\"id.orig_h\":\"10.10.10.10\",\"id.orig_p\":123,\"id.resp_h\":\"20.20.20.20\",\"id.resp_p\":321,\"query\":\"time.missouri.edu\",\"qtype_name\":\"A\",\"num\":4}"
+      }
+    },
+    {
+      "integration": "cisco_nx_os",
+      "source": "system-message-logging#repeated-system-messages",
+      "origin": "cisco-nx-os-docs",
+      "transport": "file",
+      "framing": "yearfirst_nopri",
+      "line": "2019 Mar 11 13:42:44 Cisco-customer %PTP-2-PTP_INCORRECT_PACKET_ON_SLAVE: Incorrect delay response packet received on slave interface Eth1/48 by 2c:5a:0f:ff:fe:51:e9:9f. Source Port Identity is 08:00:11:ff:fe:22:3e:4e. Requesting Port Identity is 00:1c:73:ff:ff:ee:f6:e5",
+      "want": {
+        "pri": -1,
+        "timestamp": "2019 Mar 11 13:42:44",
+        "hostname": "Cisco-customer",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "%PTP-2-PTP_INCORRECT_PACKET_ON_SLAVE: Incorrect delay response packet received on slave interface Eth1/48 by 2c:5a:0f:ff:fe:51:e9:9f. Source Port Identity is 08:00:11:ff:fe:22:3e:4e. Requesting Port Identity is 00:1c:73:ff:ff:ee:f6:e5"
+      }
+    },
+    {
+      "integration": "cisco_nx_os",
+      "source": "relay prepending its header to the NX-OS logfile form",
+      "origin": "synthesized",
+      "transport": "file",
+      "framing": "yearfirst_nopri",
+      "line": "2019 Mar 11 13:42:44 Cisco-customer Mar 11 13:42:44 %KERN-3-SYSTEM_MSG: TOTAL PORTS = 48",
+      "want": {
+        "pri": -1,
+        "timestamp": "2019 Mar 11 13:42:44",
+        "hostname": "Cisco-customer",
+        "appname": "-",
+        "procid": "-",
+        "msgid": "-",
+        "msg": "Mar 11 13:42:44 %KERN-3-SYSTEM_MSG: TOTAL PORTS = 48"
+      }
+    }
+  ]
+}

--- a/pkg/logs/internal/parsers/syslog/timestamp_variants_test.go
+++ b/pkg/logs/internal/parsers/syslog/timestamp_variants_test.go
@@ -12,10 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Each sample below is taken from the log-pipeline test fixtures of the
-// integration named in the case, i.e. these are formats real appliances emit.
-// Before these layouts were recognized, every header field came back as the
-// nilvalue and source routing on syslog.appname/hostname could not work.
+// Each sample below is quoted from the log-pipeline test fixtures of the
+// integration named in the case, except where a comment says otherwise, so these
+// are formats real appliances emit. Before these layouts were recognized, every
+// header field came back as the nilvalue and source routing on
+// syslog.appname/hostname could not work.
 func TestParseUnrecognizedTimestampLayouts(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -54,11 +55,25 @@ func TestParseUnrecognizedTimestampLayouts(t *testing.T) {
 			msg:       "payload",
 		},
 		{
+			// The fixture carries no PRI, which is the form NX-OS writes to its
+			// own logfile and hands to a relay.
 			name:      "cisco nx-os year first header",
-			line:      "<187>2024 Apr 04 08:05:06 MDS9148S-S4 %MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active",
+			line:      "2024 Apr 04 08:05:06 MDS9148S-S4 %MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active",
 			timestamp: "2024 Apr 04 08:05:06",
 			hostname:  "MDS9148S-S4",
 			appname:   nilvalue, // "%MODULE-..." is not a TAG
+			procid:    nilvalue,
+			msg:       "%MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active",
+		},
+		{
+			// Header shape from Cisco's MDS 9000 system management guide, which
+			// documents "<189>:2025 Mar 27 16:22:24 switch %SYSLOG-..." as the
+			// default format sent to a remote server. Note the colon after PRI.
+			name:      "cisco nx-os year first header, remote logging wire format",
+			line:      "<189>:2024 Apr 04 08:05:06 MDS9148S-S4 %MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active",
+			timestamp: "2024 Apr 04 08:05:06",
+			hostname:  "MDS9148S-S4",
+			appname:   nilvalue,
 			procid:    nilvalue,
 			msg:       "%MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active",
 		},
@@ -99,13 +114,26 @@ func TestParseUnrecognizedTimestampLayouts(t *testing.T) {
 			msg:       "CEF:0|Thycotic Software|Secret Server|11.7|10005|SECRET - EDIT|2|msg=x",
 		},
 		{
-			name:      "iso timestamp with numeric offset (ivanti connect secure)",
-			line:      `<134>2024-12-04T01:18:01-05:00 test.com PulseSecure[7]: {"message_id":"WEB20174"}`,
-			timestamp: "2024-12-04T01:18:01-05:00",
-			hostname:  "test.com",
-			appname:   "PulseSecure",
-			procid:    "7",
-			msg:       `{"message_id":"WEB20174"}`,
+			// Not every ASA emits "Z": this offset form is from a reported
+			// capture of an ASA running "logging timestamp rfc5424".
+			name:      "cisco asa iso timestamp with numeric offset",
+			line:      "<190>2020-07-16T09:39:32+02:00: %ASA-6-110002: Failed to locate egress interface for 192.0.2.1/443",
+			timestamp: "2020-07-16T09:39:32+02:00",
+			hostname:  nilvalue,
+			appname:   nilvalue,
+			procid:    nilvalue,
+			msg:       "%ASA-6-110002: Failed to locate egress interface for 192.0.2.1/443",
+		},
+		{
+			// Cisco's EMBLEM format puts a colon after the PRI as well. Documented
+			// in the ASA syslog guide as "<166>:2018-06-27T12:17:46Z: %ASA-...".
+			name:      "cisco asa emblem, colon after pri",
+			line:      "<166>:2018-06-27T12:17:46Z: %ASA-6-110002: Failed to locate egress interface for 192.0.2.1/443",
+			timestamp: "2018-06-27T12:17:46Z",
+			hostname:  nilvalue,
+			appname:   nilvalue,
+			procid:    nilvalue,
+			msg:       "%ASA-6-110002: Failed to locate egress interface for 192.0.2.1/443",
 		},
 	}
 
@@ -128,9 +156,11 @@ func TestParseUnrecognizedTimestampLayouts(t *testing.T) {
 	}
 }
 
-// Cisco ISE repeats the BSD timestamp after the management IP. The month
-// abbreviation of that second timestamp used to be extracted as the APP-NAME.
-func TestParseCiscoISEDoubleBSDHeader(t *testing.T) {
+// A relay that does not recognize an incoming line as already-formatted syslog
+// prepends its own timestamp and host, leaving two BSD headers. The month
+// abbreviation of the second one used to be extracted as the APP-NAME. The
+// sample is Cisco ISE, but any source behind such a relay can produce it.
+func TestParseDoubleBSDHeader(t *testing.T) {
 	line := "<184>Apr 27 11:16:44 172.0.0.10 Apr 27 11:16:44 xyz12 CISE_Passed_Authentications 0000000487 1 0"
 	msg, err := Parse([]byte(line))
 	require.NoError(t, err)
@@ -141,19 +171,14 @@ func TestParseCiscoISEDoubleBSDHeader(t *testing.T) {
 	assert.Equal(t, "Apr 27 11:16:44 xyz12 CISE_Passed_Authentications 0000000487 1 0", string(msg.Msg))
 }
 
-// Claroty CTD emits two spaces between the RFC 5424 VERSION and the TIMESTAMP.
-func TestParseRFC5424ExtraSpaceAfterVersion(t *testing.T) {
-	line := "<134>1  2025-05-13T04:57:18Z EMC syslog-healthcheck-Central - - - CEF:0|Claroty|CTD|5.0.1.0|HealthCheck|Health|0|k=v"
-	msg, err := Parse([]byte(line))
+// A colon after the PRI is only skipped when a timestamp follows it, so content
+// that merely starts with a colon keeps its leading colon in MSG.
+func TestColonAfterPRIWithoutTimestamp(t *testing.T) {
+	msg, err := Parse([]byte("<134>: not a timestamp"))
 	require.NoError(t, err)
 
-	assert.Equal(t, "1", msg.Version)
-	assert.Equal(t, "2025-05-13T04:57:18Z", msg.Timestamp)
-	assert.Equal(t, "EMC", msg.Hostname)
-	assert.Equal(t, "syslog-healthcheck-Central", msg.AppName)
-	assert.Equal(t, nilvalue, msg.ProcID)
-	assert.Equal(t, nilvalue, msg.MsgID)
-	assert.Equal(t, "CEF:0|Claroty|CTD|5.0.1.0|HealthCheck|Health|0|k=v", string(msg.Msg))
+	assert.Equal(t, nilvalue, msg.Timestamp)
+	assert.Equal(t, ": not a timestamp", string(msg.Msg))
 }
 
 func TestISOTimestampLen(t *testing.T) {

--- a/pkg/logs/internal/parsers/syslog/timestamp_variants_test.go
+++ b/pkg/logs/internal/parsers/syslog/timestamp_variants_test.go
@@ -17,6 +17,11 @@ import (
 // are formats real appliances emit. Before these layouts were recognized, every
 // header field came back as the nilvalue and source routing on
 // syslog.appname/hostname could not work.
+//
+// A sample carrying a PRI was captured off the wire and goes through Parse; one
+// without a PRI is a file rendering and goes through ParseBSDLine. That says
+// nothing about the sender: a PRI is mandatory on the wire, but the default file
+// templates of both rsyslog and syslog-ng omit it.
 func TestParseUnrecognizedTimestampLayouts(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -55,9 +60,9 @@ func TestParseUnrecognizedTimestampLayouts(t *testing.T) {
 			msg:       "payload",
 		},
 		{
-			// The fixture carries no PRI, which is the form NX-OS writes to its
-			// own logfile and hands to a relay.
-			name:      "cisco nx-os year first header",
+			// Cisco documents this PRI-less form as what NX-OS writes to its own
+			// logfile and console, separately from the wire format below.
+			name:      "cisco nx-os year first header, logfile form",
 			line:      "2024 Apr 04 08:05:06 MDS9148S-S4 %MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active",
 			timestamp: "2024 Apr 04 08:05:06",
 			hostname:  "MDS9148S-S4",
@@ -105,7 +110,10 @@ func TestParseUnrecognizedTimestampLayouts(t *testing.T) {
 			msg:       `{"common":{"unique_id":"609249cb"}}`,
 		},
 		{
-			name:      "iso timestamp with fractional seconds and host (delinea secret server)",
+			// Delinea documents the ISO timestamp and the CEF payload but not the
+			// framing; the fixture has no PRI, which is what rsyslog's file
+			// template produces, so read this as the tailed-file form.
+			name:      "iso timestamp with fractional seconds, no pri (delinea secret server)",
 			line:      "2025-02-26T06:47:27.458Z DSS-01 CEF:0|Thycotic Software|Secret Server|11.7|10005|SECRET - EDIT|2|msg=x",
 			timestamp: "2025-02-26T06:47:27.458Z",
 			hostname:  "DSS-01",

--- a/pkg/logs/internal/parsers/syslog/timestamp_variants_test.go
+++ b/pkg/logs/internal/parsers/syslog/timestamp_variants_test.go
@@ -14,9 +14,9 @@ import (
 
 // Each sample below is quoted from the log-pipeline test fixtures of the
 // integration named in the case, except where a comment says otherwise, so these
-// are formats real appliances emit. Before these layouts were recognized, every
-// header field came back as the nilvalue and source routing on
-// syslog.appname/hostname could not work.
+// are formats real appliances emit. A layout that goes unrecognized costs the
+// message every header field — they all come back as the nilvalue — and source
+// routing on syslog.appname/hostname stops working.
 //
 // A sample carrying a PRI was captured off the wire and goes through Parse; one
 // without a PRI is a file rendering and goes through ParseBSDLine. That says
@@ -60,27 +60,29 @@ func TestParseUnrecognizedTimestampLayouts(t *testing.T) {
 			msg:       "payload",
 		},
 		{
-			// Cisco documents this PRI-less form as what NX-OS writes to its own
-			// logfile and console, separately from the wire format below.
+			// Header and hostname as printed in Cisco's Nexus 9000 system message
+			// logging guide, which shows this PRI-less form as what NX-OS writes
+			// to its own logfile and console, separately from the wire format
+			// below.
 			name:      "cisco nx-os year first header, logfile form",
-			line:      "2024 Apr 04 08:05:06 MDS9148S-S4 %MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active",
-			timestamp: "2024 Apr 04 08:05:06",
-			hostname:  "MDS9148S-S4",
-			appname:   nilvalue, // "%MODULE-..." is not a TAG
+			line:      "2019 Mar 11 13:42:44 Cisco-customer %ETHPORT-5-IF_DOWN_ADMIN_DOWN: Interface Ethernet3/1 is down (Administratively down)",
+			timestamp: "2019 Mar 11 13:42:44",
+			hostname:  "Cisco-customer",
+			appname:   nilvalue, // "%ETHPORT-..." is not a TAG
 			procid:    nilvalue,
-			msg:       "%MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active",
+			msg:       "%ETHPORT-5-IF_DOWN_ADMIN_DOWN: Interface Ethernet3/1 is down (Administratively down)",
 		},
 		{
 			// Header shape from Cisco's MDS 9000 system management guide, which
 			// documents "<189>:2025 Mar 27 16:22:24 switch %SYSLOG-..." as the
 			// default format sent to a remote server. Note the colon after PRI.
 			name:      "cisco nx-os year first header, remote logging wire format",
-			line:      "<189>:2024 Apr 04 08:05:06 MDS9148S-S4 %MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active",
-			timestamp: "2024 Apr 04 08:05:06",
-			hostname:  "MDS9148S-S4",
+			line:      "<189>:2019 Mar 11 13:42:44 Cisco-customer %ETHPORT-5-IF_DOWN_ADMIN_DOWN: Interface Ethernet3/1 is down (Administratively down)",
+			timestamp: "2019 Mar 11 13:42:44",
+			hostname:  "Cisco-customer",
 			appname:   nilvalue,
 			procid:    nilvalue,
-			msg:       "%MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active",
+			msg:       "%ETHPORT-5-IF_DOWN_ADMIN_DOWN: Interface Ethernet3/1 is down (Administratively down)",
 		},
 		{
 			name:      "cisco asa iso timestamp then colon, no host or tag",
@@ -101,11 +103,14 @@ func TestParseUnrecognizedTimestampLayouts(t *testing.T) {
 			msg:       "%FTD-6-113039: Group RemoteUsers User harper.green IP 8.8.4.4",
 		},
 		{
-			name:      "picus iso timestamp with host and tag",
-			line:      `<6>2025-02-17T06:46:46Z app.picussecurity.com PICUS[1]: {"common":{"unique_id":"609249cb"}}`,
+			// The ISO variant with a full HOSTNAME and a TAG[PID], which several
+			// appliances emit under an rfc5424-style timestamp setting. Values
+			// are synthetic; only the header shape is under test.
+			name:      "iso timestamp with host and tag",
+			line:      `<6>2025-02-17T06:46:46Z app.example.com APPLIANCE[1]: {"common":{"unique_id":"609249cb"}}`,
 			timestamp: "2025-02-17T06:46:46Z",
-			hostname:  "app.picussecurity.com",
-			appname:   "PICUS",
+			hostname:  "app.example.com",
+			appname:   "APPLIANCE",
 			procid:    "1",
 			msg:       `{"common":{"unique_id":"609249cb"}}`,
 		},
@@ -179,22 +184,24 @@ func TestParseUnrecognizedTimestampLayouts(t *testing.T) {
 		},
 		{
 			// ASA under "logging timestamp" writes the legacy MMM dd yyyy
-			// HH:mm:ss form and terminates it with a colon, with no Device-ID.
-			// The existing colon skip only covered the ISO timestamp, so this
-			// variant used to fail with "BSD: missing hostname".
+			// HH:mm:ss form and terminates it with a colon, with no Device-ID,
+			// so separator handling has to cover the BSD layouts too, not only
+			// the ISO timestamp the same appliance emits under rfc5424.
+			// Message body follows the 302013 template in Cisco's ASA syslog
+			// messages guide, with documentation addresses.
 			name:      "cisco asa legacy timestamp then colon, no host or tag",
-			line:      "<166>May 17 2023 03:04:28: %ASA-6-302013: Built outbound TCP connection 704117",
+			line:      "<166>May 17 2023 03:04:28: %ASA-6-302013: Built outbound TCP connection 1 for outside:192.0.2.1/80 to inside:198.51.100.2/1024",
 			timestamp: "May 17 2023 03:04:28",
 			hostname:  nilvalue,
 			appname:   nilvalue,
 			procid:    nilvalue,
-			msg:       "%ASA-6-302013: Built outbound TCP connection 704117",
+			msg:       "%ASA-6-302013: Built outbound TCP connection 1 for outside:192.0.2.1/80 to inside:198.51.100.2/1024",
 		},
 		{
 			// Legacy timestamp with the Device-ID still enabled, quoted from the
-			// FTD syslog guide. The Device-ID is a real hostname and must keep
-			// being read as one. The separating " : " is left in MSG exactly as it
-			// was before mnemonic detection existed.
+			// FTD syslog guide. The Device-ID is a real hostname and must be read
+			// as one; only the separator that stands in for an absent Device-ID
+			// is consumed, so the " : " that follows a present one stays in MSG.
 			name:      "cisco ftd with device id keeps hostname",
 			line:      "Apr 10 18:52:47 labuser-ftdv : %FTD-6-305012: Teardown dynamic UDP translation",
 			timestamp: "Apr 10 18:52:47",
@@ -235,9 +242,9 @@ func TestColonAfterPRIWithoutTimestamp(t *testing.T) {
 }
 
 // Formats that place something other than a HOSTNAME in the HOSTNAME position.
-// Each of these used to parse without error while attributing fields wrongly,
-// which is worse than failing: syslog.hostname and syslog.appname drive source
-// and service routing, so a bogus value silently misroutes the log.
+// Each of these parses without error, so a misattribution here is worse than a
+// failure: syslog.hostname and syslog.appname drive source and service routing,
+// and a bogus value misroutes the log with nothing to signal it.
 func TestNoHostnameInHostnamePosition(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -250,8 +257,8 @@ func TestNoHostnameInHostnamePosition(t *testing.T) {
 	}{
 		{
 			// BIND with print-category/print-severity emits
-			// "<category>: <severity>: <message>" and no hostname at all.
-			// "network:" was being read as the HOSTNAME and "info" as the TAG.
+			// "<category>: <severity>: <message>" and no hostname at all, so
+			// the category is the TAG and the severity belongs to the body.
 			name:      "bind9 category in hostname position",
 			line:      "2024-09-20T10:20:26.751Z network: info: no longer listening on 10.10.10.10#50",
 			timestamp: "2024-09-20T10:20:26.751Z",
@@ -261,9 +268,8 @@ func TestNoHostnameInHostnamePosition(t *testing.T) {
 			msg:       "info: no longer listening on 10.10.10.10#50",
 		},
 		{
-			// A yum transaction line tailed by Wazuh. This previously produced
-			// hostname="Erased:", appname="libhugetlbfs-lib" and an empty MSG,
-			// dropping the body outright.
+			// A yum transaction line tailed by Wazuh: the action sits in the
+			// HOSTNAME position and the package name is the whole body.
 			name:      "yum action in hostname position",
 			line:      "Aug 20 12:51:21 Erased: libhugetlbfs-lib",
 			timestamp: "Aug 20 12:51:21",
@@ -301,44 +307,44 @@ func TestNoHostnameInHostnamePosition(t *testing.T) {
 // mined for an APP-NAME.
 func TestRelayDoubleHeader(t *testing.T) {
 	t.Run("bsd timestamp in tag position", func(t *testing.T) {
-		line := "May 31 14:06:58 10.50.3.134 May 31 08:36:58 ISELAB CISE_System_Statistics 0000000718"
+		line := "May 31 14:06:58 10.50.3.134 May 31 08:36:58 ise CISE_System_Statistics 0000000718"
 		msg, err := ParseBSDLine([]byte(line))
 		require.NoError(t, err)
 
 		assert.Equal(t, "May 31 14:06:58", msg.Timestamp)
 		assert.Equal(t, "10.50.3.134", msg.Hostname)
 		assert.Equal(t, nilvalue, msg.AppName, "the month abbrev is not an appname")
-		assert.Equal(t, "May 31 08:36:58 ISELAB CISE_System_Statistics 0000000718", string(msg.Msg))
+		assert.Equal(t, "May 31 08:36:58 ise CISE_System_Statistics 0000000718", string(msg.Msg))
 	})
 
 	t.Run("bsd timestamp in tag position after year-first header", func(t *testing.T) {
-		line := "2009 Oct 11 08:05:22 MDS9148S-S4 Oct 11 08:05:22 %KERN-3-SYSTEM_MSG: TOTAL PORTS = 48"
+		line := "2019 Mar 11 13:42:44 Cisco-customer Mar 11 13:42:44 %KERN-3-SYSTEM_MSG: TOTAL PORTS = 48"
 		msg, err := ParseBSDLine([]byte(line))
 		require.NoError(t, err)
 
-		assert.Equal(t, "2009 Oct 11 08:05:22", msg.Timestamp)
-		assert.Equal(t, "MDS9148S-S4", msg.Hostname)
+		assert.Equal(t, "2019 Mar 11 13:42:44", msg.Timestamp)
+		assert.Equal(t, "Cisco-customer", msg.Hostname)
 		assert.Equal(t, nilvalue, msg.AppName)
-		assert.Equal(t, "Oct 11 08:05:22 %KERN-3-SYSTEM_MSG: TOTAL PORTS = 48", string(msg.Msg))
+		assert.Equal(t, "Mar 11 13:42:44 %KERN-3-SYSTEM_MSG: TOTAL PORTS = 48", string(msg.Msg))
 	})
 }
 
 // RFC 5424 mandates a single SP between HEADER fields. Padding must not shift
-// the fields along, which previously left TIMESTAMP as the empty string and
-// moved every other value one position to the right.
+// the fields along, leaving TIMESTAMP empty and moving every other value one
+// position to the right.
 func TestRFC5424PaddedHeaderSeparators(t *testing.T) {
-	line := "<134>1  2025-05-13T04:57:18Z EMC syslog-healthcheck-Central - - - CEF:0|Claroty|CTD|5.0.1.0|HealthCheck"
+	line := "<134>1  2025-05-13T04:57:18Z host01 syslog-healthcheck - - - CEF:0|Vendor|Product|1.0|HealthCheck"
 	msg, err := Parse([]byte(line))
 	require.NoError(t, err)
 
 	assert.Equal(t, 134, msg.Pri)
 	assert.Equal(t, "1", msg.Version)
 	assert.Equal(t, "2025-05-13T04:57:18Z", msg.Timestamp)
-	assert.Equal(t, "EMC", msg.Hostname)
-	assert.Equal(t, "syslog-healthcheck-Central", msg.AppName)
+	assert.Equal(t, "host01", msg.Hostname)
+	assert.Equal(t, "syslog-healthcheck", msg.AppName)
 	assert.Equal(t, nilvalue, msg.ProcID)
 	assert.Equal(t, nilvalue, msg.MsgID)
-	assert.Equal(t, "CEF:0|Claroty|CTD|5.0.1.0|HealthCheck", string(msg.Msg))
+	assert.Equal(t, "CEF:0|Vendor|Product|1.0|HealthCheck", string(msg.Msg))
 }
 
 // A TAG is only recognized by its terminator. Without one there is no TAG, and
@@ -366,9 +372,8 @@ func TestIPv6HostnameIsNotATag(t *testing.T) {
 }
 
 // Skipping the gap before a Cisco mnemonic must not turn into a general
-// tolerance for ragged whitespace: anything that is not a mnemonic is still
-// read as a HOSTNAME, and a run of spaces followed by a non-mnemonic still
-// fails exactly as it did before.
+// tolerance for ragged whitespace: anything that is not a mnemonic is read as
+// a HOSTNAME, and a run of spaces followed by a non-mnemonic is still an error.
 func TestCiscoMnemonicDoesNotOverCapture(t *testing.T) {
 	t.Run("padded gap before a non-mnemonic still fails", func(t *testing.T) {
 		_, err := ParseBSDLine([]byte("2024-01-05T05:45:16Z   somehost app: payload"))
@@ -428,7 +433,7 @@ func TestSkipCiscoSeparator(t *testing.T) {
 		{" : %FTD", 3},
 		{"  :  %FTD", 5},
 		{" :%FTD", 2},
-		{":%FTD", 1},  // ASA writes the colon with no preceding space
+		{":%FTD", 1}, // ASA writes the colon with no preceding space
 		{": %FTD", 2},
 		{"%FTD", 0},   // neither space nor colon, nothing consumed
 		{"::%FTD", 1}, // only one colon belongs to the separator

--- a/pkg/logs/internal/parsers/syslog/timestamp_variants_test.go
+++ b/pkg/logs/internal/parsers/syslog/timestamp_variants_test.go
@@ -231,6 +231,41 @@ func TestParseUnrecognizedTimestampLayouts(t *testing.T) {
 	}
 }
 
+// The colon ASA writes after an ISO timestamp is skipped whatever follows it,
+// not only a Cisco mnemonic. Every ASA and FTD sample happens to carry one, so
+// nothing else in the suite covers the general case: drop this handling and a
+// body the mnemonic check does not recognize is lost along with the message.
+func TestISOTimestampColonWithoutMnemonic(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		msg  string
+	}{
+		{
+			name: "space after the colon",
+			line: "<190>2025-11-25T07:19:40Z: connection teardown, no mnemonic",
+			msg:  "connection teardown, no mnemonic",
+		},
+		{
+			name: "no space after the colon",
+			line: "<190>2025-11-25T07:19:40Z:connection teardown, no mnemonic",
+			msg:  "connection teardown, no mnemonic",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg, err := Parse([]byte(tc.line))
+			require.NoError(t, err)
+
+			assert.Equal(t, "2025-11-25T07:19:40Z", msg.Timestamp)
+			assert.Equal(t, nilvalue, msg.Hostname)
+			assert.Equal(t, nilvalue, msg.AppName)
+			assert.Equal(t, tc.msg, string(msg.Msg), "the body must reach MSG")
+		})
+	}
+}
+
 // A colon after the PRI is only skipped when a timestamp follows it, so content
 // that merely starts with a colon keeps its leading colon in MSG.
 func TestColonAfterPRIWithoutTimestamp(t *testing.T) {

--- a/pkg/logs/internal/parsers/syslog/timestamp_variants_test.go
+++ b/pkg/logs/internal/parsers/syslog/timestamp_variants_test.go
@@ -1,0 +1,202 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package syslog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Each sample below is taken from the log-pipeline test fixtures of the
+// integration named in the case, i.e. these are formats real appliances emit.
+// Before these layouts were recognized, every header field came back as the
+// nilvalue and source routing on syslog.appname/hostname could not work.
+func TestParseUnrecognizedTimestampLayouts(t *testing.T) {
+	cases := []struct {
+		name      string
+		line      string
+		timestamp string
+		hostname  string
+		appname   string
+		procid    string
+		msg       string
+	}{
+		{
+			name:      "non-padded single digit day (beyondtrust privileged remote access)",
+			line:      "<133>Jan 9 03:47:40 pf60fc91 BG[81869] 1427:01:01:event=fido2_credential_added",
+			timestamp: "Jan 9 03:47:40",
+			hostname:  "pf60fc91",
+			appname:   "BG",
+			procid:    "81869",
+			msg:       "1427:01:01:event=fido2_credential_added",
+		},
+		{
+			name:      "non-padded single digit day (infoblox ddi)",
+			line:      "<30>Mar 7 08:32:59 infoblox.localdomain dhcpd[20397]: DHCPDECLINE of 1.1.1.1",
+			timestamp: "Mar 7 08:32:59",
+			hostname:  "infoblox.localdomain",
+			appname:   "dhcpd",
+			procid:    "20397",
+			msg:       "DHCPDECLINE of 1.1.1.1",
+		},
+		{
+			name:      "space padded day still parses (rfc 3164 conformant)",
+			line:      "<133>Jan  9 03:47:40 pf60fc91 BG[81869] payload",
+			timestamp: "Jan  9 03:47:40",
+			hostname:  "pf60fc91",
+			appname:   "BG",
+			procid:    "81869",
+			msg:       "payload",
+		},
+		{
+			name:      "cisco nx-os year first header",
+			line:      "<187>2024 Apr 04 08:05:06 MDS9148S-S4 %MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active",
+			timestamp: "2024 Apr 04 08:05:06",
+			hostname:  "MDS9148S-S4",
+			appname:   nilvalue, // "%MODULE-..." is not a TAG
+			procid:    nilvalue,
+			msg:       "%MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active",
+		},
+		{
+			name:      "cisco asa iso timestamp then colon, no host or tag",
+			line:      "<190>2025-11-25T07:17:18Z: %ASA-4-733102: Threat-detection adds host 192.0.2.3 to shun list",
+			timestamp: "2025-11-25T07:17:18Z",
+			hostname:  nilvalue,
+			appname:   nilvalue,
+			procid:    nilvalue,
+			msg:       "%ASA-4-733102: Threat-detection adds host 192.0.2.3 to shun list",
+		},
+		{
+			name:      "cisco ftd iso timestamp then colon",
+			line:      "<190>2025-12-05T10:51:21Z: %FTD-6-113039: Group RemoteUsers User harper.green IP 8.8.4.4",
+			timestamp: "2025-12-05T10:51:21Z",
+			hostname:  nilvalue,
+			appname:   nilvalue,
+			procid:    nilvalue,
+			msg:       "%FTD-6-113039: Group RemoteUsers User harper.green IP 8.8.4.4",
+		},
+		{
+			name:      "picus iso timestamp with host and tag",
+			line:      `<6>2025-02-17T06:46:46Z app.picussecurity.com PICUS[1]: {"common":{"unique_id":"609249cb"}}`,
+			timestamp: "2025-02-17T06:46:46Z",
+			hostname:  "app.picussecurity.com",
+			appname:   "PICUS",
+			procid:    "1",
+			msg:       `{"common":{"unique_id":"609249cb"}}`,
+		},
+		{
+			name:      "iso timestamp with fractional seconds and host (delinea secret server)",
+			line:      "2025-02-26T06:47:27.458Z DSS-01 CEF:0|Thycotic Software|Secret Server|11.7|10005|SECRET - EDIT|2|msg=x",
+			timestamp: "2025-02-26T06:47:27.458Z",
+			hostname:  "DSS-01",
+			appname:   nilvalue, // CEF body is not a TAG
+			procid:    nilvalue,
+			msg:       "CEF:0|Thycotic Software|Secret Server|11.7|10005|SECRET - EDIT|2|msg=x",
+		},
+		{
+			name:      "iso timestamp with numeric offset (ivanti connect secure)",
+			line:      `<134>2024-12-04T01:18:01-05:00 test.com PulseSecure[7]: {"message_id":"WEB20174"}`,
+			timestamp: "2024-12-04T01:18:01-05:00",
+			hostname:  "test.com",
+			appname:   "PulseSecure",
+			procid:    "7",
+			msg:       `{"message_id":"WEB20174"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var msg SyslogMessage
+			var err error
+			if tc.line[0] == '<' {
+				msg, err = Parse([]byte(tc.line))
+			} else {
+				msg, err = ParseBSDLine([]byte(tc.line))
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.timestamp, msg.Timestamp, "timestamp")
+			assert.Equal(t, tc.hostname, msg.Hostname, "hostname")
+			assert.Equal(t, tc.appname, msg.AppName, "appname")
+			assert.Equal(t, tc.procid, msg.ProcID, "procid")
+			assert.Equal(t, tc.msg, string(msg.Msg), "msg")
+		})
+	}
+}
+
+// Cisco ISE repeats the BSD timestamp after the management IP. The month
+// abbreviation of that second timestamp used to be extracted as the APP-NAME.
+func TestParseCiscoISEDoubleBSDHeader(t *testing.T) {
+	line := "<184>Apr 27 11:16:44 172.0.0.10 Apr 27 11:16:44 xyz12 CISE_Passed_Authentications 0000000487 1 0"
+	msg, err := Parse([]byte(line))
+	require.NoError(t, err)
+
+	assert.Equal(t, "Apr 27 11:16:44", msg.Timestamp)
+	assert.Equal(t, "172.0.0.10", msg.Hostname)
+	assert.Equal(t, nilvalue, msg.AppName, "the second timestamp must not become the appname")
+	assert.Equal(t, "Apr 27 11:16:44 xyz12 CISE_Passed_Authentications 0000000487 1 0", string(msg.Msg))
+}
+
+// Claroty CTD emits two spaces between the RFC 5424 VERSION and the TIMESTAMP.
+func TestParseRFC5424ExtraSpaceAfterVersion(t *testing.T) {
+	line := "<134>1  2025-05-13T04:57:18Z EMC syslog-healthcheck-Central - - - CEF:0|Claroty|CTD|5.0.1.0|HealthCheck|Health|0|k=v"
+	msg, err := Parse([]byte(line))
+	require.NoError(t, err)
+
+	assert.Equal(t, "1", msg.Version)
+	assert.Equal(t, "2025-05-13T04:57:18Z", msg.Timestamp)
+	assert.Equal(t, "EMC", msg.Hostname)
+	assert.Equal(t, "syslog-healthcheck-Central", msg.AppName)
+	assert.Equal(t, nilvalue, msg.ProcID)
+	assert.Equal(t, nilvalue, msg.MsgID)
+	assert.Equal(t, "CEF:0|Claroty|CTD|5.0.1.0|HealthCheck|Health|0|k=v", string(msg.Msg))
+}
+
+func TestISOTimestampLen(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"2025-11-25T07:19:40Z", 20},
+		{"2025-11-25T07:19:40Z rest", 20},
+		{"2025-02-26T06:47:27.458Z", 24},
+		{"2024-12-04T01:18:01-05:00", 25},
+		{"2024-12-04T01:18:01-0500", 24},
+		{"2024-12-04T01:18:01", 19},
+		{"2024-12-04T01:18:01.", 19}, // dangling '.' is not fractional seconds
+		{"2024-12-04 01:18:01", 0},   // space separator is not accepted
+		{"2024-12-04T01:18", 0},      // too short
+		{"2024 Apr 04 08:05:06", 0},  // year-first BSD, not ISO
+		{"Jan  9 03:47:40", 0},       // BSD
+		{"20251125T071940Z", 0},      // basic format not accepted
+		{"2025-13-25T07:19:40Z", 20}, // structural check only, not calendar validation
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, isoTimestampLen([]byte(tc.in)), "input %q", tc.in)
+	}
+}
+
+func TestBSDTimestampLen(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"Jan  9 03:47:40", 15},
+		{"Jan 09 03:47:40", 15},
+		{"Jan 9 03:47:40", 14},
+		{"Apr 04 2024 08:05:06", 20},
+		{"2024 Apr 04 08:05:06", 20},
+		{"2024 Apr  4 08:05:06", 20},
+		{"December sales were up", 0},
+		{"Jan 9 03-47-40", 0},
+		{"2024-04-04T08:05:06Z", 0},
+		{"", 0},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, bsdTimestampLen([]byte(tc.in)), "input %q", tc.in)
+	}
+}

--- a/pkg/logs/internal/parsers/syslog/timestamp_variants_test.go
+++ b/pkg/logs/internal/parsers/syslog/timestamp_variants_test.go
@@ -143,6 +143,66 @@ func TestParseUnrecognizedTimestampLayouts(t *testing.T) {
 			procid:    nilvalue,
 			msg:       "%ASA-6-110002: Failed to locate egress interface for 192.0.2.1/443",
 		},
+		{
+			// "logging device-id" is off, so the Device-ID field is empty and only
+			// whitespace separates the timestamp from the mnemonic. Cisco's syslog
+			// guide tells collectors to allow an optional colon here "followed by
+			// zero or more spaces", so the gap width carries no meaning. Sample is
+			// from the cisco_secure_firewall pipeline fixtures.
+			name:      "cisco ftd no device id, padded gap before mnemonic",
+			line:      "2024-01-05T05:45:16Z   %FTD-1-430003: EventPriority: Low, SrcIP: 10.40.1.16",
+			timestamp: "2024-01-05T05:45:16Z",
+			hostname:  nilvalue,
+			appname:   nilvalue,
+			procid:    nilvalue,
+			msg:       "%FTD-1-430003: EventPriority: Low, SrcIP: 10.40.1.16",
+		},
+		{
+			name:      "cisco ftd no device id, single space before mnemonic",
+			line:      "<181>2024-01-05T05:45:16Z %FTD-1-430003: EventPriority: Low",
+			timestamp: "2024-01-05T05:45:16Z",
+			hostname:  nilvalue,
+			appname:   nilvalue,
+			procid:    nilvalue,
+			msg:       "%FTD-1-430003: EventPriority: Low",
+		},
+		{
+			// FTD 7.0.5+/7.2+ add a colon between the (absent) Device-ID and the
+			// mnemonic.
+			name:      "cisco ftd no device id, colon before mnemonic",
+			line:      "2024-01-05T05:45:16Z : %FTD-1-430003: EventPriority: Low",
+			timestamp: "2024-01-05T05:45:16Z",
+			hostname:  nilvalue,
+			appname:   nilvalue,
+			procid:    nilvalue,
+			msg:       "%FTD-1-430003: EventPriority: Low",
+		},
+		{
+			// ASA under "logging timestamp" writes the legacy MMM dd yyyy
+			// HH:mm:ss form and terminates it with a colon, with no Device-ID.
+			// The existing colon skip only covered the ISO timestamp, so this
+			// variant used to fail with "BSD: missing hostname".
+			name:      "cisco asa legacy timestamp then colon, no host or tag",
+			line:      "<166>May 17 2023 03:04:28: %ASA-6-302013: Built outbound TCP connection 704117",
+			timestamp: "May 17 2023 03:04:28",
+			hostname:  nilvalue,
+			appname:   nilvalue,
+			procid:    nilvalue,
+			msg:       "%ASA-6-302013: Built outbound TCP connection 704117",
+		},
+		{
+			// Legacy timestamp with the Device-ID still enabled, quoted from the
+			// FTD syslog guide. The Device-ID is a real hostname and must keep
+			// being read as one. The separating " : " is left in MSG exactly as it
+			// was before mnemonic detection existed.
+			name:      "cisco ftd with device id keeps hostname",
+			line:      "Apr 10 18:52:47 labuser-ftdv : %FTD-6-305012: Teardown dynamic UDP translation",
+			timestamp: "Apr 10 18:52:47",
+			hostname:  "labuser-ftdv",
+			appname:   nilvalue,
+			procid:    nilvalue,
+			msg:       ": %FTD-6-305012: Teardown dynamic UDP translation",
+		},
 	}
 
 	for _, tc := range cases {
@@ -172,6 +232,212 @@ func TestColonAfterPRIWithoutTimestamp(t *testing.T) {
 
 	assert.Equal(t, nilvalue, msg.Timestamp)
 	assert.Equal(t, ": not a timestamp", string(msg.Msg))
+}
+
+// Formats that place something other than a HOSTNAME in the HOSTNAME position.
+// Each of these used to parse without error while attributing fields wrongly,
+// which is worse than failing: syslog.hostname and syslog.appname drive source
+// and service routing, so a bogus value silently misroutes the log.
+func TestNoHostnameInHostnamePosition(t *testing.T) {
+	cases := []struct {
+		name      string
+		line      string
+		timestamp string
+		hostname  string
+		appname   string
+		procid    string
+		msg       string
+	}{
+		{
+			// BIND with print-category/print-severity emits
+			// "<category>: <severity>: <message>" and no hostname at all.
+			// "network:" was being read as the HOSTNAME and "info" as the TAG.
+			name:      "bind9 category in hostname position",
+			line:      "2024-09-20T10:20:26.751Z network: info: no longer listening on 10.10.10.10#50",
+			timestamp: "2024-09-20T10:20:26.751Z",
+			hostname:  nilvalue,
+			appname:   "network",
+			procid:    nilvalue,
+			msg:       "info: no longer listening on 10.10.10.10#50",
+		},
+		{
+			// A yum transaction line tailed by Wazuh. This previously produced
+			// hostname="Erased:", appname="libhugetlbfs-lib" and an empty MSG,
+			// dropping the body outright.
+			name:      "yum action in hostname position",
+			line:      "Aug 20 12:51:21 Erased: libhugetlbfs-lib",
+			timestamp: "Aug 20 12:51:21",
+			hostname:  nilvalue,
+			appname:   "Erased",
+			procid:    nilvalue,
+			msg:       "libhugetlbfs-lib",
+		},
+		{
+			name:      "tag with pid in hostname position",
+			line:      "Aug 20 12:51:21 sshd[1234]: Accepted publickey for root",
+			timestamp: "Aug 20 12:51:21",
+			hostname:  nilvalue,
+			appname:   "sshd",
+			procid:    "1234",
+			msg:       "Accepted publickey for root",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg, err := ParseBSDLine([]byte(tc.line))
+			require.NoError(t, err)
+			assert.Equal(t, tc.timestamp, msg.Timestamp, "timestamp")
+			assert.Equal(t, tc.hostname, msg.Hostname, "hostname")
+			assert.Equal(t, tc.appname, msg.AppName, "appname")
+			assert.Equal(t, tc.procid, msg.ProcID, "procid")
+			assert.Equal(t, tc.msg, string(msg.Msg), "msg")
+		})
+	}
+}
+
+// A relay that prepends its own header leaves the originating device's header
+// in place. The second timestamp sits where a TAG would be, and must not be
+// mined for an APP-NAME.
+func TestRelayDoubleHeader(t *testing.T) {
+	t.Run("bsd timestamp in tag position", func(t *testing.T) {
+		line := "May 31 14:06:58 10.50.3.134 May 31 08:36:58 ISELAB CISE_System_Statistics 0000000718"
+		msg, err := ParseBSDLine([]byte(line))
+		require.NoError(t, err)
+
+		assert.Equal(t, "May 31 14:06:58", msg.Timestamp)
+		assert.Equal(t, "10.50.3.134", msg.Hostname)
+		assert.Equal(t, nilvalue, msg.AppName, "the month abbrev is not an appname")
+		assert.Equal(t, "May 31 08:36:58 ISELAB CISE_System_Statistics 0000000718", string(msg.Msg))
+	})
+
+	t.Run("bsd timestamp in tag position after year-first header", func(t *testing.T) {
+		line := "2009 Oct 11 08:05:22 MDS9148S-S4 Oct 11 08:05:22 %KERN-3-SYSTEM_MSG: TOTAL PORTS = 48"
+		msg, err := ParseBSDLine([]byte(line))
+		require.NoError(t, err)
+
+		assert.Equal(t, "2009 Oct 11 08:05:22", msg.Timestamp)
+		assert.Equal(t, "MDS9148S-S4", msg.Hostname)
+		assert.Equal(t, nilvalue, msg.AppName)
+		assert.Equal(t, "Oct 11 08:05:22 %KERN-3-SYSTEM_MSG: TOTAL PORTS = 48", string(msg.Msg))
+	})
+}
+
+// RFC 5424 mandates a single SP between HEADER fields. Padding must not shift
+// the fields along, which previously left TIMESTAMP as the empty string and
+// moved every other value one position to the right.
+func TestRFC5424PaddedHeaderSeparators(t *testing.T) {
+	line := "<134>1  2025-05-13T04:57:18Z EMC syslog-healthcheck-Central - - - CEF:0|Claroty|CTD|5.0.1.0|HealthCheck"
+	msg, err := Parse([]byte(line))
+	require.NoError(t, err)
+
+	assert.Equal(t, 134, msg.Pri)
+	assert.Equal(t, "1", msg.Version)
+	assert.Equal(t, "2025-05-13T04:57:18Z", msg.Timestamp)
+	assert.Equal(t, "EMC", msg.Hostname)
+	assert.Equal(t, "syslog-healthcheck-Central", msg.AppName)
+	assert.Equal(t, nilvalue, msg.ProcID)
+	assert.Equal(t, nilvalue, msg.MsgID)
+	assert.Equal(t, "CEF:0|Claroty|CTD|5.0.1.0|HealthCheck", string(msg.Msg))
+}
+
+// A TAG is only recognized by its terminator. Without one there is no TAG, and
+// the remainder must reach MSG rather than being claimed as an APP-NAME and
+// silently dropped.
+func TestDelimiterlessTagIsContent(t *testing.T) {
+	msg, err := ParseBSDLine([]byte("Aug 20 12:51:21 myhost libhugetlbfs-lib"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "myhost", msg.Hostname)
+	assert.Equal(t, nilvalue, msg.AppName)
+	assert.Equal(t, "libhugetlbfs-lib", string(msg.Msg))
+}
+
+// An IPv6 address may end in "::", which must not be mistaken for a TAG
+// terminator and cost the message its HOSTNAME.
+func TestIPv6HostnameIsNotATag(t *testing.T) {
+	msg, err := ParseBSDLine([]byte("Aug 20 12:51:21 2001:db8:: sshd[1]: payload"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "2001:db8::", msg.Hostname)
+	assert.Equal(t, "sshd", msg.AppName)
+	assert.Equal(t, "1", msg.ProcID)
+	assert.Equal(t, "payload", string(msg.Msg))
+}
+
+// Skipping the gap before a Cisco mnemonic must not turn into a general
+// tolerance for ragged whitespace: anything that is not a mnemonic is still
+// read as a HOSTNAME, and a run of spaces followed by a non-mnemonic still
+// fails exactly as it did before.
+func TestCiscoMnemonicDoesNotOverCapture(t *testing.T) {
+	t.Run("padded gap before a non-mnemonic still fails", func(t *testing.T) {
+		_, err := ParseBSDLine([]byte("2024-01-05T05:45:16Z   somehost app: payload"))
+		assert.ErrorIs(t, err, errBSDHostname)
+	})
+
+	t.Run("token starting with percent but not a mnemonic is a hostname", func(t *testing.T) {
+		msg, err := ParseBSDLine([]byte("2024-01-05T05:45:16Z %notamnemonic payload"))
+		require.NoError(t, err)
+		assert.Equal(t, "%notamnemonic", msg.Hostname)
+	})
+
+	t.Run("ordinary hostname is untouched", func(t *testing.T) {
+		msg, err := ParseBSDLine([]byte("2024-01-05T05:45:16Z firepower sshd[42]: payload"))
+		require.NoError(t, err)
+		assert.Equal(t, "firepower", msg.Hostname)
+		assert.Equal(t, "sshd", msg.AppName)
+		assert.Equal(t, "42", msg.ProcID)
+		assert.Equal(t, "payload", string(msg.Msg))
+	})
+}
+
+func TestStartsWithCiscoMnemonic(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"%FTD-1-430003: EventPriority: Low", true},
+		{"%ASA-6-302013: Built outbound TCP connection", true},
+		{"%MODULE-5-ACTIVE_SUP_OK: Supervisor 1 is active", true},
+		{"%ETHPORT-5-IF_DOWN_CFG_CHANGE: Interface down", true},
+		{"%FTD-1-430003", true},  // trailing colon is not required
+		{"%FTD-8-430003", false}, // severity is a single 0-7 digit
+		{"%FTD--430003", false},  // severity missing
+		{"%FTD-1-", false},       // mnemonic missing
+		{"%FTD-1", false},        // truncated
+		{"%FTD", false},
+		{"%-1-430003", false}, // facility missing
+		{"%notamnemonic payload", false},
+		{"firepower : %FTD-6-110002:", false}, // must be at the start
+		{"FTD-1-430003:", false},              // no leading '%'
+		{"%", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, startsWithCiscoMnemonic([]byte(tc.in)), "input %q", tc.in)
+	}
+}
+
+func TestSkipCiscoSeparator(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"   %FTD", 3},
+		{" %FTD", 1},
+		{" : %FTD", 3},
+		{"  :  %FTD", 5},
+		{" :%FTD", 2},
+		{":%FTD", 1},  // ASA writes the colon with no preceding space
+		{": %FTD", 2},
+		{"%FTD", 0},   // neither space nor colon, nothing consumed
+		{"::%FTD", 1}, // only one colon belongs to the separator
+		{"", 0},
+		{"   ", 3},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, skipCiscoSeparator([]byte(tc.in), 0), "input %q", tc.in)
+	}
 }
 
 func TestISOTimestampLen(t *testing.T) {

--- a/pkg/logs/internal/parsers/syslog/timestamp_variants_test.go
+++ b/pkg/logs/internal/parsers/syslog/timestamp_variants_test.go
@@ -164,21 +164,6 @@ func TestParseUnrecognizedTimestampLayouts(t *testing.T) {
 	}
 }
 
-// A relay that does not recognize an incoming line as already-formatted syslog
-// prepends its own timestamp and host, leaving two BSD headers. The month
-// abbreviation of the second one used to be extracted as the APP-NAME. The
-// sample is Cisco ISE, but any source behind such a relay can produce it.
-func TestParseDoubleBSDHeader(t *testing.T) {
-	line := "<184>Apr 27 11:16:44 172.0.0.10 Apr 27 11:16:44 xyz12 CISE_Passed_Authentications 0000000487 1 0"
-	msg, err := Parse([]byte(line))
-	require.NoError(t, err)
-
-	assert.Equal(t, "Apr 27 11:16:44", msg.Timestamp)
-	assert.Equal(t, "172.0.0.10", msg.Hostname)
-	assert.Equal(t, nilvalue, msg.AppName, "the second timestamp must not become the appname")
-	assert.Equal(t, "Apr 27 11:16:44 xyz12 CISE_Passed_Authentications 0000000487 1 0", string(msg.Msg))
-}
-
 // A colon after the PRI is only skipped when a timestamp follows it, so content
 // that merely starts with a colon keeps its leading colon in MSG.
 func TestColonAfterPRIWithoutTimestamp(t *testing.T) {

--- a/pkg/logs/internal/parsers/syslog/timestamp_variants_test.go
+++ b/pkg/logs/internal/parsers/syslog/timestamp_variants_test.go
@@ -210,6 +210,66 @@ func TestParseUnrecognizedTimestampLayouts(t *testing.T) {
 			procid:    nilvalue,
 			msg:       ": %FTD-6-305012: Teardown dynamic UDP translation",
 		},
+		{
+			// Cisco documents the IOS header as
+			// "seq no:timestamp: %facility-severity-MNEMONIC:description", the
+			// part before the '%' varying with "service timestamps log". The
+			// msec option is what its own Embedded Syslog Manager guide prints:
+			// "000013: Mar 18 14:52:10.039:%LINK-5-CHANGED: ...". Without the
+			// fractional seconds the timestamp ends mid-token and the header
+			// fails to parse at all.
+			name:      "cisco ios datetime msec",
+			line:      "<187>Mar 18 14:52:10.039: %LINK-5-CHANGED: Interface Serial3/3, changed state to administratively down",
+			timestamp: "Mar 18 14:52:10.039",
+			hostname:  nilvalue,
+			appname:   nilvalue,
+			procid:    nilvalue,
+			msg:       "%LINK-5-CHANGED: Interface Serial3/3, changed state to administratively down",
+		},
+		{
+			// The same guide prints no space between the colon and the '%'.
+			name:      "cisco ios datetime msec, no space before mnemonic",
+			line:      "<187>Mar 18 14:52:10.039:%LINK-5-CHANGED: Interface Serial3/3, changed state",
+			timestamp: "Mar 18 14:52:10.039",
+			hostname:  nilvalue,
+			appname:   nilvalue,
+			procid:    nilvalue,
+			msg:       "%LINK-5-CHANGED: Interface Serial3/3, changed state",
+		},
+		{
+			// "service timestamps log datetime show-timezone" appends the zone
+			// name, which lands in the TAG position. Read as a TAG it becomes
+			// the APP-NAME, so every device in a given zone would route under
+			// a service named after its timezone.
+			name:      "cisco ios show-timezone",
+			line:      "<187>Mar  1 18:46:11 UTC: %LINK-3-UPDOWN: Interface Serial0, changed state to up",
+			timestamp: "Mar  1 18:46:11 UTC",
+			hostname:  nilvalue,
+			appname:   nilvalue,
+			procid:    nilvalue,
+			msg:       "%LINK-3-UPDOWN: Interface Serial0, changed state to up",
+		},
+		{
+			name:      "cisco ios msec and show-timezone together",
+			line:      "<187>Mar 18 14:52:10.039 CEST: %LINK-5-CHANGED: Interface Serial3/3, changed state",
+			timestamp: "Mar 18 14:52:10.039 CEST",
+			hostname:  nilvalue,
+			appname:   nilvalue,
+			procid:    nilvalue,
+			msg:       "%LINK-5-CHANGED: Interface Serial3/3, changed state",
+		},
+		{
+			// Cisco documents '*' before the time as meaning the system clock
+			// never synchronized to a reliable source. It is a marker, not part
+			// of the time, and the header behind it parses normally.
+			name:      "cisco ios unsynchronized clock marker",
+			line:      "<187>*Mar  1 18:46:11.000: %LINK-3-UPDOWN: Interface Serial0, changed state to up",
+			timestamp: "Mar  1 18:46:11.000",
+			hostname:  nilvalue,
+			appname:   nilvalue,
+			procid:    nilvalue,
+			msg:       "%LINK-3-UPDOWN: Interface Serial0, changed state to up",
+		},
 	}
 
 	for _, tc := range cases {
@@ -228,6 +288,87 @@ func TestParseUnrecognizedTimestampLayouts(t *testing.T) {
 			assert.Equal(t, tc.procid, msg.ProcID, "procid")
 			assert.Equal(t, tc.msg, string(msg.Msg), "msg")
 		})
+	}
+}
+
+// Absorbing a timezone name into the TIMESTAMP is only safe while it stays
+// narrow. An uppercase token after the time is otherwise indistinguishable from
+// a short TAG or a hostname, so nothing here may be given up to recognize a
+// zone: the Cisco mnemonic behind the colon is the whole justification.
+func TestTimezoneSuffixDoesNotEatTags(t *testing.T) {
+	cases := []struct {
+		name      string
+		line      string
+		timestamp string
+		hostname  string
+		appname   string
+		msg       string
+	}{
+		{
+			// Shaped exactly like the zone case but without a mnemonic, so the
+			// token is a TAG and has to stay one.
+			name:      "uppercase tag is not a timezone",
+			line:      "<134>Jan  1 00:00:00 GW: session opened for user root",
+			timestamp: "Jan  1 00:00:00",
+			hostname:  nilvalue,
+			appname:   "GW",
+			msg:       "session opened for user root",
+		},
+		{
+			// A zone-shaped token in the HOSTNAME position with no colon is a
+			// hostname, whatever it is named.
+			name:      "zone-shaped hostname is left alone",
+			line:      "<134>Feb 10 12:00:00 UTC sshd: not a mnemonic body",
+			timestamp: "Feb 10 12:00:00",
+			hostname:  "UTC",
+			appname:   "sshd",
+			msg:       "not a mnemonic body",
+		},
+		{
+			// Only the token directly after the timestamp can be a zone; once a
+			// HOSTNAME has been read, the next one is a TAG.
+			name:      "zone-shaped tag after a hostname",
+			line:      "<134>Feb 10 12:00:00 myhost UTC: still a tag",
+			timestamp: "Feb 10 12:00:00",
+			hostname:  "myhost",
+			appname:   "UTC",
+			msg:       "still a tag",
+		},
+		{
+			// Fractional seconds end at the digits and must not run into the
+			// HOSTNAME behind them.
+			name:      "fraction does not consume the hostname",
+			line:      "<134>Feb 10 12:00:00.5 myhost sshd: ok",
+			timestamp: "Feb 10 12:00:00.5",
+			hostname:  "myhost",
+			appname:   "sshd",
+			msg:       "ok",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg, err := Parse([]byte(tc.line))
+			require.NoError(t, err)
+			assert.Equal(t, tc.timestamp, msg.Timestamp, "timestamp")
+			assert.Equal(t, tc.hostname, msg.Hostname, "hostname")
+			assert.Equal(t, tc.appname, msg.AppName, "appname")
+			assert.Equal(t, tc.msg, string(msg.Msg), "msg")
+		})
+	}
+}
+
+// '*' is only a clock marker when a timestamp follows it. Anywhere else it is
+// ordinary content and must reach MSG intact.
+func TestAsteriskWithoutTimestampIsContent(t *testing.T) {
+	for _, line := range []string{
+		"<134>*** ALERT *** disk full on /var",
+		"<134>*not a timestamp at all",
+	} {
+		msg, err := Parse([]byte(line))
+		require.NoError(t, err)
+		assert.Equal(t, nilvalue, msg.Timestamp)
+		assert.Equal(t, line[len("<134>"):], string(msg.Msg), "input %q", line)
 	}
 }
 
@@ -519,8 +660,39 @@ func TestBSDTimestampLen(t *testing.T) {
 		{"Jan 9 03-47-40", 0},
 		{"2024-04-04T08:05:06Z", 0},
 		{"", 0},
+
+		// Fractional seconds attach to every layout.
+		{"Mar 18 14:52:10.039", 19},
+		{"Jan 9 03:47:40.5", 16},
+		{"Apr 04 2024 08:05:06.123456", 27},
+		{"2024 Apr 04 08:05:06.039", 24},
+		{"Mar 18 14:52:10.", 15},    // '.' with no digits is not a fraction
+		{"Mar 18 14:52:10.x", 15},   // nor is a non-digit
+		{"Mar 18 14:52:10 UTC", 15}, // the zone is not part of the bare layout
 	}
 	for _, tc := range cases {
 		assert.Equal(t, tc.want, bsdTimestampLen([]byte(tc.in)), "input %q", tc.in)
+	}
+}
+
+func TestBSDZoneSuffixLen(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{" UTC: %LINK-3-UPDOWN: up", 4},
+		{" CEST: %ASA-6-302013: built", 5},
+		{" AEDT:%FTD-1-430003: x", 5},
+		{" UTC:   %SYS-5-CONFIG_I: x", 4}, // Cisco allows spaces after the colon
+		{" GW: session opened", 0},        // no mnemonic: a TAG, not a zone
+		{" UTC %LINK-3-UPDOWN: up", 0},    // no colon terminating the zone
+		{" U: %LINK-3-UPDOWN: up", 0},     // too short to be a zone
+		{" TOOLONGZONE: %LINK-3-UPDOWN: up", 0},
+		{" utc: %LINK-3-UPDOWN: up", 0}, // zone names are uppercase
+		{"UTC: %LINK-3-UPDOWN: up", 0},  // must be preceded by SP
+		{"", 0},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, bsdZoneSuffixLen([]byte(tc.in)), "input %q", tc.in)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Fixes two classes of defect in syslog collection over sockets, and adds a regression harness for the second.

The TCP framer no longer commits to RFC 6587 octet counting on the strength of a leading digit. It requires the whole `MSG-LEN SP PRI` signature — with a complete PRI, meaning `<`, a one-to-three digit PRIVAL, then `>` — before any digits are read as a length, and falls back to newline recovery otherwise. Because a TCP read can split anywhere, the test is three-way: an incomplete signature waits for more bytes rather than guessing. Frame detection and malformed-run resynchronization now share that one test, so the two cannot disagree about where a frame starts.

The parser recognizes the header layouts appliances actually emit, and stops putting values in the wrong fields. Newly handled: non-padded single-digit days, Cisco NX-OS year-first timestamps, a colon terminating the PRI as in Cisco's EMBLEM dialect, ISO 8601 in place of the BSD timestamp, and the Cisco IOS `service timestamps` options for fractional seconds, timezone names, and the unsynchronized-clock marker. Newly corrected: a TAG sitting in the HOSTNAME position, a relay's second timestamp mined for an APP-NAME, padded RFC 5424 field separators, an unterminated TAG swallowing the body, and the separator Cisco leaves behind when the Device-ID is disabled.

Alongside those, `testdata/corpus.json` pins the parser's complete output for 75 messages across 22 integrations, spanning all seven framing classes and both the wire form and the PRI-less rendering a tailed file carries.

### Motivation

The framing bug lost data silently and without bound, but only behind a payload that was already malformed. Framing method is chosen at a frame boundary, and conformant traffic opens every frame with a PRI, so reaching the digit-leading path at all requires the payload sitting at that boundary to be non-conformant. From there `MSG-LEN` is the authoritative frame boundary and the body it declares is never re-scanned for frame starts, so a digit run misread as a length swallowed everything behind it into one truncated log. The messages it swallowed could themselves be perfectly well-formed, which is what turned a single malformed payload into unbounded loss.

The parser defects degraded attribution rather than content. An unrecognized layout returns every header field as the nilvalue, which alone makes source remapping on `syslog.appname` or `syslog.hostname` impossible. A misattributed field is worse, because those same attributes drive source and service routing, so the log is misrouted with nothing to signal that anything went wrong — a timezone name read as an APP-NAME would route every device in a zone under a service named after it. The original line is preserved throughout; only extracted attributes change.

The corpus exists because targeted tests cannot catch that second class. One sample per parsing decision is the right shape for asserting a behaviour, but nobody writes an assertion that HOSTNAME is not `network:`, so nothing fails when it is. Comparing every field of every message turns a quiet misattribution into a diff.

Every accepted layout is corroborated by vendor documentation or an independent parser implementation rather than by a single fixture; one tolerance that could not be reproduced beyond its originating fixture was dropped rather than shipped. Cisco's documented collector expectations drove the most recent round: the guides define the IOS header as `seq no:timestamp: %facility-severity-MNEMONIC:description` and enumerate the `service timestamps` options that vary everything ahead of the `%`.

### Describe how you validated your changes

`dda inv test --targets=./pkg/logs/internal/framer,./pkg/logs/internal/parsers/syslog`, also run under `-race`.

The golden corpus is the primary check on the parser work: reverting any one of the fixes makes it fail and name the integration, the fixture line, and the field that moved. Each framer regression test was run against the unfixed framer to confirm it reproduces the corruption rather than passing vacuously. Both parser entry points were fuzzed with no crashes, and `benchstat` reports the combined parser changes as throughput-neutral with allocations per operation unchanged.

New coverage sits in `syslog_octet_prefix_test.go`, which asserts that a genuine octet-counted frame is still framed by length, that digit-leading non-frames fall through to newline recovery instead of swallowing their successors, and that a length prefix straddling a read boundary is not misclassified; and in `timestamp_variants_test.go`, which covers each accepted layout and cites the fixture or vendor guide it came from, noting whether the sample is a wire capture or a file rendering since only the former carries a PRI.

### Additional Notes

Two layouts Cisco documents are deliberately left unhandled. Uptime timestamps (`00:00:46:`, `1w2d:`) are time since reboot rather than wall clock, so there is nothing to extract and passing the line through as content is already correct. The IOS sequence-number prefix is not yet recognized and remains a follow-up.

Repeated BSD headers are also out of scope here. Unlike the other layouts, a doubled BSD header is not something any integration documents its devices as emitting — it comes from a relay that fails to recognize an already-formatted line — so it is a separate problem with a separate scope. The ISO form of that check is untouched.

Every corpus message names its origin, and each origin records the public repository and pinned commit, the vendor document, or that the sample was synthesized, so any entry can be traced without guesswork. Regenerate after an intentional parser change with:

```
go test ./pkg/logs/internal/parsers/syslog -run TestCorpusGolden -update-golden
```