### PR TITLE
Also wait for `monitorWorkerUtilization` in `Runner.Stop()`

### DIFF
--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -94,8 +94,7 @@ func NewRunner(senderManager sender.SenderManager, haAgent haagent.Component) *R
 	r.ensureMinWorkers(numWorkers)
 
 	// Start monitoring worker utilization
-	r.stopWG.Add(1)
-	go r.monitorWorkerUtilization()
+	r.stopWG.Go(r.monitorWorkerUtilization)
 
 	return r
 }
@@ -243,15 +242,12 @@ func (r *Runner) Stop() {
 		terminateChecksRunningProcesses()
 
 		for _, c := range runningChecks {
-			r.stopWG.Add(1)
-			go func(ch check.Check) {
-				err := r.StopCheck(ch.ID())
+			r.stopWG.Go(func() {
+				err := r.StopCheck(c.ID())
 				if err != nil {
-					log.Warnf("Check %v not responding after %v: %s", ch, stopCheckTimeout, err)
+					log.Warnf("Check %v not responding after %v: %s", c, stopCheckTimeout, err)
 				}
-
-				r.stopWG.Done()
-			}(c)
+			})
 		}
 	})
 
@@ -359,8 +355,6 @@ func (r *Runner) logWorkerUtilization() {
 }
 
 func (r *Runner) monitorWorkerUtilization() {
-	defer r.stopWG.Done()
-
 	interval := pkgconfigsetup.Datadog().GetDuration("check_runner_utilization_monitor_interval")
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()

--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -57,6 +57,7 @@ type Runner struct {
 	schedulerLock       sync.RWMutex                  // Lock around operations on the scheduler
 	utilizationMonitor  *worker.UtilizationMonitor    // Monitor in charge of checking the worker utilization
 	utilizationLogLimit *log.Limit                    // Log limiter for utilization warnings
+	stopWG              sync.WaitGroup                // Goroutines Stop waits for: monitor and checks
 	// ctx is cancelled when the runner stops, providing a cancellation signal
 	// to any context-aware operation inside workers (e.g. hostname resolution).
 	ctx    context.Context
@@ -93,6 +94,7 @@ func NewRunner(senderManager sender.SenderManager, haAgent haagent.Component) *R
 	r.ensureMinWorkers(numWorkers)
 
 	// Start monitoring worker utilization
+	r.stopWG.Add(1)
 	go r.monitorWorkerUtilization()
 
 	return r
@@ -227,14 +229,13 @@ func (r *Runner) Stop() {
 	}
 
 	// Cancel the runner context to unblock any context-aware operations in workers
-	// (e.g. hostname resolution via EC2 IMDS) that may be waiting on I/O.
+	// (e.g. hostname resolution via EC2 IMDS) that may be waiting on I/O, and to
+	// wake up monitorWorkerUtilization immediately instead of on its next tick.
 	r.cancel()
 
 	log.Infof("Runner %d is shutting down...", r.id)
 	close(r.pendingChecksChan)
 	close(r.shadowChecksChan)
-
-	wg := sync.WaitGroup{}
 
 	// Stop running checks
 	r.checksTracker.WithRunningChecks(func(runningChecks map[checkid.ID]check.Check) {
@@ -242,14 +243,14 @@ func (r *Runner) Stop() {
 		terminateChecksRunningProcesses()
 
 		for _, c := range runningChecks {
-			wg.Add(1)
+			r.stopWG.Add(1)
 			go func(ch check.Check) {
 				err := r.StopCheck(ch.ID())
 				if err != nil {
 					log.Warnf("Check %v not responding after %v: %s", ch, stopCheckTimeout, err)
 				}
 
-				wg.Done()
+				r.stopWG.Done()
 			}(c)
 		}
 	})
@@ -257,7 +258,7 @@ func (r *Runner) Stop() {
 	globalDone := make(chan struct{})
 	go func() {
 		log.Debugf("Runner %d waiting for all the workers to exit...", r.id)
-		wg.Wait()
+		r.stopWG.Wait()
 
 		log.Debugf("All runner %d workers have been shut down", r.id)
 		close(globalDone)
@@ -358,12 +359,18 @@ func (r *Runner) logWorkerUtilization() {
 }
 
 func (r *Runner) monitorWorkerUtilization() {
+	defer r.stopWG.Done()
+
 	interval := pkgconfigsetup.Datadog().GetDuration("check_runner_utilization_monitor_interval")
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
-	for r.isRunning.Load() {
-		<-ticker.C
-		r.logWorkerUtilization()
+	for {
+		select {
+		case <-r.ctx.Done():
+			return
+		case <-ticker.C:
+			r.logWorkerUtilization()
+		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?
Make `Stop()` also wait for `monitorWorkerUtilization` to actually exit before returning, instead of leaving it running until its next tick.
The loop now wakes up on context cancellation rather than only between ticker ticks.

Its exit is tracked through the same `sync.WaitGroup` and timeout/error-log fallback `Stop()` already used for check goroutines.
That WaitGroup moves from a `Stop()`-local variable to a field, so `NewRunner` can register the monitor goroutine on it too, without introducing a new synchronization primitive.

### Motivation
`pkg/collector/runner.TestRunnerShouldAddCheckStats` has been flaking:
```
panic: non-positive interval for NewTicker
time.NewTicker(0x0)
github.com/DataDog/datadog-agent/pkg/collector/runner.(*Runner).monitorWorkerUtilization(...)
    pkg/collector/runner/runner.go:362
```
preceded by:
```
[Error] attempt to read key before config is constructed: check_runner_utilization_monitor_interval
```

It is tracked as an active flaky test in Datadog: https://app.datadoghq.com/ci/test/flaky?query=fingerprint_fqn%3Afb40c2b54df8d97e

The chain: reading a config key before the config has finished building returns "", and casting "" to a duration falls back to 0.

`Stop()` used to return before `monitorWorkerUtilization` had actually exited, so a runner left over from one test could still be reading `pkgconfigsetup.Datadog()` while the next test's `SetupTest` swapped in a fresh, not-yet-built mock config, landing exactly in that window.

### Describe how you validated your changes
Reproduced the race directly against `pkg/config/setup.SetDatadog`/`InitConfig`/`BuildSchema`, reliably hitting the same not-ready-config / duration-0 / `NewTicker` panic sequence.

Confirmed via goroutine-stack inspection that the monitor goroutine was still alive immediately after `Stop()` returned before this fix, and gone immediately after it with the fix applied.

`pkg/collector/runner` tests pass under `-race`, including `TestRunnerShouldAddCheckStats`.
