### PR TITLE
[CWS] fix matching sub-expression reporting in the And/Or operators

### DIFF
--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -1763,7 +1763,7 @@ func TestMatchingSubExprReportedValues(t *testing.T) {
 		{Expr: `false || process.is_root`, Expected: []interface{}{true}},
 		// StringEquals, dynamic on both sides
 		{Expr: `true && process.name == process.name`, Expected: []interface{}{"ls", "ls"}},
-		// already correct, kept to guard the other branches of the same operators
+		// the mirrored branches of the same operators, which report from the other side
 		{Expr: `process.is_root || false`, Expected: []interface{}{true}},
 		{Expr: `true && process.name == "ls"`, Expected: []interface{}{"ls", "ls"}},
 		{Expr: `true && "ls" == process.name`, Expected: []interface{}{"ls", "ls"}},
@@ -1842,6 +1842,82 @@ func TestMatchingSubExprSingleEvaluation(t *testing.T) {
 
 			if event.isRootEvalCount > 1 {
 				t.Errorf("`process.is_root` evaluated %d times, expected at most once", event.isRootEvalCount)
+			}
+		})
+	}
+}
+
+// TestMatchingSubExprOperandSwap ensures that the operand reordering performed by `Or` and `And`,
+// which evaluates the cheaper operand first, doesn't attribute a match to the wrong operand.
+//
+// The evaluators are built by hand because the test model has no boolean field carrying a weight,
+// so the reordering can't be triggered from a SECL expression here.
+func TestMatchingSubExprOperandSwap(t *testing.T) {
+	newOperand := func(field string, offset int, weight int, res bool) *BoolEvaluator {
+		return &BoolEvaluator{
+			Field:   field,
+			Offset:  offset,
+			Weight:  weight,
+			EvalFnc: func(*Context) bool { return res },
+		}
+	}
+
+	tests := []struct {
+		Name           string
+		A, B           *BoolEvaluator
+		ExpectedField  string
+		ExpectedOffset int
+	}{
+		{
+			Name:           "heavier operand first, the cheaper one matches",
+			A:              newOperand("process.heavy", 0, RegexpWeight, false),
+			B:              newOperand("process.cheap", 20, 0, true),
+			ExpectedField:  "process.cheap",
+			ExpectedOffset: 20,
+		},
+		{
+			Name:           "heavier operand first, it is the one matching",
+			A:              newOperand("process.heavy", 0, RegexpWeight, true),
+			B:              newOperand("process.cheap", 20, 0, false),
+			ExpectedField:  "process.heavy",
+			ExpectedOffset: 0,
+		},
+		{
+			Name:           "cheaper operand first, no reordering",
+			A:              newOperand("process.cheap", 0, 0, true),
+			B:              newOperand("process.heavy", 20, RegexpWeight, false),
+			ExpectedField:  "process.cheap",
+			ExpectedOffset: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			evaluator, err := Or(test.A, test.B, NewState(&testModel{}, "", nil))
+			if err != nil {
+				t.Fatalf("failed to build the `Or` evaluator: %s", err)
+			}
+
+			ctx := NewContext(&testEvent{})
+			if !evaluator.EvalFnc(ctx) {
+				t.Fatal("expected the expression to match")
+			}
+
+			subExprs := ctx.GetMatchingSubExprs()
+			if len(subExprs) != 1 {
+				t.Fatalf("expected a single matching sub expression, got %d", len(subExprs))
+			}
+
+			reported := subExprs[0].ValueA
+			if reported.Field == "" {
+				reported = subExprs[0].ValueB
+			}
+
+			if reported.Field != test.ExpectedField {
+				t.Errorf("expected field `%s` to be reported, got `%s`", test.ExpectedField, reported.Field)
+			}
+			if reported.Offset != test.ExpectedOffset {
+				t.Errorf("expected offset `%d` to be reported, got `%d`", test.ExpectedOffset, reported.Offset)
 			}
 		})
 	}

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -1800,6 +1800,53 @@ func TestMatchingSubExprReportedValues(t *testing.T) {
 	}
 }
 
