### PR TITLE
Improve Bazel test coverage to get it closer to the legacy

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,8 +1,9 @@
 # Global build settings
 # gazelle:dd_agent_go_test on
-# gazelle:go_canonical_test_tag_set docker kubelet
 # gazelle:go_canonical_test_tag_set cel clusterchecks kubeapiserver kubelet orchestrator
 # gazelle:go_canonical_test_tag_set linux_bpf
+# gazelle:go_canonical_test_tag_set containerd cel
+# gazelle:go_canonical_test_tag_set docker kubelet cel
 
 load("@bazel_lib//lib:write_source_files.bzl", "write_source_file", "write_source_files")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")

--- a/bazel/AGENTS.md
+++ b/bazel/AGENTS.md
@@ -302,6 +302,26 @@ package-local tag combinations from `//go:build` constraints. Dependency-only op
 tags it names. Gazelle uses those combinations instead of unsafe partial modes and only considers
 embedded library constraints when a configured combination satisfies them.
 
+Some `//go:build` constraints name a tag that a canonical set covers *and* a tag that no canonical
+set mentions. `//go:build trivy && containerd` is one: `containerd` belongs to the canonical set
+`containerd cel`, but no canonical set mentions `trivy`, so that set on its own cannot compile the
+file. Gazelle does not give up there — it derives the minimal combination the constraint needs
+(`containerd trivy`) and adds every canonical set that shares a tag with it, producing
+`cel containerd trivy`. The canonical grouping is still honoured, and the sources still get a test
+target.
+
+This only applies when the canonical set and the constraint can coexist. A constraint that
+contradicts a canonical set produces no combination at all, and its sources stay out of the wildcard
+test runs. For example `//go:build kubeapiserver && !kubelet` grows to include `kubelet`, because
+`kubeapiserver` and `kubelet` share the canonical set
+`cel clusterchecks kubeapiserver kubelet orchestrator` — and the result then fails the constraint's
+own `!kubelet`.
+
+Combinations built this way can be long, and target names are budgeted against the Windows runfiles
+path length (see the Windows section). When `dd_agent_go_test` fails with a path-length error, add a
+short suffix for the combination to `_TAG_SET_SUFFIX_ALIASES` in
+`//bazel/rules/go:dd_agent_go_test.bzl`.
+
 ## Starlark language
 
 Starlark is Python-like but with deliberate restrictions for hermeticity and parallelism. Key divergences:

