### PR TITLE
[CWS] Fix kernel space filtering silently dropping events for flag values above 31

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/approvers.h
+++ b/pkg/security/ebpf/c/include/helpers/approvers.h
@@ -256,7 +256,7 @@ static enum SYSCALL_STATE __attribute__((always_inline)) approve_by_auid(struct 
     u32 auid = pid_entry->credentials.auid;
 
     struct event_mask_filter_t *mask_filter = bpf_map_lookup_elem(&auid_approvers, &auid);
-    if (mask_filter && mask_filter->event_mask & (1 << (event_type - 1))) {
+    if (mask_filter && mask_filter->event_mask & ((u64)1 << (event_type - 1))) {
         monitor_event_approved(syscall->type, AUID_APPROVER_TYPE);
         return ACCEPTED;
     }
@@ -285,7 +285,7 @@ static enum SYSCALL_STATE __attribute__((always_inline)) flag_approver (struct u
 
 static int __attribute__((always_inline)) is_basename_in_map(struct basename_t *basename, u64 event_type) {
     struct event_mask_filter_t *filter = bpf_map_lookup_elem(&basename_approvers, basename);
-    return filter && filter->event_mask & (1 << (event_type - 1));
+    return filter && filter->event_mask & ((u64)1 << (event_type - 1));
 }
 
 static enum SYSCALL_STATE __attribute__((always_inline)) approve_by_basename(struct dentry *dentry, u64 event_type) {
@@ -327,7 +327,7 @@ static enum SYSCALL_STATE __attribute__((always_inline)) approve_by_basename(str
 static enum SYSCALL_STATE __attribute__((always_inline)) approve_by_in_upper_layer(u64 event_type, struct file_t *file) {
     u32 key = 0;
     struct event_mask_filter_t *filter = bpf_map_lookup_elem(&in_upper_layer_approvers, &key);
-    if (filter && filter->event_mask & (1 << (event_type - 1)) && (file->flags & UPPER_LAYER) > 0) {
+    if (filter && filter->event_mask & ((u64)1 << (event_type - 1)) && (file->flags & UPPER_LAYER) > 0) {
         monitor_event_approved(event_type, IN_UPPER_LAYER_APPROVER_TYPE);
         return APPROVED;
     }

--- a/pkg/security/ebpf/c/include/helpers/approvers.h
+++ b/pkg/security/ebpf/c/include/helpers/approvers.h
@@ -274,7 +274,9 @@ static enum SYSCALL_STATE __attribute__((always_inline)) flag_approver (struct u
     if (filter == NULL || !filter->is_set) {
         return DISCARDED;
     }
-    if (((1 << (value % 64)) & filter->flags) > 0) {
+    // the shift has to be done on a u64: flags is a 64 bit mask and value % 64
+    // reaches 63, so an int shift would truncate every bit above 31.
+    if ((((u64)1 << (value % 64)) & filter->flags) > 0) {
         monitor_event_approved(type, FLAG_APPROVER_TYPE);
         return APPROVED;
     }

--- a/pkg/security/ebpf/c/include/helpers/events.h
+++ b/pkg/security/ebpf/c/include/helpers/events.h
@@ -25,7 +25,7 @@ static __attribute__((always_inline)) void add_event_to_mask(u64 *mask, enum eve
     if (event == EVENT_ALL) {
         *mask = event;
     } else {
-        *mask |= 1 << (event - EVENT_FIRST_DISCARDER);
+        *mask |= (u64)1 << (event - EVENT_FIRST_DISCARDER);
     }
 }
 

--- a/pkg/security/ebpf/c/include/tests/approvers_test.h
+++ b/pkg/security/ebpf/c/include/tests/approvers_test.h
@@ -1,0 +1,57 @@
+#ifndef _APPROVERS_TEST_H
+#define _APPROVERS_TEST_H
+
+#include "helpers/approvers.h"
+#include "baloum.h"
+
+// A flag approver holds one bit per approved value in a 64 bit mask, and user
+// space sets bit `value % 64`, so every shift from 0 to 63 has to round trip.
+#define assert_flag_approver_bit(bit)                                                                          \
+    {                                                                                                          \
+        struct u64_flags_filter_t filter = {                                                                   \
+            .flags = (u64)1 << (bit),                                                                          \
+            .is_set = 1,                                                                                       \
+        };                                                                                                     \
+        assert_equals(flag_approver(&filter, EVENT_SOCKET, (bit)), APPROVED,                                   \
+                      "value in the mask should be approved");                                                 \
+        assert_equals(flag_approver(&filter, EVENT_SOCKET, ((bit) + 1) % 64), DISCARDED,                       \
+                      "value outside the mask should be discarded");                                           \
+    }
+
+SEC("test/flag_approver_low_bits")
+int test_flag_approver_low_bits() {
+#pragma unroll
+    for (int bit = 0; bit < 32; bit++) {
+        assert_flag_approver_bit(bit);
+    }
+
+    return 1;
+}
+
+// AF_VSOCK, BPF_LINK_DETACH, PR_SET_NO_NEW_PRIVS and SO_ATTACH_BPF are among
+// the values that land in the upper half of the mask.
+SEC("test/flag_approver_high_bits")
+int test_flag_approver_high_bits() {
+#pragma unroll
+    for (int bit = 32; bit < 64; bit++) {
+        assert_flag_approver_bit(bit);
+    }
+
+    return 1;
+}
+
+SEC("test/flag_approver_unset")
+int test_flag_approver_unset() {
+    struct u64_flags_filter_t filter = {
+        .flags = ~(u64)0,
+        .is_set = 0,
+    };
+
+    // an approver that was never installed approves nothing, whatever it holds
+    assert_equals(flag_approver(&filter, EVENT_SOCKET, 0), DISCARDED, "unset filter should discard");
+    assert_equals(flag_approver(NULL, EVENT_SOCKET, 0), DISCARDED, "missing filter should discard");
+
+    return 1;
+}
+
+#endif /* _APPROVERS_TEST_H */

--- a/pkg/security/ebpf/c/include/tests/tests.h
+++ b/pkg/security/ebpf/c/include/tests/tests.h
@@ -5,5 +5,6 @@
 #include "activity_dump_ratelimiter_test.h"
 #include "raw_packet_test.h"
 #include "path_id_test.h"
+#include "approvers_test.h"
 
 #endif

--- a/pkg/security/ebpf/tests/approvers_test.go
+++ b/pkg/security/ebpf/tests/approvers_test.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && ebpf_bindata
+
+// Package tests holds tests related files
+package tests
+
+import (
+	"testing"
+
+	"github.com/safchain/baloum/pkg/baloum"
+)
+
+func TestFlagApprover(t *testing.T) {
+	for _, section := range []string{
+		"test/flag_approver_low_bits",
+		"test/flag_approver_high_bits",
+		"test/flag_approver_unset",
+	} {
+		t.Run(section, func(t *testing.T) {
+			var ctx baloum.StdContext
+			code, err := newVM(t).RunProgram(&ctx, section)
+			if err != nil || code != 1 {
+				t.Errorf("unexpected error: %v, %d", err, code)
+			}
+		})
+	}
+}

--- a/pkg/security/tests/prctl_test.go
+++ b/pkg/security/tests/prctl_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
 	"syscall"
 	"testing"
 	"time"
@@ -32,6 +33,13 @@ func TestPrCtl(t *testing.T) {
 		{
 			ID:         "test_rule_prctl_get_dumpable",
 			Expression: `prctl.option == PR_GET_DUMPABLE`,
+		},
+		{
+			// PR_GET_NO_NEW_PRIVS is 39. The flag approver holds one bit per approved option
+			// in a 64 bit mask, so an option of 32 or more only reaches user space if the
+			// kernel side reads the upper half of that mask.
+			ID:         "test_rule_prctl_get_no_new_privs",
+			Expression: `prctl.option == PR_GET_NO_NEW_PRIVS`,
 		},
 	}
 
@@ -67,6 +75,21 @@ func TestPrCtl(t *testing.T) {
 		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_prctl_get_dumpable")
 		}, "test_rule_prctl_get_dumpable")
+	})
+	t.Run("prctl-get-no-new-privs", func(t *testing.T) {
+		test.WaitSignalFromRule(t, func() error {
+			_, _, errno := syscall.Syscall6(
+				syscall.SYS_PRCTL,
+				uintptr(unix.PR_GET_NO_NEW_PRIVS),
+				0, 0, 0, 0, 0,
+			)
+			if errno != 0 {
+				return fmt.Errorf("prctl(PR_GET_NO_NEW_PRIVS) failed: %v", errno)
+			}
+			return nil
+		}, func(_ *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_rule_prctl_get_no_new_privs")
+		}, "test_rule_prctl_get_no_new_privs")
 	})
 }
 

--- a/releasenotes/notes/cws-flag-approver-high-values-3f1a6c8d94e2b705.yaml
+++ b/releasenotes/notes/cws-flag-approver-high-values-3f1a6c8d94e2b705.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    CWS: fixed kernel space filtering dropping events for rules that match a flag value of
+    32 or more. This affected ``bpf.cmd``, ``connect.addr_family``, ``prctl.option``,
+    ``setsockopt.level``, ``setsockopt.optname``, ``socket.domain``, ``socket.type`` and
+    ``socket.protocol``, for values such as ``AF_VSOCK``, ``BPF_LINK_DETACH``,
+    ``PR_SET_NO_NEW_PRIVS`` and ``SO_ATTACH_BPF``. Rules using those values never triggered.


### PR DESCRIPTION
### What does this PR do?

Fixes a kernel space filtering bug that silently drops CWS events. `flag_approver` tests a value against a 64 bit approver mask by shifting a literal `1`, which is an `int`:

```c
if (((1 << (value % 64)) & filter->flags) > 0) {
```

`filter->flags` is a `u64` and `value % 64` reaches 63, so every bit above 31 is lost. User space builds the same mask correctly, on a `uint64`:

```go
flags = append(flags, 1<<(enum%64))   // enum is uint64, so this sets bit 40 for AF_VSOCK
```

The two sides therefore disagree for any approved value of 32 or more. The kernel looks for a bit that user space never asked it to look at, the approver never matches, and the event is discarded before it reaches user space. **The rule silently never fires.**

### Motivation

This is a missed detection, which is the worst direction for a filtering bug: nothing errors, nothing is logged, the rule simply never triggers.

#### What the compiler actually emits

For the BPF target with the clang version pinned in `MODULE.bazel` (19.1.7), the shift is performed in 64 bits and then truncated back to 32 and sign extended:

```
bad:                          # ((1 << (value % 64)) & filter->flags) > 0
        r2 &= 63
        r3 = 1
        r3 <<= r2             # 64 bit shift
        r3 <<= 32
        r3 s>>= 32            # truncate to 32 bits, sign extend
        r1 &= r3

good:                         # (((u64)1 << (value % 64)) & filter->flags) > 0
        r2 &= 63
        r0 = *(u64 *)(r1 + 0)
        r0 >>= r2
        r0 &= 1
```

So the mask the kernel tests against is:

| shift | value tested | effect |
|---|---|---|
| 0 to 30 | correct | correct |
| 31 | `0xffffffff80000000` | over-approves, bits 31 to 63 all match |
| 32 to 63 | `0` | **never matches, event discarded** |

This is undefined behaviour, not merely a wrong result. Built against the original expression, the unit test added here for the upper half of the mask is emitted by clang **with a size of zero** — the optimiser deleted the whole function body.

#### Which rules are affected

Six fields route through `flag_approver`: `bpf.cmd`, `connect.addr_family`, `prctl.option`, `setsockopt.level`, `setsockopt.optname` and `socket.domain` / `socket.type` / `socket.protocol`.

130 SECL constants across those fields land in the dead window. Tracing a rule end to end, from the expression through approver derivation to the bytes written into the eBPF map, and then through the kernel expression:

| rule | mask written by user space | kernel verdict |
|---|---|---|
| `socket.domain == AF_INET` | `0x0000000000000004` | APPROVED |
| `socket.domain == AF_VSOCK` | `0x0000010000000000` | **DISCARDED** |
| `bpf.cmd == BPF_LINK_DETACH` | `0x0000000400000000` | **DISCARDED** |
| `setsockopt.optname == SO_ATTACH_BPF` | `0x0004000000000000` | **DISCARDED** |

Other security relevant values in the same window include `prctl.option == PR_SET_PTRACER` (Yama ptrace scope manipulation), `prctl.option == PR_SET_NO_NEW_PRIVS`, `connect.addr_family == AF_XDP` and 15 of the 50 address families.

For `bpf` and `prctl`, `flag_approver` is the only approver, so a discard drops the event outright. `socket`, `setsockopt` and `connect` fall back to their other fields, but a rule constraining only the affected field installs no other filter, so those fall through to a discard as well.

No rule in the default policy uses these fields, so this affects custom and remote configuration delivered rules.

#### Second commit

The same `1 <<` against a `u64` appears at three `event_mask` sites in `approvers.h` and in `add_event_to_mask`. Those are correct today only because every event type reaching them is at most `EVENT_CHDIR`, which is 15, while the mask already has to hold 69 kernel event types. `add_event_to_mask` is the sharper one: the mask it writes is read back by `mask_has_event`, which already shifts a `u64`, so the pair disagrees above bit 31. Fixed as hardening, in a separate commit, with no behaviour change today.

### Describe how you validated your changes

**eBPF unit test** (`dda inv security-agent.run-ebpf-unit-tests`). Walks all 64 bits, checking that a mask with a single bit set approves its own value and discards the neighbouring one. Split into a low and a high half so the failing section names which part of the mask broke.

I built the baloum object both with and without the fix and ran them through the VM:

```
WITH the fix
  test/flag_approver_low_bits      PASS
  test/flag_approver_high_bits     PASS
  test/flag_approver_unset         PASS

WITHOUT the fix
  test/flag_approver_low_bits      PASS
  test/flag_approver_high_bits     FAIL
  test/flag_approver_unset         PASS
```

The pre-existing `test/discarders_event_mask` and `test/path_id_*` programs still pass, which covers the second commit since they exercise `add_event_to_mask` and `mask_has_event`.

**Functional test, added but not run by me.** Every prctl option the functional suite exercised was small, `PR_SET_NAME` is 15 and `PR_GET_DUMPABLE` is 3, so the suite only ever read the lower half of the mask and passed either way. Added `prctl.option == PR_GET_NO_NEW_PRIVS`, which is 39. It is a plain read with no effect on the calling process, so it can be issued from the test process directly.

I could not execute this one, or even compile it: `pkg/security/tests` does not build outside the `linux_bpf` toolchain, which does not run on macOS. It is unverified and CI is its first run. Reviewers should treat it as untested code.

**End to end trace of the derivation**, from a SECL rule through `GetEventTypeApprovers` and the kfilter marshalling to the exact bytes in the map, checked against the kernel expression as the BPF backend compiles it. That is where the table above comes from.

### Additional Notes

The fix is one cast per site. The reason it is worth the length of this description is that nothing about the symptom points at the cause: the rule is valid, the approver is derived correctly, the map is written correctly, and the event still never arrives.

The codebase already uses the correct idiom elsewhere, `1ULL << cap` in `hooks/caps.h` and `(u64)1 << ...` in `hooks/bpf.h` and `helpers/events.h`, so these sites were inconsistent rather than deliberate.

I could not run the eBPF unit tests through `dda inv` locally, since the pinned Bazel toolchain does not run on macOS. To build the object outside it I had to make `new_rate_limiter` static in a scratch copy of the tree, because plain `llc` rejects its external linkage aggregate return. That is pre-existing, unrelated to this change, and not modified here.
