### PR TITLE
fix: data race on LogSource TailingMode

### DIFF
--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -440,10 +440,10 @@ func (s *Launcher) launchTailers(source *sources.LogSource) {
 			}
 		}
 
-		mode, isSet := config.TailingModeFromString(source.Config.TailingMode)
+		mode, isSet := config.TailingModeFromString(source.GetTailingMode())
 		if !isSet && source.Config.Identifier != "" {
 			mode = config.Beginning
-			source.Config.TailingMode = mode.String()
+			source.SetTailingMode(mode.String())
 		}
 
 		newTailerStarted := s.startNewTailer(file, mode, fingerprint)

--- a/pkg/logs/sources/source.go
+++ b/pkg/logs/sources/source.go
@@ -114,6 +114,21 @@ func (s *LogSource) SetStatus(newStatus *status.LogStatus) {
 	s.lock.Unlock()
 }
 
+// GetTailingMode returns the tailing mode configured for this source.
+func (s *LogSource) GetTailingMode() string {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.Config.TailingMode
+}
+
+// SetTailingMode sets the tailing mode configured for this source. This is mutated after
+// creation when a tailing mode is inferred at launch time, so it must go through the lock.
+func (s *LogSource) SetTailingMode(mode string) {
+	s.lock.Lock()
+	s.Config.TailingMode = mode
+	s.lock.Unlock()
+}
+
 // SetSourceType sets a format that give information on how the source lines should be parsed
 func (s *LogSource) SetSourceType(sourceType SourceType) {
 	s.lock.Lock()

--- a/pkg/logs/sources/source_test.go
+++ b/pkg/logs/sources/source_test.go
@@ -52,9 +52,7 @@ func TestConcurrentTailingModeAndStatusAccess(t *testing.T) {
 	stop := make(chan struct{})
 
 	// writer: mimics (*Launcher).launchTailers/addSource mutating the source concurrently.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for i := 0; ; i++ {
 			select {
 			case <-stop:
@@ -68,7 +66,7 @@ func TestConcurrentTailingModeAndStatusAccess(t *testing.T) {
 			}
 			source.SetStatus(NewLogSource("test", nil).Status())
 		}
-	}()
+	})
 
 	// reader: mimics (*Builder).toDictionary/getIntegrations reading the source concurrently.
 	for i := 0; i < 1000; i++ {

--- a/pkg/logs/sources/source_test.go
+++ b/pkg/logs/sources/source_test.go
@@ -6,10 +6,13 @@
 package sources
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 )
 
 type LogSourceSuite struct {
@@ -37,4 +40,43 @@ func (s *LogSourceSuite) TestDump() {
 
 func TestTrackerSuite(t *testing.T) {
 	suite.Run(t, new(LogSourceSuite))
+}
+
+// TestConcurrentTailingModeAndStatusAccess guards against a regression of a data race where
+// the file launcher mutates a LogSource's Config.TailingMode and Status pointer from a
+// background goroutine while the status builder reads them concurrently to render `agent
+// status`. Both accesses must go through LogSource's lock. Run with `-race` to verify.
+func TestConcurrentTailingModeAndStatusAccess(t *testing.T) {
+	t.Parallel()
+	source := NewLogSource("test", &config.LogsConfig{TailingMode: "end"})
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// writer: mimics (*Launcher).launchTailers/addSource mutating the source concurrently.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if i%2 == 0 {
+				source.SetTailingMode("beginning")
+			} else {
+				source.SetTailingMode("end")
+			}
+			source.SetStatus(NewLogSource("test", nil).Status())
+		}
+	}()
+
+	// reader: mimics (*Builder).toDictionary/getIntegrations reading the source concurrently.
+	for i := 0; i < 1000; i++ {
+		_ = source.GetTailingMode()
+		_ = source.Status()
+	}
+	close(stop)
+	wg.Wait()
 }

--- a/pkg/logs/sources/source_test.go
+++ b/pkg/logs/sources/source_test.go
@@ -68,7 +68,7 @@ func TestConcurrentTailingModeAndStatusAccess(t *testing.T) {
 		}
 	})
 
