### PR TITLE
Fix `ddflareextension` TLS listener leak in shutdown and tests

### DIFF
--- a/comp/otelcol/ddflareextension/impl/BUILD.bazel
+++ b/comp/otelcol/ddflareextension/impl/BUILD.bazel
@@ -95,6 +95,5 @@ dd_agent_go_test(
         "@io_opentelemetry_go_collector_receiver_nopreceiver//:nopreceiver",
         "@io_opentelemetry_go_collector_receiver_otlpreceiver//:otlpreceiver",
         "@io_opentelemetry_go_collector_service//telemetry/otelconftelemetry",
-        "@org_uber_go_zap//:zap",
     ],
 )

--- a/comp/otelcol/ddflareextension/impl/configstore_test.go
+++ b/comp/otelcol/ddflareextension/impl/configstore_test.go
@@ -77,8 +77,11 @@ func TestGetConfDump(t *testing.T) {
 		factories:              &factories,
 		configProviderSettings: newConfigProviderSettings(uriFromFile("simple-dd/config.yaml"), false),
 	}
-	extension, err := NewComponent(context.TODO(), &config, componenttest.NewNopTelemetrySettings(), component.BuildInfo{}, option.None[ipc.Component](), true, false)
+	extension, err := NewComponent(t.Context(), &config, componenttest.NewNopTelemetrySettings(), component.BuildInfo{}, option.None[ipc.Component](), true, false)
 	assert.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, extension.Shutdown(t.Context()))
+	})
 
 	ext, ok := extension.(*ddExtension)
 	assert.True(t, ok)
