### PR TITLE
ebpf: validate runtime-compiler cache directory and open cached objects via verified fd

### DIFF
--- a/pkg/ebpf/bytecode/BUILD.bazel
+++ b/pkg/ebpf/bytecode/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 load("//bazel/rules/ebpf:runtime_compilation.bzl", "runtime_compilation_bundle")
 
 _EBPF_HEADERS = ["//pkg/ebpf/c:ebpf_c_headers_files"]
@@ -141,4 +141,22 @@ go_library(
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/ebpf/bytecode",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "bytecode_test",
+    srcs = ["permissions_test.go"],
+    embed = [":bytecode"],
+    gotags = ["test"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/pkg/ebpf/bytecode/BUILD.bazel
+++ b/pkg/ebpf/bytecode/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_go//go:def.bzl", "go_library")
 load("//bazel/rules/ebpf:runtime_compilation.bzl", "runtime_compilation_bundle")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 _EBPF_HEADERS = ["//pkg/ebpf/c:ebpf_c_headers_files"]
 
@@ -141,4 +142,21 @@ go_library(
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/ebpf/bytecode",
     visibility = ["//visibility:public"],
+)
+
+dd_agent_go_test(
+    name = "bytecode_test",
+    srcs = ["permissions_test.go"],
+    embed = [":bytecode"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/pkg/ebpf/bytecode/asset_reader_nobindata.go
+++ b/pkg/ebpf/bytecode/asset_reader_nobindata.go
@@ -11,7 +11,18 @@ import (
 	"path"
 )
 
-// GetReader returns a new AssetReader for the specified file asset
+// GetReader returns a new AssetReader for the specified file asset.
+//
+// This is the shared entry point for loading on-disk eBPF objects across all
+// system-probe consumers (precompiled and CO-RE assets for NPM, USM, CWS and
+// dynamic instrumentation), all of which run as root. Every asset is already
+// required to be root-owned — VerifyAssetPermissionsAndOpen enforces that on
+// the returned descriptor, as VerifyAssetPermissions did before it — so the
+// only behavioral change from opening with O_NOFOLLOW is that a symlink at the
+// final path component is rejected instead of followed. That is intentional and
+// safe: these objects are always shipped or compiled as regular root-owned
+// files (intermediate directory symlinks, e.g. a versioned install path, are
+// still followed, since O_NOFOLLOW only affects the final component).
 func GetReader(dir, name string) (AssetReader, error) {
 	assetPath := path.Join(dir, path.Base(name))
 	// Open and permission-check the same descriptor (O_NOFOLLOW) so there is no

--- a/pkg/ebpf/bytecode/asset_reader_nobindata.go
+++ b/pkg/ebpf/bytecode/asset_reader_nobindata.go
@@ -8,22 +8,17 @@
 package bytecode
 
 import (
-	"fmt"
-	"os"
 	"path"
 )
 
 // GetReader returns a new AssetReader for the specified file asset
 func GetReader(dir, name string) (AssetReader, error) {
 	assetPath := path.Join(dir, path.Base(name))
-	err := VerifyAssetPermissions(assetPath)
+	// Open and permission-check the same descriptor (O_NOFOLLOW) so there is no
+	// path re-resolution between the check and the returned reader.
+	asset, err := VerifyAssetPermissionsAndOpen(assetPath)
 	if err != nil {
 		return nil, err
-	}
-
-	asset, err := os.Open(assetPath)
-	if err != nil {
-		return nil, fmt.Errorf("could not find asset: %w", err)
 	}
 
 	return asset, nil

--- a/pkg/ebpf/bytecode/permissions.go
+++ b/pkg/ebpf/bytecode/permissions.go
@@ -52,10 +52,22 @@ func VerifyAssetPermissionsAndOpen(assetPath string) (*os.File, error) {
 		f.Close()
 		return nil, fmt.Errorf("error getting permissions for output file %s", assetPath)
 	}
-	// Enforce that we only load root-owned, non-group/other-writable object files.
-	if stat.Uid != 0 || stat.Gid != 0 || info.Mode().Perm()&os.FileMode(0022) != 0 {
+	if err := verifyOwnerPermissions(assetPath, stat.Uid, stat.Gid, info.Mode().Perm()); err != nil {
 		f.Close()
-		return nil, fmt.Errorf("%s has incorrect permissions: user=%v, group=%v, permissions=%v", assetPath, stat.Uid, stat.Gid, info.Mode().Perm())
+		return nil, err
 	}
 	return f, nil
+}
+
+// verifyOwnerPermissions enforces that the given ownership and permission bits
+// describe a root-owned file that is not writable by group or other. It is kept
+// separate from the filesystem access above so the policy can be unit-tested
+// with synthetic values, without needing to create root-owned files (which a
+// test run as non-root cannot do).
+func verifyOwnerPermissions(assetPath string, uid, gid uint32, perm os.FileMode) error {
+	// Enforce that we only load root-owned, non-group/other-writable object files.
+	if uid != 0 || gid != 0 || perm&os.FileMode(0022) != 0 {
+		return fmt.Errorf("%s has incorrect permissions: user=%v, group=%v, permissions=%v", assetPath, uid, gid, perm)
+	}
+	return nil
 }

--- a/pkg/ebpf/bytecode/permissions.go
+++ b/pkg/ebpf/bytecode/permissions.go
@@ -15,19 +15,47 @@ import (
 
 // VerifyAssetPermissions checks that the file at the given path is owned by root,
 // and does not have write permission for group and other;
-// returns an error if this isn't the case
+// returns an error if this isn't the case.
+//
+// Prefer VerifyAssetPermissionsAndOpen when the file is going to be read: it runs
+// the same check on the descriptor it returns, so the file that is checked is the
+// file that is used.
 func VerifyAssetPermissions(assetPath string) error {
-	// Enforce that we only load root-writeable object files
-	info, err := os.Stat(assetPath)
+	f, err := VerifyAssetPermissionsAndOpen(assetPath)
 	if err != nil {
-		return fmt.Errorf("error stat-ing asset file %s: %w", assetPath, err)
+		return err
+	}
+	return f.Close()
+}
+
+// VerifyAssetPermissionsAndOpen opens the asset at the given path with
+// O_NOFOLLOW and verifies, using the opened file descriptor, that the file is
+// owned by root and is not writable by group or other. On success it returns the
+// open *os.File so the caller can read the exact bytes that were verified: the
+// check and the read use the same descriptor rather than resolving the path a
+// second time. The caller owns the returned file and must close it.
+func VerifyAssetPermissionsAndOpen(assetPath string) (*os.File, error) {
+	f, err := os.OpenFile(assetPath, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("error opening asset file %s: %w", assetPath, err)
+	}
+
+	// Stat the descriptor (fstat), not the path, so the checked file is exactly
+	// the one we hold open.
+	info, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, fmt.Errorf("error stat-ing asset file %s: %w", assetPath, err)
 	}
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
-		return fmt.Errorf("error getting permissions for output file %s", assetPath)
+		f.Close()
+		return nil, fmt.Errorf("error getting permissions for output file %s", assetPath)
 	}
+	// Enforce that we only load root-owned, non-group/other-writable object files.
 	if stat.Uid != 0 || stat.Gid != 0 || info.Mode().Perm()&os.FileMode(0022) != 0 {
-		return fmt.Errorf("%s has incorrect permissions: user=%v, group=%v, permissions=%v", assetPath, stat.Uid, stat.Gid, info.Mode().Perm())
+		f.Close()
+		return nil, fmt.Errorf("%s has incorrect permissions: user=%v, group=%v, permissions=%v", assetPath, stat.Uid, stat.Gid, info.Mode().Perm())
 	}
-	return nil
+	return f, nil
 }

--- a/pkg/ebpf/bytecode/permissions_test.go
+++ b/pkg/ebpf/bytecode/permissions_test.go
@@ -51,3 +51,36 @@ func TestVerifyAssetPermissionsAndOpenRejectsNonRoot(t *testing.T) {
 	}
 	assert.Error(t, err, "a non-root-owned asset must be rejected")
 }
+
+// verifyOwnerPermissions is the pure policy behind the descriptor check above.
+// Exercising it directly covers the ownership/permission rejection logic
+// regardless of the euid the suite runs under (the filesystem-level test above
+// skips when run as root).
+func TestVerifyOwnerPermissions(t *testing.T) {
+	tests := []struct {
+		name    string
+		uid     uint32
+		gid     uint32
+		perm    os.FileMode
+		wantErr bool
+	}{
+		{"root-owned 0644", 0, 0, 0644, false},
+		{"root-owned 0600", 0, 0, 0600, false},
+		{"root-owned 0755", 0, 0, 0755, false},
+		{"non-root uid", 1000, 0, 0644, true},
+		{"non-root gid", 0, 1000, 0644, true},
+		{"group-writable", 0, 0, 0664, true},
+		{"other-writable", 0, 0, 0646, true},
+		{"world-writable", 0, 0, 0666, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := verifyOwnerPermissions("asset.o", tc.uid, tc.gid, tc.perm)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/ebpf/bytecode/permissions_test.go
+++ b/pkg/ebpf/bytecode/permissions_test.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package bytecode
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// VerifyAssetPermissionsAndOpen opens with O_NOFOLLOW, so a symlink at the final
+// path component must be rejected rather than followed to its target.
+func TestVerifyAssetPermissionsAndOpenRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+
+	target := filepath.Join(dir, "target")
+	require.NoError(t, os.WriteFile(target, []byte("data"), 0644))
+
+	link := filepath.Join(dir, "link")
+	require.NoError(t, os.Symlink(target, link))
+
+	f, err := VerifyAssetPermissionsAndOpen(link)
+	if f != nil {
+		f.Close()
+	}
+	require.Error(t, err, "opening a symlink must fail with O_NOFOLLOW")
+}
+
+// A regular file that is not owned by root must be rejected by the permission
+// check even though it opens successfully.
+func TestVerifyAssetPermissionsAndOpenRejectsNonRoot(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("test must run as non-root to observe the ownership rejection")
+	}
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "asset.o")
+	require.NoError(t, os.WriteFile(file, []byte("data"), 0644))
+
+	f, err := VerifyAssetPermissionsAndOpen(file)
+	if f != nil {
+		f.Close()
+	}
+	assert.Error(t, err, "a non-root-owned asset must be rejected")
+}

--- a/pkg/ebpf/bytecode/permissions_windows.go
+++ b/pkg/ebpf/bytecode/permissions_windows.go
@@ -9,9 +9,15 @@ package bytecode
 
 import (
 	"errors"
+	"os"
 )
 
 // VerifyAssetPermissions is for verifying the permissions of bpf programs
 func VerifyAssetPermissions(_ string) error {
 	return errors.New("verification of bpf assets is not supported on windows")
+}
+
+// VerifyAssetPermissionsAndOpen is for verifying the permissions of bpf programs
+func VerifyAssetPermissionsAndOpen(_ string) (*os.File, error) {
+	return nil, errors.New("verification of bpf assets is not supported on windows")
 }

--- a/pkg/ebpf/bytecode/runtime/BUILD.bazel
+++ b/pkg/ebpf/bytecode/runtime/BUILD.bazel
@@ -92,7 +92,10 @@ go_library(
 # of clang-bpf in the agent's installation path.
 go_test(
     name = "runtime_test",
-    srcs = ["helpers_test.go"],
+    srcs = [
+        "asset_test.go",
+        "helpers_test.go",
+    ],
     embed = [":runtime"],
     gotags = ["linux_bpf"],  # keep
     tags = ["manual"],  # keep

--- a/pkg/ebpf/bytecode/runtime/BUILD.bazel
+++ b/pkg/ebpf/bytecode/runtime/BUILD.bazel
@@ -90,7 +90,10 @@ go_library(
 
 dd_agent_go_test(
     name = "runtime_test",
-    srcs = ["helpers_test.go"],
+    srcs = [
+        "asset_test.go",
+        "helpers_test.go",
+    ],
     embed = [":runtime"],
     gotags_sets = [["linux_bpf"]],
     include_default = False,

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"time"
 
@@ -23,6 +24,39 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kernel/headers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+// runtimeDirLogState dedupes the runtime-directory warnings, which would
+// otherwise repeat once per asset compiled (secureRuntimeDir runs inside the
+// per-asset compile()).
+var runtimeDirLogState struct {
+	sync.Mutex
+	seen map[string]struct{}
+}
+
+// logRuntimeDirOnce reports whether the given reason has not yet been logged,
+// recording it so subsequent identical reasons are suppressed.
+func logRuntimeDirOnce(reason string) bool {
+	runtimeDirLogState.Lock()
+	defer runtimeDirLogState.Unlock()
+	if _, ok := runtimeDirLogState.seen[reason]; ok {
+		return false
+	}
+	if runtimeDirLogState.seen == nil {
+		runtimeDirLogState.seen = make(map[string]struct{})
+	}
+	runtimeDirLogState.seen[reason] = struct{}{}
+	return true
+}
+
+// logRuntimeDirReclaimed warns (once per reclaimed path) that a stale
+// runtime-directory component was moved aside and recreated. A recurring reclaim
+// points at something else recreating the directory as non-root, so it is worth
+// surfacing rather than doing it silently.
+func logRuntimeDirReclaimed(p string) {
+	if logRuntimeDirOnce("reclaimed:" + p) {
+		log.Warnf("recreated runtime compiler output directory component %s: it was not a root-owned directory", p)
+	}
+}
 
 // asset represents an asset that needs its content integrity checked at runtime
 type asset struct {
@@ -100,8 +134,12 @@ func (a *asset) compile(config *ebpf.Config, opts CompileOptions) (CompiledOutpu
 	if err := secureRuntimeDir(outputDir); err != nil {
 		// Surface the policy refusal distinctly so operators can tell "runtime
 		// compilation disabled because the output directory is not under root's
-		// control" apart from an ordinary compilation failure.
-		log.Warnf("skipping runtime compilation of %s: %v", a.filename, err)
+		// control" apart from an ordinary compilation failure. compile() runs
+		// once per asset, so dedupe by reason to avoid one warning per asset for
+		// the same misconfigured directory.
+		if logRuntimeDirOnce(err.Error()) {
+			log.Warnf("skipping runtime compilation: %v", err)
+		}
 		return nil, err
 	}
 
@@ -176,14 +214,75 @@ func (a *asset) compile(config *ebpf.Config, opts CompileOptions) (CompiledOutpu
 // set. The sticky-bit exception permits the default location under /var/tmp
 // (root-owned, mode 1777): the sticky bit keeps other users from renaming or
 // deleting the datadog-agent directory that root creates beneath it.
+//
+// The default parent /var/tmp is shared and writable by every user, so the
+// datadog-agent directory beneath it may already exist owned by a non-root user
+// (left over from a previous install, or created by another process). Rather
+// than refusing in that case for the lifetime of the process - which would break
+// upgraded hosts and leave runtime compilation disabled - secureRuntimeDir
+// repairs the common case: a wrong-owner directory below the sticky boundary is
+// renamed aside and the path recreated fresh as root. Only root can rename
+// entries inside a sticky directory, so the repair is not subject to
+// interference, and renaming aside (rather than reusing or chown-ing the
+// existing tree) means we never write through whatever it previously contained.
+//
+// The repair is deliberately narrow (see verifyRuntimeDirChain): it happens only
+// as root, only below a verified root-owned sticky directory, and only for a real
+// directory with the wrong owner/permissions. A symlink, a non-directory, or
+// anything at or above the sticky boundary is still refused, so unexpected or
+// broken layouts fail closed rather than being silently rewritten.
 func secureRuntimeDir(outputDir string) error {
 	if err := os.MkdirAll(outputDir, 0700); err != nil {
 		return fmt.Errorf("unable to create compiler output directory %s: %w", outputDir, err)
 	}
 
+	// Anything re-creating the component between the rename and the recreate
+	// cannot take effect (the recreated component is root-owned and, under a
+	// sticky parent, only root can replace it), so a single repair pass is
+	// sufficient; the retry is only a safety bound.
+	const maxAttempts = 3
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		badPath, healable, err := verifyRuntimeDirChain(outputDir)
+		if err == nil {
+			return nil
+		}
+		if !healable {
+			return err
+		}
+		if rErr := reclaimDirComponent(badPath); rErr != nil {
+			return fmt.Errorf("%w (attempted reclaim failed: %v)", err, rErr)
+		}
+		logRuntimeDirReclaimed(badPath)
+		// Recreate the freshly reclaimed path before re-verifying.
+		if mErr := os.MkdirAll(outputDir, 0700); mErr != nil {
+			return fmt.Errorf("unable to recreate compiler output directory %s after reclaim: %w", outputDir, mErr)
+		}
+		lastErr = err
+	}
+	return fmt.Errorf("unable to secure compiler output directory %s after %d reclaim attempts: %w", outputDir, maxAttempts, lastErr)
+}
+
+// verifyRuntimeDirChain walks outputDir and every ancestor up to the filesystem
+// root, enforcing verifyDirComponent on each. On the first failure it reports the
+// offending path and whether that failure is safely reclaimable.
+//
+// A failure is reclaimable only when all of the following hold, so the repair
+// stays conservative and never runs in a context where it could damage unrelated
+// directories:
+//   - we are running as root (system-probe's normal state); a non-root process
+//     must not start renaming directories it happens not to own,
+//   - the component lies strictly below a verified root-owned sticky directory
+//     (a shared, writable-by-anyone parent such as /var/tmp, whose sticky bit
+//     means only root can rename the entries beneath it), and
+//   - the component is itself a real directory that merely has the wrong owner or
+//     permissions. A symlink or non-directory at a path component is unexpected
+//     rather than a routine leftover, so it is still refused (fail-closed)
+//     instead of being rewritten.
+func verifyRuntimeDirChain(outputDir string) (badPath string, healable bool, err error) {
 	abs, err := filepath.Abs(outputDir)
 	if err != nil {
-		return fmt.Errorf("unable to resolve compiler output directory %s: %w", outputDir, err)
+		return "", false, fmt.Errorf("unable to resolve compiler output directory %s: %w", outputDir, err)
 	}
 
 	// Collect every path component from outputDir up to the filesystem root.
@@ -197,18 +296,54 @@ func secureRuntimeDir(outputDir string) error {
 		p = parent
 	}
 
-	for _, p := range components {
-		info, err := os.Lstat(p)
-		if err != nil {
-			return fmt.Errorf("unable to verify compiler output directory component %s: %w", p, err)
+	// Walk root -> leaf so we know a component sits below a verified sticky
+	// boundary before we decide whether its failure is reclaimable.
+	belowStickyBoundary := false
+	for i := len(components) - 1; i >= 0; i-- {
+		p := components[i]
+		info, lerr := os.Lstat(p)
+		if lerr != nil {
+			return p, false, fmt.Errorf("unable to verify compiler output directory component %s: %w", p, lerr)
 		}
 		stat, ok := info.Sys().(*syscall.Stat_t)
 		if !ok {
-			return fmt.Errorf("unable to read ownership of compiler output directory component %s", p)
+			return p, false, fmt.Errorf("unable to read ownership of compiler output directory component %s", p)
 		}
-		if err := verifyDirComponent(p, info.Mode(), stat.Uid); err != nil {
-			return err
+		if verr := verifyDirComponent(p, info.Mode(), stat.Uid); verr != nil {
+			// Reclaim only a real, wrong-owner/permission directory below the
+			// sticky boundary, and only as root. info.Mode().IsDir() is false for
+			// a symlink or a regular file, so those remain fail-closed.
+			healable := belowStickyBoundary && os.Geteuid() == 0 && info.Mode().IsDir()
+			return p, healable, verr
 		}
+		// This component is verified good. If it is a sticky directory it marks
+		// the shared-parent boundary; anything deeper may be repaired.
+		if info.Mode()&os.ModeSticky != 0 {
+			belowStickyBoundary = true
+		}
+	}
+	return "", false, nil
+}
+
+// reclaimDirComponent moves a stale path component aside and removes it. The
+// caller must only invoke this for a component that verifyRuntimeDirChain
+// reported as repairable (below a verified root-owned sticky directory), which
+// guarantees the parent is root-owned so root can rename the entry regardless of
+// who owns it, and the sticky bit means the rename cannot be interfered with.
+// Renaming aside (never reusing or chown-ing the existing entry) ensures we do
+// not follow a symlink or reuse whatever the entry previously contained.
+func reclaimDirComponent(p string) error {
+	// os.Rename does not follow a symlink at p: a symlinked component is moved as
+	// the link itself. The aside name is in the same (root-owned) parent so the
+	// rename stays within one directory.
+	aside := fmt.Sprintf("%s.reclaimed-%d-%d", p, os.Getpid(), time.Now().UnixNano())
+	if err := os.Rename(p, aside); err != nil {
+		return fmt.Errorf("unable to move aside stale component %s: %w", p, err)
+	}
+	// Best-effort cleanup of the moved-aside tree. os.RemoveAll uses O_NOFOLLOW
+	// openat internally, so it will not traverse symlinks beneath it.
+	if err := os.RemoveAll(aside); err != nil {
+		log.Debugf("unable to remove reclaimed component %s: %s", aside, err)
 	}
 	return nil
 }

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -203,6 +203,16 @@ func (a *asset) compile(config *ebpf.Config, opts CompileOptions) (CompiledOutpu
 	return out, err
 }
 
+// dedicatedDirName is the agent-owned top-level component of the runtime
+// compiler cache path (the default is /var/tmp/datadog-agent/system-probe/build).
+// Reclaim is confined to this subtree: a wrong-owner component is only ever
+// renamed aside and deleted once we are provably inside .../datadog-agent/...,
+// so a misconfigured or attacker-supplied output_dir nested under a shared,
+// non-dedicated directory (e.g. /var/tmp/shared/datadog/build) is refused rather
+// than causing that shared directory to be destroyed. Keep this in sync with the
+// runtime_compiler_output_dir default (pkg/config/setup/system_probe_settings.go).
+const dedicatedDirName = "datadog-agent"
+
 // secureRuntimeDir creates the runtime-compiler output directory (root-only,
 // 0700) and verifies that it, and every ancestor up to the filesystem root, is a
 // real directory owned by root and not writable by other users. The compiler
@@ -220,17 +230,23 @@ func (a *asset) compile(config *ebpf.Config, opts CompileOptions) (CompiledOutpu
 // (left over from a previous install, or created by another process). Rather
 // than refusing in that case for the lifetime of the process - which would break
 // upgraded hosts and leave runtime compilation disabled - secureRuntimeDir
-// repairs the common case: a wrong-owner directory below the sticky boundary is
-// renamed aside and the path recreated fresh as root. Only root can rename
-// entries inside a sticky directory, so the repair is not subject to
-// interference, and renaming aside (rather than reusing or chown-ing the
-// existing tree) means we never write through whatever it previously contained.
+// repairs the common case: a wrong-owner directory that is both below the sticky
+// boundary and inside the agent's own datadog-agent subtree is renamed aside and
+// the path recreated fresh as root. Only root can rename entries inside a sticky
+// directory, so the repair is not subject to interference, and renaming aside
+// (rather than reusing or chown-ing the existing tree) means we never write
+// through whatever it previously contained.
 //
 // The repair is deliberately narrow (see verifyRuntimeDirChain): it happens only
-// as root, only below a verified root-owned sticky directory, and only for a real
-// directory with the wrong owner/permissions. A symlink, a non-directory, or
-// anything at or above the sticky boundary is still refused, so unexpected or
-// broken layouts fail closed rather than being silently rewritten.
+// as root, only below a verified root-owned sticky directory, only inside the
+// agent's own dedicated subtree (dedicatedDirName), and only for a real directory
+// with the wrong owner/permissions. This last condition is what keeps a
+// misconfigured or attacker-supplied output_dir nested under a shared directory
+// (e.g. /var/tmp/shared/datadog/build) from causing that shared directory to be
+// renamed aside and recursively deleted. A symlink, a non-directory, anything at
+// or above the sticky boundary, and anything outside the datadog-agent subtree
+// are all still refused, so unexpected or broken layouts fail closed rather than
+// being silently rewritten.
 func secureRuntimeDir(outputDir string) error {
 	if err := os.MkdirAll(outputDir, 0700); err != nil {
 		return fmt.Errorf("unable to create compiler output directory %s: %w", outputDir, err)
@@ -274,7 +290,12 @@ func secureRuntimeDir(outputDir string) error {
 //     must not start renaming directories it happens not to own,
 //   - the component lies strictly below a verified root-owned sticky directory
 //     (a shared, writable-by-anyone parent such as /var/tmp, whose sticky bit
-//     means only root can rename the entries beneath it), and
+//     means only root can rename the entries beneath it),
+//   - the component lies inside the agent's own dedicated subtree (at or below a
+//     component named dedicatedDirName). Without this, the first insecure
+//     ancestor on a custom output_dir could be a shared directory unrelated to
+//     the agent (e.g. /var/tmp/shared), which reclaim would then rename aside and
+//     recursively delete along with its contents, and
 //   - the component is itself a real directory that merely has the wrong owner or
 //     permissions. A symlink or non-directory at a path component is unexpected
 //     rather than a routine leftover, so it is still refused (fail-closed)
@@ -297,10 +318,18 @@ func verifyRuntimeDirChain(outputDir string) (badPath string, healable bool, err
 	}
 
 	// Walk root -> leaf so we know a component sits below a verified sticky
-	// boundary before we decide whether its failure is reclaimable.
+	// boundary, and inside the agent's dedicated subtree, before we decide
+	// whether its failure is reclaimable.
 	belowStickyBoundary := false
+	inDedicatedSubtree := false
 	for i := len(components) - 1; i >= 0; i-- {
 		p := components[i]
+		// A component named dedicatedDirName marks the start of the agent's own
+		// subtree; it and anything deeper may be repaired. Set this before the
+		// verify below so the datadog-agent component itself is repairable.
+		if filepath.Base(p) == dedicatedDirName {
+			inDedicatedSubtree = true
+		}
 		info, lerr := os.Lstat(p)
 		if lerr != nil {
 			return p, false, fmt.Errorf("unable to verify compiler output directory component %s: %w", p, lerr)
@@ -310,10 +339,12 @@ func verifyRuntimeDirChain(outputDir string) (badPath string, healable bool, err
 			return p, false, fmt.Errorf("unable to read ownership of compiler output directory component %s", p)
 		}
 		if verr := verifyDirComponent(p, info.Mode(), stat.Uid); verr != nil {
-			// Reclaim only a real, wrong-owner/permission directory below the
-			// sticky boundary, and only as root. info.Mode().IsDir() is false for
-			// a symlink or a regular file, so those remain fail-closed.
-			healable := belowStickyBoundary && os.Geteuid() == 0 && info.Mode().IsDir()
+			// Reclaim only a real, wrong-owner/permission directory that is below
+			// the sticky boundary, inside the agent's dedicated subtree, and only
+			// as root. info.Mode().IsDir() is false for a symlink or a regular
+			// file, so those remain fail-closed; requiring the dedicated subtree
+			// keeps reclaim from ever deleting a shared, non-agent directory.
+			healable := belowStickyBoundary && inDedicatedSubtree && os.Geteuid() == 0 && info.Mode().IsDir()
 			return p, healable, verr
 		}
 		// This component is verified good. If it is a sticky directory it marks
@@ -327,11 +358,15 @@ func verifyRuntimeDirChain(outputDir string) (badPath string, healable bool, err
 
 // reclaimDirComponent moves a stale path component aside and removes it. The
 // caller must only invoke this for a component that verifyRuntimeDirChain
-// reported as repairable (below a verified root-owned sticky directory), which
-// guarantees the parent is root-owned so root can rename the entry regardless of
-// who owns it, and the sticky bit means the rename cannot be interfered with.
-// Renaming aside (never reusing or chown-ing the existing entry) ensures we do
-// not follow a symlink or reuse whatever the entry previously contained.
+// reported as repairable (below a verified root-owned sticky directory and inside
+// the agent's dedicated datadog-agent subtree), which guarantees the parent is
+// root-owned so root can rename the entry regardless of who owns it. Renaming
+// aside (never reusing or chown-ing the existing entry) ensures we do not follow
+// a symlink or reuse whatever the entry previously contained; even if the
+// component's non-root owner races us (they may rename their own entry in a
+// sticky parent), os.Rename does not dereference a symlink at p and we recreate
+// the path fresh afterwards, so the worst case is a transient error, never
+// loading or writing through an attacker-controlled path.
 func reclaimDirComponent(p string) error {
 	// os.Rename does not follow a symlink at p: a symlinked component is moved as
 	// the link itself. The aside name is in the same (root-owned) parent so the

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -213,11 +213,20 @@ func (a *asset) compile(config *ebpf.Config, opts CompileOptions) (CompiledOutpu
 // runtime_compiler_output_dir default (pkg/config/setup/system_probe_settings.go).
 const dedicatedDirName = "datadog-agent"
 
-// secureRuntimeDir creates the runtime-compiler output directory (root-only,
-// 0700) and verifies that it, and every ancestor up to the filesystem root, is a
-// real directory owned by root and not writable by other users. The compiler
+// secureRuntimeDir ensures the runtime-compiler output directory exists, is
+// root-only (0700), and that it and every ancestor up to the filesystem root is
+// a real directory owned by root and not writable by other users. The compiler
 // writes object files here and system-probe later re-reads them to load into the
 // kernel as root, so the whole path must be under root's control.
+//
+// It verifies the already-existing prefix of the path before creating anything,
+// then creates only the missing tail one component at a time. Creation never
+// follows a symlink: every existing ancestor is verified as a real (non-symlink)
+// root-owned directory first, so os.Mkdir of the next component resolves only
+// through verified directories and returns EEXIST rather than traversing an entry
+// that appeared underneath it. This is deliberately not os.MkdirAll over the
+// whole path, which would resolve - and create through - a symlinked component
+// before any check ran.
 //
 // It rejects the directory if any ancestor is a symlink, is not a directory, is
 // not owned by root, or is writable by group or other without the sticky bit
@@ -237,7 +246,7 @@ const dedicatedDirName = "datadog-agent"
 // (rather than reusing or chown-ing the existing tree) means we never write
 // through whatever it previously contained.
 //
-// The repair is deliberately narrow (see verifyRuntimeDirChain): it happens only
+// The repair is deliberately narrow (see ensureRuntimeDirChain): it happens only
 // as root, only below a verified root-owned sticky directory, only inside the
 // agent's own dedicated subtree (dedicatedDirName), and only for a real directory
 // with the wrong owner/permissions. This last condition is what keeps a
@@ -248,44 +257,66 @@ const dedicatedDirName = "datadog-agent"
 // are all still refused, so unexpected or broken layouts fail closed rather than
 // being silently rewritten.
 func secureRuntimeDir(outputDir string) error {
-	if err := os.MkdirAll(outputDir, 0700); err != nil {
-		return fmt.Errorf("unable to create compiler output directory %s: %w", outputDir, err)
+	components, err := runtimeDirComponents(outputDir)
+	if err != nil {
+		return err
 	}
 
-	// Anything re-creating the component between the rename and the recreate
-	// cannot take effect (the recreated component is root-owned and, under a
-	// sticky parent, only root can replace it), so a single repair pass is
-	// sufficient; the retry is only a safety bound.
+	// A single pass verifies the existing prefix, repairs one offending
+	// component if needed, and creates the missing tail. The bounded retry only
+	// guards against a concurrent actor racing a component between our check and
+	// our create (os.Mkdir returning EEXIST on a freshly appeared entry); it is
+	// not needed in the normal single-process case.
 	const maxAttempts = 3
 	var lastErr error
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		badPath, healable, err := verifyRuntimeDirChain(outputDir)
+		retryable, err := ensureRuntimeDirChain(components)
 		if err == nil {
 			return nil
 		}
-		if !healable {
+		if !retryable {
 			return err
-		}
-		if rErr := reclaimDirComponent(badPath); rErr != nil {
-			return fmt.Errorf("%w (attempted reclaim failed: %v)", err, rErr)
-		}
-		logRuntimeDirReclaimed(badPath)
-		// Recreate the freshly reclaimed path before re-verifying.
-		if mErr := os.MkdirAll(outputDir, 0700); mErr != nil {
-			return fmt.Errorf("unable to recreate compiler output directory %s after reclaim: %w", outputDir, mErr)
 		}
 		lastErr = err
 	}
-	return fmt.Errorf("unable to secure compiler output directory %s after %d reclaim attempts: %w", outputDir, maxAttempts, lastErr)
+	return fmt.Errorf("unable to secure compiler output directory %s after %d attempts: %w", outputDir, maxAttempts, lastErr)
 }
 
-// verifyRuntimeDirChain walks outputDir and every ancestor up to the filesystem
-// root, enforcing verifyDirComponent on each. On the first failure it reports the
-// offending path and whether that failure is safely reclaimable.
+// runtimeDirComponents returns the absolute form of outputDir and every ancestor
+// up to the filesystem root, ordered leaf-first: index 0 is the leaf and the last
+// element is the filesystem root ("/").
+func runtimeDirComponents(outputDir string) ([]string, error) {
+	abs, err := filepath.Abs(outputDir)
+	if err != nil {
+		return nil, fmt.Errorf("unable to resolve compiler output directory %s: %w", outputDir, err)
+	}
+	var components []string
+	for p := filepath.Clean(abs); ; {
+		components = append(components, p)
+		parent := filepath.Dir(p)
+		if parent == p {
+			break
+		}
+		p = parent
+	}
+	return components, nil
+}
+
+// ensureRuntimeDirChain walks the components root -> leaf, enforcing
+// verifyDirComponent on each one that already exists, creating each one that does
+// not, and reclaiming (rename-aside + delete + recreate) a repairable wrong-owner
+// component. Verifying the existing prefix before creating the missing tail is
+// what makes creation symlink-safe: os.Mkdir of a component only ever resolves
+// through ancestors already verified as real (non-symlink) root-owned
+// directories.
 //
-// A failure is reclaimable only when all of the following hold, so the repair
-// stays conservative and never runs in a context where it could damage unrelated
-// directories:
+// It returns whether the failure it hit (if any) is worth retrying: a race on
+// creation (os.Mkdir returning EEXIST because something appeared underneath a
+// verified parent) is retryable; a policy refusal or a failed reclaim is
+// terminal.
+//
+// A component is reclaimable only when all of the following hold, so the repair
+// stays conservative and never damages unrelated directories:
 //   - we are running as root (system-probe's normal state); a non-root process
 //     must not start renaming directories it happens not to own,
 //   - the component lies strictly below a verified root-owned sticky directory
@@ -300,23 +331,7 @@ func secureRuntimeDir(outputDir string) error {
 //     permissions. A symlink or non-directory at a path component is unexpected
 //     rather than a routine leftover, so it is still refused (fail-closed)
 //     instead of being rewritten.
-func verifyRuntimeDirChain(outputDir string) (badPath string, healable bool, err error) {
-	abs, err := filepath.Abs(outputDir)
-	if err != nil {
-		return "", false, fmt.Errorf("unable to resolve compiler output directory %s: %w", outputDir, err)
-	}
-
-	// Collect every path component from outputDir up to the filesystem root.
-	var components []string
-	for p := filepath.Clean(abs); ; {
-		components = append(components, p)
-		parent := filepath.Dir(p)
-		if parent == p {
-			break
-		}
-		p = parent
-	}
-
+func ensureRuntimeDirChain(components []string) (retryable bool, err error) {
 	// Walk root -> leaf so we know a component sits below a verified sticky
 	// boundary, and inside the agent's dedicated subtree, before we decide
 	// whether its failure is reclaimable.
@@ -330,13 +345,26 @@ func verifyRuntimeDirChain(outputDir string) (badPath string, healable bool, err
 		if filepath.Base(p) == dedicatedDirName {
 			inDedicatedSubtree = true
 		}
+
 		info, lerr := os.Lstat(p)
-		if lerr != nil {
-			return p, false, fmt.Errorf("unable to verify compiler output directory component %s: %w", p, lerr)
+		if os.IsNotExist(lerr) {
+			// This component and everything below it are the missing tail. Every
+			// existing ancestor was verified above as a real (non-symlink)
+			// root-owned directory, so os.Mkdir resolves only through verified
+			// directories and will not create through a symlink at p.
+			if mErr := os.Mkdir(p, 0700); mErr != nil {
+				// A racing actor may have created p first; re-walking re-checks it.
+				return true, fmt.Errorf("unable to create compiler output directory component %s: %w", p, mErr)
+			}
+			continue
 		}
+		if lerr != nil {
+			return false, fmt.Errorf("unable to verify compiler output directory component %s: %w", p, lerr)
+		}
+
 		stat, ok := info.Sys().(*syscall.Stat_t)
 		if !ok {
-			return p, false, fmt.Errorf("unable to read ownership of compiler output directory component %s", p)
+			return false, fmt.Errorf("unable to read ownership of compiler output directory component %s", p)
 		}
 		if verr := verifyDirComponent(p, info.Mode(), stat.Uid); verr != nil {
 			// Reclaim only a real, wrong-owner/permission directory that is below
@@ -345,7 +373,19 @@ func verifyRuntimeDirChain(outputDir string) (badPath string, healable bool, err
 			// file, so those remain fail-closed; requiring the dedicated subtree
 			// keeps reclaim from ever deleting a shared, non-agent directory.
 			healable := belowStickyBoundary && inDedicatedSubtree && os.Geteuid() == 0 && info.Mode().IsDir()
-			return p, healable, verr
+			if !healable {
+				return false, verr
+			}
+			if rErr := reclaimDirComponent(p); rErr != nil {
+				return false, fmt.Errorf("%w (attempted reclaim failed: %v)", verr, rErr)
+			}
+			logRuntimeDirReclaimed(p)
+			// Recreate this component fresh; deeper components were removed with
+			// the reclaimed subtree and are created as the walk continues.
+			if mErr := os.Mkdir(p, 0700); mErr != nil {
+				return true, fmt.Errorf("unable to recreate compiler output directory component %s after reclaim: %w", p, mErr)
+			}
+			continue
 		}
 		// This component is verified good. If it is a sticky directory it marks
 		// the shared-parent boundary; anything deeper may be repaired.
@@ -353,11 +393,11 @@ func verifyRuntimeDirChain(outputDir string) (badPath string, healable bool, err
 			belowStickyBoundary = true
 		}
 	}
-	return "", false, nil
+	return false, nil
 }
 
 // reclaimDirComponent moves a stale path component aside and removes it. The
-// caller must only invoke this for a component that verifyRuntimeDirChain
+// caller must only invoke this for a component that ensureRuntimeDirChain
 // reported as repairable (below a verified root-owned sticky directory and inside
 // the agent's dedicated datadog-agent subtree), which guarantees the parent is
 // root-owned so root can rename the entry regardless of who owns it. Renaming

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"syscall"
 	"time"
@@ -283,8 +284,8 @@ func secureRuntimeDir(outputDir string) error {
 }
 
 // runtimeDirComponents returns the absolute form of outputDir and every ancestor
-// up to the filesystem root, ordered leaf-first: index 0 is the leaf and the last
-// element is the filesystem root ("/").
+// up to the filesystem root, ordered root-first: index 0 is the filesystem root
+// ("/") and the last element is the leaf output directory.
 func runtimeDirComponents(outputDir string) ([]string, error) {
 	abs, err := filepath.Abs(outputDir)
 	if err != nil {
@@ -299,6 +300,8 @@ func runtimeDirComponents(outputDir string) ([]string, error) {
 		}
 		p = parent
 	}
+	// Collected leaf-first; reverse so the walk below can range root -> leaf.
+	slices.Reverse(components)
 	return components, nil
 }
 
@@ -337,8 +340,7 @@ func ensureRuntimeDirChain(components []string) (retryable bool, err error) {
 	// whether its failure is reclaimable.
 	belowStickyBoundary := false
 	inDedicatedSubtree := false
-	for i := len(components) - 1; i >= 0; i-- {
-		p := components[i]
+	for i, p := range components {
 		// A component named dedicatedDirName marks the start of the agent's own
 		// subtree; it and anything deeper may be repaired. Set this before the
 		// verify below so the datadog-agent component itself is repairable.
@@ -366,9 +368,9 @@ func ensureRuntimeDirChain(components []string) (retryable bool, err error) {
 		if !ok {
 			return false, fmt.Errorf("unable to read ownership of compiler output directory component %s", p)
 		}
-		// index 0 is the leaf output directory, which is held to the stricter
-		// no-group/other-write rule (see verifyDirComponent).
-		if verr := verifyDirComponent(p, info.Mode(), stat.Uid, i == 0); verr != nil {
+		// The last component is the leaf output directory, which is held to the
+		// stricter no-group/other-write rule (see verifyDirComponent).
+		if verr := verifyDirComponent(p, info.Mode(), stat.Uid, i == len(components)-1); verr != nil {
 			// Reclaim only a real, wrong-owner/permission directory that is below
 			// the sticky boundary, inside the agent's dedicated subtree, and only
 			// as root. info.Mode().IsDir() is false for a symlink or a regular

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -366,7 +366,9 @@ func ensureRuntimeDirChain(components []string) (retryable bool, err error) {
 		if !ok {
 			return false, fmt.Errorf("unable to read ownership of compiler output directory component %s", p)
 		}
-		if verr := verifyDirComponent(p, info.Mode(), stat.Uid); verr != nil {
+		// index 0 is the leaf output directory, which is held to the stricter
+		// no-group/other-write rule (see verifyDirComponent).
+		if verr := verifyDirComponent(p, info.Mode(), stat.Uid, i == 0); verr != nil {
 			// Reclaim only a real, wrong-owner/permission directory that is below
 			// the sticky boundary, inside the agent's dedicated subtree, and only
 			// as root. info.Mode().IsDir() is false for a symlink or a regular
@@ -426,11 +428,19 @@ func reclaimDirComponent(p string) error {
 // verifyDirComponent enforces the runtime-directory policy on a single path
 // component, described by the mode returned from Lstat and its owning uid: it
 // must be a real (non-symlink) directory owned by root and not writable by other
-// users. A group/other-writable directory is only accepted when the sticky bit
-// is set (as for the default /var/tmp parent). It is kept separate from the
-// filesystem walk above so the policy can be unit-tested with synthetic values,
-// without needing to build a root-owned directory tree.
-func verifyDirComponent(p string, mode os.FileMode, uid uint32) error {
+// users. It is kept separate from the filesystem walk above so the policy can be
+// unit-tested with synthetic values, without needing to build a root-owned
+// directory tree.
+//
+// The group/other-writable-but-sticky exception applies to ancestors only. It
+// exists for the shared parent the default lives under (/var/tmp is 1777), which
+// the agent does not own and cannot expect to tighten. The leaf output directory
+// is different: it is where object files are written and re-read under
+// predictable names, so a group/other-writable leaf would let another user
+// interpose an entry at one of those names between our check and the compiler's
+// write. The leaf must therefore have no group/other write bits regardless of the
+// sticky bit; isLeaf selects that stricter rule.
+func verifyDirComponent(p string, mode os.FileMode, uid uint32, isLeaf bool) error {
 	if mode&os.ModeSymlink != 0 {
 		return fmt.Errorf("refusing to use compiler output directory: %s is a symlink", p)
 	}
@@ -440,8 +450,8 @@ func verifyDirComponent(p string, mode os.FileMode, uid uint32) error {
 	if uid != 0 {
 		return fmt.Errorf("refusing to use compiler output directory: %s is not owned by root (uid=%d)", p, uid)
 	}
-	if mode.Perm()&0022 != 0 && mode&os.ModeSticky == 0 {
-		return fmt.Errorf("refusing to use compiler output directory: %s is writable by non-root and not sticky (mode=%#o)", p, mode.Perm())
+	if mode.Perm()&0022 != 0 && (isLeaf || mode&os.ModeSticky == 0) {
+		return fmt.Errorf("refusing to use compiler output directory: %s is writable by non-root (mode=%#o)", p, mode.Perm())
 	}
 	return nil
 }

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
@@ -96,8 +97,8 @@ func (a *asset) compile(config *ebpf.Config, opts CompileOptions) (CompiledOutpu
 	}
 	defer f.Close()
 
-	if err := os.MkdirAll(outputDir, 0755); err != nil {
-		return nil, fmt.Errorf("unable to create compiler output directory %s: %w", outputDir, err)
+	if err := secureRuntimeDir(outputDir); err != nil {
+		return nil, err
 	}
 
 	diskProtectedFile, err := createProtectedFile(fmt.Sprintf("%s-%s", a.filename, a.hash), outputDir, f)
@@ -158,6 +159,63 @@ func (a *asset) compile(config *ebpf.Config, opts CompileOptions) (CompiledOutpu
 	a.tm.compilationResult = result
 
 	return out, err
+}
+
+// secureRuntimeDir creates the runtime-compiler output directory (root-only,
+// 0700) and verifies that it, and every ancestor up to the filesystem root, is a
+// real directory owned by root and not writable by other users. The compiler
+// writes object files here and system-probe later re-reads them to load into the
+// kernel as root, so the whole path must be under root's control.
+//
+// It rejects the directory if any ancestor is a symlink, is not a directory, is
+// not owned by root, or is writable by group or other without the sticky bit
+// set. The sticky-bit exception permits the default location under /var/tmp
+// (root-owned, mode 1777): the sticky bit keeps other users from renaming or
+// deleting the datadog-agent directory that root creates beneath it.
+func secureRuntimeDir(outputDir string) error {
+	if err := os.MkdirAll(outputDir, 0700); err != nil {
+		return fmt.Errorf("unable to create compiler output directory %s: %w", outputDir, err)
+	}
+
+	abs, err := filepath.Abs(outputDir)
+	if err != nil {
+		return fmt.Errorf("unable to resolve compiler output directory %s: %w", outputDir, err)
+	}
+
+	// Collect every path component from outputDir up to the filesystem root.
+	var components []string
+	for p := filepath.Clean(abs); ; {
+		components = append(components, p)
+		parent := filepath.Dir(p)
+		if parent == p {
+			break
+		}
+		p = parent
+	}
+
+	for _, p := range components {
+		info, err := os.Lstat(p)
+		if err != nil {
+			return fmt.Errorf("unable to verify compiler output directory component %s: %w", p, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to use compiler output directory: %s is a symlink", p)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("refusing to use compiler output directory: %s is not a directory", p)
+		}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return fmt.Errorf("unable to read ownership of compiler output directory component %s", p)
+		}
+		if stat.Uid != 0 {
+			return fmt.Errorf("refusing to use compiler output directory: %s is not owned by root (uid=%d)", p, stat.Uid)
+		}
+		if info.Mode().Perm()&0022 != 0 && info.Mode()&os.ModeSticky == 0 {
+			return fmt.Errorf("refusing to use compiler output directory: %s is writable by non-root and not sticky (mode=%#o)", p, info.Mode().Perm())
+		}
+	}
+	return nil
 }
 
 // creates a ram backed file from the given reader. The file is made immutable

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel/headers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -414,8 +415,14 @@ func ensureRuntimeDirChain(components []string) (retryable bool, err error) {
 func reclaimDirComponent(p string) error {
 	// os.Rename does not follow a symlink at p: a symlinked component is moved as
 	// the link itself. The aside name is in the same (root-owned) parent so the
-	// rename stays within one directory.
-	aside := fmt.Sprintf("%s.reclaimed-%d-%d", p, os.Getpid(), time.Now().UnixNano())
+	// rename stays within one directory. Use the root-namespace PID: os.Getpid
+	// returns a namespaced PID inside a container, which is not unique across the
+	// host and could collide with a concurrent reclaim from another namespace.
+	pid, err := kernel.RootNSPID()
+	if err != nil {
+		pid = os.Getpid()
+	}
+	aside := fmt.Sprintf("%s.reclaimed-%d-%d", p, pid, time.Now().UnixNano())
 	if err := os.Rename(p, aside); err != nil {
 		return fmt.Errorf("unable to move aside stale component %s: %w", p, err)
 	}

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -98,6 +98,10 @@ func (a *asset) compile(config *ebpf.Config, opts CompileOptions) (CompiledOutpu
 	defer f.Close()
 
 	if err := secureRuntimeDir(outputDir); err != nil {
+		// Surface the policy refusal distinctly so operators can tell "runtime
+		// compilation disabled because the output directory is not under root's
+		// control" apart from an ordinary compilation failure.
+		log.Warnf("skipping runtime compilation of %s: %v", a.filename, err)
 		return nil, err
 	}
 

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -198,22 +198,36 @@ func secureRuntimeDir(outputDir string) error {
 		if err != nil {
 			return fmt.Errorf("unable to verify compiler output directory component %s: %w", p, err)
 		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("refusing to use compiler output directory: %s is a symlink", p)
-		}
-		if !info.IsDir() {
-			return fmt.Errorf("refusing to use compiler output directory: %s is not a directory", p)
-		}
 		stat, ok := info.Sys().(*syscall.Stat_t)
 		if !ok {
 			return fmt.Errorf("unable to read ownership of compiler output directory component %s", p)
 		}
-		if stat.Uid != 0 {
-			return fmt.Errorf("refusing to use compiler output directory: %s is not owned by root (uid=%d)", p, stat.Uid)
+		if err := verifyDirComponent(p, info.Mode(), stat.Uid); err != nil {
+			return err
 		}
-		if info.Mode().Perm()&0022 != 0 && info.Mode()&os.ModeSticky == 0 {
-			return fmt.Errorf("refusing to use compiler output directory: %s is writable by non-root and not sticky (mode=%#o)", p, info.Mode().Perm())
-		}
+	}
+	return nil
+}
+
+// verifyDirComponent enforces the runtime-directory policy on a single path
+// component, described by the mode returned from Lstat and its owning uid: it
+// must be a real (non-symlink) directory owned by root and not writable by other
+// users. A group/other-writable directory is only accepted when the sticky bit
+// is set (as for the default /var/tmp parent). It is kept separate from the
+// filesystem walk above so the policy can be unit-tested with synthetic values,
+// without needing to build a root-owned directory tree.
+func verifyDirComponent(p string, mode os.FileMode, uid uint32) error {
+	if mode&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to use compiler output directory: %s is a symlink", p)
+	}
+	if !mode.IsDir() {
+		return fmt.Errorf("refusing to use compiler output directory: %s is not a directory", p)
+	}
+	if uid != 0 {
+		return fmt.Errorf("refusing to use compiler output directory: %s is not owned by root (uid=%d)", p, uid)
+	}
+	if mode.Perm()&0022 != 0 && mode&os.ModeSticky == 0 {
+		return fmt.Errorf("refusing to use compiler output directory: %s is writable by non-root and not sticky (mode=%#o)", p, mode.Perm())
 	}
 	return nil
 }

--- a/pkg/ebpf/bytecode/runtime/asset_test.go
+++ b/pkg/ebpf/bytecode/runtime/asset_test.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// secureRuntimeDir must reject a cache directory that is not owned by root,
+// since only root should be able to write or read the compiled objects stored
+// there.
+func TestSecureRuntimeDirRejectsNonRootOwned(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("test must run as non-root: a root-created dir would legitimately pass")
+	}
+
+	dir := filepath.Join(t.TempDir(), "build")
+	err := secureRuntimeDir(dir)
+	require.Error(t, err, "a non-root-owned cache directory must be rejected")
+}
+
+// secureRuntimeDir must reject a directory whose path traverses a symlinked
+// component.
+func TestSecureRuntimeDirRejectsSymlinkComponent(t *testing.T) {
+	base := t.TempDir()
+
+	realDir := filepath.Join(base, "real")
+	require.NoError(t, os.MkdirAll(realDir, 0700))
+
+	link := filepath.Join(base, "link")
+	require.NoError(t, os.Symlink(realDir, link))
+
+	err := secureRuntimeDir(filepath.Join(link, "build"))
+	require.Error(t, err, "a cache directory reached through a symlink must be rejected")
+}

--- a/pkg/ebpf/bytecode/runtime/asset_test.go
+++ b/pkg/ebpf/bytecode/runtime/asset_test.go
@@ -42,3 +42,39 @@ func TestSecureRuntimeDirRejectsSymlinkComponent(t *testing.T) {
 	err := secureRuntimeDir(filepath.Join(link, "build"))
 	require.Error(t, err, "a cache directory reached through a symlink must be rejected")
 }
+
+// verifyDirComponent is the pure policy behind the ancestor walk in
+// secureRuntimeDir. Exercising it directly covers the accept/reject logic
+// regardless of the euid the suite runs under (the filesystem-level test above
+// skips when run as root, which is common for eBPF suites).
+func TestVerifyDirComponent(t *testing.T) {
+	const (
+		rootUID    uint32 = 0
+		nonRootUID uint32 = 1000
+	)
+	tests := []struct {
+		name    string
+		mode    os.FileMode
+		uid     uint32
+		wantErr bool
+	}{
+		{"root-owned 0700 dir", os.ModeDir | 0700, rootUID, false},
+		{"root-owned 0755 dir", os.ModeDir | 0755, rootUID, false},
+		{"root-owned sticky 1777 dir (/var/tmp)", os.ModeDir | os.ModeSticky | 0777, rootUID, false},
+		{"symlink", os.ModeSymlink | 0777, rootUID, true},
+		{"regular file", 0644, rootUID, true},
+		{"non-root-owned dir", os.ModeDir | 0700, nonRootUID, true},
+		{"group-writable dir without sticky", os.ModeDir | 0770, rootUID, true},
+		{"world-writable dir without sticky", os.ModeDir | 0777, rootUID, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := verifyDirComponent("/some/path", tc.mode, tc.uid)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/ebpf/bytecode/runtime/asset_test.go
+++ b/pkg/ebpf/bytecode/runtime/asset_test.go
@@ -262,6 +262,52 @@ func TestSecureRuntimeDirRefusesSharedNonDedicatedAncestor(t *testing.T) {
 	require.False(t, hasReclaimedLeftover(t, sticky))
 }
 
+// A group/other-writable leaf output directory inside the agent's own subtree is
+// repaired to 0700, even when it carries the sticky bit (which is tolerated on
+// ancestors but not on the leaf, where object files are written under predictable
+// names).
+func TestSecureRuntimeDirRepairsWritableStickyLeaf(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("test must run as root")
+	}
+	_, build := stickyParent(t)
+	require.NoError(t, os.MkdirAll(build, 0700))
+	// Pre-existing leaf that is root-owned but sticky + world-writable.
+	require.NoError(t, os.Chmod(build, 0777|os.ModeSticky))
+
+	require.NoError(t, secureRuntimeDir(build))
+	require.Equal(t, uint32(0), dirUID(t, build), "leaf must be root-owned")
+	info, err := os.Lstat(build)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0700), info.Mode().Perm(), "writable leaf must be repaired to 0700")
+	require.Equal(t, os.FileMode(0), info.Mode()&os.ModeSticky, "sticky bit must be gone after repair")
+}
+
+// A root-owned but group/other-writable leaf that is NOT inside the agent's
+// dedicated subtree must be refused (not reclaimed): tightening or deleting a
+// shared/system directory the agent does not own would be destructive, so it
+// fails closed instead.
+func TestSecureRuntimeDirRefusesWritableLeafOutsideSubtree(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("test must run as root")
+	}
+	// t.TempDir lives under sticky /tmp, so there is a sticky ancestor, but no
+	// component is named datadog-agent.
+	base := filepath.Join(t.TempDir(), "shared")
+	require.NoError(t, os.Mkdir(base, 0755))
+	leaf := filepath.Join(base, "build")
+	require.NoError(t, os.Mkdir(leaf, 0700))
+	require.NoError(t, os.Chmod(leaf, 0777|os.ModeSticky)) // root-owned, sticky, world-writable
+
+	err := secureRuntimeDir(leaf)
+	require.Error(t, err, "a writable leaf outside the dedicated subtree must be refused")
+	info, lerr := os.Lstat(leaf)
+	require.NoError(t, lerr)
+	require.Equal(t, os.FileMode(0777), info.Mode().Perm(), "the leaf must be left untouched, not tightened")
+	require.NotEqual(t, os.FileMode(0), info.Mode()&os.ModeSticky, "the leaf must be left untouched, not reclaimed")
+	require.False(t, hasReclaimedLeftover(t, base))
+}
+
 // verifyDirComponent is the pure policy behind the ancestor walk in
 // secureRuntimeDir. Exercising it directly covers the accept/reject logic
 // regardless of the euid the suite runs under (the filesystem-level test above
@@ -275,20 +321,27 @@ func TestVerifyDirComponent(t *testing.T) {
 		name    string
 		mode    os.FileMode
 		uid     uint32
+		isLeaf  bool
 		wantErr bool
 	}{
-		{"root-owned 0700 dir", os.ModeDir | 0700, rootUID, false},
-		{"root-owned 0755 dir", os.ModeDir | 0755, rootUID, false},
-		{"root-owned sticky 1777 dir (/var/tmp)", os.ModeDir | os.ModeSticky | 0777, rootUID, false},
-		{"symlink", os.ModeSymlink | 0777, rootUID, true},
-		{"regular file", 0644, rootUID, true},
-		{"non-root-owned dir", os.ModeDir | 0700, nonRootUID, true},
-		{"group-writable dir without sticky", os.ModeDir | 0770, rootUID, true},
-		{"world-writable dir without sticky", os.ModeDir | 0777, rootUID, true},
+		{"root-owned 0700 dir", os.ModeDir | 0700, rootUID, false, false},
+		{"root-owned 0755 dir", os.ModeDir | 0755, rootUID, false, false},
+		{"root-owned sticky 1777 dir (/var/tmp)", os.ModeDir | os.ModeSticky | 0777, rootUID, false, false},
+		{"symlink", os.ModeSymlink | 0777, rootUID, false, true},
+		{"regular file", 0644, rootUID, false, true},
+		{"non-root-owned dir", os.ModeDir | 0700, nonRootUID, false, true},
+		{"group-writable dir without sticky", os.ModeDir | 0770, rootUID, false, true},
+		{"world-writable dir without sticky", os.ModeDir | 0777, rootUID, false, true},
+		// The leaf output directory is held to a stricter rule: no group/other
+		// write bits even when the sticky bit is set.
+		{"leaf root-owned 0700 dir", os.ModeDir | 0700, rootUID, true, false},
+		{"leaf root-owned 0755 dir", os.ModeDir | 0755, rootUID, true, false},
+		{"leaf sticky 1777 dir", os.ModeDir | os.ModeSticky | 0777, rootUID, true, true},
+		{"leaf group-writable sticky dir", os.ModeDir | os.ModeSticky | 0770, rootUID, true, true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := verifyDirComponent("/some/path", tc.mode, tc.uid)
+			err := verifyDirComponent("/some/path", tc.mode, tc.uid, tc.isLeaf)
 			if tc.wantErr {
 				require.Error(t, err)
 			} else {

--- a/pkg/ebpf/bytecode/runtime/asset_test.go
+++ b/pkg/ebpf/bytecode/runtime/asset_test.go
@@ -232,6 +232,36 @@ func TestSecureRuntimeDirRefusesNonRootWithoutStickyAncestor(t *testing.T) {
 	require.Equal(t, uint32(1), dirUID(t, parent), "the component must be left untouched, not reclaimed")
 }
 
+// A non-root component that sits below a sticky boundary but OUTSIDE the agent's
+// dedicated (datadog-agent) subtree must be refused, never reclaimed. Reclaiming
+// it would rename the shared parent aside and recursively delete it along with
+// unrelated contents, so this guards that data-loss regression for a custom
+// output_dir nested under a shared directory (e.g. /var/tmp/shared/datadog/build).
+func TestSecureRuntimeDirRefusesSharedNonDedicatedAncestor(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("test must run as root to create the non-root component")
+	}
+
+	// Root-owned sticky parent standing in for /var/tmp.
+	sticky := filepath.Join(t.TempDir(), "sticky")
+	require.NoError(t, os.Mkdir(sticky, 0777))
+	require.NoError(t, os.Chmod(sticky, 0777|os.ModeSticky))
+
+	// A shared, non-root-owned directory that is NOT named datadog-agent and
+	// holds unrelated data.
+	shared := filepath.Join(sticky, "shared")
+	require.NoError(t, os.Mkdir(shared, 0777))
+	require.NoError(t, syscall.Chown(shared, 1, 1))
+	bystander := filepath.Join(shared, "unrelated.txt")
+	require.NoError(t, os.WriteFile(bystander, []byte("keep me"), 0644))
+
+	err := secureRuntimeDir(filepath.Join(shared, "datadog", "build"))
+	require.Error(t, err, "a non-dedicated shared ancestor must be refused, not reclaimed")
+	require.FileExists(t, bystander, "unrelated contents must be preserved")
+	require.Equal(t, uint32(1), dirUID(t, shared), "the shared dir must be left untouched, not reclaimed")
+	require.False(t, hasReclaimedLeftover(t, sticky))
+}
+
 // verifyDirComponent is the pure policy behind the ancestor walk in
 // secureRuntimeDir. Exercising it directly covers the accept/reject logic
 // regardless of the euid the suite runs under (the filesystem-level test above

--- a/pkg/ebpf/bytecode/runtime/asset_test.go
+++ b/pkg/ebpf/bytecode/runtime/asset_test.go
@@ -10,6 +10,7 @@ package runtime
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -74,6 +75,161 @@ func TestSecureRuntimeDirReclaimsNonRootComponent(t *testing.T) {
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	require.True(t, ok)
 	require.Equal(t, uint32(0), stat.Uid, "repaired component must be owned by root")
+}
+
+// stickyParent returns a fresh root-owned sticky directory standing in for
+// /var/tmp, and a build path beneath a datadog-agent component under it.
+func stickyParent(t *testing.T) (sticky, buildPath string) {
+	t.Helper()
+	sticky = filepath.Join(t.TempDir(), "sticky")
+	require.NoError(t, os.Mkdir(sticky, 0777))
+	require.NoError(t, os.Chmod(sticky, 0777|os.ModeSticky))
+	return sticky, filepath.Join(sticky, "datadog-agent", "system-probe", "build")
+}
+
+func dirUID(t *testing.T, p string) uint32 {
+	t.Helper()
+	info, err := os.Lstat(p)
+	require.NoError(t, err)
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	require.True(t, ok)
+	return stat.Uid
+}
+
+func dirIno(t *testing.T, p string) uint64 {
+	t.Helper()
+	info, err := os.Lstat(p)
+	require.NoError(t, err)
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	require.True(t, ok)
+	return stat.Ino
+}
+
+// hasReclaimedLeftover reports whether any component under root retains a
+// moved-aside ".reclaimed-" directory, which must not survive a successful run.
+func hasReclaimedLeftover(t *testing.T, root string) bool {
+	t.Helper()
+	found := false
+	require.NoError(t, filepath.Walk(root, func(p string, _ os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if strings.Contains(p, ".reclaimed-") {
+			found = true
+		}
+		return nil
+	}))
+	return found
+}
+
+// B1: an absent directory is created root-owned and 0700.
+func TestSecureRuntimeDirCreatesRootOwnedWhenAbsent(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("test must run as root")
+	}
+	_, build := stickyParent(t)
+
+	require.NoError(t, secureRuntimeDir(build))
+	require.Equal(t, uint32(0), dirUID(t, build), "created dir must be root-owned")
+	info, err := os.Lstat(build)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0700), info.Mode().Perm(), "created dir must be 0700")
+}
+
+// B2: a normal upgrade over a pre-existing root-owned tree is accepted without
+// any reclaim (the inode is preserved).
+func TestSecureRuntimeDirAcceptsPreexistingRootDir(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("test must run as root")
+	}
+	sticky, build := stickyParent(t)
+	require.NoError(t, os.MkdirAll(build, 0755))
+	da := filepath.Join(sticky, "datadog-agent")
+	require.NoError(t, os.Chmod(da, 0755))
+	before := dirIno(t, da)
+
+	require.NoError(t, secureRuntimeDir(build))
+	// A valid root-owned dir must be left untouched: same inode and same mode
+	// (a reclaim would recreate it 0700).
+	require.Equal(t, before, dirIno(t, da))
+	info, err := os.Lstat(da)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0755), info.Mode().Perm(), "a valid dir must not be reclaimed to 0700")
+	require.False(t, hasReclaimedLeftover(t, sticky))
+}
+
+// B4: a non-root-owned deep component (not the top datadog-agent one) is
+// repaired too.
+func TestSecureRuntimeDirRepairsDeepNonRootComponent(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("test must run as root to create a non-root-owned directory")
+	}
+	sticky, build := stickyParent(t)
+	sp := filepath.Join(sticky, "datadog-agent", "system-probe")
+	require.NoError(t, os.MkdirAll(sp, 0755))
+	require.NoError(t, syscall.Chown(sp, 1, 1))
+
+	require.NoError(t, secureRuntimeDir(build))
+	require.Equal(t, uint32(0), dirUID(t, sp), "deep non-root component must be repaired to root")
+	require.False(t, hasReclaimedLeftover(t, sticky))
+}
+
+// B5: a group/other-writable, non-sticky directory below the sticky boundary is
+// repaired (it violates the policy even though it is root-owned).
+func TestSecureRuntimeDirRepairsWritableNonStickyDir(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("test must run as root")
+	}
+	sticky, build := stickyParent(t)
+	da := filepath.Join(sticky, "datadog-agent")
+	require.NoError(t, os.Mkdir(da, 0700))
+	require.NoError(t, os.Chmod(da, 0777)) // explicit chmod bypasses umask: root-owned, world-writable, no sticky
+
+	require.NoError(t, secureRuntimeDir(build))
+	require.Equal(t, uint32(0), dirUID(t, da))
+	// A reclaim recreates the component 0700; if it were wrongly accepted as-is
+	// it would still be 0777. (Inode numbers are unreliable here: ext4 recycles
+	// them, so a recreated dir can reuse the freed number.)
+	info, err := os.Lstat(da)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0700), info.Mode().Perm(), "writable non-sticky dir must be reclaimed to 0700")
+}
+
+// B9: running twice is idempotent - the second run finds a valid tree, repairs
+// nothing, and leaves no moved-aside directories behind.
+func TestSecureRuntimeDirIdempotent(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("test must run as root to create a non-root-owned directory")
+	}
+	sticky, build := stickyParent(t)
+	da := filepath.Join(sticky, "datadog-agent")
+	require.NoError(t, os.Mkdir(da, 0777))
+	require.NoError(t, syscall.Chown(da, 1, 1))
+
+	require.NoError(t, secureRuntimeDir(build)) // repairs
+	inoAfterFirst := dirIno(t, da)
+	require.NoError(t, secureRuntimeDir(build)) // no-op
+	require.Equal(t, inoAfterFirst, dirIno(t, da), "second run must not reclaim again")
+	require.False(t, hasReclaimedLeftover(t, sticky), "no moved-aside dirs may remain")
+}
+
+// B8: a non-root component with NO sticky ancestor is refused, never repaired.
+// Uses /root as a non-sticky root-only base (t.TempDir lives under sticky /tmp).
+func TestSecureRuntimeDirRefusesNonRootWithoutStickyAncestor(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("test must run as root to create the non-root component")
+	}
+	base, err := os.MkdirTemp("/root", "sp-rc-nosticky-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+
+	parent := filepath.Join(base, "parent")
+	require.NoError(t, os.Mkdir(parent, 0755))
+	require.NoError(t, syscall.Chown(parent, 1, 1))
+
+	err = secureRuntimeDir(filepath.Join(parent, "build"))
+	require.Error(t, err, "a non-root component with no sticky ancestor must be refused, not repaired")
+	require.Equal(t, uint32(1), dirUID(t, parent), "the component must be left untouched, not reclaimed")
 }
 
 // verifyDirComponent is the pure policy behind the ancestor walk in

--- a/pkg/ebpf/bytecode/runtime/asset_test.go
+++ b/pkg/ebpf/bytecode/runtime/asset_test.go
@@ -10,6 +10,7 @@ package runtime
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -41,6 +42,38 @@ func TestSecureRuntimeDirRejectsSymlinkComponent(t *testing.T) {
 
 	err := secureRuntimeDir(filepath.Join(link, "build"))
 	require.Error(t, err, "a cache directory reached through a symlink must be rejected")
+}
+
+// secureRuntimeDir must repair a non-root-owned component that sits below a
+// root-owned sticky directory (as with a pre-existing datadog-agent directory
+// under /var/tmp) by moving it aside and recreating the path as root, instead of
+// refusing for the lifetime of the process. This requires root to create the
+// non-root-owned component, so it runs only as root (as eBPF CI suites do).
+func TestSecureRuntimeDirReclaimsNonRootComponent(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("test must run as root to create a non-root-owned directory")
+	}
+
+	// Root-owned sticky parent standing in for /var/tmp.
+	sticky := filepath.Join(t.TempDir(), "sticky")
+	require.NoError(t, os.Mkdir(sticky, 0777))
+	require.NoError(t, os.Chmod(sticky, 0777|os.ModeSticky))
+
+	// A pre-existing datadog-agent directory owned by a non-root user.
+	preexisting := filepath.Join(sticky, "datadog-agent")
+	require.NoError(t, os.Mkdir(preexisting, 0777))
+	require.NoError(t, syscall.Chown(preexisting, 1, 1))
+
+	build := filepath.Join(preexisting, "system-probe", "build")
+	require.NoError(t, secureRuntimeDir(build), "secureRuntimeDir should repair the non-root component and succeed")
+
+	// The repaired component must now be a root-owned directory.
+	info, err := os.Lstat(preexisting)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	require.True(t, ok)
+	require.Equal(t, uint32(0), stat.Uid, "repaired component must be owned by root")
 }
 
 // verifyDirComponent is the pure policy behind the ancestor walk in

--- a/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
@@ -63,9 +63,17 @@ func compileToObjectFile(inFile, outputDir, filename, inHash string, additionalF
 	}
 
 	var result CompilationResult
-	if _, err := os.Stat(outputFile); err != nil {
-		if !os.IsNotExist(err) {
+	// Use Lstat and only treat a regular file as a valid cache entry; a
+	// non-regular entry (e.g. a symlink) is removed and recompiled so we never
+	// write through it or read its target.
+	if fi, err := os.Lstat(outputFile); err != nil || !fi.Mode().IsRegular() {
+		if err != nil && !os.IsNotExist(err) {
 			return nil, outputFileErr, fmt.Errorf("error stat-ing output file %s: %w", outputFile, err)
+		}
+		if err == nil {
+			if rmErr := os.Remove(outputFile); rmErr != nil {
+				return nil, outputFileErr, fmt.Errorf("error removing unexpected output file %s: %w", outputFile, rmErr)
+			}
 		}
 
 		kv, err := kernel.HostVersion()
@@ -101,14 +109,12 @@ func compileToObjectFile(inFile, outputDir, filename, inHash string, additionalF
 		result = compiledOutputFound
 	}
 
-	err = bytecode.VerifyAssetPermissions(outputFile)
+	// Open the compiled object with O_NOFOLLOW and verify permissions on the
+	// resulting descriptor, then hand that same descriptor to the caller so the
+	// bytes we load are exactly the bytes we verified.
+	out, err := bytecode.VerifyAssetPermissionsAndOpen(outputFile)
 	if err != nil {
 		return nil, outputFileErr, err
-	}
-
-	out, err := os.Open(outputFile)
-	if err != nil {
-		return nil, resultReadErr, err
 	}
 	return out, result, nil
 }

--- a/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
@@ -10,8 +10,10 @@ package runtime
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,7 +69,7 @@ func compileToObjectFile(inFile, outputDir, filename, inHash string, additionalF
 	// non-regular entry (e.g. a symlink) is removed and recompiled so we never
 	// write through it or read its target.
 	if fi, err := os.Lstat(outputFile); err != nil || !fi.Mode().IsRegular() {
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return nil, outputFileErr, fmt.Errorf("error stat-ing output file %s: %w", outputFile, err)
 		}
 		if err == nil {

--- a/pkg/ebpf/bytecode/runtime/telemetry.go
+++ b/pkg/ebpf/bytecode/runtime/telemetry.go
@@ -38,6 +38,11 @@ const (
 	outputFileErr
 	_
 	compilationErr
+	// resultReadErr is retained for stability of the RuntimeCompilationResult
+	// payload enum but is no longer emitted: reading the compiled object was
+	// folded into the permission check (VerifyAssetPermissionsAndOpen), so a
+	// failure to open/read a verified object is now reported as outputFileErr.
+	// Do not remove or reorder these values.
 	resultReadErr
 	headerFetchErr
 	compiledOutputFound

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -56,7 +56,11 @@ type Config struct {
 	// KernelHeadersDownloadDir is the directory where the system-probe will attempt to download kernel headers, if necessary
 	KernelHeadersDownloadDir string
 
-	// RuntimeCompilerOutputDir is the directory where the runtime compiler will store compiled programs
+	// RuntimeCompilerOutputDir is the directory where the runtime compiler will store compiled programs.
+	// This directory and every parent up to the filesystem root must be a root-owned directory that is
+	// not writable by other users (a sticky, world-writable parent such as the default /var/tmp is
+	// allowed). If that is not the case system-probe refuses to use the directory and skips runtime
+	// compilation instead of loading objects from an untrusted location; see secureRuntimeDir.
 	RuntimeCompilerOutputDir string
 
 	// BTFOutputDir is the directory where extracted BTF files are stored


### PR DESCRIPTION
### What does this PR do?

Tightens how system-probe's runtime-compiled eBPF object cache is created and consumed:

- Adds `secureRuntimeDir`, which creates the runtime-compiler output directory root-only (`0700`) and verifies that it — and every ancestor up to the filesystem root — is a real directory owned by root and not writable by other users. The sticky bit is accepted for the default `/var/tmp` parent. If the tree is not under root's control, runtime compilation is skipped instead of using it.
- Adds `VerifyAssetPermissionsAndOpen`, which opens the compiled object with `O_NOFOLLOW` and checks ownership/permissions on the returned file descriptor. The runtime compiler and `GetReader` now consume that descriptor directly instead of re-opening the file by path, so the bytes that are loaded are the same bytes that were verified.
- Treats only a regular file as a valid cache entry (a non-regular entry is removed and recompiled).

### Motivation

The runtime-compiler cache defaults to a location under the world-writable `/var/tmp`, and the compiled object was previously verified and then re-opened by path in two separate steps. Making the directory root-owned and reusing the verified descriptor keeps the whole compile → verify → kernel-load path under root's control and removes the second path resolution. Hardening / robustness improvement.

### Describe how you validated your changes

- New unit tests for the rejection paths: `O_NOFOLLOW` symlink rejection and non-root-owned file rejection (`permissions_test.go`); non-root-owned and symlinked-component cache directory rejection (`asset_test.go`).
- Ran `dda inv test --targets=./pkg/ebpf/bytecode/` and `--targets=./pkg/ebpf/bytecode/runtime/ --build-include=linux_bpf` — all pass.
- Manually validated on an Ubuntu 24.04 (kernel 6.8, arm64) VM with `enable_runtime_compiler: true`, `enable_co_re: false`, `allow_precompiled_fallback: false`:
  - Correctly provisioned host: `tracer.c` / `conntrack.c` runtime-compiled and loaded into the kernel; cache tree created `root:root 0700`. No behavior change.
  - Directory pre-created by a non-root user: system-probe declines to use it (`refusing to use compiler output directory: … is not owned by root`) and the module falls back cleanly instead of loading from the untrusted location.

### Additional Notes

No release note is included in this PR (a `changelog/no-changelog` label will be needed to satisfy the reno CI check).
