### PR TITLE
make invalid-config issues actionable

### DIFF
--- a/comp/healthplatform/issues/invalidconfig/check.go
+++ b/comp/healthplatform/issues/invalidconfig/check.go
@@ -46,7 +46,7 @@ func (c *checker) validate() ([]runnerdef.IssueReport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalidconfig: normalize config: %w", err)
 	}
-	errs, schemaErr := schema.ValidateCoreConfig(normalized)
+	errs, schemaErr := schema.ValidateCoreConfigDetailed(normalized)
 	if schemaErr != nil {
 		pkglog.Warnf("invalidconfig: schema validator unavailable; skipping check: %v", schemaErr)
 		return nil, schemaErr
@@ -65,7 +65,9 @@ func (c *checker) validate() ([]runnerdef.IssueReport, error) {
 					contextKeyErrorCount: strconv.Itoa(len(errs)),
 				}
 				for i, e := range errs {
-					ctx[contextErrorKey(i)] = e
+					ctx[contextErrorKey(i)] = e.Message
+					ctx[contextPointerKey(i)] = e.Pointer
+					ctx[contextFixKey(i)] = e.Fix
 				}
 				return ctx
 			}(),

--- a/comp/healthplatform/issues/invalidconfig/invalidconfig_test.go
+++ b/comp/healthplatform/issues/invalidconfig/invalidconfig_test.go
@@ -41,8 +41,14 @@ func TestBuildIssue_SchemaViolationProducesMediumSeverity(t *testing.T) {
 		contextKeyConfigPath: "/etc/datadog-agent/datadog.yaml",
 		contextKeyErrorCount: "2",
 	}
-	ctx[contextErrorKey(0)] = "at '/agent_ipc/port': got string, want integer"
-	ctx[contextErrorKey(1)] = "at '/tags': got object, want array"
+	// the check writes message, pointer and fix as parallel keys; BuildIssue never re-parses
+	ctx[contextErrorKey(0)] = `agent_ipc.port must be a whole number, but it is the text "8125".`
+	ctx[contextPointerKey(0)] = "/agent_ipc/port"
+	ctx[contextFixKey(0)] = "Remove the quotes: `agent_ipc.port: 8125`."
+	ctx[contextErrorKey(1)] = `tags must be a list of text values, but it is a set of key/value pairs.`
+	ctx[contextPointerKey(1)] = "/tags"
+	ctx[contextFixKey(1)] = "Set `tags` to something like `[\"first\", \"second\"]`."
+
 	issue, err := InvalidConfigIssue{}.BuildIssue(ctx)
 	require.NoError(t, err)
 	assert.Empty(t, issue.GetId(), "Id is set by the runner (ReportIssue), not by the template")
@@ -52,15 +58,36 @@ func TestBuildIssue_SchemaViolationProducesMediumSeverity(t *testing.T) {
 	assert.Equal(t, "Datadog Agent Configuration Has 2 Schema Violations in datadog.yaml", issue.GetTitle())
 	assert.Equal(t, float64(2),
 		issue.GetExtra().GetFields()[contextKeyErrorCount].GetNumberValue())
-	assert.Contains(t, issue.GetDescription(), "agent_ipc/port")
-	assert.Contains(t, issue.GetDescription(), "/tags")
-	assert.Contains(t, issue.GetDescription(), "; ", "description must use a visible delimiter between violations so the UI renders them legibly")
 
+	// the description is the only field `agent diagnose` renders, so it must stand alone:
+	// the file, every diagnosis, and the consequence
+	desc := issue.GetDescription()
+	assert.Contains(t, desc, "/etc/datadog-agent/datadog.yaml")
+	assert.Contains(t, desc, "agent_ipc.port must be a whole number")
+	assert.Contains(t, desc, "tags must be a list")
+	assert.Contains(t, desc, "falls back to the default")
+
+	// path-keyed, with the correction alongside the diagnosis so an inline renderer has both
 	errorsStruct := issue.GetExtra().GetFields()[contextKeyErrors].GetStructValue()
 	require.NotNil(t, errorsStruct, "extra.errors must be a struct with one entry per violation")
 	assert.Len(t, errorsStruct.GetFields(), 2, "each violation must get its own key")
-	assert.Equal(t, "got string, want integer", errorsStruct.GetFields()["/agent_ipc/port"].GetListValue().GetValues()[0].GetStringValue())
-	assert.Equal(t, "got object, want array", errorsStruct.GetFields()["/tags"].GetListValue().GetValues()[0].GetStringValue())
+	portLines := errorsStruct.GetFields()["/agent_ipc/port"].GetListValue().GetValues()
+	require.Len(t, portLines, 2, "diagnosis then fix")
+	assert.Contains(t, portLines[0].GetStringValue(), "must be a whole number")
+	assert.Contains(t, portLines[1].GetStringValue(), "Remove the quotes")
+
+	// every violation gets a step naming what to change; nothing restates the problem
+	var texts []string
+	for _, s := range issue.GetRemediation().GetSteps() {
+		texts = append(texts, s.GetText())
+	}
+	assert.Contains(t, texts[0], "in an editor")
+	assert.Contains(t, texts, "Remove the quotes: `agent_ipc.port: 8125`.")
+	assert.NotContains(t, texts, "Fix each violation listed in the description.")
+	assert.Contains(t, texts[len(texts)-1], "datadog-agent diagnose")
+	for i, s := range issue.GetRemediation().GetSteps() {
+		assert.Equal(t, int32(i+1), s.GetOrder(), "Order must be contiguous and 1-indexed")
+	}
 }
 
 // A vanilla mock has only defaults, which round-trip through YAML cleanly and
