### PR TITLE
fix(windows): avoid MSI 1603 on corrupt uninstall

### DIFF
--- a/releasenotes/notes/fix-windows-uninstall-corrupted-config-root-659a419420adaa88.yaml
+++ b/releasenotes/notes/fix-windows-uninstall-corrupted-config-root-659a419420adaa88.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Windows, fixed an issue where uninstalling the Agent could fail with MSI error code 1603
+    when the Agent's install state in the registry had been removed or corrupted. The configuration
+    directory owner check no longer blocks the operation when the configuration directory cannot be
+    resolved, since there is nothing to secure in that case.

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/CustomActions.Tests.csproj
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/CustomActions.Tests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="IntegrationTests\TestConfig.cs" />
     <Compile Include="Logs\ProcessConfigTests.cs" />
     <Compile Include="Native\SecureDirectoryTests.cs" />
+    <Compile Include="Prerequisites\EnsureSecureConfigRootTests.cs" />
     <Compile Include="ProcessUserCustomActions\TestDelegate.cs" />
     <Compile Include="Process\ProcessConfigTests.cs" />
     <Compile Include="Proxy\ProcessConfigTests.cs" />

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/Prerequisites/EnsureSecureConfigRootTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/Prerequisites/EnsureSecureConfigRootTests.cs
@@ -1,0 +1,34 @@
+using Datadog.CustomActions;
+using FluentAssertions;
+using WixToolset.Dtf.WindowsInstaller;
+using Xunit;
+
+namespace CustomActions.Tests.Prerequisites
+{
+    public class EnsureSecureConfigRootTests : SessionTestBaseSetup
+    {
+        // Uninstalling an Agent whose install state (the registry values that record the configuration
+        // directory) was removed or corrupted leaves APPLICATIONDATADIRECTORY unset. The configuration
+        // directory owner check must not fail in that case, otherwise the custom action returns Failure
+        // and the MSI aborts with exit code 1603, making a broken install impossible to uninstall.
+        // See incident 58787.
+        [Fact]
+        public void EnsureSecureConfigRoot_Succeeds_When_ConfigRoot_Is_Not_Set()
+        {
+            PrerequisitesCustomActions.EnsureSecureConfigRoot(Session.Object)
+                .Should()
+                .Be(ActionResult.Success);
+        }
+
+        [Fact]
+        public void EnsureSecureConfigRootUI_Reports_Valid_When_ConfigRoot_Is_Not_Set()
+        {
+            PrerequisitesCustomActions.EnsureSecureConfigRoot(Session.Object, calledFromUIControl: true)
+                .Should()
+                .Be(ActionResult.Success);
+
+            Properties.Should()
+                .Contain(PrerequisitesCustomActions.ConfigRootValidProperty, "True");
+        }
+    }
+}

--- a/tools/windows/DatadogAgentInstaller/CustomActions/PrerequisitesCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/PrerequisitesCustomActions.cs
@@ -66,7 +66,7 @@ namespace Datadog.CustomActions
         /// dialog cannot send a message to the user, and returning failure exits the installer.
         /// https://learn.microsoft.com/en-us/windows/win32/msi/sending-messages-to-windows-installer-using-msiprocessmessage
         /// </remarks>