-	// reader: mimics (*Builder).toDictionary/getIntegrations reading the source concurrently.
+	// reader: mimics (*Builder).configToDictionary/getIntegrations reading the source concurrently.
 	for i := 0; i < 1000; i++ {
 		_ = source.GetTailingMode()
 		_ = source.Status()

--- a/pkg/logs/sources/source_test.go
+++ b/pkg/logs/sources/source_test.go
@@ -42,10 +42,8 @@ func TestTrackerSuite(t *testing.T) {
 	suite.Run(t, new(LogSourceSuite))
 }
 
-// TestConcurrentTailingModeAndStatusAccess guards against a regression of a data race where
-// the file launcher mutates a LogSource's Config.TailingMode and Status pointer from a
-// background goroutine while the status builder reads them concurrently to render `agent
-// status`. Both accesses must go through LogSource's lock. Run with `-race` to verify.
+// TestConcurrentTailingModeAndStatusAccess guards against a regression of the data race
+// between the file launcher mutating TailingMode/Status and the status builder reading them.
 func TestConcurrentTailingModeAndStatusAccess(t *testing.T) {
 	t.Parallel()
 	source := NewLogSource("test", &config.LogsConfig{TailingMode: "end"})

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -317,7 +317,7 @@ func (b *Builder) getIntegrations() []Integration {
 		for _, source := range logSources {
 			sources = append(sources, Source{
 				Type:          source.Config.Type,
-				Configuration: b.toDictionary(source.Config, source.GetTailingMode()),
+				Configuration: b.configToDictionary(source),
 				Status:        b.toString(source.Status()),
 				Inputs:        source.GetInputs(),
 				Messages:      source.Messages.GetMessages(),
@@ -378,9 +378,9 @@ func (b *Builder) toString(status *status.LogStatus) string {
 	return value
 }
 
-// toDictionary returns a representation of the configuration. tailingMode is passed in
-// separately since it's mutated concurrently and must be read through LogSource's lock.
-func (b *Builder) toDictionary(c *config.LogsConfig, tailingMode string) map[string]interface{} {
+// configToDictionary returns a representation of the source's configuration.
+func (b *Builder) configToDictionary(source *sourcesPkg.LogSource) map[string]interface{} {
+	c := source.Config
 	dictionary := make(map[string]interface{})
 	dictionary["Service"] = c.Service
 	dictionary["Source"] = c.Source
@@ -412,7 +412,7 @@ func (b *Builder) toDictionary(c *config.LogsConfig, tailingMode string) map[str
 		}
 	case config.FileType:
 		dictionary["Path"] = c.Path
-		dictionary["TailingMode"] = tailingMode
+		dictionary["TailingMode"] = source.GetTailingMode()
 		dictionary["Identifier"] = c.Identifier
 		if c.Format != "" {
 			dictionary["Format"] = c.Format

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -317,7 +317,7 @@ func (b *Builder) getIntegrations() []Integration {
 		for _, source := range logSources {
 			sources = append(sources, Source{
 				Type:          source.Config.Type,
-				Configuration: b.toDictionary(source.Config),
+				Configuration: b.toDictionary(source.Config, source.GetTailingMode()),
 				Status:        b.toString(source.Status()),
 				Inputs:        source.GetInputs(),
 				Messages:      source.Messages.GetMessages(),
@@ -378,8 +378,10 @@ func (b *Builder) toString(status *status.LogStatus) string {
 	return value
 }
 
-// toDictionary returns a representation of the configuration.
-func (b *Builder) toDictionary(c *config.LogsConfig) map[string]interface{} {
+// toDictionary returns a representation of the configuration. tailingMode is passed in
+// separately (rather than read from c.TailingMode) because it can be mutated concurrently
+// by the file launcher after the source is created, and must go through LogSource's lock.
+func (b *Builder) toDictionary(c *config.LogsConfig, tailingMode string) map[string]interface{} {
 	dictionary := make(map[string]interface{})
 	dictionary["Service"] = c.Service
 	dictionary["Source"] = c.Source
@@ -411,7 +413,7 @@ func (b *Builder) toDictionary(c *config.LogsConfig) map[string]interface{} {
 		}
 	case config.FileType:
 		dictionary["Path"] = c.Path
-		dictionary["TailingMode"] = c.TailingMode
+		dictionary["TailingMode"] = tailingMode
 		dictionary["Identifier"] = c.Identifier
 		if c.Format != "" {
 			dictionary["Format"] = c.Format

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -379,8 +379,7 @@ func (b *Builder) toString(status *status.LogStatus) string {
 }
 
 // toDictionary returns a representation of the configuration. tailingMode is passed in
-// separately (rather than read from c.TailingMode) because it can be mutated concurrently
-// by the file launcher after the source is created, and must go through LogSource's lock.
+// separately since it's mutated concurrently and must be read through LogSource's lock.
 func (b *Builder) toDictionary(c *config.LogsConfig, tailingMode string) map[string]interface{} {
 	dictionary := make(map[string]interface{})
 	dictionary["Service"] = c.Service


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Fixes a data race on `LogSource.Config.TailingMode` between `(*Launcher).launchTailers` (write) and the status builder's `toDictionary` (read), by routing both through `LogSource`'s existing lock via new `GetTailingMode`/`SetTailingMode` accessors.

### Motivation

Fix a race, found via a race-detector-enabled build in staging.

### Describe how you validated your changes

Added `TestConcurrentTailingModeAndStatusAccess` in `pkg/logs/sources/source_test.go`, which fails under `-race` without the fix and passes with it (`dda inv test --targets=./pkg/logs/sources/... --race`).