@@ -102,7 +129,12 @@ func TestCheck_SchemaViolationProducesReport(t *testing.T) {
 	require.Len(t, reports, 1)
 	assert.Equal(t, IssueName, reports[0].IssueName)
 	assert.True(t, strings.HasPrefix(reports[0].IssueID, IssueID+":"), "IssueID %q must be scoped with a host+path suffix", reports[0].IssueID)
-	assert.Contains(t, reports[0].Context[contextErrorKey(0)], "agent_ipc/port")
+	// the message uses the dotted key the customer typed; the json pointer travels separately
+	// so a consumer can still attach the violation to a line
+	assert.Contains(t, reports[0].Context[contextErrorKey(0)], "agent_ipc.port")
+	assert.Contains(t, reports[0].Context[contextErrorKey(0)], `the text "not-a-number"`)
+	assert.Equal(t, "/agent_ipc/port", reports[0].Context[contextPointerKey(0)])
+	assert.NotEmpty(t, reports[0].Context[contextFixKey(0)], "every violation must carry a correction")
 }
 
 // Two checkers with the same hostname but different config files must not

--- a/comp/healthplatform/issues/invalidconfig/issue.go
+++ b/comp/healthplatform/issues/invalidconfig/issue.go
@@ -15,6 +15,10 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+// impactText is shared by the description and extra.impact so the consequence is stated on
+// every surface, including the ones that only render the description.
+const impactText = "Until this is corrected the Agent falls back to the default for each setting, so it may not behave as configured."
+
 const (
 	contextKeyConfigPath = "config_path"
 	contextKeyErrors     = "errors"
@@ -22,10 +26,12 @@ const (
 	contextKeyImpact     = "impact"
 )
 
-// contextErrorKey returns the Context key for the i-th error line.
-func contextErrorKey(i int) string {
-	return "error." + strconv.Itoa(i)
-}
+// The check writes each violation as three parallel keys rather than one string, so BuildIssue
+// never has to parse a message back apart. The previous form split on ": ", which silently
+// produced a garbage pointer for any message containing that sequence.
+func contextErrorKey(i int) string   { return "error." + strconv.Itoa(i) }
+func contextPointerKey(i int) string { return "error." + strconv.Itoa(i) + ".pointer" }
+func contextFixKey(i int) string     { return "error." + strconv.Itoa(i) + ".fix" }
 
 // InvalidConfigIssue is the template for "invalid-config" issues.
 type InvalidConfigIssue struct{}
@@ -38,10 +44,15 @@ func (InvalidConfigIssue) BuildIssue(ctx map[string]string) (*healthplatform.Iss
 	}
 	count, _ := strconv.Atoi(ctx[contextKeyErrorCount])
 
-	errLines := make([]string, 0, count)
+	type violation struct{ message, fix, pointer string }
+	violations := make([]violation, 0, count)
 	for i := 0; i < count; i++ {
-		if v := ctx[contextErrorKey(i)]; v != "" {
-			errLines = append(errLines, v)
+		if m := ctx[contextErrorKey(i)]; m != "" {
+			violations = append(violations, violation{
+				message: m,
+				fix:     ctx[contextFixKey(i)],
+				pointer: ctx[contextPointerKey(i)],
+			})
 		}
 	}
 
@@ -49,35 +60,79 @@ func (InvalidConfigIssue) BuildIssue(ctx map[string]string) (*healthplatform.Iss
 	if count != 1 {
 		suffix = "s"
 	}
-	desc := fmt.Sprintf("Found %d schema violation%s in %s", count, suffix, path)
-	if len(errLines) > 0 {
-		desc += ": " + strings.Join(errLines, "; ")
-	} else {
-		desc += "."
+	// The only field `agent diagnose` renders, so it carries the diagnosis and the consequence.
+	var descBuilder strings.Builder
+	fmt.Fprintf(&descBuilder, "Found %d problem%s in %s.", count, suffix, path)
+	for _, v := range violations {
+		descBuilder.WriteString(" " + v.message)
 	}
+	descBuilder.WriteString(" " + impactText)
+	desc := descBuilder.String()
 
-	errGroups := make(map[string][]string, len(errLines))
-	for _, line := range errLines {
-		// Schema errors have the form: at '<path>': <message>
-		// Strip the "at '" prefix and trailing "'" to get a bare JSON path.
-		before, msg, _ := strings.Cut(line, ": ")
-		path := strings.TrimSuffix(strings.TrimPrefix(before, "at '"), "'")
-		errGroups[path] = append(errGroups[path], msg)
+	// Path-keyed so a consumer can attach each one to the config line it came from; the
+	// diagnosis and its correction sit under the same key.
+	errGroups := make(map[string][]string, len(violations))
+	order := make([]string, 0, len(violations))
+	for _, v := range violations {
+		key := v.pointer
+		if key == "" {
+			key = "/"
+		}
+		if _, seen := errGroups[key]; !seen {
+			order = append(order, key)
+		}
+		errGroups[key] = append(errGroups[key], v.message)
+		if v.fix != "" {
+			errGroups[key] = append(errGroups[key], v.fix)
+		}
 	}
 	errMap := make(map[string]any, len(errGroups))
-	for path, msgs := range errGroups {
+	for _, key := range order {
+		msgs := errGroups[key]
 		slice := make([]any, len(msgs))
 		for i, m := range msgs {
 			slice[i] = m
 		}
-		errMap[path] = slice
+		errMap[key] = slice
 	}
+
+	// One step per violation. "Fix each violation listed in the description" was the only
+	// remediation step in the package that told the user nothing they did not already know.
+	// Capped because a bad 50-element list would otherwise produce 50 steps.
+	const maxViolationSteps = 10
+	steps := []*healthplatform.RemediationStep{
+		{Order: 1, Text: fmt.Sprintf("Open %s in an editor.", path)},
+	}
+	for _, v := range violations {
+		if len(steps) > maxViolationSteps {
+			break
+		}
+		text := v.fix
+		if text == "" {
+			text = v.message
+		}
+		steps = append(steps, &healthplatform.RemediationStep{Order: int32(len(steps) + 1), Text: text})
+	}
+	if hidden := len(violations) - maxViolationSteps; hidden > 0 {
+		plural := "s"
+		if hidden == 1 {
+			plural = ""
+		}
+		steps = append(steps, &healthplatform.RemediationStep{
+			Order: int32(len(steps) + 1),
+			Text:  fmt.Sprintf("Correct the remaining %d setting%s listed in the issue details.", hidden, plural),
+		})
+	}
+	steps = append(steps,
+		&healthplatform.RemediationStep{Order: int32(len(steps) + 1), Text: "Restart the Datadog Agent."},
+		&healthplatform.RemediationStep{Order: int32(len(steps) + 2), Text: "Run `datadog-agent diagnose` to confirm the configuration is now valid."},
+	)
 
 	extra, _ := structpb.NewStruct(map[string]any{
 		contextKeyConfigPath: path,
 		contextKeyErrorCount: count,
 		contextKeyErrors:     errMap,
-		contextKeyImpact:     "The Datadog Agent may apply defaults for incorrectly-typed fields and may not behave as configured.",
+		contextKeyImpact:     impactText,
 	})
 
 	return &healthplatform.Issue{
@@ -92,13 +147,9 @@ func (InvalidConfigIssue) BuildIssue(ctx map[string]string) (*healthplatform.Iss
 		Extra:       extra,
 		Tags:        []string{"config", "schema"},
 		Remediation: &healthplatform.Remediation{
-			Summary: "Fix each schema violation in the configuration file, then restart the Datadog Agent.",
-			Steps: []*healthplatform.RemediationStep{
-				{Order: 1, Text: fmt.Sprintf("Open %s in an editor.", path)},
-				{Order: 2, Text: "Fix each violation listed in the description."},
-				{Order: 3, Text: "Restart the Datadog Agent."},
-				{Order: 4, Text: "Run `datadog-agent diagnose` to confirm the configuration is now valid."},
-			},
+			Summary: fmt.Sprintf("Correct %d setting%s in %s, then restart the Datadog Agent.",
+				count, suffix, filepath.Base(path)),
+			Steps: steps,
 		},
 	}, nil
 }

--- a/pkg/config/schema/BUILD.bazel
+++ b/pkg/config/schema/BUILD.bazel
@@ -148,7 +148,11 @@ pkg_install(
 
 go_library(
     name = "schema",
-    srcs = ["schema.go"],
+    srcs = [
+        "navigate.go",
+        "schema.go",
+        "violation.go",
+    ],
     embedsrcs = [
         "compressed/.embed",
         "compressed/core_schema.yaml.zstd",
@@ -159,6 +163,7 @@ go_library(
     deps = [
         "@com_github_datadog_zstd//:zstd",
         "@com_github_santhosh_tekuri_jsonschema_v6//:jsonschema",
+        "@com_github_santhosh_tekuri_jsonschema_v6//kind",
         "@in_yaml_go_yaml_v3//:yaml",
     ],
 )

--- a/pkg/config/schema/navigate.go
+++ b/pkg/config/schema/navigate.go
@@ -1,0 +1,171 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package schema
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+var errNoSchema = errors.New("no embedded schema")
+
+// escapeTokens re-applies RFC 6901 escaping so the pointer we hand out matches what any other
+// JSON Schema tool would produce for the same location.
+func escapeTokens(tokens []string) []string {
+	out := make([]string, 0, len(tokens))
+	for _, t := range tokens {
+		t = strings.ReplaceAll(t, "~", "~0")
+		t = strings.ReplaceAll(t, "/", "~1")
+		out = append(out, t)
+	}
+	return out
+}
+
+// dottedKey renders an instance location the way the customer wrote it in YAML:
+// [apm_config enabled] -> apm_config.enabled, [tags 0] -> tags[0].
+// A token that is not a bare identifier (a URL used as a map key) is bracketed and quoted so the
+// result stays readable and unambiguous.
+func dottedKey(tokens []string) string {
+	if len(tokens) == 0 {
+		return "(root)"
+	}
+	var b strings.Builder
+	for _, t := range tokens {
+		switch {
+		case isIndex(t):
+			b.WriteString("[" + t + "]")
+		case isBareIdentifier(t):
+			if b.Len() > 0 {
+				b.WriteString(".")
+			}
+			b.WriteString(t)
+		default:
+			b.WriteString("[" + strconv.Quote(t) + "]")
+		}
+	}
+	return b.String()
+}
+
+func isIndex(t string) bool {
+	if t == "" {
+		return false
+	}
+	for _, r := range t {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func isBareIdentifier(t string) bool {
+	if t == "" {
+		return false
+	}
+	for _, r := range t {
+		ok := r == '_' ||
+			(r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9')
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// schemaNodeAt walks the compiled schema to the node that failed. The compiled form exposes
+// Properties, Items and AdditionalProperties, which is enough to reach every leaf this schema
+// has — it uses no $ref, oneOf or patternProperties.
+func schemaNodeAt(root *jsonschema.Schema, tokens []string) *jsonschema.Schema {
+	node := root
+	for _, t := range tokens {
+		if node == nil {
+			return nil
+		}
+		if isIndex(t) {
+			node = itemsOf(node)
+			continue
+		}
+		if child, ok := node.Properties[t]; ok {
+			node = child
+			continue
+		}
+		node = additionalOf(node)
+	}
+	return node
+}
+
+// itemsOf resolves the element schema. Our schemas are draft 2020-12, where the library stores
+// `items` in Items2020; the untyped Items field holds the pre-2020 form, which is why reading it
+// alone silently finds nothing.
+func itemsOf(node *jsonschema.Schema) *jsonschema.Schema {
+	if node == nil {
+		return nil
+	}
+	if node.Items2020 != nil {
+		return node.Items2020
+	}
+	switch items := node.Items.(type) {
+	case *jsonschema.Schema:
+		return items
+	case []*jsonschema.Schema:
+		if len(items) > 0 {
+			return items[0]
+		}
+	}
+	return nil
+}
+
+// additionalOf normalises AdditionalProperties, which is nil, a bool, or a schema. Every map
+// setting in this schema uses the schema form; the bool form carries no type to report.
+func additionalOf(node *jsonschema.Schema) *jsonschema.Schema {
+	if node == nil {
+		return nil
+	}
+	if sch, ok := node.AdditionalProperties.(*jsonschema.Schema); ok {
+		return sch
+	}
+	return nil
+}
+
+func typeOf(node *jsonschema.Schema) string {
+	if node == nil || node.Types == nil {
+		return ""
+	}
+	if ts := node.Types.ToStrings(); len(ts) == 1 {
+		return ts[0]
+	}
+	return ""
+}
+
+// valueAt walks the validated instance to the offending value. ValidationError carries the
+// location but not the value, and the caller already holds the instance, so this costs one walk.
+func valueAt(config interface{}, tokens []string) interface{} {
+	current := config
+	for _, t := range tokens {
+		switch node := current.(type) {
+		case map[string]interface{}:
+			v, ok := node[t]
+			if !ok {
+				return nil
+			}
+			current = v
+		case []interface{}:
+			i, err := strconv.Atoi(t)
+			if err != nil || i < 0 || i >= len(node) {
+				return nil
+			}
+			current = node[i]
+		default:
+			return nil
+		}
+	}
+	return current
+}

--- a/pkg/config/schema/violation.go
+++ b/pkg/config/schema/violation.go
@@ -1,0 +1,300 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/santhosh-tekuri/jsonschema/v6/kind"
+)
+
+// Violation describes a schema failure for someone editing datadog.yaml, rather than for
+// someone reading JSON Schema. The library's own message ("got string, want boolean") names
+// our internal model instead of the customer's problem, which is why it is not used directly.
+type Violation struct {
+	// Pointer is the RFC 6901 location, e.g. /apm_config/enabled. Kept so a consumer can
+	// attach the violation to the line it came from.
+	Pointer string
+	// Key is the dotted YAML key the customer actually typed, e.g. apm_config.enabled.
+	Key string
+	// Message states what the setting needs and what was found instead.
+	Message string
+	// Fix is one imperative sentence naming its own setting, so it reads correctly both as a
+	// remediation step and on its own beside a config line.
+	Fix string
+}
+
+// goDuration matches the Go duration literals used by every duration-valued setting.
+// Only 60 of the ~92 duration settings carry `format: duration`, and format assertion is not
+// enabled for 2020-12, so the shape of the setting's default is the reliable signal.
+var goDuration = regexp.MustCompile(`^-?\d+(\.\d+)?(ns|us|µs|ms|s|m|h)([0-9.]+(ns|us|µs|ms|s|m|h))*$`)
+
+// numeric matches a bare number written as text, i.e. the Helm/envsubst quoting mistake.
+var numeric = regexp.MustCompile(`^-?\d+(\.\d+)?$`)
+
+// apm_config.max_memory is `type: number` with `default: "5e+08"` — the one setting whose
+// default fails its own schema. Offering it as an example would hand back an invalid value.
+const defaultDisagreesWithType = "apm_config.max_memory"
+
+var truthy = map[string]bool{"yes": true, "y": true, "on": true, "1": true}
+var falsy = map[string]bool{"no": true, "n": true, "off": true, "0": true}
+
+// ValidateCoreConfigDetailed validates against the core agent schema and describes each failure
+// in terms the customer can act on. ValidateCoreConfig remains the plain-string form.
+func ValidateCoreConfigDetailed(config interface{}) ([]Violation, error) {
+	sch, err := coreSchemaGetter()
+	if err != nil {
+		return nil, err
+	}
+	leaves, err := validationLeaves(sch, config)
+	if err != nil {
+		return nil, err
+	}
+	violations := make([]Violation, 0, len(leaves))
+	for _, leaf := range leaves {
+		violations = append(violations, describe(leaf, sch, config))
+	}
+	return violations, nil
+}
+
+// validationLeaves returns the innermost validation errors, which are the ones that name a
+// concrete instance location rather than a wrapping schema.
+func validationLeaves(sch *jsonschema.Schema, config interface{}) ([]*jsonschema.ValidationError, error) {
+	if sch == nil {
+		return nil, errNoSchema
+	}
+	err := sch.Validate(config)
+	if err == nil {
+		return nil, nil
+	}
+	ve, ok := err.(*jsonschema.ValidationError)
+	if !ok {
+		return nil, nil
+	}
+	var out []*jsonschema.ValidationError
+	collectLeaves(ve, &out)
+	return out, nil
+}
+
+func collectLeaves(ve *jsonschema.ValidationError, out *[]*jsonschema.ValidationError) {
+	if len(ve.Causes) == 0 {
+		*out = append(*out, ve)
+		return
+	}
+	for _, cause := range ve.Causes {
+		collectLeaves(cause, out)
+	}
+}
+
+func describe(ve *jsonschema.ValidationError, root *jsonschema.Schema, config interface{}) Violation {
+	pointer := "/" + strings.Join(escapeTokens(ve.InstanceLocation), "/")
+	if len(ve.InstanceLocation) == 0 {
+		pointer = ""
+	}
+	key := dottedKey(ve.InstanceLocation)
+	node := schemaNodeAt(root, ve.InstanceLocation)
+	value := valueAt(config, ve.InstanceLocation)
+	want := wantedType(ve, node)
+
+	// A bare `logs_enabled:` line resolves to nil. Nothing in the schema accepts null, so this
+	// is the most common failure — and "must be boolean" describes a value never written.
+	if value == nil {
+		return Violation{
+			Pointer: pointer,
+			Key:     key,
+			Message: key + " was left empty, so the Agent cannot use it.",
+			Fix: fmt.Sprintf("Give `%s` a value such as `%s`, or delete the line to keep the default.",
+				key, example(key, node, want)),
+		}
+	}
+
+	return Violation{
+		Pointer: pointer,
+		Key:     key,
+		Message: fmt.Sprintf("%s must be %s, but it is %s.", key, wantPhrase(node, want), renderValue(value)),
+		Fix:     fix(key, node, want, value, example(key, node, want)),
+	}
+}
+
+// wantedType prefers the schema node's own type; kind.Type carries it too but only as the set
+// of acceptable types, and every node in this schema declares exactly one.
+func wantedType(ve *jsonschema.ValidationError, node *jsonschema.Schema) string {
+	if t, ok := ve.ErrorKind.(*kind.Type); ok && len(t.Want) == 1 {
+		return t.Want[0]
+	}
+	if node != nil && node.Types != nil {
+		if ts := node.Types.ToStrings(); len(ts) == 1 {
+			return ts[0]
+		}
+	}
+	return ""
+}
+
+func wantPhrase(node *jsonschema.Schema, want string) string {
+	if isDuration(node) {
+		return fmt.Sprintf("a duration such as %q", *node.Default)
+	}
+	switch want {
+	case "boolean":
+		return "true or false"
+	case "integer":
+		return "a whole number"
+	case "number":
+		return "a number"
+	case "array":
+		if itemsOf(node) != nil && typeOf(itemsOf(node)) == "string" {
+			return "a list of text values"
+		}
+		return "a list"
+	case "object":
+		return "a set of key/value pairs"
+	default:
+		return "text"
+	}
+}
+
+func renderValue(value interface{}) string {
+	switch v := value.(type) {
+	case string:
+		return fmt.Sprintf("the text %q", v)
+	case bool:
+		return strconv.FormatBool(v)
+	case float64:
+		return "the number " + strconv.FormatFloat(v, 'f', -1, 64)
+	case int:
+		return fmt.Sprintf("the number %d", v)
+	case int64:
+		return fmt.Sprintf("the number %d", v)
+	case []interface{}:
+		return "a list"
+	case map[string]interface{}:
+		return "a set of key/value pairs"
+	}
+	return fmt.Sprintf("%v", value)
+}
+
+// example returns a value the customer can paste. The schema default covers all but 11 settings,
+// but roughly a fifth of those are "" / [] / {}, so fall back to a shape rather than suggest an
+// empty token.
+func example(key string, node *jsonschema.Schema, want string) string {
+	if node != nil && node.Default != nil && key != defaultDisagreesWithType {
+		if rendered, ok := renderDefault(*node.Default); ok {
+			return rendered
+		}
+	}
+	switch want {
+	case "boolean":
+		return "true"
+	case "integer", "number":
+		return "10"
+	case "array":
+		return `["first", "second"]`
+	case "object":
+		return "key: value"
+	default:
+		return `"value"`
+	}
+}
+
+func renderDefault(d interface{}) (string, bool) {
+	switch v := d.(type) {
+	case string:
+		if v == "" {
+			return "", false
+		}
+	case float64:
+		if v == 0 {
+			return "", false
+		}
+	case []interface{}:
+		if len(v) == 0 {
+			return "", false
+		}
+	case map[string]interface{}:
+		if len(v) == 0 {
+			return "", false
+		}
+	case nil:
+		return "", false
+	}
+	encoded, err := json.Marshal(d)
+	if err != nil {
+		return "", false
+	}
+	return string(encoded), true
+}
+
+// fix suggests a correction only where the customer's intent is unambiguous. A confident wrong
+// suggestion is worse than a generic one: telling someone to quote a duration yields "30", which
+// passes validation and is still wrong at runtime.
+func fix(key string, node *jsonschema.Schema, want string, value interface{}, example string) string {
+	if s, ok := value.(string); ok {
+		trimmed := strings.TrimSpace(s)
+		lower := strings.ToLower(trimmed)
+		// YAML 1.2 resolves yes/no/on/off to text, so they look boolean but are not
+		if want == "boolean" && truthy[lower] {
+			return fmt.Sprintf("Set `%s: true`.", key)
+		}
+		if want == "boolean" && falsy[lower] {
+			return fmt.Sprintf("Set `%s: false`.", key)
+		}
+		if want == "boolean" && (lower == "true" || lower == "false") {
+			return fmt.Sprintf("Remove the quotes: `%s: %s`.", key, lower)
+		}
+		if (want == "integer" || want == "number") && numeric.MatchString(trimmed) {
+			return fmt.Sprintf("Remove the quotes: `%s: %s`.", key, trimmed)
+		}
+		// the reverse duration mistake: a duration literal on a plain-number setting
+		if (want == "integer" || want == "number") && goDuration.MatchString(trimmed) {
+			return fmt.Sprintf("`%s` takes a plain number, not a duration — for example `%s: %s`.", key, key, example)
+		}
+		if want == "array" && strings.ContainsAny(trimmed, ", \t") {
+			items := strings.FieldsFunc(trimmed, func(r rune) bool {
+				return r == ',' || r == ' ' || r == '\t'
+			})
+			encoded, err := json.Marshal(items)
+			if err == nil {
+				return fmt.Sprintf("Write it as a list: `%s: %s`.", key, encoded)
+			}
+		}
+	}
+	// a bare number on a duration setting: name the unit rather than the quotes
+	if isDuration(node) {
+		if n, ok := asNumber(value); ok {
+			return fmt.Sprintf("If you meant %s seconds, set `%s: \"%ss\"`.", n, key, n)
+		}
+	}
+	// a section groups other settings, so suggesting `key: value` for it makes no sense
+	if want == "object" && node != nil && len(node.Properties) > 0 {
+		return fmt.Sprintf("`%s` groups other settings — indent them beneath it instead of giving it a value.", key)
+	}
+	return fmt.Sprintf("Set `%s` to something like `%s`.", key, example)
+}
+
+func asNumber(value interface{}) (string, bool) {
+	switch v := value.(type) {
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64), true
+	case int:
+		return strconv.Itoa(v), true
+	case int64:
+		return strconv.FormatInt(v, 10), true
+	}
+	return "", false
+}
+
+func isDuration(node *jsonschema.Schema) bool {
+	if node == nil || node.Default == nil || typeOf(node) != "string" {
+		return false
+	}
+	s, ok := (*node.Default).(string)
+	return ok && goDuration.MatchString(s)
+}

--- a/releasenotes/notes/invalidconfig-actionable-messages-4b1e9c7a2f6d80e3.yaml
+++ b/releasenotes/notes/invalidconfig-actionable-messages-4b1e9c7a2f6d80e3.yaml
@@ -1,0 +1,15 @@
+---
+enhancements:
+  - |
+    The ``invalid-config`` Agent Health issue now states what to change instead of naming a JSON
+    Schema type. Each violation reports the setting using the dotted key from ``datadog.yaml``, the
+    value that was found, and a correction, for example::
+
+        logs_enabled must be true or false, but it is the text "yes". Set logs_enabled: true.
+
+    Remediation lists one step per violation rather than a single generic instruction.
+fixes:
+  - |
+    Duration settings in the ``invalid-config`` Agent Health issue no longer report ``want string``,
+    which led to quoting the number as ``"30"`` -- a value that satisfies the schema but is still
+    wrong at runtime. They now report the expected duration form, such as ``"30s"``.


### PR DESCRIPTION
### What this does

`invalid-config` issues were turned off in prod because a type mismatch doesn't tell a customer how to fix their config. This makes each violation say what to change.

**The strongest reason isn't tone — the current message produces a broken config.** For the ~92 duration-valued settings:

```
tls_handshake_timeout: 30   ->  "at '/tls_handshake_timeout': got number, want string"
customer writes "30"        ->  VALIDATES CLEAN
runtime                     ->  still wrong (correct value is "30s")
```

They follow our advice, the warning disappears, and the config is still broken.

### Before / after

```
- at '/agent_ipc/port': got string, want integer
- at '/tls_handshake_timeout': got number, want string
- at '/additional_endpoints/https:~1~1trace.datadoghq.eu': got string, want array

+ agent_ipc.port must be a whole number, but it is the text "8125".
+     Remove the quotes: `agent_ipc.port: 8125`.
+ tls_handshake_timeout must be a duration such as "10s", but it is the number 30.
+     If you meant 30 seconds, set `tls_handshake_timeout: "30s"`.
+ additional_endpoints["https://trace.datadoghq.eu"] must be a list of text values, but it is the text "key".
```

Remediation stops restating the problem:

```
  1. Open /etc/datadog-agent/datadog.yaml in an editor.
  2. Set `logs_enabled: true`.
  3. If you meant 30 seconds, set `tls_handshake_timeout: "30s"`.
  4. Restart the Datadog Agent.
  5. Run `datadog-agent diagnose` to confirm the configuration is now valid.
```

Step 2 was previously `"Fix each violation listed in the description."` — the only remediation step in the whole `issues/` package that told the user nothing.

### Changes

- **`pkg/config/schema`** gains `ValidateCoreConfigDetailed`, returning `[]Violation{Pointer, Key, Message, Fix}`. `ValidateCoreConfig` is **untouched**, so `invalidsysprobeconfig` and `pkg/config/lite` keep the existing strings.
- **`invalidconfig/check.go`** writes `message`, `pointer` and `fix` as parallel context keys.
- **`invalidconfig/issue.go`** builds from those keys instead of splitting the message on `": "` to recover the path — that silently produced a garbage pointer for any message containing that sequence. `extra.errors` stays path-keyed (unchanged contract) but now carries the diagnosis *and* the correction under each key. `description` folds in the impact text, since it is the only field `agent diagnose` renders.

### Design notes

- **Suggestions only where intent is unambiguous.** A confident wrong suggestion is worse than a generic one — it's how "quote it" produced configs that passed validation and were still broken.
- **The example comes from the schema `default`**, which covers all but 11 settings — but roughly a fifth are `""` / `[]` / `{}`, so those fall back to a shape example. `apm_config.max_memory` is excluded: it is `type: number` with `default: "5e+08"`, the one setting whose default fails its own schema.
- **Durations are detected from the default's shape**, not `format: duration`. Only 60 of the ~92 duration settings carry the marker, and format assertion is off for 2020-12 so `format` is inert either way.
- **Steps are capped** at 10 violations plus a summary line; `allErrors` on a bad 50-element list would otherwise produce 50 steps.
- Values are already scrubbed before validation (`normalizeForSchema` -> `ScrubYaml`), so echoing them back is safe by construction.

### Testing

`dda inv test --targets=./pkg/config/schema,./comp/healthplatform/issues/invalidconfig,./comp/healthplatform/issues/invalidsysprobeconfig` — 19 passing. `dda inv linter.go` clean.

The existing `invalidconfig_integration_test.go` (agent -> store -> forwarder -> fakeintake) is unchanged and still asserts `/agent_ipc/port` in `extra.errors`, so it guards the wire contract through the real path.

### Matching backfill change

The backfill worker for 7.80–7.81 produces byte-identical wording, so a fleet spanning both versions reads the same: [dd-source#46811](https://github.com/ddoghq/dd-source/pull/46811).

### Not in this PR

- `enum` is used **zero** times in the schema, so `log_level: verbose` validates clean and "valid values are ..." can't be generated.
- The JSON compiler strips `example`, `env_vars` and `platform_default` (`tasks/schema/produce_byproduct.py`); `env_vars` in particular would enable "you probably meant `DD_URL`".
- The stale comment at `invalidconfig/module.go:62-66` says the compiled schema is retained for the process lifetime; commit `4000108c8bf` deleted that cache, so the ~8 MiB figure that led to the check shipping disabled in 7.81 no longer applies.
