### PR TITLE
[ACTP] wire split runner ownership

### DIFF
--- a/cmd/privateactionrunner/subcommands/run/command.go
+++ b/cmd/privateactionrunner/subcommands/run/command.go
@@ -130,7 +130,7 @@ func runPrivateActionRunner(ctx context.Context, confPath string, extraConfFiles
 	}
 
 	err := fxutil.Run(fxOptions...)
-	if errors.Is(err, privateactionrunner.ErrNotEnabled) {
+	if errors.Is(err, privateactionrunner.ErrNotEnabled) || errors.Is(err, privateactionrunner.ErrSplitDeployment) {
 		return nil
 	}
 	return err

--- a/comp/privateactionrunner/def/component.go
+++ b/comp/privateactionrunner/def/component.go
@@ -17,6 +17,10 @@ type Component interface {
 // ErrNotEnabled is returned when the private action runner is not enabled
 var ErrNotEnabled = errors.New("private action runner is not enabled")
 
+// ErrSplitDeployment is returned when the private action runner runs in split
+// deployment mode, where par-control owns OPMS polling.
+var ErrSplitDeployment = errors.New("private action runner is running in split deployment mode")
+
 // Configuration keys for the private action runner.
 // Duplicated from pkg/config/setup/privateactionrunner.go because comp/
 // packages cannot import pkg/config/setup (depguard rule).

--- a/comp/privateactionrunner/impl/BUILD.bazel
+++ b/comp/privateactionrunner/impl/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//comp/networkpath/traceroute/def",
         "//comp/privateactionrunner/def",
         "//comp/remote-config/rcclient/def",
+        "//pkg/config/env",
         "//pkg/config/helper",
         "//pkg/config/model",
         "//pkg/config/utils",

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"runtime"
 	"sync"
 	"time"
 
@@ -20,7 +21,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
@@ -32,6 +33,7 @@ import (
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
 	privateactionrunner "github.com/DataDog/datadog-agent/comp/privateactionrunner/def"
 	rcclient "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/def"
+	configenv "github.com/DataDog/datadog-agent/pkg/config/env"
 	confighelper "github.com/DataDog/datadog-agent/pkg/config/helper"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
@@ -59,6 +61,19 @@ const (
 // isEnabled checks if the private action runner is enabled in the configuration
 func isEnabled(cfg config.Component) bool {
 	return cfg.GetBool(privateactionrunner.PAREnabled)
+}
+
+func splitDeploymentSupported(goos string, containerized bool) bool {
+	if containerized {
+		return false
+	}
+
+	switch goos {
+	case "linux", "windows":
+		return true
+	default:
+		return false
+	}
 }
 
 // Requires defines the dependencies for the privateactionrunner component
@@ -137,6 +152,14 @@ func NewComponent(reqs Requires) (Provides, error) {
 		reqs.Log.Info("private-action-runner is not enabled. Set private_action_runner.enabled: true in your datadog.yaml file or set the environment variable DD_PRIVATE_ACTION_RUNNER_ENABLED=true.")
 		reqs.Log.Flush()
 		return Provides{}, privateactionrunner.ErrNotEnabled
+	}
+	if reqs.Config.GetBool(privateactionrunner.PARSplitEnabled) {
+		if splitDeploymentSupported(runtime.GOOS, configenv.IsContainerized()) {
+			reqs.Log.Info("Split deployment is enabled; the monolithic PAR is standing down")
+			reqs.Log.Flush()
+			return Provides{}, privateactionrunner.ErrSplitDeployment
+		}
+		reqs.Log.Warn("Split deployment is not supported in this environment; continuing with the monolithic PAR")
 	}
 
 	// The standalone runner sends metrics over a DogStatsD socket/UDP, built from

--- a/comp/privateactionrunner/impl/privateactionrunner_test.go
+++ b/comp/privateactionrunner/impl/privateactionrunner_test.go
@@ -70,6 +70,27 @@ func TestGetRunnerConfigDiscardsCorruptIdentity(t *testing.T) {
 	assert.Equal(t, urn, cfg.Urn)
 }
 
+func TestSplitDeploymentSupported(t *testing.T) {
+	tests := []struct {
+		name          string
+		goos          string
+		containerized bool
+		want          bool
+	}{
+		{name: "linux host", goos: "linux", want: true},
+		{name: "windows host", goos: "windows", want: true},
+		{name: "linux container", goos: "linux", containerized: true},
+		{name: "windows container", goos: "windows", containerized: true},
+		{name: "unsupported host platform", goos: "darwin"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, splitDeploymentSupported(tt.goos, tt.containerized))
+		})
+	}
+}
+
 func TestStopCleansUpMetricsClient(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/pkg/config/schema/yaml/private_action_runner.yaml
+++ b/pkg/config/schema/yaml/private_action_runner.yaml
@@ -195,7 +195,7 @@ properties:
     node_type: setting
     type: boolean
     default: false
-    comment: Enables split runner mode.
+    comment: Enables split runner mode on supported Linux and Windows hosts.
   urn:
     node_type: setting
     type: string


### PR DESCRIPTION
### What does this PR do?

Makes the monolithic Go runner stand down when split mode is enabled on supported Linux and Windows host installations.

Containers and unsupported platforms keep the monolithic runner because they do not yet launch the complete replacement topology. This preserves the invariant that exactly one runner polls OPMS without disabling the only available runner.

### Validation

- `bazel test //comp/privateactionrunner/impl:impl_test`

Tests cover Linux and Windows hosts, containers, and unsupported platforms.

_Stack 8 of 9; based on #54593 and followed by #54529._
