### PR TITLE
dyninst/irgen: name the unsupported operation in condition errors

### DIFF
--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -891,7 +891,7 @@ func analyzeCondition(
 	if len(leaves) == 0 {
 		return nil, ir.Issue{
 			Kind:    ir.IssueKindUnsupportedFeature,
-			Message: fmt.Sprintf("unsupported condition expression type: %T", condExpr),
+			Message: conditionUnsupportedMessage(condExpr),
 		}
 	}
 	// Validate every leaf is a supported shape first so error messages
@@ -901,7 +901,7 @@ func analyzeCondition(
 		if !ok {
 			return nil, ir.Issue{
 				Kind:    ir.IssueKindUnsupportedFeature,
-				Message: fmt.Sprintf("unsupported condition expression type: %T", leaf),
+				Message: conditionUnsupportedMessage(leaf),
 			}
 		}
 		// A condition leaf's LHS must be a variable-derived path
@@ -1100,6 +1100,8 @@ func checkConditionLHS(expr exprlang.Expr) error {
 		)
 	case *exprlang.LiteralExpr:
 		return errors.New("condition leaf LHS may not be a literal")
+	case *exprlang.UnsupportedExpr:
+		return errors.New(conditionUnsupportedMessage(e))
 	default:
 		return fmt.Errorf("unsupported condition leaf LHS type: %T", expr)
 	}
@@ -1160,6 +1162,14 @@ func conditionLeafSubExpr(leaf exprlang.Expr) (exprlang.Expr, bool) {
 	default:
 		return nil, false
 	}
+}
+
+func conditionUnsupportedMessage(e exprlang.Expr) string {
+	if unsupported, ok := e.(*exprlang.UnsupportedExpr); ok {
+		return "unsupported condition operation: " + unsupported.Operation
+	}
+	// we don't expect to reach this return
+	return fmt.Sprintf("unsupported condition expression type: %T", e)
 }
 
 // rewriteReturnRefs rewrites every @return reference in expr to reference
