### PR TITLE
[ACTP] wire par-control into the existing runner

### DIFF
--- a/cmd/privateactionrunner/subcommands/run/command.go
+++ b/cmd/privateactionrunner/subcommands/run/command.go
@@ -130,7 +130,7 @@ func runPrivateActionRunner(ctx context.Context, confPath string, extraConfFiles
 	}
 
 	err := fxutil.Run(fxOptions...)
-	if errors.Is(err, privateactionrunner.ErrNotEnabled) {
+	if errors.Is(err, privateactionrunner.ErrNotEnabled) || errors.Is(err, privateactionrunner.ErrSplitDeployment) {
 		return nil
 	}
 	return err

--- a/comp/privateactionrunner/def/component.go
+++ b/comp/privateactionrunner/def/component.go
@@ -14,12 +14,9 @@ import "errors"
 type Component interface {
 }
 
-// ErrNotEnabled is returned when the private action runner is not enabled
 var ErrNotEnabled = errors.New("private action runner is not enabled")
+var ErrSplitDeployment = errors.New("private action runner is running in split deployment mode")
 
-// Configuration keys for the private action runner.
-// Duplicated from pkg/config/setup/privateactionrunner.go because comp/
-// packages cannot import pkg/config/setup (depguard rule).
 const (
 	PAREnabled                = "private_action_runner.enabled"
 	PARSelfEnroll             = "private_action_runner.self_enroll"
@@ -31,4 +28,5 @@ const (
 	PARDefaultActionsEnabled  = "private_action_runner.default_actions_enabled"
 
 	PARExecutorSocketPath = "private_action_runner.executor.socket_path"
+	PARSplitEnabled       = "private_action_runner.split_enabled"
 )

--- a/comp/privateactionrunner/impl/BUILD.bazel
+++ b/comp/privateactionrunner/impl/BUILD.bazel
@@ -49,6 +49,8 @@ go_test(
     embed = [":impl"],
     gotags = ["test"],
     deps = [
+        "//comp/privateactionrunner/def",
+        "//pkg/config/mock",
         "@com_github_datadog_datadog_go_v5//statsd",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"runtime"
 	"sync"
 	"time"
 
@@ -20,7 +21,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
@@ -57,6 +58,15 @@ const (
 // isEnabled checks if the private action runner is enabled in the configuration
 func isEnabled(cfg config.Component) bool {
 	return cfg.GetBool(privateactionrunner.PAREnabled)
+}
+
+func splitDeploymentEnabled(cfg config.Component, goos string) bool {
+	switch goos {
+	case "linux", "windows":
+		return cfg.GetBool(privateactionrunner.PARSplitEnabled)
+	default:
+		return false
+	}
 }
 
 // Requires defines the dependencies for the privateactionrunner component
@@ -116,6 +126,11 @@ func NewComponent(reqs Requires) (Provides, error) {
 		reqs.Log.Info("private-action-runner is not enabled. Set private_action_runner.enabled: true in your datadog.yaml file or set the environment variable DD_PRIVATE_ACTION_RUNNER_ENABLED=true.")
 		reqs.Log.Flush()
 		return Provides{}, privateactionrunner.ErrNotEnabled
+	}
+	if splitDeploymentEnabled(reqs.Config, runtime.GOOS) {
+		reqs.Log.Info("Split deployment is enabled; the monolithic PAR is standing down")
+		reqs.Log.Flush()
+		return Provides{}, privateactionrunner.ErrSplitDeployment
 	}
 
 	// The standalone runner sends metrics over a DogStatsD socket/UDP, built from

--- a/comp/privateactionrunner/impl/privateactionrunner_test.go
+++ b/comp/privateactionrunner/impl/privateactionrunner_test.go
@@ -13,7 +13,23 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	privateactionrunner "github.com/DataDog/datadog-agent/comp/privateactionrunner/def"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 )
+
+func TestSplitDeploymentEnabled(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.SetInTest(privateactionrunner.PARSplitEnabled, true)
+
+	assert.True(t, splitDeploymentEnabled(cfg, "linux"))
+	assert.True(t, splitDeploymentEnabled(cfg, "windows"))
+	assert.False(t, splitDeploymentEnabled(cfg, "darwin"))
+
+	cfg.SetInTest(privateactionrunner.PARSplitEnabled, false)
+	assert.False(t, splitDeploymentEnabled(cfg, "linux"))
+	assert.False(t, splitDeploymentEnabled(cfg, "windows"))
+}
 
 func TestStopCleansUpMetricsClient(t *testing.T) {
 	tests := []struct {

--- a/pkg/config/schema/yaml/private_action_runner.yaml
+++ b/pkg/config/schema/yaml/private_action_runner.yaml
@@ -206,7 +206,8 @@ properties:
     node_type: setting
     type: boolean
     default: false
-    comment: Enables the Rust control plane and on-demand Go executor on Linux.
+    comment: Enables the Rust control plane and on-demand Go executor on Linux and
+      Windows. Other platforms continue using the monolithic runner.
   urn:
     node_type: setting
     type: string

--- a/pkg/config/setup/privateactionrunner_settings.go
+++ b/pkg/config/setup/privateactionrunner_settings.go
@@ -34,7 +34,8 @@ func setupPrivateActionRunner(config pkgconfigmodel.Setup) {
 		"other":   "${run_path}/par-executor.sock",
 	}))
 
-	// Enables the Rust control plane and on-demand Go executor on Linux.
+	// Enables the Rust control plane and on-demand Go executor on Linux and Windows.
+	// Other platforms continue using the monolithic runner.
 	config.BindEnvAndSetDefault("private_action_runner.split_enabled", false)
 
 	// Control-plane settings consumed by par-control.

--- a/pkg/privateactionrunner/par-control/README.md
+++ b/pkg/privateactionrunner/par-control/README.md
@@ -6,6 +6,8 @@ Windows without adding the binary to Agent packages.
 
 - `par-control` runs only when both `private_action_runner.enabled` and
   `private_action_runner.split_enabled` are true. Otherwise it exits cleanly.
+- On Linux and Windows, the monolithic Go runner also exits cleanly when split
+  mode is enabled. Other platforms continue to use the monolithic runner.
 - In split mode, `par-control` asks `dd-procmgrd` to start the existing
   `privateactionrunner run-executor` process and polls its state.
 - Graceful shutdown uses `SIGTERM` on Linux and `CTRL_BREAK` on Windows,


### PR DESCRIPTION
### What does this PR do?

Stacks on #54531 and wires split mode into the existing Private Action Runner:

- Adds the default-off `private_action_runner.split_enabled` setting.
- Makes the monolithic Go runner stand down on Linux and Windows when split mode is enabled.
- Treats the split-deployment sentinel as a clean exit from the existing run command.
- Adds coverage for platform-specific split-mode behavior.

### Motivation

Keep the existing-runner integration separate from the Rust `par-control` implementation and downstream packaging work.

### Describe how you validated your changes

- `dda inv test --targets=./comp/privateactionrunner/impl`

### Additional Notes

This is a draft stacked PR based on #54531.
