### PR TITLE
Group CWS functional tests by module config

### DIFF
--- a/pkg/security/tests/BUILD.bazel
+++ b/pkg/security/tests/BUILD.bazel
@@ -20,9 +20,11 @@ go_library(
         "syscall_tester.go",
         "syscalls_amd64.go",
         "syscalls_arm64.go",
+        "testdecl.go",
         "testdrive.go",
         "testmount.go",
         "testopts.go",
+        "testruns.go",
         "trace_pipe.go",
     ],
     # keep

--- a/pkg/security/tests/BUILD.bazel
+++ b/pkg/security/tests/BUILD.bazel
@@ -19,9 +19,11 @@ go_library(
         "syscall_tester.go",
         "syscalls_amd64.go",
         "syscalls_arm64.go",
+        "testdecl.go",
         "testdrive.go",
         "testmount.go",
         "testopts.go",
+        "testruns.go",
         "trace_pipe.go",
     ],
     # keep

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -201,6 +201,8 @@ func TestActionKill(t *testing.T) {
 	})
 }
 
+var _ = declareInlineConfig(TestActionKillExcludeBinary)
+
 func TestActionKillExcludeBinary(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -523,6 +525,20 @@ func testActionKillDisarm(t *testing.T, test *testModule, sleep, syscallTester s
 	})
 }
 
+// enforcementDisarmerPeriod is shared between TestActionKillDisarm's declared
+// config and its body, which waits out the period it configures.
+const enforcementDisarmerPeriod = 4 * time.Second
+
+var _ = declare(TestActionKillDisarm, testOpts{
+	enforcementDisarmerContainerEnabled:     true,
+	enforcementDisarmerContainerMaxAllowed:  1,
+	enforcementDisarmerContainerPeriod:      enforcementDisarmerPeriod,
+	enforcementDisarmerExecutableEnabled:    true,
+	enforcementDisarmerExecutableMaxAllowed: 1,
+	enforcementDisarmerExecutablePeriod:     enforcementDisarmerPeriod,
+	eventServerRetention:                    1 * time.Nanosecond,
+})
+
 func TestActionKillDisarm(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -543,10 +559,6 @@ func TestActionKillDisarm(t *testing.T) {
 	})
 
 	sleep := which(t, "sleep")
