### PR TITLE
Key `bazel_cache` on adjusted `MODULE.bazel.lock`

### DIFF
--- a/.github/actions/bazel-cache/action.yml
+++ b/.github/actions/bazel-cache/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Pull or push Bazel-managed repository cache(s)
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        key: bazel-${{ hashFiles('.go-version', '.python-version') }}
+        key: bazel-${{ hashFiles('MODULE.bazel.lock') }}
         path: |
           .cache/bazel/*/cache
           .cache/go

--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -24,7 +24,7 @@
       # - fix: https://github.com/microsoft/go/pull/1998
       key:
         prefix: bazel-$CI_JOB_NAME
-        files: [ .go-version, .python-version ]
+        files: [ MODULE.bazel.lock ]
       paths:
         - .cache/bazel/*/cache
         - .cache/go

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -295,19 +295,6 @@
         }
       }
     },
-    "//bazel/tools:bazelisk_check.bzl%bazelisk_check": {
-      "general": {
-        "bzlTransitiveDigest": "vIQYQXzy/Q+owB/yz0XcUOwOyn9G0aQIpTxYlBfiCcQ=",
-        "usagesDigest": "CKsn1dtme4oztWA0td45Tt6oCZK6MZnpIocVVZK14sU=",
-        "recordedInputs": [
-          "FILE:@@//.bazelversion 1b9487d55bea47fea50d226cc9c53bc548877ad2a318bac8fbc8b320f429e5c5",
-          "FILE:@@//tools/bazel f5a8a2f4756b38cd2967fa1b609c85628e3222fae35b2eae1ae4a2525d1c40c6",
-          "FILE:@@//tools/bazel.bat 19e3adf0b4c589672602f0a74f65db364d081ca9a0f2b34e32b2e45449d25ddd",
-          "FILE:@@//tools/bazelisk.md 184864dc41f9cd398f786ba7c7cd858942d19daa792203e0b18a1a3bfaf372f0"
-        ],
-        "generatedRepoSpecs": {}
-      }
-    },
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "general": {
         "bzlTransitiveDigest": "dnnhvKMf9MIXMulhbhHBblZdDAfAkiSVjApIXpUz9Y8=",

--- a/bazel/tools/bazelisk_check.bzl
+++ b/bazel/tools/bazelisk_check.bzl
@@ -26,4 +26,6 @@ def _impl(mctx):
             mctx.read(file_to_path["tools/bazelisk.md"]),
         ))
 
+    return mctx.extension_metadata(reproducible = True)
+
 bazelisk_check = module_extension(implementation = _impl)


### PR DESCRIPTION
### What does this PR do?
Key the `bazel_cache` cache entry on `MODULE.bazel.lock` instead of `.go-version` and `.python-version`, and mark the `bazelisk_check` module extension as `reproducible` so it stops contributing the lockfile.

### Motivation
Investigating why `bazel:test:linux-amd64`'s cache-restore step takes ~140s showed the downloaded `bazel_cache` is 3.8G, dominated by Bazel's repository cache.

Multiple historical versions of the same toolchain coexisted there simultaneously, e.g. 5 `rustc` versions, because the cache key barely ever changes: `.go-version` and `.python-version` are edited far less often than actual dependency pins, so a version bump never rotates the cache key, and the old, now-unreferenced blobs keep getting pulled and pushed forever alongside the new ones.

`MODULE.bazel.lock` changes on every pin bump, so keying on it instead gives each dependency change a fresh cache scope, letting superseded blobs simply age out instead of accumulating.

For that to happen, `bazelisk_check` needed fixing first: it indeed unconditionally watches orthogonal changes in auxiliary files among which `tools/bazel[.bat]` scripts, so their content ends up hashed into `MODULE.bazel.lock` even though _none of them are dependency pins_.

### Describe how you validated your changes
The extension's own checks still run: temporarily removing `tools/bazel` or corrupting `.bazelversion` still fails as expected, so `reproducible = True` only affects lockfile bookkeeping, not the validation logic.

### Additional Notes
The first pipeline after this lands will see a cold `bazel_cache` for the new key and pay a full rebuild once.
Every dependency bump after that only pays for what actually changed, instead of dragging every prior version of every toolchain forward for nothing.