### PR TITLE
[CWS] fix a nil dereference when compiling an unsupported operator on a CIDR array

### DIFF
--- a/pkg/security/secl/compiler/eval/cidr_array_op_test.go
+++ b/pkg/security/secl/compiler/eval/cidr_array_op_test.go
@@ -1,0 +1,53 @@
+package eval
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestUnsupportedOperatorOnCIDRArray checks that an unsupported operator between a CIDR array
+// field and a CIDR field is reported as an error rather than crashing the compiler.
+//
+// An ast.Comparison carries either a scalar comparison or an array one, never both, so the
+// unknown-operator error of each branch has to read its operator from the branch it is in.
+// Reading it from the other dereferences nil, and since rules come from policy configuration
+// that turns a malformed rule into a crash of rule compilation rather than a rejection.
+func TestUnsupportedOperatorOnCIDRArray(t *testing.T) {
+	model := &testModel{}
+	opts := newOptsWithParams(testConstants, nil)
+
+	for _, expr := range []string{
+		`network.ips >= network.ip`,
+		`network.ips > network.ip`,
+		`network.ips <= network.ip`,
+		`network.ips < network.ip`,
+	} {
+		t.Run(expr, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("compiling `%s` panicked: %v", expr, r)
+				}
+			}()
+
+			_, err := parseRule(expr, model, opts)
+			if err == nil {
+				t.Fatalf("expected `%s` to be rejected", expr)
+			}
+			if !strings.Contains(err.Error(), "operator") {
+				t.Errorf("expected an unknown operator error, got: %s", err)
+			}
+		})
+	}
+
+	// the supported operators on that pair must keep working
+	for _, expr := range []string{
+		`network.ips == network.ip`,
+		`network.ips != network.ip`,
+	} {
+		t.Run(expr, func(t *testing.T) {
+			if _, err := parseRule(expr, model, opts); err != nil {
+				t.Fatalf("expected `%s` to compile, got: %s", expr, err)
+			}
+		})
+	}
+}

--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -1272,7 +1272,7 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 					return boolEvaluator, obj.Pos, nil
 				}
 
-				return nil, pos, NewOpUnknownError(obj.Pos, *obj.ArrayComparison.Op)
+				return nil, pos, NewOpUnknownError(obj.Pos, *obj.ScalarComparison.Op)
 
 			case *StringArrayEvaluator:
 				nextString, ok := next.(*StringEvaluator)


### PR DESCRIPTION
### What does this PR do?

Fixes a nil pointer dereference in `nodeToEvaluator` that panics rule compilation for a comparison between a CIDR array field and a CIDR field using an operator other than `==` or `!=`. All three of these panic today:

```
dns.response.ips >= network.destination.ip
network_flow_monitor.flows.destination.ip > network.destination.ip
exec.file.path != "" && process.ancestors.user_session.ssh_client_ip >= process.user_session.ssh_client_ip
```

An `ast.Comparison` carries either a `ScalarComparison` or an `ArrayComparison`, never both. The `*CIDRArrayEvaluator` case of the scalar branch built its unknown-operator error from `*obj.ArrayComparison.Op`, which is nil in that branch, so reaching that line dereferenced nil rather than returning the error. The fix reads the operator from the branch we are actually in.

With the fix, those rules are rejected with ``operator `>=` unknown``.

### Motivation

Rules come from policy configuration, so a malformed rule crashes rule compilation instead of being rejected with a message.

The scalar and array branches are otherwise symmetric in how they dispatch on operand type, which is what made the single asymmetric reference visible.

### Describe how you validated your changes

`TestUnsupportedOperatorOnCIDRArray` in `pkg/security/secl/compiler/eval/cidr_array_op_test.go` covers the four ordering operators on that operand pair, each of which panicked before this change and now returns an unknown-operator error, plus `==` and `!=` to confirm the supported operators still compile. Verified failing before the fix and passing after.

The test uses the `eval` package's test model, since `eval` cannot import `model`. The three rules quoted above use real fields and were checked separately against `model.Model`: all three panic on `main` and are cleanly rejected with this change.

The whole `pkg/security/secl` suite passes, along with `FuzzEval`.

I also searched for the same shape elsewhere in the compiler, a branch guarded on one field of a mutually exclusive pair dereferencing the other, across `Comparison`, `Primary`, `Array`, `Macro`, `Unary` and the set member types. This is the only occurrence. The check was validated by running it against the code prior to this fix, where it reports exactly this line.

### Additional Notes

No release note: the fix turns a crash into the error that was already intended for that case, and does not change the behaviour of any rule that compiles today.