-
-	const (
-		enforcementDisarmerPeriod = 4 * time.Second
-	)
 
 	ruleDefs := []*rules.RuleDefinition{
 		{
@@ -573,15 +585,7 @@ func TestActionKillDisarm(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{
-		enforcementDisarmerContainerEnabled:     true,
-		enforcementDisarmerContainerMaxAllowed:  1,
-		enforcementDisarmerContainerPeriod:      enforcementDisarmerPeriod,
-		enforcementDisarmerExecutableEnabled:    true,
-		enforcementDisarmerExecutableMaxAllowed: 1,
-		enforcementDisarmerExecutablePeriod:     enforcementDisarmerPeriod,
-		eventServerRetention:                    1 * time.Nanosecond,
-	}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1381,6 +1385,8 @@ func TestActionKillContainerWithSignatureBroadRule(t *testing.T) {
 	containerKilled = true
 }
 
+var _ = declare(TestRemediationCustomEvents, testOpts{networkRawPacketEnabled: true})
+
 func TestRemediationCustomEvents(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -1467,7 +1473,7 @@ func TestRemediationCustomEvents(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkRawPacketEnabled: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -201,6 +201,9 @@ func TestActionKill(t *testing.T) {
 	})
 }
 
+var _ = declareInlineConfig(TestActionKillExcludeBinary,
+	"enforcementExcludeBinary is which(t, \"sleep\"), resolved at run time")
+
 func TestActionKillExcludeBinary(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -523,6 +526,20 @@ func testActionKillDisarm(t *testing.T, test *testModule, sleep, syscallTester s
 	})
 }
 
+// enforcementDisarmerPeriod is shared between TestActionKillDisarm's declared
+// config and its body, which waits out the period it configures.
+const enforcementDisarmerPeriod = 4 * time.Second
+
+var _ = declare(TestActionKillDisarm, testOpts{
+	enforcementDisarmerContainerEnabled:     true,
+	enforcementDisarmerContainerMaxAllowed:  1,
+	enforcementDisarmerContainerPeriod:      enforcementDisarmerPeriod,
+	enforcementDisarmerExecutableEnabled:    true,
+	enforcementDisarmerExecutableMaxAllowed: 1,
+	enforcementDisarmerExecutablePeriod:     enforcementDisarmerPeriod,
+	eventServerRetention:                    1 * time.Nanosecond,
+})
+
 func TestActionKillDisarm(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -543,10 +560,6 @@ func TestActionKillDisarm(t *testing.T) {
 	})
 
 	sleep := which(t, "sleep")
-
-	const (
-		enforcementDisarmerPeriod = 4 * time.Second
-	)
 
 	ruleDefs := []*rules.RuleDefinition{
 		{
@@ -573,15 +586,7 @@ func TestActionKillDisarm(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{
-		enforcementDisarmerContainerEnabled:     true,
-		enforcementDisarmerContainerMaxAllowed:  1,
-		enforcementDisarmerContainerPeriod:      enforcementDisarmerPeriod,
-		enforcementDisarmerExecutableEnabled:    true,
-		enforcementDisarmerExecutableMaxAllowed: 1,
-		enforcementDisarmerExecutablePeriod:     enforcementDisarmerPeriod,
-		eventServerRetention:                    1 * time.Nanosecond,
-	}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1381,6 +1386,8 @@ func TestActionKillContainerWithSignatureBroadRule(t *testing.T) {
 	containerKilled = true
 }
 
+var _ = declare(TestRemediationCustomEvents, testOpts{networkRawPacketEnabled: true})
+
 func TestRemediationCustomEvents(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -1467,7 +1474,7 @@ func TestRemediationCustomEvents(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkRawPacketEnabled: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -30,6 +30,8 @@ import (
 
 var testActivityDumpCleanupPeriod = 15 * time.Second
 
+var _ = declareInlineConfig(TestActivityDumps)
+
 func TestActivityDumps(t *testing.T) {
 	SkipIfNotAvailable(t)
 

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -30,6 +30,8 @@ import (
 
 var testActivityDumpCleanupPeriod = 15 * time.Second
 
+var _ = declareInlineConfig(TestActivityDumps, reasonTempDir)
+
 func TestActivityDumps(t *testing.T) {
 	SkipIfNotAvailable(t)
 

--- a/pkg/security/tests/capabilities_test.go
+++ b/pkg/security/tests/capabilities_test.go
@@ -21,6 +21,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
+var _ = declare(TestCapabilitiesEvent, testOpts{
+	capabilitiesMonitoringEnabled: true,
+})
+
 func TestCapabilitiesEvent(t *testing.T) {
 	SkipIfNotAvailable(t)
 	// skip tests if we are running within a container
@@ -57,9 +61,7 @@ func TestCapabilitiesEvent(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{
-		capabilitiesMonitoringEnabled: true,
-	}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/capture_all_syscall_errors_test.go
+++ b/pkg/security/tests/capture_all_syscall_errors_test.go
@@ -37,6 +37,10 @@ var (
 // runtime_security_config.syscalls.capture_all_errors.enabled set to true,
 // chmod() and open() syscalls failing with ENOENT (normally filtered by
 // IS_UNHANDLED_ERROR) still produce events in userspace.
+var _ = declare(TestCaptureAllSyscallErrors, testOpts{
+	captureAllSyscallErrorsEnabled: true,
+})
+
 func TestCaptureAllSyscallErrors(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -45,9 +49,7 @@ func TestCaptureAllSyscallErrors(t *testing.T) {
 		openEnoentRule,
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{
-		captureAllSyscallErrorsEnabled: true,
-	}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/dentry_test.go
+++ b/pkg/security/tests/dentry_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
+var _ = declare(TestDentryPathERPC, testOpts{disableMapDentryResolution: true})
+
 func TestDentryPathERPC(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -35,7 +37,7 @@ func TestDentryPathERPC(t *testing.T) {
 		Expression: `open.flags & (O_CREAT|O_NOCTTY|O_NOFOLLOW) != 0 && process.file.name == "testsuite"`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{disableMapDentryResolution: true}))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,6 +89,8 @@ func TestDentryPathERPC(t *testing.T) {
 	}, "test_erpc_path_rule")
 }
 
+var _ = declare(TestDentryPathMap, testOpts{disableERPCDentryResolution: true})
+
 func TestDentryPathMap(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -97,7 +101,7 @@ func TestDentryPathMap(t *testing.T) {
 		Expression: `open.flags & (O_CREAT|O_NOCTTY|O_NOFOLLOW) != 0 && process.file.name == "testsuite"`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{disableERPCDentryResolution: true}))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,6 +206,8 @@ func TestDentryName(t *testing.T) {
 	}, "test_dentry_name_rule")
 }
 
+var _ = declare(TestDentryInvalidation, testOpts{disableMapDentryResolution: true})
+
 func TestDentryInvalidation(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -212,7 +218,7 @@ func TestDentryInvalidation(t *testing.T) {
 		Expression: `open.flags & (O_CREAT|O_NOCTTY|O_NOFOLLOW) != 0 && process.file.name == "testsuite"`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{disableMapDentryResolution: true}))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,13 +297,15 @@ func TestDentryInvalidation(t *testing.T) {
 	}, "test_erpc_path_rule")
 }
 
+var _ = declare(BenchmarkERPCDentryResolutionPath, testOpts{disableMapDentryResolution: true})
+
 func BenchmarkERPCDentryResolutionPath(b *testing.B) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
 		Expression: `open.file.path == "{{.Root}}/aa/bb/cc/dd/ee" && open.flags & O_CREAT != 0`,
 	}
 
-	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{disableMapDentryResolution: true}))
+	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -360,13 +368,15 @@ func BenchmarkERPCDentryResolutionPath(b *testing.B) {
 	test.Close()
 }
 
+var _ = declare(BenchmarkMapDentryResolutionSegment, testOpts{disableERPCDentryResolution: true})
+
 func BenchmarkMapDentryResolutionSegment(b *testing.B) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
 		Expression: `open.file.path == "{{.Root}}/aa/bb/cc/dd/ee" && open.flags & O_CREAT != 0`,
 	}
 
-	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{disableERPCDentryResolution: true}))
+	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -429,13 +439,15 @@ func BenchmarkMapDentryResolutionSegment(b *testing.B) {
 	test.Close()
 }
 
+var _ = declare(BenchmarkMapDentryResolutionPath, testOpts{disableERPCDentryResolution: true})
+
 func BenchmarkMapDentryResolutionPath(b *testing.B) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
 		Expression: `open.file.path == "{{.Root}}/aa/bb/cc/dd/ee" && open.flags & O_CREAT != 0`,
 	}
 
-	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{disableERPCDentryResolution: true}))
+	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/security/tests/dns_resolver_test.go
+++ b/pkg/security/tests/dns_resolver_test.go
@@ -73,6 +73,8 @@ func getInterfaceIndex(iface string) (int, error) {
 	return 0, fmt.Errorf("interface %s not found", iface)
 }
 
+var _ = declare(TestDNSResolver, testOpts{networkIngressEnabled: true})
+
 func TestDNSResolver(t *testing.T) {
 	SkipIfNotAvailable(t)
 	checkNetworkCompatibility(t)
@@ -83,7 +85,7 @@ func TestDNSResolver(t *testing.T) {
 		}
 	}
 
-	test, err := newTestModule(t, nil, nil, withStaticOpts(testOpts{networkIngressEnabled: true}))
+	test, err := newTestModule(t, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/dns_response_test.go
+++ b/pkg/security/tests/dns_response_test.go
@@ -45,6 +45,10 @@ func justBind() *net.UDPConn {
 	return conn
 }
 
+var _ = declare(TestDNSResponse, testOpts{
+	dnsPort: DNSPort,
+})
+
 func TestDNSResponse(t *testing.T) {
 	SkipIfNotAvailable(t)
 	checkNetworkCompatibility(t)
@@ -76,9 +80,7 @@ func TestDNSResponse(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefsRcodeOK, withStaticOpts(testOpts{
-		dnsPort: DNSPort,
-	}))
+	test, err := newTestModule(t, nil, ruleDefsRcodeOK)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,9 +107,7 @@ func TestDNSResponse(t *testing.T) {
 	})
 	test.Close()
 
-	test, err = newTestModule(t, nil, ruleDefsResponseIPOnly, withStaticOpts(testOpts{
-		dnsPort: DNSPort,
-	}))
+	test, err = newTestModule(t, nil, ruleDefsResponseIPOnly)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,9 +130,7 @@ func TestDNSResponse(t *testing.T) {
 	})
 	test.Close()
 
-	test, err = newTestModule(t, nil, ruleDefsRcodeNXDomain, withStaticOpts(testOpts{
-		dnsPort: DNSPort,
-	}))
+	test, err = newTestModule(t, nil, ruleDefsRcodeNXDomain)
 
 	if err != nil {
 		t.Fatal(err)
@@ -156,6 +154,10 @@ func TestDNSResponse(t *testing.T) {
 	test.Close()
 }
 
+var _ = declare(TestDNSResponseDiscarder, testOpts{
+	dnsPort: DNSPort,
+})
+
 func TestDNSResponseDiscarder(t *testing.T) {
 	SkipIfNotAvailable(t)
 	checkNetworkCompatibility(t)
@@ -172,9 +174,7 @@ func TestDNSResponseDiscarder(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefsRcodeOK, withStaticOpts(testOpts{
-		dnsPort: DNSPort,
-	}))
+	test, err := newTestModule(t, nil, ruleDefsRcodeOK)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/ebpfless_test.go
+++ b/pkg/security/tests/ebpfless_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
+var _ = declare(TestEBPFLessAttach, testOpts{ebpfLessEnabled: true, dontWaitEBPFLessClient: true})
+
 func TestEBPFLessAttach(t *testing.T) {
 	t.Skip("not stable yet")
 
@@ -42,7 +44,7 @@ func TestEBPFLessAttach(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{ebpfLessEnabled: true, dontWaitEBPFLessClient: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/event_test.go
+++ b/pkg/security/tests/event_test.go
@@ -447,6 +447,10 @@ func cleanupABottomUp(path string) {
 	}
 }
 
+// The two subtests deliberately build different modules, one per dentry
+// resolution path, so this test cannot share one with anybody.
+var _ = declareInlineConfig(TestEventTruncatedParents)
+
 func TestEventTruncatedParents(t *testing.T) {
 	SkipIfNotAvailable(t)
 

--- a/pkg/security/tests/event_test.go
+++ b/pkg/security/tests/event_test.go
@@ -447,6 +447,11 @@ func cleanupABottomUp(path string) {
 	}
 }
 
+// The two subtests deliberately build different modules, one per dentry
+// resolution path, so this test cannot share one with anybody.
+var _ = declareInlineConfig(TestEventTruncatedParents,
+	"builds one module per dentry resolution path", buildsModules(2))
+
 func TestEventTruncatedParents(t *testing.T) {
 	SkipIfNotAvailable(t)
 

--- a/pkg/security/tests/eventmonitor_test.go
+++ b/pkg/security/tests/eventmonitor_test.go
@@ -20,6 +20,8 @@ import (
 	"go.uber.org/atomic"
 )
 
+var _ = declareInlineConfig(TestEventMonitor)
+
 func TestEventMonitor(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -74,6 +76,8 @@ func TestEventMonitor(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+var _ = declareInlineConfig(TestEventMonitorNoEnvs)
 
 func TestEventMonitorNoEnvs(t *testing.T) {
 	SkipIfNotAvailable(t)

--- a/pkg/security/tests/eventmonitor_test.go
+++ b/pkg/security/tests/eventmonitor_test.go
@@ -20,6 +20,8 @@ import (
 	"go.uber.org/atomic"
 )
 
+var _ = declareInlineConfig(TestEventMonitor, reasonCallback)
+
 func TestEventMonitor(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -74,6 +76,8 @@ func TestEventMonitor(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+var _ = declareInlineConfig(TestEventMonitorNoEnvs, reasonCallback)
 
 func TestEventMonitorNoEnvs(t *testing.T) {
 	SkipIfNotAvailable(t)

--- a/pkg/security/tests/failed_dns_test.go
+++ b/pkg/security/tests/failed_dns_test.go
@@ -57,6 +57,8 @@ func getPayloadBytes(customEvent *events.CustomEvent) (string, error) {
 	return hex.EncodeToString(decoded), nil
 }
 
+var _ = declare(TestFailedDNSFullResponse, testOpts{networkIngressEnabled: true})
+
 func TestFailedDNSFullResponse(t *testing.T) {
 	SkipIfNotAvailable(t)
 	checkNetworkCompatibility(t)
@@ -72,7 +74,7 @@ func TestFailedDNSFullResponse(t *testing.T) {
 		}
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkIngressEnabled: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,6 +103,9 @@ func TestFailedDNSFullResponse(t *testing.T) {
 		}
 	})
 }
+
+var _ = declare(TestFailedDNSRequest, testOpts{networkIngressEnabled: true})
+
 func TestFailedDNSRequest(t *testing.T) {
 	SkipIfNotAvailable(t)
 	checkNetworkCompatibility(t)
@@ -116,7 +121,7 @@ func TestFailedDNSRequest(t *testing.T) {
 		}
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkIngressEnabled: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/file_windows_test.go
+++ b/pkg/security/tests/file_windows_test.go
@@ -21,16 +21,15 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
+var _ = declare(TestBasicFileTest, testOpts{enableFIM: true})
+
 func TestBasicFileTest(t *testing.T) {
 	//ebpftest.LogLevel(t, "info")
 	cfn := &rules.RuleDefinition{
 		ID:         "test_create_file",
 		Expression: `create.file.name =~ "test.bad" && create.file.path =~ "C:\Temp\**" && create.file.extension == ".bad"`,
 	}
-	opts := testOpts{
-		enableFIM: true,
-	}
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{cfn}, withStaticOpts(opts))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{cfn})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,16 +64,15 @@ func TestBasicFileTest(t *testing.T) {
 
 }
 
+var _ = declare(TestRenameFileEvent, testOpts{enableFIM: true})
+
 func TestRenameFileEvent(t *testing.T) {
 	// ebpftest.LogLevel(t, "info")
 	cfn := &rules.RuleDefinition{
 		ID:         "test_rename_file",
 		Expression: `rename.file.name =~ "test.bad" && rename.file.path =~ "C:\Temp\**" && rename.file.extension == ".bad"`,
 	}
-	opts := testOpts{
-		enableFIM: true,
-	}
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{cfn}, withStaticOpts(opts))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{cfn})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,16 +101,15 @@ func TestRenameFileEvent(t *testing.T) {
 	})
 }
 
+var _ = declare(TestDeleteFileEvent, testOpts{enableFIM: true})
+
 func TestDeleteFileEvent(t *testing.T) {
 	// ebpftest.LogLevel(t, "info")
 	cfn := &rules.RuleDefinition{
 		ID:         "test_delete_file",
 		Expression: `delete.file.name =~ "test.bad" && delete.file.path =~ "C:\Temp\**" && delete.file.extension == ".bad"`,
 	}
-	opts := testOpts{
-		enableFIM: true,
-	}
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{cfn}, withStaticOpts(opts))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{cfn})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,16 +137,15 @@ func TestDeleteFileEvent(t *testing.T) {
 	})
 }
 
+var _ = declare(TestWriteFileEvent, testOpts{enableFIM: true})
+
 func TestWriteFileEvent(t *testing.T) {
 	// ebpftest.LogLevel(t, "info")
 	cfn := &rules.RuleDefinition{
 		ID:         "test_write_file",
 		Expression: `write.file.name =~ "test.bad" && write.file.path =~ "C:\Temp\**" && write.file.extension == ".bad"`,
 	}
-	opts := testOpts{
-		enableFIM: true,
-	}
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{cfn}, withStaticOpts(opts))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{cfn})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,6 +180,8 @@ func TestWriteFileEvent(t *testing.T) {
 	})
 }
 
+var _ = declare(TestWriteFileEventWithCreate, testOpts{enableFIM: true})
+
 func TestWriteFileEventWithCreate(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
@@ -195,10 +193,7 @@ func TestWriteFileEventWithCreate(t *testing.T) {
 			Expression: `write.file.name =~ "test.bad" && write.file.path =~ "C:\Temp\**" && write.file.extension == ".bad"`,
 		},
 	}
-	opts := testOpts{
-		enableFIM: true,
-	}
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(opts))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -349,6 +349,8 @@ func TestFilterOpenLeafDiscarder(t *testing.T) {
 
 // This test is basically the same as TestFilterOpenLeafDiscarder but activity dumps are enabled.
 // This means that the event is actually forwarded to user space, but the rule should not be evaluated
+var _ = declareInlineConfig(TestFilterOpenLeafDiscarderActivityDump)
+
 func TestFilterOpenLeafDiscarderActivityDump(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -1398,6 +1400,8 @@ func TestFilterBpfCmd(t *testing.T) {
 	}
 }
 
+var _ = declare(TestFilterRuntimeDiscarded, testOpts{discardRuntime: true})
+
 func TestFilterRuntimeDiscarded(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -1412,7 +1416,7 @@ func TestFilterRuntimeDiscarded(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{discardRuntime: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -349,6 +349,8 @@ func TestFilterOpenLeafDiscarder(t *testing.T) {
 
 // This test is basically the same as TestFilterOpenLeafDiscarder but activity dumps are enabled.
 // This means that the event is actually forwarded to user space, but the rule should not be evaluated
+var _ = declareInlineConfig(TestFilterOpenLeafDiscarderActivityDump, reasonTempDir)
+
 func TestFilterOpenLeafDiscarderActivityDump(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -1398,6 +1400,8 @@ func TestFilterBpfCmd(t *testing.T) {
 	}
 }
 
+var _ = declare(TestFilterRuntimeDiscarded, testOpts{discardRuntime: true})
+
 func TestFilterRuntimeDiscarded(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -1412,7 +1416,7 @@ func TestFilterRuntimeDiscarded(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{discardRuntime: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/hardlink_test.go
+++ b/pkg/security/tests/hardlink_test.go
@@ -21,7 +21,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
-func runHardlinkTests(t *testing.T, opts testOpts) {
+// runHardlinkTests runs the hardlink assertions against whichever dentry
+// resolution path its caller declared.
+func runHardlinkTests(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_rule_orig_exec",
@@ -37,7 +39,7 @@ func runHardlinkTests(t *testing.T, opts testOpts) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(opts))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,14 +126,18 @@ func runHardlinkTests(t *testing.T, opts testOpts) {
 	})
 }
 
+var _ = declare(TestHardLinkExecsWithERPC, testOpts{disableMapDentryResolution: true})
+
 func TestHardLinkExecsWithERPC(t *testing.T) {
 	SkipIfNotAvailable(t)
-	runHardlinkTests(t, testOpts{disableMapDentryResolution: true})
+	runHardlinkTests(t)
 }
+
+var _ = declare(TestHardLinkExecsWithMaps, testOpts{disableERPCDentryResolution: true})
 
 func TestHardLinkExecsWithMaps(t *testing.T) {
 	SkipIfNotAvailable(t)
-	runHardlinkTests(t, testOpts{disableERPCDentryResolution: true})
+	runHardlinkTests(t)
 }
 
 func TestHardLink(t *testing.T) {

--- a/pkg/security/tests/imds_test.go
+++ b/pkg/security/tests/imds_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/tests/testutils"
 )
 
+var _ = declare(TestAWSIMDSv1Request, testOpts{networkIngressEnabled: true})
+
 func TestAWSIMDSv1Request(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -68,7 +70,7 @@ func TestAWSIMDSv1Request(t *testing.T) {
 		}
 	}()
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkIngressEnabled: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,6 +96,8 @@ func TestAWSIMDSv1Request(t *testing.T) {
 		}, "test_rule_aws_imds_v1_request")
 	})
 }
+
+var _ = declare(TestAWSIMDSv1Response, testOpts{networkIngressEnabled: true})
 
 func TestAWSIMDSv1Response(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -143,7 +147,7 @@ func TestAWSIMDSv1Response(t *testing.T) {
 		}
 	}()
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkIngressEnabled: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,6 +176,8 @@ func TestAWSIMDSv1Response(t *testing.T) {
 		}, "test_rule_aws_imds_v1_response")
 	})
 }
+
+var _ = declare(TestAWSIMDSv2Request, testOpts{networkIngressEnabled: true})
 
 func TestAWSIMDSv2Request(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -221,7 +227,7 @@ func TestAWSIMDSv2Request(t *testing.T) {
 		}
 	}()
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkIngressEnabled: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,6 +258,8 @@ func TestAWSIMDSv2Request(t *testing.T) {
 		}, "test_rule_aws_imds_v2_request")
 	})
 }
+
+var _ = declare(TestAWSIMDSv2Response, testOpts{networkIngressEnabled: true})
 
 func TestAWSIMDSv2Response(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -296,7 +304,7 @@ func TestAWSIMDSv2Response(t *testing.T) {
 		}
 	}()
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkIngressEnabled: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -329,6 +337,8 @@ func TestAWSIMDSv2Response(t *testing.T) {
 		}, "test_rule_aws_imds_v2_response")
 	})
 }
+
+var _ = declare(TestGCPIMDS, testOpts{networkIngressEnabled: true})
 
 func TestGCPIMDS(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -373,7 +383,7 @@ func TestGCPIMDS(t *testing.T) {
 		}
 	}()
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkIngressEnabled: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -404,6 +414,8 @@ func TestGCPIMDS(t *testing.T) {
 		}, "test_rule_gcp_imds_request")
 	})
 }
+
+var _ = declare(TestAzureIMDS, testOpts{networkIngressEnabled: true})
 
 func TestAzureIMDS(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -448,7 +460,7 @@ func TestAzureIMDS(t *testing.T) {
 		}
 	}()
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkIngressEnabled: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -479,6 +491,8 @@ func TestAzureIMDS(t *testing.T) {
 		}, "test_rule_azure_imds_request")
 	})
 }
