### PR TITLE
fix(ebpf): use dynamic offset for ns_common.inum field access

### DIFF
--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -92,12 +92,6 @@ u32 __attribute__((always_inline)) get_mount_offset_of_mount_ns(void) {
     return offset; // offsetof(struct mount, mnt_ns)
 }
 
-u32 __attribute__((always_inline)) get_mount_offset_of_nscommon_inum(void) {
-    u64 offset;
-    LOAD_CONSTANT("ns_common_inum_offset", offset);
-    return offset; // offsetof(struct ns_common, inum)
-}
-
 u32 __attribute__((always_inline)) get_mount_offset_of_parent(void) {
     u64 offset;
     LOAD_CONSTANT("mount_parent_offset", offset);
@@ -114,6 +108,12 @@ u32 __attribute__((always_inline)) get_mnt_namespace_ns(void) {
     u64 offset;
     LOAD_CONSTANT("mnt_namespace_ns", offset);
     return offset; // offsetof(struct mnt_namespace, ns)
+}
+
+u32 __attribute__((always_inline)) get_ns_common_inum_offset(void) {
+    u64 offset;
+    LOAD_CONSTANT("ns_common_inum_offset", offset);
+    return offset; // offsetof(struct ns_common, inum)
 }
 
 static int __attribute__((always_inline)) get_vfsmount_mount_id(struct vfsmount *mnt) {
@@ -185,7 +185,7 @@ u32 __attribute__((always_inline)) get_mount_mount_ns_inum(void *mnt) {
         return 0;
     }
 
-    bpf_probe_read(&inum, sizeof(inum), mnt_ns + get_mnt_namespace_ns() + get_mount_offset_of_nscommon_inum());
+    bpf_probe_read(&inum, sizeof(inum), mnt_ns + get_mnt_namespace_ns() + get_ns_common_inum_offset());
     return inum;
 }
 

--- a/pkg/security/ebpf/c/include/constants/offsets/netns.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/netns.h
@@ -2,6 +2,7 @@
 #define _CONSTANTS_OFFSETS_NETNS_H_
 
 #include "constants/macros.h"
+#include "constants/offsets/filesystem.h"
 
 __attribute__((always_inline)) u32 get_ifindex_from_net_device(struct net_device *device) {
     u64 net_device_ifindex_offset;
@@ -37,9 +38,9 @@ __attribute__((always_inline)) u32 get_netns_from_net(struct net *net) {
     }
 
 #ifndef DO_NOT_USE_TC
-    struct ns_common ns;
-    bpf_probe_read(&ns, sizeof(ns), (void *)net + net_ns_offset);
-    return ns.inum;
+    u32 inum = 0;
+    bpf_probe_read(&inum, sizeof(inum), (void *)net + net_ns_offset + get_ns_common_inum_offset());
+    return inum;
 #else
     return 0;
 #endif

--- a/pkg/security/ebpf/c/include/hooks/namespaces.h
+++ b/pkg/security/ebpf/c/include/hooks/namespaces.h
@@ -18,7 +18,7 @@ int hook_switch_task_namespaces(ctx_t *ctx) {
     bpf_probe_read(&mnt_ns, sizeof(mnt_ns), (void *)new_ns + nsproxy_mnt_ns_offset);
     if (mnt_ns != NULL) {
         u32 inum = 0;
-        bpf_probe_read(&inum, sizeof(inum), (void *)mnt_ns + get_mount_offset_of_nscommon_inum());
+        bpf_probe_read(&inum, sizeof(inum), (void *)mnt_ns + get_ns_common_inum_offset());
 
         u32 pid = bpf_get_current_pid_tgid() >> 32;
         bpf_map_update_elem(&mntns_cache, &pid, &inum, BPF_ANY);


### PR DESCRIPTION
### What does this PR do?

Replace direct `ns.inum` access with a LOAD_CONSTANT-based offset resolved via BTF (or other fallbacks) when reading a network namespace ID.

The offset function is also renamed, since it returns an offset into `struct ns_common` rather than into `struct mount`, and is now shared by the mount and network namespace paths.

### Motivation

Linux 7.0 reworked `struct ns_common`: `inum` moved from offset 16 to 88 and the struct grew from 24 to 256 bytes  so on this kernel every network namespace resolved to 0.

### Describe how you validated your changes

Existing functional tests running on Ubuntu 26.04.

### Additional Notes

Memory layout on a 7.0.0-28-generic Ubuntu kernel:

```
struct ns_common {
	struct {
		refcount_t         __ns_ref;             /*     0     4 */
	} __attribute__((__aligned__(64)));                                               /*     0    64 */

	/* XXX last struct has 60 bytes of padding */

	/* --- cacheline 1 boundary (64 bytes) --- */
	u32                        ns_type;              /*    64     4 */

	/* XXX 4 bytes hole, try to pack */

	struct dentry *            stashed;              /*    72     8 */
	const struct proc_ns_operations  * ops;          /*    80     8 */
	unsigned int               inum;                 /*    88     4 */

	/* XXX 4 bytes hole, try to pack */

	union {
		struct ns_tree     ;                     /*    96   160 */
		struct callback_head ns_rcu;             /*    96    16 */
	};                                               /*    96   160 */

	/* size: 256, cachelines: 4, members: 6 */
	/* sum members: 248, holes: 2, sum holes: 8 */
	/* paddings: 1, sum paddings: 60 */
};
```
