### PR TITLE
Remove redundant wmi go build tag

### DIFF
--- a/bazel/rules/go/dd_agent_go_test.bzl
+++ b/bazel/rules/go/dd_agent_go_test.bzl
@@ -6,7 +6,6 @@ load(
     "DARWIN_EXCLUDED_TAGS",
     "LINUX_ONLY_TAGS",
     "WINDOWS_EXCLUDED_TAGS",
-    "WINDOWS_INCLUDED_TAGS",
 )
 
 # Short target-name suffixes for gotags sets whose joined form is too long to fit in
@@ -37,8 +36,6 @@ def _excluded_os(gotags):
     excluded = []
     if tags & LINUX_ONLY_TAGS:
         excluded.extend(["macos", "windows"])
-    if tags & WINDOWS_INCLUDED_TAGS:
-        excluded.extend(["linux", "macos"])
     if tags & WINDOWS_EXCLUDED_TAGS:
         excluded.append("windows")
     if tags & DARWIN_EXCLUDED_TAGS:
@@ -49,18 +46,8 @@ def _excluded_os(gotags):
 
 def _test_tag_set_tags(gotags = None):
     if gotags == None:
-        tags = BASE_TEST_TAGS
-    else:
-        tags = sorted(set(BASE_TEST_TAGS) | set(gotags))
-
-    # Windows builds always define WINDOWS_INCLUDED_TAGS, as
-    # filter_incompatible_tags() does in tasks/build_tags.py. Without them,
-    # sources gated on `windows && wmi` drop out while the tests covering them
-    # still compile.
-    return select({
-        "@platforms//os:windows": sorted(set(tags) | WINDOWS_INCLUDED_TAGS),
-        "//conditions:default": tags,
-    })
+        return BASE_TEST_TAGS
+    return sorted(set(BASE_TEST_TAGS) | set(gotags))
 
 def _test_tag_set_suffix(gotags):
     key = _tag_set_key(gotags)

--- a/pkg/collector/corechecks/sbom/batch_refresher.go
+++ b/pkg/collector/corechecks/sbom/batch_refresher.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
-//go:build trivy || (windows && wmi)
+//go:build trivy || windows
 
 package sbom
 

--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
-//go:build trivy || (windows && wmi)
+//go:build trivy || windows
 
 package sbom
 

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
-//go:build trivy || (windows && wmi)
+//go:build trivy || windows
 
 package sbom
 

--- a/pkg/collector/corechecks/sbom/refresher.go
+++ b/pkg/collector/corechecks/sbom/refresher.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
-//go:build trivy || (windows && wmi)
+//go:build trivy || windows
 
 package sbom
 

--- a/pkg/collector/corechecks/sbom/spread_refresher.go
+++ b/pkg/collector/corechecks/sbom/spread_refresher.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
-//go:build trivy || (windows && wmi)
+//go:build trivy || windows
 
 package sbom
 

--- a/pkg/sbom/bomconvert/convert.go
+++ b/pkg/sbom/bomconvert/convert.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
-//go:build trivy || (windows && wmi)
+//go:build trivy || windows
 
 // Package bomconvert contains some cyclonedx conversion functions
 package bomconvert

--- a/pkg/sbom/collectors/host/collector.go
+++ b/pkg/sbom/collectors/host/collector.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build trivy || (windows && wmi)
+//go:build trivy || windows
 
 package host
 

--- a/pkg/sbom/collectors/host/host_wmi.go
+++ b/pkg/sbom/collectors/host/host_wmi.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !trivy && windows && wmi
+//go:build !trivy && windows
 
 package host
 

--- a/tasks/build_tags.bzl
+++ b/tasks/build_tags.bzl
@@ -66,7 +66,6 @@ ALL_TAGS = set([
     "systemprobechecks",  # used to include system-probe based checks in the agent build
     "test",  # used for unit-tests
     "trivy",
-    "wmi",
     "zk",
     "zlib",
     "zstd",
@@ -315,9 +314,6 @@ AIX_EXCLUDED_TAGS = set([
     "systemprobechecks",
     "trivy",
 ])
-
-# List of tags to always add when building on Windows
-WINDOWS_INCLUDED_TAGS = set(["wmi"])
 
 # List of tags to always remove when building on Windows
 WINDOWS_EXCLUDED_TAGS = set([

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -69,7 +69,6 @@ AGENT_TEST_TAGS = _data.AGENT_TEST_TAGS
 # Exclusion lists
 LINUX_ONLY_TAGS = _data.LINUX_ONLY_TAGS
 AIX_EXCLUDED_TAGS = _data.AIX_EXCLUDED_TAGS
-WINDOWS_INCLUDED_TAGS = _data.WINDOWS_INCLUDED_TAGS
 WINDOWS_EXCLUDED_TAGS = _data.WINDOWS_EXCLUDED_TAGS
 DARWIN_EXCLUDED_TAGS = _data.DARWIN_EXCLUDED_TAGS
 UNIT_TEST_TAGS = _data.UNIT_TEST_TAGS
@@ -166,7 +165,6 @@ def build_tags_codegen_payload() -> dict[str, object]:
         "common_tags": sorted(COMMON_TAGS),
         "unit_test_tags": sorted(UNIT_TEST_TAGS),
         "linux_only_tags": sorted(LINUX_ONLY_TAGS),
-        "windows_included_tags": sorted(WINDOWS_INCLUDED_TAGS),
         "windows_excluded_tags": sorted(WINDOWS_EXCLUDED_TAGS),
         "darwin_excluded_tags": sorted(DARWIN_EXCLUDED_TAGS),
         "flavor_specific_tags": {
@@ -257,7 +255,6 @@ def filter_incompatible_tags(include, platform=None):
         exclude = exclude.union(LINUX_ONLY_TAGS)
 
     if target_platform == "win32":
-        include = include.union(WINDOWS_INCLUDED_TAGS)
         exclude = exclude.union(WINDOWS_EXCLUDED_TAGS)
 
     if target_platform == "darwin":

--- a/tasks/unit_tests/build_tags_tests.py
+++ b/tasks/unit_tests/build_tags_tests.py
@@ -24,7 +24,6 @@ class TestCodegenPayloadSchema(unittest.TestCase):
         "common_tags",
         "unit_test_tags",
         "linux_only_tags",
-        "windows_included_tags",
         "windows_excluded_tags",
         "darwin_excluded_tags",
         "flavor_specific_tags",
@@ -57,11 +56,6 @@ class TestCodegenPayloadData(unittest.TestCase):
 
     def test_base_excludes_requirefips(self):
         self.assertNotIn("requirefips", _payload()["flavor_specific_tags"]["base"])
-
-    def test_wmi_in_windows_included_not_in_linux_only(self):
-        payload = _payload()
-        self.assertIn("wmi", payload["windows_included_tags"])
-        self.assertNotIn("wmi", payload["linux_only_tags"])
 
     def test_common_tags_disjoint_from_flavor_specific(self):
         # The .bzl/.go consumers compose flavor tag sets as


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

During Bazel migration we have noticed that `wmi` is always set unconditionally if we build for `windows` that basically makes it a full equivalent of plane and standard `windows` tag. Thus, this PR to eliminate this redundancy and slightly simplify build tag management.

### Motivation

We are preparing to transition our test execution to Bazel and this is a perfect opportunity to clean things up before we do this.

### Describe how you validated your changes

Both `bazel test` and `dda inv test` work and succeed.
