### PR TITLE
fix(windows): Revert ADP bump

### DIFF
--- a/deps/agent_data_plane/agent_data_plane.MODULE.bazel
+++ b/deps/agent_data_plane/agent_data_plane.MODULE.bazel
@@ -1,18 +1,18 @@
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-VERSION = "1.5.0"
+VERSION = "1.4.0"
 
 SOURCE_URL_BASE = "https://binaries.ddbuild.io/saluki"
 
 HASHES = {
-    "linux-amd64": "2cf82a24ba099850d700c8c24087ebbca204d904a86e9083c2d093277a269b4f",
-    "linux-arm64": "2e875d0f0d8e68853227a73ec28c816e8932dfa21353a62973f68136bfd64112",
-    "fips-linux-amd64": "916eea25260f47a7149f55fe922afdfcb458cac15584e88ec4c886394cb97a02",
-    "fips-linux-arm64": "8552c74bbc0fb17107d07cfd8a975a644e0a3b28c718fbf39a6c2aff65123d7d",
-    "darwin-amd64": "8070767c71d9d3cb8d7045de52b9cb12d1a0ff5c68d45a190a328eba52474bee",
-    "darwin-arm64": "46a349b98be5ca0799511eee4f99fcf4445ed9613f0b072818c95215246198ac",
-    "windows-amd64": "38930d0f9f9e2f82939bd2a125d6b6919efc1b960b0dbd18fdd262b7d467ba9f",
-    "windows-amd64-fips": "e5ffd95ffc939c16178779ab2f8a84b3b0e6693974065a35e9fc802424aa37d4",
+    "linux-amd64": "3904f9ab8a11f6f21211ee87792122d3e66a72f0c103482057d44d11549738b8",
+    "linux-arm64": "c6dcca770e7df20266c68af73138cfa43db68aace57699c7557408e77925d7cc",
+    "fips-linux-amd64": "0f5d9c921a998f2b0b6b299deb3f194963f41fb0d32d55b4f6719d4da6fff7af",
+    "fips-linux-arm64": "9d079994e841d4986ae0efbefe009d3cd45b4b4c8e8831579d26c493b28c3d8d",
+    "darwin-amd64": "7586ef3041bcd11f9dad1baf7a7f26ff4e2dc239ef59c2d28ebd0e0879f41568",
+    "darwin-arm64": "e40ad02931ba893de49427d9c3a1c4683a0f615a58e96287fdd47e1b089b7699",
+    "windows-amd64": "a2692fa7d961b8e1b1f01ddcf86060f542195124397e69bfacf152ceda47d436",
+    "windows-amd64-fips": "30199587a487bf3312bad913929ee6a951e244f3cbdeafccec4ac8edbaf05cb9",
 }
 
 _BUILD_FILE_CONTENT = """\

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,51 +1,51 @@
 static_quality_gate_agent_deb_amd64:
-  max_on_disk_size: 764.0 MiB
-  max_on_wire_size: 182.75 MiB
+  max_on_disk_size: 762.87 MiB
+  max_on_wire_size: 182.52 MiB
 static_quality_gate_agent_deb_amd64_fips:
-  max_on_disk_size: 715.32 MiB
-  max_on_wire_size: 176.91 MiB
+  max_on_disk_size: 714.17 MiB
+  max_on_wire_size: 176.45 MiB
 static_quality_gate_agent_heroku_amd64:
   max_on_disk_size: 318.88 MiB
   max_on_wire_size: 81.49 MiB
 static_quality_gate_agent_msi:
-  max_on_disk_size: 660.49 MiB
-  max_on_wire_size: 159.04 MiB
+  max_on_disk_size: 657.29 MiB
+  max_on_wire_size: 157.89 MiB
 static_quality_gate_agent_rpm_amd64:
-  max_on_disk_size: 763.97 MiB
-  max_on_wire_size: 186.57 MiB
+  max_on_disk_size: 762.84 MiB
+  max_on_wire_size: 186.16 MiB
 static_quality_gate_agent_rpm_amd64_fips:
-  max_on_disk_size: 715.32 MiB
-  max_on_wire_size: 177.73 MiB
+  max_on_disk_size: 714.17 MiB
+  max_on_wire_size: 177.49 MiB
 static_quality_gate_agent_rpm_arm64:
-  max_on_disk_size: 735.06 MiB
-  max_on_wire_size: 167.0 MiB
+  max_on_disk_size: 734.03 MiB
+  max_on_wire_size: 166.82 MiB
 static_quality_gate_agent_rpm_arm64_fips:
-  max_on_disk_size: 693.29 MiB
-  max_on_wire_size: 159.4 MiB
+  max_on_disk_size: 692.25 MiB
+  max_on_wire_size: 159.22 MiB
 static_quality_gate_agent_suse_amd64:
-  max_on_disk_size: 763.97 MiB
-  max_on_wire_size: 186.56 MiB
+  max_on_disk_size: 762.84 MiB
+  max_on_wire_size: 186.13 MiB
 static_quality_gate_agent_suse_amd64_fips:
-  max_on_disk_size: 715.32 MiB
-  max_on_wire_size: 177.9 MiB
+  max_on_disk_size: 714.17 MiB
+  max_on_wire_size: 177.65 MiB
 static_quality_gate_agent_suse_arm64:
-  max_on_disk_size: 735.06 MiB
-  max_on_wire_size: 166.95 MiB
+  max_on_disk_size: 734.03 MiB
+  max_on_wire_size: 166.76 MiB
 static_quality_gate_agent_suse_arm64_fips:
-  max_on_disk_size: 693.29 MiB
-  max_on_wire_size: 159.37 MiB
+  max_on_disk_size: 692.25 MiB
+  max_on_wire_size: 159.2 MiB
 static_quality_gate_docker_agent_amd64:
-  max_on_disk_size: 819.59 MiB
-  max_on_wire_size: 277.77 MiB
+  max_on_disk_size: 818.46 MiB
+  max_on_wire_size: 277.3 MiB
 static_quality_gate_docker_agent_arm64:
-  max_on_disk_size: 820.33 MiB
-  max_on_wire_size: 265.7 MiB
+  max_on_disk_size: 819.30 MiB
+  max_on_wire_size: 265.25 MiB
 static_quality_gate_docker_agent_jmx_amd64:
-  max_on_disk_size: 1010.35 MiB
-  max_on_wire_size: 346.38 MiB
+  max_on_disk_size: 1009.22 MiB
+  max_on_wire_size: 345.91 MiB
 static_quality_gate_docker_agent_jmx_arm64:
-  max_on_disk_size: 1000.01 MiB
-  max_on_wire_size: 330.33 MiB
+  max_on_disk_size: 998.98 MiB
+  max_on_wire_size: 329.84 MiB
 static_quality_gate_docker_cluster_agent_amd64:
   max_on_disk_size: 211.25 MiB
   max_on_wire_size: 74.4 MiB


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Revert [ADP bump](https://github.com/DataDog/datadog-agent/pull/54490) causing [systematic failures](https://app.datadoghq.com/ci/ci-cd/explorer?query=ci_level%3Ajob%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20%40git.branch%3Amain%20-%40ci.status%3A%28canceled%20OR%20skipped%29%20%40gitlab.pipeline_source%3A%28push%20OR%20api%29%20-ci_partial_retry%3Atrue%20%40ci.job.name%3Anew-e2e-agent-runtimes-windows&agg_m=count&agg_m_source=base&agg_t=count&ci_cd_explorer_tab=pipelines&fromUser=false&index=cipipeline&refresh_mode=sliding&start=1785405961822&end=1786010761822&paused=false) on `new-e2e-agent-runtimes-windows`
### Motivation

### Describe how you validated your changes

### Additional Notes
