### PR TITLE
CAP-3666 [OTel] Make TranslateK8sObjects and ToManifestPayload more configurable   

### DIFF
--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter.go
@@ -45,7 +45,7 @@ func (e *Exporter) consumeK8sObjects(ctx context.Context, ld plog.Logs) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	result := logsmapping.TranslateK8sObjects(ld, e.orchestratorExporter.manifestCache, e.set.Logger)
+	result := logsmapping.TranslateK8sObjects(ld, e.orchestratorExporter.manifestCache, e.set.Logger, false)
 
 	hostname, err := e.orchestratorExporter.config.Hostname.Get(ctx)
 	if err != nil || hostname == "" {
@@ -57,7 +57,7 @@ func (e *Exporter) consumeK8sObjects(ctx context.Context, ld plog.Logs) error {
 			zap.Int("chunk_index", i),
 			zap.Int("chunk_size", len(chunk)))
 
-		payload := logsmapping.ToManifestPayload(chunk, hostname, result.ClusterName, result.ClusterID)
+		payload := logsmapping.ToManifestPayload(chunk, hostname, result.ClusterName, result.ClusterID, agentmodel.OriginCollector_datadogExporter)
 
 		if err := sendManifestPayload(ctx, e.orchestratorExporter.config.Endpoint, e.orchestratorExporter.config.Key, payload, hostname, result.ClusterID, e.set.Logger); err != nil {
 			e.set.Logger.Error("Failed to send collector manifest chunk",

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter_test.go
@@ -47,11 +47,11 @@ func TestTranslateK8sObjects_Deduplication(t *testing.T) {
 		cache := logsmapping.NewManifestCache()
 		ld := buildK8sLogs("cluster-1", "my-cluster", "pod-uid-1", "v1", false)
 
-		first := logsmapping.TranslateK8sObjects(ld, cache, logger)
+		first := logsmapping.TranslateK8sObjects(ld, cache, logger, false)
 		require.Len(t, first.Chunks, 1)
 		assert.Len(t, first.Chunks[0], 1)
 
-		second := logsmapping.TranslateK8sObjects(ld, cache, logger)
+		second := logsmapping.TranslateK8sObjects(ld, cache, logger, false)
 		assert.Empty(t, second.Chunks, "duplicate pull manifest should be skipped")
 	})
 
@@ -60,8 +60,8 @@ func TestTranslateK8sObjects_Deduplication(t *testing.T) {
 		ld1 := buildK8sLogs("cluster-1", "my-cluster", "pod-uid-2", "v1", false)
 		ld2 := buildK8sLogs("cluster-1", "my-cluster", "pod-uid-2", "v2", false)
 
-		logsmapping.TranslateK8sObjects(ld1, cache, logger)
-		second := logsmapping.TranslateK8sObjects(ld2, cache, logger)
+		logsmapping.TranslateK8sObjects(ld1, cache, logger, false)
+		second := logsmapping.TranslateK8sObjects(ld2, cache, logger, false)
 		require.Len(t, second.Chunks, 1)
 		assert.Len(t, second.Chunks[0], 1, "updated resourceVersion should not be skipped")
 	})
@@ -70,16 +70,16 @@ func TestTranslateK8sObjects_Deduplication(t *testing.T) {
 		cache := logsmapping.NewManifestCache()
 		ld := buildK8sLogs("cluster-1", "my-cluster", "pod-uid-3", "v1", true)
 
-		logsmapping.TranslateK8sObjects(ld, cache, logger)
-		second := logsmapping.TranslateK8sObjects(ld, cache, logger)
+		logsmapping.TranslateK8sObjects(ld, cache, logger, false)
+		second := logsmapping.TranslateK8sObjects(ld, cache, logger, false)
 		require.Len(t, second.Chunks, 1, "watch events should always be forwarded")
 	})
 
 	t.Run("nil cache disables deduplication", func(t *testing.T) {
 		ld := buildK8sLogs("cluster-1", "my-cluster", "pod-uid-4", "v1", false)
 
-		first := logsmapping.TranslateK8sObjects(ld, nil, logger)
-		second := logsmapping.TranslateK8sObjects(ld, nil, logger)
+		first := logsmapping.TranslateK8sObjects(ld, nil, logger, false)
+		second := logsmapping.TranslateK8sObjects(ld, nil, logger, false)
 		require.Len(t, first.Chunks, 1)
 		require.Len(t, second.Chunks, 1, "nil cache should not deduplicate")
 	})
