### PR TITLE
Fix Windows choco CI S3 credentials

### DIFF
--- a/.gitlab/windows/deploy/choco_build/windows.yml
+++ b/.gitlab/windows/deploy/choco_build/windows.yml
@@ -18,6 +18,7 @@
       -v "$(Get-Location):c:\mnt"
       -e CI
       -e GITLAB_CI
+      -e CI_IDENTITIES_GITLAB_ID_TOKEN
       -e DDA_FEATURE_FLAGS_CI_SSM_KEY_WINDOWS="${DDA_FEATURE_FLAGS_CI_SSM_KEY_WINDOWS}"
       -e CI_PROJECT_NAME
       -e CI_PIPELINE_ID

--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -42,8 +42,14 @@ Param(
     [bool] $InstallDeps = $true
 )
 
+. "$PSScriptRoot\common.ps1"
+
 $ErrorActionPreference = 'Stop';
 Set-Location c:\mnt
+
+if ($env:CI) {
+    Initialize-CIIdentity
+}
 
 if ($InstallDeps) {
     # Install chocolatey


### PR DESCRIPTION
<!-- dd-meta {"pullId":"e6f0613b-ce69-4bd6-8fed-5f9eedeee71a","source":"chat","resourceId":"aeeb378f-31f0-41d3-aed5-cc6ab1e848f9","workflowId":"e575ec32-1471-4157-95ad-80820479b011","codeChangeId":"e575ec32-1471-4157-95ad-80820479b011","sourceType":"assistant"} -->
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

- Pass `CI_IDENTITIES_GITLAB_ID_TOKEN` into the Windows choco build container.
- Source `tasks/winbuildscripts/common.ps1` in `Generate-Chocolatey-Package.ps1` and call `Initialize-CIIdentity` in CI before resolving the Agent version.

### Motivation

The `windows_choco_7_x64` and `windows_choco_7_x64-fips` jobs call `dda inv -- agent.version --url-safe`, which downloads `agent-version.cache` from `dd-ci-artefacts-build-stable`. After legacy S3 permissions were removed from Windows runner IAM roles, the choco container needs to assume the CI identity role to avoid 403 Forbidden from S3.

### Describe how you validated your changes

- Ran `git diff --check`.
- Parsed `.gitlab/windows/deploy/choco_build/windows.yml` with Ruby Psych.
- Confirmed `Initialize-CIIdentity` appears before `dda inv -- agent.version --url-safe`.

### Additional Notes

PowerShell is not installed in this Linux sandbox, so I could not run a PowerShell parser or the Windows choco CI job locally.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/aeeb378f-31f0-41d3-aed5-cc6ab1e848f9)

Comment @datadog to request changes