### PR TITLE
fix(tasks): Exclude bot comments from PR size review comment count

### DIFF
--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -732,20 +732,22 @@ def get_pr_size(pr) -> str:
     # - hard PRs are merged in more than 1 week
     # More details: https://datadoghq.atlassian.net/wiki/spaces/agent/pages/4271079846/Code+Review+Experience+Improvement#Complexity-label
     _SIZE_CRITERIA = {
-        'easy': {'files': 4, 'lines': 150, 'comments': 2},
+        'easy': {'files': 4, 'lines': 150, 'comments': 3},
         'hard': {'files': 12, 'lines': 650, 'comments': 9},
     }
-
+    human_review_comments = sum(
+        1 for comment in pr.get_review_comments() if comment.user is not None and "[bot]" not in comment.user.login
+    )
     if (
         pr.changed_files < _SIZE_CRITERIA['easy']['files']
         and pr.additions + pr.deletions < _SIZE_CRITERIA['easy']['lines']
-        and pr.review_comments < _SIZE_CRITERIA['easy']['comments']
+        and human_review_comments < _SIZE_CRITERIA['easy']['comments']
     ):
         return 'small'
     if (
         pr.changed_files > _SIZE_CRITERIA['hard']['files']
         or pr.additions + pr.deletions > _SIZE_CRITERIA['hard']['lines']
-        or pr.review_comments > _SIZE_CRITERIA['hard']['comments']
+        or human_review_comments > _SIZE_CRITERIA['hard']['comments']
     ):
         return 'large'
     return 'medium'

--- a/tasks/unit_tests/issue_tests.py
+++ b/tasks/unit_tests/issue_tests.py
@@ -446,23 +446,35 @@ class TestGetTeamFileCounts(unittest.TestCase):
         self.assertEqual(counts['network-team'], 0)
 
 
+def _make_pr(changed_files, additions, deletions, comment_logins):
+    pr = types.SimpleNamespace(changed_files=changed_files, additions=additions, deletions=deletions)
+    pr.get_review_comments = lambda: [
+        types.SimpleNamespace(user=types.SimpleNamespace(login=login)) for login in comment_logins
+    ]
+    return pr
+
+
 class TestGetPrSize(unittest.TestCase):
     def test_small(self):
-        pr = types.SimpleNamespace(changed_files=2, additions=50, deletions=30, review_comments=1)
+        pr = _make_pr(2, 50, 30, ['alice'])
+        self.assertEqual(get_pr_size(pr), 'small')
+
+    def test_small_ignores_bot_comments(self):
+        pr = _make_pr(2, 50, 30, ['alice', 'bob', 'dependabot[bot]', 'dependabot[bot]'])
         self.assertEqual(get_pr_size(pr), 'small')
 
     def test_medium(self):
-        pr = types.SimpleNamespace(changed_files=6, additions=200, deletions=100, review_comments=3)
+        pr = _make_pr(6, 200, 100, ['alice', 'bob', 'carol'])
         self.assertEqual(get_pr_size(pr), 'medium')
 
     def test_large_by_files(self):
-        pr = types.SimpleNamespace(changed_files=15, additions=10, deletions=5, review_comments=0)
+        pr = _make_pr(15, 10, 5, [])
         self.assertEqual(get_pr_size(pr), 'large')
 
     def test_large_by_lines(self):
-        pr = types.SimpleNamespace(changed_files=1, additions=600, deletions=100, review_comments=0)
+        pr = _make_pr(1, 600, 100, [])
         self.assertEqual(get_pr_size(pr), 'large')
 
     def test_large_by_comments(self):
-        pr = types.SimpleNamespace(changed_files=1, additions=10, deletions=5, review_comments=10)
+        pr = _make_pr(1, 10, 5, ['alice'] * 10)
         self.assertEqual(get_pr_size(pr), 'large')


### PR DESCRIPTION
### What does this PR do?

Updates `get_pr_size` in `tasks/libs/ciproviders/github_api.py` to exclude bot-authored review comments (e.g. dependabot) from the count used to classify PR size, and raises the "small" PR comment threshold from 2 to 3. Updates the associated unit tests in `tasks/unit_tests/issue_tests.py` accordingly, including a new test verifying bot comments are ignored.

### Motivation

Bot review comments were inflating the human review comment count, causing PRs to be misclassified as larger than they actually are for reviewers. The small-PR threshold was also too tight.

### Describe how you validated your changes

Ran the updated unit tests (`TestGetPrSize`) via `dda inv invoke-unit-tests.run`; all pass.