@@ -535,7 +535,7 @@ func TestToManifestPayload(t *testing.T) {
 		},
 	}
 
-	payload := logsmapping.ToManifestPayload(manifests, hostName, clusterName, clusterID)
+	payload := logsmapping.ToManifestPayload(manifests, hostName, clusterName, clusterID, agentmodel.OriginCollector_datadogExporter)
 
 	require.NotNil(t, payload)
 	assert.Equal(t, clusterName, payload.ClusterName)

--- a/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
@@ -221,14 +221,14 @@ func BuildManifestFromK8sResource(k8sResource map[string]interface{}, isTerminat
 }
 
 // ToManifestPayload creates a CollectorManifest payload from a list of manifests.
-func ToManifestPayload(manifests []*agentmodel.Manifest, hostName, clusterName, clusterID string) *agentmodel.CollectorManifest {
+func ToManifestPayload(manifests []*agentmodel.Manifest, hostName, clusterName, clusterID string, originCollector agentmodel.OriginCollector) *agentmodel.CollectorManifest {
 	return &agentmodel.CollectorManifest{
 		ClusterName:     clusterName,
 		ClusterId:       clusterID,
 		HostName:        hostName,
 		Manifests:       manifests,
 		Tags:            buildCommonTags(),
-		OriginCollector: agentmodel.OriginCollector_datadogExporter,
+		OriginCollector: originCollector,
 	}
 }
 
@@ -482,8 +482,9 @@ type K8sTranslationResult struct {
 
 // TranslateK8sObjects converts k8sobjectsreceiver logs into chunked orchestrator manifest payloads.
 // It handles deduplication via cache (pass nil to disable), cluster manifest creation, and chunking.
+// Set skipClusterManifest to true to skip automatic Cluster manifest creation from collected nodes.
 // Individual record errors are logged and skipped rather than aborting the batch.
-func TranslateK8sObjects(ld plog.Logs, cache *gocache.Cache, logger *zap.Logger) *K8sTranslationResult {
+func TranslateK8sObjects(ld plog.Logs, cache *gocache.Cache, logger *zap.Logger, skipClusterManifest bool) *K8sTranslationResult {
 	var manifests []*agentmodel.Manifest
 	var nodes []*agentmodel.Manifest
 	var isWatchEvent bool
@@ -536,7 +537,7 @@ func TranslateK8sObjects(ld plog.Logs, cache *gocache.Cache, logger *zap.Logger)
 		}
 	}
 
-	if len(nodes) > 0 && !isWatchEvent {
+	if len(nodes) > 0 && !isWatchEvent && !skipClusterManifest {
 		logger.Debug("Creating Cluster manifest after collecting nodes", zap.Int("total_nodes", len(nodes)))
 		if clusterManifest := CreateClusterManifest(clusterID, nodes, logger); clusterManifest != nil {
 			if !shouldSkipManifest(clusterManifest, false, cache) {


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

**no behavior change**

 - Adds a `skipClusterManifest` bool parameter to `TranslateK8sObjects` so callers can opt out of the automatic Cluster manifest creation that occurs when Node manifests are collected in pull mode.                        
  - Adds an `originCollector`  parameter to ToManifestPayload, replacing the previously hardcoded OriginCollector_datadogExporter. Callers now explicitly supply the collection origin.                                                                                        
                                                                                                                                                                                                                          
### Motivation

Better support BE dev

