### PR TITLE
fix(flare): avoid TOCTOU port race in process-agent verify-auth test

### DIFF
--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -8,12 +8,15 @@ package flare
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -91,24 +94,81 @@ func setupIPCAddress(t *testing.T, confMock model.Config, URL string) {
 	confMock.SetInTest("process_config.cmd_port", port)
 }
 
-func setupProcessAPIServer(t *testing.T) {
-	_ = fxutil.Test[processapiserver.Component](t, fx.Options(
-		processapiserverimpl.Module(),
-		fx.Provide(func() config.Component { return config.NewMock(t) }),
-		fx.Provide(func() log.Component { return logmock.New(t) }),
-		mocktelemetry.Module(),
-		workloadmetafx.Module(workloadmeta.NewParams()),
-		fx.Supply(
-			status.Params{
-				PythonVersionGetFunc: func() string { return "n/a" },
-			},
-		),
-		taggerfx.Module(),
-		statusimpl.Module(),
-		settingsmock.MockModule(),
-		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
-		fx.Provide(func() ipc.Component { return ipcmock.New(t) }),
-	))
+// maxBindAttempts bounds retries when a freshly-picked port loses the bind
+// race to something else between being picked and the real server binding it.
+const maxBindAttempts = 5
+
+// wsaeAddrInUse is WSAEADDRINUSE, the raw Winsock error code Go's net
+// package passes through unmodified on Windows binds; it doesn't map to the
+// stdlib syscall.EADDRINUSE constant, which is a different synthetic value.
+const wsaeAddrInUse = syscall.Errno(10048)
+
+// isAddrInUse reports whether err is a failure to bind because the port was
+// already taken.
+func isAddrInUse(err error) bool {
+	if runtime.GOOS == "windows" {
+		return errors.Is(err, wsaeAddrInUse)
+	}
+	return errors.Is(err, syscall.EADDRINUSE)
+}
+
+// freeTCPPort asks the OS for a currently-free TCP port.
+func freeTCPPort(t testing.TB) int {
+	t.Helper()
+	l, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// setupProcessAPIServer starts the real process-agent API server on a
+// freshly-picked port, retrying with a new port if the previous pick lost
+// the bind race. Unlike probing a port and reusing its number later, each
+// attempt is a real bind, so there's no gap between checking and using it.
+func setupProcessAPIServer(t *testing.T, cfg model.Config) {
+	var lastErr error
+	for attempt := 0; attempt < maxBindAttempts; attempt++ {
+		cfg.SetInTest("process_config.cmd_port", freeTCPPort(t))
+
+		var comp processapiserver.Component
+		app := fx.New(
+			fxutil.FxAgentBase(),
+			fx.Supply(fx.Annotate(t, fx.As(new(testing.TB)))),
+			fx.Populate(&comp),
+			processapiserverimpl.Module(),
+			fx.Provide(func() config.Component { return config.NewMock(t) }),
+			fx.Provide(func() log.Component { return logmock.New(t) }),
+			mocktelemetry.Module(),
+			workloadmetafx.Module(workloadmeta.NewParams()),
+			fx.Supply(
+				status.Params{
+					PythonVersionGetFunc: func() string { return "n/a" },
+				},
+			),
+			taggerfx.Module(),
+			statusimpl.Module(),
+			settingsmock.MockModule(),
+			fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
+			fx.Provide(func() ipc.Component { return ipcmock.New(t) }),
+		)
+
+		startCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		err := app.Start(startCtx)
+		cancel()
+		if err == nil {
+			t.Cleanup(func() {
+				stopCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+				defer cancel()
+				require.NoError(t, app.Stop(stopCtx))
+			})
+			return
+		}
+		if !isAddrInUse(err) {
+			t.Fatalf("failed to start process API server: %v", err)
+		}
+		lastErr = err
+	}
+	t.Fatalf("could not bind process API server after %d attempts: %v", maxBindAttempts, lastErr)
 }
 
 func TestVersionHistory(t *testing.T) {
@@ -181,16 +241,9 @@ process_config:
 	})
 
 	t.Run("verify auth", func(t *testing.T) {
-		listener, err := net.Listen("tcp", ":0")
-		require.NoError(t, err)
-		port := listener.Addr().(*net.TCPAddr).Port
-		listener.Close()
-
 		cfg := configmock.New(t)
-		cfg.SetInTest("process_config.cmd_port", port)
 		cfg.SetInTest("process_config.process_discovery.enabled", true)
-		cfg.SetInTest("process_config.cmd_port", port)
-		setupProcessAPIServer(t)
+		setupProcessAPIServer(t, cfg)
 
 		content, err := remoteProvider.getProcessAgentFullConfig()
 		require.NoError(t, err)
@@ -288,16 +341,9 @@ func TestProcessAgentChecks(t *testing.T) {
 		mock.AssertFileContent(string(expectedProcessDiscoveryJSON), "process_discovery_check_output.json")
 	})
 	t.Run("verify auth", func(t *testing.T) {
-		listener, err := net.Listen("tcp", ":0")
-		require.NoError(t, err)
-		port := listener.Addr().(*net.TCPAddr).Port
-		listener.Close()
-
 		cfg := configmock.New(t)
-		cfg.SetInTest("process_config.cmd_port", port)
 		cfg.SetInTest("process_config.process_discovery.enabled", true)
-		cfg.SetInTest("process_config.cmd_port", port)
-		setupProcessAPIServer(t)
+		setupProcessAPIServer(t, cfg)
 
 		mock := flarehelpers.NewFlareBuilderMock(t, false)
 		remoteProvider := RemoteFlareProvider{


### PR DESCRIPTION
### What does this PR do?

Fixes a flaky test in `pkg/flare` (`TestProcessAgentFullConfig/verify_auth` and `TestProcessAgentChecks/verify_auth`).

### Motivation

These tests picked a free port by opening a listener on `:0`, reading its port, and immediately closing it — then reused that port number later when starting the real `comp/process/apiserver` component. On CI runners executing many test binaries in parallel (e.g. `-parallel 12`), another process could grab the same port in the gap between close and reuse, causing intermittent failures such as:

```
app.go:61: application didn't start cleanly: listen tcp 127.0.0.1:49592: bind: address already in use
```

Seen here: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1934056302

Instead of probing a port and reusing its number later (which is inherently racy no matter how the candidate port is chosen — a concern raised on an earlier version of this PR by both an automated reviewer and a human reviewer), this retries the *real* component startup: pick a free port, actually try to bind it via the real `fx` app, and if that loses the race (`EADDRINUSE`, detected portably including Windows' distinct `WSAEADDRINUSE` code), pick a fresh port and try again. There's no gap between checking and using the port, so a lost race just costs a retry instead of a flaky failure.

A companion PR (#54619, stacked on this branch) applies the same fix to `comp/process/apiserver/impl/apiserver_test.go` and deduplicates the shared helpers into `pkg/util/testutil`.

### Describe how you validated your changes

`dda inv test --targets=./pkg/flare/...` — all 54 tests pass. Also verified the Windows-specific error-detection path compiles for `GOOS=windows` via an isolated cross-compile check (the full package cross-compile hits an unrelated pre-existing `pkg/gohai/cpu` limitation in this environment).

### Additional Notes