### PR TITLE
Fix `exception-threshold-bump` when restoring lost headroom

### DIFF
--- a/tasks/static_quality_gates/metrics.py
+++ b/tasks/static_quality_gates/metrics.py
@@ -109,7 +109,7 @@ def fetch_main_headroom(failing_gates: list[str]) -> dict[str, dict[str, int]]:
         f"avg:datadog.agent.static_quality_gate.{m}{{git_ref:main AND ({gate_filter})}} by {{gate_name}}"
         for m in metric_map
     )
-    result = query_metrics(queries, from_time="now-1d", to_time="now")
+    result = query_metrics(queries, from_time="now-7d", to_time="now")  # accounts for weekends
 
     for series in result:
         gate_name = _extract_gate_name_from_scope(series.get("scope", ""))
@@ -127,13 +127,15 @@ def fetch_main_headroom(failing_gates: list[str]) -> dict[str, dict[str, int]]:
                     main_metrics[gate_name][key] = int(latest_value)
                 break
 
+    from tasks.static_quality_gates.thresholds import BUFFER_SIZE  # avoids a circular import
+
     headroom: dict[str, dict[str, int]] = {}
     for gate_name, metrics in main_metrics.items():
         disk_headroom = metrics.get("max_disk", 0) - metrics.get("current_disk", 0)
         wire_headroom = metrics.get("max_wire", 0) - metrics.get("current_wire", 0)
         headroom[gate_name] = {
-            "disk_headroom": max(0, disk_headroom),
-            "wire_headroom": max(0, wire_headroom),
+            "disk_headroom": max(BUFFER_SIZE, disk_headroom),
+            "wire_headroom": max(BUFFER_SIZE, wire_headroom),
         }
 
     return headroom

--- a/tasks/unit_tests/static_quality_gates/metrics_tests.py
+++ b/tasks/unit_tests/static_quality_gates/metrics_tests.py
@@ -8,6 +8,7 @@ from tasks.static_quality_gates.metrics import (
     fetch_main_headroom,
     fetch_pr_metrics,
 )
+from tasks.static_quality_gates.thresholds import BUFFER_SIZE
 
 
 class MockPoint:
@@ -248,8 +249,8 @@ class TestFetchMainHeadroom(unittest.TestCase):
         self.assertEqual(headroom["wire_headroom"], 25 * 1024 * 1024)
 
     @patch("tasks.static_quality_gates.metrics.query_metrics")
-    def test_headroom_never_negative(self, mock_query):
-        """Headroom should never be negative (clamped to 0)."""
+    def test_headroom_floored_when_main_over_its_own_limit(self, mock_query):
+        """Headroom should floor at BUFFER_SIZE, not 0-, when main is over its own limit."""
         # Single API call with current > max
         mock_query.return_value = [
             {
@@ -277,8 +278,8 @@ class TestFetchMainHeadroom(unittest.TestCase):
         result = fetch_main_headroom(["static_quality_gate_agent_deb_amd64"])
 
         headroom = result["static_quality_gate_agent_deb_amd64"]
-        # disk_headroom = max(0, 150 - 200) = 0
-        self.assertEqual(headroom["disk_headroom"], 0)
+        # disk_headroom = max(BUFFER_SIZE, 150 - 200) = BUFFER_SIZE
+        self.assertEqual(headroom["disk_headroom"], BUFFER_SIZE)
 
     def test_returns_empty_for_no_gates(self):
         """Should return empty dict when no gates provided."""


### PR DESCRIPTION
### What does this PR do?
Fix `fetch_main_headroom()` in tasks/static_quality_gates/metrics.py: widen its lookback from 1 day to 7 so it doesn't miss `main`'s last report over a weekend, and floor the computed headroom at `BUFFER_SIZE` instead of 0 when main is already over its own limit.

### Motivation
`agent_rpm_arm64`/`agent_suse_arm64` exceeded their 735.07 MiB limit on `main`, driven mainly by #54204's Rust data-security check (+3.49 MiB).
Restoring headroom via `quality-gates.exception-threshold-bump` should have been a one-line fix, but the script failed to produce a usable threshold, for two reasons:
1. its 1-day lookback missed `main`'s last report across the weekend gap between Friday's merges and the incident, since main only reports this metric when a commit lands,
2. it sets the new limit to the PR's own reported size plus main's headroom, so whenever main's headroom was at or below 0 (as it was here) the new limit collapsed to just the PR's own size: a threshold still below main's actual usage, one that would not even have unblocked `main`.

### Describe how you validated your changes
Added `test_headroom_floored_when_main_over_its_own_limit` (renamed from the now-inverted `test_headroom_never_negative`) asserting the floor applies when main is over budget.

Reran `quality-gates.exception-threshold-bump` twice independently: both runs produced identical thresholds, confirming the fix is deterministic.