### PR TITLE
Restore static quality gates headroom for #54400

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -15,13 +15,13 @@ static_quality_gate_agent_rpm_amd64:
   max_on_wire_size: 186.5 MiB
 static_quality_gate_agent_rpm_amd64_fips:
   max_on_disk_size: 715.68 MiB
-  max_on_wire_size: 177.74 MiB
+  max_on_wire_size: 177.89 MiB
 static_quality_gate_agent_rpm_arm64:
-  max_on_disk_size: 735.50 MiB
+  max_on_disk_size: 736.49 MiB
   max_on_wire_size: 167.01 MiB
 static_quality_gate_agent_rpm_arm64_fips:
   max_on_disk_size: 693.64 MiB
-  max_on_wire_size: 159.3 MiB
+  max_on_wire_size: 159.34 MiB
 static_quality_gate_agent_suse_amd64:
   max_on_disk_size: 764.4 MiB
   max_on_wire_size: 186.5 MiB
@@ -29,8 +29,8 @@ static_quality_gate_agent_suse_amd64_fips:
   max_on_disk_size: 715.68 MiB
   max_on_wire_size: 177.89 MiB
 static_quality_gate_agent_suse_arm64:
-  max_on_disk_size: 735.50 MiB
-  max_on_wire_size: 166.98 MiB
+  max_on_disk_size: 736.49 MiB
+  max_on_wire_size: 167.01 MiB
 static_quality_gate_agent_suse_arm64_fips:
   max_on_disk_size: 693.64 MiB
   max_on_wire_size: 159.34 MiB
@@ -96,4 +96,4 @@ static_quality_gate_iot_agent_rpm_amd64:
   max_on_wire_size: 13.65 MiB
 static_quality_gate_iot_agent_suse_amd64:
   max_on_disk_size: 46.44 MiB
-  max_on_wire_size: 13.64 MiB
+  max_on_wire_size: 13.65 MiB


### PR DESCRIPTION
### What does this PR do?
Bump `agent_rpm_arm64`/`agent_suse_arm64`'s `max_on_disk_size` using `quality-gates.exception-threshold-bump`'s fix from #54615: the only two gates PR #54400 is actually short on headroom for.

Also align each RPM/SUSE twin gate pair's `max_on_wire_size` up to the higher of the two (`agent_rpm_amd64_fips`, `agent_rpm_arm64_fips`, `agent_suse_arm64`, `iot_agent_suse_amd64`): RPM and SUSE packages are the same format, so a twin pair drifting apart is noise, not signal.

### Motivation
#54400 (an incident fix) is blocked by these two gates, both at zero margin on `main` after #54204's Rust data-security check.
A rebase alone left it short by 34 KiB.

### Describe how you validated your changes
Confirmed against #54400's live metrics: it currently fails only `agent_rpm_arm64`/`agent_suse_arm64` on-disk, by 34.26 KiB.
Against these new thresholds, none of its 33 gates fail.