-        private static ActionResult EnsureSecureConfigRoot(ISession session, bool calledFromUIControl = false)
+        internal static ActionResult EnsureSecureConfigRoot(ISession session, bool calledFromUIControl = false)
         {
             if (calledFromUIControl)
             {
@@ -78,15 +78,27 @@ namespace Datadog.CustomActions
             // Read outside the try so that the messages below can name the directory
             var configRoot = session.Property("APPLICATIONDATADIRECTORY");
 
-            try
+            if (string.IsNullOrEmpty(configRoot))
             {
-                if (string.IsNullOrEmpty(configRoot))
+                // On a fresh install or a maintenance (Change/Repair) run, CostFinalize resolves this
+                // property to a concrete path before this action runs, so an empty value means the
+                // install state that records the configuration directory is unavailable. That happens
+                // when operating on an install whose registry state was removed or corrupted - for
+                // example uninstalling it. There is no directory to verify or secure in that case, and
+                // returning Failure would fail the MSI (exit code 1603) and make a broken-but-removable
+                // install impossible to uninstall. Treat it as nothing to verify and let the operation
+                // proceed. See incident 58787.
+                session.Log("APPLICATIONDATADIRECTORY is not set, skipping the configuration directory owner check");
+                if (calledFromUIControl)
                 {
-                    // Resolved by CostFinalize, which runs before this action in both sequences, so an
-                    // empty value means something is wrong. Fail rather than skip the check.
-                    throw new InvalidOperationException("APPLICATIONDATADIRECTORY is not set");
+                    session[ConfigRootValidProperty] = "True";
                 }
 
+                return ActionResult.Success;
+            }
+
+            try
+            {
                 SecureDirectory.AssertSecureOwner(session, configRoot);
             }
             catch (SecureDirectoryException e)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"fa9f1fd3-88f1-47fd-98fc-188d533c65f5","source":"chat","resourceId":"078ad4ff-4c57-4bd8-be42-2c586e3cf498","workflowId":"b5197dcb-ca64-44da-ba83-26175c4364d5","codeChangeId":"b5197dcb-ca64-44da-ba83-26175c4364d5","sourceType":"slack"} -->
### What does this PR do?

Makes the MSI `EnsureSecureConfigRoot` custom action treat an unresolved (empty) `APPLICATIONDATADIRECTORY` as "nothing to verify" and return `Success`, instead of throwing and failing the installer. Adds a deterministic unit test and a release note.

Changes:
- `tools/windows/DatadogAgentInstaller/CustomActions/PrerequisitesCustomActions.cs`: when `APPLICATIONDATADIRECTORY` is empty, log and return `ActionResult.Success` (mark the UI property valid) instead of throwing `InvalidOperationException`. The owner check for a resolved, existing directory is unchanged, so untrusted config roots still fail a fresh install. Made the helper `internal` so it can be unit-tested.
- `tools/windows/DatadogAgentInstaller/CustomActions.Tests/Prerequisites/EnsureSecureConfigRootTests.cs`: new tests asserting empty config root returns `Success` on both the execute-sequence and UI paths; registered the file in `CustomActions.Tests.csproj`.
- Added a `fixes` release note.

### Motivation

Incident 58787: the `new-e2e-windows-agent-msi-windows-server-a7-x86_64: [TestInstallAltDirAndCorruptForUninstall]` job has been flaking on `main` with MSI error code 1603 during uninstall.

PR #54269 added the configuration-directory owner check. That check reads `APPLICATIONDATADIRECTORY`, which is populated at AppSearch from the registry value `HKLM\SOFTWARE\Datadog\Datadog Agent\ConfigRoot`. `TestInstallAltDirAndCorruptForUninstall` deletes that registry key before uninstalling to simulate a corrupted install, so during removal the property resolves empty. The check then threw `InvalidOperationException` -> `ActionResult.Failure` -> msiexec exit 1603, which the uninstall wrapper classifies as a permanent error. The net effect: a broken-but-removable install could no longer be uninstalled.

On a real fresh install or a maintenance (Change/Repair) run, CostFinalize always resolves `APPLICATIONDATADIRECTORY` to a concrete path, so the empty case only occurs when the recorded install state is unavailable — i.e. when removing a corrupted install, where there is no directory to secure. Returning `Success` there is safe and does not weaken the install-time guarantee.

Why the failure was flaky: MSI's handling of a corrupted install (missing component keypaths) is nondeterministic about whether this immediate custom action runs during removal, so the same code and test alternated pass/fail run to run. This change makes the action harmless when it does run on a removal, closing the failure regardless of that nondeterminism.

### Describe how you validated your changes

- Added `EnsureSecureConfigRootTests` covering the empty-config-root case for both the execute-sequence and UI entry points.
- The existing `TestInstallAltDirAndCorruptForUninstall` Windows e2e test exercises the end-to-end scenario (install to a custom directory, delete the install-state registry key, uninstall) and is the integration-level regression guard.
- Limitation: this sandbox cannot build the .NET Framework installer project (no NuGet restore) or run the Windows MSI, so CI — the installer unit tests and the Windows MSI e2e job — is the validation of record for this change.

### Additional Notes

- This is a targeted step toward resolving incident 58787; the incident should stay open until CI confirms the flake is gone.
- Deeper follow-up for the Windows installer owners (author of #54269): consider hardening the WiX run condition for this action (`Conditions.Uninstalling` depends on the `Installed` property, which is what lets the action slip through on a corrupted removal) so it is reliably skipped on all removal paths. That requires a real MSI build to validate and is intentionally out of scope here.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/078ad4ff-4c57-4bd8-be42-2c586e3cf498)

Comment @datadog to request changes