### PR TITLE
[SECL] Record a bare boolean field wherever it appears in a rule

### DIFF
--- a/pkg/security/secl/compiler/eval/BUILD.bazel
+++ b/pkg/security/secl/compiler/eval/BUILD.bazel
@@ -74,6 +74,7 @@ operators(
 dd_agent_go_test(
     name = "eval_test",
     srcs = [
+        "bare_bool_test.go",
         "eval_test.go",
         "glob_test.go",
         "model_test.go",

--- a/pkg/security/secl/compiler/eval/bare_bool_test.go
+++ b/pkg/security/secl/compiler/eval/bare_bool_test.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package eval holds eval related files
+package eval
+
+import "testing"
+
+// TestBareBoolFieldRecordedRegardlessOfPosition pins that a bare boolean field records its
+// value wherever it is written.
+//
+// Unary is the only place that records it, and it is reached from two positions: an
+// Expression, and the operand of a negation. Recording from fewer than both would tie the
+// value to the syntax surrounding the field, its place in a logical chain, whether it is
+// parenthesised, whether it is negated, none of which the language distinguishes.
+//
+// It matters because approvers are derived from the recorded values: for a rule whose only
+// approver-capable field is a bare boolean, losing the record gives up kernel side filtering
+// for the whole event type.
+func TestBareBoolFieldRecordedRegardlessOfPosition(t *testing.T) {
+	tests := []struct {
+		expr     string
+		expected bool
+	}{
+		{`process.is_root`, true},
+		{`process.is_root && process.name == "ls"`, true},
+		{`process.name == "ls" && process.is_root`, true},
+		{`process.name == "ls" && process.is_root && process.uid == 0`, true},
+		{`process.is_root || process.name == "ls"`, true},
+		{`(process.is_root) && process.name == "ls"`, true},
+		{`process.is_root == true && process.name == "ls"`, true},
+
+		// negation records too, and does not depend on parentheses
+		{`!process.is_root`, true},
+		{`!(process.is_root)`, true},
+		{`!process.is_root && process.name == "ls"`, true},
+		{`!(process.is_root || process.name == "ls")`, true},
+
+		// a rule that never mentions the field records nothing for it
+		{`process.name == "ls"`, false},
+	}
+
+	model := &testModel{}
+
+	for _, test := range tests {
+		t.Run(test.expr, func(t *testing.T) {
+			opts := newOptsWithParams(testConstants, nil)
+
+			rule, err := parseRule(test.expr, model, opts)
+			if err != nil {
+				t.Fatalf("failed to compile: %s", err)
+			}
+
+			values := rule.GetFieldValues("process.is_root")
+			if got := len(values) > 0; got != test.expected {
+				t.Fatalf("expected recorded=%t for `%s`, got %t (%v)",
+					test.expected, test.expr, got, values)
+			}
+
+			for _, v := range values {
+				if v.Value != true {
+					t.Errorf("expected the recorded value to be true, got %v", v.Value)
+				}
+			}
+		})
+	}
+}

--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -760,6 +760,22 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 			return nil, pos, err
 		}
 
+		// Unary records the value of a bare boolean field. It runs here, ahead of the operator
+		// branch, so that it runs for every operand of a logical chain.
+		//
+		// The grammar nests those chains to the right, so only the last operand of one reaches
+		// an Expression carrying no operator. Recording from there alone would tie the value
+		// to where the field sits in the expression, and approvers are derived from the
+		// recorded values, so the position of an operand would decide whether the event type
+		// is filtered in kernel space.
+		//
+		// It is a no-op for anything but a bare field: a comparison evaluator carries no Field.
+		if cmpBool, ok := cmp.(*BoolEvaluator); ok {
+			if cmp, err = Unary(cmpBool, state); err != nil {
+				return nil, obj.Pos, err
+			}
+		}
+
 		if obj.Op != nil {
 			cmpBool, ok := cmp.(*BoolEvaluator)
 			if !ok {
@@ -791,13 +807,6 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 				return boolEvaluator, obj.Pos, nil
 			}
 			return nil, pos, NewOpUnknownError(obj.Pos, *obj.Op)
-		}
-
-		if cmpBool, ok := cmp.(*BoolEvaluator); ok {
-			cmp, err = Unary(cmpBool, state)
-			if err != nil {
-				return nil, obj.Pos, err
-			}
 		}
 
 		return cmp, obj.Pos, nil
@@ -1587,6 +1596,13 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 			unaryBool, ok := unary.(*BoolEvaluator)
 			if !ok {
 				return nil, pos, NewTypeError(pos, reflect.Bool)
+			}
+
+			// Not returns a fresh evaluator carrying no Field, so record the value of a bare
+			// boolean field first. A negated field is then recorded like any other occurrence
+			// of it, whether or not it is parenthesised.
+			if _, err := Unary(unaryBool, state); err != nil {
+				return nil, obj.Pos, err
 			}
 
 			return Not(unaryBool, state), obj.Pos, nil


### PR DESCRIPTION
### What does this PR do?

Whether a bare boolean field contributes a value to the compiled rule depended on where it was written in the expression. Since approvers are derived from those recorded values, reordering the operands of an `&&` could decide whether an event type is filtered in kernel space at all:

```
open.file.in_upper_layer && process.uid == 0   ->  no approver, every open event
                                                   is pushed to userspace
process.uid == 0 && open.file.in_upper_layer   ->  in_upper_layer=[true]
```

`Unary` is the only place that records the value of a bare boolean field, and it was reachable only from an `Expression` carrying no operator. The grammar nests logical chains to the right, so in `a && b && c` only `c` sits in such an `Expression`. `Not` had the mirror problem: it drops the `Field` before `Unary` can see it, so a directly negated field recorded nothing while a parenthesised one did.

Recorded value for `open.file.in_upper_layer`, before this change:

| expression | recorded |
|---|---|
| `open.file.in_upper_layer` | `true` |
| `open.file.in_upper_layer && open.file.path == "/etc/passwd"` | **nothing** |
| `open.file.path == "/etc/passwd" && open.file.in_upper_layer` | `true` |
| `(open.file.in_upper_layer) && open.file.path == "/etc/passwd"` | `true` |
| `open.file.in_upper_layer == true && open.file.path == "/etc/passwd"` | `true` |
| `!open.file.in_upper_layer` | **nothing** |
| `!(open.file.in_upper_layer)` | `true` |

Nothing about the language says any of that; it follows from where the call sat. Adding redundant parentheses, or spelling out `== true`, changed the outcome.

The fix applies `Unary` before the operator branch, and to the operand of a negation. It is a no-op for anything but a bare field, since a comparison evaluator carries no `Field`, and the recorded value is deduplicated. After it, every row above records `true`.

### Motivation

A rule author reordering an `&&`, or removing parentheses they thought were redundant, could silently lose kernel-side filtering for a whole event type.

### Describe how you validated your changes

`TestBareBoolFieldRecordedRegardlessOfPosition` in `pkg/security/secl/compiler/eval/bare_bool_test.go` pins all twelve variants: alone, first, middle and last of a chain, under `||`, parenthesised, spelled out as `== true`, negated directly and negated through parentheses, plus a rule that never mentions the field to confirm it still records nothing. Verified failing before the change and passing after.

The table above was produced against the real model and the real `open` capabilities, on this branch with and without the fix.

**Effect on the default policy** (v1.70.0, 238 rules): the recorded values change for 4 rules, all of the form `<bare bool> && ...`, and **no derived approver changes**, because in each of those a higher-weighted field was already being selected. So this closes the trap without moving the filtering of the shipped policy.

I also checked whether anything else records field values from a position-dependent place. Everything else does so from inside an operator function, which the operand type dispatch reaches for every comparison regardless of position; `Unary` was the only one affected, and both of its call sites are covered here.

### Additional Notes

This does change approver derivation for rules of the affected shape, so it is worth a look from whoever owns kfilters even though the shipped policy is unaffected.

No release note: no rule changes what it matches, and the shipped policy derives the same filters.