+
+var _ = declare(TestIBMIMDS, testOpts{networkIngressEnabled: true})
 
 func TestIBMIMDS(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -523,7 +537,7 @@ func TestIBMIMDS(t *testing.T) {
 		}
 	}()
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkIngressEnabled: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -554,6 +568,8 @@ func TestIBMIMDS(t *testing.T) {
 		}, "test_rule_idbm_imds_request")
 	})
 }
+
+var _ = declare(TestOracleIMDS, testOpts{networkIngressEnabled: true})
 
 func TestOracleIMDS(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -598,7 +614,7 @@ func TestOracleIMDS(t *testing.T) {
 		}
 	}()
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkIngressEnabled: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -629,6 +645,8 @@ func TestOracleIMDS(t *testing.T) {
 		}, "test_rule_oracle_imds_request")
 	})
 }
+
+var _ = declare(TestIMDSProcessContext, testOpts{networkIngressEnabled: true})
 
 func TestIMDSProcessContext(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -678,7 +696,7 @@ func TestIMDSProcessContext(t *testing.T) {
 		}
 	}()
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkIngressEnabled: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/main_test.go
+++ b/pkg/security/tests/main_test.go
@@ -23,6 +23,22 @@ var GitAncestorOnMain = "main"
 func TestMain(m *testing.M) {
 	flag.Parse()
 
+	if listGroups {
+		// Only advertise groups the suite can also apply, or the runner would
+		// launch one unrestricted pass per group.
+		if _, ok := entryTables(m); !ok {
+			fmt.Fprintln(os.Stderr, "cannot reach the test tables, not grouping the suite")
+			os.Exit(1)
+		}
+		printGroups()
+		os.Exit(0)
+	}
+
+	if testGroup != "" && !selectGroup(m, testGroup) {
+		fmt.Fprintf(os.Stderr, "unknown test group %q\n", testGroup)
+		os.Exit(1)
+	}
+
 	fmt.Printf("Using git ref %s as common ancestor between HEAD and main branch\n", GitAncestorOnMain)
 
 	preTestsHook()
@@ -43,10 +59,16 @@ var (
 	logPatterns     stringSlice
 	logTags         stringSlice
 	ebpfLessEnabled bool
+	listGroups      bool
+	testGroup       string
 )
 
 func init() {
 	flag.StringVar(&logLevelStr, "loglevel", log.WarnStr, "log level")
 	flag.Var(&logPatterns, "logpattern", "List of log pattern")
 	flag.Var(&logTags, "logtag", "List of log tag")
+	flag.BoolVar(&listGroups, "list-groups", false,
+		"print the groups the suite partitions into, one per line, then exit")
+	flag.StringVar(&testGroup, "group", "",
+		"run only the tests in the named group; -test.run and -test.skip are unaffected")
 }

--- a/pkg/security/tests/main_test.go
+++ b/pkg/security/tests/main_test.go
@@ -23,6 +23,17 @@ var GitAncestorOnMain = "main"
 func TestMain(m *testing.M) {
 	flag.Parse()
 
+	// Every config is registered at init() time, so the partition of the suite
+	// into runs that each build the eBPF module once needs no test execution.
+	// Keep this ahead of any other output: the KMT test runner parses stdout.
+	if listTestRuns {
+		if err := printTestRuns(os.Stdout); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
 	fmt.Printf("Using git ref %s as common ancestor between HEAD and main branch\n", GitAncestorOnMain)
 
 	preTestsHook()
@@ -43,10 +54,13 @@ var (
 	logPatterns     stringSlice
 	logTags         stringSlice
 	ebpfLessEnabled bool
+	listTestRuns    bool
 )
 
 func init() {
 	flag.StringVar(&logLevelStr, "loglevel", log.WarnStr, "log level")
 	flag.Var(&logPatterns, "logpattern", "List of log pattern")
 	flag.Var(&logTags, "logtag", "List of log tag")
+	flag.BoolVar(&listTestRuns, "list-groups", false,
+		"print how the suite partitions into runs that each build the eBPF module once, as one JSON object per line, then exit")
 }

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -622,6 +622,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 	for _, opt := range fopts {
 		opt(&opts)
 	}
+	resolveStaticOpts(t, &opts)
 
 	prevEbpfLessEnabled := ebpfLessEnabled
 	defer func() {

--- a/pkg/security/tests/module_tester_windows.go
+++ b/pkg/security/tests/module_tester_windows.go
@@ -116,6 +116,10 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 	for _, opt := range fopts {
 		opt(&opts)
 	}
+	// Windows always builds a fresh module, so the declared config only decides
+	// this test's own config here -- there is no grouping to get wrong. Resolve
+	// it anyway so that declarations behave identically on both platforms.
+	resolveStaticOpts(t, &opts)
 
 	if commonCfgDir == "" {
 		cd, err := os.MkdirTemp("", "test-cfgdir")

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -156,6 +156,11 @@ func TestMount(t *testing.T) {
 	})
 }
 
+// withForceReload() at the newTestModule call is load-bearing: this test and
+// the two TestMountSnapshot* below share the inline-config run, so without it
+// they would reuse each other's module and snapshot the wrong mounts.
+var _ = declareInlineConfig(TestMountPropagated)
+
 func TestMountPropagated(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -405,11 +410,15 @@ func testMountSnapshot(t *testing.T) {
 	assert.Equal(t, 1|2|4|8, mntResolved)
 }
 
+var _ = declareInlineConfig(TestMountSnapshotListmount)
+
 func TestMountSnapshotListmount(t *testing.T) {
 	SkipIfNotAvailable(t)
 	t.Setenv("DD_EVENT_MONITORING_CONFIG_SNAPSHOT_USING_LISTMOUNT", "true")
 	testMountSnapshot(t)
 }
+
+var _ = declareInlineConfig(TestMountSnapshotProcfs)
 
 func TestMountSnapshotProcfs(t *testing.T) {
 	SkipIfNotAvailable(t)

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -156,6 +156,12 @@ func TestMount(t *testing.T) {
 	})
 }
 
+// withForceReload() at the newTestModule call is load-bearing: this test and
+// the two TestMountSnapshot* below share the inline-config run, so without it
+// they would reuse each other's module and snapshot the wrong mounts.
+var _ = declareInlineConfig(TestMountPropagated,
+	"module must be built after the mount setup so its snapshot sees it")
+
 func TestMountPropagated(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -405,11 +411,17 @@ func testMountSnapshot(t *testing.T) {
 	assert.Equal(t, 1|2|4|8, mntResolved)
 }
 
+var _ = declareInlineConfig(TestMountSnapshotListmount,
+	"module must be built after the mount setup so its snapshot sees it")
+
 func TestMountSnapshotListmount(t *testing.T) {
 	SkipIfNotAvailable(t)
 	t.Setenv("DD_EVENT_MONITORING_CONFIG_SNAPSHOT_USING_LISTMOUNT", "true")
 	testMountSnapshot(t)
 }
+
+var _ = declareInlineConfig(TestMountSnapshotProcfs,
+	"module must be built after the mount setup so its snapshot sees it")
 
 func TestMountSnapshotProcfs(t *testing.T) {
 	SkipIfNotAvailable(t)

--- a/pkg/security/tests/network_device_test.go
+++ b/pkg/security/tests/network_device_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
+var _ = declare(TestNetDevice, testOpts{networkIngressEnabled: true})
+
 func TestNetDevice(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -50,7 +52,7 @@ func TestNetDevice(t *testing.T) {
 		Expression: `dns.question.type == A && dns.question.name == "google.com" && process.file.name == "testsuite"`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{networkIngressEnabled: true}))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,6 +153,8 @@ func TestNetDevice(t *testing.T) {
 	}
 }
 
+var _ = declare(TestTCFilters, testOpts{networkIngressEnabled: true})
+
 func TestTCFilters(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -170,7 +174,7 @@ func TestTCFilters(t *testing.T) {
 		Expression: `dns.question.type == A`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{networkIngressEnabled: true}))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -122,6 +122,8 @@ func isRawPacketNotSupported(kv *kernel.Version) bool {
 	return probe.IsRawPacketNotSupported(kv) || kv.IsSLESKernel() || kv.IsOpenSUSELeapKernel()
 }
 
+var _ = declare(TestRawPacket, testOpts{networkRawPacketEnabled: true})
+
 func TestRawPacket(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -168,7 +170,7 @@ func TestRawPacket(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkRawPacketEnabled: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -236,6 +238,9 @@ func TestRawPacket(t *testing.T) {
 		})
 	})
 }
+
+var _ = declare(TestRawPacketRouterSelFlipOnRulesetReload, testOpts{networkRawPacketEnabled: true})
+
 func TestRawPacketRouterSelFlipOnRulesetReload(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -246,7 +251,7 @@ func TestRawPacketRouterSelFlipOnRulesetReload(t *testing.T) {
 		Expression: `dns.question.name == "never.match.raw.packet.router.sel.test"`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{networkRawPacketEnabled: true}))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,6 +283,8 @@ func TestRawPacketRouterSelFlipOnRulesetReload(t *testing.T) {
 		"raw_packet_router_sel must be flipped after ruleset reload")
 }
 
+var _ = declare(TestRawPacketAction, testOpts{networkRawPacketEnabled: true})
+
 func TestRawPacketAction(t *testing.T) {
 	if testEnvironment == DockerEnvironment {
 		t.Skip("skipping cgroup ID test in docker")
@@ -301,7 +308,7 @@ func TestRawPacketAction(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{networkRawPacketEnabled: true}))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -371,6 +378,8 @@ func TestRawPacketAction(t *testing.T) {
 	})
 }
 
