### PR TITLE
fix(privileged-logs): use O_PATH for directory traversal in openPathWithoutSymlinks

### DIFF
--- a/pkg/privileged-logs/module/open.go
+++ b/pkg/privileged-logs/module/open.go
@@ -33,7 +33,14 @@ func openPathWithoutSymlinks(path string) (*os.File, error) {
 	// Split path into components
 	parts := strings.Split(filepath.Clean(path), string(filepath.Separator))
 
-	dirFd, err := unix.Open("/", unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_DIRECTORY, 0)
+	// Directory components are opened with O_PATH rather than O_RDONLY.
+	// O_PATH only requires search (execute) permission to traverse into a
+	// directory, matching the permission check that a plain os.Open(path)
+	// performs on the same directories. O_RDONLY additionally requires read
+	// (list) permission on every directory component, which would wrongly
+	// reject files under directories that are traversable but not listable
+	// (e.g. mode 0711).
+	dirFd, err := unix.Open("/", unix.O_PATH|unix.O_NOFOLLOW|unix.O_DIRECTORY, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open root directory: %w", err)
 	}
@@ -50,7 +57,7 @@ func openPathWithoutSymlinks(path string) (*os.File, error) {
 			continue
 		}
 
-		newFd, err := unix.Openat(dirFd, parts[i], unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_DIRECTORY, 0)
+		newFd, err := unix.Openat(dirFd, parts[i], unix.O_PATH|unix.O_NOFOLLOW|unix.O_DIRECTORY, 0)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open directory component %s: %w", parts[i], err)
 		}
@@ -60,7 +67,9 @@ func openPathWithoutSymlinks(path string) (*os.File, error) {
 		dirFd = newFd
 	}
 
-	// Open the final file component with O_NOFOLLOW
+	// Open the final file component with O_NOFOLLOW. dirFd was opened with
+	// O_PATH, but it can still be used as the directory fd for this openat,
+	// which enforces the normal read-permission check on the file itself.
 	fileName := parts[len(parts)-1]
 	fileFd, err := unix.Openat(dirFd, fileName, unix.O_RDONLY|unix.O_NOFOLLOW, 0)
 	if err != nil {

--- a/pkg/privileged-logs/module/open_test.go
+++ b/pkg/privileged-logs/module/open_test.go
@@ -16,14 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// isRootUser reports whether the test is running with an effective UID of 0.
-// Root bypasses directory read/search permission checks entirely (via
-// CAP_DAC_OVERRIDE), so tests relying on those checks being enforced must
-// skip rather than pass vacuously.
-func isRootUser() bool {
-	return os.Geteuid() == 0
-}
-
 // openPathWithoutSymlinksAndCheckFDs wraps openPathWithoutSymlinks and verifies
 // that no file descriptors are leaked. For success cases, it checks that exactly
 // one FD is opened. For error cases, it checks that no FDs are leaked.
@@ -109,7 +101,7 @@ func TestOpenPathWithoutSymlinks(t *testing.T) {
 		// Root bypasses the directory read-permission check below via
 		// CAP_DAC_OVERRIDE, so this test would pass vacuously without
 		// actually exercising the permission check.
-		if isRootUser() {
+		if os.Geteuid() == 0 {
 			t.Skip("test requires a non-root effective UID")
 		}
 

--- a/pkg/privileged-logs/module/open_test.go
+++ b/pkg/privileged-logs/module/open_test.go
@@ -16,6 +16,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// isRootUser reports whether the test is running with an effective UID of 0.
+// Root bypasses directory read/search permission checks entirely (via
+// CAP_DAC_OVERRIDE), so tests relying on those checks being enforced must
+// skip rather than pass vacuously.
+func isRootUser() bool {
+	return os.Geteuid() == 0
+}
+
 // openPathWithoutSymlinksAndCheckFDs wraps openPathWithoutSymlinks and verifies
 // that no file descriptors are leaked. For success cases, it checks that exactly
 // one FD is opened. For error cases, it checks that no FDs are leaked.
@@ -95,6 +103,32 @@ func TestOpenPathWithoutSymlinks(t *testing.T) {
 		fi, err := file.Stat()
 		require.NoError(t, err)
 		assert.True(t, fi.IsDir())
+	})
+
+	t.Run("success - directory component not readable but searchable", func(t *testing.T) {
+		// Root bypasses the directory read-permission check below via
+		// CAP_DAC_OVERRIDE, so this test would pass vacuously without
+		// actually exercising the permission check.
+		if isRootUser() {
+			t.Skip("test requires a non-root effective UID")
+		}
+
+		execOnlyDir := filepath.Join(testDir, "execonly")
+		require.NoError(t, os.Mkdir(execOnlyDir, 0755))
+
+		logFile := filepath.Join(execOnlyDir, "execonly.log")
+		require.NoError(t, os.WriteFile(logFile, []byte("test content"), 0644))
+
+		// Search (execute) permission only: no read bit for owner, group, or
+		// other. A plain os.Open(logFile) succeeds against this mode, since
+		// it only needs to traverse (not list) execOnlyDir.
+		require.NoError(t, os.Chmod(execOnlyDir, 0111))
+		defer os.Chmod(execOnlyDir, 0755) //nolint:errcheck // best-effort cleanup so t.TempDir() can remove it
+
+		file, err := openPathWithoutSymlinksAndCheckFDs(t, logFile)
+		require.NoError(t, err)
+		require.NotNil(t, file)
+		defer file.Close()
 	})
 
 	t.Run("error - relative path", func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Relaxes an overly strict directory permission check in
`openPathWithoutSymlinks` (the O_NOFOLLOW directory-walk helper used by the
privileged-logs module): directory components were opened with
`O_RDONLY|O_NOFOLLOW|O_DIRECTORY`, which requires *read* permission on every
directory component. That's stricter than the *search* (execute) permission a
plain `os.Open(path)` needs, and would incorrectly reject files sitting under
directories that are traversable but not readable (e.g. mode `0711`). Switched
to `O_PATH` for directory-component opens, which only requires search
permission, matching `os.Open`'s semantics. The final file-component open is
unchanged (`O_RDONLY|O_NOFOLLOW`), since we still need to actually read the
file.

Note that all [supported platforms](https://docs.datadoghq.com/agent/supported_platforms/?tab=linux) use a kernel version which supports `O_PATH` (2.6.39+).

### Motivation

Preparation for using this code from the core agent, which doesn't run as root.

**No practical effect on current production behavior.** The only caller of
`openPathWithoutSymlinks` today is `validateAndOpen`/`validateAndOpenWithPrefix`
in `pkg/privileged-logs/module/validate.go`, invoked from `openFileHandler`,
which backs the `privilegedLogsModule` wired in only from
`cmd/system-probe/modules/privileged_logs_linux.go` — i.e. it only ever runs
inside root-owned `system-probe`. Root has `CAP_DAC_OVERRIDE`, which bypasses
directory read-permission checks entirely, so this overly strict check has no
effect in production today. It becomes load-bearing once an unprivileged
caller uses this helper.

### Describe how you validated your changes

Unit tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

