### PR TITLE
[AAD-21] Update testbench detector warmup times

### DIFF
--- a/comp/anomalydetection/observer/def/types.go
+++ b/comp/anomalydetection/observer/def/types.go
@@ -14,7 +14,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	severityeventsdef "github.com/DataDog/datadog-agent/comp/anomalydetection/severityevents/def"
 )
@@ -287,8 +286,9 @@ type DetectionResult struct {
 type SeriesDetector interface {
 	// Name returns the analysis name for debugging.
 	Name() string
-	// BaselineSpec reports how long the detector needs to build a usable model.
-	BaselineSpec() BaselineSpec
+	// Ready reports whether at least one series has reached the detector's
+	// actual scoring condition. It is monotonic until Reset.
+	Ready() bool
 	// Detect examines a series and returns any detected anomalies.
 	Detect(series Series) DetectionResult
 }
@@ -573,19 +573,14 @@ type StorageReader interface {
 	SeriesGeneration() uint64
 }
 
-// BaselineSpec describes the detector's model warmup before its qualification
-// baseline begins.
-type BaselineSpec struct {
-	WarmupDuration time.Duration
-}
-
 // Detector is the flexible detection interface where detectors pull data from storage.
 // This supports multivariate detection across multiple series.
 type Detector interface {
 	Name() string
 
-	// BaselineSpec reports how long the detector needs to build a usable model.
-	BaselineSpec() BaselineSpec
+	// Ready reports whether at least one series has reached the detector's
+	// actual scoring condition. It is monotonic until Reset.
+	Ready() bool
 
 	// Detect is called periodically by the scheduler.
 	// The detector queries storage for whatever data it needs.

--- a/comp/anomalydetection/observer/def/types.go
+++ b/comp/anomalydetection/observer/def/types.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	severityeventsdef "github.com/DataDog/datadog-agent/comp/anomalydetection/severityevents/def"
 )
@@ -286,6 +287,8 @@ type DetectionResult struct {
 type SeriesDetector interface {
 	// Name returns the analysis name for debugging.
 	Name() string
+	// BaselineSpec reports how long the detector needs to build a usable model.
+	BaselineSpec() BaselineSpec
 	// Detect examines a series and returns any detected anomalies.
 	Detect(series Series) DetectionResult
 }
@@ -570,10 +573,19 @@ type StorageReader interface {
 	SeriesGeneration() uint64
 }
 
+// BaselineSpec describes the detector's model warmup before its qualification
+// baseline begins.
+type BaselineSpec struct {
+	WarmupDuration time.Duration
+}
+
 // Detector is the flexible detection interface where detectors pull data from storage.
 // This supports multivariate detection across multiple series.
 type Detector interface {
 	Name() string
+
+	// BaselineSpec reports how long the detector needs to build a usable model.
+	BaselineSpec() BaselineSpec
 
 	// Detect is called periodically by the scheduler.
 	// The detector queries storage for whatever data it needs.

--- a/comp/anomalydetection/observer/impl/baseline.go
+++ b/comp/anomalydetection/observer/impl/baseline.go
@@ -66,9 +66,10 @@ type BaselineDebugStatus struct {
 //	normal detector  model       suppress + mute    forward
 //	RRCF             model       suppress           forward
 //
-// Each detector owns its first two windows. A normal detector's qualifying
-// anomalies can mute their source series globally; RRCF has no source series
-// and therefore only uses the windows to suppress its own reports.
+// Each detector owns its first two windows and must not emit anomalies during
+// warmup. A normal detector's anomalies observed while analysing can mute their
+// source series globally; RRCF has no source series and therefore only uses the
+// windows to suppress its own reports.
 type baselineController struct {
 	config    BaselineConfig
 	startSec  int64
@@ -123,14 +124,6 @@ func (b *baselineController) isAnalyzingAt(name string, dataSec int64) bool {
 		return false
 	}
 	return dataSec < state.baselineEndSec
-}
-
-// isQualifyingAt reports whether anomalies should contribute to this
-// detector's muted-series decision. The earlier warmup interval is analysis
-// only: anomalies are suppressed but never qualify a series for muting.
-func (b *baselineController) isQualifyingAt(name string, dataSec int64) bool {
-	state := b.detectors[name]
-	return state != nil && !state.completed && dataSec >= state.warmupEndSec && dataSec < state.baselineEndSec
 }
 
 func (b *baselineController) mark(name string, h uint64) {

--- a/comp/anomalydetection/observer/impl/baseline.go
+++ b/comp/anomalydetection/observer/impl/baseline.go
@@ -81,11 +81,11 @@ type baselineController struct {
 	// mutating it, so the same map can safely be published to concurrent ingest
 	// handlers and retained by synchronous event consumers.
 	mutedHashes map[uint64]struct{}
-	mutedNames  map[string]struct{} // retained for the final verbose summary
+	mutedNames  map[string]struct{} // allocated only for the final verbose summary
 }
 
 func newBaselineController(cfg BaselineConfig, detectors []detectorBaselineSpecEntry) *baselineController {
-	b := &baselineController{config: cfg, detectors: make(map[string]*detectorBaselineState), mutedHashes: make(map[uint64]struct{}), mutedNames: make(map[string]struct{})}
+	b := &baselineController{config: cfg, detectors: make(map[string]*detectorBaselineState), mutedHashes: make(map[uint64]struct{})}
 	for _, d := range detectors {
 		if !d.spec.Participate {
 			continue
@@ -222,16 +222,25 @@ func (b *baselineController) debugStatus() BaselineDebugStatus {
 }
 
 func (b *baselineController) recordMutedNames(names []string) {
+	if len(names) == 0 {
+		return
+	}
+	if b.mutedNames == nil {
+		b.mutedNames = make(map[string]struct{}, len(names))
+	}
 	for _, name := range names {
 		b.mutedNames[name] = struct{}{}
 	}
 }
 
-func (b *baselineController) mutedDisplayNames() []string {
+// takeMutedDisplayNames returns the final verbose summary and releases the
+// retained series-name strings immediately afterwards.
+func (b *baselineController) takeMutedDisplayNames() []string {
 	names := make([]string, 0, len(b.mutedNames))
 	for name := range b.mutedNames {
 		names = append(names, name)
 	}
+	b.mutedNames = nil
 	sort.Strings(names)
 	return names
 }

--- a/comp/anomalydetection/observer/impl/baseline.go
+++ b/comp/anomalydetection/observer/impl/baseline.go
@@ -31,19 +31,8 @@ func DefaultBaselineConfig() BaselineConfig {
 // about the cadence of every incoming series.
 const baselineReferenceInterval = 15 * time.Second
 
-// detectorBaselineSpecProvider is intentionally private: baseline policy is
-// engine orchestration, not part of the public detector API.
-type detectorBaselineSpecProvider interface {
-	BaselineSpec() detectorBaselineSpec
-}
-
-type detectorBaselineSpec struct {
-	Participate    bool
-	WarmupDuration time.Duration
-}
-
 type detectorBaselineState struct {
-	spec               detectorBaselineSpec
+	spec               observerdef.BaselineSpec
 	warmupEndSec       int64
 	baselineEndSec     int64
 	completed          bool
@@ -72,6 +61,14 @@ type BaselineDebugStatus struct {
 
 // baselineController coordinates independent detector windows. All methods
 // run on the engine goroutine.
+//
+//	data time ──►  [ warmup ] [ qualification ] [ detection ]
+//	normal detector  model       suppress + mute    forward
+//	RRCF             model       suppress           forward
+//
+// Each detector owns its first two windows. A normal detector's qualifying
+// anomalies can mute their source series globally; RRCF has no source series
+// and therefore only uses the windows to suppress its own reports.
 type baselineController struct {
 	config    BaselineConfig
 	startSec  int64
@@ -87,9 +84,6 @@ type baselineController struct {
 func newBaselineController(cfg BaselineConfig, detectors []detectorBaselineSpecEntry) *baselineController {
 	b := &baselineController{config: cfg, detectors: make(map[string]*detectorBaselineState), mutedHashes: make(map[uint64]struct{})}
 	for _, d := range detectors {
-		if !d.spec.Participate {
-			continue
-		}
 		b.detectors[d.name] = &detectorBaselineState{spec: d.spec, pendingHashes: make(map[uint64]struct{})}
 	}
 	return b
@@ -97,17 +91,13 @@ func newBaselineController(cfg BaselineConfig, detectors []detectorBaselineSpecE
 
 type detectorBaselineSpecEntry struct {
 	name string
-	spec detectorBaselineSpec
+	spec observerdef.BaselineSpec
 }
 
 func baselineSpecs(detectors []observerdef.Detector) []detectorBaselineSpecEntry {
 	entries := make([]detectorBaselineSpecEntry, 0, len(detectors))
 	for _, detector := range detectors {
-		spec := detectorBaselineSpec{Participate: true}
-		if provider, ok := detector.(detectorBaselineSpecProvider); ok {
-			spec = provider.BaselineSpec()
-		}
-		entries = append(entries, detectorBaselineSpecEntry{name: detector.Name(), spec: spec})
+		entries = append(entries, detectorBaselineSpecEntry{name: detector.Name(), spec: detector.BaselineSpec()})
 	}
 	return entries
 }

--- a/comp/anomalydetection/observer/impl/baseline.go
+++ b/comp/anomalydetection/observer/impl/baseline.go
@@ -49,6 +49,7 @@ type detectorBaselineState struct {
 	completed          bool
 	windowAnomalyCount int
 	pendingHashes      map[uint64]struct{}
+	mutedCount         int
 }
 
 // BaselineDetectorDebugStatus is a testbench-facing snapshot of one detector.
@@ -72,11 +73,14 @@ type BaselineDebugStatus struct {
 // baselineController coordinates independent detector windows. All methods
 // run on the engine goroutine.
 type baselineController struct {
-	config      BaselineConfig
-	startSec    int64
-	started     bool
-	detectors   map[string]*detectorBaselineState
-	mutedHashes map[uint64]struct{} // immutable snapshot is published at each completion
+	config    BaselineConfig
+	startSec  int64
+	started   bool
+	detectors map[string]*detectorBaselineState
+	// mutedHashes is an immutable snapshot. complete replaces it rather than
+	// mutating it, so the same map can safely be published to concurrent ingest
+	// handlers and retained by synchronous event consumers.
+	mutedHashes map[uint64]struct{}
 	mutedNames  map[string]struct{} // retained for the final verbose summary
 }
 
@@ -158,20 +162,36 @@ func (b *baselineController) due(dataSec int64) []string {
 	return names
 }
 
-func (b *baselineController) complete(name string) (newHashes map[uint64]struct{}, anomalyCount int, allComplete bool) {
+func (b *baselineController) complete(name string) (newHashes map[uint64]struct{}, snapshotChanged bool, anomalyCount int, allComplete bool) {
 	state := b.detectors[name]
 	if state == nil || state.completed {
-		return nil, 0, b.allComplete()
+		return nil, false, 0, b.allComplete()
 	}
 	state.completed = true
-	newHashes = make(map[uint64]struct{})
-	for h := range state.pendingHashes {
-		if _, exists := b.mutedHashes[h]; !exists {
-			b.mutedHashes[h] = struct{}{}
-			newHashes[h] = struct{}{}
+	state.mutedCount = len(state.pendingHashes)
+	newHashes = state.pendingHashes
+	state.pendingHashes = nil // release the per-detector set after its window ends
+
+	// Reuse the detached pending set as the delta. The old union is immutable,
+	// so discard duplicates from the private delta before building one new union.
+	for h := range newHashes {
+		if _, exists := b.mutedHashes[h]; exists {
+			delete(newHashes, h)
 		}
 	}
-	return newHashes, state.windowAnomalyCount, b.allComplete()
+	if len(newHashes) == 0 {
+		return newHashes, false, state.windowAnomalyCount, b.allComplete()
+	}
+
+	next := make(map[uint64]struct{}, len(b.mutedHashes)+len(newHashes))
+	for h := range b.mutedHashes {
+		next[h] = struct{}{}
+	}
+	for h := range newHashes {
+		next[h] = struct{}{}
+	}
+	b.mutedHashes = next
+	return newHashes, true, state.windowAnomalyCount, b.allComplete()
 }
 
 func (b *baselineController) allComplete() bool {
@@ -191,7 +211,11 @@ func (b *baselineController) completedCount() int {
 func (b *baselineController) debugStatus() BaselineDebugStatus {
 	status := BaselineDebugStatus{Started: b.started, StartSec: b.startSec, AllComplete: b.allComplete(), MutedCount: len(b.mutedHashes)}
 	for name, state := range b.detectors {
-		status.Detectors = append(status.Detectors, BaselineDetectorDebugStatus{Name: name, WarmupEndSec: state.warmupEndSec, BaselineEndSec: state.baselineEndSec, Completed: state.completed, MutedCount: len(state.pendingHashes)})
+		mutedCount := len(state.pendingHashes)
+		if state.completed {
+			mutedCount = state.mutedCount
+		}
+		status.Detectors = append(status.Detectors, BaselineDetectorDebugStatus{Name: name, WarmupEndSec: state.warmupEndSec, BaselineEndSec: state.baselineEndSec, Completed: state.completed, MutedCount: mutedCount})
 	}
 	sort.Slice(status.Detectors, func(i, j int) bool { return status.Detectors[i].Name < status.Detectors[j].Name })
 	return status
@@ -210,12 +234,4 @@ func (b *baselineController) mutedDisplayNames() []string {
 	}
 	sort.Strings(names)
 	return names
-}
-
-func cloneMutedHashes(in map[uint64]struct{}) map[uint64]struct{} {
-	out := make(map[uint64]struct{}, len(in))
-	for h := range in {
-		out[h] = struct{}{}
-	}
-	return out
 }

--- a/comp/anomalydetection/observer/impl/baseline.go
+++ b/comp/anomalydetection/observer/impl/baseline.go
@@ -3,92 +3,224 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Baseline analysis suppresses false positives from metrics that are inherently
-// noisy at startup.
-//
-//	t=0                      t=window_end
-//	 │◄── baseline window ──►  │
-//	 │                         │
-//	 │  detectors run normally │  freeze: noisy series identified
-//	 │  anomalies → mark only  │   ├─ storage + detector state reclaimed
-//	 │  (not forwarded)        │   └─ hash added to filter mute set
-//	 │                         │
-//	 ▼                         ▼──────────────────────────────────►
-//	                              muted series dropped at ingest
-
 package observerimpl
 
-// BaselineConfig controls the baseline analysis window.
+import (
+	"sort"
+	"time"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+)
+
+// BaselineConfig controls detector-specific baseline qualification windows.
+// DurationSec is the qualification duration after a detector's own warmup.
 type BaselineConfig struct {
 	Enabled          bool
 	DurationSec      int64
 	MuteNoisyMetrics bool
-	Verbose          bool // log each muted series name when the window closes
+	Verbose          bool // log each muted series when every baseline has completed
 }
 
-// DefaultBaselineConfig returns the default baseline config (enabled, 10m window, muting on).
+// DefaultBaselineConfig returns the default baseline config (enabled, 10m qualification, muting on).
 func DefaultBaselineConfig() BaselineConfig {
-	return BaselineConfig{
-		Enabled:          true,
-		DurationSec:      600,
-		MuteNoisyMetrics: true,
-	}
+	return BaselineConfig{Enabled: true, DurationSec: 600, MuteNoisyMetrics: true}
 }
 
-// baselineController manages the baseline muting window. All methods run
-// exclusively from the engine run goroutine — no locking required.
-type baselineController struct {
-	config             BaselineConfig
-	startSec           int64
+// baselineReferenceInterval translates point-count detector requirements into
+// data-time warmups. It is deliberately a scheduling contract, not a claim
+// about the cadence of every incoming series.
+const baselineReferenceInterval = 15 * time.Second
+
+// detectorBaselineSpecProvider is intentionally private: baseline policy is
+// engine orchestration, not part of the public detector API.
+type detectorBaselineSpecProvider interface {
+	BaselineSpec() detectorBaselineSpec
+}
+
+type detectorBaselineSpec struct {
+	Participate    bool
+	WarmupDuration time.Duration
+}
+
+type detectorBaselineState struct {
+	spec               detectorBaselineSpec
+	warmupEndSec       int64
+	baselineEndSec     int64
+	completed          bool
 	windowAnomalyCount int
-	frozen             bool
-	// mutedHashes accumulates noisy series during the window and persists as the
-	// mute set afterwards. Keyed by seriesKeyHash(namespace, name, tags).
-	mutedHashes map[uint64]struct{}
+	pendingHashes      map[uint64]struct{}
 }
 
-func newBaselineController(cfg BaselineConfig) *baselineController {
-	return &baselineController{
-		config:      cfg,
-		mutedHashes: make(map[uint64]struct{}),
+// BaselineDetectorDebugStatus is a testbench-facing snapshot of one detector.
+type BaselineDetectorDebugStatus struct {
+	Name           string `json:"name"`
+	WarmupEndSec   int64  `json:"warmupEndSec"`
+	BaselineEndSec int64  `json:"baselineEndSec"`
+	Completed      bool   `json:"completed"`
+	MutedCount     int    `json:"mutedCount"`
+}
+
+// BaselineDebugStatus is a testbench-facing snapshot of the baseline union.
+type BaselineDebugStatus struct {
+	Started     bool                          `json:"started"`
+	StartSec    int64                         `json:"startSec"`
+	AllComplete bool                          `json:"allComplete"`
+	MutedCount  int                           `json:"mutedCount"`
+	Detectors   []BaselineDetectorDebugStatus `json:"detectors"`
+}
+
+// baselineController coordinates independent detector windows. All methods
+// run on the engine goroutine.
+type baselineController struct {
+	config      BaselineConfig
+	startSec    int64
+	started     bool
+	detectors   map[string]*detectorBaselineState
+	mutedHashes map[uint64]struct{} // immutable snapshot is published at each completion
+	mutedNames  map[string]struct{} // retained for the final verbose summary
+}
+
+func newBaselineController(cfg BaselineConfig, detectors []detectorBaselineSpecEntry) *baselineController {
+	b := &baselineController{config: cfg, detectors: make(map[string]*detectorBaselineState), mutedHashes: make(map[uint64]struct{}), mutedNames: make(map[string]struct{})}
+	for _, d := range detectors {
+		if !d.spec.Participate {
+			continue
+		}
+		b.detectors[d.name] = &detectorBaselineState{spec: d.spec, pendingHashes: make(map[uint64]struct{})}
 	}
+	return b
 }
 
-// activeAt reports whether the window is still open at dataSec, seeding
-// startSec on the first call.
-func (b *baselineController) activeAt(dataSec int64) bool {
-	if b.startSec == 0 {
-		b.startSec = dataSec
+type detectorBaselineSpecEntry struct {
+	name string
+	spec detectorBaselineSpec
+}
+
+func baselineSpecs(detectors []observerdef.Detector) []detectorBaselineSpecEntry {
+	entries := make([]detectorBaselineSpecEntry, 0, len(detectors))
+	for _, detector := range detectors {
+		spec := detectorBaselineSpec{Participate: true}
+		if provider, ok := detector.(detectorBaselineSpecProvider); ok {
+			spec = provider.BaselineSpec()
+		}
+		entries = append(entries, detectorBaselineSpecEntry{name: detector.Name(), spec: spec})
 	}
-	return dataSec < b.startSec+b.config.DurationSec
+	return entries
 }
 
-// mark records a series as noisy by its hash. No-op when frozen.
-// Caller must ensure tags are sorted so the hash matches storage.
-func (b *baselineController) mark(h uint64) {
-	if b.frozen {
+// start seeds all detector windows from the first analysis data timestamp.
+func (b *baselineController) start(dataSec int64) {
+	if b.started {
 		return
 	}
-	b.windowAnomalyCount++
-	b.mutedHashes[h] = struct{}{}
+	b.started = true
+	b.startSec = dataSec
+	for _, state := range b.detectors {
+		state.warmupEndSec = dataSec + int64(state.spec.WarmupDuration/time.Second)
+		state.baselineEndSec = state.warmupEndSec + b.config.DurationSec
+	}
 }
 
-// shouldFreeze reports whether the window should close at dataSec.
-func (b *baselineController) shouldFreeze(dataSec int64) bool {
-	return !b.frozen && b.startSec > 0 && !b.activeAt(dataSec)
+func (b *baselineController) phase(name string, dataSec int64) baselinePhase {
+	state := b.detectors[name]
+	if state == nil || state.completed {
+		return baselineActive
+	}
+	if dataSec < state.warmupEndSec {
+		return baselineWarming
+	}
+	if dataSec < state.baselineEndSec {
+		return baselineQualifying
+	}
+	return baselineComplete
 }
 
-// freeze closes the window. mutedHashes is already populated by mark calls.
-// Called at most once, guarded by shouldFreeze.
-func (b *baselineController) freeze() int {
-	b.frozen = true
-	return b.windowAnomalyCount
+type baselinePhase uint8
+
+const (
+	baselineActive baselinePhase = iota
+	baselineWarming
+	baselineQualifying
+	baselineComplete
+)
+
+func (b *baselineController) mark(name string, h uint64) {
+	state := b.detectors[name]
+	if state == nil || state.completed {
+		return
+	}
+	state.windowAnomalyCount++
+	state.pendingHashes[h] = struct{}{}
 }
 
-// reset clears all state for a fresh replay.
-func (b *baselineController) reset() {
-	b.startSec = 0
-	b.mutedHashes = make(map[uint64]struct{})
-	b.windowAnomalyCount = 0
-	b.frozen = false
+func (b *baselineController) due(dataSec int64) []string {
+	var names []string
+	for name, state := range b.detectors {
+		if !state.completed && dataSec >= state.baselineEndSec {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func (b *baselineController) complete(name string) (newHashes map[uint64]struct{}, anomalyCount int, allComplete bool) {
+	state := b.detectors[name]
+	if state == nil || state.completed {
+		return nil, 0, b.allComplete()
+	}
+	state.completed = true
+	newHashes = make(map[uint64]struct{})
+	for h := range state.pendingHashes {
+		if _, exists := b.mutedHashes[h]; !exists {
+			b.mutedHashes[h] = struct{}{}
+			newHashes[h] = struct{}{}
+		}
+	}
+	return newHashes, state.windowAnomalyCount, b.allComplete()
+}
+
+func (b *baselineController) allComplete() bool {
+	return b.completedCount() == len(b.detectors)
+}
+
+func (b *baselineController) completedCount() int {
+	count := 0
+	for _, state := range b.detectors {
+		if state.completed {
+			count++
+		}
+	}
+	return count
+}
+
+func (b *baselineController) debugStatus() BaselineDebugStatus {
+	status := BaselineDebugStatus{Started: b.started, StartSec: b.startSec, AllComplete: b.allComplete(), MutedCount: len(b.mutedHashes)}
+	for name, state := range b.detectors {
+		status.Detectors = append(status.Detectors, BaselineDetectorDebugStatus{Name: name, WarmupEndSec: state.warmupEndSec, BaselineEndSec: state.baselineEndSec, Completed: state.completed, MutedCount: len(state.pendingHashes)})
+	}
+	sort.Slice(status.Detectors, func(i, j int) bool { return status.Detectors[i].Name < status.Detectors[j].Name })
+	return status
+}
+
+func (b *baselineController) recordMutedNames(names []string) {
+	for _, name := range names {
+		b.mutedNames[name] = struct{}{}
+	}
+}
+
+func (b *baselineController) mutedDisplayNames() []string {
+	names := make([]string, 0, len(b.mutedNames))
+	for name := range b.mutedNames {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func cloneMutedHashes(in map[uint64]struct{}) map[uint64]struct{} {
+	out := make(map[uint64]struct{}, len(in))
+	for h := range in {
+		out[h] = struct{}{}
+	}
+	return out
 }

--- a/comp/anomalydetection/observer/impl/baseline.go
+++ b/comp/anomalydetection/observer/impl/baseline.go
@@ -121,28 +121,23 @@ func (b *baselineController) start(dataSec int64) {
 	}
 }
 
-func (b *baselineController) phase(name string, dataSec int64) baselinePhase {
+// isAnalyzingAt reports whether the detector's baseline decision is still in
+// progress. During analysis, anomalies are suppressed.
+func (b *baselineController) isAnalyzingAt(name string, dataSec int64) bool {
 	state := b.detectors[name]
 	if state == nil || state.completed {
-		return baselineActive
+		return false
 	}
-	if dataSec < state.warmupEndSec {
-		return baselineWarming
-	}
-	if dataSec < state.baselineEndSec {
-		return baselineQualifying
-	}
-	return baselineComplete
+	return dataSec < state.baselineEndSec
 }
 
-type baselinePhase uint8
-
-const (
-	baselineActive baselinePhase = iota
-	baselineWarming
-	baselineQualifying
-	baselineComplete
-)
+// isQualifyingAt reports whether anomalies should contribute to this
+// detector's muted-series decision. The earlier warmup interval is analysis
+// only: anomalies are suppressed but never qualify a series for muting.
+func (b *baselineController) isQualifyingAt(name string, dataSec int64) bool {
+	state := b.detectors[name]
+	return state != nil && !state.completed && dataSec >= state.warmupEndSec && dataSec < state.baselineEndSec
+}
 
 func (b *baselineController) mark(name string, h uint64) {
 	state := b.detectors[name]

--- a/comp/anomalydetection/observer/impl/baseline.go
+++ b/comp/anomalydetection/observer/impl/baseline.go
@@ -7,13 +7,12 @@ package observerimpl
 
 import (
 	"sort"
-	"time"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
 
 // BaselineConfig controls detector-specific baseline qualification windows.
-// DurationSec is the qualification duration after a detector's own warmup.
+// DurationSec is the qualification duration after a detector becomes ready.
 type BaselineConfig struct {
 	Enabled          bool
 	DurationSec      int64
@@ -26,13 +25,8 @@ func DefaultBaselineConfig() BaselineConfig {
 	return BaselineConfig{Enabled: true, DurationSec: 600, MuteNoisyMetrics: true}
 }
 
-// baselineReferenceInterval translates point-count detector requirements into
-// data-time warmups. It is deliberately a scheduling contract, not a claim
-// about the cadence of every incoming series.
-const baselineReferenceInterval = 15 * time.Second
-
 type detectorBaselineState struct {
-	spec               observerdef.BaselineSpec
+	ready              bool
 	warmupEndSec       int64
 	baselineEndSec     int64
 	completed          bool
@@ -44,19 +38,21 @@ type detectorBaselineState struct {
 // BaselineDetectorDebugStatus is a testbench-facing snapshot of one detector.
 type BaselineDetectorDebugStatus struct {
 	Name           string `json:"name"`
-	WarmupEndSec   int64  `json:"warmupEndSec"`
-	BaselineEndSec int64  `json:"baselineEndSec"`
+	Ready          bool   `json:"ready"`
+	WarmupEndSec   int64  `json:"warmupEndSec,omitempty"`
+	BaselineEndSec int64  `json:"baselineEndSec,omitempty"`
 	Completed      bool   `json:"completed"`
 	MutedCount     int    `json:"mutedCount"`
 }
 
 // BaselineDebugStatus is a testbench-facing snapshot of the baseline union.
 type BaselineDebugStatus struct {
-	Started     bool                          `json:"started"`
-	StartSec    int64                         `json:"startSec"`
-	AllComplete bool                          `json:"allComplete"`
-	MutedCount  int                           `json:"mutedCount"`
-	Detectors   []BaselineDetectorDebugStatus `json:"detectors"`
+	Started            bool                          `json:"started"`
+	StartSec           int64                         `json:"startSec"`
+	AnalyzedThroughSec int64                         `json:"analyzedThroughSec,omitempty"`
+	AllComplete        bool                          `json:"allComplete"`
+	MutedCount         int                           `json:"mutedCount"`
+	Detectors          []BaselineDetectorDebugStatus `json:"detectors"`
 }
 
 // baselineController coordinates independent detector windows. All methods
@@ -82,38 +78,43 @@ type baselineController struct {
 	mutedNames  map[string]struct{} // allocated only for the final verbose summary
 }
 
-func newBaselineController(cfg BaselineConfig, detectors []detectorBaselineSpecEntry) *baselineController {
+func newBaselineController(cfg BaselineConfig, detectorNames []string) *baselineController {
 	b := &baselineController{config: cfg, detectors: make(map[string]*detectorBaselineState), mutedHashes: make(map[uint64]struct{})}
-	for _, d := range detectors {
-		b.detectors[d.name] = &detectorBaselineState{spec: d.spec, pendingHashes: make(map[uint64]struct{})}
+	for _, name := range detectorNames {
+		b.detectors[name] = &detectorBaselineState{pendingHashes: make(map[uint64]struct{})}
 	}
 	return b
 }
 
-type detectorBaselineSpecEntry struct {
-	name string
-	spec observerdef.BaselineSpec
-}
-
-func baselineSpecs(detectors []observerdef.Detector) []detectorBaselineSpecEntry {
-	entries := make([]detectorBaselineSpecEntry, 0, len(detectors))
+func detectorNames(detectors []observerdef.Detector) []string {
+	names := make([]string, 0, len(detectors))
 	for _, detector := range detectors {
-		entries = append(entries, detectorBaselineSpecEntry{name: detector.Name(), spec: detector.BaselineSpec()})
+		names = append(names, detector.Name())
 	}
-	return entries
+	return names
 }
 
-// start seeds all detector windows from the first analysis data timestamp.
+// start records the first analysis timestamp. Individual qualification windows
+// begin only when their detector reports that it is ready to score.
 func (b *baselineController) start(dataSec int64) {
 	if b.started {
 		return
 	}
 	b.started = true
 	b.startSec = dataSec
-	for _, state := range b.detectors {
-		state.warmupEndSec = dataSec + int64(state.spec.WarmupDuration/time.Second)
-		state.baselineEndSec = state.warmupEndSec + b.config.DurationSec
+}
+
+// ready records a detector's first usable scoring advance and starts its
+// qualification baseline. It returns true only for that first transition.
+func (b *baselineController) ready(name string, dataSec int64) bool {
+	state := b.detectors[name]
+	if state == nil || state.ready {
+		return false
 	}
+	state.ready = true
+	state.warmupEndSec = dataSec
+	state.baselineEndSec = dataSec + b.config.DurationSec
+	return true
 }
 
 // isAnalyzingAt reports whether the detector's baseline decision is still in
@@ -123,12 +124,15 @@ func (b *baselineController) isAnalyzingAt(name string, dataSec int64) bool {
 	if state == nil || state.completed {
 		return false
 	}
+	if !state.ready {
+		return true
+	}
 	return dataSec < state.baselineEndSec
 }
 
 func (b *baselineController) mark(name string, h uint64) {
 	state := b.detectors[name]
-	if state == nil || state.completed {
+	if state == nil || state.completed || !state.ready {
 		return
 	}
 	state.windowAnomalyCount++
@@ -138,7 +142,7 @@ func (b *baselineController) mark(name string, h uint64) {
 func (b *baselineController) due(dataSec int64) []string {
 	var names []string
 	for name, state := range b.detectors {
-		if !state.completed && dataSec >= state.baselineEndSec {
+		if state.ready && !state.completed && dataSec >= state.baselineEndSec {
 			names = append(names, name)
 		}
 	}
@@ -147,7 +151,7 @@ func (b *baselineController) due(dataSec int64) []string {
 
 func (b *baselineController) complete(name string) (newHashes map[uint64]struct{}, snapshotChanged bool, anomalyCount int, allComplete bool) {
 	state := b.detectors[name]
-	if state == nil || state.completed {
+	if state == nil || !state.ready || state.completed {
 		return nil, false, 0, b.allComplete()
 	}
 	state.completed = true
@@ -198,7 +202,7 @@ func (b *baselineController) debugStatus() BaselineDebugStatus {
 		if state.completed {
 			mutedCount = state.mutedCount
 		}
-		status.Detectors = append(status.Detectors, BaselineDetectorDebugStatus{Name: name, WarmupEndSec: state.warmupEndSec, BaselineEndSec: state.baselineEndSec, Completed: state.completed, MutedCount: mutedCount})
+		status.Detectors = append(status.Detectors, BaselineDetectorDebugStatus{Name: name, Ready: state.ready, WarmupEndSec: state.warmupEndSec, BaselineEndSec: state.baselineEndSec, Completed: state.completed, MutedCount: mutedCount})
 	}
 	sort.Slice(status.Detectors, func(i, j int) bool { return status.Detectors[i].Name < status.Detectors[j].Name })
 	return status

--- a/comp/anomalydetection/observer/impl/baseline_test.go
+++ b/comp/anomalydetection/observer/impl/baseline_test.go
@@ -7,7 +7,6 @@ package observerimpl
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,7 +26,8 @@ type alwaysFiringDetector struct {
 // records series reclamation from another detector's baseline completion.
 type baselineTestDetector struct {
 	name          string
-	spec          observerdef.BaselineSpec
+	readyAtSec    int64
+	ready         bool
 	source        observerdef.SeriesDescriptor
 	ref           observerdef.SeriesRef
 	emitAfterSec  int64
@@ -36,10 +36,11 @@ type baselineTestDetector struct {
 }
 
 func (d *baselineTestDetector) Name() string { return d.name }
-func (d *baselineTestDetector) BaselineSpec() observerdef.BaselineSpec {
-	return d.spec
-}
+func (d *baselineTestDetector) Ready() bool  { return d.ready }
 func (d *baselineTestDetector) Detect(_ observerdef.StorageReader, dataSec int64) observerdef.DetectionResult {
+	if dataSec >= d.readyAtSec {
+		d.ready = true
+	}
 	if dataSec < d.emitAfterSec {
 		return observerdef.DetectionResult{}
 	}
@@ -59,9 +60,7 @@ func (d *baselineTestDetector) RemoveSeries(refs []observerdef.SeriesRef) {
 }
 
 func (d *alwaysFiringDetector) Name() string { return "always_firing" }
-func (*alwaysFiringDetector) BaselineSpec() observerdef.BaselineSpec {
-	return observerdef.BaselineSpec{}
-}
+func (*alwaysFiringDetector) Ready() bool    { return true }
 func (d *alwaysFiringDetector) Detect(_ observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{
 		Anomalies: []observerdef.Anomaly{{
@@ -109,21 +108,20 @@ func makeBaselineEngine(cfg BaselineConfig, correlator observerdef.Correlator) (
 
 // ---- baselineController unit tests ----
 
-func TestBaselineController_DetectorSpecificWindows(t *testing.T) {
-	b := newBaselineController(BaselineConfig{DurationSec: 600}, []detectorBaselineSpecEntry{
-		{name: "fast", spec: observerdef.BaselineSpec{}},
-		{name: "slow", spec: observerdef.BaselineSpec{WarmupDuration: 5 * time.Minute}},
-	})
+func TestBaselineController_DetectorReadinessStartsIndependentWindows(t *testing.T) {
+	b := newBaselineController(BaselineConfig{DurationSec: 600}, []string{"fast", "slow"})
 	assert.False(t, b.debugStatus().Started)
 	b.start(1000)
 	status := b.debugStatus()
 	assert.True(t, status.Started)
 	require.Len(t, status.Detectors, 2)
-	assert.Equal(t, BaselineDetectorDebugStatus{Name: "fast", WarmupEndSec: 1000, BaselineEndSec: 1600}, status.Detectors[0])
-	assert.Equal(t, BaselineDetectorDebugStatus{Name: "slow", WarmupEndSec: 1300, BaselineEndSec: 1900}, status.Detectors[1])
+	assert.Equal(t, BaselineDetectorDebugStatus{Name: "fast"}, status.Detectors[0])
+	assert.Equal(t, BaselineDetectorDebugStatus{Name: "slow"}, status.Detectors[1])
 	assert.True(t, b.isAnalyzingAt("fast", 1000))
 	assert.True(t, b.isAnalyzingAt("slow", 1299))
-	assert.True(t, b.isAnalyzingAt("slow", 1300))
+	assert.True(t, b.ready("fast", 1000))
+	assert.False(t, b.ready("fast", 1001))
+	assert.True(t, b.ready("slow", 1300))
 	assert.True(t, b.isAnalyzingAt("slow", 1899))
 	assert.False(t, b.isAnalyzingAt("slow", 1900))
 	assert.False(t, b.isAnalyzingAt("unknown", 1000))
@@ -147,12 +145,26 @@ func TestBaselineController_DetectorSpecificWindows(t *testing.T) {
 	assert.True(t, b.debugStatus().AllComplete)
 }
 
+func TestBaselineController_WaitingDetectorSuppressesWithoutMuting(t *testing.T) {
+	b := newBaselineController(BaselineConfig{DurationSec: 60}, []string{"waiting"})
+	b.start(100)
+
+	assert.True(t, b.isAnalyzingAt("waiting", 100))
+	b.mark("waiting", 1) // defensive suppression before Ready must not mute
+	assert.Empty(t, b.detectors["waiting"].pendingHashes)
+	assert.Empty(t, b.due(1_000))
+	assert.False(t, b.allComplete())
+
+	b.ready("waiting", 130)
+	b.mark("waiting", 1)
+	assert.Equal(t, []string{"waiting"}, b.due(190))
+}
+
 func TestBaselineController_CompletionPublishesImmutableUnionAndReleasesPendingHashes(t *testing.T) {
-	b := newBaselineController(BaselineConfig{DurationSec: 600}, []detectorBaselineSpecEntry{
-		{name: "first", spec: observerdef.BaselineSpec{}},
-		{name: "second", spec: observerdef.BaselineSpec{}},
-	})
+	b := newBaselineController(BaselineConfig{DurationSec: 600}, []string{"first", "second"})
 	b.start(1000)
+	b.ready("first", 1000)
+	b.ready("second", 1000)
 	b.mark("first", 1)
 	b.mark("second", 1)
 	b.mark("second", 2)
@@ -178,11 +190,10 @@ func TestBaselineController_CompletionPublishesImmutableUnionAndReleasesPendingH
 }
 
 func TestBaselineController_DuplicateCompletionDoesNotReplaceUnionSnapshot(t *testing.T) {
-	b := newBaselineController(BaselineConfig{DurationSec: 600}, []detectorBaselineSpecEntry{
-		{name: "first", spec: observerdef.BaselineSpec{}},
-		{name: "second", spec: observerdef.BaselineSpec{}},
-	})
+	b := newBaselineController(BaselineConfig{DurationSec: 600}, []string{"first", "second"})
 	b.start(1000)
+	b.ready("first", 1000)
+	b.ready("second", 1000)
 	b.mark("first", 1)
 	b.mark("second", 1)
 
@@ -202,13 +213,6 @@ func TestBaselineController_VerboseNamesAreLazyAndReleased(t *testing.T) {
 	assert.Equal(t, map[string]struct{}{"ns/cpu": {}, "ns/memory": {}}, b.mutedNames)
 	assert.Equal(t, []string{"ns/cpu", "ns/memory"}, b.takeMutedDisplayNames())
 	assert.Nil(t, b.mutedNames)
-}
-
-func TestRRCFBaselineSpec_UsesAlignedReadiness(t *testing.T) {
-	rrcf := NewRRCFDetector(RRCFConfig{NumTrees: 1, TreeSize: 64, ShingleSize: 4})
-	spec := rrcf.BaselineSpec()
-
-	assert.Equal(t, 78*baselineReferenceInterval, spec.WarmupDuration)
 }
 
 // ---- engine integration tests ----
@@ -233,6 +237,30 @@ func TestBaseline_AnomaliesForwardedAfterWindow(t *testing.T) {
 	assert.NotEmpty(t, correlator.received)
 }
 
+func TestBaseline_WaitingDetectorDoesNotMuteUntilReady(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	ref := storage.Add("ns", "cpu", 1.0, 100, nil).Ref
+	detector := &baselineTestDetector{
+		name:          "waiting",
+		readyAtSec:    200,
+		emitAfterSec:  100,
+		includeSource: true,
+		ref:           ref,
+		source:        observerdef.SeriesDescriptor{Namespace: "ns", Name: "cpu", Aggregate: AggregateAverage},
+	}
+	e := newEngine(engineConfig{storage: storage, detectors: []observerdef.Detector{detector}, baseline: BaselineConfig{Enabled: true, DurationSec: 100, MuteNoisyMetrics: true}})
+
+	e.Advance(100) // detector emits before Ready; it is suppressed but cannot mute
+	assert.Empty(t, e.baseline.mutedHashes)
+	assert.False(t, e.baseline.detectors["waiting"].ready)
+
+	e.Advance(200) // readiness transition anomaly is included in qualification
+	assert.True(t, e.baseline.detectors["waiting"].ready)
+	assert.Len(t, e.baseline.detectors["waiting"].pendingHashes, 1)
+	e.Advance(300)
+	assert.Len(t, e.baseline.mutedHashes, 1)
+}
+
 func TestBaseline_FastCompletionRemovesSeriesFromSlowerDetector(t *testing.T) {
 	storage := newTimeSeriesStorage()
 	ref := storage.Add("ns", "cpu", 1.0, 100, nil).Ref
@@ -240,7 +268,7 @@ func TestBaseline_FastCompletionRemovesSeriesFromSlowerDetector(t *testing.T) {
 	fast := &baselineTestDetector{name: "fast", source: source, ref: ref, includeSource: true}
 	slow := &baselineTestDetector{
 		name:          "slow",
-		spec:          observerdef.BaselineSpec{WarmupDuration: 5 * time.Minute},
+		readyAtSec:    400,
 		source:        source,
 		ref:           ref,
 		includeSource: true,
@@ -272,7 +300,7 @@ func TestBaseline_FastDetectorForwardsWhileSlowerDetectorStillAnalyses(t *testin
 		emitAfterSec:  200,
 		includeSource: true,
 	}
-	slow := &baselineTestDetector{name: "slow", spec: observerdef.BaselineSpec{WarmupDuration: 5 * time.Minute}, emitAfterSec: 1<<62 - 1}
+	slow := &baselineTestDetector{name: "slow", readyAtSec: 400, emitAfterSec: 1<<62 - 1}
 	correlator := &recordingCorrelator{}
 	e := newEngine(engineConfig{
 		storage:     storage,
@@ -382,9 +410,7 @@ func TestBaseline_MuteNoisyMetricsFalseDoesNotDropMetrics(t *testing.T) {
 type storageAwareDetector struct{}
 
 func (d *storageAwareDetector) Name() string { return "storage_aware" }
-func (*storageAwareDetector) BaselineSpec() observerdef.BaselineSpec {
-	return observerdef.BaselineSpec{}
-}
+func (*storageAwareDetector) Ready() bool    { return true }
 func (d *storageAwareDetector) Detect(sr observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
 	metas := sr.ListSeries(observerdef.SeriesFilter{})
 	anomalies := make([]observerdef.Anomaly, 0, len(metas))

--- a/comp/anomalydetection/observer/impl/baseline_test.go
+++ b/comp/anomalydetection/observer/impl/baseline_test.go
@@ -7,6 +7,7 @@ package observerimpl
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -70,74 +71,26 @@ func makeBaselineEngine(cfg BaselineConfig, correlator observerdef.Correlator) (
 
 // ---- baselineController unit tests ----
 
-func TestBaselineController_WindowSeededOnFirstActiveAt(t *testing.T) {
-	b := newBaselineController(BaselineConfig{DurationSec: 600})
-	assert.Equal(t, int64(0), b.startSec)
+func TestBaselineController_DetectorSpecificWindows(t *testing.T) {
+	b := newBaselineController(BaselineConfig{DurationSec: 600}, []detectorBaselineSpecEntry{
+		{name: "fast", spec: detectorBaselineSpec{Participate: true}},
+		{name: "slow", spec: detectorBaselineSpec{Participate: true, WarmupDuration: 5 * time.Minute}},
+	})
+	b.start(1000)
+	assert.Equal(t, baselineQualifying, b.phase("fast", 1000))
+	assert.Equal(t, baselineWarming, b.phase("slow", 1299))
+	assert.Equal(t, baselineQualifying, b.phase("slow", 1300))
+	assert.Equal(t, []string{"fast"}, b.due(1600))
 
-	assert.True(t, b.activeAt(1000))
-	assert.Equal(t, int64(1000), b.startSec)
-
-	assert.True(t, b.activeAt(1599))
-	assert.False(t, b.activeAt(1600))
-}
-
-func TestBaselineController_MarkAccumulatesAndDeduplicates(t *testing.T) {
-	b := newBaselineController(BaselineConfig{DurationSec: 600})
-	b.activeAt(0)
-
-	b.mark(1)
-	b.mark(2)
-	b.mark(1) // duplicate hash
-
-	assert.Equal(t, 3, b.windowAnomalyCount) // count includes re-fires
-	assert.Len(t, b.mutedHashes, 2)          // set deduplicates
-}
-
-func TestBaselineController_MarkNoOpWhenFrozen(t *testing.T) {
-	b := newBaselineController(BaselineConfig{DurationSec: 600})
-	b.activeAt(0)
-
-	b.frozen = true
-	b.mark(1)
-	assert.Empty(t, b.mutedHashes)
-}
-
-func TestBaselineController_ShouldFreeze(t *testing.T) {
-	b := newBaselineController(BaselineConfig{DurationSec: 600})
-
-	assert.False(t, b.shouldFreeze(1000)) // no startSec yet
-
-	b.activeAt(1000) // seed startSec=1000
-	assert.False(t, b.shouldFreeze(1599))
-	assert.True(t, b.shouldFreeze(1600))
-}
-
-func TestBaselineController_FreezeReturnsCount(t *testing.T) {
-	b := newBaselineController(BaselineConfig{DurationSec: 600})
-	b.activeAt(1000)
-	b.mark(100)
-	b.mark(200)
-
-	count := b.freeze()
-
+	b.mark("fast", 1)
+	b.mark("fast", 1)
+	newHashes, count, allComplete := b.complete("fast")
 	assert.Equal(t, 2, count)
-	assert.Len(t, b.mutedHashes, 2)
-	assert.True(t, b.frozen)
-}
-
-func TestBaselineController_Reset(t *testing.T) {
-	b := newBaselineController(BaselineConfig{DurationSec: 600})
-	b.activeAt(1000)
-	b.mark(100)
-	b.freeze()
-	require.True(t, b.frozen)
-
-	b.reset()
-
-	assert.Equal(t, int64(0), b.startSec)
-	assert.Empty(t, b.mutedHashes)
-	assert.Equal(t, 0, b.windowAnomalyCount)
-	assert.False(t, b.frozen)
+	assert.Len(t, newHashes, 1)
+	assert.False(t, allComplete)
+	assert.Equal(t, []string{"slow"}, b.due(1900))
+	_, _, allComplete = b.complete("slow")
+	assert.True(t, allComplete)
 }
 
 // ---- engine integration tests ----
@@ -172,11 +125,11 @@ func TestBaseline_ExactFreezeTimeBoundary(t *testing.T) {
 	e.Advance(start)           // seeds window, anomaly held back and marked
 	e.Advance(start + dur - 1) // t=699: still in window, anomaly held back
 	assert.Empty(t, correlator.received)
-	assert.False(t, e.baseline.frozen)
+	assert.False(t, e.baseline.allComplete())
 
 	e.Advance(start + dur) // t=700: exact freeze point — freeze fires, muted anomaly blocked
 	assert.Empty(t, correlator.received)
-	assert.True(t, e.baseline.frozen)
+	assert.True(t, e.baseline.allComplete())
 }
 
 func TestBaseline_FreezeAdvanceAnomalyNotForwardedToCorrelator(t *testing.T) {
@@ -245,7 +198,7 @@ func TestBaseline_MuteNoisyMetricsFalseDoesNotDropMetrics(t *testing.T) {
 	e.Advance(700) // freeze
 
 	assert.True(t, filter.isAllowed("cpu", "ns", nil))
-	assert.False(t, e.baseline.frozen && e.baseline.config.MuteNoisyMetrics)
+	assert.False(t, e.baseline.config.MuteNoisyMetrics)
 }
 
 // storageAwareDetector fires one anomaly per series found in storage.

--- a/comp/anomalydetection/observer/impl/baseline_test.go
+++ b/comp/anomalydetection/observer/impl/baseline_test.go
@@ -291,32 +291,6 @@ func TestBaseline_FastDetectorForwardsWhileSlowerDetectorStillAnalyses(t *testin
 	assert.False(t, e.baseline.allComplete())
 }
 
-func TestBaseline_RRCFStyleDetectorCannotMuteSeries(t *testing.T) {
-	storage := newTimeSeriesStorage()
-	storage.Add("ns", "cpu", 1.0, 100, nil)
-	rrcf := &baselineTestDetector{
-		name:         "rrcf",
-		spec:         observerdef.BaselineSpec{WarmupDuration: 100 * time.Second},
-		source:       observerdef.SeriesDescriptor{Namespace: "ns", Name: "cpu", Aggregate: AggregateAverage},
-		emitAfterSec: 100,
-		// RRCF anomalies intentionally do not identify a source series.
-		includeSource: false,
-	}
-	e := newEngine(engineConfig{
-		storage:   storage,
-		detectors: []observerdef.Detector{rrcf},
-		baseline:  BaselineConfig{Enabled: true, DurationSec: 100, MuteNoisyMetrics: true},
-	})
-
-	e.Advance(100)
-	e.Advance(300) // end of RRCF's warmup plus qualification window
-
-	assert.True(t, e.baseline.allComplete())
-	assert.Zero(t, e.baseline.debugStatus().MutedCount)
-	assert.Equal(t, 1, storage.TotalSeriesCount(""))
-	assert.Empty(t, rrcf.removed)
-}
-
 func TestBaseline_ExactFreezeTimeBoundary(t *testing.T) {
 	// Window: [100, 700). activeAt uses strict <, so t=699 is the last in-window
 	// second and t=700 is the first out-of-window second (exact freeze point).

--- a/comp/anomalydetection/observer/impl/baseline_test.go
+++ b/comp/anomalydetection/observer/impl/baseline_test.go
@@ -157,12 +157,20 @@ func TestBaselineController_WarmupOverrideAppliesToEveryParticipatingDetector(t 
 	b := newBaselineController(BaselineConfig{DurationSec: 600, WarmupDurationOverrideSec: 450}, []detectorBaselineSpecEntry{
 		{name: "first", spec: detectorBaselineSpec{Participate: true, WarmupDuration: time.Minute}},
 		{name: "second", spec: detectorBaselineSpec{Participate: true, WarmupDuration: 10 * time.Minute}},
-		{name: "rrcf", spec: detectorBaselineSpec{Participate: false}},
+		{name: "rrcf", spec: detectorBaselineSpec{Participate: true, WarmupDuration: 20 * time.Minute}},
 	})
 	b.start(100)
 	assert.Equal(t, int64(550), b.detectors["first"].warmupEndSec)
 	assert.Equal(t, int64(550), b.detectors["second"].warmupEndSec)
-	assert.NotContains(t, b.detectors, "rrcf")
+	assert.Equal(t, int64(550), b.detectors["rrcf"].warmupEndSec)
+}
+
+func TestRRCFBaselineSpec_UsesAlignedReadiness(t *testing.T) {
+	rrcf := NewRRCFDetector(RRCFConfig{NumTrees: 1, TreeSize: 64, ShingleSize: 4})
+	spec := rrcf.BaselineSpec()
+
+	assert.True(t, spec.Participate)
+	assert.Equal(t, 78*baselineReferenceInterval, spec.WarmupDuration)
 }
 
 // ---- engine integration tests ----

--- a/comp/anomalydetection/observer/impl/baseline_test.go
+++ b/comp/anomalydetection/observer/impl/baseline_test.go
@@ -24,6 +24,9 @@ type alwaysFiringDetector struct {
 }
 
 func (d *alwaysFiringDetector) Name() string { return "always_firing" }
+func (*alwaysFiringDetector) BaselineSpec() observerdef.BaselineSpec {
+	return observerdef.BaselineSpec{}
+}
 func (d *alwaysFiringDetector) Detect(_ observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{
 		Anomalies: []observerdef.Anomaly{{
@@ -73,8 +76,8 @@ func makeBaselineEngine(cfg BaselineConfig, correlator observerdef.Correlator) (
 
 func TestBaselineController_DetectorSpecificWindows(t *testing.T) {
 	b := newBaselineController(BaselineConfig{DurationSec: 600}, []detectorBaselineSpecEntry{
-		{name: "fast", spec: detectorBaselineSpec{Participate: true}},
-		{name: "slow", spec: detectorBaselineSpec{Participate: true, WarmupDuration: 5 * time.Minute}},
+		{name: "fast", spec: observerdef.BaselineSpec{}},
+		{name: "slow", spec: observerdef.BaselineSpec{WarmupDuration: 5 * time.Minute}},
 	})
 	b.start(1000)
 	assert.True(t, b.isAnalyzingAt("fast", 1000))
@@ -98,8 +101,8 @@ func TestBaselineController_DetectorSpecificWindows(t *testing.T) {
 
 func TestBaselineController_CompletionPublishesImmutableUnionAndReleasesPendingHashes(t *testing.T) {
 	b := newBaselineController(BaselineConfig{DurationSec: 600}, []detectorBaselineSpecEntry{
-		{name: "first", spec: detectorBaselineSpec{Participate: true}},
-		{name: "second", spec: detectorBaselineSpec{Participate: true}},
+		{name: "first", spec: observerdef.BaselineSpec{}},
+		{name: "second", spec: observerdef.BaselineSpec{}},
 	})
 	b.start(1000)
 	b.mark("first", 1)
@@ -128,8 +131,8 @@ func TestBaselineController_CompletionPublishesImmutableUnionAndReleasesPendingH
 
 func TestBaselineController_DuplicateCompletionDoesNotReplaceUnionSnapshot(t *testing.T) {
 	b := newBaselineController(BaselineConfig{DurationSec: 600}, []detectorBaselineSpecEntry{
-		{name: "first", spec: detectorBaselineSpec{Participate: true}},
-		{name: "second", spec: detectorBaselineSpec{Participate: true}},
+		{name: "first", spec: observerdef.BaselineSpec{}},
+		{name: "second", spec: observerdef.BaselineSpec{}},
 	})
 	b.start(1000)
 	b.mark("first", 1)
@@ -155,9 +158,9 @@ func TestBaselineController_VerboseNamesAreLazyAndReleased(t *testing.T) {
 
 func TestBaselineController_WarmupOverrideAppliesToEveryParticipatingDetector(t *testing.T) {
 	b := newBaselineController(BaselineConfig{DurationSec: 600, WarmupDurationOverrideSec: 450}, []detectorBaselineSpecEntry{
-		{name: "first", spec: detectorBaselineSpec{Participate: true, WarmupDuration: time.Minute}},
-		{name: "second", spec: detectorBaselineSpec{Participate: true, WarmupDuration: 10 * time.Minute}},
-		{name: "rrcf", spec: detectorBaselineSpec{Participate: true, WarmupDuration: 20 * time.Minute}},
+		{name: "first", spec: observerdef.BaselineSpec{WarmupDuration: time.Minute}},
+		{name: "second", spec: observerdef.BaselineSpec{WarmupDuration: 10 * time.Minute}},
+		{name: "rrcf", spec: observerdef.BaselineSpec{WarmupDuration: 20 * time.Minute}},
 	})
 	b.start(100)
 	assert.Equal(t, int64(550), b.detectors["first"].warmupEndSec)
@@ -169,7 +172,6 @@ func TestRRCFBaselineSpec_UsesAlignedReadiness(t *testing.T) {
 	rrcf := NewRRCFDetector(RRCFConfig{NumTrees: 1, TreeSize: 64, ShingleSize: 4})
 	spec := rrcf.BaselineSpec()
 
-	assert.True(t, spec.Participate)
 	assert.Equal(t, 78*baselineReferenceInterval, spec.WarmupDuration)
 }
 
@@ -286,6 +288,9 @@ func TestBaseline_MuteNoisyMetricsFalseDoesNotDropMetrics(t *testing.T) {
 type storageAwareDetector struct{}
 
 func (d *storageAwareDetector) Name() string { return "storage_aware" }
+func (*storageAwareDetector) BaselineSpec() observerdef.BaselineSpec {
+	return observerdef.BaselineSpec{}
+}
 func (d *storageAwareDetector) Detect(sr observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
 	metas := sr.ListSeries(observerdef.SeriesFilter{})
 	anomalies := make([]observerdef.Anomaly, 0, len(metas))

--- a/comp/anomalydetection/observer/impl/baseline_test.go
+++ b/comp/anomalydetection/observer/impl/baseline_test.go
@@ -77,9 +77,11 @@ func TestBaselineController_DetectorSpecificWindows(t *testing.T) {
 		{name: "slow", spec: detectorBaselineSpec{Participate: true, WarmupDuration: 5 * time.Minute}},
 	})
 	b.start(1000)
-	assert.Equal(t, baselineQualifying, b.phase("fast", 1000))
-	assert.Equal(t, baselineWarming, b.phase("slow", 1299))
-	assert.Equal(t, baselineQualifying, b.phase("slow", 1300))
+	assert.True(t, b.isAnalyzingAt("fast", 1000))
+	assert.True(t, b.isQualifyingAt("fast", 1000))
+	assert.True(t, b.isAnalyzingAt("slow", 1299))
+	assert.False(t, b.isQualifyingAt("slow", 1299))
+	assert.True(t, b.isQualifyingAt("slow", 1300))
 	assert.Equal(t, []string{"fast"}, b.due(1600))
 
 	b.mark("fast", 1)

--- a/comp/anomalydetection/observer/impl/baseline_test.go
+++ b/comp/anomalydetection/observer/impl/baseline_test.go
@@ -23,6 +23,41 @@ type alwaysFiringDetector struct {
 	ref       observerdef.SeriesRef
 }
 
+// baselineTestDetector can model independently timed detector baselines and
+// records series reclamation from another detector's baseline completion.
+type baselineTestDetector struct {
+	name          string
+	spec          observerdef.BaselineSpec
+	source        observerdef.SeriesDescriptor
+	ref           observerdef.SeriesRef
+	emitAfterSec  int64
+	includeSource bool
+	removed       []observerdef.SeriesRef
+}
+
+func (d *baselineTestDetector) Name() string { return d.name }
+func (d *baselineTestDetector) BaselineSpec() observerdef.BaselineSpec {
+	return d.spec
+}
+func (d *baselineTestDetector) Detect(_ observerdef.StorageReader, dataSec int64) observerdef.DetectionResult {
+	if dataSec < d.emitAfterSec {
+		return observerdef.DetectionResult{}
+	}
+	anomaly := observerdef.Anomaly{
+		Source:       d.source,
+		DetectorName: d.name,
+		Timestamp:    dataSec,
+		Title:        "anomaly",
+	}
+	if d.includeSource {
+		anomaly.SourceRef = &observerdef.QueryHandle{Ref: d.ref, Aggregate: AggregateAverage}
+	}
+	return observerdef.DetectionResult{Anomalies: []observerdef.Anomaly{anomaly}}
+}
+func (d *baselineTestDetector) RemoveSeries(refs []observerdef.SeriesRef) {
+	d.removed = append(d.removed, refs...)
+}
+
 func (d *alwaysFiringDetector) Name() string { return "always_firing" }
 func (*alwaysFiringDetector) BaselineSpec() observerdef.BaselineSpec {
 	return observerdef.BaselineSpec{}
@@ -79,10 +114,19 @@ func TestBaselineController_DetectorSpecificWindows(t *testing.T) {
 		{name: "fast", spec: observerdef.BaselineSpec{}},
 		{name: "slow", spec: observerdef.BaselineSpec{WarmupDuration: 5 * time.Minute}},
 	})
+	assert.False(t, b.debugStatus().Started)
 	b.start(1000)
+	status := b.debugStatus()
+	assert.True(t, status.Started)
+	require.Len(t, status.Detectors, 2)
+	assert.Equal(t, BaselineDetectorDebugStatus{Name: "fast", WarmupEndSec: 1000, BaselineEndSec: 1600}, status.Detectors[0])
+	assert.Equal(t, BaselineDetectorDebugStatus{Name: "slow", WarmupEndSec: 1300, BaselineEndSec: 1900}, status.Detectors[1])
 	assert.True(t, b.isAnalyzingAt("fast", 1000))
 	assert.True(t, b.isAnalyzingAt("slow", 1299))
 	assert.True(t, b.isAnalyzingAt("slow", 1300))
+	assert.True(t, b.isAnalyzingAt("slow", 1899))
+	assert.False(t, b.isAnalyzingAt("slow", 1900))
+	assert.False(t, b.isAnalyzingAt("unknown", 1000))
 	assert.Equal(t, []string{"fast"}, b.due(1600))
 
 	b.mark("fast", 1)
@@ -92,9 +136,15 @@ func TestBaselineController_DetectorSpecificWindows(t *testing.T) {
 	assert.Equal(t, 2, count)
 	assert.Len(t, newHashes, 1)
 	assert.False(t, allComplete)
+	status = b.debugStatus()
+	assert.True(t, status.Detectors[0].Completed)
+	assert.False(t, status.Detectors[1].Completed)
+	assert.Equal(t, 1, status.Detectors[0].MutedCount)
 	assert.Equal(t, []string{"slow"}, b.due(1900))
 	_, _, _, allComplete = b.complete("slow")
 	assert.True(t, allComplete)
+	assert.False(t, b.isAnalyzingAt("slow", 1900))
+	assert.True(t, b.debugStatus().AllComplete)
 }
 
 func TestBaselineController_CompletionPublishesImmutableUnionAndReleasesPendingHashes(t *testing.T) {
@@ -181,6 +231,90 @@ func TestBaseline_AnomaliesForwardedAfterWindow(t *testing.T) {
 	e.Advance(800) // past window end: anomaly forwarded, freeze fires
 
 	assert.NotEmpty(t, correlator.received)
+}
+
+func TestBaseline_FastCompletionRemovesSeriesFromSlowerDetector(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	ref := storage.Add("ns", "cpu", 1.0, 100, nil).Ref
+	source := observerdef.SeriesDescriptor{Namespace: "ns", Name: "cpu", Aggregate: AggregateAverage}
+	fast := &baselineTestDetector{name: "fast", source: source, ref: ref, includeSource: true}
+	slow := &baselineTestDetector{
+		name:          "slow",
+		spec:          observerdef.BaselineSpec{WarmupDuration: 5 * time.Minute},
+		source:        source,
+		ref:           ref,
+		includeSource: true,
+	}
+	e := newEngine(engineConfig{
+		storage:   storage,
+		detectors: []observerdef.Detector{fast, slow},
+		baseline:  BaselineConfig{Enabled: true, DurationSec: 100, MuteNoisyMetrics: true},
+	})
+
+	e.Advance(100) // both detectors are analysing and nominate cpu for muting
+	e.Advance(200) // fast completes, immediately reclaiming cpu everywhere
+
+	assert.Zero(t, storage.TotalSeriesCount(""))
+	assert.Equal(t, []observerdef.SeriesRef{ref}, fast.removed)
+	assert.Equal(t, []observerdef.SeriesRef{ref}, slow.removed)
+	assert.True(t, e.baseline.detectors["fast"].completed)
+	assert.False(t, e.baseline.detectors["slow"].completed)
+	assert.False(t, e.baseline.allComplete())
+}
+
+func TestBaseline_FastDetectorForwardsWhileSlowerDetectorStillAnalyses(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	ref := storage.Add("ns", "memory", 1.0, 100, nil).Ref
+	fast := &baselineTestDetector{
+		name:          "fast",
+		source:        observerdef.SeriesDescriptor{Namespace: "ns", Name: "memory", Aggregate: AggregateAverage},
+		ref:           ref,
+		emitAfterSec:  200,
+		includeSource: true,
+	}
+	slow := &baselineTestDetector{name: "slow", spec: observerdef.BaselineSpec{WarmupDuration: 5 * time.Minute}, emitAfterSec: 1<<62 - 1}
+	correlator := &recordingCorrelator{}
+	e := newEngine(engineConfig{
+		storage:     storage,
+		detectors:   []observerdef.Detector{fast, slow},
+		correlators: []observerdef.Correlator{correlator},
+		baseline:    BaselineConfig{Enabled: true, DurationSec: 100, MuteNoisyMetrics: true},
+	})
+
+	e.Advance(100) // starts both windows; neither detector emits
+	e.Advance(200) // fast completes and its first anomaly is forwarded
+
+	require.Len(t, correlator.received, 1)
+	assert.Equal(t, "fast", correlator.received[0].DetectorName)
+	assert.True(t, e.baseline.detectors["fast"].completed)
+	assert.False(t, e.baseline.detectors["slow"].completed)
+	assert.False(t, e.baseline.allComplete())
+}
+
+func TestBaseline_RRCFStyleDetectorCannotMuteSeries(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	storage.Add("ns", "cpu", 1.0, 100, nil)
+	rrcf := &baselineTestDetector{
+		name:         "rrcf",
+		spec:         observerdef.BaselineSpec{WarmupDuration: 100 * time.Second},
+		source:       observerdef.SeriesDescriptor{Namespace: "ns", Name: "cpu", Aggregate: AggregateAverage},
+		emitAfterSec: 100,
+		// RRCF anomalies intentionally do not identify a source series.
+		includeSource: false,
+	}
+	e := newEngine(engineConfig{
+		storage:   storage,
+		detectors: []observerdef.Detector{rrcf},
+		baseline:  BaselineConfig{Enabled: true, DurationSec: 100, MuteNoisyMetrics: true},
+	})
+
+	e.Advance(100)
+	e.Advance(300) // end of RRCF's warmup plus qualification window
+
+	assert.True(t, e.baseline.allComplete())
+	assert.Zero(t, e.baseline.debugStatus().MutedCount)
+	assert.Equal(t, 1, storage.TotalSeriesCount(""))
+	assert.Empty(t, rrcf.removed)
 }
 
 func TestBaseline_ExactFreezeTimeBoundary(t *testing.T) {

--- a/comp/anomalydetection/observer/impl/baseline_test.go
+++ b/comp/anomalydetection/observer/impl/baseline_test.go
@@ -86,13 +86,73 @@ func TestBaselineController_DetectorSpecificWindows(t *testing.T) {
 
 	b.mark("fast", 1)
 	b.mark("fast", 1)
-	newHashes, count, allComplete := b.complete("fast")
+	newHashes, changed, count, allComplete := b.complete("fast")
+	assert.True(t, changed)
 	assert.Equal(t, 2, count)
 	assert.Len(t, newHashes, 1)
 	assert.False(t, allComplete)
 	assert.Equal(t, []string{"slow"}, b.due(1900))
-	_, _, allComplete = b.complete("slow")
+	_, _, _, allComplete = b.complete("slow")
 	assert.True(t, allComplete)
+}
+
+func TestBaselineController_CompletionPublishesImmutableUnionAndReleasesPendingHashes(t *testing.T) {
+	b := newBaselineController(BaselineConfig{DurationSec: 600}, []detectorBaselineSpecEntry{
+		{name: "first", spec: detectorBaselineSpec{Participate: true}},
+		{name: "second", spec: detectorBaselineSpec{Participate: true}},
+	})
+	b.start(1000)
+	b.mark("first", 1)
+	b.mark("second", 1)
+	b.mark("second", 2)
+
+	firstDelta, changed, _, _ := b.complete("first")
+	require.True(t, changed)
+	assert.Equal(t, map[uint64]struct{}{1: {}}, firstDelta)
+	firstSnapshot := b.mutedHashes
+	assert.Nil(t, b.detectors["first"].pendingHashes)
+	assert.Equal(t, 1, b.detectors["first"].mutedCount)
+
+	secondDelta, changed, _, _ := b.complete("second")
+	require.True(t, changed)
+	assert.Equal(t, map[uint64]struct{}{2: {}}, secondDelta)
+	assert.Equal(t, map[uint64]struct{}{1: {}}, firstSnapshot)
+	assert.Equal(t, map[uint64]struct{}{1: {}, 2: {}}, b.mutedHashes)
+	assert.Nil(t, b.detectors["second"].pendingHashes)
+	assert.Equal(t, 2, b.detectors["second"].mutedCount)
+
+	status := b.debugStatus()
+	assert.Equal(t, 1, status.Detectors[0].MutedCount)
+	assert.Equal(t, 2, status.Detectors[1].MutedCount)
+}
+
+func TestBaselineController_DuplicateCompletionDoesNotReplaceUnionSnapshot(t *testing.T) {
+	b := newBaselineController(BaselineConfig{DurationSec: 600}, []detectorBaselineSpecEntry{
+		{name: "first", spec: detectorBaselineSpec{Participate: true}},
+		{name: "second", spec: detectorBaselineSpec{Participate: true}},
+	})
+	b.start(1000)
+	b.mark("first", 1)
+	b.mark("second", 1)
+
+	_, changed, _, _ := b.complete("first")
+	require.True(t, changed)
+	newHashes, changed, _, _ := b.complete("second")
+	assert.Empty(t, newHashes)
+	assert.False(t, changed)
+	assert.Equal(t, map[uint64]struct{}{1: {}}, b.mutedHashes)
+}
+
+func TestBaselineController_WarmupOverrideAppliesToEveryParticipatingDetector(t *testing.T) {
+	b := newBaselineController(BaselineConfig{DurationSec: 600, WarmupDurationOverrideSec: 450}, []detectorBaselineSpecEntry{
+		{name: "first", spec: detectorBaselineSpec{Participate: true, WarmupDuration: time.Minute}},
+		{name: "second", spec: detectorBaselineSpec{Participate: true, WarmupDuration: 10 * time.Minute}},
+		{name: "rrcf", spec: detectorBaselineSpec{Participate: false}},
+	})
+	b.start(100)
+	assert.Equal(t, int64(550), b.detectors["first"].warmupEndSec)
+	assert.Equal(t, int64(550), b.detectors["second"].warmupEndSec)
+	assert.NotContains(t, b.detectors, "rrcf")
 }
 
 // ---- engine integration tests ----

--- a/comp/anomalydetection/observer/impl/baseline_test.go
+++ b/comp/anomalydetection/observer/impl/baseline_test.go
@@ -81,10 +81,8 @@ func TestBaselineController_DetectorSpecificWindows(t *testing.T) {
 	})
 	b.start(1000)
 	assert.True(t, b.isAnalyzingAt("fast", 1000))
-	assert.True(t, b.isQualifyingAt("fast", 1000))
 	assert.True(t, b.isAnalyzingAt("slow", 1299))
-	assert.False(t, b.isQualifyingAt("slow", 1299))
-	assert.True(t, b.isQualifyingAt("slow", 1300))
+	assert.True(t, b.isAnalyzingAt("slow", 1300))
 	assert.Equal(t, []string{"fast"}, b.due(1600))
 
 	b.mark("fast", 1)
@@ -154,18 +152,6 @@ func TestBaselineController_VerboseNamesAreLazyAndReleased(t *testing.T) {
 	assert.Equal(t, map[string]struct{}{"ns/cpu": {}, "ns/memory": {}}, b.mutedNames)
 	assert.Equal(t, []string{"ns/cpu", "ns/memory"}, b.takeMutedDisplayNames())
 	assert.Nil(t, b.mutedNames)
-}
-
-func TestBaselineController_WarmupOverrideAppliesToEveryParticipatingDetector(t *testing.T) {
-	b := newBaselineController(BaselineConfig{DurationSec: 600, WarmupDurationOverrideSec: 450}, []detectorBaselineSpecEntry{
-		{name: "first", spec: observerdef.BaselineSpec{WarmupDuration: time.Minute}},
-		{name: "second", spec: observerdef.BaselineSpec{WarmupDuration: 10 * time.Minute}},
-		{name: "rrcf", spec: observerdef.BaselineSpec{WarmupDuration: 20 * time.Minute}},
-	})
-	b.start(100)
-	assert.Equal(t, int64(550), b.detectors["first"].warmupEndSec)
-	assert.Equal(t, int64(550), b.detectors["second"].warmupEndSec)
-	assert.Equal(t, int64(550), b.detectors["rrcf"].warmupEndSec)
 }
 
 func TestRRCFBaselineSpec_UsesAlignedReadiness(t *testing.T) {

--- a/comp/anomalydetection/observer/impl/baseline_test.go
+++ b/comp/anomalydetection/observer/impl/baseline_test.go
@@ -143,6 +143,16 @@ func TestBaselineController_DuplicateCompletionDoesNotReplaceUnionSnapshot(t *te
 	assert.Equal(t, map[uint64]struct{}{1: {}}, b.mutedHashes)
 }
 
+func TestBaselineController_VerboseNamesAreLazyAndReleased(t *testing.T) {
+	b := newBaselineController(BaselineConfig{}, nil)
+	assert.Nil(t, b.mutedNames)
+
+	b.recordMutedNames([]string{"ns/cpu", "ns/memory", "ns/cpu"})
+	assert.Equal(t, map[string]struct{}{"ns/cpu": {}, "ns/memory": {}}, b.mutedNames)
+	assert.Equal(t, []string{"ns/cpu", "ns/memory"}, b.takeMutedDisplayNames())
+	assert.Nil(t, b.mutedNames)
+}
+
 func TestBaselineController_WarmupOverrideAppliesToEveryParticipatingDetector(t *testing.T) {
 	b := newBaselineController(BaselineConfig{DurationSec: 600, WarmupDurationOverrideSec: 450}, []detectorBaselineSpecEntry{
 		{name: "first", spec: detectorBaselineSpec{Participate: true, WarmupDuration: time.Minute}},

--- a/comp/anomalydetection/observer/impl/component_catalog.go
+++ b/comp/anomalydetection/observer/impl/component_catalog.go
@@ -90,6 +90,36 @@ type ComponentSettings struct {
 	configs map[string]any
 }
 
+// ApplyTestbenchDetectorDefaults applies the shorter detector warmups used by
+// the offline testbench. Production builds ComponentSettings from the agent
+// config and never calls this function. An explicit testbench --config entry
+// for a detector takes precedence over this profile.
+func ApplyTestbenchDetectorDefaults(settings ComponentSettings) ComponentSettings {
+	if settings.configs == nil {
+		settings.configs = make(map[string]any)
+	}
+
+	bocpd := DefaultBOCPDConfig()
+	bocpd.WarmupPoints = 40
+	holt := DefaultHoltResidualConfig()
+	holt.WarmupPoints = 15
+	holt.ResidualWindow = 25
+	tukey := DefaultTukeyBiweightConfig()
+	tukey.WindowSize = 40
+	tukey.MinPoints = 40
+
+	for name, cfg := range map[string]any{
+		"bocpd":          bocpd,
+		"holt_residual":  holt,
+		"tukey_biweight": tukey,
+	} {
+		if _, explicitlyConfigured := settings.configs[name]; !explicitlyConfigured {
+			settings.configs[name] = cfg
+		}
+	}
+	return settings
+}
+
 // componentCatalog is the shared registry of all available pipeline components.
 // Both the live observer and the testbench use this to discover and instantiate
 // detectors, correlators, and extractors.

--- a/comp/anomalydetection/observer/impl/component_catalog_test.go
+++ b/comp/anomalydetection/observer/impl/component_catalog_test.go
@@ -72,9 +72,7 @@ func TestValidateDetectorTeardownContract_AllowlistEscape(t *testing.T) {
 type bareDetectorForValidator struct{}
 
 func (*bareDetectorForValidator) Name() string { return "bare-detector" }
-func (*bareDetectorForValidator) BaselineSpec() observerdef.BaselineSpec {
-	return observerdef.BaselineSpec{}
-}
+func (*bareDetectorForValidator) Ready() bool  { return true }
 func (*bareDetectorForValidator) Detect(_ observerdef.StorageReader, _ int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{}
 }

--- a/comp/anomalydetection/observer/impl/component_catalog_test.go
+++ b/comp/anomalydetection/observer/impl/component_catalog_test.go
@@ -72,6 +72,9 @@ func TestValidateDetectorTeardownContract_AllowlistEscape(t *testing.T) {
 type bareDetectorForValidator struct{}
 
 func (*bareDetectorForValidator) Name() string { return "bare-detector" }
+func (*bareDetectorForValidator) BaselineSpec() observerdef.BaselineSpec {
+	return observerdef.BaselineSpec{}
+}
 func (*bareDetectorForValidator) Detect(_ observerdef.StorageReader, _ int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{}
 }

--- a/comp/anomalydetection/observer/impl/component_catalog_test.go
+++ b/comp/anomalydetection/observer/impl/component_catalog_test.go
@@ -6,6 +6,7 @@
 package observerimpl
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -64,6 +65,28 @@ func TestValidateDetectorTeardownContract_AllowlistEscape(t *testing.T) {
 		},
 	}
 	require.NoError(t, cat.validateDetectorTeardownContract())
+}
+
+func TestApplyTestbenchDetectorDefaults(t *testing.T) {
+	settings := ApplyTestbenchDetectorDefaults(ComponentSettings{})
+
+	require.Equal(t, 40, settings.configs["bocpd"].(BOCPDConfig).WarmupPoints)
+	holt := settings.configs["holt_residual"].(HoltResidualConfig)
+	require.Equal(t, 15, holt.WarmupPoints)
+	require.Equal(t, 25, holt.ResidualWindow)
+	tukey := settings.configs["tukey_biweight"].(TukeyBiweightConfig)
+	require.Equal(t, 40, tukey.WindowSize)
+	require.Equal(t, 40, tukey.MinPoints)
+}
+
+func TestApplyTestbenchDetectorDefaults_PreservesExplicitConfig(t *testing.T) {
+	settings, err := ParseSettingsFromJSON(map[string]json.RawMessage{
+		"bocpd": json.RawMessage(`{"warmup_points": 42}`),
+	})
+	require.NoError(t, err)
+
+	settings = ApplyTestbenchDetectorDefaults(settings)
+	require.Equal(t, 42, settings.configs["bocpd"].(BOCPDConfig).WarmupPoints)
 }
 
 // bareDetectorForValidator is a minimal observerdef.Detector that

--- a/comp/anomalydetection/observer/impl/engine.go
+++ b/comp/anomalydetection/observer/impl/engine.go
@@ -587,18 +587,11 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 			// the same anomaly (same {source,detector,ts,title}) on consecutive advances,
 			// so captureRawAnomaly would return false (duplicate) before we could mark it.
 			// anomaly.Source.Tags are sorted (copied from storage's intern pool by seriesDetectorAdapter).
-			if e.baseline != nil {
-				switch e.baseline.phase(detector.Name(), upTo) {
-				case baselineWarming:
-					// Warmup lets the detector establish its own model but never
-					// qualifies a series for global muting.
-					continue
-				case baselineQualifying:
-					if anomaly.SourceRef != nil {
-						e.baseline.mark(detector.Name(), seriesKeyHash(anomaly.Source.Namespace, anomaly.Source.Name, anomaly.Source.Tags))
-					}
-					continue
+			if e.baseline != nil && e.baseline.isAnalyzingAt(detector.Name(), upTo) {
+				if e.baseline.isQualifyingAt(detector.Name(), upTo) && anomaly.SourceRef != nil {
+					e.baseline.mark(detector.Name(), seriesKeyHash(anomaly.Source.Namespace, anomaly.Source.Name, anomaly.Source.Tags))
 				}
+				continue
 			}
 			if e.baseline != nil && e.baseline.config.MuteNoisyMetrics && len(e.baseline.mutedHashes) > 0 {
 				h := seriesKeyHash(anomaly.Source.Namespace, anomaly.Source.Name, anomaly.Source.Tags)

--- a/comp/anomalydetection/observer/impl/engine.go
+++ b/comp/anomalydetection/observer/impl/engine.go
@@ -183,7 +183,7 @@ func newEngine(cfg engineConfig) *engine {
 		e.logCounts = newMaterializedLogCountBucketizer(cfg.logCountBuckets)
 	}
 	if cfg.baseline.Enabled {
-		e.baseline = newBaselineController(cfg.baseline)
+		e.baseline = newBaselineController(cfg.baseline, baselineSpecs(cfg.detectors))
 	}
 
 	// Cache log observers from detectors.
@@ -328,7 +328,7 @@ func (e *engine) IngestLog(source string, l *logObs) []advanceRequest {
 			// Always canonicalize so the hash computed here matches storage's
 			// seriesKeyHash, and storage.Add hits the tagsSorted fast path.
 			tags = canonicalizeTags(tags)
-			if e.baseline != nil && e.baseline.frozen && e.baseline.config.MuteNoisyMetrics && len(e.baseline.mutedHashes) > 0 {
+			if e.baseline != nil && e.baseline.config.MuteNoisyMetrics && len(e.baseline.mutedHashes) > 0 {
 				if _, ok := e.baseline.mutedHashes[seriesKeyHash(extractor.Name(), m.Name, tags)]; ok {
 					continue
 				}
@@ -495,17 +495,16 @@ func (e *engine) advanceWithReason(upToSec int64, reason advanceReason) advanceR
 	}
 
 	if e.baseline != nil {
-		e.baseline.activeAt(upToSec)
+		e.baseline.start(upToSec)
+		// Complete windows before detecting at their exact end. This removes
+		// series globally before a slower detector can process them again.
+		e.completeDueBaselines(upToSec)
 	}
 	if e.logCounts != nil {
 		e.logCounts.flush(e.storage, upToSec)
 	}
 
 	result := e.runDetectorsAndCorrelatorsSnapshot(upToSec, detectors, correlators)
-
-	if e.baseline != nil && e.baseline.shouldFreeze(upToSec) {
-		e.freezeBaseline(upToSec)
-	}
 
 	// Evict series beyond the storage cap and fan freed refs to detectors.
 	if freed := e.storage.EvictDefault(); len(freed) > 0 {
@@ -588,16 +587,20 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 			// the same anomaly (same {source,detector,ts,title}) on consecutive advances,
 			// so captureRawAnomaly would return false (duplicate) before we could mark it.
 			// anomaly.Source.Tags are sorted (copied from storage's intern pool by seriesDetectorAdapter).
-			if e.baseline != nil && e.baseline.activeAt(upTo) {
-				if anomaly.SourceRef != nil {
-					e.baseline.mark(seriesKeyHash(anomaly.Source.Namespace, anomaly.Source.Name, anomaly.Source.Tags))
+			if e.baseline != nil {
+				switch e.baseline.phase(detector.Name(), upTo) {
+				case baselineWarming:
+					// Warmup lets the detector establish its own model but never
+					// qualifies a series for global muting.
+					continue
+				case baselineQualifying:
+					if anomaly.SourceRef != nil {
+						e.baseline.mark(detector.Name(), seriesKeyHash(anomaly.Source.Namespace, anomaly.Source.Name, anomaly.Source.Tags))
+					}
+					continue
 				}
-				continue
 			}
-			// On the freeze advance activeAt returns false, so anomalies from noisy
-			// series would otherwise enter processAnomaly and land in the correlator
-			// just as the series is being reclaimed. Drop them here instead.
-			if e.baseline != nil && !e.baseline.frozen && e.baseline.config.MuteNoisyMetrics && len(e.baseline.mutedHashes) > 0 {
+			if e.baseline != nil && e.baseline.config.MuteNoisyMetrics && len(e.baseline.mutedHashes) > 0 {
 				h := seriesKeyHash(anomaly.Source.Namespace, anomaly.Source.Name, anomaly.Source.Tags)
 				if _, muted := e.baseline.mutedHashes[h]; muted {
 					continue
@@ -821,18 +824,27 @@ func (e *engine) AccumulatedCorrelations() []observerdef.ActiveCorrelation {
 	return result
 }
 
-// freezeBaseline closes the baseline window, optionally reclaims muted series,
-// and emits eventBaselineCompleted. Must be called from the engine run goroutine.
-func (e *engine) freezeBaseline(upToSec int64) {
-	windowAnomalyCount := e.baseline.freeze()
-	if e.logCounts != nil && e.baseline.config.MuteNoisyMetrics {
-		e.logCounts.removeSeriesByHashes(e.baseline.mutedHashes)
+// completeDueBaselines closes every detector window due at dataSec. It is
+// called before detection so a series muted by one detector is immediately
+// removed from storage and every other detector's local state.
+func (e *engine) completeDueBaselines(dataSec int64) {
+	names := e.baseline.due(dataSec)
+	sort.Strings(names)
+	for _, name := range names {
+		e.completeBaseline(name, dataSec)
+	}
+}
+
+func (e *engine) completeBaseline(detectorName string, upToSec int64) {
+	newHashes, windowAnomalyCount, allComplete := e.baseline.complete(detectorName)
+	if e.logCounts != nil && e.baseline.config.MuteNoisyMetrics && len(newHashes) > 0 {
+		e.logCounts.removeSeriesByHashes(newHashes)
 	}
 
 	needRefs := e.baseline.config.MuteNoisyMetrics || e.baseline.config.Verbose
 	var refs []observerdef.SeriesRef
-	if needRefs && len(e.baseline.mutedHashes) > 0 {
-		refs = e.storage.FindRefsByHashes(e.baseline.mutedHashes)
+	if needRefs && len(newHashes) > 0 {
+		refs = e.storage.FindRefsByHashes(newHashes)
 	}
 
 	// Collect display names before removal (GetSeriesMeta returns nil after RemoveSeriesByRefs).
@@ -844,17 +856,22 @@ func (e *engine) freezeBaseline(upToSec int64) {
 			}
 		}
 		sort.Strings(displayNames)
+		e.baseline.recordMutedNames(displayNames)
 	}
 
 	totalSeries := e.storage.TotalSeriesCount("")
 
-	// Emit before removal so testbench sinks can read metadata.
+	// Emit before removal so testbench sinks can read metadata. The snapshot is
+	// cloned because the ingress filter reads it concurrently with later window
+	// completions mutating the controller's union.
 	e.emit(engineEvent{
 		kind:      eventBaselineCompleted,
 		timestamp: upToSec,
 		baselineCompleted: &baselineCompletedEvent{
-			mutedHashes: e.baseline.mutedHashes,
-			mutedRefs:   refs,
+			detectorName: detectorName,
+			mutedHashes:  cloneMutedHashes(e.baseline.mutedHashes),
+			mutedRefs:    refs,
+			allComplete:  allComplete,
 		},
 	})
 
@@ -865,11 +882,14 @@ func (e *engine) freezeBaseline(upToSec int64) {
 		}
 	}
 
-	pkglog.Infof("[observer] baseline window ended: %d/%d series muted from anomaly detection (%d anomalies seen)",
-		len(e.baseline.mutedHashes), totalSeries, windowAnomalyCount)
+	pkglog.Debugf("[observer] baseline %d/%d ended for detector %q: %d new series muted (%d anomalies seen)",
+		e.baseline.completedCount(), len(e.baseline.detectors), detectorName, len(newHashes), windowAnomalyCount)
 
-	if e.baseline.config.Verbose {
-		for _, name := range displayNames {
+	if allComplete {
+		pkglog.Infof("[observer] all baseline windows ended: %d/%d series muted from anomaly detection", len(e.baseline.mutedHashes), totalSeries)
+	}
+	if allComplete && e.baseline.config.Verbose {
+		for _, name := range e.baseline.mutedDisplayNames() {
 			pkglog.Infof("[observer] baseline muted: %s", name)
 		}
 	}
@@ -943,7 +963,7 @@ func (e *engine) Reset() {
 	}
 
 	if e.baseline != nil {
-		e.baseline.reset()
+		e.baseline = newBaselineController(e.baseline.config, baselineSpecs(e.detectors))
 	}
 }
 
@@ -997,7 +1017,7 @@ func (e *engine) resetAnalysisState() {
 	// log ingestion and is needed by enrichAnomaly during replay.
 
 	if e.baseline != nil {
-		e.baseline.reset()
+		e.baseline = newBaselineController(e.baseline.config, baselineSpecs(e.detectors))
 	}
 
 	e.resetRawAnomalies()
@@ -1031,7 +1051,7 @@ func (e *engine) ResetForReplay(detectors []observerdef.Detector, correlators []
 	e.trackCorrelationHistory = storageCfg.TrackCorrelationHistory
 	e.mu.Unlock()
 	if baselineCfg.Enabled {
-		e.baseline = newBaselineController(baselineCfg)
+		e.baseline = newBaselineController(baselineCfg, baselineSpecs(detectors))
 	} else {
 		e.baseline = nil
 	}

--- a/comp/anomalydetection/observer/impl/engine.go
+++ b/comp/anomalydetection/observer/impl/engine.go
@@ -588,7 +588,7 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 			// so captureRawAnomaly would return false (duplicate) before we could mark it.
 			// anomaly.Source.Tags are sorted (copied from storage's intern pool by seriesDetectorAdapter).
 			if e.baseline != nil && e.baseline.isAnalyzingAt(detector.Name(), upTo) {
-				if e.baseline.isQualifyingAt(detector.Name(), upTo) && anomaly.SourceRef != nil {
+				if anomaly.SourceRef != nil {
 					e.baseline.mark(detector.Name(), seriesKeyHash(anomaly.Source.Namespace, anomaly.Source.Name, anomaly.Source.Tags))
 				}
 				continue

--- a/comp/anomalydetection/observer/impl/engine.go
+++ b/comp/anomalydetection/observer/impl/engine.go
@@ -829,7 +829,7 @@ func (e *engine) completeDueBaselines(dataSec int64) {
 }
 
 func (e *engine) completeBaseline(detectorName string, upToSec int64) {
-	newHashes, windowAnomalyCount, allComplete := e.baseline.complete(detectorName)
+	newHashes, snapshotChanged, windowAnomalyCount, allComplete := e.baseline.complete(detectorName)
 	if e.logCounts != nil && e.baseline.config.MuteNoisyMetrics && len(newHashes) > 0 {
 		e.logCounts.removeSeriesByHashes(newHashes)
 	}
@@ -854,17 +854,18 @@ func (e *engine) completeBaseline(detectorName string, upToSec int64) {
 
 	totalSeries := e.storage.TotalSeriesCount("")
 
-	// Emit before removal so testbench sinks can read metadata. The snapshot is
-	// cloned because the ingress filter reads it concurrently with later window
-	// completions mutating the controller's union.
+	// Emit before removal so testbench sinks can read metadata. The controller
+	// uses copy-on-write snapshots, so this immutable union can be published to
+	// concurrent ingress handlers without another full-map copy.
 	e.emit(engineEvent{
 		kind:      eventBaselineCompleted,
 		timestamp: upToSec,
 		baselineCompleted: &baselineCompletedEvent{
-			detectorName: detectorName,
-			mutedHashes:  cloneMutedHashes(e.baseline.mutedHashes),
-			mutedRefs:    refs,
-			allComplete:  allComplete,
+			detectorName:    detectorName,
+			mutedHashes:     e.baseline.mutedHashes,
+			snapshotChanged: snapshotChanged,
+			mutedRefs:       refs,
+			allComplete:     allComplete,
 		},
 	})
 

--- a/comp/anomalydetection/observer/impl/engine.go
+++ b/comp/anomalydetection/observer/impl/engine.go
@@ -883,7 +883,7 @@ func (e *engine) completeBaseline(detectorName string, upToSec int64) {
 		pkglog.Infof("[observer] all baseline windows ended: %d/%d series muted from anomaly detection", len(e.baseline.mutedHashes), totalSeries)
 	}
 	if allComplete && e.baseline.config.Verbose {
-		for _, name := range e.baseline.mutedDisplayNames() {
+		for _, name := range e.baseline.takeMutedDisplayNames() {
 			pkglog.Infof("[observer] baseline muted: %s", name)
 		}
 	}

--- a/comp/anomalydetection/observer/impl/engine.go
+++ b/comp/anomalydetection/observer/impl/engine.go
@@ -183,7 +183,7 @@ func newEngine(cfg engineConfig) *engine {
 		e.logCounts = newMaterializedLogCountBucketizer(cfg.logCountBuckets)
 	}
 	if cfg.baseline.Enabled {
-		e.baseline = newBaselineController(cfg.baseline, baselineSpecs(cfg.detectors))
+		e.baseline = newBaselineController(cfg.baseline, detectorNames(cfg.detectors))
 	}
 
 	// Cache log observers from detectors.
@@ -558,6 +558,9 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 		}
 
 		result := detector.Detect(storageForDetect, upTo)
+		if e.baseline != nil && detector.Ready() {
+			e.baseline.ready(detector.Name(), upTo)
+		}
 
 		// Emit detect digest (captures raw result BEFORE dedup).
 		if e.onDetectDigest != nil {
@@ -957,7 +960,7 @@ func (e *engine) Reset() {
 	}
 
 	if e.baseline != nil {
-		e.baseline = newBaselineController(e.baseline.config, baselineSpecs(e.detectors))
+		e.baseline = newBaselineController(e.baseline.config, detectorNames(e.detectors))
 	}
 }
 
@@ -1011,7 +1014,7 @@ func (e *engine) resetAnalysisState() {
 	// log ingestion and is needed by enrichAnomaly during replay.
 
 	if e.baseline != nil {
-		e.baseline = newBaselineController(e.baseline.config, baselineSpecs(e.detectors))
+		e.baseline = newBaselineController(e.baseline.config, detectorNames(e.detectors))
 	}
 
 	e.resetRawAnomalies()
@@ -1045,7 +1048,7 @@ func (e *engine) ResetForReplay(detectors []observerdef.Detector, correlators []
 	e.trackCorrelationHistory = storageCfg.TrackCorrelationHistory
 	e.mu.Unlock()
 	if baselineCfg.Enabled {
-		e.baseline = newBaselineController(baselineCfg, baselineSpecs(detectors))
+		e.baseline = newBaselineController(baselineCfg, detectorNames(detectors))
 	} else {
 		e.baseline = nil
 	}

--- a/comp/anomalydetection/observer/impl/engine_stepadvance_test.go
+++ b/comp/anomalydetection/observer/impl/engine_stepadvance_test.go
@@ -19,9 +19,7 @@ type fixedDetector struct {
 }
 
 func (d *fixedDetector) Name() string { return "fixed" }
-func (*fixedDetector) BaselineSpec() observer.BaselineSpec {
-	return observer.BaselineSpec{}
-}
+func (*fixedDetector) Ready() bool    { return true }
 
 func (d *fixedDetector) Detect(_ observer.StorageReader, _ int64) observer.DetectionResult {
 	if d.fired {

--- a/comp/anomalydetection/observer/impl/engine_stepadvance_test.go
+++ b/comp/anomalydetection/observer/impl/engine_stepadvance_test.go
@@ -19,6 +19,9 @@ type fixedDetector struct {
 }
 
 func (d *fixedDetector) Name() string { return "fixed" }
+func (*fixedDetector) BaselineSpec() observer.BaselineSpec {
+	return observer.BaselineSpec{}
+}
 
 func (d *fixedDetector) Detect(_ observer.StorageReader, _ int64) observer.DetectionResult {
 	if d.fired {

--- a/comp/anomalydetection/observer/impl/events.go
+++ b/comp/anomalydetection/observer/impl/events.go
@@ -36,8 +36,10 @@ type engineEvent struct {
 
 // baselineCompletedEvent carries the muted hash set produced at window end.
 type baselineCompletedEvent struct {
-	mutedHashes map[uint64]struct{}
-	mutedRefs   []observerdef.SeriesRef
+	detectorName string
+	mutedHashes  map[uint64]struct{}
+	mutedRefs    []observerdef.SeriesRef
+	allComplete  bool
 }
 
 // advanceCompletedEvent is emitted after the engine finishes an Advance call.

--- a/comp/anomalydetection/observer/impl/events.go
+++ b/comp/anomalydetection/observer/impl/events.go
@@ -34,12 +34,14 @@ type engineEvent struct {
 	baselineCompleted  *baselineCompletedEvent
 }
 
-// baselineCompletedEvent carries the muted hash set produced at window end.
+// baselineCompletedEvent carries an immutable mute-union snapshot when the
+// completion changed it. Event consumers must not mutate mutedHashes.
 type baselineCompletedEvent struct {
-	detectorName string
-	mutedHashes  map[uint64]struct{}
-	mutedRefs    []observerdef.SeriesRef
-	allComplete  bool
+	detectorName    string
+	mutedHashes     map[uint64]struct{}
+	snapshotChanged bool
+	mutedRefs       []observerdef.SeriesRef
+	allComplete     bool
 }
 
 // advanceCompletedEvent is emitted after the engine finishes an Advance call.

--- a/comp/anomalydetection/observer/impl/events_test.go
+++ b/comp/anomalydetection/observer/impl/events_test.go
@@ -109,9 +109,7 @@ type anomalyDetector struct {
 }
 
 func (d *anomalyDetector) Name() string { return d.name }
-func (*anomalyDetector) BaselineSpec() observerdef.BaselineSpec {
-	return observerdef.BaselineSpec{}
-}
+func (*anomalyDetector) Ready() bool    { return true }
 func (d *anomalyDetector) Detect(_ observerdef.StorageReader, _ int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{
 		Anomalies: d.anomalies,
@@ -139,9 +137,7 @@ type resettableDetector struct {
 }
 
 func (d *resettableDetector) Name() string { return d.name }
-func (*resettableDetector) BaselineSpec() observerdef.BaselineSpec {
-	return observerdef.BaselineSpec{}
-}
+func (*resettableDetector) Ready() bool    { return true }
 func (d *resettableDetector) Detect(_ observerdef.StorageReader, _ int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{}
 }
@@ -166,9 +162,7 @@ type emitOnSeriesDetector struct {
 }
 
 func (d *emitOnSeriesDetector) Name() string { return d.name }
-func (*emitOnSeriesDetector) BaselineSpec() observerdef.BaselineSpec {
-	return observerdef.BaselineSpec{}
-}
+func (*emitOnSeriesDetector) Ready() bool    { return true }
 
 func (d *emitOnSeriesDetector) Detect(series observerdef.Series) observerdef.DetectionResult {
 	if len(series.Points) == 0 {

--- a/comp/anomalydetection/observer/impl/events_test.go
+++ b/comp/anomalydetection/observer/impl/events_test.go
@@ -109,6 +109,9 @@ type anomalyDetector struct {
 }
 
 func (d *anomalyDetector) Name() string { return d.name }
+func (*anomalyDetector) BaselineSpec() observerdef.BaselineSpec {
+	return observerdef.BaselineSpec{}
+}
 func (d *anomalyDetector) Detect(_ observerdef.StorageReader, _ int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{
 		Anomalies: d.anomalies,
@@ -136,6 +139,9 @@ type resettableDetector struct {
 }
 
 func (d *resettableDetector) Name() string { return d.name }
+func (*resettableDetector) BaselineSpec() observerdef.BaselineSpec {
+	return observerdef.BaselineSpec{}
+}
 func (d *resettableDetector) Detect(_ observerdef.StorageReader, _ int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{}
 }
@@ -160,6 +166,9 @@ type emitOnSeriesDetector struct {
 }
 
 func (d *emitOnSeriesDetector) Name() string { return d.name }
+func (*emitOnSeriesDetector) BaselineSpec() observerdef.BaselineSpec {
+	return observerdef.BaselineSpec{}
+}
 
 func (d *emitOnSeriesDetector) Detect(series observerdef.Series) observerdef.DetectionResult {
 	if len(series.Points) == 0 {

--- a/comp/anomalydetection/observer/impl/filter_rules.go
+++ b/comp/anomalydetection/observer/impl/filter_rules.go
@@ -196,15 +196,11 @@ func (f *metricsFilterRules) isAllowed(name, source string, tags []string) bool 
 	return true
 }
 
-// setMuted publishes an immutable snapshot of the baseline mute union. The
-// engine calls it as each detector completes; handle goroutines observe the
-// new union on their next ingest.
-func (f *metricsFilterRules) setMuted(m map[uint64]struct{}) {
-	snapshot := make(map[uint64]struct{}, len(m))
-	for h := range m {
-		snapshot[h] = struct{}{}
-	}
-	f.muted.Store(&snapshot)
+// publishMutedSnapshot atomically publishes an immutable baseline mute union.
+// The engine owns constructing this copy-on-write snapshot; callers and
+// readers must never mutate m after publication.
+func (f *metricsFilterRules) publishMutedSnapshot(m map[uint64]struct{}) {
+	f.muted.Store(&m)
 }
 
 // matches reports whether the rule applies to the given metric.

--- a/comp/anomalydetection/observer/impl/filter_rules.go
+++ b/comp/anomalydetection/observer/impl/filter_rules.go
@@ -196,10 +196,15 @@ func (f *metricsFilterRules) isAllowed(name, source string, tags []string) bool 
 	return true
 }
 
-// setMuted publishes the baseline mute set atomically. Called once at freeze
-// from the engine run goroutine; all handle goroutines observe it on next ingest.
+// setMuted publishes an immutable snapshot of the baseline mute union. The
+// engine calls it as each detector completes; handle goroutines observe the
+// new union on their next ingest.
 func (f *metricsFilterRules) setMuted(m map[uint64]struct{}) {
-	f.muted.Store(&m)
+	snapshot := make(map[uint64]struct{}, len(m))
+	for h := range m {
+		snapshot[h] = struct{}{}
+	}
+	f.muted.Store(&snapshot)
 }
 
 // matches reports whether the rule applies to the given metric.

--- a/comp/anomalydetection/observer/impl/filter_rules_test.go
+++ b/comp/anomalydetection/observer/impl/filter_rules_test.go
@@ -101,7 +101,7 @@ func TestMetricsFilterRulesMuteSetBlocksMatchingMetric(t *testing.T) {
 
 	tags := []string{"env:prod"}
 	h := seriesKeyHash("check", "system.cpu.user", tags)
-	filter.setMuted(map[uint64]struct{}{h: {}})
+	filter.publishMutedSnapshot(map[uint64]struct{}{h: {}})
 
 	assert.False(t, filter.isAllowed("system.cpu.user", "check", tags))
 	assert.True(t, filter.isAllowed("system.mem.used", "check", tags))

--- a/comp/anomalydetection/observer/impl/log_pattern_extractor_test.go
+++ b/comp/anomalydetection/observer/impl/log_pattern_extractor_test.go
@@ -568,9 +568,7 @@ type statelessTestDetector struct {
 }
 
 func (s *statelessTestDetector) Name() string { return s.name }
-func (*statelessTestDetector) BaselineSpec() observerdef.BaselineSpec {
-	return observerdef.BaselineSpec{}
-}
+func (*statelessTestDetector) Ready() bool    { return true }
 func (s *statelessTestDetector) Detect(_ observerdef.StorageReader, _ int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{}
 }

--- a/comp/anomalydetection/observer/impl/log_pattern_extractor_test.go
+++ b/comp/anomalydetection/observer/impl/log_pattern_extractor_test.go
@@ -568,6 +568,9 @@ type statelessTestDetector struct {
 }
 
 func (s *statelessTestDetector) Name() string { return s.name }
+func (*statelessTestDetector) BaselineSpec() observerdef.BaselineSpec {
+	return observerdef.BaselineSpec{}
+}
 func (s *statelessTestDetector) Detect(_ observerdef.StorageReader, _ int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{}
 }

--- a/comp/anomalydetection/observer/impl/metrics_detector_bocpd.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_bocpd.go
@@ -182,8 +182,8 @@ func (b *BOCPDDetector) Name() string {
 	return "bocpd"
 }
 
-func (b *BOCPDDetector) BaselineSpec() detectorBaselineSpec {
-	return detectorBaselineSpec{Participate: true, WarmupDuration: time.Duration(b.config.WarmupPoints) * baselineReferenceInterval}
+func (b *BOCPDDetector) BaselineSpec() observer.BaselineSpec {
+	return observer.BaselineSpec{WarmupDuration: time.Duration(b.config.WarmupPoints) * baselineReferenceInterval}
 }
 
 // Detect implements Detector. It discovers series, reads only newly visible

--- a/comp/anomalydetection/observer/impl/metrics_detector_bocpd.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_bocpd.go
@@ -8,7 +8,6 @@ package observerimpl
 import (
 	"fmt"
 	"math"
-	"time"
 
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
@@ -125,6 +124,7 @@ func DefaultBOCPDConfig() BOCPDConfig {
 // posterior state and processes only newly visible points on each advance.
 type BOCPDDetector struct {
 	config BOCPDConfig
+	ready  bool
 
 	// per-(series, aggregation) state.
 	series map[bocpdStateKey]*bocpdSeriesState
@@ -182,9 +182,7 @@ func (b *BOCPDDetector) Name() string {
 	return "bocpd"
 }
 
-func (b *BOCPDDetector) BaselineSpec() observer.BaselineSpec {
-	return observer.BaselineSpec{WarmupDuration: time.Duration(b.config.WarmupPoints) * baselineReferenceInterval}
-}
+func (b *BOCPDDetector) Ready() bool { return b.ready }
 
 // Detect implements Detector. It discovers series, reads only newly visible
 // points, and updates per-series BOCPD posterior state incrementally.
@@ -251,6 +249,7 @@ func (b *BOCPDDetector) Reset() {
 	b.series = make(map[bocpdStateKey]*bocpdSeriesState)
 	b.cachedRefs = nil
 	b.cachedGen = 0
+	b.ready = false
 }
 
 // RemoveSeries drops posterior state for refs that storage has freed.
@@ -315,6 +314,7 @@ func (b *BOCPDDetector) warmupPoint(state *bocpdSeriesState, x float64) *observe
 
 	if state.warmupCount >= b.config.WarmupPoints {
 		b.initializeFromWarmup(state)
+		b.ready = true
 	}
 	return nil
 }

--- a/comp/anomalydetection/observer/impl/metrics_detector_bocpd.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_bocpd.go
@@ -8,6 +8,7 @@ package observerimpl
 import (
 	"fmt"
 	"math"
+	"time"
 
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
@@ -179,6 +180,10 @@ func NewBOCPDDetector(config BOCPDConfig) *BOCPDDetector {
 // Name returns the detector name.
 func (b *BOCPDDetector) Name() string {
 	return "bocpd"
+}
+
+func (b *BOCPDDetector) BaselineSpec() detectorBaselineSpec {
+	return detectorBaselineSpec{Participate: true, WarmupDuration: time.Duration(b.config.WarmupPoints) * baselineReferenceInterval}
 }
 
 // Detect implements Detector. It discovers series, reads only newly visible

--- a/comp/anomalydetection/observer/impl/metrics_detector_cusum.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_cusum.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"math"
 	"strings"
-	"time"
 
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
@@ -57,6 +56,7 @@ func DefaultCUSUMConfig() CUSUMConfig {
 // An anomaly is emitted when either S_high[t] or S_low[t] first exceeds threshold h.
 type CUSUMDetector struct {
 	config CUSUMConfig
+	ready  bool
 }
 
 // NewCUSUMDetector creates a CUSUMDetector with the given config.
@@ -83,9 +83,10 @@ func (c *CUSUMDetector) Name() string {
 	return "cusum"
 }
 
-func (c *CUSUMDetector) BaselineSpec() observer.BaselineSpec {
-	return observer.BaselineSpec{WarmupDuration: time.Duration(c.config.MinPoints) * baselineReferenceInterval}
-}
+func (c *CUSUMDetector) Ready() bool { return c.ready }
+
+// Reset clears the readiness signal for replay/reanalysis.
+func (c *CUSUMDetector) Reset() { c.ready = false }
 
 // Detect runs CUSUM on the series and returns an anomaly if a shift is detected.
 // The anomaly's Timestamp indicates when the shift was first detected (threshold crossing).
@@ -122,6 +123,7 @@ func (c *CUSUMDetector) Detect(series observer.Series) observer.DetectionResult 
 			return observer.DetectionResult{}
 		}
 	}
+	c.ready = true
 
 	// CUSUM parameters
 	k := cfg.SlackFactor * baselineStddev     // slack: ignore small deviations

--- a/comp/anomalydetection/observer/impl/metrics_detector_cusum.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_cusum.go
@@ -83,8 +83,8 @@ func (c *CUSUMDetector) Name() string {
 	return "cusum"
 }
 
-func (c *CUSUMDetector) BaselineSpec() detectorBaselineSpec {
-	return detectorBaselineSpec{Participate: true, WarmupDuration: time.Duration(c.config.MinPoints) * baselineReferenceInterval}
+func (c *CUSUMDetector) BaselineSpec() observer.BaselineSpec {
+	return observer.BaselineSpec{WarmupDuration: time.Duration(c.config.MinPoints) * baselineReferenceInterval}
 }
 
 // Detect runs CUSUM on the series and returns an anomaly if a shift is detected.

--- a/comp/anomalydetection/observer/impl/metrics_detector_cusum.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_cusum.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
@@ -80,6 +81,10 @@ func NewCUSUMDetector(config CUSUMConfig) *CUSUMDetector {
 // Name returns the detector name.
 func (c *CUSUMDetector) Name() string {
 	return "cusum"
+}
+
+func (c *CUSUMDetector) BaselineSpec() detectorBaselineSpec {
+	return detectorBaselineSpec{Participate: true, WarmupDuration: time.Duration(c.config.MinPoints) * baselineReferenceInterval}
 }
 
 // Detect runs CUSUM on the series and returns an anomaly if a shift is detected.

--- a/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
@@ -8,6 +8,7 @@ package observerimpl
 import (
 	"fmt"
 	"math"
+	"time"
 
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
@@ -202,6 +203,12 @@ func NewHoltResidualDetectorWithConfig(cfg HoltResidualConfig) *HoltResidualDete
 
 // Name implements observer.Detector.
 func (d *HoltResidualDetector) Name() string { return "holt_residual" }
+
+func (d *HoltResidualDetector) BaselineSpec() detectorBaselineSpec {
+	d.ensureDefaults()
+	points := d.WarmupPoints + d.ResidualWindow + d.ConfirmM
+	return detectorBaselineSpec{Participate: true, WarmupDuration: time.Duration(points) * baselineReferenceInterval}
+}
 
 // Reset clears all per-series state for replay/reanalysis.
 func (d *HoltResidualDetector) Reset() {

--- a/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
@@ -204,10 +204,10 @@ func NewHoltResidualDetectorWithConfig(cfg HoltResidualConfig) *HoltResidualDete
 // Name implements observer.Detector.
 func (d *HoltResidualDetector) Name() string { return "holt_residual" }
 
-func (d *HoltResidualDetector) BaselineSpec() detectorBaselineSpec {
+func (d *HoltResidualDetector) BaselineSpec() observer.BaselineSpec {
 	d.ensureDefaults()
 	points := d.WarmupPoints + d.ResidualWindow + d.ConfirmM
-	return detectorBaselineSpec{Participate: true, WarmupDuration: time.Duration(points) * baselineReferenceInterval}
+	return observer.BaselineSpec{WarmupDuration: time.Duration(points) * baselineReferenceInterval}
 }
 
 // Reset clears all per-series state for replay/reanalysis.

--- a/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
@@ -8,7 +8,6 @@ package observerimpl
 import (
 	"fmt"
 	"math"
-	"time"
 
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
@@ -114,6 +113,7 @@ type holtSeriesState struct {
 // are exported so callers (testbench, tests) may override defaults after
 // construction; NewHoltResidualDetector populates them.
 type HoltResidualDetector struct {
+	ready bool
 	// Alpha is the level smoothing factor (0..1). Higher = more reactive.
 	Alpha float64
 	// Beta is the trend smoothing factor (0..1). Lower = more stable.
@@ -204,17 +204,14 @@ func NewHoltResidualDetectorWithConfig(cfg HoltResidualConfig) *HoltResidualDete
 // Name implements observer.Detector.
 func (d *HoltResidualDetector) Name() string { return "holt_residual" }
 
-func (d *HoltResidualDetector) BaselineSpec() observer.BaselineSpec {
-	d.ensureDefaults()
-	points := d.WarmupPoints + d.ResidualWindow + d.ConfirmM
-	return observer.BaselineSpec{WarmupDuration: time.Duration(points) * baselineReferenceInterval}
-}
+func (d *HoltResidualDetector) Ready() bool { return d.ready }
 
 // Reset clears all per-series state for replay/reanalysis.
 func (d *HoltResidualDetector) Reset() {
 	d.series = make(map[holtStateKey]*holtSeriesState)
 	d.cachedSeries = nil
 	d.cachedGen = 0
+	d.ready = false
 }
 
 // RemoveSeries drops per-series state for refs that storage has freed. Each
@@ -373,6 +370,9 @@ func (d *HoltResidualDetector) ingestNewPoints(
 		}
 
 		anomaly, hasFire := d.processPoint(state, p, agg)
+		if len(state.resWin) >= d.ResidualWindow && len(state.valWin) >= d.ResidualWindow {
+			d.ready = true
+		}
 
 		if hasFire {
 			fired = append(fired, anomaly)

--- a/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
@@ -168,6 +168,12 @@ func (r *RRCFDetector) Name() string {
 	return "rrcf"
 }
 
+// BaselineSpec opts out because RRCF's aligned-vector model has its own
+// readiness and cannot attribute its synthetic anomalies to one source series.
+func (r *RRCFDetector) BaselineSpec() detectorBaselineSpec {
+	return detectorBaselineSpec{Participate: false}
+}
+
 // SetObserverTelemetry wires direct observer telemetry emission.
 func (r *RRCFDetector) SetObserverTelemetry(t *observerTelemetry) {
 	r.telemetry = t

--- a/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
@@ -178,9 +178,9 @@ func (r *RRCFDetector) Name() string {
 // post-warmup scores are needed before the next score has a dynamic threshold.
 // RRCF participates in suppression during this interval and qualification, but
 // its synthetic anomalies have no SourceRef and therefore never mute a series.
-func (r *RRCFDetector) BaselineSpec() detectorBaselineSpec {
+func (r *RRCFDetector) BaselineSpec() observer.BaselineSpec {
 	alignedPoints := r.config.TreeSize + r.config.ShingleSize + rrcfMinScoresForThreshold
-	return detectorBaselineSpec{Participate: true, WarmupDuration: time.Duration(alignedPoints) * baselineReferenceInterval}
+	return observer.BaselineSpec{WarmupDuration: time.Duration(alignedPoints) * baselineReferenceInterval}
 }
 
 // SetObserverTelemetry wires direct observer telemetry emission.

--- a/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"time"
 
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
@@ -73,6 +74,10 @@ type RRCFConfig struct {
 	// Metrics defines which series to include. If nil, uses DefaultRRCFMetrics().
 	Metrics []RRCFMetricDef `json:"-"`
 }
+
+// rrcfMinScoresForThreshold is the minimum score history required before
+// dynamicThreshold can evaluate a new score.
+const rrcfMinScoresForThreshold = 10
 
 // DefaultRRCFConfig returns sensible defaults for RRCF.
 func DefaultRRCFConfig() RRCFConfig {
@@ -168,10 +173,14 @@ func (r *RRCFDetector) Name() string {
 	return "rrcf"
 }
 
-// BaselineSpec opts out because RRCF's aligned-vector model has its own
-// readiness and cannot attribute its synthetic anomalies to one source series.
+// BaselineSpec estimates RRCF readiness from aligned input points. A shingle
+// needs ShingleSize points, TreeSize shingles fill the forest, and ten prior
+// post-warmup scores are needed before the next score has a dynamic threshold.
+// RRCF participates in suppression during this interval and qualification, but
+// its synthetic anomalies have no SourceRef and therefore never mute a series.
 func (r *RRCFDetector) BaselineSpec() detectorBaselineSpec {
-	return detectorBaselineSpec{Participate: false}
+	alignedPoints := r.config.TreeSize + r.config.ShingleSize + rrcfMinScoresForThreshold
+	return detectorBaselineSpec{Participate: true, WarmupDuration: time.Duration(alignedPoints) * baselineReferenceInterval}
 }
 
 // SetObserverTelemetry wires direct observer telemetry emission.
@@ -492,7 +501,7 @@ func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.Dete
 
 // dynamicThreshold returns mean + ThresholdSigma*stddev of the recent score window.
 func (r *RRCFDetector) dynamicThreshold() float64 {
-	if len(r.recentScores) < 10 {
+	if len(r.recentScores) < rrcfMinScoresForThreshold {
 		return 0 // not enough data yet
 	}
 	return r.rollingMean() + r.config.ThresholdSigma*r.rollingStddev()

--- a/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
@@ -176,8 +176,8 @@ func (r *RRCFDetector) Name() string {
 // BaselineSpec estimates RRCF readiness from aligned input points. A shingle
 // needs ShingleSize points, TreeSize shingles fill the forest, and ten prior
 // post-warmup scores are needed before the next score has a dynamic threshold.
-// RRCF participates in suppression during this interval and qualification, but
-// its synthetic anomalies have no SourceRef and therefore never mute a series.
+// RRCF participates in suppression during warmup and qualification, but its
+// synthetic anomalies have no SourceRef and therefore never mute a series.
 func (r *RRCFDetector) BaselineSpec() observer.BaselineSpec {
 	alignedPoints := r.config.TreeSize + r.config.ShingleSize + rrcfMinScoresForThreshold
 	return observer.BaselineSpec{WarmupDuration: time.Duration(alignedPoints) * baselineReferenceInterval}

--- a/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_rrcf.go
@@ -11,7 +11,6 @@ import (
 	"math"
 	"sort"
 	"strings"
-	"time"
 
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
@@ -141,6 +140,7 @@ type RRCFDetector struct {
 	// alignedCount and shingleCount track pipeline throughput for diagnostics.
 	alignedCount int
 	shingleCount int
+	ready        bool
 }
 
 // NewRRCFDetector creates an RRCF detector with the given config.
@@ -173,15 +173,8 @@ func (r *RRCFDetector) Name() string {
 	return "rrcf"
 }
 
-// BaselineSpec estimates RRCF readiness from aligned input points. A shingle
-// needs ShingleSize points, TreeSize shingles fill the forest, and ten prior
-// post-warmup scores are needed before the next score has a dynamic threshold.
-// RRCF participates in suppression during warmup and qualification, but its
-// synthetic anomalies have no SourceRef and therefore never mute a series.
-func (r *RRCFDetector) BaselineSpec() observer.BaselineSpec {
-	alignedPoints := r.config.TreeSize + r.config.ShingleSize + rrcfMinScoresForThreshold
-	return observer.BaselineSpec{WarmupDuration: time.Duration(alignedPoints) * baselineReferenceInterval}
-}
+// Ready reports when an aligned model can evaluate a dynamic threshold.
+func (r *RRCFDetector) Ready() bool { return r.ready }
 
 // SetObserverTelemetry wires direct observer telemetry emission.
 func (r *RRCFDetector) SetObserverTelemetry(t *observerTelemetry) {
@@ -466,6 +459,9 @@ func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.Dete
 
 		// Compute dynamic threshold from recent scores
 		threshold := r.dynamicThreshold()
+		if threshold > 0 {
+			r.ready = true
+		}
 		if threshold > 0 && r.telemetry != nil {
 			r.telemetry.recordRRCFThreshold(r.Name(), threshold)
 		}
@@ -549,6 +545,7 @@ func (r *RRCFDetector) Reset() {
 	r.totalScored = 0
 	r.alignedCount = 0
 	r.shingleCount = 0
+	r.ready = false
 	r.forest.reset()
 }
 

--- a/comp/anomalydetection/observer/impl/metrics_detector_scanmw.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_scanmw.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"math"
 	"sort"
-	"time"
 
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
@@ -48,6 +47,7 @@ type scanmwSeriesState struct {
 // Implements Detector (streaming) — after finding a changepoint, advances
 // the segment start so subsequent scans only examine post-change data.
 type ScanMWDetector struct {
+	ready bool
 	// MinSegment is the minimum number of points in each segment.
 	// Default: 12
 	MinSegment int
@@ -100,16 +100,14 @@ func (d *ScanMWDetector) Name() string {
 	return "scanmw"
 }
 
-func (d *ScanMWDetector) BaselineSpec() observer.BaselineSpec {
-	d.ensureDefaults()
-	return observer.BaselineSpec{WarmupDuration: time.Duration(d.MinPoints) * baselineReferenceInterval}
-}
+func (d *ScanMWDetector) Ready() bool { return d.ready }
 
 // Reset clears all per-series state for replay/reanalysis.
 func (d *ScanMWDetector) Reset() {
 	d.series = make(map[scanmwStateKey]*scanmwSeriesState)
 	d.cachedRefs = nil
 	d.cachedGen = 0
+	d.ready = false
 }
 
 // RemoveSeries drops segment-tracking state for refs that storage has freed.
@@ -194,6 +192,7 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 				state.lastWriteGen = status.writeGeneration
 				continue
 			}
+			d.ready = true
 
 			anomaly, changeIdx, found := d.scanMW(state.buf, seriesMeta, agg)
 			if found {

--- a/comp/anomalydetection/observer/impl/metrics_detector_scanmw.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_scanmw.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"time"
 
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
@@ -97,6 +98,11 @@ func NewScanMWDetector() *ScanMWDetector {
 // Name returns the detector name.
 func (d *ScanMWDetector) Name() string {
 	return "scanmw"
+}
+
+func (d *ScanMWDetector) BaselineSpec() detectorBaselineSpec {
+	d.ensureDefaults()
+	return detectorBaselineSpec{Participate: true, WarmupDuration: time.Duration(d.MinPoints) * baselineReferenceInterval}
 }
 
 // Reset clears all per-series state for replay/reanalysis.

--- a/comp/anomalydetection/observer/impl/metrics_detector_scanmw.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_scanmw.go
@@ -100,9 +100,9 @@ func (d *ScanMWDetector) Name() string {
 	return "scanmw"
 }
 
-func (d *ScanMWDetector) BaselineSpec() detectorBaselineSpec {
+func (d *ScanMWDetector) BaselineSpec() observer.BaselineSpec {
 	d.ensureDefaults()
-	return detectorBaselineSpec{Participate: true, WarmupDuration: time.Duration(d.MinPoints) * baselineReferenceInterval}
+	return observer.BaselineSpec{WarmupDuration: time.Duration(d.MinPoints) * baselineReferenceInterval}
 }
 
 // Reset clears all per-series state for replay/reanalysis.

--- a/comp/anomalydetection/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_scanwelch.go
@@ -8,6 +8,7 @@ package observerimpl
 import (
 	"fmt"
 	"math"
+	"time"
 
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
@@ -91,6 +92,11 @@ func NewScanWelchDetector() *ScanWelchDetector {
 // Name returns the detector name.
 func (d *ScanWelchDetector) Name() string {
 	return "scanwelch"
+}
+
+func (d *ScanWelchDetector) BaselineSpec() detectorBaselineSpec {
+	d.ensureDefaults()
+	return detectorBaselineSpec{Participate: true, WarmupDuration: time.Duration(d.MinPoints) * baselineReferenceInterval}
 }
 
 // Reset clears all per-series state for replay/reanalysis.

--- a/comp/anomalydetection/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_scanwelch.go
@@ -8,7 +8,6 @@ package observerimpl
 import (
 	"fmt"
 	"math"
-	"time"
 
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
@@ -43,6 +42,7 @@ type scanwelchSeriesState struct {
 // Implements Detector (streaming) — after finding a changepoint, advances
 // the segment start so subsequent scans only examine post-change data.
 type ScanWelchDetector struct {
+	ready bool
 	// MinSegment is the minimum number of points in each segment.
 	MinSegment int
 
@@ -94,16 +94,14 @@ func (d *ScanWelchDetector) Name() string {
 	return "scanwelch"
 }
 
-func (d *ScanWelchDetector) BaselineSpec() observer.BaselineSpec {
-	d.ensureDefaults()
-	return observer.BaselineSpec{WarmupDuration: time.Duration(d.MinPoints) * baselineReferenceInterval}
-}
+func (d *ScanWelchDetector) Ready() bool { return d.ready }
 
 // Reset clears all per-series state for replay/reanalysis.
 func (d *ScanWelchDetector) Reset() {
 	d.series = make(map[scanwelchStateKey]*scanwelchSeriesState)
 	d.cachedRefs = nil
 	d.cachedGen = 0
+	d.ready = false
 }
 
 // RemoveSeries drops segment-tracking state for refs that storage has freed.
@@ -184,6 +182,7 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 				state.lastWriteGen = status.writeGeneration
 				continue
 			}
+			d.ready = true
 
 			anomaly, changeIdx, found := d.scanWelch(state.buf, seriesMeta, agg)
 			if found {

--- a/comp/anomalydetection/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_scanwelch.go
@@ -94,9 +94,9 @@ func (d *ScanWelchDetector) Name() string {
 	return "scanwelch"
 }
 
-func (d *ScanWelchDetector) BaselineSpec() detectorBaselineSpec {
+func (d *ScanWelchDetector) BaselineSpec() observer.BaselineSpec {
 	d.ensureDefaults()
-	return detectorBaselineSpec{Participate: true, WarmupDuration: time.Duration(d.MinPoints) * baselineReferenceInterval}
+	return observer.BaselineSpec{WarmupDuration: time.Duration(d.MinPoints) * baselineReferenceInterval}
 }
 
 // Reset clears all per-series state for replay/reanalysis.

--- a/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight.go
@@ -8,6 +8,7 @@ package observerimpl
 import (
 	"fmt"
 	"math"
+	"time"
 
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
@@ -156,6 +157,11 @@ func NewTukeyBiweightDetectorWithConfig(cfg TukeyBiweightConfig) *TukeyBiweightD
 
 // Name returns the detector name as registered in the catalog.
 func (d *TukeyBiweightDetector) Name() string { return "tukey_biweight" }
+
+func (d *TukeyBiweightDetector) BaselineSpec() detectorBaselineSpec {
+	d.ensureDefaults()
+	return detectorBaselineSpec{Participate: true, WarmupDuration: time.Duration(d.MinPoints) * baselineReferenceInterval}
+}
 
 // Reset clears all per-series state for replay/reanalysis.
 func (d *TukeyBiweightDetector) Reset() {

--- a/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight.go
@@ -158,9 +158,9 @@ func NewTukeyBiweightDetectorWithConfig(cfg TukeyBiweightConfig) *TukeyBiweightD
 // Name returns the detector name as registered in the catalog.
 func (d *TukeyBiweightDetector) Name() string { return "tukey_biweight" }
 
-func (d *TukeyBiweightDetector) BaselineSpec() detectorBaselineSpec {
+func (d *TukeyBiweightDetector) BaselineSpec() observer.BaselineSpec {
 	d.ensureDefaults()
-	return detectorBaselineSpec{Participate: true, WarmupDuration: time.Duration(d.MinPoints) * baselineReferenceInterval}
+	return observer.BaselineSpec{WarmupDuration: time.Duration(d.MinPoints) * baselineReferenceInterval}
 }
 
 // Reset clears all per-series state for replay/reanalysis.

--- a/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight.go
@@ -8,7 +8,6 @@ package observerimpl
 import (
 	"fmt"
 	"math"
-	"time"
 
 	observer "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
 )
@@ -70,6 +69,7 @@ type tbSeriesState struct {
 // shape matches the other streaming metric detectors: cache series, bulk-fetch
 // per-ref status, then advance each per-series cursor with ForEachPoint.
 type TukeyBiweightDetector struct {
+	ready bool
 	// WindowSize is the number of recent points held in the IRLS window.
 	// Default: 80, enough context for a robust local baseline without making
 	// each scoring tick too expensive.
@@ -158,16 +158,14 @@ func NewTukeyBiweightDetectorWithConfig(cfg TukeyBiweightConfig) *TukeyBiweightD
 // Name returns the detector name as registered in the catalog.
 func (d *TukeyBiweightDetector) Name() string { return "tukey_biweight" }
 
-func (d *TukeyBiweightDetector) BaselineSpec() observer.BaselineSpec {
-	d.ensureDefaults()
-	return observer.BaselineSpec{WarmupDuration: time.Duration(d.MinPoints) * baselineReferenceInterval}
-}
+func (d *TukeyBiweightDetector) Ready() bool { return d.ready }
 
 // Reset clears all per-series state for replay/reanalysis.
 func (d *TukeyBiweightDetector) Reset() {
 	d.series = make(map[tbStateKey]*tbSeriesState)
 	d.cachedSeries = nil
 	d.cachedGen = 0
+	d.ready = false
 }
 
 // RemoveSeries drops per-series state for refs that storage has freed.
@@ -260,6 +258,7 @@ func (d *TukeyBiweightDetector) Detect(storage observer.StorageReader, dataTime 
 				state.ticksSinceScore++
 
 				if state.count >= d.MinPoints && state.cooldownLeft == 0 && state.ticksSinceScore >= d.ScoreEvery {
+					d.ready = true
 					state.ticksSinceScore = 0
 					if anomaly, fired := d.scoreBiweight(state, seriesMeta, agg, p.Timestamp); fired {
 						anomaly.SourceRef = &observer.QueryHandle{Ref: meta.Ref, Aggregate: agg}

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -828,8 +828,8 @@ func (s *baselineEventSink) onEngineEvent(evt engineEvent) {
 	if evt.kind != eventBaselineCompleted || evt.baselineCompleted == nil {
 		return
 	}
-	if len(evt.baselineCompleted.mutedHashes) > 0 {
-		s.filter.setMuted(evt.baselineCompleted.mutedHashes)
+	if evt.baselineCompleted.snapshotChanged {
+		s.filter.publishMutedSnapshot(evt.baselineCompleted.mutedHashes)
 	}
 }
 
@@ -856,6 +856,11 @@ func (o *observerImpl) DebugSubscribeBaselineCompleted(callback func(endSec int6
 // DebugBaselineStatus returns the per-detector baseline state for the
 // testbench. It is deliberately outside DebugView's production contract.
 func (o *observerImpl) DebugBaselineStatus() BaselineDebugStatus {
+	// This method is testbench-only. Serializing it with direct replay and the
+	// dispatch loop avoids reading the controller's maps concurrently without
+	// adding synchronization or allocations to the live agent's ingest path.
+	o.replayMu.Lock()
+	defer o.replayMu.Unlock()
 	if o.engine.baseline == nil {
 		return BaselineDebugStatus{}
 	}

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -565,11 +565,8 @@ func (a *seriesDetectorAdapter) Name() string {
 	return a.detector.Name()
 }
 
-func (a *seriesDetectorAdapter) BaselineSpec() detectorBaselineSpec {
-	if provider, ok := a.detector.(detectorBaselineSpecProvider); ok {
-		return provider.BaselineSpec()
-	}
-	return detectorBaselineSpec{Participate: true}
+func (a *seriesDetectorAdapter) BaselineSpec() observerdef.BaselineSpec {
+	return a.detector.BaselineSpec()
 }
 
 // Reset clears adapter-local caches and resets the wrapped detector when supported.

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -898,6 +898,9 @@ func (s *baselineCompletedCallbackSink) onEngineEvent(evt engineEvent) {
 	}
 	sort.Strings(groups)
 	s.callback(evt.timestamp, groups)
+	// The sink is retained across testbench replays. Release this run's groups
+	// so a later replay reports only its own muted series.
+	s.mutedGroups = nil
 }
 
 // GetReplayProgress returns lock-free replay progress counters. Implements DebugView.

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -565,8 +565,8 @@ func (a *seriesDetectorAdapter) Name() string {
 	return a.detector.Name()
 }
 
-func (a *seriesDetectorAdapter) BaselineSpec() observerdef.BaselineSpec {
-	return a.detector.BaselineSpec()
+func (a *seriesDetectorAdapter) Ready() bool {
+	return a.detector.Ready()
 }
 
 // Reset clears adapter-local caches and resets the wrapped detector when supported.
@@ -861,7 +861,11 @@ func (o *observerImpl) DebugBaselineStatus() BaselineDebugStatus {
 	if o.engine.baseline == nil {
 		return BaselineDebugStatus{}
 	}
-	return o.engine.baseline.debugStatus()
+	status := o.engine.baseline.debugStatus()
+	o.engine.mu.RLock()
+	status.AnalyzedThroughSec = o.engine.lastAnalyzedDataTime
+	o.engine.mu.RUnlock()
+	return status
 }
 
 type baselineCompletedCallbackSink struct {

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -565,6 +565,13 @@ func (a *seriesDetectorAdapter) Name() string {
 	return a.detector.Name()
 }
 
+func (a *seriesDetectorAdapter) BaselineSpec() detectorBaselineSpec {
+	if provider, ok := a.detector.(detectorBaselineSpecProvider); ok {
+		return provider.BaselineSpec()
+	}
+	return detectorBaselineSpec{Participate: true}
+}
+
 // Reset clears adapter-local caches and resets the wrapped detector when supported.
 func (a *seriesDetectorAdapter) Reset() {
 	a.lastVisibleCount = make(map[observerdef.SeriesRef]int)
@@ -846,13 +853,22 @@ func (o *observerImpl) DebugSubscribeBaselineCompleted(callback func(endSec int6
 	})
 }
 
+// DebugBaselineStatus returns the per-detector baseline state for the
+// testbench. It is deliberately outside DebugView's production contract.
+func (o *observerImpl) DebugBaselineStatus() BaselineDebugStatus {
+	if o.engine.baseline == nil {
+		return BaselineDebugStatus{}
+	}
+	return o.engine.baseline.debugStatus()
+}
+
 type baselineCompletedCallbackSink struct {
 	engine   *engine
 	callback func(int64, []string)
 }
 
 func (s *baselineCompletedCallbackSink) onEngineEvent(evt engineEvent) {
-	if evt.kind != eventBaselineCompleted || evt.baselineCompleted == nil {
+	if evt.kind != eventBaselineCompleted || evt.baselineCompleted == nil || !evt.baselineCompleted.allComplete {
 		return
 	}
 	seen := make(map[string]struct{}, len(evt.baselineCompleted.mutedRefs))

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -865,26 +865,32 @@ func (o *observerImpl) DebugBaselineStatus() BaselineDebugStatus {
 }
 
 type baselineCompletedCallbackSink struct {
-	engine   *engine
-	callback func(int64, []string)
+	engine      *engine
+	callback    func(int64, []string)
+	mutedGroups map[string]struct{}
 }
 
 func (s *baselineCompletedCallbackSink) onEngineEvent(evt engineEvent) {
-	if evt.kind != eventBaselineCompleted || evt.baselineCompleted == nil || !evt.baselineCompleted.allComplete {
+	if evt.kind != eventBaselineCompleted || evt.baselineCompleted == nil {
 		return
 	}
-	seen := make(map[string]struct{}, len(evt.baselineCompleted.mutedRefs))
-	var groups []string
+	if s.mutedGroups == nil {
+		s.mutedGroups = make(map[string]struct{})
+	}
 	for _, ref := range evt.baselineCompleted.mutedRefs {
 		meta := s.engine.storage.GetSeriesMeta(ref)
 		if meta == nil {
 			continue
 		}
 		key := meta.Namespace + "/" + meta.Name
-		if _, ok := seen[key]; !ok {
-			seen[key] = struct{}{}
-			groups = append(groups, key)
-		}
+		s.mutedGroups[key] = struct{}{}
+	}
+	if !evt.baselineCompleted.allComplete {
+		return
+	}
+	groups := make([]string, 0, len(s.mutedGroups))
+	for group := range s.mutedGroups {
+		groups = append(groups, group)
 	}
 	sort.Strings(groups)
 	s.callback(evt.timestamp, groups)

--- a/comp/anomalydetection/observer/impl/observer_test.go
+++ b/comp/anomalydetection/observer/impl/observer_test.go
@@ -105,6 +105,9 @@ type countingSeriesDetector struct {
 }
 
 func (d *countingSeriesDetector) Name() string { return "counting" }
+func (*countingSeriesDetector) BaselineSpec() observerdef.BaselineSpec {
+	return observerdef.BaselineSpec{}
+}
 
 func (d *countingSeriesDetector) Detect(_ observerdef.Series) observerdef.DetectionResult {
 	return observerdef.DetectionResult{

--- a/comp/anomalydetection/observer/impl/observer_test.go
+++ b/comp/anomalydetection/observer/impl/observer_test.go
@@ -143,9 +143,7 @@ type countingSeriesDetector struct {
 }
 
 func (d *countingSeriesDetector) Name() string { return "counting" }
-func (*countingSeriesDetector) BaselineSpec() observerdef.BaselineSpec {
-	return observerdef.BaselineSpec{}
-}
+func (*countingSeriesDetector) Ready() bool    { return true }
 
 func (d *countingSeriesDetector) Detect(_ observerdef.Series) observerdef.DetectionResult {
 	return observerdef.DetectionResult{

--- a/comp/anomalydetection/observer/impl/observer_test.go
+++ b/comp/anomalydetection/observer/impl/observer_test.go
@@ -104,13 +104,15 @@ func TestBaselineCompletedCallbackSink_AccumulatesGroupsUntilAllBaselinesComplet
 	storage := newTimeSeriesStorage()
 	ref := storage.Add("ns", "cpu", 1.0, 100, nil).Ref
 
-	var callbackEndSec int64
-	var callbackGroups []string
+	type callbackResult struct {
+		endSec int64
+		groups []string
+	}
+	var callbacks []callbackResult
 	sink := &baselineCompletedCallbackSink{
 		engine: newEngine(engineConfig{storage: storage}),
 		callback: func(endSec int64, groups []string) {
-			callbackEndSec = endSec
-			callbackGroups = groups
+			callbacks = append(callbacks, callbackResult{endSec: endSec, groups: groups})
 		},
 	}
 
@@ -130,11 +132,34 @@ func TestBaselineCompletedCallbackSink_AccumulatesGroupsUntilAllBaselinesComplet
 		},
 	})
 
-	if callbackEndSec != 200 {
-		t.Fatalf("callback end time = %d, want 200", callbackEndSec)
+	if len(callbacks) != 1 || callbacks[0].endSec != 200 {
+		t.Fatalf("callbacks = %v, want one callback at 200", callbacks)
 	}
-	if len(callbackGroups) != 1 || callbackGroups[0] != "ns/cpu" {
-		t.Fatalf("callback groups = %v, want [ns/cpu]", callbackGroups)
+	if len(callbacks[0].groups) != 1 || callbacks[0].groups[0] != "ns/cpu" {
+		t.Fatalf("first callback groups = %v, want [ns/cpu]", callbacks[0].groups)
+	}
+
+	// A second replay must not inherit groups accumulated for the first one.
+	secondRef := storage.Add("ns", "memory", 1.0, 300, nil).Ref
+	sink.onEngineEvent(engineEvent{
+		kind: eventBaselineCompleted,
+		baselineCompleted: &baselineCompletedEvent{
+			mutedRefs: []observerdef.SeriesRef{secondRef},
+		},
+	})
+	sink.onEngineEvent(engineEvent{
+		kind:      eventBaselineCompleted,
+		timestamp: 400,
+		baselineCompleted: &baselineCompletedEvent{
+			allComplete: true,
+		},
+	})
+
+	if len(callbacks) != 2 || callbacks[1].endSec != 400 {
+		t.Fatalf("callbacks = %v, want second callback at 400", callbacks)
+	}
+	if len(callbacks[1].groups) != 1 || callbacks[1].groups[0] != "ns/memory" {
+		t.Fatalf("second callback groups = %v, want [ns/memory]", callbacks[1].groups)
 	}
 }
 

--- a/comp/anomalydetection/observer/impl/observer_test.go
+++ b/comp/anomalydetection/observer/impl/observer_test.go
@@ -100,6 +100,44 @@ func TestSeriesDetectorAdapter_ResetClearsVisibleCountCache(t *testing.T) {
 	}
 }
 
+func TestBaselineCompletedCallbackSink_AccumulatesGroupsUntilAllBaselinesComplete(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	ref := storage.Add("ns", "cpu", 1.0, 100, nil).Ref
+
+	var callbackEndSec int64
+	var callbackGroups []string
+	sink := &baselineCompletedCallbackSink{
+		engine: newEngine(engineConfig{storage: storage}),
+		callback: func(endSec int64, groups []string) {
+			callbackEndSec = endSec
+			callbackGroups = groups
+		},
+	}
+
+	// The first detector finds a metric-backed anomaly. The final detector
+	// models a detector such as RRCF, which has no per-series source refs.
+	sink.onEngineEvent(engineEvent{
+		kind: eventBaselineCompleted,
+		baselineCompleted: &baselineCompletedEvent{
+			mutedRefs: []observerdef.SeriesRef{ref},
+		},
+	})
+	sink.onEngineEvent(engineEvent{
+		kind:      eventBaselineCompleted,
+		timestamp: 200,
+		baselineCompleted: &baselineCompletedEvent{
+			allComplete: true,
+		},
+	})
+
+	if callbackEndSec != 200 {
+		t.Fatalf("callback end time = %d, want 200", callbackEndSec)
+	}
+	if len(callbackGroups) != 1 || callbackGroups[0] != "ns/cpu" {
+		t.Fatalf("callback groups = %v, want [ns/cpu]", callbackGroups)
+	}
+}
+
 type countingSeriesDetector struct {
 	anomalies []observerdef.Anomaly
 }

--- a/comp/anomalydetection/observer/impl/stateview_test.go
+++ b/comp/anomalydetection/observer/impl/stateview_test.go
@@ -180,9 +180,7 @@ type mockDetector struct {
 }
 
 func (d *mockDetector) Name() string { return d.name }
-func (*mockDetector) BaselineSpec() observerdef.BaselineSpec {
-	return observerdef.BaselineSpec{}
-}
+func (*mockDetector) Ready() bool    { return true }
 func (d *mockDetector) Detect(_ observerdef.StorageReader, _ int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{}
 }

--- a/comp/anomalydetection/observer/impl/stateview_test.go
+++ b/comp/anomalydetection/observer/impl/stateview_test.go
@@ -180,6 +180,9 @@ type mockDetector struct {
 }
 
 func (d *mockDetector) Name() string { return d.name }
+func (*mockDetector) BaselineSpec() observerdef.BaselineSpec {
+	return observerdef.BaselineSpec{}
+}
 func (d *mockDetector) Detect(_ observerdef.StorageReader, _ int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{}
 }

--- a/comp/anomalydetection/observer/impl/streaming_replay_test.go
+++ b/comp/anomalydetection/observer/impl/streaming_replay_test.go
@@ -18,6 +18,9 @@ type streamAdvanceRecorder struct {
 }
 
 func (d *streamAdvanceRecorder) Name() string { return "stream_advance_recorder" }
+func (*streamAdvanceRecorder) BaselineSpec() observerdef.BaselineSpec {
+	return observerdef.BaselineSpec{}
+}
 func (d *streamAdvanceRecorder) Detect(_ observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
 	d.times = append(d.times, dataTime)
 	return observerdef.DetectionResult{}

--- a/comp/anomalydetection/observer/impl/streaming_replay_test.go
+++ b/comp/anomalydetection/observer/impl/streaming_replay_test.go
@@ -18,9 +18,7 @@ type streamAdvanceRecorder struct {
 }
 
 func (d *streamAdvanceRecorder) Name() string { return "stream_advance_recorder" }
-func (*streamAdvanceRecorder) BaselineSpec() observerdef.BaselineSpec {
-	return observerdef.BaselineSpec{}
-}
+func (*streamAdvanceRecorder) Ready() bool    { return true }
 func (d *streamAdvanceRecorder) Detect(_ observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
 	d.times = append(d.times, dataTime)
 	return observerdef.DetectionResult{}

--- a/comp/anomalydetection/observer/impl/test_helpers_test.go
+++ b/comp/anomalydetection/observer/impl/test_helpers_test.go
@@ -52,9 +52,7 @@ type dynamicAnomalyDetector struct {
 }
 
 func (d *dynamicAnomalyDetector) Name() string { return "dynamic_anomaly_detector" }
-func (*dynamicAnomalyDetector) BaselineSpec() observerdef.BaselineSpec {
-	return observerdef.BaselineSpec{}
-}
+func (*dynamicAnomalyDetector) Ready() bool    { return true }
 func (d *dynamicAnomalyDetector) Detect(_ observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{
 		Anomalies: []observerdef.Anomaly{

--- a/comp/anomalydetection/observer/impl/test_helpers_test.go
+++ b/comp/anomalydetection/observer/impl/test_helpers_test.go
@@ -52,6 +52,9 @@ type dynamicAnomalyDetector struct {
 }
 
 func (d *dynamicAnomalyDetector) Name() string { return "dynamic_anomaly_detector" }
+func (*dynamicAnomalyDetector) BaselineSpec() observerdef.BaselineSpec {
+	return observerdef.BaselineSpec{}
+}
 func (d *dynamicAnomalyDetector) Detect(_ observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{
 		Anomalies: []observerdef.Anomaly{

--- a/internal/qbranch/anomalydetection-testbench/bench/bench.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/bench.go
@@ -128,6 +128,10 @@ type BaselineInfo struct {
 	Enabled          bool                                       `json:"enabled"`
 	DurationSec      int64                                      `json:"durationSec"`
 	MuteNoisyMetrics bool                                       `json:"muteNoisyMetrics"`
+	Started          bool                                       `json:"started"`
+	StartSec         int64                                      `json:"startSec"`
+	AllComplete      bool                                       `json:"allComplete"`
+	MutedCount       int                                        `json:"mutedCount"`
 	Active           bool                                       `json:"active"`
 	WindowEndSec     int64                                      `json:"windowEndSec,omitempty"`
 	MutedSeries      []string                                   `json:"mutedSeries,omitempty"`
@@ -754,6 +758,10 @@ func (tb *Bench) GetStatus() StatusResponse {
 			Enabled:          true,
 			DurationSec:      tb.settings.Baseline.DurationSec,
 			MuteNoisyMetrics: tb.settings.Baseline.MuteNoisyMetrics,
+			Started:          status.Started,
+			StartSec:         status.StartSec,
+			AllComplete:      status.AllComplete,
+			MutedCount:       status.MutedCount,
 			Active:           status.Started && !status.AllComplete && !frozen,
 			WindowEndSec:     windowEndSec,
 			MutedSeries:      mutedSeries,

--- a/internal/qbranch/anomalydetection-testbench/bench/bench.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/bench.go
@@ -120,16 +120,18 @@ type ComponentInfo struct {
 type testbenchView interface {
 	observerimpl.DebugView
 	DebugSubscribeBaselineCompleted(func(endSec int64, mutedGroups []string))
+	DebugBaselineStatus() observerimpl.BaselineDebugStatus
 }
 
 // BaselineInfo is the baseline analysis window state exposed to the testbench UI.
 type BaselineInfo struct {
-	Enabled          bool     `json:"enabled"`
-	DurationSec      int64    `json:"durationSec"`
-	MuteNoisyMetrics bool     `json:"muteNoisyMetrics"`
-	Active           bool     `json:"active"`
-	WindowEndSec     int64    `json:"windowEndSec,omitempty"`
-	MutedSeries      []string `json:"mutedSeries,omitempty"`
+	Enabled          bool                                       `json:"enabled"`
+	DurationSec      int64                                      `json:"durationSec"`
+	MuteNoisyMetrics bool                                       `json:"muteNoisyMetrics"`
+	Active           bool                                       `json:"active"`
+	WindowEndSec     int64                                      `json:"windowEndSec,omitempty"`
+	MutedSeries      []string                                   `json:"mutedSeries,omitempty"`
+	Detectors        []observerimpl.BaselineDetectorDebugStatus `json:"detectors,omitempty"`
 }
 
 // StatusResponse is the response for /api/status.
@@ -737,6 +739,12 @@ func (tb *Bench) GetStatus() StatusResponse {
 
 	var baselineInfo *BaselineInfo
 	if tb.settings.Baseline.Enabled {
+		status := observerimpl.BaselineDebugStatus{}
+		if debugBaseline, ok := tb.obs.(interface {
+			DebugBaselineStatus() observerimpl.BaselineDebugStatus
+		}); ok {
+			status = debugBaseline.DebugBaselineStatus()
+		}
 		tb.baselineMu.Lock()
 		frozen := tb.baselineFrozen
 		windowEndSec := tb.baselineWindowEndSec
@@ -746,9 +754,10 @@ func (tb *Bench) GetStatus() StatusResponse {
 			Enabled:          true,
 			DurationSec:      tb.settings.Baseline.DurationSec,
 			MuteNoisyMetrics: tb.settings.Baseline.MuteNoisyMetrics,
-			Active:           !frozen,
+			Active:           status.Started && !status.AllComplete && !frozen,
 			WindowEndSec:     windowEndSec,
 			MutedSeries:      mutedSeries,
+			Detectors:        status.Detectors,
 		}
 	}
 

--- a/internal/qbranch/anomalydetection-testbench/bench/bench.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/bench.go
@@ -125,17 +125,18 @@ type testbenchView interface {
 
 // BaselineInfo is the baseline analysis window state exposed to the testbench UI.
 type BaselineInfo struct {
-	Enabled          bool                                       `json:"enabled"`
-	DurationSec      int64                                      `json:"durationSec"`
-	MuteNoisyMetrics bool                                       `json:"muteNoisyMetrics"`
-	Started          bool                                       `json:"started"`
-	StartSec         int64                                      `json:"startSec"`
-	AllComplete      bool                                       `json:"allComplete"`
-	MutedCount       int                                        `json:"mutedCount"`
-	Active           bool                                       `json:"active"`
-	WindowEndSec     int64                                      `json:"windowEndSec,omitempty"`
-	MutedSeries      []string                                   `json:"mutedSeries,omitempty"`
-	Detectors        []observerimpl.BaselineDetectorDebugStatus `json:"detectors,omitempty"`
+	Enabled            bool                                       `json:"enabled"`
+	DurationSec        int64                                      `json:"durationSec"`
+	MuteNoisyMetrics   bool                                       `json:"muteNoisyMetrics"`
+	Started            bool                                       `json:"started"`
+	StartSec           int64                                      `json:"startSec"`
+	AnalyzedThroughSec int64                                      `json:"analyzedThroughSec,omitempty"`
+	AllComplete        bool                                       `json:"allComplete"`
+	MutedCount         int                                        `json:"mutedCount"`
+	Active             bool                                       `json:"active"`
+	WindowEndSec       int64                                      `json:"windowEndSec,omitempty"`
+	MutedSeries        []string                                   `json:"mutedSeries,omitempty"`
+	Detectors          []observerimpl.BaselineDetectorDebugStatus `json:"detectors,omitempty"`
 }
 
 // StatusResponse is the response for /api/status.
@@ -755,17 +756,18 @@ func (tb *Bench) GetStatus() StatusResponse {
 		mutedSeries := tb.baselineMutedSeries
 		tb.baselineMu.Unlock()
 		baselineInfo = &BaselineInfo{
-			Enabled:          true,
-			DurationSec:      tb.settings.Baseline.DurationSec,
-			MuteNoisyMetrics: tb.settings.Baseline.MuteNoisyMetrics,
-			Started:          status.Started,
-			StartSec:         status.StartSec,
-			AllComplete:      status.AllComplete,
-			MutedCount:       status.MutedCount,
-			Active:           status.Started && !status.AllComplete && !frozen,
-			WindowEndSec:     windowEndSec,
-			MutedSeries:      mutedSeries,
-			Detectors:        status.Detectors,
+			Enabled:            true,
+			DurationSec:        tb.settings.Baseline.DurationSec,
+			MuteNoisyMetrics:   tb.settings.Baseline.MuteNoisyMetrics,
+			Started:            status.Started,
+			StartSec:           status.StartSec,
+			AnalyzedThroughSec: status.AnalyzedThroughSec,
+			AllComplete:        status.AllComplete,
+			MutedCount:         status.MutedCount,
+			Active:             status.Started && !status.AllComplete && !frozen,
+			WindowEndSec:       windowEndSec,
+			MutedSeries:        mutedSeries,
+			Detectors:          status.Detectors,
 		}
 	}
 

--- a/internal/qbranch/anomalydetection-testbench/main.go
+++ b/internal/qbranch/anomalydetection-testbench/main.go
@@ -80,7 +80,7 @@ func main() {
 	logsOnly := flag.Bool("logs-only", false, "Load only log rows from scenarios; skip parquet metrics and trace stats (interactive and headless)")
 	parquetFormat := flag.String("parquet-format", "", "Parquet layout: v1 (observer-metrics-*/observer-logs-*), v2 (contexts.parquet + metrics-*/logs-*), or empty to auto-detect")
 	retainParquet := flag.Bool("retain-parquet", false, "Retain and sort all parquet rows instead of streaming them (headless mode only)")
-	baselineDuration := flag.String("baseline-duration", "", "Baseline analysis window duration (e.g. \"7m\", \"0\" to disable). Default: enabled with 10m window.")
+	baselineDuration := flag.String("baseline-duration", "", "Baseline analysis window duration (e.g. \"7m\", \"0\" to disable). Default: enabled with 2m window.")
 	muteNoisyMetrics := flag.Bool("mute-noisy-metrics", true, "Mute metrics that fire anomalies during the baseline window")
 	flag.Parse()
 
@@ -146,10 +146,11 @@ func main() {
 	} else {
 		componentSettings.Baseline = observerimpl.BaselineConfig{
 			Enabled:          true,
-			DurationSec:      300,
+			DurationSec:      120,
 			MuteNoisyMetrics: *muteNoisyMetrics,
 		}
 	}
+	componentSettings = observerimpl.ApplyTestbenchDetectorDefaults(componentSettings)
 
 	if *headless == "" {
 		fmt.Printf("Observer Test Bench\n")

--- a/internal/qbranch/anomalydetection-testbench/ui/src/App.tsx
+++ b/internal/qbranch/anomalydetection-testbench/ui/src/App.tsx
@@ -717,7 +717,7 @@ function App() {
             state={state}
             actions={actions}
             sidebarWidth={sidebarWidth}
-            phaseMarkers={phaseMarkers}
+            phaseMarkers={phaseMarkers.filter(marker => marker.key !== 'baseline' && marker.key !== 'baseline-mute')}
             timeRange={activeTimeRange}
             onTimeRangeChange={commitTimeRange}
           />

--- a/internal/qbranch/anomalydetection-testbench/ui/src/api/client.ts
+++ b/internal/qbranch/anomalydetection-testbench/ui/src/api/client.ts
@@ -55,6 +55,7 @@ export interface StatusResponse {
     muteNoisyMetrics: boolean;
     started: boolean;
     startSec?: number;
+    analyzedThroughSec?: number;
     allComplete: boolean;
     mutedCount: number;
     active: boolean;
@@ -66,8 +67,9 @@ export interface StatusResponse {
 
 export interface BaselineDetectorStatus {
   name: string;
-  warmupEndSec: number;
-  baselineEndSec: number;
+  ready: boolean;
+  warmupEndSec?: number;
+  baselineEndSec?: number;
   completed: boolean;
   mutedCount: number;
 }

--- a/internal/qbranch/anomalydetection-testbench/ui/src/api/client.ts
+++ b/internal/qbranch/anomalydetection-testbench/ui/src/api/client.ts
@@ -53,10 +53,23 @@ export interface StatusResponse {
     enabled: boolean;
     durationSec: number;
     muteNoisyMetrics: boolean;
+    started: boolean;
+    startSec?: number;
+    allComplete: boolean;
+    mutedCount: number;
     active: boolean;
     windowEndSec?: number;
     mutedSeries?: string[];
+    detectors?: BaselineDetectorStatus[];
   };
+}
+
+export interface BaselineDetectorStatus {
+  name: string;
+  warmupEndSec: number;
+  baselineEndSec: number;
+  completed: boolean;
+  mutedCount: number;
 }
 
 export interface ScenarioInfo {

--- a/internal/qbranch/anomalydetection-testbench/ui/src/components/BaselineView.tsx
+++ b/internal/qbranch/anomalydetection-testbench/ui/src/components/BaselineView.tsx
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+import type { StatusResponse, BaselineDetectorStatus } from '../api/client';
+
+const noDetectors: BaselineDetectorStatus[] = [];
+
+function formatTime(timestamp: number): string {
+  return new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false }).format(new Date(timestamp * 1000));
+}
+
+function percent(timestamp: number, start: number, end: number): number {
+  return Math.max(0, Math.min(100, ((timestamp - start) / Math.max(1, end - start)) * 100));
+}
+
+// BaselineTimelineWidget deliberately uses the complete scenario span rather
+// than the selected chart range: the period before first analysis is useful
+// context when warmup does not begin at scenario start.
+export function BaselineTimelineWidget({ status }: { status: StatusResponse | null }) {
+  const baseline = status?.baseline;
+  const detectors = baseline?.detectors ?? noDetectors;
+  const timeline = useMemo(() => {
+    if (!baseline?.enabled || detectors.length === 0 || !baseline.started) return null;
+    const scenarioStart = status?.scenarioStart ?? baseline.startSec;
+    const scenarioEnd = status?.scenarioEnd ?? Math.max(...detectors.map(d => d.baselineEndSec)) + 1;
+    return { start: Math.min(scenarioStart, baseline.startSec), end: Math.max(scenarioEnd, ...detectors.map(d => d.baselineEndSec + 1)) };
+  }, [baseline, detectors, status?.scenarioEnd, status?.scenarioStart]);
+
+  if (!baseline?.enabled) return null;
+  if (!timeline) return <div className="rounded-lg border border-slate-700 bg-slate-800 px-4 py-6 text-center text-sm text-slate-500">Waiting for the first analysis advance.</div>;
+
+  const midpoint = timeline.start + (timeline.end - timeline.start) / 2;
+  return (
+    <section className="rounded-lg border border-slate-700 bg-slate-800 overflow-hidden">
+      <div className="px-4 py-3 border-b border-slate-700 flex flex-wrap justify-between gap-3">
+        <div><h2 className="text-sm font-medium text-slate-200">Detector baselines</h2><p className="mt-0.5 text-xs text-slate-500">Full scenario timeline · qualification window: {Math.round(baseline.durationSec / 60)}m</p></div>
+        <div className="flex flex-wrap gap-2 text-xs text-slate-300"><Legend className="border-slate-600 bg-slate-700/50" label="Before analysis" /><Legend className="border-blue-400 bg-blue-500/20" label="Warmup" /><Legend className="border-emerald-400 bg-emerald-500/20" label="Baseline" /><Legend className="border-purple-400 bg-purple-500/20" label="Detection" /></div>
+      </div>
+      <div className="p-4">
+        <div className="ml-40 flex justify-between pb-2 text-xs text-slate-500 tabular-nums"><span>{formatTime(timeline.start)}</span><span>{formatTime(midpoint)}</span><span>{formatTime(timeline.end)}</span></div>
+        <div className="space-y-3">
+          {detectors.map(detector => <DetectorLane key={detector.name} detector={detector} analysisStart={baseline.startSec!} start={timeline.start} end={timeline.end} />)}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function DetectorLane({ detector, analysisStart, start, end }: { detector: BaselineDetectorStatus; analysisStart: number; start: number; end: number }) {
+  const before = percent(analysisStart, start, end);
+  const warmup = percent(detector.warmupEndSec, start, end) - before;
+  const baseline = percent(detector.baselineEndSec, start, end) - before - warmup;
+  const detection = 100 - before - warmup - baseline;
+  return <div className="grid grid-cols-[9rem_minmax(28rem,1fr)] items-stretch gap-4"><div className="py-2"><div className="text-sm font-medium text-slate-200">{detector.name}</div><div className="mt-1 text-xs text-slate-500">{detector.completed ? `${detector.mutedCount} muted` : 'baseline active'}</div></div><div className="flex min-w-0 gap-1" aria-label={`${detector.name} baseline timeline`}><PhaseBox className="border-slate-600 bg-slate-700/50" width={before} title="Waiting" detail="before analysis" /><PhaseBox className="border-blue-400 bg-blue-500/20" width={warmup} title="Warmup" detail={`until ${formatTime(detector.warmupEndSec)}`} /><PhaseBox className="border-emerald-400 bg-emerald-500/20" width={baseline} title="Baseline" detail={`until ${formatTime(detector.baselineEndSec)}`} /><PhaseBox className="border-purple-400 bg-purple-500/20" width={detection} title="Detection" detail={detector.completed ? 'enabled' : 'pending'} /></div></div>;
+}
+
+function PhaseBox({ className, width, title, detail }: { className: string; width: number; title: string; detail: string }) { return <div className={`min-w-0 rounded border px-3 py-2 ${className}`} style={{ width: `${Math.max(0, width)}%` }}><div className="truncate text-xs font-medium text-slate-100">{title}</div><div className="truncate mt-0.5 text-[11px] text-slate-300">{detail}</div></div>; }
+function Legend({ className, label }: { className: string; label: string }) { return <span className={`rounded border px-2 py-1 ${className}`}>{label}</span>; }

--- a/internal/qbranch/anomalydetection-testbench/ui/src/components/BaselineView.tsx
+++ b/internal/qbranch/anomalydetection-testbench/ui/src/components/BaselineView.tsx
@@ -1,10 +1,17 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import type { StatusResponse, BaselineDetectorStatus } from '../api/client';
+import type { PhaseMarker } from './ChartWithAnomalyDetails';
 
 const noDetectors: BaselineDetectorStatus[] = [];
 
 function formatTime(timestamp: number): string {
   return new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false }).format(new Date(timestamp * 1000));
+}
+
+function formatTimestamp(timestamp: number): string {
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+  }).format(new Date(timestamp * 1000));
 }
 
 function formatDuration(seconds: number): string {
@@ -22,20 +29,24 @@ function percent(timestamp: number, start: number, end: number): number {
 // BaselineTimelineWidget deliberately uses the complete scenario span rather
 // than the selected chart range: the period before first analysis is useful
 // context when warmup does not begin at scenario start.
-export function BaselineTimelineWidget({ status }: { status: StatusResponse | null }) {
+export function BaselineTimelineWidget({ status, phaseMarkers = [] }: { status: StatusResponse | null; phaseMarkers?: PhaseMarker[] }) {
   const baseline = status?.baseline;
   const detectors = baseline?.detectors ?? noDetectors;
+  const [hoverPercent, setHoverPercent] = useState<number | null>(null);
   const timeline = useMemo(() => {
     if (!baseline?.enabled || detectors.length === 0 || !baseline.started) return null;
     const scenarioStart = status?.scenarioStart ?? baseline.startSec;
-    const scenarioEnd = status?.scenarioEnd ?? Math.max(...detectors.map(d => d.baselineEndSec)) + 1;
-    return { start: Math.min(scenarioStart, baseline.startSec), end: Math.max(scenarioEnd, ...detectors.map(d => d.baselineEndSec + 1)) };
+    const knownEnds = detectors.flatMap(d => d.baselineEndSec === undefined ? [] : [d.baselineEndSec + 1]);
+    const scenarioEnd = status?.scenarioEnd ?? Math.max(baseline.startSec + 1, ...knownEnds);
+    return { start: Math.min(scenarioStart, baseline.startSec), end: Math.max(scenarioEnd, ...knownEnds) };
   }, [baseline, detectors, status?.scenarioEnd, status?.scenarioStart]);
 
   if (!baseline?.enabled) return null;
   if (!timeline) return <div className="rounded-lg border border-slate-700 bg-slate-800 px-4 py-6 text-center text-sm text-slate-500">Waiting for the first analysis advance.</div>;
 
   const midpoint = timeline.start + (timeline.end - timeline.start) / 2;
+  const hoverTimestamp = hoverPercent === null ? null : timeline.start + (hoverPercent / 100) * (timeline.end - timeline.start);
+  const visibleMarkers = phaseMarkers.filter(marker => marker.timestamp >= timeline.start && marker.timestamp <= timeline.end);
   return (
     <section className="rounded-lg border border-slate-700 bg-slate-800 overflow-hidden">
       <div className="px-4 py-3 border-b border-slate-700 flex flex-wrap justify-between gap-3">
@@ -43,21 +54,57 @@ export function BaselineTimelineWidget({ status }: { status: StatusResponse | nu
         <div className="flex flex-wrap gap-2 text-xs text-slate-300"><Legend className="border-slate-600 bg-slate-700/50" label="Before analysis" /><Legend className="border-blue-400 bg-blue-500/20" label="Warmup" /><Legend className="border-emerald-400 bg-emerald-500/20" label="Baseline" /><Legend className="border-purple-400 bg-purple-500/20" label="Detection" /></div>
       </div>
       <div className="p-4">
+        <div className="relative ml-40 h-3 text-[9px] font-mono">
+          {visibleMarkers.map(marker => {
+            const left = percent(marker.timestamp, timeline.start, timeline.end);
+            return <span key={marker.key} className="absolute left-1 whitespace-nowrap" style={{ left: `${left}%`, color: marker.color }}>{marker.label}</span>;
+          })}
+        </div>
         <div className="ml-40 flex justify-between pb-2 text-xs text-slate-500 tabular-nums"><span>{formatTime(timeline.start)}</span><span>{formatTime(midpoint)}</span><span>{formatTime(timeline.end)}</span></div>
-        <div className="space-y-3">
-          {detectors.map(detector => <DetectorLane key={detector.name} detector={detector} analysisStart={baseline.startSec!} start={timeline.start} end={timeline.end} />)}
+        <div className="relative">
+          <div className="space-y-3">
+            {detectors.map(detector => <DetectorLane key={detector.name} detector={detector} analysisStart={baseline.startSec!} analyzedThrough={baseline.analyzedThroughSec ?? timeline.end} start={timeline.start} end={timeline.end} />)}
+          </div>
+          <div className="absolute inset-y-0 left-40 right-0 pointer-events-none">
+            {visibleMarkers.map(marker => {
+              const left = percent(marker.timestamp, timeline.start, timeline.end);
+              return <div key={marker.key} className="absolute inset-y-0" style={{ left: `${left}%` }}>
+                <div className="h-full border-l border-dashed opacity-80" style={{ borderColor: marker.color }} />
+              </div>;
+            })}
+          </div>
+          <div
+            className="absolute inset-y-0 left-40 right-0 cursor-crosshair"
+            onMouseMove={(event) => {
+              const rect = event.currentTarget.getBoundingClientRect();
+              setHoverPercent(Math.max(0, Math.min(100, ((event.clientX - rect.left) / rect.width) * 100)));
+            }}
+            onMouseLeave={() => setHoverPercent(null)}
+          >
+            {hoverPercent !== null && hoverTimestamp !== null && <>
+              <div className="absolute inset-y-0 border-l border-dashed border-slate-300/60" style={{ left: `${hoverPercent}%` }} />
+              <div className="absolute top-1 z-10 -translate-x-1/2 rounded bg-slate-950 px-2 py-1 text-[10px] font-mono text-slate-100 shadow" style={{ left: `${hoverPercent}%` }}>
+                {formatTimestamp(hoverTimestamp)}
+              </div>
+            </>}
+          </div>
         </div>
       </div>
     </section>
   );
 }
 
-function DetectorLane({ detector, analysisStart, start, end }: { detector: BaselineDetectorStatus; analysisStart: number; start: number; end: number }) {
+function DetectorLane({ detector, analysisStart, analyzedThrough, start, end }: { detector: BaselineDetectorStatus; analysisStart: number; analyzedThrough: number; start: number; end: number }) {
   const before = percent(analysisStart, start, end);
+  const observedEnd = Math.max(analysisStart, Math.min(analyzedThrough, end));
+  if (!detector.ready || detector.warmupEndSec === undefined || detector.baselineEndSec === undefined) {
+    return <div className="grid grid-cols-[9rem_minmax(28rem,1fr)] items-stretch gap-4"><div className="py-2"><div className="text-sm font-medium text-slate-200">{detector.name}</div><div className="mt-1 text-xs text-slate-500">waiting for readiness</div></div><div className="flex min-w-0 gap-1" aria-label={`${detector.name} baseline timeline`}><PhaseBox className="border-slate-600 bg-slate-700/50" width={before} title="Before analysis" detail={formatDuration(analysisStart - start)} /><PhaseBox className="border-blue-400 bg-blue-500/20" width={100 - before} title="Warmup" detail={`${formatDuration(observedEnd - analysisStart)} · waiting`} /></div></div>;
+  }
   const warmup = percent(detector.warmupEndSec, start, end) - before;
-  const baseline = percent(detector.baselineEndSec, start, end) - before - warmup;
-  const detection = 100 - before - warmup - baseline;
-  return <div className="grid grid-cols-[9rem_minmax(28rem,1fr)] items-stretch gap-4"><div className="py-2"><div className="text-sm font-medium text-slate-200">{detector.name}</div><div className="mt-1 text-xs text-slate-500">{detector.completed ? `${detector.mutedCount} muted` : 'baseline active'}</div></div><div className="flex min-w-0 gap-1" aria-label={`${detector.name} baseline timeline`}><PhaseBox className="border-slate-600 bg-slate-700/50" width={before} title="Waiting" detail={formatDuration(analysisStart - start)} /><PhaseBox className="border-blue-400 bg-blue-500/20" width={warmup} title="Warmup" detail={formatDuration(detector.warmupEndSec - analysisStart)} /><PhaseBox className="border-emerald-400 bg-emerald-500/20" width={baseline} title="Baseline" detail={formatDuration(detector.baselineEndSec - detector.warmupEndSec)} /><PhaseBox className="border-purple-400 bg-purple-500/20" width={detection} title="Detection" detail={formatDuration(end - detector.baselineEndSec)} /></div></div>;
+  const qualificationEnd = detector.completed ? detector.baselineEndSec : Math.min(detector.baselineEndSec, observedEnd);
+  const baseline = percent(qualificationEnd, start, end) - before - warmup;
+  const detection = detector.completed ? 100 - before - warmup - baseline : 0;
+  return <div className="grid grid-cols-[9rem_minmax(28rem,1fr)] items-stretch gap-4"><div className="py-2"><div className="text-sm font-medium text-slate-200">{detector.name}</div><div className="mt-1 text-xs text-slate-500">{detector.completed ? `${detector.mutedCount} muted` : 'baseline active'}</div></div><div className="flex min-w-0 gap-1" aria-label={`${detector.name} baseline timeline`}><PhaseBox className="border-slate-600 bg-slate-700/50" width={before} title="Before analysis" detail={formatDuration(analysisStart - start)} /><PhaseBox className="border-blue-400 bg-blue-500/20" width={warmup} title="Warmup" detail={formatDuration(detector.warmupEndSec - analysisStart)} /><PhaseBox className="border-emerald-400 bg-emerald-500/20" width={baseline} title="Baseline" detail={formatDuration(qualificationEnd - detector.warmupEndSec)} />{detector.completed && <PhaseBox className="border-purple-400 bg-purple-500/20" width={detection} title="Detection" detail={formatDuration(end - detector.baselineEndSec)} />}</div></div>;
 }
 
 function PhaseBox({ className, width, title, detail }: { className: string; width: number; title: string; detail: string }) { return <div className={`min-w-0 rounded border px-3 py-2 ${className}`} style={{ width: `${Math.max(0, width)}%` }}><div className="truncate text-xs font-medium text-slate-100">{title}</div><div className="truncate mt-0.5 text-[11px] text-slate-300">{detail}</div></div>; }

--- a/internal/qbranch/anomalydetection-testbench/ui/src/components/BaselineView.tsx
+++ b/internal/qbranch/anomalydetection-testbench/ui/src/components/BaselineView.tsx
@@ -7,6 +7,14 @@ function formatTime(timestamp: number): string {
   return new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false }).format(new Date(timestamp * 1000));
 }
 
+function formatDuration(seconds: number): string {
+  const rounded = Math.max(0, Math.round(seconds));
+  if (rounded < 60) return `${rounded}s`;
+  const minutes = Math.floor(rounded / 60);
+  const remainder = rounded % 60;
+  return remainder === 0 ? `${minutes}m` : `${minutes}m ${remainder}s`;
+}
+
 function percent(timestamp: number, start: number, end: number): number {
   return Math.max(0, Math.min(100, ((timestamp - start) / Math.max(1, end - start)) * 100));
 }
@@ -49,7 +57,7 @@ function DetectorLane({ detector, analysisStart, start, end }: { detector: Basel
   const warmup = percent(detector.warmupEndSec, start, end) - before;
   const baseline = percent(detector.baselineEndSec, start, end) - before - warmup;
   const detection = 100 - before - warmup - baseline;
-  return <div className="grid grid-cols-[9rem_minmax(28rem,1fr)] items-stretch gap-4"><div className="py-2"><div className="text-sm font-medium text-slate-200">{detector.name}</div><div className="mt-1 text-xs text-slate-500">{detector.completed ? `${detector.mutedCount} muted` : 'baseline active'}</div></div><div className="flex min-w-0 gap-1" aria-label={`${detector.name} baseline timeline`}><PhaseBox className="border-slate-600 bg-slate-700/50" width={before} title="Waiting" detail="before analysis" /><PhaseBox className="border-blue-400 bg-blue-500/20" width={warmup} title="Warmup" detail={`until ${formatTime(detector.warmupEndSec)}`} /><PhaseBox className="border-emerald-400 bg-emerald-500/20" width={baseline} title="Baseline" detail={`until ${formatTime(detector.baselineEndSec)}`} /><PhaseBox className="border-purple-400 bg-purple-500/20" width={detection} title="Detection" detail={detector.completed ? 'enabled' : 'pending'} /></div></div>;
+  return <div className="grid grid-cols-[9rem_minmax(28rem,1fr)] items-stretch gap-4"><div className="py-2"><div className="text-sm font-medium text-slate-200">{detector.name}</div><div className="mt-1 text-xs text-slate-500">{detector.completed ? `${detector.mutedCount} muted` : 'baseline active'}</div></div><div className="flex min-w-0 gap-1" aria-label={`${detector.name} baseline timeline`}><PhaseBox className="border-slate-600 bg-slate-700/50" width={before} title="Waiting" detail={formatDuration(analysisStart - start)} /><PhaseBox className="border-blue-400 bg-blue-500/20" width={warmup} title="Warmup" detail={formatDuration(detector.warmupEndSec - analysisStart)} /><PhaseBox className="border-emerald-400 bg-emerald-500/20" width={baseline} title="Baseline" detail={formatDuration(detector.baselineEndSec - detector.warmupEndSec)} /><PhaseBox className="border-purple-400 bg-purple-500/20" width={detection} title="Detection" detail={formatDuration(end - detector.baselineEndSec)} /></div></div>;
 }
 
 function PhaseBox({ className, width, title, detail }: { className: string; width: number; title: string; detail: string }) { return <div className={`min-w-0 rounded border px-3 py-2 ${className}`} style={{ width: `${Math.max(0, width)}%` }}><div className="truncate text-xs font-medium text-slate-100">{title}</div><div className="truncate mt-0.5 text-[11px] text-slate-300">{detail}</div></div>; }

--- a/internal/qbranch/anomalydetection-testbench/ui/src/components/ScorerView.tsx
+++ b/internal/qbranch/anomalydetection-testbench/ui/src/components/ScorerView.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useCallback } from 'react';
 import { AnomalyScoreTimeline } from './AnomalyScoreTimeline';
+import { BaselineTimelineWidget } from './BaselineView';
 import type { PhaseMarker } from './ChartWithAnomalyDetails';
 import type { ObserverState, ObserverActions } from '../hooks/useObserver';
 import type { ScoreState, SeverityEvent, Anomaly, LogAnomaly } from '../api/client';
@@ -368,6 +369,10 @@ export function ScorerView({ state, actions, sidebarWidth, phaseMarkers, timeRan
               </div>
             </div>
           )}
+
+          <div className="px-4 pb-6">
+            <BaselineTimelineWidget status={state.status} />
+          </div>
         </div>
       </main>
     </div>

--- a/internal/qbranch/anomalydetection-testbench/ui/src/components/ScorerView.tsx
+++ b/internal/qbranch/anomalydetection-testbench/ui/src/components/ScorerView.tsx
@@ -371,7 +371,7 @@ export function ScorerView({ state, actions, sidebarWidth, phaseMarkers, timeRan
           )}
 
           <div className="px-4 pb-6">
-            <BaselineTimelineWidget status={state.status} />
+            <BaselineTimelineWidget status={state.status} phaseMarkers={phaseMarkers} />
           </div>
         </div>
       </main>

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -2338,7 +2338,7 @@ func anomalyDetection(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("anomaly_detection.storage.eviction_floor_ratio", float64(0.5))
 	config.BindEnvAndSetDefault("anomaly_detection.storage.point_retention", 2*time.Minute)
 
-	// Per-detector baseline qualification window, after each detector's warmup.
+	// Baseline analysis window.
 	config.BindEnvAndSetDefault("anomaly_detection.baseline_analysis.enabled", true)
 	config.BindEnvAndSetDefault("anomaly_detection.baseline_analysis.mute_noisy_metrics", true)
 	config.BindEnvAndSetDefault("anomaly_detection.baseline_analysis.duration", "10m")

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -2338,7 +2338,7 @@ func anomalyDetection(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("anomaly_detection.storage.eviction_floor_ratio", float64(0.5))
 	config.BindEnvAndSetDefault("anomaly_detection.storage.point_retention", 2*time.Minute)
 
-	// Baseline analysis window.
+	// Per-detector baseline qualification window, after each detector's warmup.
 	config.BindEnvAndSetDefault("anomaly_detection.baseline_analysis.enabled", true)
 	config.BindEnvAndSetDefault("anomaly_detection.baseline_analysis.mute_noisy_metrics", true)
 	config.BindEnvAndSetDefault("anomaly_detection.baseline_analysis.duration", "10m")

--- a/tasks/libs/anomalydetection/eval.py
+++ b/tasks/libs/anomalydetection/eval.py
@@ -43,6 +43,17 @@ AWS_PROFILE = "sso-agent-sandbox-account-admin-8h"
 # not for Gaussian F1 eval (eval_scenarios / eval_combinations). This study
 # evaluates scorer-produced correlation periods only.
 DETECTORS = ["bocpd", "cusum", "holt_residual", "rrcf", "scanmw", "scanwelch", "tukey_biweight"]
+
+# The testbench applies these shorter warmups for interactive and headless
+# evaluation. Eval-generated configs name every detector, so carry the profile
+# explicitly: otherwise an enabled-only entry would lock the Go parser to its
+# production defaults and bypass the testbench profile.
+TESTBENCH_WARMUP_PARAMS = {
+    "bocpd": {"warmup_points": 40},
+    "holt_residual": {"warmup_points": 15, "residual_window": 25},
+    "tukey_biweight": {"window_size": 40, "min_points": 40},
+}
+
 ABLATION_CORRELATORS = ["anomaly_scorer"]
 SUPPORTED_CORRELATORS = ["anomaly_scorer", "cross_signal", "time_cluster"]
 
@@ -444,6 +455,9 @@ def random_component_combinations(
 def _component_base_config(name: str, enabled: bool) -> dict:
     """Base JSON config for a component in eval-generated testbench params."""
     cfg: dict[str, object] = {"enabled": enabled}
+    # Keep generated Optuna and combination configs aligned with testbench-only
+    # detector warmups. Sampled values below can intentionally override these.
+    cfg.update(TESTBENCH_WARMUP_PARAMS.get(name, {}))
     if enabled and name == "anomaly_scorer":
         # The scorer only contributes to Gaussian F1 when it emits Medium- or
         # High-severity episodes as anomaly_periods. Keep cooldown at zero so
@@ -513,7 +527,6 @@ def _sample_component_params(trial, component: str) -> dict:
         return {
             "alpha": alpha,
             "beta": alpha * beta_ratio,
-            "residual_window": trial.suggest_int("holt_residual.residual_window", 20, 90),
             "z_threshold": trial.suggest_float("holt_residual.z_threshold", 2.5, 8.0),
             "confirm_m": trial.suggest_int("holt_residual.confirm_m", 1, 3),
             "min_deviation_mad": trial.suggest_float("holt_residual.min_deviation_mad", 1.5, 6.0),
@@ -521,10 +534,7 @@ def _sample_component_params(trial, component: str) -> dict:
         }
 
     def sample_tukey_biweight() -> dict:
-        window_size = trial.suggest_int("tukey_biweight.window_size", 30, 120)
         return {
-            "window_size": window_size,
-            "min_points": window_size,
             "biweight_c": trial.suggest_float("tukey_biweight.biweight_c", 3.5, 6.0),
             "z_threshold": trial.suggest_float("tukey_biweight.z_threshold", 2.5, 10.0),
             "score_every": trial.suggest_int("tukey_biweight.score_every", 1, 6),

--- a/tasks/unit_tests/anomalydetection_eval_tests.py
+++ b/tasks/unit_tests/anomalydetection_eval_tests.py
@@ -80,7 +80,35 @@ class TestAblationConfig(unittest.TestCase):
         tukey = _sample_component_params(trial, "tukey_biweight")
 
         self.assertLessEqual(holt["beta"], holt["alpha"])
-        self.assertEqual(tukey["min_points"], tukey["window_size"])
+        self.assertNotIn("residual_window", holt)
+        self.assertNotIn("window_size", tukey)
+        self.assertNotIn("min_points", tukey)
+
+    def test_generated_configs_include_testbench_warmup_profile(self):
+        components = _build_optuna_config(
+            trial=None,
+            components=["anomaly_scorer"],
+            locked={"anomaly_scorer"},
+        )["components"]
+
+        self.assertEqual(components["bocpd"]["warmup_points"], 40)
+        self.assertEqual(components["holt_residual"]["warmup_points"], 15)
+        self.assertEqual(components["holt_residual"]["residual_window"], 25)
+        self.assertEqual(components["tukey_biweight"]["window_size"], 40)
+        self.assertEqual(components["tukey_biweight"]["min_points"], 40)
+
+    def test_optuna_cannot_override_testbench_warmup_profile(self):
+        components = _build_optuna_config(
+            trial=MinimumTrial(),
+            components=["bocpd", "holt_residual", "tukey_biweight"],
+            locked=set(),
+        )["components"]
+
+        self.assertEqual(components["bocpd"]["warmup_points"], 40)
+        self.assertEqual(components["holt_residual"]["warmup_points"], 15)
+        self.assertEqual(components["holt_residual"]["residual_window"], 25)
+        self.assertEqual(components["tukey_biweight"]["window_size"], 40)
+        self.assertEqual(components["tukey_biweight"]["min_points"], 40)
 
 
 class TestPipelineResume(unittest.TestCase):


### PR DESCRIPTION
### What does this PR do?

Some detectors take too much time to warmup + to have the baseline, this overrides their warmup points only for testbench. Production will use more points which will reduce even more false positives in theory.

- BOCPD: 120 -> 40 points
- Tukey biweight: 80 -> 40 points
- Holt residual: 24 + 60 -> 15 bootstrap + 25 residual

Also changes the baseline to be 2m on the testbench and disable tuning warmup params via optuna.

Here are some stats about the false positive exposure (duration after warmup + 2m baseline end up to disruption start, negative exposure = detectors can output anomalies only after disruptions starts ~= cheating):

Detector | Min exposure | Median exposure | Max exposure
-- | -- | -- | --
BOCPD | −6m 28s → 4m | 5m 13s → 8m 46s | 9m 25s → 27m 48s
Holt residual | −4m 52s → 4m | 6m → 8m 46s | 10m 44s → 27m 48s
Tukey biweight | −4m 40s → 4m | 6m 4s → 8m 46s | 10m 52s → 27m 48s


### Motivation

### Describe how you validated your changes

### Additional Notes

Benchmark with default settings (bocpd / rrcf) + 2min of baseline and bocpd warmup of 120 points (before) vs 40 points (after).

Scenario | F1 (120 → 40) | TP | FP | Predictions
-- | -- | -- | -- | --
block-building-outage | 0.000 → 0.500 | 0.000 → 1.000 | 0 → 2 | 21 → 56
byzantine-fault-cascade | 0.040 → 0.050 | 0.406 → 0.485 | 19 → 18 | 62 → 55
cascading-payment-failure | 0.000 → 0.000 | 0.000 → 0.000 | 0 → 0 | 4 → 38
cassandra-repair-degradation | 0.000 → 0.276 | 0.000 → 0.640 | 0 → 3 | 0 → 14
dns-upstream-outage | 0.056 → 0.059 | 0.143 → 0.945 | 4 → 30 | 71 → 109
kafka-partition-saturation | 0.655 → 0.177 | 0.974 → 0.974 | 1 → 9 | 41 → 41
lock-contention | 0.619 → 0.619 | 0.896 → 0.896 | 1 → 1 | 5 → 39
memcached-saturation | 0.190 → 0.142 | 0.841 → 0.841 | 7 → 10 | 26 → 32
pool-saturation | 0.166 → 0.151 | 0.816 → 0.816 | 8 → 9 | 28 → 47
redis-cascade-billing | 0.000 → 0.000 | 0.000 → 0.000 | 0 → 1 | 7 → 36
redis-cpu-saturation | 0.000 → 0.000 | 0.000 → 0.000 | 0 → 0 | 3 → 22
tiered-cache-header-corruption | 0.000 → 0.914 | 0.000 → 0.841 | 0 → 0 | 8 → 35

Aggregate | 120 → 40
-- | --
Mean F1 | 0.144 → 0.241
TP sum | 4.076 → 7.439
FP sum | 40 → 83
Predictions | 276 → 524