+var _ = declare(TestRawPacketDropMetricAccuracyWithReload, testOpts{networkRawPacketEnabled: true})
+
 func TestRawPacketDropMetricAccuracyWithReload(t *testing.T) {
 	if testEnvironment == DockerEnvironment {
 		t.Skip("skipping cgroup ID test in docker")
@@ -393,7 +402,7 @@ func TestRawPacketDropMetricAccuracyWithReload(t *testing.T) {
 		Expression: `exec.file.name == "id"`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{bootstrapRule}, withStaticOpts(testOpts{networkRawPacketEnabled: true}))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{bootstrapRule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -528,6 +537,8 @@ func TestRawPacketDropMetricAccuracyWithReload(t *testing.T) {
 	waitForMetric(ruleID1, totalExpected)
 }
 
+var _ = declare(TestRawPacketActionWithSignature, testOpts{networkRawPacketEnabled: true})
+
 func TestRawPacketActionWithSignature(t *testing.T) {
 	if testEnvironment == DockerEnvironment {
 		t.Skip("skipping cgroup ID test in docker")
@@ -553,7 +564,7 @@ func TestRawPacketActionWithSignature(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkRawPacketEnabled: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -688,6 +699,8 @@ func TestRawPacketActionWithSignature(t *testing.T) {
 	}
 }
 
+var _ = declare(TestRawPacketActionProcessScopeWithSignature, testOpts{networkRawPacketEnabled: true})
+
 func TestRawPacketActionProcessScopeWithSignature(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -704,7 +717,7 @@ func TestRawPacketActionProcessScopeWithSignature(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkRawPacketEnabled: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -999,6 +1012,12 @@ func TestRawPacketFilter(t *testing.T) {
 	})
 }
 
+var _ = declare(TestNetworkFlowSendUDP4,
+	testOpts{
+		networkFlowMonitorEnabled: true,
+	},
+)
+
 func TestNetworkFlowSendUDP4(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -1022,11 +1041,7 @@ func TestNetworkFlowSendUDP4(t *testing.T) {
 		Expression: `network_flow_monitor.flows.length > 0 && process.file.name == "syscall_tester"`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(
-		testOpts{
-			networkFlowMonitorEnabled: true,
-		},
-	))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/ondemand_test.go
+++ b/pkg/security/tests/ondemand_test.go
@@ -22,6 +22,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+var _ = declare(TestOnDemandOpen, testOpts{disableOnDemandRateLimiter: true})
+
 func TestOnDemandOpen(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -32,7 +34,7 @@ func TestOnDemandOpen(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{disableOnDemandRateLimiter: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -607,8 +607,10 @@ func openMountByID(mountID int) (f *os.File, err error) {
 	return nil, errors.New("mountID not found")
 }
 
-func benchmarkOpenSameFile(b *testing.B, disableFilters bool, rules ...*rules.RuleDefinition) {
-	test, err := newTestModule(b, nil, rules, withStaticOpts(testOpts{disableFilters: disableFilters}))
+// benchmarkOpenSameFile benchmarks repeated opens of one file, with or without
+// filters depending on what its caller declared.
+func benchmarkOpenSameFile(b *testing.B, rules ...*rules.RuleDefinition) {
+	test, err := newTestModule(b, nil, rules)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -633,26 +635,32 @@ func benchmarkOpenSameFile(b *testing.B, disableFilters bool, rules ...*rules.Ru
 	}
 }
 
+var _ = declare(BenchmarkOpenNoApprover, testOpts{disableFilters: true})
+
 func BenchmarkOpenNoApprover(b *testing.B) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
 		Expression: `open.filename == "{{.Root}}/donotmatch"`,
 	}
 
-	benchmarkOpenSameFile(b, true, rule)
+	benchmarkOpenSameFile(b, rule)
 }
 
+// BenchmarkOpenWithApprover keeps filters on, which is the default config, so it
+// needs no declaration.
 func BenchmarkOpenWithApprover(b *testing.B) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
 		Expression: `open.filename == "{{.Root}}/donotmatch"`,
 	}
 
-	benchmarkOpenSameFile(b, false, rule)
+	benchmarkOpenSameFile(b, rule)
 }
 
+var _ = declare(BenchmarkOpenNoKprobe, testOpts{disableFilters: true})
+
 func BenchmarkOpenNoKprobe(b *testing.B) {
-	benchmarkOpenSameFile(b, true)
+	benchmarkOpenSameFile(b)
 }
 
 func createFolder(current string, filesPerFolder, maxDepth int) error {

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -1078,6 +1078,8 @@ func TestProcessContext(t *testing.T) {
 	testProcessContextRule(t, "test_rule_ctx_4", "test-process-ctx-4")
 }
 
+var _ = declare(TestProcessEnvsWithValue, testOpts{envsWithValue: []string{"LD_PRELOAD"}})
+
 func TestProcessEnvsWithValue(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -1089,11 +1091,7 @@ func TestProcessEnvsWithValue(t *testing.T) {
 		},
 	}
 
-	opts := testOpts{
-		envsWithValue: []string{"LD_PRELOAD"},
-	}
-
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(opts))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/registry_windows_test.go
+++ b/pkg/security/tests/registry_windows_test.go
@@ -27,6 +27,8 @@ import (
  * individual tests so that the underlying event system is starting fresh each time
  */
 
+var _ = declare(TestBasicRegistryTestPowershell, testOpts{enableFIM: true})
+
 func TestBasicRegistryTestPowershell(t *testing.T) {
 	openDef := &rules.RuleDefinition{
 		ID:         "test_open_rule",
@@ -37,10 +39,7 @@ func TestBasicRegistryTestPowershell(t *testing.T) {
 		Expression: `create.registry.key_path == "HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run"`,
 	}
 
-	opts := testOpts{
-		enableFIM: true,
-	}
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{openDef, createDef}, withStaticOpts(opts))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{openDef, createDef})
 
 	if err != nil {
 		t.Fatal(err)
@@ -75,6 +74,8 @@ func TestBasicRegistryTestPowershell(t *testing.T) {
 	})
 }
 
+var _ = declare(TestBasicRegistryTestRegExe, testOpts{enableFIM: true})
+
 func TestBasicRegistryTestRegExe(t *testing.T) {
 	openDef := &rules.RuleDefinition{
 		ID:         "test_open_rule",
@@ -85,10 +86,7 @@ func TestBasicRegistryTestRegExe(t *testing.T) {
 		Expression: `create.registry.key_path == "HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run"`,
 	}
 
-	opts := testOpts{
-		enableFIM: true,
-	}
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{openDef, createDef}, withStaticOpts(opts))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{openDef, createDef})
 
 	if err != nil {
 		t.Fatal(err)
@@ -124,6 +122,8 @@ func TestBasicRegistryTestRegExe(t *testing.T) {
 	})
 }
 
+var _ = declare(TestBasicRegistryTestAPI, testOpts{enableFIM: true})
+
 func TestBasicRegistryTestAPI(t *testing.T) {
 	openDef := &rules.RuleDefinition{
 		ID:         "test_open_rule",
@@ -134,10 +134,7 @@ func TestBasicRegistryTestAPI(t *testing.T) {
 		Expression: `create.registry.key_path == "HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run"`,
 	}
 
-	opts := testOpts{
-		enableFIM: true,
-	}
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{openDef, createDef}, withStaticOpts(opts))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{openDef, createDef})
 
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/security/tests/replay_test.go
+++ b/pkg/security/tests/replay_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
+var _ = declareInlineConfig(TestReplay)
+
 func TestReplay(t *testing.T) {
 	SkipIfNotAvailable(t)
 

--- a/pkg/security/tests/replay_test.go
+++ b/pkg/security/tests/replay_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
+var _ = declareInlineConfig(TestReplay, reasonCallback, buildsModules(4))
+
 func TestReplay(t *testing.T) {
 	SkipIfNotAvailable(t)
 

--- a/pkg/security/tests/sbom_test.go
+++ b/pkg/security/tests/sbom_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 )
 
+var _ = declare(TestSBOM, testOpts{enableSBOM: true, enableHostSBOM: true})
+
 func TestSBOM(t *testing.T) {
 	t.Skip("this test is currently flaky, needs to be stabilized before re-enabling")
 
@@ -64,7 +66,7 @@ func TestSBOM(t *testing.T) {
 				`&& process.file.path != "" && process.file.package.name == "coreutils"`,
 		},
 	}
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{enableSBOM: true, enableHostSBOM: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/security_profile_test.go
+++ b/pkg/security/tests/security_profile_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/ktime"
 )
 
+var _ = declareInlineConfig(TestSecurityProfile)
+
 func TestSecurityProfile(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -206,6 +208,8 @@ func TestSecurityProfile(t *testing.T) {
 			})
 	})
 }
+
+var _ = declareInlineConfig(TestAnomalyDetection)
 
 func TestAnomalyDetection(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -385,6 +389,8 @@ func TestAnomalyDetection(t *testing.T) {
 	})
 }
 
+var _ = declareInlineConfig(TestAnomalyDetectionVariables)
+
 func TestAnomalyDetectionVariables(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -502,6 +508,8 @@ func TestAnomalyDetectionVariables(t *testing.T) {
 		}
 	})
 }
+
+var _ = declareInlineConfig(TestAnomalyDetectionWarmup)
 
 func TestAnomalyDetectionWarmup(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -661,6 +669,8 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
 }
+
+var _ = declareInlineConfig(TestSecurityProfileReinsertionPeriod)
 
 func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -846,6 +856,8 @@ func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 
 }
 
+var _ = declareInlineConfig(TestSecurityProfileDifferentiateArgs)
+
 func TestSecurityProfileDifferentiateArgs(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -954,6 +966,8 @@ func TestSecurityProfileDifferentiateArgs(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+var _ = declareInlineConfig(TestSecurityProfileLifeCycleExecs)
 
 func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -1129,6 +1143,8 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 	})
 }
 
+var _ = declareInlineConfig(TestSecurityProfileLifeCycleDNS)
+
 func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -1300,6 +1316,8 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
 }
+
+var _ = declareInlineConfig(TestSecurityProfileLifeCycleSyscall)
 
 func TestSecurityProfileLifeCycleSyscall(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -1490,6 +1508,8 @@ func TestSecurityProfileLifeCycleSyscall(t *testing.T) {
 	})
 }
 
+var _ = declareInlineConfig(TestSecurityProfileLifeCycleEvictionProcess)
+
 func TestSecurityProfileLifeCycleEvictionProcess(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -1667,6 +1687,8 @@ func TestSecurityProfileLifeCycleEvictionProcess(t *testing.T) {
 		}
 	})
 }
+
+var _ = declareInlineConfig(TestSecurityProfileLifeCycleEvictionDNS)
 
 func TestSecurityProfileLifeCycleEvictionDNS(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -1846,6 +1868,8 @@ func TestSecurityProfileLifeCycleEvictionDNS(t *testing.T) {
 	})
 }
 
+var _ = declareInlineConfig(TestSecurityProfileLifeCycleEvictionProcessUnstable)
+
 func TestSecurityProfileLifeCycleEvictionProcessUnstable(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -2019,6 +2043,8 @@ func TestSecurityProfileLifeCycleEvictionProcessUnstable(t *testing.T) {
 		}
 	})
 }
+
+var _ = declareInlineConfig(TestSecurityProfilePersistence)
 
 func TestSecurityProfilePersistence(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -2226,6 +2252,8 @@ func checkExpectedSyscalls(t *testing.T, got []model.Syscall, expectedSyscalls [
 	return testOutput[model.ExecveReason] && testOutput[model.ExitReason] && testOutput[model.SyscallMonitorPeriodReason]
 }
 
+var _ = declareInlineConfig(TestSecurityProfileSyscallDrift)
+
 func TestSecurityProfileSyscallDrift(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -2348,6 +2376,8 @@ func TestSecurityProfileSyscallDrift(t *testing.T) {
 	})
 }
 
+var _ = declareInlineConfig(TestSecurityProfileSyscallDriftExecExitInProfile)
+
 func TestSecurityProfileSyscallDriftExecExitInProfile(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -2468,6 +2498,8 @@ func TestSecurityProfileSyscallDriftExecExitInProfile(t *testing.T) {
 	})
 }
 
+var _ = declareInlineConfig(TestSecurityProfileSyscallDriftNoNewSyscall)
+
 func TestSecurityProfileSyscallDriftNoNewSyscall(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -2553,6 +2585,8 @@ func TestSecurityProfileSyscallDriftNoNewSyscall(t *testing.T) {
 // TestSecurityProfileSystemd tests the security profile functionality for systemd services.
 // It verifies that security profiles are correctly generated for systemd-managed services,
 // including proper metadata extraction and process tree capture.
+var _ = declareInlineConfig(TestSecurityProfileSystemd)
+
 func TestSecurityProfileSystemd(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -2680,6 +2714,8 @@ func TestSecurityProfileSystemd(t *testing.T) {
 	})
 }
 
+var _ = declareInlineConfig(TestAnomalyDetectionSystemd)
+
 func TestAnomalyDetectionSystemd(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -2798,6 +2834,8 @@ func TestAnomalyDetectionSystemd(t *testing.T) {
 // TestSecurityProfileSystemdLifeCycle tests the lifecycle management of security profiles for systemd services.
 // It verifies that profiles transition correctly between learning and stable states, and that
 // multiple versions of the same service are handled properly with appropriate anomaly detection behavior.
+var _ = declareInlineConfig(TestSecurityProfileSystemdLifeCycle)
+
 func TestSecurityProfileSystemdLifeCycle(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -2949,6 +2987,8 @@ func TestSecurityProfileSystemdLifeCycle(t *testing.T) {
 		}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
 }
+
+var _ = declareInlineConfig(TestSecurityProfileNodeEviction)
 
 func TestSecurityProfileNodeEviction(t *testing.T) {
 	SkipIfNotAvailable(t)

--- a/pkg/security/tests/security_profile_test.go
+++ b/pkg/security/tests/security_profile_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/ktime"
 )
 
+var _ = declareInlineConfig(TestSecurityProfile, reasonTempDir)
+
 func TestSecurityProfile(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -206,6 +208,8 @@ func TestSecurityProfile(t *testing.T) {
 			})
 	})
 }
+
+var _ = declareInlineConfig(TestAnomalyDetection, reasonTempDir)
 
 func TestAnomalyDetection(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -385,6 +389,8 @@ func TestAnomalyDetection(t *testing.T) {
 	})
 }
 
+var _ = declareInlineConfig(TestAnomalyDetectionVariables, reasonTempDir)
+
 func TestAnomalyDetectionVariables(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -502,6 +508,8 @@ func TestAnomalyDetectionVariables(t *testing.T) {
 		}
 	})
 }
+
+var _ = declareInlineConfig(TestAnomalyDetectionWarmup, reasonTempDir)
 
 func TestAnomalyDetectionWarmup(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -661,6 +669,8 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
 }
+
+var _ = declareInlineConfig(TestSecurityProfileReinsertionPeriod, reasonTempDir)
 
 func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -846,6 +856,8 @@ func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 
 }
 
+var _ = declareInlineConfig(TestSecurityProfileDifferentiateArgs, reasonTempDir)
+
 func TestSecurityProfileDifferentiateArgs(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -954,6 +966,8 @@ func TestSecurityProfileDifferentiateArgs(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+var _ = declareInlineConfig(TestSecurityProfileLifeCycleExecs, reasonTempDir)
 
 func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -1129,6 +1143,8 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 	})
 }
 
+var _ = declareInlineConfig(TestSecurityProfileLifeCycleDNS, reasonTempDir)
+
 func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -1300,6 +1316,8 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
 }
+
+var _ = declareInlineConfig(TestSecurityProfileLifeCycleSyscall, reasonTempDir)
 
 func TestSecurityProfileLifeCycleSyscall(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -1490,6 +1508,8 @@ func TestSecurityProfileLifeCycleSyscall(t *testing.T) {
 	})
 }
 
+var _ = declareInlineConfig(TestSecurityProfileLifeCycleEvictionProcess, reasonTempDir)
+
 func TestSecurityProfileLifeCycleEvictionProcess(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -1667,6 +1687,8 @@ func TestSecurityProfileLifeCycleEvictionProcess(t *testing.T) {
 		}
 	})
 }
+
+var _ = declareInlineConfig(TestSecurityProfileLifeCycleEvictionDNS, reasonTempDir)
 
 func TestSecurityProfileLifeCycleEvictionDNS(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -1846,6 +1868,8 @@ func TestSecurityProfileLifeCycleEvictionDNS(t *testing.T) {
 	})
 }
 