+// TestMatchingSubExprSingleEvaluation ensures that reporting a matching sub expression doesn't
+// re-evaluate the operands it reports. Operands can be arbitrarily expensive (patterns, regexps,
+// iterators), so evaluating them twice on every match is not acceptable.
+func TestMatchingSubExprSingleEvaluation(t *testing.T) {
+	tests := []struct {
+		Expr     string
+		Expected bool
+	}{
+		// `process.is_root` is a bare boolean field, so the `And` operator itself reports it
+		{Expr: `process.is_root && process.uid == 22`, Expected: true},
+		{Expr: `process.uid == 22 && process.is_root`, Expected: true},
+		{Expr: `process.is_root && true`, Expected: true},
+		{Expr: `true && process.is_root`, Expected: true},
+		{Expr: `process.is_root || process.uid == 22`, Expected: true},
+		{Expr: `false || process.is_root`, Expected: true},
+		{Expr: `process.is_root || false`, Expected: true},
+		// non matching rules, the operand still must not be evaluated more than once
+		{Expr: `process.is_root && process.uid == 33`, Expected: false},
+		{Expr: `process.uid == 33 || process.is_root == false`, Expected: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Expr, func(t *testing.T) {
+			event := &testEvent{
+				process: testProcess{
+					uid:    22,
+					isRoot: true,
+				},
+			}
+			ctx := NewContext(event)
+
+			res, _, err := eval(ctx, test.Expr)
+			if err != nil {
+				t.Fatalf("error while evaluating `%s`: %s", test.Expr, err)
+			}
+
+			if res != test.Expected {
+				t.Fatalf("expected result `%t`, got `%t`", test.Expected, res)
+			}
+
+			if event.isRootEvalCount > 1 {
+				t.Errorf("`process.is_root` evaluated %d times, expected at most once", event.isRootEvalCount)
+			}
+		})
+	}
+}
+
 func FuzzEval(f *testing.F) {
 	// Add SECL expressions from all test cases as seeds
 

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"reflect"
 	"runtime"
 	"strings"
 	"syscall"
@@ -1737,6 +1738,63 @@ func TestMatchingSubExprs(t *testing.T) {
 			decorated, err := decorateRuleExprs(&subExprs, test.Expr, "<b>", "</b>")
 			if test.Expected != decorated {
 				t.Errorf("rule decoration error : %s vs %s => %v : %v", test.Expected, decorated, res, err)
+			}
+		})
+	}
+}
+
+// TestMatchingSubExprReportedValues ensures that the values reported along with the matching
+// sub expressions are the evaluated values, and not the evaluator functions themselves.
+func TestMatchingSubExprReportedValues(t *testing.T) {
+	event := &testEvent{
+		process: testProcess{
+			name:   "ls",
+			argv0:  "-al",
+			uid:    22,
+			isRoot: true,
+		},
+	}
+
+	tests := []struct {
+		Expr     string
+		Expected []interface{}
+	}{
+		// Or, static left hand side and dynamic right hand side
+		{Expr: `false || process.is_root`, Expected: []interface{}{true}},
+		// StringEquals, dynamic on both sides
+		{Expr: `true && process.name == process.name`, Expected: []interface{}{"ls", "ls"}},
+		// already correct, kept to guard the other branches of the same operators
+		{Expr: `process.is_root || false`, Expected: []interface{}{true}},
+		{Expr: `true && process.name == "ls"`, Expected: []interface{}{"ls", "ls"}},
+		{Expr: `true && "ls" == process.name`, Expected: []interface{}{"ls", "ls"}},
+		{Expr: `true && process.uid == 22`, Expected: []interface{}{22, 22}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Expr, func(t *testing.T) {
+			ctx := NewContext(event)
+
+			if _, _, err := eval(ctx, test.Expr); err != nil {
+				t.Fatalf("error while evaluating `%s`: %s", test.Expr, err)
+			}
+
+			var values []interface{}
+			for _, subExpr := range ctx.GetMatchingSubExprs() {
+				for _, value := range []MatchingValue{subExpr.ValueA, subExpr.ValueB} {
+					if value.Field == "" && value.Value == nil {
+						continue
+					}
+
+					if kind := reflect.ValueOf(value.Value).Kind(); kind == reflect.Func {
+						t.Errorf("reported an evaluator function instead of a value for `%s`", value.Field)
+						continue
+					}
+					values = append(values, value.Value)
+				}
+			}
+
+			if !reflect.DeepEqual(test.Expected, values) {
+				t.Errorf("expected reported values `%v`, got `%v`", test.Expected, values)
 			}
 		})
 	}

--- a/pkg/security/secl/compiler/eval/model_test.go
+++ b/pkg/security/secl/compiler/eval/model_test.go
@@ -79,6 +79,8 @@ type testEvent struct {
 	listEvaluated bool
 	uidEvaluated  bool
 	gidEvaluated  bool
+
+	isRootEvalCount int
 }
 
 type testModel struct {
@@ -238,9 +240,14 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID, offset int) (Eva
 	case "process.is_root":
 
 		return &BoolEvaluator{
-			EvalFnc: func(ctx *Context) bool { return ctx.Event.(*testEvent).process.isRoot },
-			Field:   field,
-			Offset:  offset,
+			EvalFnc: func(ctx *Context) bool {
+				// to test that the evaluator isn't called more than once per evaluation
+				ctx.Event.(*testEvent).isRootEvalCount++
+
+				return ctx.Event.(*testEvent).process.isRoot
+			},
+			Field:  field,
+			Offset: offset,
 		}, nil
 
 	case "process.list.length":

--- a/pkg/security/secl/compiler/eval/operators.go
+++ b/pkg/security/secl/compiler/eval/operators.go
@@ -163,7 +163,7 @@ func Or(a *BoolEvaluator, b *BoolEvaluator, state *State) (*BoolEvaluator, error
 		va, vb := ea, eb(ctx)
 		res := va || vb
 		if res && b.Field != "" {
-			ctx.AddMatchingSubExpr(MatchingValue{}, MatchingValue{Field: b.Field, Value: eb, Offset: b.Offset})
+			ctx.AddMatchingSubExpr(MatchingValue{}, MatchingValue{Field: b.Field, Value: vb, Offset: b.Offset})
 		}
 		return res
 	}
@@ -382,7 +382,7 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, state *State) (*BoolEv
 			va, vb := ea(ctx), eb(ctx)
 			res := op(va, vb)
 			if res {
-				ctx.AddMatchingSubExpr(MatchingValue{Field: a.Field, Value: va, Offset: a.Offset}, MatchingValue{Field: b.Field, Value: eb, Offset: b.Offset})
+				ctx.AddMatchingSubExpr(MatchingValue{Field: a.Field, Value: va, Offset: a.Offset}, MatchingValue{Field: b.Field, Value: vb, Offset: b.Offset})
 			}
 			return res
 		}

--- a/pkg/security/secl/compiler/eval/operators.go
+++ b/pkg/security/secl/compiler/eval/operators.go
@@ -202,17 +202,23 @@ func And(a *BoolEvaluator, b *BoolEvaluator, state *State) (*BoolEvaluator, erro
 		}
 
 		evalFnc := func(ctx *Context) bool {
-			res := ea(ctx) && eb(ctx)
-			if res {
-				if a.Field != "" {
-					ctx.AddMatchingSubExpr(MatchingValue{Field: a.Field, Value: ea(ctx), Offset: a.Offset}, MatchingValue{})
-				}
-				if b.Field != "" {
-					ctx.AddMatchingSubExpr(MatchingValue{}, MatchingValue{Field: b.Field, Value: eb(ctx), Offset: b.Offset})
-
-				}
+			va := ea(ctx)
+			if !va {
+				return false
 			}
-			return res
+
+			vb := eb(ctx)
+			if !vb {
+				return false
+			}
+
+			if a.Field != "" {
+				ctx.AddMatchingSubExpr(MatchingValue{Field: a.Field, Value: va, Offset: a.Offset}, MatchingValue{})
+			}
+			if b.Field != "" {
+				ctx.AddMatchingSubExpr(MatchingValue{}, MatchingValue{Field: b.Field, Value: vb, Offset: b.Offset})
+			}
+			return true
 		}
 
 		return &BoolEvaluator{
@@ -252,9 +258,10 @@ func And(a *BoolEvaluator, b *BoolEvaluator, state *State) (*BoolEvaluator, erro
 		}
 
 		evalFnc := func(ctx *Context) bool {
-			res := ea(ctx) && eb
+			va := ea(ctx)
+			res := va && eb
 			if res && a.Field != "" {
-				ctx.AddMatchingSubExpr(MatchingValue{Field: a.Field, Value: ea(ctx), Offset: a.Offset}, MatchingValue{})
+				ctx.AddMatchingSubExpr(MatchingValue{Field: a.Field, Value: va, Offset: a.Offset}, MatchingValue{})
 			}
 			return res
 		}
@@ -286,11 +293,15 @@ func And(a *BoolEvaluator, b *BoolEvaluator, state *State) (*BoolEvaluator, erro
 	}
 
 	evalFnc := func(ctx *Context) bool {
-		res := ea && eb(ctx)
-		if res && b.Field != "" {
-			ctx.AddMatchingSubExpr(MatchingValue{}, MatchingValue{Field: b.Field, Value: eb(ctx), Offset: b.Offset})
+		if !ea {
+			return false
 		}
-		return res
+
+		vb := eb(ctx)
+		if vb && b.Field != "" {
+			ctx.AddMatchingSubExpr(MatchingValue{}, MatchingValue{Field: b.Field, Value: vb, Offset: b.Offset})
+		}
+		return vb
 	}
 
 	return &BoolEvaluator{

--- a/pkg/security/secl/compiler/eval/operators.go
+++ b/pkg/security/secl/compiler/eval/operators.go
@@ -66,22 +66,27 @@ func Or(a *BoolEvaluator, b *BoolEvaluator, state *State) (*BoolEvaluator, error
 			}
 		}
 
+		// the field and the offset describe the operand that the evaluator next to them
+		// evaluates, they have to be swapped along with the evaluators below
+		fieldA, offsetA := a.Field, a.Offset
+		fieldB, offsetB := b.Field, b.Offset
+
 		if a.Weight > b.Weight {
-			tmp := ea
-			ea = eb
-			eb = tmp
+			ea, eb = eb, ea
+			fieldA, fieldB = fieldB, fieldA
+			offsetA, offsetB = offsetB, offsetA
 		}
 
 		evalFnc := func(ctx *Context) bool {
 			if ea(ctx) {
-				if a.Field != "" {
-					ctx.AddMatchingSubExpr(MatchingValue{Field: a.Field, Value: true, Offset: a.Offset}, MatchingValue{})
+				if fieldA != "" {
+					ctx.AddMatchingSubExpr(MatchingValue{Field: fieldA, Value: true, Offset: offsetA}, MatchingValue{})
 				}
 				return true
 			}
 			if eb(ctx) {
-				if b.Field != "" {
-					ctx.AddMatchingSubExpr(MatchingValue{}, MatchingValue{Field: b.Field, Value: true, Offset: b.Offset})
+				if fieldB != "" {
+					ctx.AddMatchingSubExpr(MatchingValue{}, MatchingValue{Field: fieldB, Value: true, Offset: offsetB})
 				}
 				return true
 			}
@@ -195,10 +200,15 @@ func And(a *BoolEvaluator, b *BoolEvaluator, state *State) (*BoolEvaluator, erro
 			}
 		}
 
+		// the field and the offset describe the operand that the evaluator next to them
+		// evaluates, they have to be swapped along with the evaluators below
+		fieldA, offsetA := a.Field, a.Offset
+		fieldB, offsetB := b.Field, b.Offset
+
 		if a.Weight > b.Weight {
-			tmp := ea
-			ea = eb
-			eb = tmp
+			ea, eb = eb, ea
+			fieldA, fieldB = fieldB, fieldA
+			offsetA, offsetB = offsetB, offsetA
 		}
 
 		evalFnc := func(ctx *Context) bool {
@@ -212,11 +222,11 @@ func And(a *BoolEvaluator, b *BoolEvaluator, state *State) (*BoolEvaluator, erro
 				return false
 			}
 
-			if a.Field != "" {
-				ctx.AddMatchingSubExpr(MatchingValue{Field: a.Field, Value: va, Offset: a.Offset}, MatchingValue{})
+			if fieldA != "" {
+				ctx.AddMatchingSubExpr(MatchingValue{Field: fieldA, Value: va, Offset: offsetA}, MatchingValue{})
 			}
-			if b.Field != "" {
-				ctx.AddMatchingSubExpr(MatchingValue{}, MatchingValue{Field: b.Field, Value: vb, Offset: b.Offset})
+			if fieldB != "" {
+				ctx.AddMatchingSubExpr(MatchingValue{}, MatchingValue{Field: fieldB, Value: vb, Offset: offsetB})
 			}
 			return true
 		}


### PR DESCRIPTION
### What does this PR do?

Fixes three defects in the way `And` and `Or` record matching sub-expressions in `pkg/security/secl/compiler/eval/operators.go`. One commit per fix, each with a test that fails before the corresponding change:

1. **Report evaluated values, not evaluator closures.** `Or` and `StringEquals` passed the operand's `EvalFnc` to `AddMatchingSubExpr` instead of the value it returned, so `MatchingValue.Value` held a `func(*Context) T` rather than the matched bool/string.
2. **Stop re-evaluating `And` operands.** The three dynamic branches of `And` invoked their operand evaluators a second time purely to fill in `MatchingValue.Value`, so every reported operand was evaluated twice on a match.
3. **Keep the reported field paired with its operand across the weight swap.** `And`/`Or` reorder their operands so the cheaper one runs first, but only the evaluators were swapped — the `Field` and `Offset` used for reporting kept the original order.

### Motivation

(1) is user-visible. `newRuleContext` in `pkg/security/serializers/serializers_base.go` runs the reported value through a type switch whose `default` branch does `fmt.Sprintf("%v", value)`; a func lands there, so the event payload carried a pointer address instead of the matched value.

(2) is on the hot path. Operands can be patterns, regexps or iterators (weights up to 2000 in `eval.go`), so this doubled their cost on every match, and it silently assumed the evaluators were side-effect free.

(3) makes `Or` attribute a match to the operand that did not match, highlighting the wrong span of the rule expression. It only triggers when the weights are such that a swap happens. `And` was not observably affected, since both operands are true whenever it reports, but it is reordered the same way and is updated for consistency.

The generated operators in `eval_operators.go` and their template in `pkg/security/generators/operators` were checked and are already correct — all four sites were in the hand-written `operators.go`.

### Describe how you validated your changes

Three new tests in `compiler/eval/eval_test.go`, each verified to fail against the unfixed operator and pass after:

- `TestMatchingSubExprReportedValues` — asserts the reported values are the evaluated ones and rejects any `reflect.Func`. Fails on `false || process.is_root` and `true && process.name == process.name`.
- `TestMatchingSubExprSingleEvaluation` — counts evaluations of `process.is_root` through a new `isRootEvalCount` counter on the test model (alongside the existing `uidEvaluated`/`gidEvaluated`). Fails on all four affected `And` branches.
- `TestMatchingSubExprOperandSwap` — builds the operands by hand, because the test model has no boolean field carrying a weight, so the reordering cannot be triggered from a SECL expression. Covers both swap directions plus a no-swap regression guard.

The existing `TestMatchingSubExprs` and the full `pkg/security/secl` suite pass; `gofmt` and `go vet` are clean.

### Additional Notes

No release note: none of these change documented behavior, and the payload defect in (1) was emitting a pointer address where a value was expected.