### PR TITLE
fix(process): avoid TOCTOU port race in apiserver lifecycle tests

### DIFF
--- a/comp/process/apiserver/impl/BUILD.bazel
+++ b/comp/process/apiserver/impl/BUILD.bazel
@@ -45,6 +45,7 @@ dd_agent_go_test(
         "//comp/process/apiserver/fx",
         "//pkg/util/fxutil",
         "//pkg/util/log",
+        "//pkg/util/testutil",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_uber_go_fx//:fx",

--- a/comp/process/apiserver/impl/apiserver_test.go
+++ b/comp/process/apiserver/impl/apiserver_test.go
@@ -8,8 +8,8 @@
 package apiserverimpl_test
 
 import (
+	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -37,36 +37,73 @@ import (
 	apiserverfx "github.com/DataDog/datadog-agent/comp/process/apiserver/fx"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil"
 )
 
+// startAPIServer starts the apiserver fx app on a freshly-picked port,
+// retrying with a new port if the previous pick lost the bind race. Unlike
+// probing a port and reusing its number later, each attempt is a real bind,
+// so there's no gap between checking and using the port.
+func startAPIServer(t *testing.T, buildOpts func(port int) []fx.Option) (apiserver.Component, int) {
+	t.Helper()
+	var lastErr error
+	for attempt := 0; attempt < testutil.MaxBindAttempts; attempt++ {
+		port := testutil.FreeTCPPort(t)
+
+		var comp apiserver.Component
+		app := fx.New(
+			fxutil.FxAgentBase(),
+			fx.Supply(fx.Annotate(t, fx.As(new(testing.TB)))),
+			fx.Populate(&comp),
+			fx.Options(buildOpts(port)...),
+		)
+
+		startCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+		err := app.Start(startCtx)
+		cancel()
+		if err == nil {
+			t.Cleanup(func() {
+				stopCtx, cancel := context.WithTimeout(context.Background(), fx.DefaultTimeout)
+				defer cancel()
+				require.NoError(t, app.Stop(stopCtx))
+			})
+			return comp, port
+		}
+		if !testutil.IsAddrInUse(err) {
+			t.Fatalf("failed to start apiserver: %v", err)
+		}
+		lastErr = err
+	}
+	t.Fatalf("could not bind apiserver after %d attempts: %v", testutil.MaxBindAttempts, lastErr)
+	return nil, 0
+}
+
 func TestLifecycle(t *testing.T) {
-	listener, err := net.Listen("tcp", ":0")
-	require.NoError(t, err)
-	port := listener.Addr().(*net.TCPAddr).Port
-	listener.Close()
 	var ipcComp ipc.Component
 
-	_ = fxutil.Test[apiserver.Component](t, fx.Options(
-		apiserverfx.Module(),
-		fx.Provide(func(t testing.TB) logcomp.Component { return logmock.New(t) }),
-		fx.Provide(func(t testing.TB) config.Component {
-			return config.NewMockWithOverrides(t, map[string]interface{}{
-				"process_config.cmd_port": port,
-			})
-		}),
-		workloadmetafx.Module(workloadmeta.NewParams()),
-		fx.Supply(
-			status.Params{
-				PythonVersionGetFunc: func() string { return "n/a" },
-			},
-		),
-		fx.Provide(func() tagger.Component { return taggerfxmock.SetupFakeTagger(t) }),
-		statusimpl.Module(),
-		settingsmock.MockModule(),
-		fx.Provide(func() ipc.Component { return ipcmock.New(t) }),
-		fx.Populate(&ipcComp),
-		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
-	))
+	_, port := startAPIServer(t, func(port int) []fx.Option {
+		return []fx.Option{
+			apiserverfx.Module(),
+			fx.Provide(func(t testing.TB) logcomp.Component { return logmock.New(t) }),
+			fx.Provide(func(t testing.TB) config.Component {
+				return config.NewMockWithOverrides(t, map[string]interface{}{
+					"process_config.cmd_port": port,
+				})
+			}),
+			workloadmetafx.Module(workloadmeta.NewParams()),
+			fx.Supply(
+				status.Params{
+					PythonVersionGetFunc: func() string { return "n/a" },
+				},
+			),
+			fx.Provide(func() tagger.Component { return taggerfxmock.SetupFakeTagger(t) }),
+			statusimpl.Module(),
+			settingsmock.MockModule(),
+			fx.Provide(func() ipc.Component { return ipcmock.New(t) }),
+			fx.Populate(&ipcComp),
+			fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
+		}
+	})
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("https://localhost:%d/agent/status", port)
@@ -76,33 +113,31 @@ func TestLifecycle(t *testing.T) {
 }
 
 func TestPostAuthentication(t *testing.T) {
-	listener, err := net.Listen("tcp", ":0")
-	require.NoError(t, err)
-	port := listener.Addr().(*net.TCPAddr).Port
-	listener.Close()
 	var ipcComp ipc.Component
 
-	_ = fxutil.Test[apiserver.Component](t, fx.Options(
-		apiserverfx.Module(),
-		fx.Provide(func(t testing.TB) logcomp.Component { return logmock.New(t) }),
-		fx.Provide(func(t testing.TB) config.Component {
-			return config.NewMockWithOverrides(t, map[string]interface{}{
-				"process_config.cmd_port": port,
-			})
-		}),
-		workloadmetafx.Module(workloadmeta.NewParams()),
-		fx.Supply(
-			status.Params{
-				PythonVersionGetFunc: func() string { return "n/a" },
-			},
-		),
-		fx.Provide(func() tagger.Component { return taggerfxmock.SetupFakeTagger(t) }),
-		statusimpl.Module(),
-		settingsmock.MockModule(),
-		fx.Provide(func() ipc.Component { return ipcmock.New(t) }),
-		fx.Populate(&ipcComp),
-		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
-	))
+	_, port := startAPIServer(t, func(port int) []fx.Option {
+		return []fx.Option{
+			apiserverfx.Module(),
+			fx.Provide(func(t testing.TB) logcomp.Component { return logmock.New(t) }),
+			fx.Provide(func(t testing.TB) config.Component {
+				return config.NewMockWithOverrides(t, map[string]interface{}{
+					"process_config.cmd_port": port,
+				})
+			}),
+			workloadmetafx.Module(workloadmeta.NewParams()),
+			fx.Supply(
+				status.Params{
+					PythonVersionGetFunc: func() string { return "n/a" },
+				},
+			),
+			fx.Provide(func() tagger.Component { return taggerfxmock.SetupFakeTagger(t) }),
+			statusimpl.Module(),
+			settingsmock.MockModule(),
+			fx.Provide(func() ipc.Component { return ipcmock.New(t) }),
+			fx.Populate(&ipcComp),
+			fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
+		}
+	})
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		// No authentication

--- a/pkg/flare/BUILD.bazel
+++ b/pkg/flare/BUILD.bazel
@@ -107,6 +107,7 @@ dd_agent_go_test(
         "//pkg/config/mock",
         "//pkg/config/model",
         "//pkg/util/fxutil",
+        "//pkg/util/testutil",
         "@com_github_datadog_agent_payload_v5//process",
         "@com_github_fatih_color//:color",
         "@com_github_stretchr_testify//assert",

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -8,15 +8,12 @@ package flare
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
-	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,6 +43,7 @@ import (
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	model "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil"
 )
 
 func TestGoRoutines(t *testing.T) {
@@ -94,41 +92,14 @@ func setupIPCAddress(t *testing.T, confMock model.Config, URL string) {
 	confMock.SetInTest("process_config.cmd_port", port)
 }
 
-// maxBindAttempts bounds retries when a freshly-picked port loses the bind
-// race to something else between being picked and the real server binding it.
-const maxBindAttempts = 5
-
-// wsaeAddrInUse is WSAEADDRINUSE, the raw Winsock error code Go's net
-// package passes through unmodified on Windows binds; it doesn't map to the
-// stdlib syscall.EADDRINUSE constant, which is a different synthetic value.
-const wsaeAddrInUse = syscall.Errno(10048)
-
-// isAddrInUse reports whether err is a failure to bind because the port was
-// already taken.
-func isAddrInUse(err error) bool {
-	if runtime.GOOS == "windows" {
-		return errors.Is(err, wsaeAddrInUse)
-	}
-	return errors.Is(err, syscall.EADDRINUSE)
-}
-
-// freeTCPPort asks the OS for a currently-free TCP port.
-func freeTCPPort(t testing.TB) int {
-	t.Helper()
-	l, err := net.Listen("tcp", ":0")
-	require.NoError(t, err)
-	defer l.Close()
-	return l.Addr().(*net.TCPAddr).Port
-}
-
 // setupProcessAPIServer starts the real process-agent API server on a
 // freshly-picked port, retrying with a new port if the previous pick lost
 // the bind race. Unlike probing a port and reusing its number later, each
 // attempt is a real bind, so there's no gap between checking and using it.
 func setupProcessAPIServer(t *testing.T, cfg model.Config) {
 	var lastErr error
-	for attempt := 0; attempt < maxBindAttempts; attempt++ {
-		cfg.SetInTest("process_config.cmd_port", freeTCPPort(t))
+	for attempt := 0; attempt < testutil.MaxBindAttempts; attempt++ {
+		cfg.SetInTest("process_config.cmd_port", testutil.FreeTCPPort(t))
 
 		var comp processapiserver.Component
 		app := fx.New(
@@ -163,12 +134,12 @@ func setupProcessAPIServer(t *testing.T, cfg model.Config) {
 			})
 			return
 		}
-		if !isAddrInUse(err) {
+		if !testutil.IsAddrInUse(err) {
 			t.Fatalf("failed to start process API server: %v", err)
 		}
 		lastErr = err
 	}
-	t.Fatalf("could not bind process API server after %d attempts: %v", maxBindAttempts, lastErr)
+	t.Fatalf("could not bind process API server after %d attempts: %v", testutil.MaxBindAttempts, lastErr)
 }
 
 func TestVersionHistory(t *testing.T) {

--- a/pkg/util/testutil/BUILD.bazel
+++ b/pkg/util/testutil/BUILD.bazel
@@ -4,6 +4,7 @@ load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 go_library(
     name = "testutil",
     srcs = [
+        "bindretry.go",
         "doc.go",
         "elements.go",
         "error.go",

--- a/pkg/util/testutil/bindretry.go
+++ b/pkg/util/testutil/bindretry.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package testutil
+
+import (
+	"errors"
+	"net"
+	"runtime"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// MaxBindAttempts bounds retries when a freshly-picked port loses the bind
+// race to something else between being picked and the real server binding it.
+const MaxBindAttempts = 5
+
+// wsaeAddrInUse is WSAEADDRINUSE, the raw Winsock error code Go's net
+// package passes through unmodified on Windows binds; it doesn't map to the
+// stdlib syscall.EADDRINUSE constant, which is a different synthetic value.
+const wsaeAddrInUse = syscall.Errno(10048)
+
+// IsAddrInUse reports whether err is a failure to bind because the port was
+// already taken.
+func IsAddrInUse(err error) bool {
+	if runtime.GOOS == "windows" {
+		return errors.Is(err, wsaeAddrInUse)
+	}
+	return errors.Is(err, syscall.EADDRINUSE)
+}
+
+// FreeTCPPort asks the OS for a currently-free TCP port.
+func FreeTCPPort(t testing.TB) int {
+	t.Helper()
+	l, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}


### PR DESCRIPTION
### What does this PR do?

Fixes the same class of flaky-port failure as #54618 in `comp/process/apiserver/impl/apiserver_test.go` (`TestLifecycle`, `TestPostAuthentication`). Stacked on #54618 since it consumes the `UniqueTestPort` helper introduced there.

### Motivation

`TestLifecycle` and `TestPostAuthentication` picked a free port by opening a listener on `:0`, reading its port, and immediately closing it — then reused that port number later when starting the real `apiserver` component. On CI runners executing many test binaries in parallel, another process could grab the same port in that gap, causing intermittent "address already in use" failures — the same failure mode fixed for `pkg/flare` in #54618, which introduced `UniqueTestPort`.

### Describe how you validated your changes

`dda inv test --targets=./comp/process/apiserver/...,./pkg/flare/...,./pkg/networkdevice/testutils/...,./comp/snmptraps/...` — all 145 tests pass.

### Additional Notes

Merge #54618 first.