+var _ = declareInlineConfig(TestSecurityProfileLifeCycleEvictionProcessUnstable, reasonTempDir)
+
 func TestSecurityProfileLifeCycleEvictionProcessUnstable(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -2019,6 +2043,8 @@ func TestSecurityProfileLifeCycleEvictionProcessUnstable(t *testing.T) {
 		}
 	})
 }
+
+var _ = declareInlineConfig(TestSecurityProfilePersistence, reasonTempDir)
 
 func TestSecurityProfilePersistence(t *testing.T) {
 	SkipIfNotAvailable(t)
@@ -2226,6 +2252,8 @@ func checkExpectedSyscalls(t *testing.T, got []model.Syscall, expectedSyscalls [
 	return testOutput[model.ExecveReason] && testOutput[model.ExitReason] && testOutput[model.SyscallMonitorPeriodReason]
 }
 
+var _ = declareInlineConfig(TestSecurityProfileSyscallDrift, reasonTempDir)
+
 func TestSecurityProfileSyscallDrift(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -2348,6 +2376,8 @@ func TestSecurityProfileSyscallDrift(t *testing.T) {
 	})
 }
 
+var _ = declareInlineConfig(TestSecurityProfileSyscallDriftExecExitInProfile, reasonTempDir)
+
 func TestSecurityProfileSyscallDriftExecExitInProfile(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -2468,6 +2498,8 @@ func TestSecurityProfileSyscallDriftExecExitInProfile(t *testing.T) {
 	})
 }
 
