### PR TITLE
Bound decompression reads with io.CopyN to prevent decompression-bomb resource exhaustion

### DIFF
--- a/cmd/cluster-agent/api/v2/series/series.go
+++ b/cmd/cluster-agent/api/v2/series/series.go
@@ -38,6 +38,11 @@ var bufferPool = sync.Pool{
 	},
 }
 
+// maxDecompressedBodySize is the maximum number of bytes handle will read from a
+// (possibly compressed) request body. It guards against decompression bombs sent by a
+// node agent; exceeding it is a request error, not a silent truncation.
+const maxDecompressedBodySize = 100 << 20 // 100 MiB
+
 // InstallNodeMetricsEndpoints register handler for node metrics collection
 func InstallNodeMetricsEndpoints(ctx context.Context, r *http.ServeMux, cfg config.Component) {
 	leaderHander := newSeriesHandler(ctx)
@@ -96,10 +101,15 @@ func (h *seriesHandler) handle(w http.ResponseWriter, r *http.Request) {
 	buf := bufferPool.Get().(*bytes.Buffer)
 	defer bufferPool.Put(buf)
 	buf.Reset() // Reset the buffer before using it
-	_, err = io.Copy(buf, rc)
-	if err != nil {
+	n, err := io.CopyN(buf, rc, maxDecompressedBodySize+1)
+	if err != nil && !errors.Is(err, io.EOF) {
 		api.SetSpanError(w, fmt.Errorf("failed to read request body: %w", err))
 		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if n > maxDecompressedBodySize {
+		api.SetSpanError(w, fmt.Errorf("request body exceeds maximum allowed decompressed size of %d bytes", maxDecompressedBodySize))
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
 		return
 	}
 

--- a/pkg/security/security_profile/profile/utils.go
+++ b/pkg/security/security_profile/profile/utils.go
@@ -10,6 +10,7 @@ package profile
 
 import (
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -17,6 +18,11 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 )
+
+// maxDecompressedSize is the maximum number of bytes unzip will write to disk when
+// decompressing a security-profile gzip file. It guards against decompression bombs;
+// exceeding it is an error, not a silent truncation.
+const maxDecompressedSize = 2 << 30 // 2 GiB
 
 func unzip(inputFile string, ext string) (string, error) {
 	// uncompress the file first
@@ -39,9 +45,12 @@ func unzip(inputFile string, ext string) (string, error) {
 	}
 	defer outputFile.Close()
 
-	_, err = io.Copy(outputFile, gzipReader)
-	if err != nil {
+	n, err := io.CopyN(outputFile, gzipReader, maxDecompressedSize+1)
+	if err != nil && !errors.Is(err, io.EOF) {
 		return "", fmt.Errorf("couldn't unzip %s: %w", inputFile, err)
+	}
+	if n > maxDecompressedSize {
+		return "", fmt.Errorf("couldn't unzip %s: decompressed size exceeds maximum allowed size of %d bytes", inputFile, maxDecompressedSize)
 	}
 
 	if err = outputFile.Close(); err != nil {

--- a/pkg/util/archive/tar_xz.go
+++ b/pkg/util/archive/tar_xz.go
@@ -20,6 +20,12 @@ import (
 // ErrStopWalk can be returned in WalkTarXZArchive to stop walking
 var ErrStopWalk = errors.New("stop walk")
 
+// maxExtractedFileSize is the maximum number of bytes untarFile will write for a single
+// archive entry. It guards against decompression bombs in the xz stream (a declared tar
+// header size cannot be trusted on its own); exceeding it is an error, not a silent
+// truncation.
+const maxExtractedFileSize = 5 << 30 // 5 GiB
+
 // WalkTarXZArchive walks the provided .tar.xz archive, calling walkFunc for each entry.
 // If ErrStopWalk is returned from walkFunc, then the walk is stopped.
 func WalkTarXZArchive(tarxzArchive string, walkFunc func(*tar.Reader, *tar.Header) error) error {
@@ -122,9 +128,12 @@ func untarFile(tr *tar.Reader, hdr *tar.Header, destinationDir string) error {
 	}
 	defer out.Close()
 
-	_, err = io.Copy(out, tr)
-	if err != nil {
+	n, err := io.CopyN(out, tr, maxExtractedFileSize+1)
+	if err != nil && !errors.Is(err, io.EOF) {
 		return fmt.Errorf("copy file %s: %w", fpath, err)
+	}
+	if n > maxExtractedFileSize {
+		return fmt.Errorf("copy file %s: decompressed size exceeds maximum allowed size of %d bytes", fpath, maxExtractedFileSize)
 	}
 	return nil
 }

--- a/pkg/util/compression/impl-gzip/gzip_strategy.go
+++ b/pkg/util/compression/impl-gzip/gzip_strategy.go
@@ -9,11 +9,18 @@ package gzipimpl
 import (
 	"bytes"
 	"compress/gzip"
+	"errors"
+	"fmt"
 	"io"
 
 	"github.com/DataDog/datadog-agent/pkg/util/compression"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+// maxDecompressedSize is the maximum number of bytes Decompress will read from a gzip
+// stream. It guards against decompression bombs; exceeding it is an error, not a silent
+// truncation.
+const maxDecompressedSize = 500 * 1024 * 1024 // 500 MiB
 
 // Requires contains the compression level for gzip compression
 type Requires struct {
@@ -75,11 +82,14 @@ func (s *GzipStrategy) Decompress(src []byte) ([]byte, error) {
 	}
 	defer reader.Close()
 
-	// Read all decompressed data
+	// Read all decompressed data, but never more than maxDecompressedSize.
 	var result bytes.Buffer
-	_, err = io.Copy(&result, reader)
-	if err != nil {
+	n, err := io.CopyN(&result, reader, maxDecompressedSize+1)
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
+	}
+	if n > maxDecompressedSize {
+		return nil, fmt.Errorf("gzip decompress: decompressed payload exceeds maximum allowed size of %d bytes", maxDecompressedSize)
 	}
 
 	return result.Bytes(), nil


### PR DESCRIPTION
## What changed
Four call sites used unbounded `io.Copy` to read decompressed (or otherwise
compressed/expandable) data into memory or onto disk, with no limit on how
much data could be produced. A small malicious or corrupt input can cause
these reads to consume unbounded memory/disk ("decompression bomb"),
matching static-analysis rule `go-security/decompression-bomb`
(CWE-409: Improper Handling of Highly Compressed Data).

This PR replaces each unbounded `io.Copy` with `io.CopyN` bounded to an
explicit maximum, treating exceeding the limit as a hard error rather than
silently truncating output:

- `pkg/util/compression/impl-gzip/gzip_strategy.go`: `GzipStrategy.Decompress`
  now caps in-memory gzip decompression at 500 MiB.
- `pkg/security/security_profile/profile/utils.go`: `unzip` now caps
  decompression of a security-profile `.gz` file at 2 GiB.
- `pkg/util/archive/tar_xz.go`: `untarFile` now caps extraction of a single
  `.tar.xz` archive entry at 5 GiB.
- `cmd/cluster-agent/api/v2/series/series.go`: the `/series` handler now caps
  decompression of a (gzip/deflate/zstd) request body at 100 MiB.

This is a suggested remediation generated from a security finding, not an
authoritative or auto-applied fix — please review before merging.

## Related cases
- https://app.datadoghq.com/cases/VMSAST-16
- https://app.datadoghq.com/cases/VMSAST-10
- https://app.datadoghq.com/cases/VMSAST-8
- https://app.datadoghq.com/cases/VMSAST-7

## ⚠️ Operational caveats — please verify before merging
The chosen limits (500 MiB / 2 GiB / 5 GiB / 100 MiB) are conservative
estimates based on reading each function's immediate purpose, **not**
verified against real production payload/file sizes at every call site:

- `tar_xz.go`: callers of `TarXZExtractFile` / `TarXZExtractAll` /
  `TarXZExtractAllReader` were not all traced. If any legitimate archive
  entry exceeds 5 GiB, extraction will now fail instead of truncating
  silently — the safer failure mode, but the limit should be validated
  against real archive contents.
- `series.go`: 100 MiB is a guess for a single node's metrics-series batch.
  A legitimate payload exceeding this will now be rejected with 413 instead
  of processed.
- `utils.go` (security profiles): activity-dump files can grow large on busy
  hosts over long collection windows; 2 GiB may be too tight for some
  legitimate dumps.
- `gzip_strategy.go`: 500 MiB assumes typical serializer/metadata payload
  sizes; not all callers of `Compressor.Decompress` were traced.

In all four cases, a payload that legitimately exceeds the new limit will
now fail loudly (error / HTTP 4xx) rather than being processed. Please
confirm these limits are safe for real traffic/data before merging.
