### PR TITLE
Remove obsolete v3 sampling overrides

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -197,7 +197,6 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 	// The otel-agent forces zlib compression, which is incompatible with the v3
 	// metrics intake.
 	pkgconfig.Set("use_v3_api.series.enabled", "false", pkgconfigmodel.SourceAgentRuntime)
-	pkgconfig.Set("serializer_experimental_use_v3_api.series.shadow_sample_rate", float64(0), pkgconfigmodel.SourceAgentRuntime)
 
 	// Log configs
 	pkgconfig.Set("logs_enabled", true, pkgconfigmodel.SourceDefault)

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
@@ -93,7 +93,6 @@ func setupSerializer(config pkgconfigmodel.Config, cfg *ExporterConfig) {
 	// The serializer exporter forces zlib compression (metricscompressionfx
 	// fx-otel), which is incompatible with the v3 metrics intake.
 	config.Set("use_v3_api.series.enabled", "false", pkgconfigmodel.SourceAgentRuntime)
-	config.Set("serializer_experimental_use_v3_api.series.shadow_sample_rate", float64(0), pkgconfigmodel.SourceAgentRuntime)
 
 	// Serializer: allow user to blacklist any kind of payload to be sent
 	config.Set("enable_payloads.events", true, pkgconfigmodel.SourceDefault)


### PR DESCRIPTION
### What does this PR do?

Remove obsolete v3 sampling overrides

### Motivation

Shadow sample rate now defaults to zero and will be removed soon.

### Describe how you validated your changes

### Additional Notes
