### PR TITLE
fix: lock fixedSizeQueue to prevent race on shared SBOM negative cache

### DIFF
--- a/pkg/security/resolvers/sbom/file_querier.go
+++ b/pkg/security/resolvers/sbom/file_querier.go
@@ -11,6 +11,7 @@ package sbom
 import (
 	"slices"
 	"strings"
+	"sync"
 
 	sbomtypes "github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom/types"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
@@ -138,7 +139,10 @@ func (fq *fileQuerier) len() int {
 	return len(fq.files)
 }
 
+// fixedSizeQueue is shared across containers with the same image (see newData),
+// so it needs its own lock rather than relying on the caller's SBOM lock.
 type fixedSizeQueue[T comparable] struct {
+	mu      sync.Mutex
 	queue   []T
 	maxSize int
 }
@@ -148,6 +152,9 @@ func newFixedSizeQueue[T comparable](maxSize int) *fixedSizeQueue[T] {
 }
 
 func (q *fixedSizeQueue[T]) push(value T) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
 	if len(q.queue) == q.maxSize {
 		q.queue = q.queue[1:]
 	}
@@ -159,6 +166,9 @@ func (q *fixedSizeQueue[T]) contains(value T) bool {
 	if q == nil {
 		return false
 	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
 
 	return slices.Contains(q.queue, value)
 }

--- a/pkg/security/resolvers/sbom/file_querier_test.go
+++ b/pkg/security/resolvers/sbom/file_querier_test.go
@@ -70,24 +70,23 @@ func TestFixedSizeQueueConcurrentAccess(t *testing.T) {
 	const iterations = 200
 
 	var wg sync.WaitGroup
-	wg.Add(goroutines * 2)
 
 	for g := 0; g < goroutines; g++ {
-		go func(seed uint64) {
-			defer wg.Done()
+		seed := uint64(g)
+		wg.Go(func() {
 			for i := uint64(0); i < iterations; i++ {
 				q.push(seed*iterations + i)
 			}
-		}(uint64(g))
+		})
 	}
 
 	for g := 0; g < goroutines; g++ {
-		go func(seed uint64) {
-			defer wg.Done()
+		seed := uint64(g)
+		wg.Go(func() {
 			for i := uint64(0); i < iterations; i++ {
 				q.contains(seed*iterations + i)
 			}
-		}(uint64(g))
+		})
 	}
 
 	wg.Wait()

--- a/pkg/security/resolvers/sbom/file_querier_test.go
+++ b/pkg/security/resolvers/sbom/file_querier_test.go
@@ -8,6 +8,7 @@
 package sbom
 
 import (
+	"sync"
 	"testing"
 
 	sbomtypes "github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom/types"
@@ -57,5 +58,43 @@ func TestQueryFileUsrMerge(t *testing.T) {
 	plain := newFileQuerier(report, backing, false)
 	if pkg := plain.queryFile("/usr/bin/mount"); pkg != nil {
 		t.Errorf("queryFile(/usr/bin/mount) attributed to %q on a non-usr-merged layout, want no match", pkg.Name)
+	}
+}
+
+// TestFixedSizeQueueConcurrentAccess calls push/contains concurrently on a
+// shared fixedSizeQueue, as happens when containers share an image. Run with -race.
+func TestFixedSizeQueueConcurrentAccess(t *testing.T) {
+	q := newFixedSizeQueue[uint64](2)
+
+	const goroutines = 50
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	for g := 0; g < goroutines; g++ {
+		go func(seed uint64) {
+			defer wg.Done()
+			for i := uint64(0); i < iterations; i++ {
+				q.push(seed*iterations + i)
+			}
+		}(uint64(g))
+	}
+
+	for g := 0; g < goroutines; g++ {
+		go func(seed uint64) {
+			defer wg.Done()
+			for i := uint64(0); i < iterations; i++ {
+				q.contains(seed*iterations + i)
+			}
+		}(uint64(g))
+	}
+
+	wg.Wait()
+
+	// The queue must never grow past its configured bound, even under
+	// concurrent access.
+	if got := len(q.queue); got > 2 {
+		t.Errorf("queue length = %d, want at most 2", got)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Adds an internal mutex to `fixedSizeQueue` (`pkg/security/resolvers/sbom/file_querier.go`), used as `fileQuerier.lastNegativeCache`. This queue is cached and shared across containers running the same image, so it needs its own lock instead of relying on each container's separate `SBOM` lock.

### Motivation

Fix a race, found via a race-detector-enabled build in staging.

### Describe how you validated your changes

Added `TestFixedSizeQueueConcurrentAccess`; fails under `-race` before this fix, passes after.
