### PR TITLE
Split macOS-only corechecks into MACOS_CORECHECKS

### DIFF
--- a/.cursor/rules/agent_corecheck.mdc
+++ b/.cursor/rules/agent_corecheck.mdc
@@ -271,7 +271,7 @@ Notes:
 
 ### 2. Register in build system
 
-Add your check name to `tasks/agent.py` in the `AGENT_CORECHECKS` list:
+Add your check name to `tasks/core_checks.py` in the `AGENT_CORECHECKS` list:
 
 ```python
 AGENT_CORECHECKS = [
@@ -284,6 +284,18 @@ AGENT_CORECHECKS = [
 ```
 
 This ensures the configuration files are copied to `cmd/agent/dist/conf.d/` during the build process. Without this step, your configuration template won't be included in the agent package.
+
+`AGENT_CORECHECKS` is for checks that ship on every platform. If your check only
+works on some platforms, use the matching list instead — `MACOS_CORECHECKS`,
+`WINDOWS_CORECHECKS`, `AIX_CORECHECKS` — and add it to each list it applies to
+(a check that works on both macOS and Windows belongs in both). `IOT_AGENT_CORECHECKS`
+covers the IoT flavor. Shipping a config on a platform where the check cannot
+collect only schedules a check that always fails.
+
+`tasks/core_checks.py` and `cmd/agent/dist/core_checks.bzl` must be **byte-identical**
+— the Python copy drives `dda inv agent.build`, the Starlark copy drives Bazel
+packaging. The `//cmd/agent/dist:core_checks_list_sync_test` diff test enforces this,
+so edit both.
 
 ---
 
@@ -302,7 +314,9 @@ Provide a `stub.go` with a `Factory()` returning `option.None[...]()` and a warn
 ## Ensuring the Check Runs
 
 1. Add the config template in `cmd/agent/dist/conf.d/<checkname>.d/conf.yaml.example` (or `.default` for Autodiscovery).
-2. Add check name to `AGENT_CORECHECKS` list in `tasks/agent.py`.
+2. Add check name to `AGENT_CORECHECKS` list in `tasks/core_checks.py` (and mirror the
+   edit into `cmd/agent/dist/core_checks.bzl`). For a platform-specific check use
+   `MACOS_CORECHECKS` / `WINDOWS_CORECHECKS` / `AIX_CORECHECKS` instead.
 3. Confirm registration is in a file that compiles in your agent flavor/build tags.
 4. Build the Agent:
 
@@ -680,7 +694,9 @@ import (
 
 - [ ] `pkg/collector/corechecks/<checkname>/<checkname>.go` with `Check`, `Factory`, `Configure`, `Run`
 - [ ] Registration via `corecheckLoader.RegisterCheck(...)` in `pkg/commonchecks/corechecks.go`
-- [ ] Add check name to `AGENT_CORECHECKS` list in `tasks/agent.py`
+- [ ] Add check name to the right list in `tasks/core_checks.py` (`AGENT_CORECHECKS` for
+      all-platform checks, else `MACOS_CORECHECKS` / `WINDOWS_CORECHECKS` / `AIX_CORECHECKS`)
+      and mirror the identical edit into `cmd/agent/dist/core_checks.bzl`
 - [ ] `cmd/agent/dist/conf.d/<checkname>.d/conf.yaml.example` (or `.default` for Autodiscovery)
 - [ ] Optional: platform build tags and stubs
 - [ ] Unit tests for `Run()` and `Configure`

--- a/cmd/agent/dist/conf.d/BUILD.bazel
+++ b/cmd/agent/dist/conf.d/BUILD.bazel
@@ -1,7 +1,7 @@
 """core checks and some configuration files"""
 
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "strip_prefix")
-load("//cmd/agent/dist:core_checks.bzl", "AGENT_CORECHECKS", "IOT_AGENT_CORECHECKS", "WINDOWS_CORECHECKS")
+load("//cmd/agent/dist:core_checks.bzl", "AGENT_CORECHECKS", "IOT_AGENT_CORECHECKS", "MACOS_CORECHECKS", "WINDOWS_CORECHECKS")
 load("//packages/agent:defs.bzl", "CONF_DIR_SELECTOR")
 
 pkg_files(
@@ -54,6 +54,17 @@ pkg_files(
     strip_prefix = strip_prefix.from_pkg(),
 )
 
+# Additional macos checks. You also need the code checks.
+pkg_files(
+    name = "macos_checks_files",
+    srcs = glob(
+        ["%s.d/**" % check for check in MACOS_CORECHECKS],
+        exclude = ["BUILD.bazel"],
+    ),
+    attributes = pkg_attributes(mode = "0644"),
+    strip_prefix = strip_prefix.from_pkg(),
+)
+
 pkg_filegroup(
     name = "all_files",
     srcs = select({
@@ -63,7 +74,7 @@ pkg_filegroup(
             ":base_checks_files",
         ],
     }) + select({
-        "@platforms//os:macos": [":macos_files"],
+        "@platforms//os:macos": [":macos_files", ":macos_checks_files"],
         "@platforms//os:windows": [":windows_checks_files"],
         "//conditions:default": [],
     }),

--- a/cmd/agent/dist/conf.d/BUILD.bazel
+++ b/cmd/agent/dist/conf.d/BUILD.bazel
@@ -74,7 +74,10 @@ pkg_filegroup(
             ":base_checks_files",
         ],
     }) + select({
-        "@platforms//os:macos": [":macos_files", ":macos_checks_files"],
+        "@platforms//os:macos": [
+            ":macos_checks_files",
+            ":macos_files",
+        ],
         "@platforms//os:windows": [":windows_checks_files"],
         "//conditions:default": [],
     }),