+var _ = declareInlineConfig(TestSecurityProfileSyscallDriftNoNewSyscall, reasonTempDir)
+
 func TestSecurityProfileSyscallDriftNoNewSyscall(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -2553,6 +2585,8 @@ func TestSecurityProfileSyscallDriftNoNewSyscall(t *testing.T) {
 // TestSecurityProfileSystemd tests the security profile functionality for systemd services.
 // It verifies that security profiles are correctly generated for systemd-managed services,
 // including proper metadata extraction and process tree capture.
+var _ = declareInlineConfig(TestSecurityProfileSystemd, reasonTempDir)
+
 func TestSecurityProfileSystemd(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -2680,6 +2714,8 @@ func TestSecurityProfileSystemd(t *testing.T) {
 	})
 }
 
+var _ = declareInlineConfig(TestAnomalyDetectionSystemd, reasonTempDir)
+
 func TestAnomalyDetectionSystemd(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -2798,6 +2834,8 @@ func TestAnomalyDetectionSystemd(t *testing.T) {
 // TestSecurityProfileSystemdLifeCycle tests the lifecycle management of security profiles for systemd services.
 // It verifies that profiles transition correctly between learning and stable states, and that
 // multiple versions of the same service are handled properly with appropriate anomaly detection behavior.
+var _ = declareInlineConfig(TestSecurityProfileSystemdLifeCycle, reasonTempDir)
+
 func TestSecurityProfileSystemdLifeCycle(t *testing.T) {
 	SkipIfNotAvailable(t)
 
@@ -2949,6 +2987,8 @@ func TestSecurityProfileSystemdLifeCycle(t *testing.T) {
 		}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
 }
+
+var _ = declareInlineConfig(TestSecurityProfileNodeEviction, reasonTempDir)
 
 func TestSecurityProfileNodeEviction(t *testing.T) {
 	SkipIfNotAvailable(t)

--- a/pkg/security/tests/selftests_test.go
+++ b/pkg/security/tests/selftests_test.go
@@ -24,11 +24,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var _ = declare(TestSelfTests, testOpts{enableSelfTests: true})
+
 func TestSelfTests(t *testing.T) {
 	SkipIfNotAvailable(t)
 	flake.MarkOnJobName(t, "ubuntu_25.10")
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, withStaticOpts(testOpts{enableSelfTests: true}))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/ssh_user_session_test.go
+++ b/pkg/security/tests/ssh_user_session_test.go
@@ -571,6 +571,11 @@ func TestSSHUserSessionRotated(t *testing.T) {
 	})
 }
 
+// withForceReload() at the newTestModule call is load-bearing: this test and
+// TestSSHUserSessionSnapshot share the inline-config run, so without it the
+// second would reuse the first's module.
+var _ = declareInlineConfig(TestSSHUserSessionBlocking)
+
 func TestSSHUserSessionBlocking(t *testing.T) {
 	SkipIfNotAvailable(t)
 	if testEnvironment == DockerEnvironment {
@@ -690,6 +695,8 @@ func TestSSHUserSessionBlocking(t *testing.T) {
 	_ = exec.Command("ssh", exitArgs...).Run()
 
 }
+
+var _ = declareInlineConfig(TestSSHUserSessionSnapshot)
 
 func TestSSHUserSessionSnapshot(t *testing.T) {
 	SkipIfNotAvailable(t)

--- a/pkg/security/tests/ssh_user_session_test.go
+++ b/pkg/security/tests/ssh_user_session_test.go
@@ -571,6 +571,12 @@ func TestSSHUserSessionRotated(t *testing.T) {
 	})
 }
 
+// withForceReload() at the newTestModule call is load-bearing: this test and
+// TestSSHUserSessionSnapshot share the inline-config run, so without it the
+// second would reuse the first's module.
+var _ = declareInlineConfig(TestSSHUserSessionBlocking,
+	"module must be built after the ssh session is established")
+
 func TestSSHUserSessionBlocking(t *testing.T) {
 	SkipIfNotAvailable(t)
 	if testEnvironment == DockerEnvironment {
@@ -690,6 +696,9 @@ func TestSSHUserSessionBlocking(t *testing.T) {
 	_ = exec.Command("ssh", exitArgs...).Run()
 
 }
+
+var _ = declareInlineConfig(TestSSHUserSessionSnapshot,
+	"module must be built after the ssh session is established")
 
 func TestSSHUserSessionSnapshot(t *testing.T) {
 	SkipIfNotAvailable(t)

--- a/pkg/security/tests/testdecl.go
+++ b/pkg/security/tests/testdecl.go
@@ -1,0 +1,199 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build functionaltests
+
+// Package tests holds tests related files
+package tests
+
+// The declaration registry lets a test state the static module config it needs
+// next to the test function:
+//
+//	var _ = declare(TestDNSResolver, testOpts{networkIngressEnabled: true})
+//
+// newTestModule rebuilds the eBPF module whenever a test's static config
+// differs from the live one, so declaring it makes the grouping computable at
+// init() time (testruns.go). A test that declares nothing gets the default
+// config, which is most of the suite and one shared group.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// declaredConfig is the static config declared for one test function.
+type declaredConfig struct {
+	name      string
+	opts      testOpts
+	signature string
+
+	// inlineConfig marks a test that passes its config to newTestModule itself
+	// and so builds its own module.
+	inlineConfig bool
+
+	declaredAt string
+}
+
+// declaredConfigs is keyed by test function name ("TestFoo").
+var declaredConfigs = map[string]*declaredConfig{}
+
+// declare records the static config a test needs, from a package-level var.
+// fn is the function itself, not its name, so a rename cannot leave the
+// declaration pointing at nothing.
+//
+//	var _ = declare(TestFoo, testOpts{networkIngressEnabled: true})
+func declare(fn any, opts testOpts) struct{} {
+	d := &declaredConfig{
+		name:       testFuncName(fn),
+		opts:       opts,
+		signature:  configSignature(opts),
+		declaredAt: declarationSite(),
+	}
+	if bad := unshareableFields(opts); len(bad) > 0 {
+		panic(fmt.Sprintf("declare(%s): a config setting %s never compares equal to "+
+			"the live module's, so it would rebuild inside its own group: pass it with "+
+			"withStaticOpts and declare the test with declareInlineConfig",
+			d.name, strings.Join(bad, ", ")))
+	}
+	return register(d)
+}
+
+// declareInlineConfig marks a test that passes its config to newTestModule
+// itself. Such tests are scheduled apart from the declared groups.
+func declareInlineConfig(fn any) struct{} {
+	return register(&declaredConfig{
+		name:         testFuncName(fn),
+		inlineConfig: true,
+		declaredAt:   declarationSite(),
+	})
+}
+
+func register(d *declaredConfig) struct{} {
+	if prev, ok := declaredConfigs[d.name]; ok {
+		panic(fmt.Sprintf("declare(%s): already declared at %s (re-declared at %s)",
+			d.name, prev.declaredAt, d.declaredAt))
+	}
+	declaredConfigs[d.name] = d
+	return struct{}{}
+}
+
+// declarationSite returns the file:line of the declare* call, so an error can
+// point at a declaration that may be in any file in the package.
+func declarationSite() string {
+	// 0 = here, 1 = declare/declareInlineConfig, 2 = the caller.
+	_, file, line, ok := runtime.Caller(2)
+	if !ok {
+		return "unknown"
+	}
+	return fmt.Sprintf("%s:%d", file[strings.LastIndex(file, "/")+1:], line)
+}
+
+// testFuncName turns ".../pkg/security/tests.TestFoo" into "TestFoo".
+func testFuncName(fn any) string {
+	v := reflect.ValueOf(fn)
+	if v.Kind() != reflect.Func {
+		panic(fmt.Sprintf("declare: want a test function, got %T", fn))
+	}
+	f := runtime.FuncForPC(v.Pointer())
+	if f == nil {
+		panic("declare: cannot resolve the name of the given function")
+	}
+	full := f.Name()
+	name := full[strings.LastIndex(full, "/")+1:] // "tests.TestFoo"
+	if i := strings.Index(name, "."); i >= 0 {
+		name = name[i+1:] // "TestFoo"
+	}
+	if strings.ContainsAny(name, ".·") {
+		panic(fmt.Sprintf("declare: %q is not a top-level test function; pass the "+
+			"function itself, not a closure or a method value", full))
+	}
+	if !strings.HasPrefix(name, "Test") && !strings.HasPrefix(name, "Benchmark") {
+		panic(fmt.Sprintf("declare: %q is neither a test nor a benchmark function", full))
+	}
+	return name
+}
+
+// lookupDeclaredConfig walks up a t.Name() subtest path -- "TestX/a/b", then
+// "TestX/a", then "TestX" -- so a subtest is covered by its parent.
+func lookupDeclaredConfig(name string) (*declaredConfig, bool) {
+	for {
+		if d, ok := declaredConfigs[name]; ok {
+			return d, true
+		}
+		i := strings.LastIndex(name, "/")
+		if i < 0 {
+			return nil, false
+		}
+		name = name[:i]
+	}
+}
+
+// unshareableFields reports the fields of opts whose identity, rather than
+// their content, decides equality: testOpts.Equal is reflect.DeepEqual, which
+// calls two non-nil funcs different even when they are the same function.
+func unshareableFields(opts testOpts) []string {
+	var bad []string
+	v := reflect.ValueOf(opts)
+	tp := v.Type()
+	for i := range v.NumField() {
+		switch v.Field(i).Kind() {
+		// Only kinds IsNil accepts; a slice is fine, DeepEqual compares it.
+		case reflect.Func, reflect.Interface, reflect.Map, reflect.Chan, reflect.Pointer:
+			if !v.Field(i).IsNil() {
+				bad = append(bad, tp.Field(i).Name)
+			}
+		}
+	}
+	return bad
+}
+
+// configSignature keys the equality class of a static config. Invariant, for
+// any config unshareableFields accepts: a.Equal(b) == (sig(a) == sig(b)). The
+// signature decides which tests share a run, Equal decides whether
+// newTestModule reuses the module; if they disagree, grouping stops paying off.
+func configSignature(opts testOpts) string {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%#v", opts)))
+	return hex.EncodeToString(sum[:6])
+}
+
+var defaultSignature = configSignature(testOpts{})
+
+// resolveStaticOpts decides which static config a newTestModule call runs with:
+// the call site's withStaticOpts when it supplied one, otherwise the config
+// declared for this test, otherwise the default config. It is called after
+// newTestModule has applied fopts, so forceReload is already set.
+func resolveStaticOpts(t testing.TB, opts *tmOpts) {
+	decl, declared := lookupDeclaredConfig(t.Name())
+
+	switch {
+	case opts.staticOptsSet && declared && !decl.inlineConfig:
+		t.Fatalf("%s passes withStaticOpts but is also declared at %s: drop one of "+
+			"the two, or switch the declaration to declareInlineConfig if the test "+
+			"supplies its own config at the call site", t.Name(), decl.declaredAt)
+
+	case (opts.staticOptsSet || opts.forceReload) && !declared:
+		t.Fatalf("%s builds a module of its own -- it passes withStaticOpts or "+
+			"withForceReload -- but declares nothing, so it would do it inside the "+
+			"default group. If every field of that config is a compile-time value, "+
+			"move it to declare(%s, testOpts{...}) so the test shares one module "+
+			"with the others using the same config; if any of it is only knowable "+
+			"at run time, or the test forces a reload, add declareInlineConfig(%s)",
+			t.Name(), t.Name(), t.Name())
+
+	case declared && decl.inlineConfig && !opts.staticOptsSet && !opts.forceReload:
+		t.Fatalf("%s is declared at %s as supplying its own config, but this "+
+			"newTestModule call passes neither withStaticOpts nor withForceReload: "+
+			"supply one, or drop the declaration so the test joins the default run",
+			t.Name(), decl.declaredAt)
+
+	case declared && !decl.inlineConfig:
+		opts.staticOpts = decl.opts
+	}
+}

--- a/pkg/security/tests/testdecl.go
+++ b/pkg/security/tests/testdecl.go
@@ -1,0 +1,285 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build functionaltests
+
+// Package tests holds tests related files
+package tests
+
+// The declaration registry lets a test state the static module config it needs
+// next to the test function instead of at its newTestModule call site:
+//
+//	var _ = declare(TestDNSResolver, testOpts{networkIngressEnabled: true})
+//
+// newTestModule rebuilds the eBPF manager whenever a test's static config
+// differs from the live module's, which costs seconds to tens of seconds
+// depending on the kernel. Declaring it makes the partition into runs that each
+// build the module once computable at init() time, without running a test --
+// see testruns.go. A test that declares nothing gets the default config, which
+// is most of the suite and one shared run.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// declaredConfig is the static config declared for one test function.
+type declaredConfig struct {
+	name      string
+	opts      testOpts
+	signature string
+
+	// inlineConfig marks a test that passes its config to newTestModule itself
+	// and so builds its own module; reason says why it cannot share one.
+	inlineConfig bool
+	reason       string
+
+	// moduleBuilds is how many modules an inline-config test builds, >1 only for
+	// the tests that switch config mid-run. Feeds testRun.ExpectedRebuilds.
+	moduleBuilds int
+
+	declaredAt string
+}
+
+// declaredConfigs is keyed by test function name ("TestFoo"), populated at
+// init() time by the declare* functions.
+var declaredConfigs = map[string]*declaredConfig{}
+
+type declOption func(*declaredConfig)
+
+func buildsModules(n int) declOption {
+	return func(d *declaredConfig) { d.moduleBuilds = n }
+}
+
+// declare records the static config a test needs, from a package-level var:
+//
+//	var _ = declare(TestFoo, testOpts{networkIngressEnabled: true})
+//
+// fn is the test function itself, not its name, so a rename cannot leave the
+// declaration pointing at nothing.
+func declare(fn any, opts testOpts, mods ...declOption) struct{} {
+	d := &declaredConfig{
+		name:       testFuncName(fn),
+		opts:       opts,
+		signature:  configSignature(opts),
+		declaredAt: declarationSite(),
+	}
+	if bad := unshareableFields(opts); len(bad) > 0 {
+		panic(fmt.Sprintf("declare(%s): a config setting %s never compares equal to "+
+			"the live module's, so it would rebuild inside its own group: pass it with "+
+			"withStaticOpts and declare the test with declareInlineConfig",
+			d.name, strings.Join(bad, ", ")))
+	}
+	return register(d, mods)
+}
+
+// declareInlineConfig marks a test that passes its config to newTestModule
+// itself, because the config is only knowable once the test runs, holds a
+// callback, or the test deliberately builds several modules. It is scheduled
+// apart from the declared groups, and reason records why.
+func declareInlineConfig(fn any, reason string, mods ...declOption) struct{} {
+	return register(&declaredConfig{
+		name:         testFuncName(fn),
+		inlineConfig: true,
+		reason:       reason,
+		moduleBuilds: 1,
+		declaredAt:   declarationSite(),
+	}, mods)
+}
+
+// Recurring declareInlineConfig reasons.
+const (
+	// reasonTempDir covers the activity-dump and security-profile tests, whose
+	// t.TempDir() lands in activityDumpLocalStorageDirectory or
+	// securityProfileDir, so no two of them ever have equal configs.
+	reasonTempDir = "config embeds t.TempDir()"
+
+	reasonCallback = "config holds a callback, which never compares equal"
+)
+
+func register(d *declaredConfig, mods []declOption) struct{} {
+	for _, mod := range mods {
+		mod(d)
+	}
+	if prev, ok := declaredConfigs[d.name]; ok {
+		panic(fmt.Sprintf("declare(%s): already declared at %s (re-declared at %s)",
+			d.name, prev.declaredAt, d.declaredAt))
+	}
+	declaredConfigs[d.name] = d
+	return struct{}{}
+}
+
+// declarationSite returns the file:line of the declare* call, so an error can
+// point at a declaration that may be in any file in the package.
+func declarationSite() string {
+	// 0 = declarationSite, 1 = declare/declareInlineConfig, 2 = the caller.
+	_, file, line, ok := runtime.Caller(2)
+	if !ok {
+		return "unknown"
+	}
+	return fmt.Sprintf("%s:%d", file[strings.LastIndex(file, "/")+1:], line)
+}
+
+// testFuncName resolves a test function value to its bare name, turning
+// "github.com/DataDog/datadog-agent/pkg/security/tests.TestFoo" into "TestFoo".
+func testFuncName(fn any) string {
+	v := reflect.ValueOf(fn)
+	if v.Kind() != reflect.Func {
+		panic(fmt.Sprintf("declare: want a test function, got %T", fn))
+	}
+	f := runtime.FuncForPC(v.Pointer())
+	if f == nil {
+		panic("declare: cannot resolve the name of the given function")
+	}
+	full := f.Name()
+	name := full[strings.LastIndex(full, "/")+1:] // "tests.TestFoo"
+	if i := strings.Index(name, "."); i >= 0 {
+		name = name[i+1:] // "TestFoo"
+	}
+	if strings.ContainsAny(name, ".·") {
+		panic(fmt.Sprintf("declare: %q is not a top-level test function; pass the "+
+			"function itself, not a closure or a method value", full))
+	}
+	if !strings.HasPrefix(name, "Test") && !strings.HasPrefix(name, "Benchmark") {
+		panic(fmt.Sprintf("declare: %q is neither a test nor a benchmark function", full))
+	}
+	return name
+}
+
+// lookupDeclaredConfig walks up a t.Name() subtest path so that a subtest is
+// covered by its parent's declaration: "TestX/a/b", then "TestX/a", then "TestX".
+func lookupDeclaredConfig(name string) (*declaredConfig, bool) {
+	for {
+		if d, ok := declaredConfigs[name]; ok {
+			return d, true
+		}
+		i := strings.LastIndex(name, "/")
+		if i < 0 {
+			return nil, false
+		}
+		name = name[:i]
+	}
+}
+
+// unshareableFields reports the fields of opts whose identity, rather than
+// their content, decides equality: testOpts.Equal is reflect.DeepEqual, which
+// calls two non-nil funcs different even when they are the same function.
+func unshareableFields(opts testOpts) []string {
+	var bad []string
+	v := reflect.ValueOf(opts)
+	tp := v.Type()
+	for i := range v.NumField() {
+		switch v.Field(i).Kind() {
+		// Only kinds reflect.Value.IsNil accepts; a slice is fine, DeepEqual
+		// compares its contents.
+		case reflect.Func, reflect.Interface, reflect.Map, reflect.Chan, reflect.Pointer:
+			if !v.Field(i).IsNil() {
+				bad = append(bad, tp.Field(i).Name)
+			}
+		}
+	}
+	return bad
+}
+
+// configSignature is a stable key for the equality class of a static config.
+//
+// Invariant: for any config unshareableFields accepts,
+// a.Equal(b) == (signature(a) == signature(b)). The signature decides which
+// tests share a run, Equal decides whether newTestModule really reuses the
+// module; if they disagree, grouping silently stops paying off.
+func configSignature(opts testOpts) string {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%#v", opts)))
+	return hex.EncodeToString(sum[:6])
+}
+
+func defaultConfigSignature() string {
+	return configSignature(testOpts{})
+}
+
+// nonDefaultFields renders what a group actually is, so -list-groups shows
+// more than a hash.
+func nonDefaultFields(opts testOpts) []string {
+	var out []string
+	v := reflect.ValueOf(opts)
+	tp := v.Type()
+	for i := range v.NumField() {
+		if f := v.Field(i); !f.IsZero() {
+			out = append(out, tp.Field(i).Name+"="+renderFieldValue(f))
+		}
+	}
+	return out
+}
+
+var durationType = reflect.TypeOf(time.Duration(0))
+
+// renderFieldValue formats a testOpts field without going through
+// reflect.Value.Interface(), which panics on the unexported fields of testOpts.
+func renderFieldValue(v reflect.Value) string {
+	switch v.Kind() {
+	case reflect.Bool:
+		return strconv.FormatBool(v.Bool())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if v.Type() == durationType {
+			return time.Duration(v.Int()).String()
+		}
+		return strconv.FormatInt(v.Int(), 10)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return strconv.FormatUint(v.Uint(), 10)
+	case reflect.String:
+		return v.String()
+	case reflect.Slice, reflect.Array:
+		parts := make([]string, v.Len())
+		for i := range parts {
+			parts[i] = renderFieldValue(v.Index(i))
+		}
+		return "[" + strings.Join(parts, ",") + "]"
+	default:
+		return "<set>"
+	}
+}
+
+// resolveStaticOpts decides which static config a newTestModule call runs with:
+// the call site's withStaticOpts when it supplied one, otherwise the config
+// declared for this test, otherwise the default config.
+func resolveStaticOpts(t testing.TB, opts *tmOpts) {
+	decl, declared := lookupDeclaredConfig(t.Name())
+
+	switch {
+	case opts.staticOptsSet && declared && !decl.inlineConfig:
+		// Letting the call site win would run the test in a group whose config
+		// it does not use, rebuilding the module in the middle of that group.
+		t.Fatalf("%s passes withStaticOpts but is also declared at %s: drop one of "+
+			"the two, or switch the declaration to declareInlineConfig if the test "+
+			"supplies its own config at the call site", t.Name(), decl.declaredAt)
+
+	case (opts.staticOptsSet || opts.forceReload) && !declared:
+		// Both flags mean "build me my own module", and undeclared puts that
+		// build inside the default run, which is scheduled to cost exactly one.
+		// newTestModule applies fopts before calling us, so forceReload is set.
+		t.Fatalf("%s builds a module of its own -- it passes withStaticOpts or "+
+			"withForceReload -- but declares nothing, so it would do it inside the "+
+			"default run: add declareInlineConfig(%s, \"<why it cannot share one>\") "+
+			"next to the test", t.Name(), t.Name())
+
+	case declared && decl.inlineConfig && !opts.staticOptsSet && !opts.forceReload:
+		// The converse: the declaration promises a module of its own, so the
+		// test is scheduled apart and charged a rebuild, but this call takes the
+		// default config and would just ride the live module.
+		t.Fatalf("%s is declared at %s as supplying its own config, but this "+
+			"newTestModule call passes neither withStaticOpts nor withForceReload: "+
+			"supply one, or drop the declaration so the test joins the default run",
+			t.Name(), decl.declaredAt)
+
+	case !opts.staticOptsSet && declared && !decl.inlineConfig:
+		opts.staticOpts = decl.opts
+	}
+}

--- a/pkg/security/tests/testopts.go
+++ b/pkg/security/tests/testopts.go
@@ -87,13 +87,23 @@ type tmOpts struct {
 	staticOpts  testOpts
 	dynamicOpts dynamicTestOpts
 	forceReload bool
+
+	// staticOptsSet distinguishes "no static opts" from "the default config,
+	// explicitly": an empty testOpts is a legitimate config, so the zero value
+	// of staticOpts cannot answer that on its own.
+	staticOptsSet bool
 }
 
 type optFunc = func(opts *tmOpts)
 
+// withStaticOpts supplies the config for this newTestModule call, for a config
+// only knowable at run time; it pairs with declareInlineConfig. Prefer
+// declaring it next to the test function (testdecl.go), which lets the test
+// share a module with the others using the same config.
 func withStaticOpts(opts testOpts) optFunc {
 	return func(tmo *tmOpts) {
 		tmo.staticOpts = opts
+		tmo.staticOptsSet = true
 	}
 }
 

--- a/pkg/security/tests/testopts.go
+++ b/pkg/security/tests/testopts.go
@@ -87,13 +87,25 @@ type tmOpts struct {
 	staticOpts  testOpts
 	dynamicOpts dynamicTestOpts
 	forceReload bool
+
+	// staticOptsSet records that the call site supplied withStaticOpts, so that
+	// resolveStaticOpts can tell "no static opts" from "the default config,
+	// explicitly". An empty testOpts is a legitimate config, so the zero value
+	// of staticOpts cannot answer that on its own.
+	staticOptsSet bool
 }
 
 type optFunc = func(opts *tmOpts)
 
+// withStaticOpts supplies the config for this newTestModule call. Prefer
+// declaring it next to the test function (see testdecl.go), which lets the test
+// share a module with the others that use the same config; supplying it here is
+// the route for a config that is only knowable at run time, and pairs with
+// declareInlineConfig.
 func withStaticOpts(opts testOpts) optFunc {
 	return func(tmo *tmOpts) {
 		tmo.staticOpts = opts
+		tmo.staticOptsSet = true
 	}
 }
 

--- a/pkg/security/tests/testruns.go
+++ b/pkg/security/tests/testruns.go
@@ -1,0 +1,132 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build functionaltests
+
+// Package tests holds tests related files
+package tests
+
+// The suite is partitioned into groups that each build the eBPF module once.
+// m.Run() cannot be reordered, so a group is a separate invocation of the test
+// binary: the KMT runner (test/new-e2e/system-probe/test-runner) reads the
+// names from -list-groups and runs one pass per name with -group.
+//
+// Membership derives from the declaration registry (testdecl.go), so
+// -list-groups runs no test.
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"testing"
+	"unsafe"
+)
+
+const (
+	// groupLinePrefix marks the -list-groups lines: the suite shares stdout
+	// with anything logged during init().
+	groupLinePrefix = "testgroup "
+
+	configGroupPrefix = "config-"
+	inlineGroup       = "inline-config"
+
+	// defaultGroup is a real config group, not a leftover bucket: its tests all
+	// use the default config, so it builds the module once for most of the
+	// suite. Its membership is negative, which is what lands a test that
+	// declares nothing in a group at all.
+	defaultGroup = "default"
+)
+
+// groupNames returns the groups in execution order, defaultGroup last so a
+// suite with nothing declared degenerates to one pass.
+func groupNames() []string {
+	sigs := map[string]bool{}
+	var inline bool
+	for _, d := range declaredConfigs {
+		switch {
+		case d.inlineConfig:
+			inline = true
+		case d.signature != defaultSignature:
+			sigs[d.signature] = true
+		}
+	}
+
+	names := make([]string, 0, len(sigs)+2)
+	for sig := range sigs {
+		names = append(names, configGroupPrefix+sig)
+	}
+	slices.Sort(names)
+	if inline {
+		names = append(names, inlineGroup)
+	}
+	return append(names, defaultGroup)
+}
+
+// groupOf returns the one group a top-level entry belongs to. Being a total
+// function is what makes the groups a partition: every entry lands in exactly
+// one pass, whether or not it declares anything.
+func groupOf(name string) string {
+	d, declared := declaredConfigs[name]
+	switch {
+	case !declared:
+		return defaultGroup
+	case d.inlineConfig:
+		return inlineGroup
+	case d.signature == defaultSignature:
+		return defaultGroup
+	default:
+		return configGroupPrefix + d.signature
+	}
+}
+
+func printGroups() {
+	for _, name := range groupNames() {
+		fmt.Println(groupLinePrefix + name)
+	}
+}
+
+// entryTables are the tables go test generated for this binary, the same ones
+// -test.list walks. All four are trimmed: examples and fuzz targets execute in
+// a plain `go test`, benchmarks under -bench.
+//
+// The fields are unexported, so callers must handle !ok -- a future Go could
+// rename them, and running the wrong set of tests is worse than not grouping.
+func entryTables(m *testing.M) ([]reflect.Value, bool) {
+	v := reflect.ValueOf(m).Elem()
+
+	var tables []reflect.Value
+	for _, name := range []string{"tests", "benchmarks", "fuzzTargets", "examples"} {
+		f := v.FieldByName(name)
+		if !f.IsValid() || !f.CanAddr() || f.Kind() != reflect.Slice {
+			return nil, false
+		}
+		tables = append(tables, reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem())
+	}
+	return tables, true
+}
+
+// selectGroup trims the test tables to group, which leaves -test.run and
+// -test.skip entirely the job's. It reports false for an unknown group or for
+// tables it cannot reach.
+func selectGroup(m *testing.M, group string) bool {
+	if !slices.Contains(groupNames(), group) {
+		return false
+	}
+	tables, ok := entryTables(m)
+	if !ok {
+		return false
+	}
+
+	for _, table := range tables {
+		kept := reflect.MakeSlice(table.Type(), 0, table.Len())
+		for i := range table.Len() {
+			if e := table.Index(i); groupOf(e.FieldByName("Name").String()) == group {
+				kept = reflect.Append(kept, e)
+			}
+		}
+		table.Set(kept)
+	}
+	return true
+}

--- a/pkg/security/tests/testruns.go
+++ b/pkg/security/tests/testruns.go
@@ -1,0 +1,132 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build functionaltests
+
+// Package tests holds tests related files
+package tests
+
+// testRuns partitions the suite into `go test` invocations that each build the
+// eBPF module as few times as possible. Go's testing package cannot reorder
+// m.Run(), so the ordering has to be separate invocations of the test binary.
+// The partition comes from the declaration registry alone (testdecl.go), so
+// -list-groups can report it without running anything.
+
+import (
+	"encoding/json"
+	"io"
+	"sort"
+)
+
+// testRun is one invocation of the test binary, consumed as JSON by the KMT
+// test runner (test/new-e2e/system-probe/test-runner). Run and Skip hold plain
+// top-level test names; the runner turns them into an anchored alternation.
+type testRun struct {
+	Name      string `json:"name"`
+	Signature string `json:"signature,omitempty"`
+
+	// Fields and Reasons are for humans reading -list-groups: the config
+	// this run is, and why the inline-config tests cannot share a module.
+	Fields  []string `json:"fields,omitempty"`
+	Reasons []string `json:"reasons,omitempty"`
+
+	Run  []string `json:"run,omitempty"`
+	Skip []string `json:"skip,omitempty"`
+
+	// ExpectedRebuilds is what the run is predicted to cost, which the runner
+	// prints. An upper bound: a skipped test builds nothing, and most
+	// activity-dump tests are gated on DEDICATED_ACTIVITY_DUMP_NODE.
+	ExpectedRebuilds int `json:"expectedRebuilds"`
+}
+
+// defaultRunName is a real config group, not a leftover bucket: every test in
+// it uses the default config, so it builds the module once for most of the
+// suite. Expressing it as a skip of everything declared is what sweeps in a
+// newly added default-config test with no declaration at all.
+const defaultRunName = "default"
+
+// inlineConfigRunName holds the tests that build their own module. Each builds
+// one regardless, so one shared run costs the same as several.
+const inlineConfigRunName = "inline-config"
+
+// testRuns returns the partition in execution order, default run last so that a
+// suite with nothing declared degenerates to exactly one unfiltered pass.
+func testRuns() []testRun {
+	defaultSig := defaultConfigSignature()
+
+	bySig := map[string][]*declaredConfig{}
+	var inlineConfig []*declaredConfig
+
+	for _, d := range declaredConfigs {
+		switch {
+		case d.inlineConfig:
+			inlineConfig = append(inlineConfig, d)
+		case d.signature == defaultSig:
+			// Redundant but not an error; the test is already in the default run.
+		default:
+			bySig[d.signature] = append(bySig[d.signature], d)
+		}
+	}
+
+	sigs := make([]string, 0, len(bySig))
+	for sig := range bySig {
+		sigs = append(sigs, sig)
+	}
+	sort.Strings(sigs)
+
+	var runs []testRun
+	var declaredElsewhere []string // what the default run has to skip
+
+	for _, sig := range sigs {
+		group := bySig[sig]
+		run := testRun{
+			Name:      "config-" + sig,
+			Signature: sig,
+			Fields:    nonDefaultFields(group[0].opts),
+		}
+		for _, d := range group {
+			run.Run = append(run.Run, d.name)
+		}
+		sort.Strings(run.Run)
+		run.ExpectedRebuilds = 1
+		declaredElsewhere = append(declaredElsewhere, run.Run...)
+		runs = append(runs, run)
+	}
+
+	if len(inlineConfig) > 0 {
+		run := testRun{Name: inlineConfigRunName}
+		for _, d := range inlineConfig {
+			run.Run = append(run.Run, d.name)
+			run.Reasons = append(run.Reasons, d.name+": "+d.reason)
+			run.ExpectedRebuilds += max(1, d.moduleBuilds)
+		}
+		sort.Strings(run.Run)
+		sort.Strings(run.Reasons)
+		declaredElsewhere = append(declaredElsewhere, run.Run...)
+		runs = append(runs, run)
+	}
+
+	sort.Strings(declaredElsewhere)
+	runs = append(runs, testRun{
+		Name:             defaultRunName,
+		Signature:        defaultSig,
+		Skip:             declaredElsewhere,
+		ExpectedRebuilds: 1,
+	})
+
+	return runs
+}
+
+// printTestRuns writes one JSON object per line, so a human and the KMT test
+// runner read the same output.
+func printTestRuns(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	for _, run := range testRuns() {
+		if err := enc.Encode(run); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/security/tests/threat_score_test.go
+++ b/pkg/security/tests/threat_score_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/dump"
 )
 
+var _ = declareInlineConfig(TestActivityDumpsThreatScore)
+
 func TestActivityDumpsThreatScore(t *testing.T) {
 	SkipIfNotAvailable(t)
 

--- a/pkg/security/tests/threat_score_test.go
+++ b/pkg/security/tests/threat_score_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/dump"
 )
 
+var _ = declareInlineConfig(TestActivityDumpsThreatScore, reasonTempDir)
+
 func TestActivityDumpsThreatScore(t *testing.T) {
 	SkipIfNotAvailable(t)
 

--- a/pkg/security/tests/tracer_memfd_test.go
+++ b/pkg/security/tests/tracer_memfd_test.go
@@ -107,6 +107,8 @@ func (c *tracerMemfdConsumer) Copy(ev *model.Event) any {
 	return event
 }
 
+var _ = declareInlineConfig(TestTracerMemfd)
+
 func TestTracerMemfd(t *testing.T) {
 	SkipIfNotAvailable(t)
 

--- a/pkg/security/tests/tracer_memfd_test.go
+++ b/pkg/security/tests/tracer_memfd_test.go
@@ -107,6 +107,8 @@ func (c *tracerMemfdConsumer) Copy(ev *model.Event) any {
 	return event
 }
 
+var _ = declareInlineConfig(TestTracerMemfd, reasonCallback)
+
 func TestTracerMemfd(t *testing.T) {
 	SkipIfNotAvailable(t)
 

--- a/test/new-e2e/system-probe/test-runner/BUILD.bazel
+++ b/test/new-e2e/system-probe/test-runner/BUILD.bazel
@@ -4,6 +4,7 @@ load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 go_library(
     name = "test-runner_lib",
     srcs = [
+        "groups.go",
         "main.go",
         "testcontainer.go",
         "xml.go",

--- a/test/new-e2e/system-probe/test-runner/groups.go
+++ b/test/new-e2e/system-probe/test-runner/groups.go
@@ -1,0 +1,87 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package main
+
+// The CWS suite rebuilds its eBPF module whenever a test needs a different
+// static config than the live one, costing seconds to tens of seconds. Go
+// cannot reorder m.Run(), so the suite groups its tests by config
+// (pkg/security/tests/testruns.go) and this file runs one pass per group.
+// Anything unexpected falls back to a single pass.
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+const (
+	listGroupsFlag = "-list-groups"
+	groupFlag      = "-group"
+
+	// groupLinePrefix is what the suite marks its group names with, since it
+	// shares stdout with anything logged during init().
+	groupLinePrefix = "testgroup "
+)
+
+// groupablePackages are the suites supporting listGroupsFlag; the others are
+// not launched just to reject it. KMT deploys CWS as pkg/security, not
+// pkg/security/tests (tasks/kmt.py, kmt_secagent_prepare).
+var groupablePackages = regexp.MustCompile(`^pkg/security(/|$)`)
+
+// discoverTestGroups asks a suite how it wants to be partitioned. A nil slice
+// means a single pass, and is never an error.
+func discoverTestGroups(pkg string, suiteArgs, env []string, dir string) []string {
+	if !groupablePackages.MatchString(pkg) {
+		return nil
+	}
+
+	cmd := exec.Command(suiteArgs[0], append(slices.Clone(suiteArgs[1:]), listGroupsFlag)...)
+	cmd.Dir = dir
+	cmd.Env = append(cmd.Environ(), env...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "[groups] could not list groups for %s (%s), running a single pass\n%s",
+			pkg, err, stderr.String())
+		return nil
+	}
+
+	var groups []string
+	for line := range strings.SplitSeq(stdout.String(), "\n") {
+		if name, ok := strings.CutPrefix(strings.TrimSpace(line), groupLinePrefix); ok {
+			groups = append(groups, name)
+		}
+	}
+	fmt.Printf("[groups] %s: %d passes %v\n", pkg, len(groups), groups)
+	return groups
+}
+
+// testPasses returns the passes to run a suite in: one per group it reports,
+// or the single nameless pass, which runs everything the job selects.
+func testPasses(pkg string, suiteArgs, env []string, dir string) []string {
+	if groups := discoverTestGroups(pkg, suiteArgs, env, dir); len(groups) > 0 {
+		return groups
+	}
+	return []string{""}
+}
+
+// groupPass returns what one pass changes about the command: the suffix that
+// keeps its reports from clobbering the other passes', since the paths derive
+// from the package alone, and the suite args selecting the group.
+func groupPass(suiteArgs []string, group string) (string, []string) {
+	if group == "" {
+		return "", suiteArgs
+	}
+	// Clone: appending in place would carry the group over to the next pass.
+	return "-" + group, append(slices.Clone(suiteArgs), groupFlag+"="+group)
+}

--- a/test/new-e2e/system-probe/test-runner/groups.go
+++ b/test/new-e2e/system-probe/test-runner/groups.go
@@ -1,0 +1,155 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package main
+
+// The CWS functional suite rebuilds its eBPF manager whenever a test needs a
+// different static config than the live one has, which costs seconds to tens of
+// seconds. Tests sharing a config are scattered through source order, and Go
+// cannot reorder m.Run(), so the suite reports how it wants to be partitioned
+// (-list-groups, see pkg/security/tests/testruns.go) and this file runs one
+// pass per group.
+//
+// Anything unexpected falls back to a single pass: grouping must never make a
+// job worse than not grouping.
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// listGroupsFlag is the flag a test suite advertises to describe its partition.
+const listGroupsFlag = "-list-groups"
+
+// groupablePackages keeps the other suites from being launched just to have
+// them reject the flag; a suite that grows support for it adds itself here.
+// KMT deploys the CWS suite as pkg/security, not pkg/security/tests
+// (tasks/kmt.py, kmt_secagent_prepare).
+var groupablePackages = regexp.MustCompile(`^pkg/security(/|$)`)
+
+// testGroup is one pass of the test binary, as reported by the suite. Exactly
+// one of Run and Skip is set; the skip form is how the default group covers
+// every test that declared nothing, including ones added later. A group with
+// neither, i.e. the zero value, is the unfiltered fallback pass.
+type testGroup struct {
+	Name      string   `json:"name"`
+	Signature string   `json:"signature"`
+	Fields    []string `json:"fields"`
+	Reasons   []string `json:"reasons"`
+	Run       []string `json:"run"`
+	Skip      []string `json:"skip"`
+
+	ExpectedRebuilds int `json:"expectedRebuilds"`
+}
+
+// runConfig expresses a group as the per-package filter buildCommandArgs
+// already applies, so a pass needs no argument-building of its own.
+func (g testGroup) runConfig() packageRunConfiguration {
+	return packageRunConfiguration{RunOnly: anchored(g.Run), Skip: anchored(g.Skip)}
+}
+
+// anchored builds the alternation as a single element, since buildCommandArgs
+// joins with '|' and the anchoring has to end up inside it. The anchoring
+// matters: -test.run matches unanchored, so a bare TestMount would drag in
+// TestMountEvent. It cannot move into buildCommandArgs, whose job-configured
+// filters rely on staying unanchored -- cws_ad's "TestActivityDump" is a prefix
+// of the tests it selects, not one of their names.
+func anchored(names []string) []string {
+	if len(names) == 0 {
+		return nil
+	}
+	return []string{"^(" + strings.Join(names, "|") + ")$"}
+}
+
+// discoverTestGroups asks a suite how it wants to be partitioned. A nil slice
+// means "run it as a single pass", which is never an error.
+func discoverTestGroups(pkg string, suiteArgs, env []string, dir string) []testGroup {
+	if !groupablePackages.MatchString(pkg) {
+		return nil
+	}
+
+	cmd := exec.Command(suiteArgs[0], append(append([]string{}, suiteArgs[1:]...), listGroupsFlag)...)
+	cmd.Dir = dir
+	cmd.Env = append(cmd.Environ(), env...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		// The overwhelmingly likely cause is a suite that predates the flag.
+		fmt.Fprintf(os.Stderr, "[groups] could not list groups for %s (%s), running it as a single pass\n%s",
+			pkg, err, stderr.String())
+		return nil
+	}
+
+	groups, err := decodeTestGroups(&stdout)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[groups] %s: cannot read the partition (%s), running it as a single pass\n", pkg, err)
+		return nil
+	}
+
+	expected := 0
+	for _, g := range groups {
+		expected += g.ExpectedRebuilds
+	}
+	fmt.Printf("[groups] %s: %d passes, %d expected module rebuilds\n", pkg, len(groups), expected)
+	for _, g := range groups {
+		what := fmt.Sprintf("%d tests", len(g.Run))
+		if len(g.Run) == 0 {
+			what = fmt.Sprintf("everything except %d declared tests", len(g.Skip))
+		}
+		fmt.Printf("[groups]   %-24s rebuilds=%-3d %s %s\n",
+			g.Name, g.ExpectedRebuilds, what, strings.Join(g.Fields, ","))
+	}
+	return groups
+}
+
+func decodeTestGroups(r *bytes.Buffer) ([]testGroup, error) {
+	var groups []testGroup
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		if !bytes.HasPrefix(line, []byte("{")) {
+			// Only parse what looks like JSON: the suite shares stdout with
+			// anything that logs during init(), before the logger is
+			// configured and before -list-groups can exit.
+			continue
+		}
+		// Unknown fields are ignored so that a field added suite-side does not
+		// make an older runner reject the partition and silently fall back.
+		var g testGroup
+		if err := json.Unmarshal(line, &g); err != nil {
+			return nil, fmt.Errorf("decode %q: %w", truncate(string(line)), err)
+		}
+		groups = append(groups, g)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if len(groups) == 0 {
+		return nil, errors.New("no groups reported")
+	}
+	return groups, nil
+}
+
+func truncate(s string) string {
+	if len(s) > 120 {
+		return s[:120] + "..."
+	}
+	return s
+}

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -282,30 +282,34 @@ func testPass(testConfig *testConfig, props map[string]string) error {
 			return fmt.Errorf("could not get relative path for %s: %w", testsuite, err)
 		}
 		junitfilePrefix := strings.ReplaceAll(pkg, "/", "-")
-		xmlpath := filepath.Join(xmlDir, junitfilePrefix+".xml")
-		jsonpath := filepath.Join(jsonDir, junitfilePrefix+".json")
 
 		testsuiteArgs := []string{testsuite}
 		if testContainer != nil {
 			testsuiteArgs = testContainer.buildDockerExecArgs(testsuite, envVars)
 		}
 
-		args := buildCommandArgs(pkg, xmlpath, jsonpath, testsuiteArgs, testConfig)
-		cmd := exec.Command(filepath.Join(testConfig.testingTools, "go/bin/gotestsum"), args...)
+		for _, group := range testPasses(pkg, testsuiteArgs, envVars, filepath.Dir(testsuite)) {
+			suffix, groupArgs := groupPass(testsuiteArgs, group)
+			xmlpath := filepath.Join(xmlDir, junitfilePrefix+suffix+".xml")
+			jsonpath := filepath.Join(jsonDir, junitfilePrefix+suffix+".json")
 
-		cmd.Env = append(cmd.Environ(), envVars...)
+			args := buildCommandArgs(pkg, xmlpath, jsonpath, groupArgs, testConfig)
+			cmd := exec.Command(filepath.Join(testConfig.testingTools, "go/bin/gotestsum"), args...)
 
-		cmd.Dir = filepath.Dir(testsuite)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
+			cmd.Env = append(cmd.Environ(), envVars...)
 
-		if err := cmd.Run(); err != nil {
-			// log but do not return error
-			fmt.Fprintf(os.Stderr, "cmd run %s: %s\n", strings.Join(cmd.Args, " "), err)
-		}
+			cmd.Dir = filepath.Dir(testsuite)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
 
-		if err := addProperties(xmlpath, props); err != nil {
-			return fmt.Errorf("xml add props: %s", err)
+			if err := cmd.Run(); err != nil {
+				// log but do not return error
+				fmt.Fprintf(os.Stderr, "cmd run %s: %s\n", strings.Join(cmd.Args, " "), err)
+			}
+
+			if err := addProperties(xmlpath, props); err != nil {
+				return fmt.Errorf("xml add props: %s", err)
+			}
 		}
 	}
 

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -126,6 +126,29 @@ func glob(dir, filePattern string, filterFn func(path string) bool) ([]string, e
 	return matches, nil
 }
 
+// isRunFilterFlag reports whether arg is a -test.run / -test.skip flag
+func isRunFilterFlag(arg string) bool {
+	name, _, _ := strings.Cut(strings.TrimLeft(arg, "-"), "=")
+	return name == "test.run" || name == "test.skip"
+}
+
+// hasRunFilters reports whether the configuration already narrows this package
+// with -test.run / -test.skip. A configured filter takes precedence over
+// grouping, which replaces rather than merges.
+func hasRunFilters(testConfig *testConfig, pkg string) bool {
+	for _, key := range []string{pkg, matchAllPackages} {
+		if config, ok := testConfig.PackagesRunConfig[key]; ok && (config.RunOnly != nil || config.Skip != nil) {
+			return true
+		}
+	}
+	for _, arg := range append(strings.Fields(testConfig.extraParams), testConfig.AdditionalTestArgs...) {
+		if isRunFilterFlag(arg) {
+			return true
+		}
+	}
+	return false
+}
+
 func buildCommandArgs(pkg string, xmlpath string, jsonpath string, testArgs []string, testConfig *testConfig) []string {
 	verbosity := "testname"
 	if testConfig.verbose {
@@ -282,30 +305,54 @@ func testPass(testConfig *testConfig, props map[string]string) error {
 			return fmt.Errorf("could not get relative path for %s: %w", testsuite, err)
 		}
 		junitfilePrefix := strings.ReplaceAll(pkg, "/", "-")
-		xmlpath := filepath.Join(xmlDir, junitfilePrefix+".xml")
-		jsonpath := filepath.Join(jsonDir, junitfilePrefix+".json")
 
 		testsuiteArgs := []string{testsuite}
 		if testContainer != nil {
 			testsuiteArgs = testContainer.buildDockerExecArgs(testsuite, envVars)
 		}
 
-		args := buildCommandArgs(pkg, xmlpath, jsonpath, testsuiteArgs, testConfig)
-		cmd := exec.Command(filepath.Join(testConfig.testingTools, "go/bin/gotestsum"), args...)
-
-		cmd.Env = append(cmd.Environ(), envVars...)
-
-		cmd.Dir = filepath.Dir(testsuite)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-
-		if err := cmd.Run(); err != nil {
-			// log but do not return error
-			fmt.Fprintf(os.Stderr, "cmd run %s: %s\n", strings.Join(cmd.Args, " "), err)
+		// The nameless zero group is a single unfiltered pass; a suite that
+		// reports config groups gets one pass per group instead.
+		passes := []testGroup{{}}
+		if !hasRunFilters(testConfig, pkg) {
+			if groups := discoverTestGroups(pkg, testsuiteArgs, envVars, filepath.Dir(testsuite)); len(groups) > 0 {
+				passes = groups
+			}
 		}
 
-		if err := addProperties(xmlpath, props); err != nil {
-			return fmt.Errorf("xml add props: %s", err)
+		for _, pass := range passes {
+			// The report paths are derived from the package alone, so without a
+			// per-pass suffix every pass but the last would be clobbered.
+			var suffix string
+			passConfig := testConfig
+			if pass.Name != "" {
+				suffix = "-" + pass.Name
+				// Copy: overwriting the filter map in place would outlive the
+				// pass and drop the filters of every package still to come.
+				cfg := *testConfig
+				cfg.PackagesRunConfig = map[string]packageRunConfiguration{pkg: pass.runConfig()}
+				passConfig = &cfg
+			}
+			xmlpath := filepath.Join(xmlDir, junitfilePrefix+suffix+".xml")
+			jsonpath := filepath.Join(jsonDir, junitfilePrefix+suffix+".json")
+
+			args := buildCommandArgs(pkg, xmlpath, jsonpath, testsuiteArgs, passConfig)
+			cmd := exec.Command(filepath.Join(testConfig.testingTools, "go/bin/gotestsum"), args...)
+
+			cmd.Env = append(cmd.Environ(), envVars...)
+
+			cmd.Dir = filepath.Dir(testsuite)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+
+			if err := cmd.Run(); err != nil {
+				// log but do not return error
+				fmt.Fprintf(os.Stderr, "cmd run %s: %s\n", strings.Join(cmd.Args, " "), err)
+			}
+
+			if err := addProperties(xmlpath, props); err != nil {
+				return fmt.Errorf("xml add props: %s", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

Makes the CWS functional suite run as one `go test` pass per module config instead of one pass for everything.

A test declares the static config it needs next to the test function:

```go
var _ = declare(TestDNSResolver, testOpts{networkIngressEnabled: true})
```

Declaring nothing means the default config, which covers most of the suite and shares a single pass — so ~180 call sites are untouched. A config that is only knowable at run time (a `t.TempDir()`, a `which(t, "sleep")`, a callback) is still passed to `newTestModule` directly, and `declareInlineConfig` records that the test builds its own module.

Because declarations register at `init()`, the partition is computable without running a test. The suite prints it as JSON with `-list-groups`, and the KMT test runner (`test/new-e2e/system-probe/test-runner`) runs one `gotestsum` pass per group, each with its own junit/testjson suffix and `-test.timeout`.

Everything degrades to today's single unfiltered pass — a suite that predates the flag, output that does not parse, or a package the job already narrows with `-test.run`/`-test.skip` (`cws_ad`, `cws_peds`, `cws_req`).

### Motivation

`newTestModule` rebuilds the eBPF manager whenever a test's static config differs from the live module's, at seconds to tens of seconds per rebuild (measured 34s teardown on `amazon_6.12`, 7s on 5.15). Only ~16 distinct configs exist, but the tests using them are scattered through source order, so an isolated non-default test costs two rebuilds — switch in, switch back. `cws_host` does up to **52** rebuilds today; the partition does **28** on that job.

### Describe how you validated your changes

### Additional Notes
