### PR TITLE
fix(kmt): stop provisioning microVMs for test sets with no CI job on that arch

### DIFF
--- a/tasks/kernel_matrix_testing/platforms.py
+++ b/tasks/kernel_matrix_testing/platforms.py
@@ -35,7 +35,8 @@ class KMTTestJob:
         self.kernels = kernels
 
 
-def filter_by_ci_component(platforms: Platforms, component: Component) -> dict[str, Platforms]:
+def get_ci_test_jobs(component: Component) -> list[KMTTestJob]:
+    """Return the KMT test jobs declared in the gitlab CI config for the given component."""
     job_arch_mapping: dict[KMTArchName, str] = {
         "x86_64": "x64",
         "arm64": "arm64",
@@ -60,7 +61,7 @@ def filter_by_ci_component(platforms: Platforms, component: Component) -> dict[s
     for arch in KMT_SUPPORTED_ARCHS:
         job_prefixes.append(f"kmt_run_{job_component_mapping[component]}_tests_{job_arch_mapping[arch]}")
 
-    test_jobs = []
+    test_jobs: list[KMTTestJob] = []
     for job in ci_config:
         for prefix in job_prefixes:
             if not job.startswith(prefix):
@@ -72,28 +73,36 @@ def filter_by_ci_component(platforms: Platforms, component: Component) -> dict[s
 
             test_jobs.append(KMTTestJob(job, Arch.from_str(arch).kmt_arch, sets, set(kernels)))
 
-    new_platforms_by_set = {}
+    return test_jobs
+
+
+def filter_by_ci_component(platforms: Platforms, component: Component) -> dict[str, Platforms]:
+    test_jobs = get_ci_test_jobs(component)
+
+    new_platforms_by_set: dict[str, Platforms] = {}
     for job in test_jobs:
+        # we need to index `new_platforms_by_set` by a literal to
+        # avoid mypy errors, which is why assign arch to `cur_arch`
+        cur_arch = None
+        for arch in KMT_SUPPORTED_ARCHS:
+            if job.arch == arch:
+                cur_arch = arch
+
+        if cur_arch is None:
+            raise Exit(f"Unsupported architecture {job.arch} detected for job {job.name}")
+
+        missing_kernels = job.kernels - set(platforms[cur_arch].keys())
+        if missing_kernels:
+            raise Exit(f"Kernels {missing_kernels} not found in {platforms_file} for {job.arch}")
+
         for s in job.test_set:
             if s not in new_platforms_by_set:
-                new_platforms_by_set[s] = platforms.copy()
+                # Every architecture starts empty: a test set only gets microVMs on the
+                # architectures that actually have a CI job running it. Seeding with the
+                # full platform list would provision VMs for architectures with no job
+                # (e.g. `cws_req`, which only runs on x86_64) that nothing ever uses.
+                new_platforms_by_set[s] = cast("Platforms", {**platforms, **{arch: {} for arch in KMT_SUPPORTED_ARCHS}})
 
-            # we need to index `new_platforms_by_set` by a literal to
-            # avoid mypy errors, which is why assign arch to `cur_arch`
-            cur_arch = None
-            for arch in KMT_SUPPORTED_ARCHS:
-                if job.arch == arch:
-                    cur_arch = arch
-
-            if cur_arch is None:
-                raise Exit(f"Unsupported architecture {job.arch} detected for job {job.name}")
-
-            new_platforms_by_set[s][cur_arch] = {
-                k: v for k, v in new_platforms_by_set[s][cur_arch].items() if k in job.kernels
-            }
-
-            missing_kernels = job.kernels - set(new_platforms_by_set[s][cur_arch].keys())
-            if missing_kernels:
-                raise Exit(f"Kernels {missing_kernels} not found in {platforms_file} for {job.arch}")
+            new_platforms_by_set[s][cur_arch].update({k: v for k, v in platforms[cur_arch].items() if k in job.kernels})
 
     return new_platforms_by_set

--- a/tasks/unit_tests/kmt_tests.py
+++ b/tasks/unit_tests/kmt_tests.py
@@ -2,9 +2,11 @@ import unittest
 from typing import TYPE_CHECKING, cast
 
 from tasks.kernel_matrix_testing import platforms, vmconfig
+from tasks.kernel_matrix_testing.vars import KMT_SUPPORTED_ARCHS
 from tasks.libs.types.arch import Arch
 
 if TYPE_CHECKING:
+    from tasks.kernel_matrix_testing.types import Component
     from tasks.libs.types.arch import KMTArchName
 
 
@@ -45,3 +47,46 @@ class TestVmconfig(unittest.TestCase):
 
         for input, expected in cases:
             self.assertEqual(vmconfig.normalize_vm_def(possible, input), expected)
+
+
+class TestFilterByCIComponent(unittest.TestCase):
+    """The generated vmconfig decides which microVMs get booted on the metal instances.
+
+    Any (test set, architecture) pair that has no CI job would boot VMs nothing ever
+    connects to, while still eating vCPU and memory on a heavily oversubscribed box.
+    """
+
+    components: "list[Component]" = ["security-agent", "system-probe"]
+
+    def test_no_microvms_without_a_matching_ci_job(self):
+        plats = platforms.get_platforms()
+
+        for component in self.components:
+            expected: dict[tuple[str, str], set[str]] = {}
+            for job in platforms.get_ci_test_jobs(component):
+                for test_set in job.test_set:
+                    expected.setdefault((test_set, job.arch), set()).update(job.kernels)
+
+            by_set = platforms.filter_by_ci_component(plats, component)
+            for test_set, plat in by_set.items():
+                for arch in KMT_SUPPORTED_ARCHS:
+                    self.assertEqual(
+                        set(plat[arch].keys()),
+                        expected.get((test_set, arch), set()),
+                        f"{component}: vmset {test_set} on {arch} does not match the kernels "
+                        "of the CI jobs running that test set",
+                    )
+
+    def test_every_ci_job_gets_its_microvms(self):
+        plats = platforms.get_platforms()
+
+        for component in self.components:
+            by_set = platforms.filter_by_ci_component(plats, component)
+            for job in platforms.get_ci_test_jobs(component):
+                for test_set in job.test_set:
+                    self.assertIn(test_set, by_set, f"{component}: job {job.name} has no vmset")
+                    self.assertTrue(
+                        job.kernels.issubset(by_set[test_set][job.arch].keys()),
+                        f"{component}: job {job.name} is missing microVMs for "
+                        f"{job.kernels - set(by_set[test_set][job.arch].keys())}",
+                    )


### PR DESCRIPTION
### What does this PR do?

Stops the KMT CI vmconfig generator from provisioning microVMs for `(test set, architecture)`
pairs that have no CI job.

`filter_by_ci_component` seeded each test set with a full copy of `platforms.json`
(every distro on every architecture) and then narrowed it down per job. An architecture
with no job for a given test set was never narrowed, so it kept the complete distro list.
The new code starts every architecture empty and only adds the kernels that a real CI job
asks for.

### Motivation

The `cws_req` test set only runs on x86_64, but the generated arm64 vmconfig still contained
a `cws_req` vmset with all 30 arm64 distros.

### Describe how you validated your changes

The generated vmconfig is a pure function of `platforms.json` and the job list in
`.gitlab/test/kernel_matrix_testing/*.yml`, so the change can be measured exactly by
generating the config before and after:

```bash
for c in system-probe security-agent; do for a in x86_64 arm64; do
  dda inv -- -e kmt.gen-config --ci --arch=$a --output-file=/tmp/new-$c-$a.json \
    --vmconfig-template=$c --memory=12288
done; done
# repeat with the previous revision of tasks/kernel_matrix_testing/platforms.py into /tmp/old-*.json
```

microVM counts (kernels × vcpu × memory combinations), before → after:

| component / arch      | before | after | delta |
|-----------------------|-------:|------:|------:|
| system-probe / x86_64 |     42 |    42 |     0 |
| system-probe / arm64  |     36 |    36 |     0 |
| security-agent / x86_64 |   76 |    76 |     0 |
| security-agent / arm64  |   86 |    56 |   −30 |

```
### Additional Notes
