### PR TITLE
[SNMP] Cache the legacy profile detection result with the profiles

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -471,15 +471,22 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 			return nil, err
 		}
 	} else {
-		var haveLegacyProfile bool
-		c.ProfileProvider, haveLegacyProfile, err = profile.GetProfileProvider(initConfig.Profiles)
+		var legacyProfiles []string
+		c.ProfileProvider, legacyProfiles, err = profile.GetProfileProvider(initConfig.Profiles)
 		if err != nil {
 			return nil, err
 		}
-		if haveLegacyProfile || profiledefinition.IsLegacyMetrics(instance.Metrics) {
-			if initConfig.Loader == "" && instance.Loader == "" {
-				return nil, errors.New("legacy profile detected with no loader specified, falling back to the Python loader")
-			}
+		// The Core loader cannot handle the legacy Python metric syntax, so a config relying on
+		// it is handed over to the Python loader unless a loader was explicitly requested.
+		var legacySources []string
+		if len(legacyProfiles) > 0 {
+			legacySources = append(legacySources, "profile(s) "+strings.Join(legacyProfiles, ", "))
+		}
+		if profiledefinition.IsLegacyMetrics(instance.Metrics) {
+			legacySources = append(legacySources, "the instance metrics")
+		}
+		if len(legacySources) > 0 && initConfig.Loader == "" && instance.Loader == "" {
+			return nil, fmt.Errorf("legacy profile detected with no loader specified, falling back to the Python loader; legacy syntax found in %s", strings.Join(legacySources, " and "))
 		}
 	}
 

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -1948,6 +1948,8 @@ func TestHaveLegacyProfile(t *testing.T) {
 		rawInitConfig             []byte
 		mockConfd                 string
 		expectedHaveLegacyProfile bool
+		// expectedLegacySource is the part of the error naming what uses the legacy syntax
+		expectedLegacySource string
 	}{
 		{
 			name: "legacy custom profile (no oid) with loader specified should not fallback to Python",
@@ -2045,6 +2047,7 @@ profile: legacy
 			rawInitConfig:             []byte(``),
 			mockConfd:                 "legacy_no_oid.d",
 			expectedHaveLegacyProfile: true,
+			expectedLegacySource:      "profile(s) legacy",
 		},
 		{
 			name: "legacy custom profile (string symbol type) without loader specified should fallback to Python",
@@ -2059,6 +2062,7 @@ profile: legacy
 			rawInitConfig:             []byte(``),
 			mockConfd:                 "legacy_symbol_type.d",
 			expectedHaveLegacyProfile: true,
+			expectedLegacySource:      "profile(s) legacy",
 		},
 		{
 			name: "legacy init config profile without loader specified should fallback to Python",
@@ -2082,6 +2086,7 @@ profiles:
 `),
 			mockConfd:                 "conf.d",
 			expectedHaveLegacyProfile: true,
+			expectedLegacySource:      "profile(s) legacy-init-config",
 		},
 		{
 			name: "legacy instance config profile without loader specified should fallback to Python",
@@ -2110,6 +2115,7 @@ metrics:
 			rawInitConfig:             []byte(``),
 			mockConfd:                 "conf.d",
 			expectedHaveLegacyProfile: true,
+			expectedLegacySource:      "the instance metrics",
 		},
 	}
 
@@ -2121,7 +2127,8 @@ metrics:
 
 			_, err := NewCheckConfig(tt.rawInstanceConfig, tt.rawInitConfig, nil)
 			if tt.expectedHaveLegacyProfile {
-				assert.EqualError(t, err, "legacy profile detected with no loader specified, falling back to the Python loader")
+				require.ErrorContains(t, err, "legacy profile detected with no loader specified, falling back to the Python loader")
+				assert.ErrorContains(t, err, tt.expectedLegacySource)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/pkg/collector/corechecks/snmp/internal/profile/profile.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile.go
@@ -15,41 +15,42 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 )
 
-// GetProfileProvider returns a Provider that knows the on-disk profiles as well as any overrides from the initConfig.
-func GetProfileProvider(initConfigProfiles ProfileConfigMap) (Provider, bool, error) {
-	profiles, haveLegacyProfile, err := loadProfiles(initConfigProfiles)
+// GetProfileProvider returns a Provider that knows the on-disk profiles as well as any overrides
+// from the initConfig, along with the sorted names of the profiles using the legacy Python syntax.
+func GetProfileProvider(initConfigProfiles ProfileConfigMap) (Provider, []string, error) {
+	profiles, legacyProfiles, err := loadProfiles(initConfigProfiles)
 	if err != nil {
-		return nil, false, err
+		return nil, nil, err
 	}
-	return StaticProvider(profiles), haveLegacyProfile, nil
+	return StaticProvider(profiles), legacyProfiles, nil
 }
 
-func loadProfiles(initConfigProfiles ProfileConfigMap) (ProfileConfigMap, bool, error) {
+func loadProfiles(initConfigProfiles ProfileConfigMap) (ProfileConfigMap, []string, error) {
 	var profiles ProfileConfigMap
-	var haveLegacyProfile bool
+	var legacyProfiles []string
 
 	if len(initConfigProfiles) > 0 {
 		// TODO: [PERFORMANCE] Load init config custom profiles once for all integrations
 		//   There are possibly multiple init configs
-		customProfiles, haveLegacyCustomProfile, err := loadInitConfigProfiles(initConfigProfiles)
+		customProfiles, legacyCustomProfiles, err := loadInitConfigProfiles(initConfigProfiles)
 		if err != nil {
-			return nil, haveLegacyCustomProfile, fmt.Errorf("failed to load profiles from initConfig: %w", err)
+			return nil, legacyCustomProfiles, fmt.Errorf("failed to load profiles from initConfig: %w", err)
 		}
 		profiles = customProfiles
-		haveLegacyProfile = haveLegacyCustomProfile
+		legacyProfiles = legacyCustomProfiles
 	} else {
-		defaultProfiles, haveLegacyYamlProfile, err := loadYamlProfiles()
+		defaultProfiles, legacyYamlProfiles, err := loadYamlProfiles()
 		if err != nil {
-			return nil, haveLegacyYamlProfile, fmt.Errorf("failed to load yaml profiles: %w", err)
+			return nil, legacyYamlProfiles, fmt.Errorf("failed to load yaml profiles: %w", err)
 		}
 		profiles = defaultProfiles
-		haveLegacyProfile = haveLegacyYamlProfile
+		legacyProfiles = legacyYamlProfiles
 	}
 	for _, profileDef := range profiles {
 		profiledefinition.NormalizeMetrics(profileDef.Definition.Metrics)
 	}
 
-	return profiles, haveLegacyProfile, nil
+	return profiles, legacyProfiles, nil
 }
 
 // getProfileForSysObjectID return a profile for a sys object id

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_cache.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_cache.go
@@ -6,13 +6,29 @@
 package profile
 
 var globalProfileConfigMap ProfileConfigMap
+var globalLegacyProfiles []string
 
 // SetGlobalProfileConfigMap sets global globalProfileConfigMap
 func SetGlobalProfileConfigMap(configMap ProfileConfigMap) {
+	setGlobalProfiles(configMap, nil)
+}
+
+// setGlobalProfiles caches the profiles together with the names of the profiles
+// that use the legacy Python syntax. The two must be cached together: callers of
+// loadYamlProfiles need the legacy profile names on cache hits as well, otherwise
+// the loader picked for a check instance depends on whether that instance happened
+// to be the one that populated the cache.
+func setGlobalProfiles(configMap ProfileConfigMap, legacyProfiles []string) {
 	globalProfileConfigMap = configMap
+	globalLegacyProfiles = legacyProfiles
 }
 
 // GetGlobalProfileConfigMap gets global globalProfileConfigMap
 func GetGlobalProfileConfigMap() ProfileConfigMap {
 	return globalProfileConfigMap
+}
+
+// getGlobalLegacyProfiles gets the names of the cached profiles using the legacy Python syntax
+func getGlobalLegacyProfiles() []string {
+	return globalLegacyProfiles
 }

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_initconfig.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_initconfig.go
@@ -7,19 +7,25 @@ package profile
 
 import (
 	"expvar"
+	"slices"
 
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func loadInitConfigProfiles(rawInitConfigProfiles ProfileConfigMap) (ProfileConfigMap, bool, error) {
+// loadInitConfigProfiles returns the profiles declared in the check init config, resolved
+// against the on-disk profiles, along with the sorted names of the profiles using the
+// legacy Python syntax.
+func loadInitConfigProfiles(rawInitConfigProfiles ProfileConfigMap) (ProfileConfigMap, []string, error) {
 	initConfigProfiles := make(ProfileConfigMap, len(rawInitConfigProfiles))
 
-	var haveLegacyInitConfigProfile bool
+	var legacyProfiles []string
 	for name, profConfig := range rawInitConfigProfiles {
 		if profConfig.DefinitionFile != "" {
 			profDefinition, isLegacyInitConfigProfile, err := readProfileDefinition(profConfig.DefinitionFile)
-			haveLegacyInitConfigProfile = haveLegacyInitConfigProfile || isLegacyInitConfigProfile
+			if isLegacyInitConfigProfile {
+				legacyProfiles = append(legacyProfiles, name)
+			}
 			if err != nil {
 				log.Warnf("unable to load profile %q: %s", name, err)
 				errMsg := err.Error()
@@ -29,9 +35,8 @@ func loadInitConfigProfiles(rawInitConfigProfiles ProfileConfigMap) (ProfileConf
 				continue
 			}
 			profConfig.Definition = *profDefinition
-		} else {
-			isLegacyMetrics := profiledefinition.IsLegacyMetrics(profConfig.Definition.Metrics)
-			haveLegacyInitConfigProfile = haveLegacyInitConfigProfile || isLegacyMetrics
+		} else if profiledefinition.IsLegacyMetrics(profConfig.Definition.Metrics) {
+			legacyProfiles = append(legacyProfiles, name)
 		}
 		if profConfig.Definition.Name == "" {
 			profConfig.Definition.Name = name
@@ -39,7 +44,8 @@ func loadInitConfigProfiles(rawInitConfigProfiles ProfileConfigMap) (ProfileConf
 		initConfigProfiles[name] = profConfig
 	}
 
-	userProfiles, haveLegacyUserProfile := getYamlUserProfiles()
+	userProfiles, legacyUserProfiles := getYamlUserProfiles()
+	legacyProfiles = append(legacyProfiles, legacyUserProfiles...)
 	userProfiles = mergeProfiles(userProfiles, initConfigProfiles)
 
 	defaultProfiles := getYamlDefaultProfiles()
@@ -55,5 +61,6 @@ func loadInitConfigProfiles(rawInitConfigProfiles ProfileConfigMap) (ProfileConf
 		filteredResolvedProfiles[key] = val
 	}
 
-	return filteredResolvedProfiles, haveLegacyInitConfigProfile || haveLegacyUserProfile, nil
+	slices.Sort(legacyProfiles)
+	return filteredResolvedProfiles, slices.Compact(legacyProfiles), nil
 }

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_initconfig_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_initconfig_test.go
@@ -19,9 +19,9 @@ func Test_loadInitConfigProfiles_legacyProfiles(t *testing.T) {
 	SetConfdPathAndCleanProfiles()
 
 	tests := []struct {
-		name                      string
-		metrics                   []profiledefinition.MetricsConfig
-		expectedHaveLegacyProfile bool
+		name                   string
+		metrics                []profiledefinition.MetricsConfig
+		expectedLegacyProfiles []string
 	}{
 		{
 			name: "ok profile",
@@ -59,7 +59,7 @@ func Test_loadInitConfigProfiles_legacyProfiles(t *testing.T) {
 					},
 				},
 			},
-			expectedHaveLegacyProfile: false,
+			expectedLegacyProfiles: nil,
 		},
 		{
 			name: "legacy profile because no OID",
@@ -69,7 +69,7 @@ func Test_loadInitConfigProfiles_legacyProfiles(t *testing.T) {
 					Name: "fooName",
 				},
 			},
-			expectedHaveLegacyProfile: true,
+			expectedLegacyProfiles: []string{"my-init-config-profile"},
 		},
 		{
 			name: "legacy profile because no Symbol.OID",
@@ -81,7 +81,7 @@ func Test_loadInitConfigProfiles_legacyProfiles(t *testing.T) {
 					},
 				},
 			},
-			expectedHaveLegacyProfile: true,
+			expectedLegacyProfiles: []string{"my-init-config-profile"},
 		},
 		{
 			name: "legacy profile because no Symbols[...].OID",
@@ -103,13 +103,13 @@ func Test_loadInitConfigProfiles_legacyProfiles(t *testing.T) {
 					},
 				},
 			},
-			expectedHaveLegacyProfile: true,
+			expectedLegacyProfiles: []string{"my-init-config-profile"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, haveLegacyProfile, err := loadInitConfigProfiles(ProfileConfigMap{
+			_, legacyProfiles, err := loadInitConfigProfiles(ProfileConfigMap{
 				"my-init-config-profile": {
 					Definition: profiledefinition.ProfileDefinition{
 						Metrics: tt.metrics,
@@ -117,7 +117,7 @@ func Test_loadInitConfigProfiles_legacyProfiles(t *testing.T) {
 				},
 			})
 			assert.NoError(t, err)
-			assert.Equal(t, tt.expectedHaveLegacyProfile, haveLegacyProfile)
+			assert.Equal(t, tt.expectedLegacyProfiles, legacyProfiles)
 		})
 	}
 }

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_resolver_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_resolver_test.go
@@ -24,21 +24,21 @@ func Test_resolveProfiles(t *testing.T) {
 	defaultTestConfdPath, _ := filepath.Abs(filepath.Join("..", "test", "conf.d"))
 	mockConfig.SetInTest("confd_path", defaultTestConfdPath)
 	defaultTestConfdProfiles := ProfileConfigMap{}
-	userTestConfdProfiles, haveLegacyProfile, err := getProfileDefinitions(userProfilesFolder, true)
+	userTestConfdProfiles, legacyProfiles, err := getProfileDefinitions(userProfilesFolder, true)
 	require.NoError(t, err)
-	require.False(t, haveLegacyProfile)
+	require.Empty(t, legacyProfiles)
 
 	profilesWithInvalidExtendConfdPath, _ := filepath.Abs(filepath.Join("..", "test", "invalid_ext.d"))
 	mockConfig.SetInTest("confd_path", profilesWithInvalidExtendConfdPath)
-	profilesWithInvalidExtendProfiles, haveLegacyProfile, err := getProfileDefinitions(userProfilesFolder, true)
+	profilesWithInvalidExtendProfiles, legacyProfiles, err := getProfileDefinitions(userProfilesFolder, true)
 	require.NoError(t, err)
-	require.False(t, haveLegacyProfile)
+	require.Empty(t, legacyProfiles)
 
 	invalidCyclicConfdPath, _ := filepath.Abs(filepath.Join("..", "test", "invalid_cyclic.d"))
 	mockConfig.SetInTest("confd_path", invalidCyclicConfdPath)
-	invalidCyclicProfiles, haveLegacyProfile, err := getProfileDefinitions(userProfilesFolder, true)
+	invalidCyclicProfiles, legacyProfiles, err := getProfileDefinitions(userProfilesFolder, true)
 	require.NoError(t, err)
-	require.False(t, haveLegacyProfile)
+	require.Empty(t, legacyProfiles)
 
 	profileWithInvalidExtendsFile, _ := filepath.Abs(filepath.Join("..", "test", "test_profiles", "profile_with_invalid_extends.yaml"))
 	profileWithInvalidExtends, haveLegacyProfile, err := readProfileDefinition(profileWithInvalidExtendsFile)
@@ -52,12 +52,12 @@ func Test_resolveProfiles(t *testing.T) {
 
 	userProfilesCaseConfdPath, _ := filepath.Abs(filepath.Join("..", "test", "user_profiles.d"))
 	mockConfig.SetInTest("confd_path", userProfilesCaseConfdPath)
-	userProfilesCaseUserProfiles, haveLegacyProfile, err := getProfileDefinitions(userProfilesFolder, true)
+	userProfilesCaseUserProfiles, legacyProfiles, err := getProfileDefinitions(userProfilesFolder, true)
 	require.NoError(t, err)
-	require.False(t, haveLegacyProfile)
-	userProfilesCaseDefaultProfiles, haveLegacyProfile, err := getProfileDefinitions(defaultProfilesFolder, true)
+	require.Empty(t, legacyProfiles)
+	userProfilesCaseDefaultProfiles, legacyProfiles, err := getProfileDefinitions(defaultProfilesFolder, true)
 	require.NoError(t, err)
-	require.False(t, haveLegacyProfile)
+	require.Empty(t, legacyProfiles)
 
 	tests := []struct {
 		name                    string

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_test.go
@@ -20,13 +20,13 @@ import (
 func Test_loadProfiles(t *testing.T) {
 	mockConfig := configmock.New(t)
 	tests := []struct {
-		name                      string
-		mockConfd                 string
-		profiles                  ProfileConfigMap
-		expectedProfileMetrics    []string
-		expectedProfileNames      []string
-		expectedHaveLegacyProfile bool
-		expectedErr               string
+		name                   string
+		mockConfd              string
+		profiles               ProfileConfigMap
+		expectedProfileMetrics []string
+		expectedProfileNames   []string
+		expectedLegacyProfiles []string
+		expectedErr            string
 	}{
 		{
 			name:      "OK Use init config profiles",
@@ -53,7 +53,7 @@ func Test_loadProfiles(t *testing.T) {
 			expectedProfileMetrics: []string{
 				"init_config_metric",
 			},
-			expectedHaveLegacyProfile: false,
+			expectedLegacyProfiles: nil,
 		},
 		{
 			name:      "OK init config contains invalid profiles with warnings logs",
@@ -69,8 +69,8 @@ func Test_loadProfiles(t *testing.T) {
 					},
 				},
 			},
-			expectedProfileNames:      []string(nil), // invalid profiles are skipped
-			expectedHaveLegacyProfile: false,
+			expectedProfileNames:   []string(nil), // invalid profiles are skipped
+			expectedLegacyProfiles: nil,
 		},
 		{
 			name:      "OK init config contains legacy profiles",
@@ -89,8 +89,8 @@ func Test_loadProfiles(t *testing.T) {
 					},
 				},
 			},
-			expectedProfileNames:      []string(nil),
-			expectedHaveLegacyProfile: true,
+			expectedProfileNames:   []string(nil),
+			expectedLegacyProfiles: []string{"my-init-config-profile"},
 		},
 		// yaml profiles
 		{
@@ -100,13 +100,13 @@ func Test_loadProfiles(t *testing.T) {
 				"another_profile",
 				"f5-big-ip",
 			},
-			expectedHaveLegacyProfile: false,
+			expectedLegacyProfiles: nil,
 		},
 		{
-			name:                      "OK contains yaml profiles with warning logs",
-			mockConfd:                 "does_not_exist.d",
-			expectedProfileNames:      []string(nil),
-			expectedHaveLegacyProfile: false,
+			name:                   "OK contains yaml profiles with warning logs",
+			mockConfd:              "does_not_exist.d",
+			expectedProfileNames:   []string(nil),
+			expectedLegacyProfiles: nil,
 		},
 		{
 			name:      "OK yaml profiles contains legacy profile (no OID)",
@@ -114,7 +114,7 @@ func Test_loadProfiles(t *testing.T) {
 			expectedProfileNames: []string{
 				"valid",
 			},
-			expectedHaveLegacyProfile: true,
+			expectedLegacyProfiles: []string{"legacy"},
 		},
 		{
 			name:      "OK yaml profiles contains legacy profile (string symbol type)",
@@ -122,7 +122,7 @@ func Test_loadProfiles(t *testing.T) {
 			expectedProfileNames: []string{
 				"valid",
 			},
-			expectedHaveLegacyProfile: true,
+			expectedLegacyProfiles: []string{"legacy"},
 		},
 	}
 	for _, tt := range tests {
@@ -131,7 +131,7 @@ func Test_loadProfiles(t *testing.T) {
 			path, _ := filepath.Abs(filepath.Join("..", "test", tt.mockConfd))
 			mockConfig.SetInTest("confd_path", path)
 
-			actualProfiles, haveLegacyProfile, err := loadProfiles(tt.profiles)
+			actualProfiles, legacyProfiles, err := loadProfiles(tt.profiles)
 			if tt.expectedErr != "" {
 				assert.ErrorContains(t, err, tt.expectedErr)
 			}
@@ -153,7 +153,7 @@ func Test_loadProfiles(t *testing.T) {
 				assert.ElementsMatch(t, tt.expectedProfileMetrics, metricsNames)
 			}
 
-			assert.Equal(t, tt.expectedHaveLegacyProfile, haveLegacyProfile)
+			assert.Equal(t, tt.expectedLegacyProfiles, legacyProfiles)
 		})
 	}
 }

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_yaml.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_yaml.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 
@@ -32,27 +33,30 @@ var defaultProfilesMu = &sync.Mutex{}
 // in globalProfileConfigMap. The subsequent call to it will return profiles stored in
 // globalProfileConfigMap. The mutex will help loading once when `loadYamlProfiles`
 // is called by multiple check instances.
-func loadYamlProfiles() (ProfileConfigMap, bool, error) {
+// It also returns the names of the user profiles using the legacy Python syntax.
+func loadYamlProfiles() (ProfileConfigMap, []string, error) {
 	defaultProfilesMu.Lock()
 	defer defaultProfilesMu.Unlock()
 
 	profileConfigMap := GetGlobalProfileConfigMap()
 	if profileConfigMap != nil {
 		log.Debugf("load yaml profiles from cache")
-		return profileConfigMap, false, nil
+		return profileConfigMap, getGlobalLegacyProfiles(), nil
 	}
 	log.Debugf("build yaml profiles")
 
-	userProfiles, haveLegacyUserProfile := getYamlUserProfiles()
+	userProfiles, legacyUserProfiles := getYamlUserProfiles()
 	defaultProfiles := getYamlDefaultProfiles()
 	profiles := resolveProfiles(userProfiles, defaultProfiles)
 
-	SetGlobalProfileConfigMap(profiles)
+	setGlobalProfiles(profiles, legacyUserProfiles)
 
-	return profiles, haveLegacyUserProfile, nil
+	return profiles, legacyUserProfiles, nil
 }
 
-func getProfileDefinitions(profilesFolder string, isUserProfile bool) (ProfileConfigMap, bool, error) {
+// getProfileDefinitions returns the profiles found in profilesFolder, along with the
+// sorted names of those using the legacy Python syntax.
+func getProfileDefinitions(profilesFolder string, isUserProfile bool) (ProfileConfigMap, []string, error) {
 	profilesRoot := getProfileConfdRoot(profilesFolder)
 	if isUserProfile {
 		log.Debugf("Reading user profiles from %s", profilesRoot)
@@ -61,11 +65,11 @@ func getProfileDefinitions(profilesFolder string, isUserProfile bool) (ProfileCo
 	}
 	files, err := os.ReadDir(profilesRoot)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to read profile dir %q: %w", profilesRoot, err)
+		return nil, nil, fmt.Errorf("failed to read profile dir %q: %w", profilesRoot, err)
 	}
 
 	profiles := make(ProfileConfigMap)
-	var haveLegacyProfile bool
+	var legacyProfiles []string
 	for _, f := range files {
 
 		fName := f.Name()
@@ -77,7 +81,9 @@ func getProfileDefinitions(profilesFolder string, isUserProfile bool) (ProfileCo
 
 		absPath := filepath.Join(profilesRoot, fName)
 		definition, isLegacyProfile, err := readProfileDefinition(absPath)
-		haveLegacyProfile = haveLegacyProfile || isLegacyProfile
+		if isLegacyProfile {
+			legacyProfiles = append(legacyProfiles, profileName)
+		}
 		if err != nil {
 			log.Warnf("cannot load profile %q: %v", profileName, err)
 			errMsg := err.Error()
@@ -94,7 +100,8 @@ func getProfileDefinitions(profilesFolder string, isUserProfile bool) (ProfileCo
 			IsUserProfile: isUserProfile,
 		}
 	}
-	return profiles, haveLegacyProfile, nil
+	slices.Sort(legacyProfiles)
+	return profiles, legacyProfiles, nil
 }
 
 func readProfileDefinition(definitionFile string) (*profiledefinition.ProfileDefinition, bool, error) {
@@ -137,13 +144,13 @@ func getProfileConfdRoot(profileFolderName string) string {
 	return filepath.Join(confdPath, "snmp.d", profileFolderName)
 }
 
-func getYamlUserProfiles() (ProfileConfigMap, bool) {
-	userProfiles, haveLegacyProfile, err := getProfileDefinitions(userProfilesFolder, true)
+func getYamlUserProfiles() (ProfileConfigMap, []string) {
+	userProfiles, legacyProfiles, err := getProfileDefinitions(userProfilesFolder, true)
 	if err != nil {
 		log.Warnf("failed to load user profile definitions: %s", err)
-		return ProfileConfigMap{}, haveLegacyProfile
+		return ProfileConfigMap{}, legacyProfiles
 	}
-	return userProfiles, haveLegacyProfile
+	return userProfiles, legacyProfiles
 }
 
 func getYamlDefaultProfiles() ProfileConfigMap {

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_yaml_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_yaml_test.go
@@ -70,13 +70,13 @@ func Test_resolveProfileDefinitionPath(t *testing.T) {
 func Test_loadYamlProfiles(t *testing.T) {
 	SetConfdPathAndCleanProfiles()
 	SetGlobalProfileConfigMap(nil)
-	defaultProfiles, haveLegacyProfile, err := loadYamlProfiles()
+	defaultProfiles, legacyProfiles, err := loadYamlProfiles()
 	assert.Nil(t, err)
-	defaultProfiles2, haveLegacyProfile2, err := loadYamlProfiles()
+	defaultProfiles2, legacyProfiles2, err := loadYamlProfiles()
 	assert.Nil(t, err)
 
 	assert.Equal(t, fmt.Sprintf("%p", defaultProfiles), fmt.Sprintf("%p", defaultProfiles2))
-	assert.Equal(t, haveLegacyProfile, haveLegacyProfile2)
+	assert.Equal(t, legacyProfiles, legacyProfiles2)
 }
 
 func Test_loadYamlProfiles_withUserProfiles(t *testing.T) {
@@ -85,12 +85,12 @@ func Test_loadYamlProfiles_withUserProfiles(t *testing.T) {
 	SetGlobalProfileConfigMap(nil)
 	mockConfig.SetInTest("confd_path", defaultTestConfdPath)
 
-	defaultProfiles, haveLegacyProfile, err := loadYamlProfiles()
+	defaultProfiles, legacyProfiles, err := loadYamlProfiles()
 	assert.Nil(t, err)
 
 	assert.Len(t, defaultProfiles, 6)
 	assert.NotNil(t, defaultProfiles)
-	assert.False(t, haveLegacyProfile)
+	assert.Empty(t, legacyProfiles)
 
 	p1 := defaultProfiles["p1"].Definition // user p1 overrides datadog p1
 	p2 := defaultProfiles["p2"].Definition // datadog p2
@@ -117,10 +117,10 @@ func Test_loadYamlProfiles_invalidDir(t *testing.T) {
 	mockConfig.SetInTest("confd_path", invalidPath)
 	SetGlobalProfileConfigMap(nil)
 
-	defaultProfiles, haveLegacyProfile, err := loadYamlProfiles()
+	defaultProfiles, legacyProfiles, err := loadYamlProfiles()
 	assert.Nil(t, err)
 	assert.Len(t, defaultProfiles, 0)
-	assert.False(t, haveLegacyProfile)
+	assert.Empty(t, legacyProfiles)
 }
 
 func Test_loadYamlProfiles_invalidExtendProfile(t *testing.T) {
@@ -131,12 +131,12 @@ func Test_loadYamlProfiles_invalidExtendProfile(t *testing.T) {
 	mockConfig.SetInTest("confd_path", profilesWithInvalidExtendConfdPath)
 	SetGlobalProfileConfigMap(nil)
 
-	defaultProfiles, haveLegacyProfile, err := loadYamlProfiles()
+	defaultProfiles, legacyProfiles, err := loadYamlProfiles()
 	require.NoError(t, err)
 
 	logs.AssertPresent(t, "failed to expand profile \"f5-big-ip\"")
 	assert.Equal(t, ProfileConfigMap{}, defaultProfiles)
-	assert.False(t, haveLegacyProfile)
+	assert.Empty(t, legacyProfiles)
 
 	expVarEntry := profileExpVar.Get("f5-big-ip")
 	require.NotNil(t, expVarEntry, "expected f5-big-ip error in snmpProfileErrors expvar")
@@ -151,7 +151,7 @@ func Test_loadYamlProfiles_userAndDefaultProfileFolderDoesNotExist(t *testing.T)
 	mockConfig.SetInTest("confd_path", profilesWithInvalidExtendConfdPath)
 	SetGlobalProfileConfigMap(nil)
 
-	defaultProfiles, haveLegacyProfile, err := loadYamlProfiles()
+	defaultProfiles, legacyProfiles, err := loadYamlProfiles()
 	require.NoError(t, err)
 
 	logs.AssertPresent(t,
@@ -160,7 +160,7 @@ func Test_loadYamlProfiles_userAndDefaultProfileFolderDoesNotExist(t *testing.T)
 	)
 
 	assert.Equal(t, ProfileConfigMap{}, defaultProfiles)
-	assert.False(t, haveLegacyProfile)
+	assert.Empty(t, legacyProfiles)
 }
 
 func Test_loadYamlProfiles_validAndInvalidProfiles(t *testing.T) {
@@ -172,7 +172,7 @@ func Test_loadYamlProfiles_validAndInvalidProfiles(t *testing.T) {
 	mockConfig.SetInTest("confd_path", profilesWithInvalidExtendConfdPath)
 	SetGlobalProfileConfigMap(nil)
 
-	defaultProfiles, haveLegacyProfile, err := loadYamlProfiles()
+	defaultProfiles, legacyProfiles, err := loadYamlProfiles()
 	require.NoError(t, err)
 
 	for _, profile := range defaultProfiles {
@@ -183,7 +183,7 @@ func Test_loadYamlProfiles_validAndInvalidProfiles(t *testing.T) {
 
 	assert.Contains(t, defaultProfiles, "f5-big-ip")
 	assert.NotContains(t, defaultProfiles, "f5-invalid")
-	assert.True(t, haveLegacyProfile)
+	assert.Equal(t, []string{"f5-invalid"}, legacyProfiles)
 
 	expVarEntry := profileExpVar.Get("f5-invalid")
 	require.NotNil(t, expVarEntry, "expected f5-invalid error in snmpProfileErrors expvar")
@@ -197,23 +197,23 @@ func Test_getProfileDefinitions_legacyProfiles(t *testing.T) {
 	legacyNoOIDProfilesConfdPath, _ := filepath.Abs(filepath.Join("..", "test", "legacy_no_oid.d"))
 	mockConfig.SetInTest("confd_path", legacyNoOIDProfilesConfdPath)
 	SetGlobalProfileConfigMap(nil)
-	defaultProfiles, haveLegacyProfile, err := getProfileDefinitions(userProfilesFolder, true)
+	defaultProfiles, legacyProfiles, err := getProfileDefinitions(userProfilesFolder, true)
 	require.NoError(t, err)
 	assert.Len(t, defaultProfiles, 2)
 	assert.Contains(t, defaultProfiles, "legacy")
 	assert.Contains(t, defaultProfiles, "valid")
-	assert.True(t, haveLegacyProfile)
+	assert.Equal(t, []string{"legacy"}, legacyProfiles)
 	legacyNoOIDLogs.AssertPresent(t, "found legacy metrics in profile")
 
 	legacySymbolTypeLogs := TrapLogs(t, log.DebugLvl)
 	legacySymbolTypeProfilesConfdPath, _ := filepath.Abs(filepath.Join("..", "test", "legacy_symbol_type.d"))
 	mockConfig.SetInTest("confd_path", legacySymbolTypeProfilesConfdPath)
 	SetGlobalProfileConfigMap(nil)
-	defaultProfiles, haveLegacyProfile, err = getProfileDefinitions(userProfilesFolder, true)
+	defaultProfiles, legacyProfiles, err = getProfileDefinitions(userProfilesFolder, true)
 	require.NoError(t, err)
 	assert.Len(t, defaultProfiles, 1)
 	assert.Contains(t, defaultProfiles, "valid")
-	assert.True(t, haveLegacyProfile)
+	assert.Equal(t, []string{"legacy"}, legacyProfiles)
 	legacySymbolTypeLogs.AssertPresent(t, "found legacy symbol type in profile")
 }
 
@@ -224,21 +224,40 @@ func Test_loadYamlProfiles_legacyProfiles(t *testing.T) {
 	legacyNoOIDProfilesConfdPath, _ := filepath.Abs(filepath.Join("..", "test", "legacy_no_oid.d"))
 	mockConfig.SetInTest("confd_path", legacyNoOIDProfilesConfdPath)
 	SetGlobalProfileConfigMap(nil)
-	defaultProfiles, haveLegacyProfile, err := loadYamlProfiles()
+	defaultProfiles, legacyProfiles, err := loadYamlProfiles()
 	require.NoError(t, err)
 	assert.Len(t, defaultProfiles, 1)
 	assert.Contains(t, defaultProfiles, "valid")
-	assert.True(t, haveLegacyProfile)
+	assert.Equal(t, []string{"legacy"}, legacyProfiles)
 	legacyNoOIDLogs.AssertPresent(t, "found legacy metrics in profile")
 
 	legacySymbolTypeLogs := TrapLogs(t, log.DebugLvl)
 	legacySymbolTypeProfilesConfdPath, _ := filepath.Abs(filepath.Join("..", "test", "legacy_symbol_type.d"))
 	mockConfig.SetInTest("confd_path", legacySymbolTypeProfilesConfdPath)
 	SetGlobalProfileConfigMap(nil)
-	defaultProfiles, haveLegacyProfile, err = loadYamlProfiles()
+	defaultProfiles, legacyProfiles, err = loadYamlProfiles()
 	require.NoError(t, err)
 	assert.Len(t, defaultProfiles, 1)
 	assert.Contains(t, defaultProfiles, "valid")
-	assert.True(t, haveLegacyProfile)
+	assert.Equal(t, []string{"legacy"}, legacyProfiles)
 	legacySymbolTypeLogs.AssertPresent(t, "found legacy symbol type in profile")
+}
+
+func Test_loadYamlProfiles_legacyProfilesAreCached(t *testing.T) {
+	// Profiles are read from disk once and cached for every subsequent check instance.
+	// The legacy profile names must be cached alongside them, otherwise only the instance
+	// that happened to populate the cache would be sent to the Python loader.
+	mockConfig := configmock.New(t)
+
+	legacyProfilesConfdPath, _ := filepath.Abs(filepath.Join("..", "test", "legacy_no_oid.d"))
+	mockConfig.SetInTest("confd_path", legacyProfilesConfdPath)
+	SetGlobalProfileConfigMap(nil)
+
+	_, legacyProfiles, err := loadYamlProfiles()
+	require.NoError(t, err)
+	require.Equal(t, []string{"legacy"}, legacyProfiles)
+
+	_, cachedLegacyProfiles, err := loadYamlProfiles()
+	require.NoError(t, err)
+	assert.Equal(t, legacyProfiles, cachedLegacyProfiles)
 }

--- a/releasenotes/notes/snmp-cache-legacy-profile-detection-3f0b2c9d1a4e7d52.yaml
+++ b/releasenotes/notes/snmp-cache-legacy-profile-detection-3f0b2c9d1a4e7d52.yaml
@@ -1,0 +1,18 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    SNMP: Fix the detection of profiles using the legacy Python metric syntax. The
+    detection result is now cached along with the profiles, so every check instance
+    is consistently handed over to the Python loader instead of only the first
+    instance to be configured. Previously the remaining instances silently kept using
+    the Core loader.
+  - |
+    SNMP: The error reported when a legacy profile forces the fallback to the Python
+    loader now names the profiles using the legacy syntax.


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Fixes non-deterministic loader selection for the SNMP check when a profile using the legacy Python metric syntax is present on disk.

`loadYamlProfiles` reads the on-disk profiles once and caches them for every subsequent check instance, but the "one of these profiles uses the legacy Python syntax" flag was not cached with them — the cache-hit path returned a hardcoded `false`:

```go
profileConfigMap := GetGlobalProfileConfigMap()
if profileConfigMap != nil {
    log.Debugf("load yaml profiles from cache")
    return profileConfigMap, false, nil   // <-- legacy flag lost
}
```

The flag was introduced in #36207 along with the legacy detection itself.

Three changes:

1. **Cache the legacy profile names alongside the profile map** (`profile_cache.go`), so every instance sees the same detection result.
2. **Replace the opaque `bool` with the sorted list of offending profile names** through `getProfileDefinitions` → `getYamlUserProfiles` → `loadYamlProfiles` / `loadInitConfigProfiles` → `loadProfiles` → `GetProfileProvider`. This is what makes (1) possible and (3) useful.
3. **Name the offending profiles in the error** surfaced to the user.

Before:
```
could not configure check snmp: build config failed: legacy profile detected with no loader specified, falling back to the Python loader
```
After:
```
could not configure check snmp: build config failed: legacy profile detected with no loader specified, falling back to the Python loader; legacy syntax found in profile(s) vmware-esxi
```

### Motivation

Found while debugging a customer flare. A single legacy custom profile in `conf.d/snmp.d/profiles/` (`MIB:` + a bare string `symbol:`, no OIDs) meant that only the **first** SNMP instance to be configured fell back to the Python loader; the other seven silently kept the Core loader. `status.log` showed `conf.yaml[1]` through `conf.yaml[7]` running under the Core check and `conf.yaml[0]` missing entirely.

Which instance loses is down to scheduling order, so the same config picks a different victim across restarts. In that flare the fallback then hit a broken Python SNMP check (`RuntimeError: There is no current event loop in thread 'Dummy-22'` from pysnmp on Python 3.12), so the affected device collected nothing at all — with no indication in the logs of which profile caused any of it.

### Describe how you validated your changes

`dda inv test --targets=./pkg/collector/corechecks/snmp/...` — 552 tests pass.

New test `Test_loadYamlProfiles_legacyProfilesAreCached` asserts the legacy profile names survive a cache hit; it fails on `main` and passes here. Existing legacy-detection tests in `profile_test.go`, `profile_yaml_test.go`, `profile_initconfig_test.go`, and `checkconfig/config_test.go` were updated from the bool to the profile-name list, and `TestHaveLegacyProfile` now also asserts the error names the source of the legacy syntax.

### Additional Notes

**This is a user-visible behavior change and deserves a careful look.** Making the detection consistent means *all* instances now fall back to the Python loader, where previously all but one stayed on Core. For a deployment with a stale legacy profile that is not actually referenced by any instance, that is a larger fallback than before. It is the behavior #36207 intended, and the new error message makes the misconfiguration a quick fix rather than a flare-level investigation, but reviewers should confirm this is the direction we want.

**Known remaining gap, deliberately out of scope.** The legacy flag is a property of the whole profile directory, not of the instance being configured: one legacy profile forces the Python loader on instances that never reference it. Scoping it per instance is not straightforward — `normalizeProfiles` resolves `extends` against the merged user+default map, so an init-config profile can inherit legacy metrics from an otherwise unreferenced user profile, and getting the narrowing wrong would silently drop the Python fallback for a config that needs it. That wants an NDM owner's call and a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
