### PR TITLE
fix(macos): Update system-probe test failing on macos install script- #54602

### DIFF
--- a/cmd/system-probe/common/BUILD.bazel
+++ b/cmd/system-probe/common/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "common",
     srcs = [
         "common.go",
+        "common_darwin.go",
         "common_nix.go",
         "common_unsupported.go",
         "common_windows.go",
@@ -14,6 +15,12 @@ go_library(
         "//pkg/system-probe/utils",
     ] + select({
         "@rules_go//go/platform:android": [
+            "//pkg/util/defaultpaths",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "//pkg/util/defaultpaths",
+        ],
+        "@rules_go//go/platform:ios": [
             "//pkg/util/defaultpaths",
         ],
         "@rules_go//go/platform:linux": [

--- a/cmd/system-probe/common/common_darwin.go
+++ b/cmd/system-probe/common/common_darwin.go
@@ -3,12 +3,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux && !windows && !darwin
-
 package common
 
+import "github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
+
 // DefaultLogFile returns the default path to the system-probe log file
-// (empty on unsupported platforms)
 func DefaultLogFile() string {
-	return ""
+	return defaultpaths.GetDefaultSystemProbeLogFile()
 }


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
This PR resolves system-probe default log file for darwin,  which addresses the issue documented in PR #54586. It's also a cleaner version of test PR #54602.

### Motivation
We have noticed frequent new-e2e-agent-platform-install-script-macos-x64 failure (PR #54586).

### Describe how you validated your changes
Validation via manually triggered new-e2e-agent-platform-install-script-macos-x64 over CI pipeline.

### Additional Notes
