### PR TITLE
fix(e2e): quote api_key in generated datadog.yaml for ADP 1.5.0

### DIFF
--- a/test/e2e-framework/components/datadog/agent/host.go
+++ b/test/e2e-framework/components/datadog/agent/host.go
@@ -207,7 +207,9 @@ func (h *HostAgent) updateCoreAgentConfig(
 		}
 
 		if !skipAPIKeyInConfig {
-			extraConfigs = append(extraConfigs, fmt.Sprintf("api_key: %s", apiKey))
+			// Use %q, not %s: fmt.Sprintf("api_key: %s", "00000000000000000000000000000000") writes an
+			// unquoted YAML value that parsers treat as integer 0; %q emits a quoted string.
+			extraConfigs = append(extraConfigs, fmt.Sprintf("api_key: %q", apiKey))
 		}
 
 		var err error


### PR DESCRIPTION
### What does this PR do?

Quotes the `api_key` value when the E2E host provisioner merges config into `datadog.yaml` (`fmt.Sprintf("api_key: %q", apiKey)` instead of `%s`).

### Motivation

The E2E framework writes a minimal `datadog.yaml` after MSI install. When the dummy API key is all digits (e.g. `00000000000000000000000000000000`), an unquoted YAML value is parsed as integer `0`.

That was tolerated by older ADP bootstrap (loose `GenericConfiguration` loading), but **ADP 1.5.0** reads local config through typed bootstrap (`LoadedConfiguration::load` in Saluki), which expects `api_key` to be a string. ADP then fails at startup with:

```text
invalid type: integer `0`, expected a string
```

This breaks Windows procmgr/ADP E2E tests such as `TestADPCOATTelemetry` when the agent ships ADP 1.5.0+.

### Describe how you validated your changes

- Verified locally that `TestProcmgrSmokeWindowsSuite/TestADPCOATTelemetry` passes after the fix when ADP reads the provisioned `datadog.yaml`
- Confirmed generated config contains a quoted string (e.g. api_key: "00000000000000000000000000000000") instead of bare 0

### Additional Notes
