### PR TITLE
fix: avoid aliasing caller's proto.Client in remote config clients map

### DIFF
--- a/pkg/config/remote/service/BUILD.bazel
+++ b/pkg/config/remote/service/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//proto",
         "@org_golang_x_time//rate",
     ],
 )
@@ -62,5 +63,6 @@ dd_agent_go_test(
         "@org_golang_google_grpc//stats",
         "@org_golang_google_grpc//status",
         "@org_golang_google_grpc//test/bufconn",
+        "@org_golang_google_protobuf//proto",
     ],
 )

--- a/pkg/config/remote/service/clients.go
+++ b/pkg/config/remote/service/clients.go
@@ -77,15 +77,10 @@ func (c *clients) seen(pbClient *pbgo.Client) {
 	defer c.m.Unlock()
 	now := c.clock.Now().UTC()
 	pbClient.LastSeen = uint64(now.UnixMilli())
-	// Store a defensive copy rather than the caller's own pointer: the
-	// caller may keep mutating/reusing its pbClient after this call
-	// returns, while the copy stored here can be concurrently read (e.g.
-	// marshaled) by activeClients() callers after we release c.m.
+	// Store a copy: the caller may keep mutating pbClient after this returns.
 	pbCopy, ok := proto.Clone(pbClient).(*pbgo.Client)
 	if !ok {
-		// Should never happen: proto.Clone on a *pbgo.Client always
-		// returns a *pbgo.Client. Fall back to the original pointer
-		// rather than dropping the client entirely.
+		// Unreachable: proto.Clone always returns the same concrete type.
 		pbCopy = pbClient
 	}
 	c.clients[pbClient.Id] = &client{

--- a/pkg/config/remote/service/clients.go
+++ b/pkg/config/remote/service/clients.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
+	"google.golang.org/protobuf/proto"
 
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 )
@@ -76,14 +77,27 @@ func (c *clients) seen(pbClient *pbgo.Client) {
 	defer c.m.Unlock()
 	now := c.clock.Now().UTC()
 	pbClient.LastSeen = uint64(now.UnixMilli())
+	// Store a defensive copy rather than the caller's own pointer: the
+	// caller may keep mutating/reusing its pbClient after this call
+	// returns, while the copy stored here can be concurrently read (e.g.
+	// marshaled) by activeClients() callers after we release c.m.
+	pbCopy, ok := proto.Clone(pbClient).(*pbgo.Client)
+	if !ok {
+		// Should never happen: proto.Clone on a *pbgo.Client always
+		// returns a *pbgo.Client. Fall back to the original pointer
+		// rather than dropping the client entirely.
+		pbCopy = pbClient
+	}
 	c.clients[pbClient.Id] = &client{
 		lastSeen: now,
-		pbClient: pbClient,
+		pbClient: pbCopy,
 	}
 }
 
 // active checks whether a certain client is active
 func (c *clients) active(pbClient *pbgo.Client) bool {
+	c.m.Lock()
+	defer c.m.Unlock()
 	client, ok := c.clients[pbClient.Id]
 	if !ok {
 		return false

--- a/pkg/config/remote/service/clients_test.go
+++ b/pkg/config/remote/service/clients_test.go
@@ -67,22 +67,13 @@ func TestCacheBypassClientsRateLimit(t *testing.T) {
 	assert.False(t, cacheBypassClients.Limit())
 }
 
-// TestClientsSeenActiveClientsRace reproduces the data race that used to
-// exist between (*clients).seen() mutating/storing the caller's live
-// *pbgo.Client pointer and a concurrent reader (e.g. proto.Marshal on the
-// result of activeClients()) reading that same object. seen() must store a
-// defensive copy so activeClients() never hands out an object that a
-// concurrent seen() call can still mutate.
-//
-// Run with -race (e.g. `dda inv test --targets=./pkg/config/remote/service --race`)
-// to confirm this fails without the defensive copy and passes with it.
+// TestClientsSeenActiveClientsRace catches concurrent mutation of a *pbgo.Client shared via seen()/activeClients(); run with -race.
 func TestClientsSeenActiveClientsRace(t *testing.T) {
 	testTTL := time.Second * 5
 	realClock := clock.New()
 	clients := newClients(realClock, testTTL)
 
-	// A single, shared *pbgo.Client, owned by the "caller" goroutine, mimicking
-	// the same request.Client object being reused across ClientGetConfigs calls.
+	// Shared *pbgo.Client, mimicking a reused request.Client.
 	pbClient := &pbgo.Client{
 		Id:       "client1",
 		Products: []string{"APM_SAMPLING"},
@@ -92,8 +83,7 @@ func TestClientsSeenActiveClientsRace(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	// Goroutine 1: repeatedly mark the client as seen, mutating pbClient.LastSeen
-	// in place, just like ClientGetConfigs does.
+	// Repeatedly mark the client as seen, like ClientGetConfigs does.
 	go func() {
 		defer wg.Done()
 		for i := 0; i < iterations; i++ {
@@ -101,8 +91,7 @@ func TestClientsSeenActiveClientsRace(t *testing.T) {
 		}
 	}()
 
-	// Goroutine 2: repeatedly fetch active clients and marshal them, just like
-	// refresh() does while building the outgoing request.
+	// Repeatedly fetch and marshal active clients, like refresh() does.
 	go func() {
 		defer wg.Done()
 		for i := 0; i < iterations; i++ {

--- a/pkg/config/remote/service/clients_test.go
+++ b/pkg/config/remote/service/clients_test.go
@@ -81,19 +81,15 @@ func TestClientsSeenActiveClientsRace(t *testing.T) {
 
 	const iterations = 2000
 	var wg sync.WaitGroup
-	wg.Add(2)
-
 	// Repeatedly mark the client as seen, like ClientGetConfigs does.
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for i := 0; i < iterations; i++ {
 			clients.seen(pbClient)
 		}
-	}()
+	})
 
 	// Repeatedly fetch and marshal active clients, like refresh() does.
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for i := 0; i < iterations; i++ {
 			for _, active := range clients.activeClients() {
 				if _, err := proto.Marshal(active); err != nil {
@@ -101,7 +97,7 @@ func TestClientsSeenActiveClientsRace(t *testing.T) {
 				}
 			}
 		}
-	}()
+	})
 
 	wg.Wait()
 }

--- a/pkg/config/remote/service/clients_test.go
+++ b/pkg/config/remote/service/clients_test.go
@@ -6,11 +6,13 @@
 package service
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
 
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 )
@@ -63,4 +65,54 @@ func TestCacheBypassClientsRateLimit(t *testing.T) {
 	// New window
 	clock.Add(4 * time.Second)
 	assert.False(t, cacheBypassClients.Limit())
+}
+
+// TestClientsSeenActiveClientsRace reproduces the data race that used to
+// exist between (*clients).seen() mutating/storing the caller's live
+// *pbgo.Client pointer and a concurrent reader (e.g. proto.Marshal on the
+// result of activeClients()) reading that same object. seen() must store a
+// defensive copy so activeClients() never hands out an object that a
+// concurrent seen() call can still mutate.
+//
+// Run with -race (e.g. `dda inv test --targets=./pkg/config/remote/service --race`)
+// to confirm this fails without the defensive copy and passes with it.
+func TestClientsSeenActiveClientsRace(t *testing.T) {
+	testTTL := time.Second * 5
+	realClock := clock.New()
+	clients := newClients(realClock, testTTL)
+
+	// A single, shared *pbgo.Client, owned by the "caller" goroutine, mimicking
+	// the same request.Client object being reused across ClientGetConfigs calls.
+	pbClient := &pbgo.Client{
+		Id:       "client1",
+		Products: []string{"APM_SAMPLING"},
+	}
+
+	const iterations = 2000
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Goroutine 1: repeatedly mark the client as seen, mutating pbClient.LastSeen
+	// in place, just like ClientGetConfigs does.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			clients.seen(pbClient)
+		}
+	}()
+
+	// Goroutine 2: repeatedly fetch active clients and marshal them, just like
+	// refresh() does while building the outgoing request.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			for _, active := range clients.activeClients() {
+				if _, err := proto.Marshal(active); err != nil {
+					t.Errorf("failed to marshal client: %v", err)
+				}
+			}
+		}
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
### What does this PR do?

Fixes a data race on `pbgo.Client.LastSeen`/other fields: `(*clients).seen()` stored and mutated the caller's own `*pbgo.Client` pointer, which `activeClients()` later handed to `refresh()` for marshaling. Now `seen()` stores a `proto.Clone()`'d copy instead.

### Motivation

Fix a race, found via a race-detector-enabled build in staging.

### Describe how you validated your changes

Added `TestClientsSeenActiveClientsRace`, which reproduces the race under `-race` without the fix and passes with it.
