### PR TITLE
ci(adp): Run full pipeline on version bumps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -548,6 +548,19 @@ workflow:
     - <<: *if_run_all_e2e_tests
     - !reference [.if_deploy_installer]
     - <<: *if_mergequeue
+    # ADP is shipped in every Agent package and exercised across several test suites.
+    # Treat an ADP version bump like a full pipeline so platform-specific regressions
+    # (notably in new-e2e-agent-runtimes-windows) are caught before merge.
+    - changes:
+        paths:
+          - deps/agent_data_plane/agent_data_plane.MODULE.bazel
+        compare_to: main
+      variables:
+        RUN_ALL_BUILDS: "true"
+        RUN_E2E_TESTS: "on"
+        RUN_KMT_TESTS: "on"
+        RUN_UNIT_TESTS: "on"
+        SKIP_WINDOWS: "false"
     - changes:
         paths: *windows_path
         compare_to: main


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Promotes branch pipelines that modify `deps/agent_data_plane/agent_data_plane.MODULE.bazel` to full test pipelines. These pipelines run all builds, E2E tests, Kernel Matrix Testing jobs, and unit tests, with Windows CI enabled.

This ensures ADP version bumps automatically run platform-specific coverage, including `new-e2e-agent-runtimes-windows`.

### Motivation

The ADP 1.5.0 bump in #54490 broke `new-e2e-agent-runtimes-windows`, but that job did not run before the change merged and the bump had to be reverted in #54505. ADP is shipped across Agent packages and platforms, so version bumps need broader pre-merge coverage comparable to a full pipeline.

### Describe how you validated your changes

- Ran `dda inv linter.gitlab-ci --test=all` successfully across all preset GitLab pipeline contexts.
- Ran `git diff --check`.
- Ran `codex review --base main`; no actionable findings were reported.
- Tested in https://github.com/DataDog/datadog-agent/pull/54515
  - Modification added [here](https://github.com/DataDog/datadog-agent/pull/54515/changes#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7)
  - Pipeline executed [launched](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1931115482) windows job 
