### PR TITLE
[anomalydetection] Guard testbench packages

### DIFF
--- a/comp/anomalydetection/reporter/fx-testbench/BUILD.bazel
+++ b/comp/anomalydetection/reporter/fx-testbench/BUILD.bazel
@@ -4,7 +4,7 @@ go_library(
     name = "fx-testbench",
     srcs = ["fx.go"],
     importpath = "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/fx-testbench",
-    visibility = ["//visibility:public"],
+    visibility = ["//visibility:private"],
     deps = [
         "//comp/anomalydetection/reporter/impl-testbench",
         "//pkg/util/fxutil",

--- a/comp/anomalydetection/reporter/fx-testbench/BUILD.bazel
+++ b/comp/anomalydetection/reporter/fx-testbench/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library")
 go_library(
     name = "fx-testbench",
     srcs = ["fx.go"],
+    gotags = ["anomalydetectiontestbench"],
     importpath = "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/fx-testbench",
     visibility = ["//visibility:public"],
     deps = [

--- a/comp/anomalydetection/reporter/fx-testbench/fx.go
+++ b/comp/anomalydetection/reporter/fx-testbench/fx.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build anomalydetectiontestbench
+
 // Package fx provides the testbench fx module for the reporter component.
 // Wire this in the testbench binary: it provides the SSE-pushing reporter.Reporter
 // and exposes SSEAccess for the HTTP API to register browser clients.

--- a/comp/anomalydetection/reporter/impl-testbench/BUILD.bazel
+++ b/comp/anomalydetection/reporter/impl-testbench/BUILD.bazel
@@ -7,6 +7,6 @@ go_library(
         "sse.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/impl-testbench",
-    visibility = ["//visibility:public"],
+    visibility = ["//comp/anomalydetection/reporter/fx-testbench:__pkg__"],
     deps = ["//comp/anomalydetection/reporter/def"],
 )

--- a/comp/anomalydetection/reporter/impl-testbench/BUILD.bazel
+++ b/comp/anomalydetection/reporter/impl-testbench/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "reporter.go",
         "sse.go",
     ],
+    gotags = ["anomalydetectiontestbench"],
     importpath = "github.com/DataDog/datadog-agent/comp/anomalydetection/reporter/impl-testbench",
     visibility = ["//visibility:public"],
     deps = ["//comp/anomalydetection/reporter/def"],

--- a/comp/anomalydetection/reporter/impl-testbench/reporter.go
+++ b/comp/anomalydetection/reporter/impl-testbench/reporter.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build anomalydetectiontestbench
+
 package testbenchimpl
 
 import (

--- a/comp/anomalydetection/reporter/impl-testbench/sse.go
+++ b/comp/anomalydetection/reporter/impl-testbench/sse.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build anomalydetectiontestbench
+
 // Package testbenchimpl provides the testbench SSE reporter implementation.
 package testbenchimpl
 

--- a/tasks/anomalydetection.py
+++ b/tasks/anomalydetection.py
@@ -74,7 +74,7 @@ def build_testbench(ctx):
     Builds the anomalydetection-testbench binary to bin/anomalydetection-testbench.
     """
     ctx.run(
-        "go build -C internal/qbranch/anomalydetection-testbench -tags python -o ../../../bin/anomalydetection-testbench ."
+        "go build -C internal/qbranch/anomalydetection-testbench -tags python,anomalydetectiontestbench -o ../../../bin/anomalydetection-testbench ."
     )
 
 

--- a/tasks/build_tags.bzl
+++ b/tasks/build_tags.bzl
@@ -84,6 +84,7 @@ GAZELLE_EXTRA_TAGS = set([
     "functionaltests",
     "manualtest",
     "private_runner_experimental",
+    "anomalydetectiontestbench",  # used to analyze anomaly-detection testbench-only packages
 ])
 
 # Tags in ALL_TAGS that we deliberately keep out of Gazelle's set, typically


### PR DESCRIPTION
### What does this PR do?

Add an `anomalydetectiontestbench` build tag to ensure we never ship the testbench code at compile time.

### Motivation

### Describe how you validated your changes

`dda inv agent.build`

`dda inv anomalydetection.build-testbench`

### Additional Notes