### PR TITLE
Add BUILD file for pkg/network/protocols/http/gotls/lookup/internal

### DIFF
--- a/pkg/network/protocols/http/gotls/lookup/internal/BUILD.bazel
+++ b/pkg/network/protocols/http/gotls/lookup/internal/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_binary(
+    name = "generate_luts",
+    embed = [":internal_lib"],
+    tags = ["manual"],
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:private"],
+)
+
+go_library(
+    name = "internal_lib",
+    srcs = ["generate_luts.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/network/protocols/http/gotls/lookup/internal",
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:private"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "//pkg/network/go/bininspect",
+            "//pkg/network/go/goversion",
+            "//pkg/network/go/lutgen",
+            "//pkg/util/safeelf",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//pkg/network/go/bininspect",
+            "//pkg/network/go/goversion",
+            "//pkg/network/go/lutgen",
+            "//pkg/util/safeelf",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/pkg/network/protocols/http/gotls/lookup/internal/generate_luts.go
+++ b/pkg/network/protocols/http/gotls/lookup/internal/generate_luts.go
@@ -5,6 +5,7 @@
 
 //go:build linux
 
+// Package main for luts generator.
 package main
 
 import (

--- a/pkg/network/protocols/http/gotls/lookup/internal/generate_luts.go
+++ b/pkg/network/protocols/http/gotls/lookup/internal/generate_luts.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
-//go:build ignore
+//go:build linux
 
 package main
 


### PR DESCRIPTION
### What does this PR do?

Add BUILD file for pkg/network/protocols/http/gotls/lookup/internal. Remove the `go:build nobuild` tag preventing this from being seen by gazelle.

### Motivation
Cleaning up.

### Describe how you validated your changes
```
bazel build //pkg/network/protocols/http/gotls/lookup/internal:generate_luts
```