--- a/bazel/rules/go/_gazelle_extension.go
+++ b/bazel/rules/go/_gazelle_extension.go
@@ -486,10 +486,40 @@ func tagSetsForExpression(expr constraint.Expr, baseTags map[string]bool, config
 	if len(matches) > 0 {
 		return mergeTagSets(matches)
 	}
-	if referencesAnyTag(expr, configuredTags) || !deriveTagSets {
-		return mergeTagSets(matches)
+	if !deriveTagSets {
+		return nil
+	}
+	if referencesAnyTag(expr, configuredTags) {
+		return canonicalizedTagSets(expr, baseTags, configuredTagSets)
 	}
 	return minimalTagSets(expr, baseTags)
+}
+
+// canonicalizedTagSets handles constraints that pair a canonical tag with tags
+// no canonical set declares, such as `trivy && containerd` where the only set
+// naming containerd is {cel, containerd}. The set alone cannot satisfy the
+// constraint, but the grouping it expresses still holds, so each minimal set is
+// grown by the canonical sets it touches. Growth is measured against the
+// minimal set rather than the accumulating result: canonical sets frequently
+// share a tag, and re-scanning would chain them all together.
+//
+// A constraint that contradicts the grouping — `kubeapiserver && !kubelet`
+// against {cel, clusterchecks, kubeapiserver, kubelet, orchestrator} — survives
+// no such growth and still yields nothing.
+func canonicalizedTagSets(expr constraint.Expr, baseTags map[string]bool, configuredTagSets [][]string) [][]string {
+	var out [][]string
+	for _, minimal := range minimalTagSets(expr, baseTags) {
+		candidate := minimal
+		for _, tagSet := range configuredTagSets {
+			if stringSetsIntersect(minimal, tagSet) {
+				candidate = normalizeTagSet(append(append([]string(nil), candidate...), tagSet...))
+			}
+		}
+		if canSatisfy(expr, activeTagSet(baseTags, candidate)) {
+			out = append(out, candidate)
+		}
+	}
+	return mergeTagSets(out)
 }
 
 func referencesAnyTag(expr constraint.Expr, tags map[string]bool) bool {

--- a/bazel/rules/go/_gazelle_extension_test.go
+++ b/bazel/rules/go/_gazelle_extension_test.go
@@ -707,6 +707,7 @@ func TestApplicableTagSets(t *testing.T) {
 	tagCombined := write("combo_test.go", "//go:build kubeapiserver && linux")
 	twoTags := write("two_tags_test.go", "//go:build trivy && containerd")
 	relatedTags := write("related_tags_test.go", "//go:build trivy && docker")
+	crioTags := write("crio_tags_test.go", "//go:build trivy && crio")
 	oneTag := write("one_tag_test.go", "//go:build trivy")
 	negativeTag := write("negative_tag_test.go", "//go:build zlib && !zstd")
 	compression := write("compression_test.go", "//go:build zlib && zstd")
@@ -717,6 +718,8 @@ func TestApplicableTagSets(t *testing.T) {
 	orchestrator := write("orchestrator_test.go", "//go:build orchestrator")
 	kubeAPIServerWithoutKubelet := write("kube_no_kubelet_test.go", "//go:build kubeapiserver && !kubelet")
 	kubernetesTagSet := tagsList("cel", "clusterchecks", "kubeapiserver", "kubelet", "orchestrator")
+	containerdTagSet := tagsList("cel", "containerd")
+	dockerTagSet := tagsList("cel", "docker", "kubelet")
 	var manyTagNames []string
 	for tag := range AutoTestTags {
 		manyTagNames = append(manyTagNames, tag)
@@ -860,6 +863,24 @@ func TestApplicableTagSets(t *testing.T) {
 			srcs:              []string{linuxBpf},
 			configuredTagSets: [][]string{kubernetesTagSet},
 			wantTagSets:       [][]string{tagsList("linux_bpf")},
+		},
+		{
+			name:              "configured set grows to cover tags it does not name",
+			srcs:              []string{twoTags},
+			configuredTagSets: [][]string{containerdTagSet},
+			wantTagSets:       [][]string{tagsList("cel", "containerd", "trivy")},
+		},
+		{
+			name:              "only the configured sets a constraint touches are added",
+			srcs:              []string{relatedTags},
+			configuredTagSets: [][]string{containerdTagSet, dockerTagSet},
+			wantTagSets:       [][]string{tagsList("cel", "docker", "kubelet", "trivy")},
+		},
+		{
+			name:              "unconfigured alternative coalesces with the grown set",
+			srcs:              []string{twoTags, crioTags},
+			configuredTagSets: [][]string{containerdTagSet},
+			wantTagSets:       [][]string{tagsList("cel", "containerd", "crio", "trivy")},
 		},
 		{
 			name:              "embedded library selects configured set",

--- a/bazel/rules/go/dd_agent_go_test.bzl
+++ b/bazel/rules/go/dd_agent_go_test.bzl
@@ -16,6 +16,7 @@ _TAG_SET_SUFFIX_ALIASES = {
     "cel+clusterchecks+kubeapiserver+kubelet+orchestrator": "dca",
     "cel+clusterchecks+docker+kubeapiserver+kubelet+orchestrator": "dca_docker",
     "cel+clusterchecks+containerd+docker+kubeapiserver+kubelet+orchestrator": "dca_containerd_docker",
+    "cel+clusterchecks+docker+kubeapiserver+kubelet+orchestrator+python": "dca_docker_python",
 }
 
 # Windows caps a process's current directory at MAX_PATH even where longer paths

--- a/bazel/rules/go/dd_agent_go_test.bzl
+++ b/bazel/rules/go/dd_agent_go_test.bzl
@@ -15,6 +15,7 @@ load(
 _TAG_SET_SUFFIX_ALIASES = {
     "cel+clusterchecks+kubeapiserver+kubelet+orchestrator": "dca",
     "cel+clusterchecks+docker+kubeapiserver+kubelet+orchestrator": "dca_docker",
+    "cel+clusterchecks+containerd+docker+kubeapiserver+kubelet+orchestrator": "dca_containerd_docker",
 }
 
 # Windows caps a process's current directory at MAX_PATH even where longer paths

--- a/cmd/agent/common/BUILD.bazel
+++ b/cmd/agent/common/BUILD.bazel
@@ -66,6 +66,7 @@ dd_agent_go_test(
     data = glob(["testdata/**"]),
     embed = [":common"],
     gotags_sets = [[
+        "cel",
         "docker",
         "kubelet",
     ]],

--- a/cmd/cluster-agent/subcommands/coverage/BUILD.bazel
+++ b/cmd/cluster-agent/subcommands/coverage/BUILD.bazel
@@ -1,6 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
-
-# gazelle:dd_agent_go_test off
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "coverage",
@@ -195,15 +194,18 @@ go_library(
     }),
 )
 
-go_test(
+dd_agent_go_test(
     name = "coverage_test",
     srcs = ["command_test.go"],
     embed = [":coverage"],
-    gotags = [
-        "test",
+    gotags_sets = [[
+        "cel",
+        "clusterchecks",
         "kubeapiserver",
-        "e2ecoverage",
-    ],  # keep
+        "kubelet",
+        "orchestrator",
+    ]],
+    include_default = False,
     deps = select({
         "@rules_go//go/platform:aix": [
             "//cmd/cluster-agent/command",

--- a/cmd/installer/BUILD.bazel
+++ b/cmd/installer/BUILD.bazel
@@ -1,8 +1,7 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 load("//bazel/rules/go:go_binary.bzl", "dd_agent_go_binary")
 load("//tasks:build_tags.bzl", "INSTALLER_TAGS")
-
-# gazelle:dd_agent_go_test off
 
 go_library(
     name = "installer_lib",
@@ -37,11 +36,10 @@ dd_agent_go_binary(
     visibility = ["//visibility:public"],
 )
 
-go_test(
+dd_agent_go_test(
     name = "installer_test",
     srcs = ["main_test.go"],
     embed = [":installer_lib"],
-    gotags = sorted(["test"] + list(INSTALLER_TAGS)),
     deps = [
         "//pkg/fleet/installer/commands",
         "@com_github_spf13_cobra//:cobra",

--- a/cmd/system-probe/modules/BUILD.bazel
+++ b/cmd/system-probe/modules/BUILD.bazel
@@ -261,7 +261,13 @@ dd_agent_go_test(
         "traceroute_test.go",
     ],
     embed = [":modules"],
-    gotags_sets = [["linux_bpf"]],
+    gotags_sets = [
+        ["linux_bpf"],
+        [
+            "linux_bpf",
+            "nvml",
+        ],
+    ],
     deps = select({
         "@rules_go//go/platform:android": [
             "//pkg/compliance/dbconfig",

--- a/comp/core/autodiscovery/common/utils/BUILD.bazel
+++ b/comp/core/autodiscovery/common/utils/BUILD.bazel
@@ -1,8 +1,6 @@
 load("@rules_go//go:def.bzl", "go_library")
 load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
-# gazelle:dd_agent_go_test on
-
 go_library(
     name = "utils",
     srcs = [
@@ -62,6 +60,7 @@ dd_agent_go_test(
             "orchestrator",
         ],
         [
+            "cel",
             "docker",
             "kubelet",
         ],

--- a/comp/core/autodiscovery/integration/BUILD.bazel
+++ b/comp/core/autodiscovery/integration/BUILD.bazel
@@ -35,6 +35,8 @@ dd_agent_go_test(
     gotags_sets = [[
         "cel",
         "clusterchecks",
+        "containerd",
+        "docker",
         "kubeapiserver",
         "kubelet",
         "orchestrator",

--- a/comp/core/autodiscovery/listeners/BUILD.bazel
+++ b/comp/core/autodiscovery/listeners/BUILD.bazel
@@ -1,8 +1,6 @@
 load("@rules_go//go:def.bzl", "go_library")
 load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
-# gazelle:dd_agent_go_test on
-
 go_library(
     name = "listeners",
     srcs = [
@@ -110,6 +108,15 @@ dd_agent_go_test(
     ],
     embed = [":listeners"],
     gotags_sets = [
+        [
+            "cel",
+            "clusterchecks",
+            "containerd",
+            "docker",
+            "kubeapiserver",
+            "kubelet",
+            "orchestrator",
+        ],
         [
             "cel",
             "clusterchecks",

--- a/comp/core/autodiscovery/providers/BUILD.bazel
+++ b/comp/core/autodiscovery/providers/BUILD.bazel
@@ -1,8 +1,6 @@
 load("@rules_go//go:def.bzl", "go_library")
 load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
-# gazelle:dd_agent_go_test on
-
 go_library(
     name = "providers",
     srcs = [
@@ -155,6 +153,7 @@ dd_agent_go_test(
         [
             "cel",
             "clusterchecks",
+            "containerd",
             "docker",
             "kubeapiserver",
             "kubelet",
@@ -167,11 +166,12 @@ dd_agent_go_test(
             "kubelet",
             "orchestrator",
         ],
-        ["consul"],
         [
+            "cel",
             "docker",
             "kubelet",
         ],
+        ["consul"],
         ["etcd"],
         ["zk"],
     ],

--- a/comp/core/configfilesdiscovery/impl/BUILD.bazel
+++ b/comp/core/configfilesdiscovery/impl/BUILD.bazel
@@ -65,11 +65,20 @@ dd_agent_go_test(
         "process_commandline_test.go",
     ],
     embed = [":impl"],
-    gotags_sets = [[
-        "cel",
-        "docker",
-        "kubelet",
-    ]],
+    gotags_sets = [
+        [
+            "cel",
+            "containerd",
+            "cri",
+            "docker",
+            "kubelet",
+        ],
+        [
+            "cel",
+            "docker",
+            "kubelet",
+        ],
+    ],
     deps = [
         "//comp/core/autodiscovery/def",
         "//comp/core/autodiscovery/integration",

--- a/comp/core/configfilesdiscovery/impl/BUILD.bazel
+++ b/comp/core/configfilesdiscovery/impl/BUILD.bazel
@@ -65,16 +65,11 @@ dd_agent_go_test(
         "process_commandline_test.go",
     ],
     embed = [":impl"],
-    gotags_sets = [
-        [
-            "containerd",
-            "cri",
-        ],
-        [
-            "docker",
-            "kubelet",
-        ],
-    ],
+    gotags_sets = [[
+        "cel",
+        "docker",
+        "kubelet",
+    ]],
     deps = [
         "//comp/core/autodiscovery/def",
         "//comp/core/autodiscovery/integration",

--- a/comp/core/workloadfilter/catalog/BUILD.bazel
+++ b/comp/core/workloadfilter/catalog/BUILD.bazel
@@ -42,6 +42,8 @@ dd_agent_go_test(
     gotags_sets = [[
         "cel",
         "clusterchecks",
+        "containerd",
+        "docker",
         "kubeapiserver",
         "kubelet",
         "orchestrator",

--- a/comp/core/workloadfilter/impl/BUILD.bazel
+++ b/comp/core/workloadfilter/impl/BUILD.bazel
@@ -32,6 +32,8 @@ dd_agent_go_test(
     gotags_sets = [[
         "cel",
         "clusterchecks",
+        "containerd",
+        "docker",
         "kubeapiserver",
         "kubelet",
         "orchestrator",

--- a/comp/core/workloadfilter/program/BUILD.bazel
+++ b/comp/core/workloadfilter/program/BUILD.bazel
@@ -38,6 +38,8 @@ dd_agent_go_test(
     gotags_sets = [[
         "cel",
         "clusterchecks",
+        "containerd",
+        "docker",
         "kubeapiserver",
         "kubelet",
         "orchestrator",

--- a/comp/core/workloadmeta/collectors/internal/containerd/BUILD.bazel
+++ b/comp/core/workloadmeta/collectors/internal/containerd/BUILD.bazel
@@ -67,7 +67,10 @@ dd_agent_go_test(
         "image_test.go",
     ],
     embed = [":containerd"],
-    gotags_sets = [["containerd"]],
+    gotags_sets = [[
+        "cel",
+        "containerd",
+    ]],
     include_default = False,
     target_compatible_with = ["@platforms//os:linux"],  # keep
     deps = [

--- a/comp/core/workloadmeta/collectors/internal/docker/BUILD.bazel
+++ b/comp/core/workloadmeta/collectors/internal/docker/BUILD.bazel
@@ -45,6 +45,7 @@ dd_agent_go_test(
     srcs = ["docker_test.go"],
     embed = [":docker"],
     gotags_sets = [[
+        "cel",
         "docker",
         "kubelet",
     ]],

--- a/comp/core/workloadmeta/collectors/internal/ecs/BUILD.bazel
+++ b/comp/core/workloadmeta/collectors/internal/ecs/BUILD.bazel
@@ -51,6 +51,7 @@ dd_agent_go_test(
     data = glob(["testdata/**"]),
     embed = [":ecs"],
     gotags_sets = [[
+        "cel",
         "docker",
         "kubelet",
     ]],

--- a/comp/host-profiler/symboluploader/BUILD.bazel
+++ b/comp/host-profiler/symboluploader/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
-# gazelle:dd_agent_go_test off
 # gazelle:go_test file
 
 go_library(
@@ -47,12 +47,11 @@ go_library(
     }),
 )
 
-go_test(
+dd_agent_go_test(
     name = "symbol_query_batching_test",
     srcs = ["symbol_query_batching_test.go"],
     data = glob(["testdata/**"]),
     embed = [":symboluploader"],
-    gotags = ["test"],
     deps = select({
         "@rules_go//go/platform:android": [
             "//comp/host-profiler/symboluploader/symbol",
@@ -71,12 +70,11 @@ go_test(
 # TODO: This test can't work from CI as written because it depends on direct
 # access to the go compiler outside of bazel control. It does work from the
 # developer command line.
-go_test(
+dd_agent_go_test(
     name = "symbol_uploader_test",
     srcs = ["symbol_uploader_test.go"],
     data = glob(["testdata/**"]),
     embed = [":symboluploader"],
-    gotags = ["test"],
     tags = ["manual"],
     deps = select({
         "@rules_go//go/platform:android": [

--- a/comp/host-profiler/symboluploader/pclntab/BUILD.bazel
+++ b/comp/host-profiler/symboluploader/pclntab/BUILD.bazel
@@ -25,7 +25,6 @@ dd_agent_go_test(
     name = "pclntab_internal_test",
     srcs = ["pclntab_internal_test.go"],
     embed = [":pclntab"],
-    tags = ["manual"],
 )
 
 dd_agent_go_test(

--- a/comp/host-profiler/symboluploader/pclntab/BUILD.bazel
+++ b/comp/host-profiler/symboluploader/pclntab/BUILD.bazel
@@ -1,6 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
-
-# gazelle:dd_agent_go_test off
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "pclntab",
@@ -22,12 +21,16 @@ go_library(
     }),
 )
 
-# TODO: This test can not run under bazel yet because it depends on direct
-# access to the go compiler executable.
-go_test(
+dd_agent_go_test(
+    name = "pclntab_internal_test",
+    srcs = ["pclntab_internal_test.go"],
+    embed = [":pclntab"],
+    tags = ["manual"],
+)
+
+dd_agent_go_test(
     name = "pclntab_test",
     srcs = ["pclntab_test.go"],
-    gotags = ["test"],
     tags = ["manual"],
     deps = select({
         "@rules_go//go/platform:android": [
@@ -48,11 +51,4 @@ go_test(
         ],
         "//conditions:default": [],
     }),
-)
-
-go_test(
-    name = "pclntab_internal_test",
-    srcs = ["pclntab_internal_test.go"],
-    embed = [":pclntab"],
-    gotags = ["test"],
 )

--- a/comp/host-profiler/symboluploader/pipeline/BUILD.bazel
+++ b/comp/host-profiler/symboluploader/pipeline/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "pipeline",
@@ -11,11 +12,10 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "pipeline_test",
     srcs = ["pipeline_test.go"],
     embed = [":pipeline"],
-    gotags = ["test"],
     deps = [
         "@com_github_jonboulle_clockwork//:clockwork",
         "@com_github_stretchr_testify//require",

--- a/comp/privateactionrunner/impl/BUILD.bazel
+++ b/comp/privateactionrunner/impl/BUILD.bazel
@@ -1,6 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
-
-# gazelle:dd_agent_go_test off
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "impl",
@@ -43,11 +42,10 @@ go_library(
     ],
 )
 
-go_test(
+dd_agent_go_test(
     name = "impl_test",
     srcs = ["privateactionrunner_test.go"],
     embed = [":impl"],
-    gotags = ["test"],
     deps = [
         "@com_github_datadog_datadog_go_v5//statsd",
         "@com_github_stretchr_testify//assert",

--- a/comp/trace/config/impl/BUILD.bazel
+++ b/comp/trace/config/impl/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
 load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
-load("//tasks:build_tags.bzl", "COMMON_TAGS", "TRACE_AGENT_TAGS")
 
 go_library(
     name = "impl",

--- a/comp/trace/config/impl/BUILD.bazel
+++ b/comp/trace/config/impl/BUILD.bazel
@@ -1,7 +1,6 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 load("//tasks:build_tags.bzl", "COMMON_TAGS", "TRACE_AGENT_TAGS")
-
-# gazelle:dd_agent_go_test off
 
 go_library(
     name = "impl",
@@ -111,7 +110,7 @@ go_library(
     }),
 )
 
-go_test(
+dd_agent_go_test(
     name = "impl_test",
     srcs = [
         "aliases_test.go",
@@ -122,7 +121,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":impl"],
     embedsrcs = ["testdata/stringcode.go.tmpl"],
-    gotags = sorted(["test"] + list(COMMON_TAGS) + list(TRACE_AGENT_TAGS)),
+    gotags_sets = [["otlp"]],
     tags = ["manual"],
     deps = [
         "//comp/core/config",

--- a/pkg/cli/subcommands/workloadfilter/BUILD.bazel
+++ b/pkg/cli/subcommands/workloadfilter/BUILD.bazel
@@ -37,6 +37,8 @@ dd_agent_go_test(
     gotags_sets = [[
         "cel",
         "clusterchecks",
+        "containerd",
+        "docker",
         "kubeapiserver",
         "kubelet",
         "orchestrator",

--- a/pkg/collector/corechecks/containers/containerd/BUILD.bazel
+++ b/pkg/collector/corechecks/containers/containerd/BUILD.bazel
@@ -51,7 +51,10 @@ dd_agent_go_test(
         "events_test.go",
     ],
     embed = [":containerd"],
-    gotags_sets = [["containerd"]],
+    gotags_sets = [[
+        "cel",
+        "containerd",
+    ]],
     include_default = False,
     deps = [
         "//comp/core/tagger/fx-mock",

--- a/pkg/collector/corechecks/containers/docker/BUILD.bazel
+++ b/pkg/collector/corechecks/containers/docker/BUILD.bazel
@@ -62,6 +62,7 @@ dd_agent_go_test(
     ],
     embed = [":docker"],
     gotags_sets = [[
+        "cel",
         "docker",
         "kubelet",
     ]],

--- a/pkg/collector/python/BUILD.bazel
+++ b/pkg/collector/python/BUILD.bazel
@@ -194,7 +194,15 @@ dd_agent_go_test(
         "version_test.go",
     ],
     embed = [":python"],
-    gotags_sets = [["python"]],
+    gotags_sets = [[
+        "cel",
+        "clusterchecks",
+        "docker",
+        "kubeapiserver",
+        "kubelet",
+        "orchestrator",
+        "python",
+    ]],
     include_default = False,
     deps = [
         "//pkg/util/cache",

--- a/pkg/compliance/BUILD.bazel
+++ b/pkg/compliance/BUILD.bazel
@@ -207,6 +207,7 @@ dd_agent_go_test(
             "orchestrator",
         ],
         [
+            "cel",
             "docker",
             "kubelet",
         ],

--- a/pkg/config/legacy/BUILD.bazel
+++ b/pkg/config/legacy/BUILD.bazel
@@ -36,6 +36,7 @@ dd_agent_go_test(
     data = glob(["testdata/**"]),
     embed = [":legacy"],
     gotags_sets = [[
+        "cel",
         "docker",
         "kubelet",
     ]],

--- a/pkg/flare/BUILD.bazel
+++ b/pkg/flare/BUILD.bazel
@@ -94,6 +94,7 @@ dd_agent_go_test(
             "orchestrator",
         ],
         [
+            "cel",
             "docker",
             "kubelet",
         ],

--- a/pkg/gpu/BUILD.bazel
+++ b/pkg/gpu/BUILD.bazel
@@ -84,7 +84,14 @@ dd_agent_go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":gpu"],
-    gotags_sets = [["linux_bpf"]],
+    gotags_sets = [
+        ["linux_bpf"],
+        [
+            "linux_bpf",
+            "nvml",
+        ],
+    ],
+    tags = ["manual"],
     deps = [
         "//comp/core/telemetry/def",
         "//comp/core/workloadmeta/def",

--- a/pkg/gpu/cuda/BUILD.bazel
+++ b/pkg/gpu/cuda/BUILD.bazel
@@ -58,10 +58,10 @@ dd_agent_go_test(
         "//pkg/network/usm/testdata/site-packages/ddtrace:testdata",
     ],
     embed = [":cuda"],
-    gotags_sets = [
-        ["linux_bpf"],
-        ["nvml"],
-    ],
+    gotags_sets = [[
+        "linux_bpf",
+        "nvml",
+    ]],
     deps = [
         "//pkg/gpu/cuda/testutil",
         "//pkg/gpu/safenvml",

--- a/pkg/logs/internal/util/containersorpods/BUILD.bazel
+++ b/pkg/logs/internal/util/containersorpods/BUILD.bazel
@@ -43,6 +43,7 @@ dd_agent_go_test(
             "orchestrator",
         ],
         [
+            "cel",
             "docker",
             "kubelet",
         ],

--- a/pkg/logs/launchers/container/tailerfactory/BUILD.bazel
+++ b/pkg/logs/launchers/container/tailerfactory/BUILD.bazel
@@ -68,6 +68,7 @@ dd_agent_go_test(
             "orchestrator",
         ],
         [
+            "cel",
             "docker",
             "kubelet",
         ],

--- a/pkg/network/driver/BUILD.bazel
+++ b/pkg/network/driver/BUILD.bazel
@@ -1,8 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
 load("//bazel/rules/ebpf:cgo_godefs.bzl", "cgo_godefs")
-
-# gazelle:dd_agent_go_test off
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 exports_files(["types_windows.go"])
 
@@ -47,11 +46,12 @@ go_library(
     }),
 )
 
-go_test(
+dd_agent_go_test(
     name = "driver_test",
     srcs = ["driver_test.go"],
     embed = [":driver"],
-    gotags = ["test"],
+    gotags_sets = [["npm"]],
+    include_default = False,
     deps = select({
         "@rules_go//go/platform:windows": [
             "@com_github_stretchr_testify//assert",

--- a/pkg/network/driver/BUILD.bazel
+++ b/pkg/network/driver/BUILD.bazel
@@ -52,6 +52,9 @@ dd_agent_go_test(
     embed = [":driver"],
     gotags_sets = [["npm"]],
     include_default = False,
+    # Opens the ddnpm kernel device, so it only passes on a host where that
+    # driver is loaded. Run from the sysprobe-functional e2e suite instead.
+    tags = ["manual"],
     deps = select({
         "@rules_go//go/platform:windows": [
             "@com_github_stretchr_testify//assert",

--- a/pkg/network/encoding/BUILD.bazel
+++ b/pkg/network/encoding/BUILD.bazel
@@ -1,6 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
-
-# gazelle:dd_agent_go_test off
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "encoding",
@@ -9,14 +8,15 @@ go_library(
     visibility = ["//visibility:public"],
 )
 
-go_test(
+dd_agent_go_test(
     name = "encoding_test",
     srcs = [
         "encoding_linux_test.go",
         "encoding_test.go",
     ],
     embed = [":encoding"],
-    gotags = ["test"],
+    gotags_sets = [["linux_bpf"]],
+    include_default = False,
     deps = select({
         "@rules_go//go/platform:android": [
             "//pkg/config/mock",

--- a/pkg/security/secl/model/utils/BUILD.bazel
+++ b/pkg/security/secl/model/utils/BUILD.bazel
@@ -1,6 +1,5 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
-
-# gazelle:dd_agent_go_test off
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 # Source-level export so the //pkg/security/secl/model:event_deep_copy_*
 # Bazel codegens can resolve types defined here (e.g. utils.TraceID).
@@ -16,9 +15,8 @@ go_library(
     visibility = ["//visibility:public"],
 )
 
-go_test(
+dd_agent_go_test(
     name = "utils_test",
     srcs = ["uint128_test.go"],
     embed = [":utils"],
-    gotags = ["test"],
 )

--- a/pkg/util/containerd/BUILD.bazel
+++ b/pkg/util/containerd/BUILD.bazel
@@ -38,7 +38,10 @@ dd_agent_go_test(
         "namespaces_test.go",
     ],
     embed = [":containerd"],
-    gotags_sets = [["containerd"]],
+    gotags_sets = [[
+        "cel",
+        "containerd",
+    ]],
     include_default = False,
     deps = [
         "//pkg/config/mock",

--- a/pkg/util/containers/metrics/containerd/BUILD.bazel
+++ b/pkg/util/containers/metrics/containerd/BUILD.bazel
@@ -74,7 +74,10 @@ dd_agent_go_test(
         "collector_windows_test.go",
     ],
     embed = [":containerd"],
-    gotags_sets = [["containerd"]],
+    gotags_sets = [[
+        "cel",
+        "containerd",
+    ]],
     include_default = False,
     deps = select({
         "@rules_go//go/platform:android": [

--- a/pkg/util/containers/metrics/docker/BUILD.bazel
+++ b/pkg/util/containers/metrics/docker/BUILD.bazel
@@ -64,6 +64,7 @@ dd_agent_go_test(
     ],
     embed = [":docker"],
     gotags_sets = [[
+        "cel",
         "docker",
         "kubelet",
     ]],

--- a/pkg/util/containers/metrics/ecsfargate/BUILD.bazel
+++ b/pkg/util/containers/metrics/ecsfargate/BUILD.bazel
@@ -26,6 +26,7 @@ dd_agent_go_test(
     srcs = ["collector_test.go"],
     embed = [":ecsfargate"],
     gotags_sets = [[
+        "cel",
         "docker",
         "kubelet",
     ]],

--- a/pkg/util/containers/metrics/ecsmanagedinstances/BUILD.bazel
+++ b/pkg/util/containers/metrics/ecsmanagedinstances/BUILD.bazel
@@ -27,6 +27,7 @@ dd_agent_go_test(
     srcs = ["collector_test.go"],
     embed = [":ecsmanagedinstances"],
     gotags_sets = [[
+        "cel",
         "docker",
         "kubelet",
     ]],

--- a/pkg/util/docker/BUILD.bazel
+++ b/pkg/util/docker/BUILD.bazel
@@ -62,6 +62,7 @@ dd_agent_go_test(
     ],
     embed = [":docker"],
     gotags_sets = [[
+        "cel",
         "docker",
         "kubelet",
     ]],

--- a/pkg/util/ecs/BUILD.bazel
+++ b/pkg/util/ecs/BUILD.bazel
@@ -31,6 +31,7 @@ dd_agent_go_test(
     srcs = ["ecs_test.go"],
     embed = [":ecs"],
     gotags_sets = [[
+        "cel",
         "docker",
         "kubelet",
     ]],

--- a/pkg/util/ecs/metadata/BUILD.bazel
+++ b/pkg/util/ecs/metadata/BUILD.bazel
@@ -33,6 +33,7 @@ dd_agent_go_test(
     data = ["//pkg/util/ecs/metadata/v1:testdata"],
     embed = [":metadata"],
     gotags_sets = [[
+        "cel",
         "docker",
         "kubelet",
     ]],

--- a/pkg/util/ecs/metadata/v1/BUILD.bazel
+++ b/pkg/util/ecs/metadata/v1/BUILD.bazel
@@ -28,6 +28,7 @@ dd_agent_go_test(
     data = glob(["testdata/**"]),
     embed = [":metadata"],
     gotags_sets = [[
+        "cel",
         "docker",
         "kubelet",
     ]],

--- a/pkg/util/ecs/metadata/v2/BUILD.bazel
+++ b/pkg/util/ecs/metadata/v2/BUILD.bazel
@@ -22,6 +22,7 @@ dd_agent_go_test(
     data = glob(["testdata/**"]),
     embed = [":metadata"],
     gotags_sets = [[
+        "cel",
         "docker",
         "kubelet",
     ]],

--- a/pkg/util/ecs/metadata/v3or4/BUILD.bazel
+++ b/pkg/util/ecs/metadata/v3or4/BUILD.bazel
@@ -24,6 +24,7 @@ dd_agent_go_test(
     data = glob(["testdata/**"]),
     embed = [":v3or4"],
     gotags_sets = [[
+        "cel",
         "docker",
         "kubelet",
     ]],

--- a/pkg/util/kubernetes/hostinfo/BUILD.bazel
+++ b/pkg/util/kubernetes/hostinfo/BUILD.bazel
@@ -59,6 +59,7 @@ dd_agent_go_test(
             "orchestrator",
         ],
         [
+            "cel",
             "docker",
             "kubelet",
         ],

--- a/pkg/util/kubernetes/kubelet/BUILD.bazel
+++ b/pkg/util/kubernetes/kubelet/BUILD.bazel
@@ -86,6 +86,7 @@ dd_agent_go_test(
             "orchestrator",
         ],
         [
+            "cel",
             "docker",
             "kubelet",
         ],

--- a/pkg/util/trivy/BUILD.bazel
+++ b/pkg/util/trivy/BUILD.bazel
@@ -90,7 +90,6 @@ dd_agent_go_test(
     ],
     embed = [":trivy"],
     gotags_sets = [[
-        "containerd",
         "crio",
         "trivy",
     ]],

--- a/pkg/util/trivy/BUILD.bazel
+++ b/pkg/util/trivy/BUILD.bazel
@@ -90,7 +90,11 @@ dd_agent_go_test(
     ],
     embed = [":trivy"],
     gotags_sets = [[
+        "cel",
+        "containerd",
         "crio",
+        "docker",
+        "kubelet",
         "trivy",
     ]],
     include_default = False,


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

This PR introduces some changes here and there to bridge the gap in the reported code coverage between Bazel and the legacy approach. Changes worth mentioning:

- There was a bug in the fallback mechanism in our custom Gazelle extension that sometimes returned no go tags to set at all. Now the fallback will come back with a minimal set of tags that is needed to build and run a test binary.
- `cel` tag wasn't set in some cases at all, so we add 2 new custom tag sets.
- `gazelle:dd_agent_go_test off` directives were removed in files that were regenerated by Gazelle.

