### PR TITLE
Fix docs pointer on size gates error.

### DIFF
--- a/tasks/static_quality_gates/pr_comment.py
+++ b/tasks/static_quality_gates/pr_comment.py
@@ -224,9 +224,8 @@ def display_pr_comment(
     if with_blocking_error:
         body_error_footer += (
             "\n</details>\n\n"
-            "Static quality gates prevent the PR to merge!\n"
-            "You can check the static quality gates [confluence page](https://datadoghq.atlassian.net/wiki/spaces/agent/pages/4805854687/Static+Quality+Gates) for guidance. "
-            "We also have a [toolbox page](https://datadoghq.atlassian.net/wiki/spaces/agent/pages/4887448722/Static+Quality+Gates+Toolbox) available to list tools useful to debug the size increase.\n"
+            "Static quality gate failures prevent this PR from merging!\n"
+            "You can check the static quality gates [runbooks page](https://datadoghq.atlassian.net/wiki/spaces/ABLD/pages/6034456675/Static+Quality+Gates+runbooks) for guidance and tools. "
             "Please either fix the size violation or [request an exception](https://datadoghq.atlassian.net/wiki/spaces/ABLD/pages/6034456675/Static+Quality+Gates+runbooks#Exception-process).\n"
         )
         final_error_body = body_error + body_error_footer

--- a/tasks/unit_tests/static_quality_gates/pr_comment_tests.py
+++ b/tasks/unit_tests/static_quality_gates/pr_comment_tests.py
@@ -384,11 +384,12 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         body = call_args[1]['body']
         self.assertIn('### Error', body)
         self.assertIn('Change', body)
-        self.assertIn('Size (prev', body)
+        self.assertIn('Size (prev', body)  # )  to make vim indent happy
         self.assertIn('gateA', body)
         self.assertIn('gateB', body)
         self.assertIn('Gate failure full details', body)
-        self.assertIn('Static quality gates prevent the PR to merge!', body)
+        # Make sure we have a link to a docs page.
+        self.assertIn('https://datadoghq.atlassian.net/wiki', body)
         # Check dashboard link is present
         self.assertIn('Static Quality Gates Dashboard', body)
 
@@ -563,8 +564,6 @@ class TestNonBlockingPrComment(unittest.TestCase):
         body = call_args[1]['body']
         # Should show error indicator for blocking failure
         self.assertIn('❌', body)
-        # Should contain the blocking failure message
-        self.assertIn('prevent the PR to merge', body)
 
     @patch.dict(
         'os.environ',
@@ -612,7 +611,7 @@ class TestNonBlockingPrComment(unittest.TestCase):
         self.assertIn('❌', body)
         self.assertIn('⚠️', body)
         # Should contain the blocking failure message (since there's a blocking failure)
-        self.assertIn('prevent the PR to merge', body)
+        self.assertIn('prevent', body)
 
 
 class TestExceptionBanner(unittest.TestCase):


### PR DESCRIPTION
### What does this PR do?

Fixes the docs pointer in the error messages from size gate failures