@@ -125,14 +128,14 @@ func TestGetConfDump(t *testing.T) {
 	cp, err := otelcol.NewConfigProvider(newConfigProviderSettings(uriFromFile("simple-dd/config.yaml"), true))
 	assert.NoError(t, err)
 
-	c, err := cp.Get(context.Background(), factories)
+	c, err := cp.Get(t.Context(), factories)
 	assert.NoError(t, err)
 
 	conf := confmap.New()
 	err = conf.Marshal(c)
 	assert.NoError(t, err)
 
-	err = ext.NotifyConfig(context.TODO(), conf)
+	err = ext.NotifyConfig(t.Context(), conf)
 	assert.NoError(t, err)
 
 	t.Run("enhanced-string", func(t *testing.T) {
@@ -168,7 +171,7 @@ func TestGetConfDump(t *testing.T) {
 func confmapFromResolverSettings(t *testing.T, resolverSettings confmap.ResolverSettings) *confmap.Conf {
 	resolver, err := confmap.NewResolver(resolverSettings)
 	assert.NoError(t, err)
-	conf, err := resolver.Resolve(context.TODO())
+	conf, err := resolver.Resolve(t.Context())
 	assert.NoError(t, err)
 	return conf
 }

--- a/comp/otelcol/ddflareextension/impl/envconfmap_test.go
+++ b/comp/otelcol/ddflareextension/impl/envconfmap_test.go
@@ -6,7 +6,6 @@
 package ddflareextensionimpl
 
 import (
-	"context"
 	"os"
 	"path"
 	"strings"
@@ -84,7 +83,6 @@ func newEnvConfMapFromYAML(t *testing.T, yamlStr string) *envConfMap {
 	err := os.WriteFile(path, []byte(yamlStr), 0644)
 	require.NoError(t, err)
 
-	ctx := context.Background()
 	configProviderSettings := otelcol.ConfigProviderSettings{
 		ResolverSettings: confmap.ResolverSettings{
 			URIs: []string{path},
@@ -97,7 +95,7 @@ func newEnvConfMapFromYAML(t *testing.T, yamlStr string) *envConfMap {
 		},
 	}
 
-	envConfMap, err := newEnvConfMap(ctx, configProviderSettings)
+	envConfMap, err := newEnvConfMap(t.Context(), configProviderSettings)
 	require.NoError(t, err)
 	return envConfMap
 }

--- a/comp/otelcol/ddflareextension/impl/extension_test.go
+++ b/comp/otelcol/ddflareextension/impl/extension_test.go
@@ -9,7 +9,6 @@
 package ddflareextensionimpl
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -45,8 +44,6 @@ import (
 	"go.opentelemetry.io/collector/receiver/nopreceiver"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
 	"go.opentelemetry.io/collector/service/telemetry/otelconftelemetry"
-
-	"go.uber.org/zap"
 )
 
 func getExtensionTestConfig(t *testing.T) *Config {
@@ -65,12 +62,17 @@ func getExtensionTestConfig(t *testing.T) *Config {
 }
 
 func getTestExtension(t *testing.T, optIpc option.Option[ipc.Component]) (ddflareextension.Component, error) {
-	c := context.Background()
-	telemetry := component.TelemetrySettings{}
+	telemetry := componenttest.NewNopTelemetrySettings()
 	info := component.NewDefaultBuildInfo()
 	cfg := getExtensionTestConfig(t)
 
-	return NewComponent(c, cfg, telemetry, info, optIpc, true, false)
+	ext, err := NewComponent(t.Context(), cfg, telemetry, info, optIpc, true, false)
+	if err == nil {
+		t.Cleanup(func() {
+			require.NoError(t, ext.Shutdown(t.Context()))
+		})
+	}
+	return ext, err
 }
 
 func getResponseToHandlerRequest(t *testing.T, ipc ipc.Component, tokenOverride string) *httptest.ResponseRecorder {
@@ -96,7 +98,6 @@ func getResponseToHandlerRequest(t *testing.T, ipc ipc.Component, tokenOverride 
 	require.NoError(t, err)
 
 	ddExt := ext.(*ddExtension)
-	ddExt.telemetry.Logger = zap.New(zap.NewNop().Core())
 
 	host := newHostWithExtensions(
 		map[component.ID]component.Component{
@@ -104,10 +105,10 @@ func getResponseToHandlerRequest(t *testing.T, ipc ipc.Component, tokenOverride 
 		},
 	)
 
-	ddExt.Start(context.TODO(), host)
+	ddExt.Start(t.Context(), host)
 
 	conf := confmapFromResolverSettings(t, newResolverSettings(uriFromFile("config.yaml"), true))
-	ddExt.NotifyConfig(context.TODO(), conf)
+	ddExt.NotifyConfig(t.Context(), conf)
 	assert.NoError(t, err)
 
 	handler := ddExt.server.srv.Handler

--- a/comp/otelcol/ddflareextension/impl/factory_test.go
+++ b/comp/otelcol/ddflareextension/impl/factory_test.go
@@ -9,11 +9,11 @@
 package ddflareextensionimpl
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/extension"
 
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
@@ -35,9 +35,13 @@ func TestNewFactoryForAgent(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	require.NotNil(t, cfg)
 
-	ext, err := factory.Create(context.Background(), extension.Settings{}, cfg)
+	settings := extension.Settings{TelemetrySettings: componenttest.NewNopTelemetrySettings()}
+	ext, err := factory.Create(t.Context(), settings, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, ext)
+	t.Cleanup(func() {
+		require.NoError(t, ext.Shutdown(t.Context()))
+	})
 
 	_, ok := ext.(*ddExtension)
 	assert.True(t, ok)

--- a/comp/otelcol/ddflareextension/impl/server.go
+++ b/comp/otelcol/ddflareextension/impl/server.go
@@ -11,6 +11,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -68,7 +69,14 @@ func (s *server) start() error {
 }
 
 func (s *server) shutdown(ctx context.Context) error {
-	return s.srv.Shutdown(ctx)
+	if err := s.srv.Shutdown(ctx); err != nil {
+		return err
+	}
+	// close `tlsListener` in case the server was never started.
+	if err := s.listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+		return err
+	}
+	return nil
 }
 
 func generateSelfSignedCert() (tls.Config, error) {


### PR DESCRIPTION
### What does this PR do?
`server.shutdown()` now also closes its listener directly, to cover the case where `Start()` was never called.

All tests in this package that construct the extension now call `Shutdown()` via `t.Cleanup`, instead of leaking it.

### Motivation
tl;dr: address a resource leak found by running tests locally with parallel `bazel test`s.

`TestNewFactoryForAgent` creates the extension via `factory.CreateDefaultConfig()`, which binds the extension's real production default port (7777), and never releases it.

`net.Listen` happens eagerly in `newServer()`, called from `NewComponent()` at construction time, not from `Start()`. Running the test twice in the same process reproduces this directly:
```
--- FAIL: TestNewFactoryForAgent
    factory_test.go:39: 
                Error Trace:    comp/otelcol/ddflareextension/impl/factory_test.go:39
                Error:          Received unexpected error:
                                listen tcp 127.0.0.1:7777: bind: address already in use
                Test:           TestNewFactoryForAgent
```
The other tests constructing this component (`TestNewComponent`, `TestExtensionHTTPHandler*`, `TestGetConfDump`) have the identical leak, but never surface it: they bind `"localhost:0"`, an OS-assigned _ephemeral_ port, so a leaked listener from a previous run can never collide with anything.

Fixing the tests alone isn't enough: `server.shutdown()` only called `http.Server.Shutdown()`, which only closes listeners it is tracking, and it only tracks a listener once `Serve()` has run on it.

`Start()` is what calls `Serve()`, and it is a separate step from construction, so `Shutdown()` on an extension that was created but never started did not release its listener either: calling `Shutdown()` without `Start()` still reproduces the same bind error before this fix.

### Describe how you validated your changes
Minimal repro (fails on `main`, passes with this fix):
```
dda inv test --targets=./comp/otelcol/ddflareextension/impl/... \
  --test-run-name=TestNewFactoryForAgent --extra-args="-count=2" \
  --build-exclude=python
```
:bulb: With `bazel`:
```
bazel test //comp/otelcol/ddflareextension/impl:impl_test \
  --test_arg=-test.run=TestNewFactoryForAgent --test_arg=-test.count=2
```

### Additional Notes
Also replaced the leftover `context.TODO()` calls in these test files with `t.Context()`, including inside `t.Cleanup`, since it is the safer default: it is canceled automatically on failure, timeout, or panic, unlike `context.Background()`, which never expires.
None of these tests open a real connection to the listener though, so `Shutdown()`'s idle-connection check never actually needs to consult it either way.