### PR TITLE
refactor(privateactionrunner): rename com.datadoghq.remoteaction.agent bundle to datadogagent

### DIFF
--- a/pkg/config/setup/BUILD.bazel
+++ b/pkg/config/setup/BUILD.bazel
@@ -32,7 +32,6 @@ run_binary(
 go_library(
     name = "setup",
     srcs = [
-        "all_settings.go",
         "config.go",
         "config_accessor.go",
         "config_darwin.go",
@@ -43,12 +42,10 @@ go_library(
         "config_windows.go",
         "constants_compat.go",
         "fixup_init.go",
-        "generated.go",
         "otlp.go",
         "privateactionrunner.go",
         "process.go",
         "system_probe.go",
-        "system_probe_settings.go",
         "test_config_accessor.go",
         "test_helpers.go",
         "unexpectedunicodefinder.go",

--- a/pkg/config/setup/BUILD.bazel
+++ b/pkg/config/setup/BUILD.bazel
@@ -32,6 +32,7 @@ run_binary(
 go_library(
     name = "setup",
     srcs = [
+        "all_settings.go",
         "config.go",
         "config_accessor.go",
         "config_darwin.go",
@@ -42,10 +43,12 @@ go_library(
         "config_windows.go",
         "constants_compat.go",
         "fixup_init.go",
+        "generated.go",
         "otlp.go",
         "privateactionrunner.go",
         "process.go",
         "system_probe.go",
+        "system_probe_settings.go",
         "test_config_accessor.go",
         "test_helpers.go",
         "unexpectedunicodefinder.go",

--- a/pkg/privateactionrunner/bundles/BUILD.bazel
+++ b/pkg/privateactionrunner/bundles/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "bundles",
-    srcs = ["registry.go"],
+    srcs = [
+        "registry.go",
+        "registry_kubeapiserver.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/privateactionrunner/bundles/BUILD.bazel
+++ b/pkg/privateactionrunner/bundles/BUILD.bazel
@@ -2,10 +2,7 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "bundles",
-    srcs = [
-        "registry.go",
-        "registry_kubeapiserver.go",
-    ],
+    srcs = ["registry.go"],
     importpath = "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles",
     visibility = ["//visibility:public"],
     deps = [
@@ -45,7 +42,7 @@ go_library(
         "//pkg/privateactionrunner/bundles/kubernetes/discovery",
         "//pkg/privateactionrunner/bundles/mongodb",
         "//pkg/privateactionrunner/bundles/remoteaction",
-        "//pkg/privateactionrunner/bundles/remoteaction/agent",
+        "//pkg/privateactionrunner/bundles/remoteaction/datadogagent",
         "//pkg/privateactionrunner/bundles/remoteaction/internalactions",
         "//pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement",
         "//pkg/privateactionrunner/bundles/remoteaction/networks",

--- a/pkg/privateactionrunner/bundles/registry.go
+++ b/pkg/privateactionrunner/bundles/registry.go
@@ -44,7 +44,7 @@ import (
 	com_datadoghq_kubernetes_discovery "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/kubernetes/discovery"
 	com_datadoghq_mongodb "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/mongodb"
 	com_datadoghq_remoteaction "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/remoteaction"
-	com_datadoghq_remoteaction_agent "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/remoteaction/agent"
+	com_datadoghq_remoteaction_datadogagent "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/remoteaction/datadogagent"
 	com_datadoghq_remoteaction_internal "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/remoteaction/internalactions"
 	com_datadoghq_remoteaction_networkconfigmanagement "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement"
 	com_datadoghq_remoteaction_networks "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/remoteaction/networks"
@@ -93,7 +93,7 @@ func NewRegistry(configuration *config.Config, traceroute traceroute.Component, 
 			"com.datadoghq.kubernetes.discovery":                 com_datadoghq_kubernetes_discovery.NewKubernetesDiscovery(),
 			"com.datadoghq.mongodb":                              com_datadoghq_mongodb.NewMongoDB(),
 			"com.datadoghq.remoteaction":                         com_datadoghq_remoteaction.NewRemoteAction(configuration),
-			"com.datadoghq.remoteaction.agent":                   com_datadoghq_remoteaction_agent.NewAgent(ipcClient),
+			"com.datadoghq.remoteaction.datadogagent":            com_datadoghq_remoteaction_datadogagent.NewAgent(ipcClient),
 			"com.datadoghq.remoteaction.internal":                com_datadoghq_remoteaction_internal.NewInternal(encryptionStore),
 			"com.datadoghq.remoteaction.networks":                com_datadoghq_remoteaction_networks.NewNetworks(traceroute, eventPlatform),
 			"com.datadoghq.remoteaction.networkconfigmanagement": com_datadoghq_remoteaction_networkconfigmanagement.NewNetworkConfigManagement(ipcClient),

--- a/pkg/privateactionrunner/bundles/remoteaction/datadogagent/BUILD.bazel
+++ b/pkg/privateactionrunner/bundles/remoteaction/datadogagent/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "agent",
+    name = "datadogagent",
     srcs = [
         "agentapi.go",
         "config.go",
@@ -10,7 +10,7 @@ go_library(
         "flare.go",
         "status.go",
     ],
-    importpath = "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/remoteaction/agent",
+    importpath = "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/remoteaction/datadogagent",
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/diagnose/def",

--- a/pkg/privateactionrunner/bundles/remoteaction/datadogagent/agentapi.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/datadogagent/agentapi.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
-// Package com_datadoghq_remoteaction_agent provides Private Action Runner actions that
+// Package com_datadoghq_remoteaction_datadogagent provides Private Action Runner actions that
 // operate on the local datadog-agent through its authenticated IPC HTTP API.
 //
 // The actions in this bundle run inside the Private Action Runner process,
@@ -15,7 +15,7 @@
 // Because targeting is local-only, this bundle must not be registered in the
 // Cluster Agent's bundle registry (registry_kubeapiserver.go): there, "local"
 // resolves to the Cluster Agent itself, not a specific node's core agent.
-package com_datadoghq_remoteaction_agent
+package com_datadoghq_remoteaction_datadogagent
 
 import (
 	"encoding/json"
@@ -35,7 +35,7 @@ import (
 // IPC command API, e.g. "https://127.0.0.1:5001".
 func agentBaseURL() (string, error) {
 	if flavor.GetFlavor() == flavor.ClusterAgent {
-		return "", errors.New("com.datadoghq.remoteaction.agent must not run in the Cluster Agent: " +
+		return "", errors.New("com.datadoghq.remoteaction.datadogagent must not run in the Cluster Agent: " +
 			"it targets the local agent via pkgconfigsetup.GetIPCAddress, which would resolve to the " +
 			"Cluster Agent itself rather than a node's core agent")
 	}

--- a/pkg/privateactionrunner/bundles/remoteaction/datadogagent/config.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/datadogagent/config.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
-package com_datadoghq_remoteaction_agent
+package com_datadoghq_remoteaction_datadogagent
 
 import (
 	"context"

--- a/pkg/privateactionrunner/bundles/remoteaction/datadogagent/diagnose.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/datadogagent/diagnose.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
-package com_datadoghq_remoteaction_agent
+package com_datadoghq_remoteaction_datadogagent
 
 import (
 	"bytes"

--- a/pkg/privateactionrunner/bundles/remoteaction/datadogagent/entrypoint.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/datadogagent/entrypoint.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
-package com_datadoghq_remoteaction_agent
+package com_datadoghq_remoteaction_datadogagent
 
 import (
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"

--- a/pkg/privateactionrunner/bundles/remoteaction/datadogagent/flare.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/datadogagent/flare.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
-package com_datadoghq_remoteaction_agent
+package com_datadoghq_remoteaction_datadogagent
 
 import (
 	"context"

--- a/pkg/privateactionrunner/bundles/remoteaction/datadogagent/status.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/datadogagent/status.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
-package com_datadoghq_remoteaction_agent
+package com_datadoghq_remoteaction_datadogagent
 
 import (
 	"context"

--- a/releasenotes/notes/rename-remoteaction-agent-par-bundle-f548b40a9a84dfbc.yaml
+++ b/releasenotes/notes/rename-remoteaction-agent-par-bundle-f548b40a9a84dfbc.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    The ``com.datadoghq.remoteaction.agent`` Private Action Runner bundle
+    (Preview) has been renamed to ``com.datadoghq.remoteaction.datadogagent``.


### PR DESCRIPTION
### What does this PR do?

Renames the `com.datadoghq.remoteaction.agent` Private Action Runner bundle package to `com.datadoghq.remoteaction.datadogagent`: directory, Go package name, `registry.go` import/key, and BUILD.bazel targets.

### Motivation

Jules Macret flagged during review of ddoghq/dd-source#22261 that `agent` is ambiguous inside the `remoteaction` namespace. The team settled on `datadogagent` as the replacement segment.

Companion PR in dd-source renames the matching bundle manifest/generated code: ddoghq/dd-source#49245.

### Describe how you validated your changes

- `bzl run //:gazelle -- ./pkg/privateactionrunner/bundles`
- `bzl build //pkg/privateactionrunner/bundles/...` passes
- `bzl test //pkg/privateactionrunner/bundles/...` passes (no test regressions)
- Manual diff review + Codex review (`codex exec review --base origin/main`): flagged an unrelated `go-mod-tidy`-hook side effect that duplicated generated sources in `pkg/config/setup/BUILD.bazel` (P1, would have broken that target's build); reverted before this PR was opened.

### Additional Notes

Bundle is still `stability: dev` / Preview, so this rename has no external compatibility impact. The deferred `getRemoteConfigState` branch (#53755) has also been updated to match.