--- a/cmd/agent/dist/core_checks.bzl
+++ b/cmd/agent/dist/core_checks.bzl
@@ -36,11 +36,9 @@ AGENT_CORECHECKS = [
     "network_path",
     "gpu",
     "nccl",
-    "wlan",
     "discovery",
     "versa",
     "network_config_management",
-    "battery",
     "cloud_hostinfo",
 ]
 
@@ -72,6 +70,11 @@ WINDOWS_CORECHECKS = [
     "windows_certificate",
     "winproc",
     "win32_event_log",
+]
+
+MACOS_CORECHECKS = [
+    "battery",
+    "wlan",
 ]
 
 IOT_AGENT_CORECHECKS = [

--- a/cmd/agent/dist/core_checks.bzl
+++ b/cmd/agent/dist/core_checks.bzl
@@ -62,6 +62,7 @@ AIX_CORECHECKS = [
 
 WINDOWS_CORECHECKS = [
     "agentcrashdetect",
+    "battery",
     "sbom",
     "thermal",
     "windows_registry",
@@ -70,6 +71,7 @@ WINDOWS_CORECHECKS = [
     "windows_certificate",
     "winproc",
     "win32_event_log",
+    "wlan",
 ]
 
 MACOS_CORECHECKS = [

--- a/releasenotes/notes/macos-only-corechecks-3f7c1a2e9b4d5068.yaml
+++ b/releasenotes/notes/macos-only-corechecks-3f7c1a2e9b4d5068.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    The ``battery`` and ``wlan`` check configurations are no longer shipped in the
+    Linux and AIX packages. Both checks can only collect on macOS and Windows, so
+    on other platforms their configuration only mattered when
+    ``infrastructure_mode`` was set to ``end_user_device``, where it scheduled a
+    check that could never report data. macOS and Windows packages are unchanged.

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -262,7 +262,17 @@ def refresh_assets(_, build_tags, development=True, flavor=AgentFlavor.base.name
                 dirs_exist_ok=True,
             )
 
+    # add additional macos-only corechecks, only on macos. Otherwise the check loader
+    # on linux will throw an error because the module is not found, but the config is.
     if sys.platform == 'darwin':
+        for check in core_checks.MACOS_CORECHECKS:
+            check_dir = os.path.join(dist_folder, f"conf.d/{check}.d/")
+            shutil.copytree(
+                f"./cmd/agent/dist/conf.d/{check}.d/",
+                check_dir,
+                ignore=shutil.ignore_patterns("BUILD.bazel"),
+                dirs_exist_ok=True,
+            )
         shutil.copy("./cmd/agent/dist/conf.d/apm.yaml.default", os.path.join(dist_folder, "conf.d/apm.yaml.default"))
         shutil.copy(
             "./cmd/agent/dist/conf.d/process_agent.yaml.default",

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -262,8 +262,7 @@ def refresh_assets(_, build_tags, development=True, flavor=AgentFlavor.base.name
                 dirs_exist_ok=True,
             )
 
-    # add additional macos-only corechecks, only on macos. Otherwise the check loader
-    # on linux will throw an error because the module is not found, but the config is.
+    # add additional macos-only corechecks, only on macos
     if sys.platform == 'darwin':
         for check in core_checks.MACOS_CORECHECKS:
             check_dir = os.path.join(dist_folder, f"conf.d/{check}.d/")
@@ -273,6 +272,8 @@ def refresh_assets(_, build_tags, development=True, flavor=AgentFlavor.base.name
                 ignore=shutil.ignore_patterns("BUILD.bazel"),
                 dirs_exist_ok=True,
             )
+            # Ensure the config folders are not world writable
+            os.chmod(check_dir, mode=0o755)
         shutil.copy("./cmd/agent/dist/conf.d/apm.yaml.default", os.path.join(dist_folder, "conf.d/apm.yaml.default"))
         shutil.copy(
             "./cmd/agent/dist/conf.d/process_agent.yaml.default",

--- a/tasks/core_checks.py
+++ b/tasks/core_checks.py
@@ -36,11 +36,9 @@ AGENT_CORECHECKS = [
     "network_path",
     "gpu",
     "nccl",
-    "wlan",
     "discovery",
     "versa",
     "network_config_management",
-    "battery",
     "cloud_hostinfo",
 ]
 
@@ -72,6 +70,11 @@ WINDOWS_CORECHECKS = [
     "windows_certificate",
     "winproc",
     "win32_event_log",
+]
+
+MACOS_CORECHECKS = [
+    "battery",
+    "wlan",
 ]
 
 IOT_AGENT_CORECHECKS = [

--- a/tasks/core_checks.py
+++ b/tasks/core_checks.py
@@ -62,6 +62,7 @@ AIX_CORECHECKS = [
 
 WINDOWS_CORECHECKS = [
     "agentcrashdetect",
+    "battery",
     "sbom",
     "thermal",
     "windows_registry",
@@ -70,6 +71,7 @@ WINDOWS_CORECHECKS = [
     "windows_certificate",
     "winproc",
     "win32_event_log",
+    "wlan",
 ]
 
 MACOS_CORECHECKS = [


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Adds a new `MACOS_CORECHECKS` list to `tasks/core_checks.py` (and its byte-identical mirror `cmd/agent/dist/core_checks.bzl`), moves `battery` and `wlan` out of `AGENT_CORECHECKS` into it, and adds both to `WINDOWS_CORECHECKS`.

Wires the new list up the same way `WINDOWS_CORECHECKS` already is:
- `tasks/agent.py`: `refresh_assets` gets a `sys.platform == 'darwin'` copy loop that installs each `MACOS_CORECHECKS` check's `conf.d` directory, alongside the existing Windows-only loop.
- `cmd/agent/dist/conf.d/BUILD.bazel`: adds a `macos_checks_files` `pkg_files` target (globbing over `MACOS_CORECHECKS`), merged into the existing `@platforms//os:macos` select branch next to `:macos_files`.

### Motivation

`AGENT_CORECHECKS` is meant for checks available on every platform, but `battery` and `wlan` only collect on macOS and Windows — `pkg/collector/corechecks/system/battery/battery_nix.go` and `pkg/collector/corechecks/net/wlan/wlan_nix.go` are both built with `//go:build !darwin && !windows` and return an error ("battery/wifi info only supported on macOS and Windows") everywhere else.

Both configs are Autodiscovery templates (`ad_identifiers: [_end_user_device]`), so on Linux and AIX they were dead files in the package on a default install, and under `infrastructure_mode: end_user_device` they scheduled a check that could never collect. Giving macOS-only checks their own list, mirroring the existing `WINDOWS_CORECHECKS` pattern, keeps `AGENT_CORECHECKS` accurate and makes the per-platform packaging explicit.

### Why `WINDOWS_CORECHECKS` also changes

`AGENT_CORECHECKS` feeds the `base_checks_files` target, which is included on *every* platform via the `//conditions:default` branch of the `select` in `cmd/agent/dist/conf.d/BUILD.bazel`. Removing `battery`/`wlan` from it would therefore have dropped both configs from the **Windows** package too, which would break `TestEUDMWindowsSuite` (`test/new-e2e/tests/agent-runtimes/infra_eudm_win_test.go`) — it asserts the `wlan` check is scheduled and runs in `end_user_device` mode. Adding both names to `WINDOWS_CORECHECKS` keeps the Windows package byte-identical to before this PR.

### Describe how you validated your changes

- Built the agent natively on macOS/arm64 with `dda inv agent.build` and confirmed `bin/agent/dist/conf.d/` contains `battery.d/` and `wlan.d/`, verifying the new darwin-only copy path in `tasks/agent.py`.
- `bazel run //bazel/buildifier` and `bazel run //:gazelle` are clean.
- `//cmd/agent/dist:core_checks_list_sync_test` passes (the `.py` and `.bzl` copies are identical).
- Verified per-platform package contents:

  ```
  bazel cquery --platforms=@platforms//os:linux   'deps(//cmd/agent/dist/conf.d:all_files)' | grep -E 'battery|wlan'  # expect empty
  bazel cquery --platforms=@platforms//os:macos   'deps(//cmd/agent/dist/conf.d:all_files)' | grep -E 'battery|wlan'  # expect present
  bazel cquery --platforms=@platforms//os:windows 'deps(//cmd/agent/dist/conf.d:all_files)' | grep -E 'battery|wlan'  # expect present
  ```

- Manually installed the agent on macOS/arm64 from a real CI pipeline build artifact (via the pipeline's `install_mac_os.sh` install script, fetched over a short-lived presigned S3 URL) and confirmed `battery.d/` and `wlan.d/` are present under the installed agent's `conf.d/`, alongside the standard cross-platform checks (e.g. `cpu.d/`, `memory.d/`) — validating the new macOS packaging end-to-end on a real installed build, not just the local dev build.

### Additional Notes

`battery` and `wlan` work on both macOS and Windows, so they are listed in `MACOS_CORECHECKS` *and* `WINDOWS_CORECHECKS`. A check belongs in every platform list that can actually collect it.

Labelled `qa/rc-required`: this changes package contents, and per-platform package contents are not verified by PR-branch CI.