@@ -4422,7 +4432,7 @@ func exploreTypesForExpressions(
 				if !ok {
 					ap.conditionIssue = ir.Issue{
 						Kind:    ir.IssueKindUnsupportedFeature,
-						Message: fmt.Sprintf("unsupported condition expression type: %T", leaf),
+						Message: conditionUnsupportedMessage(leaf),
 					}
 					ap.condition = nil
 					break

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -26114,7 +26114,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 3
-        Message: 'unsupported condition expression type: *exprlang.UnsupportedExpr'
+        Message: 'unsupported condition operation: not_a_valid_op'
     - probe_definition:
         id: condErr_bare_ref
         version: 0
@@ -26131,6 +26131,57 @@ Issues:
         Kind: 3
         Message: 'unsupported condition expression type: *exprlang.RefExpr'
     - probe_definition:
+        id: condErr_count_operand
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: count(tag) == 3
+            json: {eq: [{count: {ref: tag}}, 3]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: count'
+    - probe_definition:
+        id: condErr_endsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: endsWith(tag, "post")
+            json: {endsWith: [{ref: tag}, post]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: endsWith'
+    - probe_definition:
+        id: condErr_instanceof
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: tag instanceof "string"
+            json: {instanceof: [{ref: tag}, string]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: instanceof'
+    - probe_definition:
         id: condErr_int8_overflow
         version: 0
         type: LOG_PROBE
@@ -26146,6 +26197,23 @@ Issues:
         Kind: 8
         Message: 'failed to resolve condition: condition: literal 128 out of range for int8 (8-bit)'
     - probe_definition:
+        id: condErr_isDefined
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: isDefined(tag)
+            json: {isDefined: {ref: tag}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: isDefined'
+    - probe_definition:
         id: condErr_map
         version: 0
         type: LOG_PROBE
@@ -26160,6 +26228,40 @@ Issues:
       issue:
         Kind: 8
         Message: 'failed to resolve condition: Eq: type map[string]int can only be compared to null'
+    - probe_definition:
+        id: condErr_matches
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: matches(tag, "[0-9]+")
+            json: {matches: [{ref: tag}, '[0-9]+']}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: matches'
+    - probe_definition:
+        id: condErr_not_startsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: '!startsWith(tag, "pre")'
+            json: {not: {startsWith: [{ref: tag}, pre]}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: startsWith'
     - probe_definition:
         id: condErr_rhs_ref
         version: 0
@@ -26191,6 +26293,23 @@ Issues:
         Kind: 8
         Message: 'failed to resolve condition: Eq: type []int can only be compared to null'
     - probe_definition:
+        id: condErr_startsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: startsWith(tag, "pre")
+            json: {startsWith: [{ref: tag}, pre]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: startsWith'
+    - probe_definition:
         id: condErr_string_vs_int
         version: 0
         type: LOG_PROBE
@@ -26220,6 +26339,23 @@ Issues:
       issue:
         Kind: 8
         Message: 'failed to resolve condition: Eq: unsupported LHS type *ir.StructureType for comparison'
+    - probe_definition:
+        id: condErr_substring_operand
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: substring(tag, 0, 3) == "abc"
+            json: {eq: [{substring: [{ref: tag}, 0, 3]}, abc]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: substring'
     - probe_definition:
         id: condErr_uint32_negative
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -29754,7 +29754,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 3
-        Message: 'unsupported condition expression type: *exprlang.UnsupportedExpr'
+        Message: 'unsupported condition operation: not_a_valid_op'
     - probe_definition:
         id: condErr_bare_ref
         version: 0
@@ -29771,6 +29771,57 @@ Issues:
         Kind: 3
         Message: 'unsupported condition expression type: *exprlang.RefExpr'
     - probe_definition:
+        id: condErr_count_operand
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: count(tag) == 3
+            json: {eq: [{count: {ref: tag}}, 3]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: count'
+    - probe_definition:
+        id: condErr_endsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: endsWith(tag, "post")
+            json: {endsWith: [{ref: tag}, post]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: endsWith'
+    - probe_definition:
+        id: condErr_instanceof
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: tag instanceof "string"
+            json: {instanceof: [{ref: tag}, string]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: instanceof'
+    - probe_definition:
         id: condErr_int8_overflow
         version: 0
         type: LOG_PROBE
@@ -29786,6 +29837,23 @@ Issues:
         Kind: 8
         Message: 'failed to resolve condition: condition: literal 128 out of range for int8 (8-bit)'
     - probe_definition:
+        id: condErr_isDefined
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: isDefined(tag)
+            json: {isDefined: {ref: tag}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: isDefined'
+    - probe_definition:
         id: condErr_map
         version: 0
         type: LOG_PROBE
@@ -29800,6 +29868,40 @@ Issues:
       issue:
         Kind: 8
         Message: 'failed to resolve condition: Eq: type map[string]int can only be compared to null'
+    - probe_definition:
+        id: condErr_matches
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: matches(tag, "[0-9]+")
+            json: {matches: [{ref: tag}, '[0-9]+']}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: matches'
+    - probe_definition:
+        id: condErr_not_startsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: '!startsWith(tag, "pre")'
+            json: {not: {startsWith: [{ref: tag}, pre]}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: startsWith'
     - probe_definition:
         id: condErr_rhs_ref
         version: 0
@@ -29831,6 +29933,23 @@ Issues:
         Kind: 8
         Message: 'failed to resolve condition: Eq: type []int can only be compared to null'
     - probe_definition:
+        id: condErr_startsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: startsWith(tag, "pre")
+            json: {startsWith: [{ref: tag}, pre]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: startsWith'
+    - probe_definition:
         id: condErr_string_vs_int
         version: 0
         type: LOG_PROBE
@@ -29860,6 +29979,23 @@ Issues:
       issue:
         Kind: 8
         Message: 'failed to resolve condition: Eq: unsupported LHS type *ir.StructureType for comparison'
+    - probe_definition:
+        id: condErr_substring_operand
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: substring(tag, 0, 3) == "abc"
+            json: {eq: [{substring: [{ref: tag}, 0, 3]}, abc]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: substring'
     - probe_definition:
         id: condErr_uint32_negative
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -29919,7 +29919,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 3
-        Message: 'unsupported condition expression type: *exprlang.UnsupportedExpr'
+        Message: 'unsupported condition operation: not_a_valid_op'
     - probe_definition:
         id: condErr_bare_ref
         version: 0
@@ -29936,6 +29936,57 @@ Issues:
         Kind: 3
         Message: 'unsupported condition expression type: *exprlang.RefExpr'
     - probe_definition:
+        id: condErr_count_operand
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: count(tag) == 3
+            json: {eq: [{count: {ref: tag}}, 3]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: count'
+    - probe_definition:
+        id: condErr_endsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: endsWith(tag, "post")
+            json: {endsWith: [{ref: tag}, post]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: endsWith'
+    - probe_definition:
+        id: condErr_instanceof
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: tag instanceof "string"
+            json: {instanceof: [{ref: tag}, string]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: instanceof'
+    - probe_definition:
         id: condErr_int8_overflow
         version: 0
         type: LOG_PROBE
@@ -29951,6 +30002,23 @@ Issues:
         Kind: 8
         Message: 'failed to resolve condition: condition: literal 128 out of range for int8 (8-bit)'
     - probe_definition:
+        id: condErr_isDefined
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: isDefined(tag)
+            json: {isDefined: {ref: tag}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: isDefined'
+    - probe_definition:
         id: condErr_map
         version: 0
         type: LOG_PROBE
@@ -29965,6 +30033,40 @@ Issues:
       issue:
         Kind: 8
         Message: 'failed to resolve condition: Eq: type map[string]int can only be compared to null'
+    - probe_definition:
+        id: condErr_matches
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: matches(tag, "[0-9]+")
+            json: {matches: [{ref: tag}, '[0-9]+']}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: matches'
+    - probe_definition:
+        id: condErr_not_startsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: '!startsWith(tag, "pre")'
+            json: {not: {startsWith: [{ref: tag}, pre]}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: startsWith'
     - probe_definition:
         id: condErr_rhs_ref
         version: 0
@@ -29996,6 +30098,23 @@ Issues:
         Kind: 8
         Message: 'failed to resolve condition: Eq: type []int can only be compared to null'
     - probe_definition:
+        id: condErr_startsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: startsWith(tag, "pre")
+            json: {startsWith: [{ref: tag}, pre]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: startsWith'
+    - probe_definition:
         id: condErr_string_vs_int
         version: 0
         type: LOG_PROBE
@@ -30025,6 +30144,23 @@ Issues:
       issue:
         Kind: 8
         Message: 'failed to resolve condition: Eq: unsupported LHS type *ir.StructureType for comparison'
+    - probe_definition:
+        id: condErr_substring_operand
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: substring(tag, 0, 3) == "abc"
+            json: {eq: [{substring: [{ref: tag}, 0, 3]}, abc]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: substring'
     - probe_definition:
         id: condErr_uint32_negative
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
@@ -30009,7 +30009,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 3
-        Message: 'unsupported condition expression type: *exprlang.UnsupportedExpr'
+        Message: 'unsupported condition operation: not_a_valid_op'
     - probe_definition:
         id: condErr_bare_ref
         version: 0
@@ -30026,6 +30026,57 @@ Issues:
         Kind: 3
         Message: 'unsupported condition expression type: *exprlang.RefExpr'
     - probe_definition:
+        id: condErr_count_operand
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: count(tag) == 3
+            json: {eq: [{count: {ref: tag}}, 3]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: count'
+    - probe_definition:
+        id: condErr_endsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: endsWith(tag, "post")
+            json: {endsWith: [{ref: tag}, post]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: endsWith'
+    - probe_definition:
+        id: condErr_instanceof
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: tag instanceof "string"
+            json: {instanceof: [{ref: tag}, string]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: instanceof'
+    - probe_definition:
         id: condErr_int8_overflow
         version: 0
         type: LOG_PROBE
@@ -30041,6 +30092,23 @@ Issues:
         Kind: 8
         Message: 'failed to resolve condition: condition: literal 128 out of range for int8 (8-bit)'
     - probe_definition:
+        id: condErr_isDefined
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: isDefined(tag)
+            json: {isDefined: {ref: tag}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: isDefined'
+    - probe_definition:
         id: condErr_map
         version: 0
         type: LOG_PROBE
@@ -30055,6 +30123,40 @@ Issues:
       issue:
         Kind: 8
         Message: 'failed to resolve condition: Eq: type map[string]int can only be compared to null'
+    - probe_definition:
+        id: condErr_matches
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: matches(tag, "[0-9]+")
+            json: {matches: [{ref: tag}, '[0-9]+']}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: matches'
+    - probe_definition:
+        id: condErr_not_startsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: '!startsWith(tag, "pre")'
+            json: {not: {startsWith: [{ref: tag}, pre]}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: startsWith'
     - probe_definition:
         id: condErr_rhs_ref
         version: 0
@@ -30086,6 +30188,23 @@ Issues:
         Kind: 8
         Message: 'failed to resolve condition: Eq: type []int can only be compared to null'
     - probe_definition:
+        id: condErr_startsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: startsWith(tag, "pre")
+            json: {startsWith: [{ref: tag}, pre]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: startsWith'
+    - probe_definition:
         id: condErr_string_vs_int
         version: 0
         type: LOG_PROBE
@@ -30115,6 +30234,23 @@ Issues:
       issue:
         Kind: 8
         Message: 'failed to resolve condition: Eq: unsupported LHS type *ir.StructureType for comparison'
+    - probe_definition:
+        id: condErr_substring_operand
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: substring(tag, 0, 3) == "abc"
+            json: {eq: [{substring: [{ref: tag}, 0, 3]}, abc]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: substring'
     - probe_definition:
         id: condErr_uint32_negative
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -26102,7 +26102,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 3
-        Message: 'unsupported condition expression type: *exprlang.UnsupportedExpr'
+        Message: 'unsupported condition operation: not_a_valid_op'
     - probe_definition:
         id: condErr_bare_ref
         version: 0
@@ -26119,6 +26119,57 @@ Issues:
         Kind: 3
         Message: 'unsupported condition expression type: *exprlang.RefExpr'
     - probe_definition:
+        id: condErr_count_operand
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: count(tag) == 3
+            json: {eq: [{count: {ref: tag}}, 3]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: count'
+    - probe_definition:
+        id: condErr_endsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: endsWith(tag, "post")
+            json: {endsWith: [{ref: tag}, post]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: endsWith'
+    - probe_definition:
+        id: condErr_instanceof
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: tag instanceof "string"
+            json: {instanceof: [{ref: tag}, string]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: instanceof'
+    - probe_definition:
         id: condErr_int8_overflow
         version: 0
         type: LOG_PROBE
@@ -26134,6 +26185,23 @@ Issues:
         Kind: 8
         Message: 'failed to resolve condition: condition: literal 128 out of range for int8 (8-bit)'
     - probe_definition:
+        id: condErr_isDefined
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: isDefined(tag)
+            json: {isDefined: {ref: tag}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: isDefined'
+    - probe_definition:
         id: condErr_map
         version: 0
         type: LOG_PROBE
@@ -26148,6 +26216,40 @@ Issues:
       issue:
         Kind: 8
         Message: 'failed to resolve condition: Eq: type map[string]int can only be compared to null'
+    - probe_definition:
+        id: condErr_matches
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: matches(tag, "[0-9]+")
+            json: {matches: [{ref: tag}, '[0-9]+']}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: matches'
+    - probe_definition:
+        id: condErr_not_startsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: '!startsWith(tag, "pre")'
+            json: {not: {startsWith: [{ref: tag}, pre]}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: startsWith'
     - probe_definition:
         id: condErr_rhs_ref
         version: 0
@@ -26179,6 +26281,23 @@ Issues:
         Kind: 8
         Message: 'failed to resolve condition: Eq: type []int can only be compared to null'
     - probe_definition:
+        id: condErr_startsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: startsWith(tag, "pre")
+            json: {startsWith: [{ref: tag}, pre]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: startsWith'
+    - probe_definition:
         id: condErr_string_vs_int
         version: 0
         type: LOG_PROBE
@@ -26208,6 +26327,23 @@ Issues:
       issue:
         Kind: 8
         Message: 'failed to resolve condition: Eq: unsupported LHS type *ir.StructureType for comparison'
+    - probe_definition:
+        id: condErr_substring_operand
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: substring(tag, 0, 3) == "abc"
+            json: {eq: [{substring: [{ref: tag}, 0, 3]}, abc]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: substring'
     - probe_definition:
         id: condErr_uint32_negative
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -29754,7 +29754,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 3
-        Message: 'unsupported condition expression type: *exprlang.UnsupportedExpr'
+        Message: 'unsupported condition operation: not_a_valid_op'
     - probe_definition:
         id: condErr_bare_ref
         version: 0
@@ -29771,6 +29771,57 @@ Issues:
         Kind: 3
         Message: 'unsupported condition expression type: *exprlang.RefExpr'
     - probe_definition:
+        id: condErr_count_operand
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: count(tag) == 3
+            json: {eq: [{count: {ref: tag}}, 3]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: count'
+    - probe_definition:
+        id: condErr_endsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: endsWith(tag, "post")
+            json: {endsWith: [{ref: tag}, post]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: endsWith'
+    - probe_definition:
+        id: condErr_instanceof
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: tag instanceof "string"
+            json: {instanceof: [{ref: tag}, string]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: instanceof'
+    - probe_definition:
         id: condErr_int8_overflow
         version: 0
         type: LOG_PROBE
@@ -29786,6 +29837,23 @@ Issues:
         Kind: 8
         Message: 'failed to resolve condition: condition: literal 128 out of range for int8 (8-bit)'
     - probe_definition:
+        id: condErr_isDefined
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: isDefined(tag)
+            json: {isDefined: {ref: tag}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: isDefined'
+    - probe_definition:
         id: condErr_map
         version: 0
         type: LOG_PROBE
@@ -29800,6 +29868,40 @@ Issues:
       issue:
         Kind: 8
         Message: 'failed to resolve condition: Eq: type map[string]int can only be compared to null'
+    - probe_definition:
+        id: condErr_matches
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: matches(tag, "[0-9]+")
+            json: {matches: [{ref: tag}, '[0-9]+']}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: matches'
+    - probe_definition:
+        id: condErr_not_startsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: '!startsWith(tag, "pre")'
+            json: {not: {startsWith: [{ref: tag}, pre]}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: startsWith'
     - probe_definition:
         id: condErr_rhs_ref
         version: 0
@@ -29831,6 +29933,23 @@ Issues:
         Kind: 8
         Message: 'failed to resolve condition: Eq: type []int can only be compared to null'
     - probe_definition:
+        id: condErr_startsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: startsWith(tag, "pre")
+            json: {startsWith: [{ref: tag}, pre]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: startsWith'
+    - probe_definition:
         id: condErr_string_vs_int
         version: 0
         type: LOG_PROBE
@@ -29860,6 +29979,23 @@ Issues:
       issue:
         Kind: 8
         Message: 'failed to resolve condition: Eq: unsupported LHS type *ir.StructureType for comparison'
+    - probe_definition:
+        id: condErr_substring_operand
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: substring(tag, 0, 3) == "abc"
+            json: {eq: [{substring: [{ref: tag}, 0, 3]}, abc]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: substring'
     - probe_definition:
         id: condErr_uint32_negative
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -29977,7 +29977,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 3
-        Message: 'unsupported condition expression type: *exprlang.UnsupportedExpr'
+        Message: 'unsupported condition operation: not_a_valid_op'
     - probe_definition:
         id: condErr_bare_ref
         version: 0
@@ -29994,6 +29994,57 @@ Issues:
         Kind: 3
         Message: 'unsupported condition expression type: *exprlang.RefExpr'
     - probe_definition:
+        id: condErr_count_operand
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: count(tag) == 3
+            json: {eq: [{count: {ref: tag}}, 3]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: count'
+    - probe_definition:
+        id: condErr_endsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: endsWith(tag, "post")
+            json: {endsWith: [{ref: tag}, post]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: endsWith'
+    - probe_definition:
+        id: condErr_instanceof
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: tag instanceof "string"
+            json: {instanceof: [{ref: tag}, string]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: instanceof'
+    - probe_definition:
         id: condErr_int8_overflow
         version: 0
         type: LOG_PROBE
@@ -30009,6 +30060,23 @@ Issues:
         Kind: 8
         Message: 'failed to resolve condition: condition: literal 128 out of range for int8 (8-bit)'
     - probe_definition:
+        id: condErr_isDefined
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: isDefined(tag)
+            json: {isDefined: {ref: tag}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: isDefined'
+    - probe_definition:
         id: condErr_map
         version: 0
         type: LOG_PROBE
@@ -30023,6 +30091,40 @@ Issues:
       issue:
         Kind: 8
         Message: 'failed to resolve condition: Eq: type map[string]int can only be compared to null'
+    - probe_definition:
+        id: condErr_matches
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: matches(tag, "[0-9]+")
+            json: {matches: [{ref: tag}, '[0-9]+']}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: matches'
+    - probe_definition:
+        id: condErr_not_startsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: '!startsWith(tag, "pre")'
+            json: {not: {startsWith: [{ref: tag}, pre]}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: startsWith'
     - probe_definition:
         id: condErr_rhs_ref
         version: 0
@@ -30054,6 +30156,23 @@ Issues:
         Kind: 8
         Message: 'failed to resolve condition: Eq: type []int can only be compared to null'
     - probe_definition:
+        id: condErr_startsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: startsWith(tag, "pre")
+            json: {startsWith: [{ref: tag}, pre]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: startsWith'
+    - probe_definition:
         id: condErr_string_vs_int
         version: 0
         type: LOG_PROBE
@@ -30083,6 +30202,23 @@ Issues:
       issue:
         Kind: 8
         Message: 'failed to resolve condition: Eq: unsupported LHS type *ir.StructureType for comparison'
+    - probe_definition:
+        id: condErr_substring_operand
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: substring(tag, 0, 3) == "abc"
+            json: {eq: [{substring: [{ref: tag}, 0, 3]}, abc]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: substring'
     - probe_definition:
         id: condErr_uint32_negative
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
@@ -30073,7 +30073,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 3
-        Message: 'unsupported condition expression type: *exprlang.UnsupportedExpr'
+        Message: 'unsupported condition operation: not_a_valid_op'
     - probe_definition:
         id: condErr_bare_ref
         version: 0
@@ -30090,6 +30090,57 @@ Issues:
         Kind: 3
         Message: 'unsupported condition expression type: *exprlang.RefExpr'
     - probe_definition:
+        id: condErr_count_operand
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: count(tag) == 3
+            json: {eq: [{count: {ref: tag}}, 3]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: count'
+    - probe_definition:
+        id: condErr_endsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: endsWith(tag, "post")
+            json: {endsWith: [{ref: tag}, post]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: endsWith'
+    - probe_definition:
+        id: condErr_instanceof
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: tag instanceof "string"
+            json: {instanceof: [{ref: tag}, string]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: instanceof'
+    - probe_definition:
         id: condErr_int8_overflow
         version: 0
         type: LOG_PROBE
@@ -30105,6 +30156,23 @@ Issues:
         Kind: 8
         Message: 'failed to resolve condition: condition: literal 128 out of range for int8 (8-bit)'
     - probe_definition:
+        id: condErr_isDefined
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: isDefined(tag)
+            json: {isDefined: {ref: tag}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: isDefined'
+    - probe_definition:
         id: condErr_map
         version: 0
         type: LOG_PROBE
@@ -30119,6 +30187,40 @@ Issues:
       issue:
         Kind: 8
         Message: 'failed to resolve condition: Eq: type map[string]int can only be compared to null'
+    - probe_definition:
+        id: condErr_matches
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: matches(tag, "[0-9]+")
+            json: {matches: [{ref: tag}, '[0-9]+']}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: matches'
+    - probe_definition:
+        id: condErr_not_startsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: '!startsWith(tag, "pre")'
+            json: {not: {startsWith: [{ref: tag}, pre]}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: startsWith'
     - probe_definition:
         id: condErr_rhs_ref
         version: 0
@@ -30150,6 +30252,23 @@ Issues:
         Kind: 8
         Message: 'failed to resolve condition: Eq: type []int can only be compared to null'
     - probe_definition:
+        id: condErr_startsWith
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: startsWith(tag, "pre")
+            json: {startsWith: [{ref: tag}, pre]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: startsWith'
+    - probe_definition:
         id: condErr_string_vs_int
         version: 0
         type: LOG_PROBE
@@ -30179,6 +30298,23 @@ Issues:
       issue:
         Kind: 8
         Message: 'failed to resolve condition: Eq: unsupported LHS type *ir.StructureType for comparison'
+    - probe_definition:
+        id: condErr_substring_operand
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.condString}
+        tags: ['issue:UnsupportedFeature']
+        when:
+            dsl: substring(tag, 0, 3) == "abc"
+            json: {eq: [{substring: [{ref: tag}, 0, 3]}, abc]}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: ""
+        segments: []
+        captureSnapshot: true
+      issue:
+        Kind: 3
+        Message: 'unsupported condition operation: substring'
     - probe_definition:
         id: condErr_uint32_negative
         version: 0

--- a/pkg/dyninst/testprogs/testdata/probes/simple.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/simple.yaml
@@ -846,6 +846,110 @@ probes:
   tags:
     - "issue:UnsupportedFeature"
 
+- id: condErr_startsWith
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.condString
+  when:
+    dsl: "startsWith(tag, \"pre\")"
+    json: {startsWith: [{ref: "tag"}, "pre"]}
+  sampling:
+    snapshotsPerSecond: 10
+  tags:
+    - "issue:UnsupportedFeature"
+
+- id: condErr_endsWith
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.condString
+  when:
+    dsl: "endsWith(tag, \"post\")"
+    json: {endsWith: [{ref: "tag"}, "post"]}
+  sampling:
+    snapshotsPerSecond: 10
+  tags:
+    - "issue:UnsupportedFeature"
+
+- id: condErr_matches
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.condString
+  when:
+    dsl: "matches(tag, \"[0-9]+\")"
+    json: {matches: [{ref: "tag"}, "[0-9]+"]}
+  sampling:
+    snapshotsPerSecond: 10
+  tags:
+    - "issue:UnsupportedFeature"
+
+- id: condErr_isDefined
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.condString
+  when:
+    dsl: "isDefined(tag)"
+    json: {isDefined: {ref: "tag"}}
+  sampling:
+    snapshotsPerSecond: 10
+  tags:
+    - "issue:UnsupportedFeature"
+
+- id: condErr_instanceof
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.condString
+  when:
+    dsl: "tag instanceof \"string\""
+    json: {instanceof: [{ref: "tag"}, "string"]}
+  sampling:
+    snapshotsPerSecond: 10
+  tags:
+    - "issue:UnsupportedFeature"
+
+- id: condErr_not_startsWith
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.condString
+  when:
+    dsl: "!startsWith(tag, \"pre\")"
+    json: {not: {startsWith: [{ref: "tag"}, "pre"]}}
+  sampling:
+    snapshotsPerSecond: 10
+  tags:
+    - "issue:UnsupportedFeature"
+
+- id: condErr_substring_operand
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.condString
+  when:
+    dsl: "substring(tag, 0, 3) == \"abc\""
+    json: {eq: [{substring: [{ref: "tag"}, 0, 3]}, "abc"]}
+  sampling:
+    snapshotsPerSecond: 10
+  tags:
+    - "issue:UnsupportedFeature"
+
+- id: condErr_count_operand
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.condString
+  when:
+    dsl: "count(tag) == 3"
+    json: {eq: [{count: {ref: "tag"}}, 3]}
+  sampling:
+    snapshotsPerSecond: 10
+  tags:
+    - "issue:UnsupportedFeature"
+
 # when expression is not an EqExpr (bare ref).
 - id: condErr_bare_ref
   type: LOG_PROBE


### PR DESCRIPTION
### What does this PR do?

When a logpoint's condition uses an operation the Go debugger doesn't implement, the resulting error now names that operation.

Also an unsupported operation can appear in two places, on its own or nested inside a comparison. Both now report the operation by name.

### Motivation 

A logpoint was created in staging against a Go service with a condition using `startsWith`, which Go does not implement. It never activated. The person debugging was told the target had passed validation but the service had not applied the logpoint.

### Describe how you validated your changes

Added eight test probes covering every operation the shared expression language accepts but Go does not implement, in both positions an operation can occupy, and confirmed in the regenerated snapshots that each reports its own name.

Ran the generator test suite and the eBPF integration test for the affected test program, to confirm the added failing probes don't disturb the probes that do attach.