### PR TITLE
Remove flaky mark from test

### DIFF
--- a/comp/process/runner/impl/BUILD.bazel
+++ b/comp/process/runner/impl/BUILD.bazel
@@ -43,7 +43,6 @@ dd_agent_go_test(
         "//comp/process/submitter/mock",
         "//comp/process/types",
         "//pkg/util/fxutil",
-        "//pkg/util/testutil/flake",
         "@com_github_datadog_agent_payload_v5//process",
         "@com_github_stretchr_testify//assert",
         "@org_uber_go_fx//:fx",

--- a/comp/process/runner/impl/runner_test.go
+++ b/comp/process/runner/impl/runner_test.go
@@ -31,7 +31,6 @@ import (
 	submittermock "github.com/DataDog/datadog-agent/comp/process/submitter/mock"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 )
 
 func TestRunnerLifecycle(t *testing.T) {
@@ -39,8 +38,6 @@ func TestRunnerLifecycle(t *testing.T) {
 }
 
 func TestRunnerRealtime(t *testing.T) {
-	// https://datadoghq.atlassian.net/browse/CXP-2284
-	flake.Mark(t)
 
 	enableProcessAgent(t)
 

--- a/comp/process/runner/impl/runner_test.go
+++ b/comp/process/runner/impl/runner_test.go
@@ -38,7 +38,6 @@ func TestRunnerLifecycle(t *testing.T) {
 }
 
 func TestRunnerRealtime(t *testing.T) {
-
 	enableProcessAgent(t)
 
 	t.Run("rt allowed", func(t *testing.T) {


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Removes a flake marker from a no longer flaky test.

### Motivation

I came across this while evaluating the impact of dropping the "test washer" step when we switch to Bazel-run tests, which operates based on `flake.Mark`.

The referenced Jira card ([CXP-2284](https://datadoghq.atlassian.net/browse/CXP-2284)) and its duplicate ([CXP-3480](https://datadoghq.atlassian.net/browse/CXP-3480)) are marked as done, and CI visibility shows no failures since May 12 ([link](https://app.datadoghq.com/ci/ci-cd/explorer?query=test_level%3Atest%20%40git.branch%3Amain%20%40test.service%3Adatadog-agent%20%40test.suite%3A%2Acomp%2Fprocess%2Frunner%2Fimpl%20%40test.name%3ATestRunnerRealtime%2A%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_t=count&ci_cd_explorer_tab=tests&citest_explorer_sort=timestamp%2Cdesc&cols=%40test.status%2Ctimestamp%2C%40test.suite%3A259%2C%40ci.job.url%3A341%2C%40git.commit.sha%2C%40test.name%2C%40duration%2C%40ci.job.name%2C%40git.branch&currentTab=overview&eventStack=&fromUser=false&index=citest&refresh_mode=sliding&start=1778144605595&end=1786093405595&paused=false)).

### Describe how you validated your changes

### Additional Notes


[CXP-2284]: https://datadoghq.atlassian.net/browse/CXP-2284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CXP-3480]: https://datadoghq.atlassian.net/browse/CXP-3480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