### PR TITLE
[DOIO-171] Add MySQL query action dispatch

### DIFF
--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -25,7 +25,10 @@ import (
 
 var databaseIdentifierVariablePattern = regexp.MustCompile(`\$\$|\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$[A-Za-z_][A-Za-z0-9_]*`)
 
-const defaultPostgresPort = 5432
+const (
+	defaultMySQLPort    = 3306
+	defaultPostgresPort = 5432
+)
 
 // A "base config" is a supported DB integration.Config emitted by another provider that a DO
 // query action matched against. A single base config can bundle several instances. Throughout
@@ -60,7 +63,7 @@ type managedBaseEntry struct {
 
 // isSupportedIntegration reports whether name is a supported DB integration.
 func isSupportedIntegration(name string) bool {
-	return name == "postgres" || name == "sap_hana" || name == "sqlserver"
+	return name == "mysql" || name == "postgres" || name == "sap_hana" || name == "sqlserver"
 }
 
 // instanceHost returns the host/server field for an integration instance,
@@ -468,6 +471,8 @@ func evaluateInstanceIdentifier(instance map[string]any, identifier DBIdentifier
 		return identifierMatchEvaluation{strategy: "empty_identifier"}
 	}
 	switch integrationName {
+	case "mysql":
+		return evaluateMySQLIdentifier(instance, identifier)
 	case "postgres":
 		return evaluatePostgresIdentifier(instance, identifier)
 	case "sap_hana":
@@ -480,7 +485,7 @@ func evaluateInstanceIdentifier(instance map[string]any, identifier DBIdentifier
 }
 
 func evaluateSQLServerIdentifier(instance map[string]any, targetHost string, queries []QuerySpec) identifierMatchEvaluation {
-	match := evaluateSapHanaIdentifier(instance, targetHost)
+	match := evaluateEndpointIdentifier(instance, targetHost)
 	if !match.matched {
 		match.strategy = "sqlserver_endpoint"
 		return match
@@ -489,57 +494,80 @@ func evaluateSQLServerIdentifier(instance map[string]any, targetHost string, que
 	if !isAzureSQLDatabase {
 		return match
 	}
+	match.strategy = "azure_sql_database"
 	if len(queries) == 0 {
-		return identifierMatchEvaluation{strategy: "azure_sql_database"}
+		match.matched = false
+		return match
 	}
 	for _, query := range queries {
 		if !strings.EqualFold(query.DBName, database) {
-			return identifierMatchEvaluation{strategy: "azure_sql_database"}
+			match.matched = false
+			return match
 		}
 	}
-	match.strategy = "azure_sql_database"
 	return match
 }
 
-func evaluatePostgresIdentifier(instance map[string]any, identifier DBIdentifier) identifierMatchEvaluation {
-	host := instanceHost(instance)
-	if host == identifier.Host {
-		return identifierMatchEvaluation{matched: true, strategy: "host"}
-	}
-	if port, ok := instancePort(instance); ok {
-		if fmt.Sprintf("%s:%d", host, port) == identifier.Host {
-			return identifierMatchEvaluation{matched: true, strategy: "host_port"}
-		}
+func evaluateMySQLIdentifier(instance map[string]any, identifier DBIdentifier) (match identifierMatchEvaluation) {
+	if match = evaluateEndpointIdentifier(instance, identifier.Host); match.matched {
+		return
 	}
 
-	databaseIdentifier, ok := renderDatabaseIdentifier(instance, identifier.AgentHostname, "$resolved_hostname", defaultPostgresPort)
-	return identifierMatchEvaluation{
-		matched:            ok && databaseIdentifier == identifier.Host,
-		strategy:           "database_identifier",
-		renderedIdentifier: databaseIdentifier,
-		renderable:         ok,
+	match.renderedIdentifier, match.renderable = renderDatabaseIdentifierWithLookup(
+		instance,
+		identifier.AgentHostname,
+		"$resolved_hostname",
+		defaultMySQLPort,
+		net.LookupHost,
+	)
+	match.matched = match.renderable && match.renderedIdentifier == identifier.Host
+	match.strategy = "database_identifier"
+	return
+}
+
+func evaluatePostgresIdentifier(instance map[string]any, identifier DBIdentifier) (match identifierMatchEvaluation) {
+	if match = evaluateEndpointIdentifier(instance, identifier.Host); match.matched {
+		return
 	}
+
+	match.renderedIdentifier, match.renderable = renderDatabaseIdentifierWithLookup(
+		instance,
+		identifier.AgentHostname,
+		"$resolved_hostname",
+		defaultPostgresPort,
+		net.LookupHost,
+	)
+	match.matched = match.renderable && match.renderedIdentifier == identifier.Host
+	match.strategy = "database_identifier"
+	return
 }
 
 func evaluateSapHanaIdentifier(instance map[string]any, targetHost string) identifierMatchEvaluation {
+	match := evaluateEndpointIdentifier(instance, targetHost)
+	if !match.matched {
+		match.strategy = "sap_hana_endpoint"
+	}
+	return match
+}
+
+// evaluateEndpointIdentifier contains only the host/port mechanics shared by database-specific
+// evaluators. Template and query matching remain owned by each integration's evaluator.
+func evaluateEndpointIdentifier(instance map[string]any, targetHost string) identifierMatchEvaluation {
 	host := instanceHost(instance)
 	if host == targetHost {
 		return identifierMatchEvaluation{matched: true, strategy: "host"}
 	}
 	if port, ok := instancePort(instance); ok {
-		if fmt.Sprintf("%s:%d", host, port) == targetHost {
+		if host+":"+strconv.Itoa(port) == targetHost {
 			return identifierMatchEvaluation{matched: true, strategy: "host_port"}
 		}
 	}
-	return identifierMatchEvaluation{strategy: "sap_hana_endpoint"}
+	return identifierMatchEvaluation{}
 }
 
-// renderDatabaseIdentifier renders a database_identifier template using the same inputs as the
-// Postgres check. Unknown variables stay in the result, matching Python's safe_substitute.
-func renderDatabaseIdentifier(instance map[string]any, agentHostname, defaultTemplate string, defaultPort int) (string, bool) {
-	return renderDatabaseIdentifierWithLookup(instance, agentHostname, defaultTemplate, defaultPort, net.LookupHost)
-}
-
+// renderDatabaseIdentifierWithLookup renders a database_identifier template using the shared
+// inputs exposed by the MySQL and Postgres checks. Unknown variables stay in the result, matching
+// Python's safe_substitute.
 func renderDatabaseIdentifierWithLookup(
 	instance map[string]any,
 	agentHostname, defaultTemplate string,
@@ -584,7 +612,7 @@ func renderDatabaseIdentifierWithLookup(
 	return safeSubstitute(template, values), true
 }
 
-// resolveDatabaseHostname mirrors the Postgres check's resolve_db_host behavior used to build
+// resolveDatabaseHostname mirrors the database checks' resolve_db_host behavior used to build
 // $resolved_hostname. Besides local and socket hosts, the check reports the Agent hostname when
 // the database host and Agent hostname resolve to the same IPv4 address.
 func resolveDatabaseHostname(host, agentHostname string, lookupHost func(string) ([]string, error)) string {
@@ -629,7 +657,7 @@ func firstIPv4Address(addresses []string) (string, bool) {
 }
 
 // templateTagValues exposes each key:value instance tag as a template variable. Duplicate keys
-// are sorted and joined with commas, matching the Postgres check.
+// are sorted and joined with commas, matching the database checks.
 func templateTagValues(instance map[string]any) map[string]string {
 	var tags []string
 	switch configuredTags := instance["tags"].(type) {
@@ -659,7 +687,7 @@ func templateTagValues(instance map[string]any) map[string]string {
 	return values
 }
 
-// isLocalDBHost matches the local-address cases handled by the Postgres check's host resolver.
+// isLocalDBHost matches the local-address cases handled by the database checks' host resolver.
 func isLocalDBHost(host string) bool {
 	if host == "" || host == "localhost" || strings.HasPrefix(host, "/") {
 		return true

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -26,6 +26,11 @@ import (
 var databaseIdentifierVariablePattern = regexp.MustCompile(`\$\$|\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$[A-Za-z_][A-Za-z0-9_]*`)
 
 const (
+	postgresConfigIDPrefix = "do-"
+	mysqlConfigIDPrefix    = "do-mysql-"
+	mssqlConfigIDPrefix    = "do-mssql-"
+	sapHANAConfigIDPrefix  = "do-hana-"
+
 	mysqlPortFallback    = "0"
 	postgresPortFallback = "5432"
 )
@@ -64,6 +69,24 @@ type managedBaseEntry struct {
 // isSupportedIntegration reports whether name is a supported DB integration.
 func isSupportedIntegration(name string) bool {
 	return name == "mysql" || name == "postgres" || name == "sap_hana" || name == "sqlserver"
+}
+
+// integrationForConfigID maps the platform-specific prefixes assigned by the DO RC reconciler to
+// Agent integration names. The specific prefixes must be checked before the legacy PostgreSQL
+// prefix because they all begin with "do-".
+func integrationForConfigID(configID string) (string, bool) {
+	switch {
+	case strings.HasPrefix(configID, mysqlConfigIDPrefix):
+		return "mysql", true
+	case strings.HasPrefix(configID, mssqlConfigIDPrefix):
+		return "sqlserver", true
+	case strings.HasPrefix(configID, sapHANAConfigIDPrefix):
+		return "sap_hana", true
+	case strings.HasPrefix(configID, postgresConfigIDPrefix):
+		return "postgres", true
+	default:
+		return "", false
+	}
 }
 
 // instanceHost returns the host/server field for an integration instance,
@@ -359,7 +382,8 @@ func (c *component) resolveBaseConfig(configID string, dbID *DBIdentifier, queri
 	existing, alreadyActive := c.activeConfigs[configID]
 	c.activeConfigsMu.Unlock()
 
-	if alreadyActive {
+	expectedIntegration, scopedByConfigID := integrationForConfigID(configID)
+	if alreadyActive && (!scopedByConfigID || existing.baseCfg.Name == expectedIntegration) {
 		instance, identity, err := c.findMatchingInstance(existing.baseCfg, dbID, queries)
 		if instance != nil {
 			return existing.baseCfg, instance, identity, nil
@@ -371,22 +395,27 @@ func (c *component) resolveBaseConfig(configID string, dbID *DBIdentifier, queri
 			c.log.Warnf("Stored base config for %s no longer parses cleanly, re-resolving: %v", configID, err)
 		}
 	}
-	return c.findMatchingConfig(dbID, queries)
+	return c.findMatchingConfig(configID, dbID, queries)
 }
 
 // findMatchingConfig finds an enabled supported integration instance matching the identifier and
-// queries.
-func (c *component) findMatchingConfig(dbID *DBIdentifier, queries []QuerySpec) (*integration.Config, map[string]any, instanceConfigIdentity, error) {
+// queries. Production DO config IDs scope the search to their database integration; unscoped IDs
+// retain the legacy search behavior for compatibility with manually constructed payloads.
+func (c *component) findMatchingConfig(configID string, dbID *DBIdentifier, queries []QuerySpec) (*integration.Config, map[string]any, instanceConfigIdentity, error) {
 	if dbID.Host == "" {
 		return nil, nil, instanceConfigIdentity{}, errEmptyIdentifierHost
 	}
 
 	cfgs := c.ac.GetUnresolvedConfigs()
 	var lastParseErr error
+	expectedIntegration, scopedByConfigID := integrationForConfigID(configID)
 
 	for cfgIdx := range cfgs {
 		cfg := &cfgs[cfgIdx]
 		if !isSupportedIntegration(cfg.Name) {
+			continue
+		}
+		if scopedByConfigID && cfg.Name != expectedIntegration {
 			continue
 		}
 		instance, identity, err := c.findMatchingInstance(cfg, dbID, queries)

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -26,8 +26,8 @@ import (
 var databaseIdentifierVariablePattern = regexp.MustCompile(`\$\$|\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$[A-Za-z_][A-Za-z0-9_]*`)
 
 const (
-	defaultMySQLPort    = 3306
-	defaultPostgresPort = 5432
+	mysqlPortFallback    = "0"
+	postgresPortFallback = "5432"
 )
 
 // A "base config" is a supported DB integration.Config emitted by another provider that a DO
@@ -513,11 +513,9 @@ func evaluateMySQLIdentifier(instance map[string]any, identifier DBIdentifier) (
 		return
 	}
 
-	match.renderedIdentifier, match.renderable = renderDatabaseIdentifierWithLookup(
+	match.renderedIdentifier, match.renderable = renderMySQLDatabaseIdentifierWithLookup(
 		instance,
 		identifier.AgentHostname,
-		"$resolved_hostname",
-		defaultMySQLPort,
 		net.LookupHost,
 	)
 	match.matched = match.renderable && match.renderedIdentifier == identifier.Host
@@ -534,7 +532,8 @@ func evaluatePostgresIdentifier(instance map[string]any, identifier DBIdentifier
 		instance,
 		identifier.AgentHostname,
 		"$resolved_hostname",
-		defaultPostgresPort,
+		postgresPortFallback,
+		nil,
 		net.LookupHost,
 	)
 	match.matched = match.renderable && match.renderedIdentifier == identifier.Host
@@ -565,13 +564,33 @@ func evaluateEndpointIdentifier(instance map[string]any, targetHost string) iden
 	return identifierMatchEvaluation{}
 }
 
+// renderMySQLDatabaseIdentifierWithLookup supplies the variables exposed by the Python MySQL
+// check. Its config key is "sock", while the database_identifier template variable is
+// $mysql_sock; both $port and $mysql_sock are populated even when their config keys are absent.
+func renderMySQLDatabaseIdentifierWithLookup(
+	instance map[string]any,
+	agentHostname string,
+	lookupHost func(string) ([]string, error),
+) (string, bool) {
+	mysqlSock, _ := instance["sock"].(string)
+	return renderDatabaseIdentifierWithLookup(
+		instance,
+		agentHostname,
+		"$resolved_hostname",
+		mysqlPortFallback,
+		map[string]string{"mysql_sock": mysqlSock},
+		lookupHost,
+	)
+}
+
 // renderDatabaseIdentifierWithLookup renders a database_identifier template using the shared
 // inputs exposed by the MySQL and Postgres checks. Unknown variables stay in the result, matching
 // Python's safe_substitute.
 func renderDatabaseIdentifierWithLookup(
 	instance map[string]any,
 	agentHostname, defaultTemplate string,
-	defaultPort int,
+	portFallback string,
+	integrationValues map[string]string,
 	lookupHost func(string) ([]string, error),
 ) (string, bool) {
 	template := defaultTemplate
@@ -593,12 +612,15 @@ func renderDatabaseIdentifierWithLookup(
 	}
 
 	values := templateTagValues(instance)
+	for name, value := range integrationValues {
+		values[name] = value
+	}
 	host := instanceHost(instance)
 	values["host"] = host
 	if port, ok := instancePort(instance); ok {
 		values["port"] = strconv.Itoa(port)
-	} else if _, configured := instance["port"]; !configured && defaultPort != 0 {
-		values["port"] = strconv.Itoa(defaultPort)
+	} else if _, configured := instance["port"]; !configured && portFallback != "" {
+		values["port"] = portFallback
 	}
 
 	var resolvedHostname string

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -22,6 +22,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const defaultTestIntegration = "postgres"
+
 // mockAutodiscovery wraps a noop autodiscovery Component and overrides GetUnresolvedConfigs
 // to return a fixed set of configs. This follows the same pattern as kafka_actions_test.go.
 type mockAutodiscovery struct {
@@ -48,6 +50,20 @@ func newTestComponentWithAC(t *testing.T, configs []integration.Config) *compone
 		ac:            newMockAutodiscovery(t, configs),
 		activeConfigs: make(map[string]activeConfigEntry),
 		managedBases:  make(map[string]*managedBaseEntry),
+	}
+}
+
+func TestIsSupportedIntegration(t *testing.T) {
+	for _, integrationName := range []string{"mysql", defaultTestIntegration, "sap_hana", "sqlserver"} {
+		t.Run(integrationName, func(t *testing.T) {
+			assert.True(t, isSupportedIntegration(integrationName))
+		})
+	}
+
+	for _, integrationName := range []string{"", "redis"} {
+		t.Run(integrationName, func(t *testing.T) {
+			assert.False(t, isSupportedIntegration(integrationName))
+		})
 	}
 }
 
@@ -80,6 +96,38 @@ func TestMatchesIdentifier_HostOnly(t *testing.T) {
 		}
 		assert.True(t, matchesIdentifier(instance, dbID))
 	})
+}
+
+func TestInstanceMatchesIdentifier_MySQL(t *testing.T) {
+	t.Run("host", func(t *testing.T) {
+		instance := map[string]any{"host": "mysql.internal", "port": 3306}
+		identifier := DBIdentifier{Type: "self-hosted", Host: "mysql.internal"}
+		assert.True(t, instanceMatchesIdentifier(instance, identifier, "mysql"))
+	})
+
+	t.Run("host and port", func(t *testing.T) {
+		instance := map[string]any{"host": "mysql.internal", "port": 3307}
+		identifier := DBIdentifier{Type: "self-hosted", Host: "mysql.internal:3307"}
+		assert.True(t, instanceMatchesIdentifier(instance, identifier, "mysql"))
+	})
+
+	t.Run("database identifier uses MySQL default port", func(t *testing.T) {
+		instance := map[string]any{
+			"host": "localhost",
+			"database_identifier": map[string]any{
+				"template": "$resolved_hostname:$port",
+			},
+		}
+		identifier := DBIdentifier{
+			Type:          "self-hosted",
+			Host:          "do-test-mysql:3306",
+			AgentHostname: "do-test-mysql",
+		}
+
+		assert.True(t, instanceMatchesIdentifier(instance, identifier, "mysql"))
+		assert.False(t, instanceMatchesIdentifier(instance, identifier, defaultTestIntegration))
+	})
+
 }
 
 func TestMatchesIdentifier_DatabaseIdentifierTemplate(t *testing.T) {
@@ -126,17 +174,29 @@ func TestMatchesIdentifier_DatabaseIdentifierTemplate(t *testing.T) {
 }
 
 func TestMatchesIdentifier_DatabaseIdentifierTemplateUsesTags(t *testing.T) {
-	instance := map[string]any{
-		"host": "db.internal",
-		"port": 5432,
-		"tags": []any{"env:staging", "env:prod", "team:data-observability"},
-		"database_identifier": map[string]any{
-			"template": "${team}-$env-$host:$port",
-		},
+	testCases := []struct {
+		name string
+		tags any
+	}{
+		{name: "YAML-decoded tags", tags: []any{"env:staging", "env:prod", "team:data-observability"}},
+		{name: "typed tags", tags: []string{"env:staging", "env:prod", "team:data-observability"}},
 	}
-	dbID := &DBIdentifier{Type: "self-hosted", Host: "data-observability-prod,staging-db.internal:5432"}
 
-	assert.True(t, matchesIdentifier(instance, dbID))
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			instance := map[string]any{
+				"host": "db.internal",
+				"port": 5432,
+				"tags": testCase.tags,
+				"database_identifier": map[string]any{
+					"template": "${team}-$env-$host:$port",
+				},
+			}
+			dbID := &DBIdentifier{Type: "self-hosted", Host: "data-observability-prod,staging-db.internal:5432"}
+
+			assert.True(t, matchesIdentifier(instance, dbID))
+		})
+	}
 }
 
 func TestInstanceMatchesIdentifier_SapHanaDoesNotRenderDatabaseIdentifier(t *testing.T) {
@@ -228,7 +288,7 @@ func TestBuildCheckConfig_MultipleQueries(t *testing.T) {
 				IntervalSeconds: 60,
 				TimeoutSeconds:  10,
 				Entity: EntityMetadata{
-					Platform: "postgres",
+					Platform: defaultTestIntegration,
 					Account:  "my-account",
 					Database: "shop",
 					Schema:   "public",
@@ -242,7 +302,7 @@ func TestBuildCheckConfig_MultipleQueries(t *testing.T) {
 				IntervalSeconds: 300,
 				TimeoutSeconds:  30,
 				Entity: EntityMetadata{
-					Platform: "postgres",
+					Platform: defaultTestIntegration,
 					Account:  "my-account",
 					Database: "shop",
 					Schema:   "public",
@@ -253,7 +313,7 @@ func TestBuildCheckConfig_MultipleQueries(t *testing.T) {
 	}
 
 	baseCfg := &integration.Config{
-		Name:     "postgres",
+		Name:     defaultTestIntegration,
 		Provider: "file",
 		NodeName: "node1",
 	}
@@ -271,7 +331,7 @@ func TestBuildCheckConfig_MultipleQueries(t *testing.T) {
 	checkCfg, err := c.buildCheckConfig(payload, baseCfg, pgInstance, "rc-id-1")
 	require.NoError(t, err)
 
-	assert.Equal(t, "postgres", checkCfg.Name)
+	assert.Equal(t, defaultTestIntegration, checkCfg.Name)
 	assert.Equal(t, "file", checkCfg.Provider)
 	assert.Equal(t, "node1", checkCfg.NodeName)
 	require.Len(t, checkCfg.Instances, 1)
@@ -307,7 +367,7 @@ func TestBuildCheckConfig_MultipleQueries(t *testing.T) {
 
 	entity1, ok := q1["entity"].(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, "postgres", entity1["platform"])
+	assert.Equal(t, defaultTestIntegration, entity1["platform"])
 	assert.Equal(t, "my-account", entity1["account"])
 	assert.Equal(t, "shop", entity1["database"])
 	assert.Equal(t, "public", entity1["schema"])
@@ -330,7 +390,7 @@ func TestBuildCheckConfig_CustomSQLSelectFields(t *testing.T) {
 				Query:           "SELECT dd_value FROM my_custom_metric",
 				IntervalSeconds: 60,
 				TimeoutSeconds:  10,
-				Entity:          EntityMetadata{Platform: "postgres", Account: "acct", Database: "db", Schema: "s", Table: "t"},
+				Entity:          EntityMetadata{Platform: defaultTestIntegration, Account: "acct", Database: "db", Schema: "s", Table: "t"},
 				CustomSQLSelectFields: &CustomSQLSelectFields{
 					MetricConfigID: 42,
 					EntityID:       "entity-abc",
@@ -339,7 +399,7 @@ func TestBuildCheckConfig_CustomSQLSelectFields(t *testing.T) {
 		},
 	}
 
-	baseCfg := &integration.Config{Name: "postgres"}
+	baseCfg := &integration.Config{Name: defaultTestIntegration}
 	pgInstance := map[string]any{"host": "localhost", "port": 5432, "data_observability": map[string]any{"enabled": true}}
 
 	checkCfg, err := c.buildCheckConfig(payload, baseCfg, pgInstance, "rc-id-custom")
@@ -374,12 +434,12 @@ func TestBuildCheckConfig_NoCustomSQLSelectFields(t *testing.T) {
 				Query:           "SELECT count(*) FROM orders",
 				IntervalSeconds: 60,
 				TimeoutSeconds:  10,
-				Entity:          EntityMetadata{Platform: "postgres", Account: "acct", Database: "db", Schema: "s", Table: "t"},
+				Entity:          EntityMetadata{Platform: defaultTestIntegration, Account: "acct", Database: "db", Schema: "s", Table: "t"},
 			},
 		},
 	}
 
-	baseCfg := &integration.Config{Name: "postgres"}
+	baseCfg := &integration.Config{Name: defaultTestIntegration}
 	pgInstance := map[string]any{"host": "localhost", "port": 5432, "data_observability": map[string]any{"enabled": true}}
 
 	checkCfg, err := c.buildCheckConfig(payload, baseCfg, pgInstance, "rc-id")
@@ -441,7 +501,7 @@ func TestOnRCUpdate_EmptyConfigID(t *testing.T) {
 
 func TestOnRCUpdate_EmptyQueriesDisables(t *testing.T) {
 	postgresCfg := integration.Config{
-		Name:      "postgres",
+		Name:      defaultTestIntegration,
 		Provider:  "file",
 		NodeName:  "node1",
 		Instances: []integration.Data{integration.Data("host: localhost\ndbname: mydb\ndata_observability:\n  enabled: true\n")},
@@ -473,7 +533,7 @@ func TestOnRCUpdate_EmptyQueriesDisables(t *testing.T) {
 
 func TestOnRCUpdate_ReconcileDisablesStaleConfigs(t *testing.T) {
 	postgresCfg := integration.Config{
-		Name:      "postgres",
+		Name:      defaultTestIntegration,
 		Provider:  "file",
 		Instances: []integration.Data{integration.Data("host: localhost\ndbname: mydb\ndata_observability:\n  enabled: true\n")},
 	}
@@ -513,8 +573,8 @@ func TestRemoveActiveConfig_NotFound(t *testing.T) {
 }
 
 func TestRemoveActiveConfig_Found(t *testing.T) {
-	baseCfg := &integration.Config{Name: "postgres", Provider: "file"}
-	doCheckConfig := integration.Config{Name: "postgres", Provider: "do_query_actions"}
+	baseCfg := &integration.Config{Name: defaultTestIntegration, Provider: "file"}
+	doCheckConfig := integration.Config{Name: defaultTestIntegration, Provider: "do_query_actions"}
 	c := newTestComponent(t)
 	c.activeConfigs["my-config"] = activeConfigEntry{
 		checkConfig:   doCheckConfig,
@@ -534,72 +594,82 @@ func TestRemoveActiveConfig_Found(t *testing.T) {
 // --- Happy-path integration tests (require mocked autodiscovery) ---
 
 // TestOnRCUpdate_ValidConfig_SchedulesCheck verifies the primary use-case: a valid RC config
-// whose db_identifier matches a configured postgres instance results in a scheduled check.
+// whose db_identifier matches a configured integration instance results in a scheduled check.
 func TestOnRCUpdate_ValidConfig_SchedulesCheck(t *testing.T) {
-	postgresCfg := integration.Config{
-		Name:     "postgres",
-		Provider: "file",
-		NodeName: "node1",
-		Instances: []integration.Data{
-			integration.Data("host: localhost\nport: 5432\nusername: datadog\npassword: secret\ndbname: mydb\ndata_observability:\n  enabled: true\n"),
-		},
+	for _, testCase := range []struct {
+		integrationName string
+		port            int
+	}{
+		{integrationName: defaultTestIntegration, port: 5432},
+		{integrationName: "mysql", port: 3306},
+	} {
+		t.Run(testCase.integrationName, func(t *testing.T) {
+			integrationCfg := integration.Config{
+				Name:     testCase.integrationName,
+				Provider: "file",
+				NodeName: "node1",
+				Instances: []integration.Data{
+					integration.Data(fmt.Sprintf("host: localhost\nport: %d\nusername: datadog\npassword: secret\ndbname: mydb\ndata_observability:\n  enabled: true\n", testCase.port)),
+				},
+			}
+			c := newTestComponentWithAC(t, []integration.Config{integrationCfg})
+
+			payload := DOQueryPayload{
+				ConfigID:     "cfg-happy",
+				DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost"},
+				Queries: []QuerySpec{
+					{
+						MonitorID:       42,
+						Type:            "run_query",
+						Query:           "SELECT count(*) FROM orders",
+						IntervalSeconds: 60,
+						TimeoutSeconds:  10,
+						Entity:          EntityMetadata{Platform: testCase.integrationName, Database: "mydb", Table: "orders"},
+					},
+				},
+			}
+			payloadJSON, err := json.Marshal(payload)
+			require.NoError(t, err)
+
+			updates := map[string]state.RawConfig{
+				"path/cfg-happy": {Config: payloadJSON, Metadata: state.Metadata{ID: "rc-id-happy"}},
+			}
+			statuses, changes := collectStatuses(c, updates)
+
+			require.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-happy"].State)
+			require.Len(t, changes.Schedule, 1, "expected one scheduled DO check")
+			require.Len(t, changes.Unschedule, 1, "should unschedule base file-provider config to prevent duplicate")
+			assert.Equal(t, testCase.integrationName, changes.Schedule[0].Name)
+			assert.Equal(t, "file", changes.Schedule[0].Provider)
+			assert.Equal(t, "node1", changes.Schedule[0].NodeName)
+
+			require.Len(t, changes.Schedule[0].Instances, 1)
+			var instance map[string]any
+			require.NoError(t, yaml.Unmarshal(changes.Schedule[0].Instances[0], &instance))
+			assert.Equal(t, "localhost", instance["host"])
+			assert.Equal(t, "datadog", instance["username"])
+
+			doConfig, ok := instance["data_observability"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, true, doConfig["enabled"])
+			assert.Equal(t, "rc-id-happy", doConfig["config_id"])
+
+			queries, ok := doConfig["queries"].([]any)
+			require.True(t, ok)
+			require.Len(t, queries, 1)
+			q := queries[0].(map[string]any)
+			assert.Equal(t, "SELECT count(*) FROM orders", q["query"])
+
+			require.Contains(t, c.activeConfigs, "cfg-happy")
+		})
 	}
-	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
-
-	payload := DOQueryPayload{
-		ConfigID:     "cfg-happy",
-		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost"},
-		Queries: []QuerySpec{
-			{
-				MonitorID:       42,
-				Type:            "run_query",
-				Query:           "SELECT count(*) FROM orders",
-				IntervalSeconds: 60,
-				TimeoutSeconds:  10,
-				Entity:          EntityMetadata{Platform: "postgres", Database: "mydb", Table: "orders"},
-			},
-		},
-	}
-	payloadJSON, err := json.Marshal(payload)
-	require.NoError(t, err)
-
-	updates := map[string]state.RawConfig{
-		"path/cfg-happy": {Config: payloadJSON, Metadata: state.Metadata{ID: "rc-id-happy"}},
-	}
-	statuses, changes := collectStatuses(c, updates)
-
-	require.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-happy"].State)
-	require.Len(t, changes.Schedule, 1, "expected one scheduled DO check")
-	require.Len(t, changes.Unschedule, 1, "should unschedule base file-provider config to prevent duplicate")
-	assert.Equal(t, "postgres", changes.Schedule[0].Name)
-	assert.Equal(t, "file", changes.Schedule[0].Provider)
-	assert.Equal(t, "node1", changes.Schedule[0].NodeName)
-
-	require.Len(t, changes.Schedule[0].Instances, 1)
-	var instance map[string]any
-	require.NoError(t, yaml.Unmarshal(changes.Schedule[0].Instances[0], &instance))
-	assert.Equal(t, "localhost", instance["host"])
-	assert.Equal(t, "datadog", instance["username"])
-
-	doConfig, ok := instance["data_observability"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, true, doConfig["enabled"])
-	assert.Equal(t, "rc-id-happy", doConfig["config_id"])
-
-	queries, ok := doConfig["queries"].([]any)
-	require.True(t, ok)
-	require.Len(t, queries, 1)
-	q := queries[0].(map[string]any)
-	assert.Equal(t, "SELECT count(*) FROM orders", q["query"])
-
-	require.Contains(t, c.activeConfigs, "cfg-happy")
 }
 
 // TestOnRCUpdate_UpdateReplacesExistingCheck verifies that two sequential onRCUpdate calls
 // with the same config_id correctly unschedule the previous check and schedule the updated one.
 func TestOnRCUpdate_UpdateReplacesExistingCheck(t *testing.T) {
 	postgresCfg := integration.Config{
-		Name:      "postgres",
+		Name:      defaultTestIntegration,
 		Instances: []integration.Data{integration.Data("host: localhost\ndbname: mydb\ndata_observability:\n  enabled: true\n")},
 	}
 	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
@@ -676,7 +746,7 @@ func findScheduledWithHost(t *testing.T, changes integration.ConfigChanges, host
 func TestOnRCUpdate_PreservesUnrelatedInstances(t *testing.T) {
 	const rdsHost = "iceberg-test-postgres-demo-rds.c0lma4q6o85w.us-east-1.rds.amazonaws.com"
 	postgresCfg := integration.Config{
-		Name:     "postgres",
+		Name:     defaultTestIntegration,
 		Provider: "file",
 		Instances: []integration.Data{
 			integration.Data("host: localhost\nport: 5432\ndbname: testdb\ndata_observability:\n  enabled: true\ntags:\n  - env:demo\n"),
@@ -764,7 +834,7 @@ func TestBuildRemainder_SapHanaServerKey(t *testing.T) {
 
 func TestFindMatchingConfig_TemplatedIdentifiersDistinguishPorts(t *testing.T) {
 	postgresCfg := integration.Config{
-		Name:     "postgres",
+		Name:     defaultTestIntegration,
 		Provider: "file",
 		Instances: []integration.Data{
 			integration.Data("host: localhost\nport: 5432\ndatabase_identifier:\n  template: '$resolved_hostname:$port'\ndata_observability:\n  enabled: true\n"),
@@ -788,7 +858,7 @@ func TestFindMatchingConfig_TemplatedIdentifiersDistinguishPorts(t *testing.T) {
 
 func TestBuildRemainder_TemplatedIdentifierExcludesOnlyTargetPort(t *testing.T) {
 	base := &integration.Config{
-		Name:     "postgres",
+		Name:     defaultTestIntegration,
 		Provider: "file",
 		Instances: []integration.Data{
 			integration.Data("host: localhost\nport: 5432\ndatabase_identifier:\n  template: '$resolved_hostname:$port'\n"),
@@ -886,7 +956,7 @@ func TestOnRCUpdate_SameHostDifferentPorts_KeepsSiblingPortInRemainder(t *testin
 	const targetedPort = 5432
 	const siblingPort = 5433
 	postgresCfg := integration.Config{
-		Name:     "postgres",
+		Name:     defaultTestIntegration,
 		Provider: "file",
 		Instances: []integration.Data{
 			integration.Data(fmt.Sprintf("host: %s\nport: %d\ndata_observability:\n  enabled: true\n", sharedHost, targetedPort)),
@@ -946,7 +1016,7 @@ func TestOnRCUpdate_SameHostDifferentPorts_KeepsSiblingPortInRemainder(t *testin
 func TestOnRCUpdate_SameEndpointDifferentIdentifiers_KeepsSiblingInRemainder(t *testing.T) {
 	const sharedHost = "dbhost"
 	postgresCfg := integration.Config{
-		Name:     "postgres",
+		Name:     defaultTestIntegration,
 		Provider: "file",
 		Instances: []integration.Data{
 			integration.Data("host: dbhost\nport: 5432\ntags:\n  - env:staging\ndatabase_identifier:\n  template: '$env-$host:$port'\ndata_observability:\n  enabled: true\n"),
@@ -994,7 +1064,7 @@ func TestOnRCUpdate_PortlessMatchedInstance_KeepsPortedSiblingInRemainder(t *tes
 	const sharedHost = "dbhost"
 	const siblingPort = 5433
 	postgresCfg := integration.Config{
-		Name:     "postgres",
+		Name:     defaultTestIntegration,
 		Provider: "file",
 		Instances: []integration.Data{
 			integration.Data(fmt.Sprintf("host: %s\ndata_observability:\n  enabled: true\n", sharedHost)),
@@ -1108,7 +1178,7 @@ func TestOnRCUpdate_DuplicateLocalInstances_RejectsAmbiguousMatch(t *testing.T) 
 func TestOnRCUpdate_MultipleDOConfigsSameBase(t *testing.T) {
 	const rdsHost = "rds.example.com"
 	postgresCfg := integration.Config{
-		Name:     "postgres",
+		Name:     defaultTestIntegration,
 		Provider: "file",
 		Instances: []integration.Data{
 			integration.Data("host: localhost\ndata_observability:\n  enabled: true\n"),
@@ -1178,7 +1248,7 @@ func TestOnRCUpdate_NoMatchingPostgres_ReportsError(t *testing.T) {
 // by host only, with per-query dbname routing to different databases.
 func TestOnRCUpdate_HostOnlyMatching(t *testing.T) {
 	postgresCfg := integration.Config{
-		Name:      "postgres",
+		Name:      defaultTestIntegration,
 		Provider:  "file",
 		Instances: []integration.Data{integration.Data("host: localhost\ndbname: testdb\ndata_observability:\n  enabled: true\n")},
 	}
@@ -1225,7 +1295,7 @@ func TestBuildCheckConfig_PerQueryDBName(t *testing.T) {
 				Query:           "SELECT count(*) AS dd_value FROM shop.orders",
 				IntervalSeconds: 60,
 				TimeoutSeconds:  10,
-				Entity:          EntityMetadata{Platform: "postgres", Database: "testdb", Schema: "shop", Table: "orders"},
+				Entity:          EntityMetadata{Platform: defaultTestIntegration, Database: "testdb", Schema: "shop", Table: "orders"},
 			},
 			{
 				DBName:          "analyticsdb",
@@ -1234,12 +1304,12 @@ func TestBuildCheckConfig_PerQueryDBName(t *testing.T) {
 				Query:           "SELECT count(*) AS dd_value FROM events.clicks",
 				IntervalSeconds: 60,
 				TimeoutSeconds:  10,
-				Entity:          EntityMetadata{Platform: "postgres", Database: "analyticsdb", Schema: "events", Table: "clicks"},
+				Entity:          EntityMetadata{Platform: defaultTestIntegration, Database: "analyticsdb", Schema: "events", Table: "clicks"},
 			},
 		},
 	}
 
-	baseCfg := &integration.Config{Name: "postgres"}
+	baseCfg := &integration.Config{Name: defaultTestIntegration}
 	pgInstance := map[string]any{"host": "localhost", "dbname": "testdb", "data_observability": map[string]any{"enabled": true}}
 
 	checkCfg, err := c.buildCheckConfig(payload, baseCfg, pgInstance, "rc-multidb")
@@ -1268,7 +1338,7 @@ func TestBuildCheckConfig_PerQueryDBName(t *testing.T) {
 // the parse failure, not just "identifier not found".
 func TestOnRCUpdate_MalformedPostgresYAML_SurfacesParseError(t *testing.T) {
 	postgresCfg := integration.Config{
-		Name:      "postgres",
+		Name:      defaultTestIntegration,
 		Instances: []integration.Data{integration.Data("not: [valid: yaml")},
 	}
 	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
@@ -1297,7 +1367,7 @@ func TestOnRCUpdate_MalformedPostgresYAML_SurfacesParseError(t *testing.T) {
 // and no interval_seconds passes validation and flows through to the scheduled check.
 func TestValidateQuerySpec_ValidScheduleOnly(t *testing.T) {
 	postgresCfg := integration.Config{
-		Name:      "postgres",
+		Name:      defaultTestIntegration,
 		Provider:  "file",
 		NodeName:  "node1",
 		Instances: []integration.Data{integration.Data("host: localhost\ndata_observability:\n  enabled: true\n")},
@@ -1314,7 +1384,7 @@ func TestValidateQuerySpec_ValidScheduleOnly(t *testing.T) {
 				Query:          "SELECT count(*) FROM orders",
 				Schedule:       "20 * * * *",
 				TimeoutSeconds: 10,
-				Entity:         EntityMetadata{Platform: "postgres", Database: "shop", Table: "orders"},
+				Entity:         EntityMetadata{Platform: defaultTestIntegration, Database: "shop", Table: "orders"},
 			},
 		},
 	}
@@ -1347,7 +1417,7 @@ func TestValidateQuerySpec_ValidScheduleOnly(t *testing.T) {
 // interval_seconds are set, the config flows through (cron wins downstream in Python).
 func TestValidateQuerySpec_BothScheduleAndInterval(t *testing.T) {
 	postgresCfg := integration.Config{
-		Name:      "postgres",
+		Name:      defaultTestIntegration,
 		Provider:  "file",
 		Instances: []integration.Data{integration.Data("host: localhost\ndata_observability:\n  enabled: true\n")},
 	}
@@ -1364,7 +1434,7 @@ func TestValidateQuerySpec_BothScheduleAndInterval(t *testing.T) {
 				IntervalSeconds: 300,
 				Schedule:        "*/15 * * * *",
 				TimeoutSeconds:  10,
-				Entity:          EntityMetadata{Platform: "postgres", Database: "db", Table: "t"},
+				Entity:          EntityMetadata{Platform: defaultTestIntegration, Database: "db", Table: "t"},
 			},
 		},
 	}
@@ -1396,7 +1466,7 @@ func TestValidateQuerySpec_BothScheduleAndInterval(t *testing.T) {
 // a positive interval_seconds is rejected with ApplyStateError and no check is scheduled.
 func TestValidateQuerySpec_NeitherSetRejected(t *testing.T) {
 	postgresCfg := integration.Config{
-		Name:      "postgres",
+		Name:      defaultTestIntegration,
 		Instances: []integration.Data{integration.Data("host: localhost\ndata_observability:\n  enabled: true\n")},
 	}
 	c := newTestComponentWithAC(t, []integration.Config{postgresCfg})
@@ -1411,7 +1481,7 @@ func TestValidateQuerySpec_NeitherSetRejected(t *testing.T) {
 				Query:           "SELECT 1",
 				IntervalSeconds: 0, // zero — invalid when no schedule
 				TimeoutSeconds:  10,
-				Entity:          EntityMetadata{Platform: "postgres", Database: "db", Table: "t"},
+				Entity:          EntityMetadata{Platform: defaultTestIntegration, Database: "db", Table: "t"},
 			},
 		},
 	}
@@ -1444,7 +1514,7 @@ func TestValidateQuerySpec_InvalidCronRejected(t *testing.T) {
 				Query:          "SELECT 1",
 				Schedule:       "not-a-cron",
 				TimeoutSeconds: 10,
-				Entity:         EntityMetadata{Platform: "postgres", Database: "db", Table: "t"},
+				Entity:         EntityMetadata{Platform: defaultTestIntegration, Database: "db", Table: "t"},
 			},
 		},
 	}
@@ -1466,7 +1536,7 @@ func TestValidateQuerySpec_InvalidCronRejected(t *testing.T) {
 // does not inject a schedule field into the YAML.
 func TestValidateQuerySpec_ValidIntervalOnly(t *testing.T) {
 	postgresCfg := integration.Config{
-		Name:      "postgres",
+		Name:      defaultTestIntegration,
 		Provider:  "file",
 		Instances: []integration.Data{integration.Data("host: localhost\ndata_observability:\n  enabled: true\n")},
 	}
@@ -1482,7 +1552,7 @@ func TestValidateQuerySpec_ValidIntervalOnly(t *testing.T) {
 				Query:           "SELECT count(*) FROM orders",
 				IntervalSeconds: 60,
 				TimeoutSeconds:  10,
-				Entity:          EntityMetadata{Platform: "postgres", Database: "shop", Table: "orders"},
+				Entity:          EntityMetadata{Platform: defaultTestIntegration, Database: "shop", Table: "orders"},
 			},
 		},
 	}

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -67,6 +67,28 @@ func TestIsSupportedIntegration(t *testing.T) {
 	}
 }
 
+func TestIntegrationForConfigID(t *testing.T) {
+	testCases := []struct {
+		configID    string
+		integration string
+		matched     bool
+	}{
+		{configID: "do-0123456789abcdef", integration: "postgres", matched: true},
+		{configID: "do-mysql-0123456789abcdef", integration: "mysql", matched: true},
+		{configID: "do-mssql-0123456789abcdef", integration: "sqlserver", matched: true},
+		{configID: "do-hana-0123456789abcdef", integration: "sap_hana", matched: true},
+		{configID: "manual-config", matched: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.configID, func(t *testing.T) {
+			integrationName, ok := integrationForConfigID(testCase.configID)
+			assert.Equal(t, testCase.matched, ok)
+			assert.Equal(t, testCase.integration, integrationName)
+		})
+	}
+}
+
 func TestInstanceHasDOEnabled(t *testing.T) {
 	assert.False(t, instanceHasDOEnabled(map[string]any{}))
 	assert.False(t, instanceHasDOEnabled(map[string]any{"data_observability": "not-a-map"}))
@@ -918,13 +940,63 @@ func TestFindMatchingConfig_TemplatedIdentifiersDistinguishPorts(t *testing.T) {
 
 	for _, port := range []int{5432, 5433} {
 		t.Run(strconv.Itoa(port), func(t *testing.T) {
-			_, instance, _, err := c.findMatchingConfig(&DBIdentifier{
+			_, instance, _, err := c.findMatchingConfig("do-0123456789abcdef", &DBIdentifier{
 				Type:          "self-hosted",
 				Host:          fmt.Sprintf("do-test-postgres-staging:%d", port),
 				AgentHostname: "do-test-postgres-staging",
 			}, nil)
 			require.NoError(t, err)
 			assert.Equal(t, port, instance["port"])
+		})
+	}
+}
+
+func TestFindMatchingConfig_ConfigIDScopesIntegration(t *testing.T) {
+	const sharedHost = "shared-db.example.com"
+	configs := map[string]integration.Config{
+		"postgres": {
+			Name:      "postgres",
+			Instances: []integration.Data{integration.Data("host: " + sharedHost + "\ndata_observability:\n  enabled: true\n")},
+		},
+		"mysql": {
+			Name:      "mysql",
+			Instances: []integration.Data{integration.Data("host: " + sharedHost + "\ndata_observability:\n  enabled: true\n")},
+		},
+		"sqlserver": {
+			Name:      "sqlserver",
+			Instances: []integration.Data{integration.Data("host: " + sharedHost + "\ndata_observability:\n  enabled: true\n")},
+		},
+		"sap_hana": {
+			Name:      "sap_hana",
+			Instances: []integration.Data{integration.Data("server: " + sharedHost + "\ndata_observability:\n  enabled: true\n")},
+		},
+	}
+
+	for _, testCase := range []struct {
+		name                string
+		configID            string
+		expectedIntegration string
+		wrongIntegration    string
+	}{
+		{name: "postgres", configID: "do-0123456789abcdef", expectedIntegration: "postgres", wrongIntegration: "mysql"},
+		{name: "mysql", configID: "do-mysql-0123456789abcdef", expectedIntegration: "mysql", wrongIntegration: "postgres"},
+		{name: "mssql", configID: "do-mssql-0123456789abcdef", expectedIntegration: "sqlserver", wrongIntegration: "postgres"},
+		{name: "sap hana", configID: "do-hana-0123456789abcdef", expectedIntegration: "sap_hana", wrongIntegration: "postgres"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			c := newTestComponentWithAC(t, []integration.Config{
+				configs[testCase.wrongIntegration],
+				configs[testCase.expectedIntegration],
+			})
+
+			matchedConfig, _, _, err := c.findMatchingConfig(
+				testCase.configID,
+				&DBIdentifier{Type: "self-hosted", Host: sharedHost},
+				nil,
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedIntegration, matchedConfig.Name)
 		})
 	}
 }

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -111,21 +111,89 @@ func TestInstanceMatchesIdentifier_MySQL(t *testing.T) {
 		assert.True(t, instanceMatchesIdentifier(instance, identifier, "mysql"))
 	})
 
-	t.Run("database identifier uses MySQL default port", func(t *testing.T) {
-		instance := map[string]any{
-			"host": "localhost",
-			"database_identifier": map[string]any{
-				"template": "$resolved_hostname:$port",
+	testCases := []struct {
+		name     string
+		instance map[string]any
+		target   string
+	}{
+		{
+			name: "database identifier uses zero when port is absent",
+			instance: map[string]any{
+				"host": "localhost",
+				"database_identifier": map[string]any{
+					"template": "$resolved_hostname:$port",
+				},
 			},
-		}
-		identifier := DBIdentifier{
-			Type:          "self-hosted",
-			Host:          "do-test-mysql:3306",
-			AgentHostname: "do-test-mysql",
-		}
+			target: "do-test-mysql:0",
+		},
+		{
+			name: "socket database identifier still uses zero when port is absent",
+			instance: map[string]any{
+				"host": "localhost",
+				"sock": "/var/run/mysqld/mysqld.sock",
+				"database_identifier": map[string]any{
+					"template": "$resolved_hostname:$port",
+				},
+			},
+			target: "do-test-mysql:0",
+		},
+		{
+			name: "database identifier maps sock to mysql_sock",
+			instance: map[string]any{
+				"host": "localhost",
+				"sock": "/var/run/mysqld/mysqld.sock",
+				"database_identifier": map[string]any{
+					"template": "$resolved_hostname:$mysql_sock",
+				},
+			},
+			target: "do-test-mysql:/var/run/mysqld/mysqld.sock",
+		},
+		{
+			name: "database identifier uses explicit port",
+			instance: map[string]any{
+				"host": "localhost",
+				"port": 3307,
+				"database_identifier": map[string]any{
+					"template": "$resolved_hostname:$port",
+				},
+			},
+			target: "do-test-mysql:3307",
+		},
+	}
 
-		assert.True(t, instanceMatchesIdentifier(instance, identifier, "mysql"))
-		assert.False(t, instanceMatchesIdentifier(instance, identifier, defaultTestIntegration))
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			identifier := DBIdentifier{
+				Type:          "self-hosted",
+				Host:          testCase.target,
+				AgentHostname: "do-test-mysql",
+			}
+
+			match := evaluateInstanceIdentifier(testCase.instance, identifier, "mysql", nil)
+			require.True(t, match.matched)
+			assert.Equal(t, "database_identifier", match.strategy)
+			assert.Equal(t, testCase.target, match.renderedIdentifier)
+			assert.True(t, match.renderable)
+		})
+	}
+
+	t.Run("database identifier substitutes empty mysql_sock when sock is absent", func(t *testing.T) {
+		identifier, ok := renderMySQLDatabaseIdentifierWithLookup(
+			map[string]any{
+				"host": "localhost",
+				"database_identifier": map[string]any{
+					"template": "$mysql_sock",
+				},
+			},
+			"do-test-mysql",
+			func(string) ([]string, error) {
+				t.Fatal("local database hosts should not require a DNS lookup")
+				return nil, nil
+			},
+		)
+
+		require.True(t, ok)
+		assert.Empty(t, identifier)
 	})
 
 }
@@ -169,7 +237,10 @@ func TestMatchesIdentifier_DatabaseIdentifierTemplate(t *testing.T) {
 			Host:          "do-test-postgres-staging:5432",
 			AgentHostname: "do-test-postgres-staging",
 		}
-		assert.True(t, matchesIdentifier(instanceWithoutPort, dbID))
+		match := evaluateInstanceIdentifier(instanceWithoutPort, *dbID, "postgres", nil)
+		require.True(t, match.matched)
+		assert.Equal(t, "database_identifier", match.strategy)
+		assert.Equal(t, "do-test-postgres-staging:5432", match.renderedIdentifier)
 	})
 }
 
@@ -239,7 +310,8 @@ func TestRenderDatabaseIdentifier_UsesAgentHostnameForSameResolvedIPv4(t *testin
 		instance,
 		"agent.internal",
 		"$resolved_hostname",
-		defaultPostgresPort,
+		postgresPortFallback,
+		nil,
 		lookup,
 	)
 
@@ -252,7 +324,8 @@ func TestRenderDatabaseIdentifier_UsesDefaultPostgresTemplate(t *testing.T) {
 		map[string]any{"host": "localhost"},
 		"agent.internal",
 		"$resolved_hostname:$port",
-		defaultPostgresPort,
+		postgresPortFallback,
+		nil,
 		func(string) ([]string, error) {
 			t.Fatal("local database hosts should not require a DNS lookup")
 			return nil, nil

--- a/comp/dataobs/queryactions/impl/queryactions.go
+++ b/comp/dataobs/queryactions/impl/queryactions.go
@@ -156,7 +156,7 @@ func (c *component) Stream(ctx context.Context) <-chan integration.ConfigChanges
 		}()
 
 		// Check immediately: the file config provider runs before this one in LoadAndRun,
-		// so postgres is typically already available when Stream() is called.
+		// so a supported integration is typically already available when Stream() is called.
 		if c.hasSupportedIntegration() {
 			subscribeAndWait()
 			return

--- a/comp/dataobs/queryactions/impl/queryactions_test.go
+++ b/comp/dataobs/queryactions/impl/queryactions_test.go
@@ -86,9 +86,10 @@ func TestHasSupportedIntegration(t *testing.T) {
 		want            bool
 	}{
 		{name: "PostgreSQL", integrationName: "postgres", want: true},
+		{name: "MySQL", integrationName: "mysql", want: true},
 		{name: "SAP HANA", integrationName: "sap_hana", want: true},
 		{name: "SQL Server", integrationName: "sqlserver", want: true},
-		{name: "unsupported integration", integrationName: "mysql", want: false},
+		{name: "unsupported integration", integrationName: "redisdb", want: false},
 	}
 
 	for _, test := range tests {

--- a/comp/dataobs/queryactions/impl/types.go
+++ b/comp/dataobs/queryactions/impl/types.go
@@ -15,10 +15,10 @@ type DOQueryPayload struct {
 }
 
 // DBIdentifier identifies the integration host to target.
-// PostgreSQL compares Host with its rendered database identifier. SQL Server compares Host with
-// its configured endpoint, and Azure SQL Database additionally compares every query's DBName with
-// the top-level integration database. Type describes the producer's hosting kind and is
-// informational.
+// MySQL and PostgreSQL compare Host with their rendered database identifiers. SQL Server compares
+// Host with its configured endpoint, and Azure SQL Database additionally compares every query's
+// DBName with the top-level integration database. Type describes the producer's hosting kind and
+// is informational.
 type DBIdentifier struct {
 	Type          string `json:"type"`
 	Host          string `json:"host"`


### PR DESCRIPTION
Data Observability query actions now dispatch remote configuration payloads to MySQL checks as well as Postgres and SAP HANA. The component uses one supported-integration allowlist for startup detection and instance matching, so unrelated integrations cannot activate the subscription or receive query configs.

Closes https://linear.app/datadog/issue/DOIO-171