### PR TITLE
Fix coverage blocks counter

### DIFF
--- a/bazel/tools/coverage/go_cover_report_generator.go
+++ b/bazel/tools/coverage/go_cover_report_generator.go
@@ -29,8 +29,25 @@ func (f *stringListFlag) Set(value string) error {
 	return nil
 }
 
-// mergeBlock applies the standard go cover profile block merge (set |=, count/atomic +=).
-// Same semantics as tools like gocovmerge; independent implementation for Bazel integration.
+// mergedProfileMode is the mode declared on the merged profile. Blocks carry a
+// 0/1 covered flag rather than an execution count, which is what set mode means.
+const mergedProfileMode = "set"
+
+// unionCount collapses an execution count to a 0/1 covered flag.
+//
+// Summing counts (what gocovmerge does) is wrong here: a Bazel coverage run
+// instruments the whole dependency closure of every test target, so a block in
+// a widely depended-on package is counted once per target that links it. In CI
+// that inflated a single block to 3x10^8 executions against ~18k under a plain
+// `go test`. Only "was this reached" survives the merge meaningfully.
+func unionCount(count int) int {
+	if count > 0 {
+		return 1
+	}
+	return 0
+}
+
+// mergeBlock merges a block into profile, unioning coverage rather than summing it.
 func mergeBlock(profile *cover.Profile, block cover.ProfileBlock) error {
 	index := sort.Search(len(profile.Blocks), func(i int) bool {
 		current := profile.Blocks[i]
@@ -46,20 +63,28 @@ func mergeBlock(profile *cover.Profile, block cover.ProfileBlock) error {
 			return fmt.Errorf("incompatible coverage blocks in %s at %d.%d", profile.FileName, block.StartLine, block.StartCol)
 		}
 		switch profile.Mode {
-		case "set":
-			current.Count |= block.Count
-		case "count", "atomic":
-			current.Count += block.Count
+		case "set", "count", "atomic":
+			current.Count |= unionCount(block.Count)
 		default:
 			return fmt.Errorf("unsupported coverage mode %q", profile.Mode)
 		}
 		return nil
 	}
 
+	block.Count = unionCount(block.Count)
 	profile.Blocks = append(profile.Blocks, cover.ProfileBlock{})
 	copy(profile.Blocks[index+1:], profile.Blocks[index:])
 	profile.Blocks[index] = block
 	return nil
+}
+
+// adoptProfile takes a parsed profile as the merge base for its file, normalizing
+// counts so blocks that only ever appear in one input still read as 0/1.
+func adoptProfile(profilesByFile map[string]*cover.Profile, profile *cover.Profile) {
+	for i := range profile.Blocks {
+		profile.Blocks[i].Count = unionCount(profile.Blocks[i].Count)
+	}
+	profilesByFile[profile.FileName] = profile
 }
 
 func mergeProfiles(profilesByFile map[string]*cover.Profile, profiles []*cover.Profile, mode *string) error {
@@ -72,7 +97,7 @@ func mergeProfiles(profilesByFile map[string]*cover.Profile, profiles []*cover.P
 
 		merged, found := profilesByFile[profile.FileName]
 		if !found {
-			profilesByFile[profile.FileName] = profile
+			adoptProfile(profilesByFile, profile)
 			continue
 		}
 		for _, block := range profile.Blocks {
@@ -94,7 +119,7 @@ func mergeBaselineProfiles(profilesByFile map[string]*cover.Profile, profiles []
 		if _, found := profilesByFile[profile.FileName]; found {
 			continue
 		}
-		profilesByFile[profile.FileName] = profile
+		adoptProfile(profilesByFile, profile)
 	}
 	return nil
 }
@@ -387,31 +412,34 @@ func filterProfilesByRegex(profilesByFile map[string]*cover.Profile, patterns []
 	return nil
 }
 
-func mergeReportPaths(profilesByFile map[string]*cover.Profile, reportPaths []string) (string, error) {
+// mergeReportPaths merges every report into profilesByFile. The mode it tracks
+// is the inputs' mode, used only to reject mixing incompatible ones; the merged
+// output is always written as mergedProfileMode.
+func mergeReportPaths(profilesByFile map[string]*cover.Profile, reportPaths []string) error {
 	mode := ""
 	for _, reportPath := range reportPaths {
 		profiles, isGoProfile, err := parseGoProfiles(reportPath)
 		if err != nil {
-			return "", fmt.Errorf("parse %s: %w", reportPath, err)
+			return fmt.Errorf("parse %s: %w", reportPath, err)
 		}
 		if isGoProfile {
 			if err := mergeProfiles(profilesByFile, profiles, &mode); err != nil {
-				return "", err
+				return err
 			}
 			continue
 		}
 
 		baselineProfiles, isBaselineProfile, err := parseBaselineProfiles(reportPath)
 		if err != nil {
-			return "", fmt.Errorf("parse %s: %w", reportPath, err)
+			return fmt.Errorf("parse %s: %w", reportPath, err)
 		}
 		if isBaselineProfile {
 			if err := mergeBaselineProfiles(profilesByFile, baselineProfiles, &mode); err != nil {
-				return "", err
+				return err
 			}
 		}
 	}
-	return mode, nil
+	return nil
 }
 
 func generateCoverageDirReport(coverageDir, outputFile string, filterSources []string, sourceFileManifest, sourcesToReplaceFile string) error {
@@ -421,8 +449,7 @@ func generateCoverageDirReport(coverageDir, outputFile string, filterSources []s
 	}
 
 	profilesByFile := make(map[string]*cover.Profile)
-	mode, err := mergeReportPaths(profilesByFile, datFiles)
-	if err != nil {
+	if err := mergeReportPaths(profilesByFile, datFiles); err != nil {
 		return err
 	}
 
@@ -446,11 +473,7 @@ func generateCoverageDirReport(coverageDir, outputFile string, filterSources []s
 		return err
 	}
 
-	if mode == "" {
-		mode = "atomic"
-	}
-
-	if err := writeProfiles(outputFile, mode, profilesByFile); err != nil {
+	if err := writeProfiles(outputFile, mergedProfileMode, profilesByFile); err != nil {
 		return fmt.Errorf("write merged profile: %w", err)
 	}
 	return nil
@@ -463,15 +486,11 @@ func generateReport(reportsFile, outputFile string) error {
 	}
 
 	profilesByFile := make(map[string]*cover.Profile)
-	mode, err := mergeReportPaths(profilesByFile, reportPaths)
-	if err != nil {
+	if err := mergeReportPaths(profilesByFile, reportPaths); err != nil {
 		return err
 	}
-	if mode == "" {
-		mode = "atomic"
-	}
 
-	if err := writeProfiles(outputFile, mode, profilesByFile); err != nil {
+	if err := writeProfiles(outputFile, mergedProfileMode, profilesByFile); err != nil {
 		return fmt.Errorf("write merged profile: %w", err)
 	}
 	return nil

--- a/bazel/tools/coverage/go_cover_report_generator_test.go
+++ b/bazel/tools/coverage/go_cover_report_generator_test.go
@@ -8,6 +8,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -47,11 +48,42 @@ end_of_record
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := `mode: atomic
+	// foo.go:1.1 is covered by both inputs (2 and 3): unioned to 1, not summed to 5.
+	want := `mode: set
 example.com/bar.go:1.1,1.5 1 1
-example.com/foo.go:1.1,1.5 1 5
+example.com/foo.go:1.1,1.5 1 1
 example.com/foo.go:2.1,2.5 1 0
 `
+	if string(got) != want {
+		t.Fatalf("unexpected merged profile:\n%s", got)
+	}
+}
+
+// TestGenerateReportUnionsLargeCounts guards the invariant behind unionCount: no
+// merged block ever exceeds 1, however many targets covered it or how hot it was.
+// Summing here is what drove a real block to 3x10^8 executions in CI.
+func TestGenerateReportUnionsLargeCounts(t *testing.T) {
+	dir := t.TempDir()
+	reports := filepath.Join(dir, "reports.txt")
+	output := filepath.Join(dir, "merged.out")
+
+	var paths []string
+	for i, count := range []string{"1000000", "2000000", "3000000"} {
+		path := filepath.Join(dir, "profile"+string(rune('a'+i))+".out")
+		writeTestFile(t, path, "mode: atomic\nexample.com/hot.go:1.1,1.5 1 "+count+"\n")
+		paths = append(paths, path)
+	}
+	writeTestFile(t, reports, strings.Join(paths, "\n")+"\n")
+
+	if err := generateReport(reports, output); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "mode: set\nexample.com/hot.go:1.1,1.5 1 1\n"
 	if string(got) != want {
 		t.Fatalf("unexpected merged profile:\n%s", got)
 	}
@@ -74,7 +106,7 @@ func TestGenerateBaselineReport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := `mode: atomic
+	want := `mode: set
 example.com/foo.go:1.0,1.1 1 0
 `
 	if string(got) != want {
@@ -101,7 +133,7 @@ func TestGenerateBaselineFromSourceFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := `mode: atomic
+	want := `mode: set
 ` + source + `:1.0,1.1 1 0
 ` + source + `:3.0,3.1 1 0
 `
@@ -133,7 +165,7 @@ end_of_record
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := `mode: atomic
+	want := `mode: set
 example.com/covered.go:1.1,1.5 1 1
 example.com/uncovered.go:1.0,1.1 1 0
 `
@@ -176,9 +208,9 @@ example.com/bar.go:1.1,1.5 1 1
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := `mode: atomic
+	want := `mode: set
 example.com/bar.go:1.1,1.5 1 1
-example.com/foo.go:1.1,1.5 1 2
+example.com/foo.go:1.1,1.5 1 1
 `
 	if string(got) != want {
 		t.Fatalf("unexpected merged profile:\n%s", got)
@@ -208,7 +240,7 @@ end_of_record
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(got) != "mode: atomic\n" {
+	if string(got) != "mode: set\n" {
 		t.Fatalf("unexpected merged profile:\n%s", got)
 	}
 }


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Bazel produces several test binaries out of the same source based on a set of go build tags that were passed along through `dd_agent_go_test` macro. Each of those binaries will have its own coverage report that we merge afterwards. Current version of the report generator for Bazel would just sum up covered blocks and lead to unrealistic numbers (e.g. ~17k covered blocks in legacy report vs ~1.3kk in Bazel). This is definitely an error, we only need to count block once if it was covered by other of those binaries.

