### PR TITLE
chore(data plane): bump ADP to 1.5.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -554,7 +554,7 @@ workflow:
     - changes:
         paths:
           - deps/agent_data_plane/agent_data_plane.MODULE.bazel
-        compare_to: main
+        compare_to: $COMPARE_TO_BRANCH
       variables:
         RUN_ALL_BUILDS: "true"
         RUN_E2E_TESTS: "on"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -548,6 +548,19 @@ workflow:
     - <<: *if_run_all_e2e_tests
     - !reference [.if_deploy_installer]
     - <<: *if_mergequeue
+    # ADP is shipped in every Agent package and exercised across several test suites.
+    # Treat an ADP version bump like a full pipeline so platform-specific regressions
+    # (notably in new-e2e-agent-runtimes-windows) are caught before merge.
+    - changes:
+        paths:
+          - deps/agent_data_plane/agent_data_plane.MODULE.bazel
+        compare_to: main
+      variables:
+        RUN_ALL_BUILDS: "true"
+        RUN_E2E_TESTS: "on"
+        RUN_KMT_TESTS: "on"
+        RUN_UNIT_TESTS: "on"
+        SKIP_WINDOWS: "false"
     - changes:
         paths: *windows_path
         compare_to: main

--- a/deps/agent_data_plane/agent_data_plane.MODULE.bazel
+++ b/deps/agent_data_plane/agent_data_plane.MODULE.bazel
@@ -1,18 +1,18 @@
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-VERSION = "1.4.0"
+VERSION = "1.5.1"
 
 SOURCE_URL_BASE = "https://binaries.ddbuild.io/saluki"
 
 HASHES = {
-    "linux-amd64": "3904f9ab8a11f6f21211ee87792122d3e66a72f0c103482057d44d11549738b8",
-    "linux-arm64": "c6dcca770e7df20266c68af73138cfa43db68aace57699c7557408e77925d7cc",
-    "fips-linux-amd64": "0f5d9c921a998f2b0b6b299deb3f194963f41fb0d32d55b4f6719d4da6fff7af",
-    "fips-linux-arm64": "9d079994e841d4986ae0efbefe009d3cd45b4b4c8e8831579d26c493b28c3d8d",
-    "darwin-amd64": "7586ef3041bcd11f9dad1baf7a7f26ff4e2dc239ef59c2d28ebd0e0879f41568",
-    "darwin-arm64": "e40ad02931ba893de49427d9c3a1c4683a0f615a58e96287fdd47e1b089b7699",
-    "windows-amd64": "a2692fa7d961b8e1b1f01ddcf86060f542195124397e69bfacf152ceda47d436",
-    "windows-amd64-fips": "30199587a487bf3312bad913929ee6a951e244f3cbdeafccec4ac8edbaf05cb9",
+    "linux-amd64": "16a056be157a9f60d81b7c200a0c0adbb73f3002c06d4793d3dab4b7390d512c",
+    "linux-arm64": "a6bccc43e04e0b9fb495b73e110b47559c5978fa7f5f4d2f9a4fc89b9526ca27",
+    "fips-linux-amd64": "424bb182b8a2b905229162b3e22548c31b178e82e76a68f96d7d3c4269939a7d",
+    "fips-linux-arm64": "ad283817b3b3c27807955afb989afcc1540e4517bea4d92946844a2eee2497ce",
+    "darwin-amd64": "e9170588e0abbcae4c39caaba3e4d5e797559f4460f422db9aa5f155820dda54",
+    "darwin-arm64": "d6ec158850a8e2036b0885daaf960efab4a8760b5d8004afe50f8602a5c8c9d9",
+    "windows-amd64": "8dda0f401b838e0c80dabe41d37a665ae01090fe79d2282abd2aa43ca2e0ed97",
+    "windows-amd64-fips": "d4a1c1363e702ff5bf193a582274a024f34a1f292e292a14fac0142b36ff4cd4",
 }
 
 _BUILD_FILE_CONTENT = """\

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,51 +1,51 @@
 static_quality_gate_agent_deb_amd64:
-  max_on_disk_size: 762.87 MiB
-  max_on_wire_size: 182.52 MiB
+  max_on_disk_size: 763.83 MiB
+  max_on_wire_size: 182.62 MiB
 static_quality_gate_agent_deb_amd64_fips:
-  max_on_disk_size: 714.17 MiB
-  max_on_wire_size: 176.45 MiB
+  max_on_disk_size: 715.22 MiB
+  max_on_wire_size: 176.86 MiB
 static_quality_gate_agent_heroku_amd64:
   max_on_disk_size: 318.88 MiB
   max_on_wire_size: 81.49 MiB
 static_quality_gate_agent_msi:
-  max_on_disk_size: 657.29 MiB
-  max_on_wire_size: 157.89 MiB
+  max_on_disk_size: 660.34 MiB
+  max_on_wire_size: 158.96 MiB
 static_quality_gate_agent_rpm_amd64:
-  max_on_disk_size: 762.84 MiB
-  max_on_wire_size: 186.16 MiB
+  max_on_disk_size: 763.8 MiB
+  max_on_wire_size: 186.48 MiB
 static_quality_gate_agent_rpm_amd64_fips:
-  max_on_disk_size: 714.17 MiB
-  max_on_wire_size: 177.49 MiB
-static_quality_gate_agent_rpm_arm64:
-  max_on_disk_size: 734.03 MiB
-  max_on_wire_size: 166.82 MiB
-static_quality_gate_agent_rpm_arm64_fips:
-  max_on_disk_size: 692.25 MiB
-  max_on_wire_size: 159.22 MiB
-static_quality_gate_agent_suse_amd64:
-  max_on_disk_size: 762.84 MiB
-  max_on_wire_size: 186.13 MiB
-static_quality_gate_agent_suse_amd64_fips:
-  max_on_disk_size: 714.17 MiB
+  max_on_disk_size: 715.22 MiB
   max_on_wire_size: 177.65 MiB
+static_quality_gate_agent_rpm_arm64:
+  max_on_disk_size: 734.9 MiB
+  max_on_wire_size: 166.98 MiB
+static_quality_gate_agent_rpm_arm64_fips:
+  max_on_disk_size: 693.2 MiB
+  max_on_wire_size: 159.38 MiB
+static_quality_gate_agent_suse_amd64:
+  max_on_disk_size: 763.8 MiB
+  max_on_wire_size: 186.45 MiB
+static_quality_gate_agent_suse_amd64_fips:
+  max_on_disk_size: 715.22 MiB
+  max_on_wire_size: 177.83 MiB
 static_quality_gate_agent_suse_arm64:
-  max_on_disk_size: 734.03 MiB
-  max_on_wire_size: 166.76 MiB
+  max_on_disk_size: 734.9 MiB
+  max_on_wire_size: 166.96 MiB
 static_quality_gate_agent_suse_arm64_fips:
-  max_on_disk_size: 692.25 MiB
-  max_on_wire_size: 159.2 MiB
+  max_on_disk_size: 693.2 MiB
+  max_on_wire_size: 159.34 MiB
 static_quality_gate_docker_agent_amd64:
-  max_on_disk_size: 818.46 MiB
-  max_on_wire_size: 277.3 MiB
+  max_on_disk_size: 819.42 MiB
+  max_on_wire_size: 277.7 MiB
 static_quality_gate_docker_agent_arm64:
-  max_on_disk_size: 819.30 MiB
-  max_on_wire_size: 265.25 MiB
+  max_on_disk_size: 820.17 MiB
+  max_on_wire_size: 265.65 MiB
 static_quality_gate_docker_agent_jmx_amd64:
-  max_on_disk_size: 1009.22 MiB
-  max_on_wire_size: 345.91 MiB
+  max_on_disk_size: 1010.18 MiB
+  max_on_wire_size: 346.29 MiB
 static_quality_gate_docker_agent_jmx_arm64:
-  max_on_disk_size: 998.98 MiB
-  max_on_wire_size: 329.84 MiB
+  max_on_disk_size: 999.85 MiB
+  max_on_wire_size: 330.24 MiB
 static_quality_gate_docker_cluster_agent_amd64:
   max_on_disk_size: 211.25 MiB
   max_on_wire_size: 74.4 MiB

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,51 +1,51 @@
 static_quality_gate_agent_deb_amd64:
-  max_on_disk_size: 763.83 MiB
-  max_on_wire_size: 182.62 MiB
+  max_on_disk_size: 764.01 MiB
+  max_on_wire_size: 182.72 MiB
 static_quality_gate_agent_deb_amd64_fips:
-  max_on_disk_size: 715.22 MiB
-  max_on_wire_size: 176.86 MiB
+  max_on_disk_size: 715.32 MiB
+  max_on_wire_size: 176.9 MiB
 static_quality_gate_agent_heroku_amd64:
   max_on_disk_size: 318.88 MiB
   max_on_wire_size: 81.49 MiB
 static_quality_gate_agent_msi:
-  max_on_disk_size: 660.34 MiB
-  max_on_wire_size: 158.96 MiB
+  max_on_disk_size: 660.49 MiB
+  max_on_wire_size: 159.03 MiB
 static_quality_gate_agent_rpm_amd64:
-  max_on_disk_size: 763.8 MiB
-  max_on_wire_size: 186.48 MiB
+  max_on_disk_size: 763.98 MiB
+  max_on_wire_size: 186.49 MiB
 static_quality_gate_agent_rpm_amd64_fips:
-  max_on_disk_size: 715.22 MiB
-  max_on_wire_size: 177.65 MiB
+  max_on_disk_size: 715.32 MiB
+  max_on_wire_size: 177.67 MiB
 static_quality_gate_agent_rpm_arm64:
-  max_on_disk_size: 734.9 MiB
-  max_on_wire_size: 166.98 MiB
+  max_on_disk_size: 735.07 MiB
+  max_on_wire_size: 167.02 MiB
 static_quality_gate_agent_rpm_arm64_fips:
-  max_on_disk_size: 693.2 MiB
-  max_on_wire_size: 159.38 MiB
-static_quality_gate_agent_suse_amd64:
-  max_on_disk_size: 763.8 MiB
-  max_on_wire_size: 186.45 MiB
-static_quality_gate_agent_suse_amd64_fips:
-  max_on_disk_size: 715.22 MiB
-  max_on_wire_size: 177.83 MiB
-static_quality_gate_agent_suse_arm64:
-  max_on_disk_size: 734.9 MiB
-  max_on_wire_size: 166.96 MiB
-static_quality_gate_agent_suse_arm64_fips:
-  max_on_disk_size: 693.2 MiB
+  max_on_disk_size: 693.29 MiB
   max_on_wire_size: 159.34 MiB
+static_quality_gate_agent_suse_amd64:
+  max_on_disk_size: 763.98 MiB
+  max_on_wire_size: 186.46 MiB
+static_quality_gate_agent_suse_amd64_fips:
+  max_on_disk_size: 715.32 MiB
+  max_on_wire_size: 177.88 MiB
+static_quality_gate_agent_suse_arm64:
+  max_on_disk_size: 735.07 MiB
+  max_on_wire_size: 166.98 MiB
+static_quality_gate_agent_suse_arm64_fips:
+  max_on_disk_size: 693.29 MiB
+  max_on_wire_size: 159.32 MiB
 static_quality_gate_docker_agent_amd64:
-  max_on_disk_size: 819.42 MiB
-  max_on_wire_size: 277.7 MiB
+  max_on_disk_size: 819.6 MiB
+  max_on_wire_size: 277.77 MiB
 static_quality_gate_docker_agent_arm64:
-  max_on_disk_size: 820.17 MiB
-  max_on_wire_size: 265.65 MiB
+  max_on_disk_size: 820.34 MiB
+  max_on_wire_size: 265.7 MiB
 static_quality_gate_docker_agent_jmx_amd64:
-  max_on_disk_size: 1010.18 MiB
-  max_on_wire_size: 346.29 MiB
+  max_on_disk_size: 1010.36 MiB
+  max_on_wire_size: 346.39 MiB
 static_quality_gate_docker_agent_jmx_arm64:
-  max_on_disk_size: 999.85 MiB
-  max_on_wire_size: 330.24 MiB
+  max_on_disk_size: 1000.02 MiB
+  max_on_wire_size: 330.31 MiB
 static_quality_gate_docker_cluster_agent_amd64:
   max_on_disk_size: 211.25 MiB
   max_on_wire_size: 74.4 MiB


### PR DESCRIPTION
### What does this PR do?

Bumps ADP to 1.5.1.

### Motivation

### Describe how you validated your changes

### Additional Notes
