### PR TITLE
tagger: refuse reserved tag names from workload-controlled metadata

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -254,7 +254,7 @@ func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*types.
 
 	// extract env as tags
 	for envName, envValue := range container.EnvVars {
-		k8smetadata.AddMetadataAsTags(envName, envValue, c.containerEnvAsTags, c.globContainerEnvLabels, tagList)
+		k8smetadata.AddWorkloadMetadataAsTags(envName, envValue, c.containerEnvAsTags, c.globContainerEnvLabels, tagList)
 	}
 
 	// static tags for ECS and EKS Fargate containers
@@ -314,8 +314,9 @@ func (c *WorkloadMetaCollector) handleProcess(ev workloadmeta.Event) []*types.Ta
 				}
 
 				// Add as low cardinality tag since these are application-level
-				// metadata
-				tagList.AddLow(key, value)
+				// metadata. The tracer names them, so they go through the
+				// denylist.
+				tagList.AddLowFromWorkload(key, value)
 			}
 		}
 	}
@@ -407,7 +408,7 @@ func (c *WorkloadMetaCollector) labelsToTags(labels map[string]string, tags *tag
 
 	// container labels as tags
 	for labelName, labelValue := range labels {
-		k8smetadata.AddMetadataAsTags(labelName, labelValue, c.containerLabelsAsTags, c.globContainerLabels, tags)
+		k8smetadata.AddWorkloadMetadataAsTags(labelName, labelValue, c.containerLabelsAsTags, c.globContainerLabels, tags)
 	}
 
 	// orchestrator tags from labels
@@ -435,12 +436,12 @@ func (c *WorkloadMetaCollector) extractTagsFromPodEntity(pod *workloadmeta.Kuber
 
 	// pod labels as tags
 	for name, value := range pod.Labels {
-		k8smetadata.AddMetadataAsTags(name, value, c.k8sResourcesLabelsAsTags["pods"], c.globK8sResourcesLabels["pods"], tagList)
+		k8smetadata.AddWorkloadMetadataAsTags(name, value, c.k8sResourcesLabelsAsTags["pods"], c.globK8sResourcesLabels["pods"], tagList)
 	}
 
 	// pod annotations as tags
 	for name, value := range pod.Annotations {
-		k8smetadata.AddMetadataAsTags(name, value, c.k8sResourcesAnnotationsAsTags["pods"], c.globK8sResourcesAnnotations["pods"], tagList)
+		k8smetadata.AddWorkloadMetadataAsTags(name, value, c.k8sResourcesAnnotationsAsTags["pods"], c.globK8sResourcesAnnotations["pods"], tagList)
 	}
 
 	// namespace labels as tags
@@ -1004,7 +1005,7 @@ func (c *WorkloadMetaCollector) extractTagsFromPodLabels(pod *workloadmeta.Kuber
 			tagList.AddLow(tags.KubeAppManagedBy, value)
 		}
 
-		k8smetadata.AddMetadataAsTags(name, value, c.k8sResourcesLabelsAsTags["pods"], c.globK8sResourcesLabels["pods"], tagList)
+		k8smetadata.AddWorkloadMetadataAsTags(name, value, c.k8sResourcesLabelsAsTags["pods"], c.globK8sResourcesLabels["pods"], tagList)
 	}
 }
 
@@ -1482,19 +1483,21 @@ func parseJSONValue(value string, tags *taglist.TagList) error {
 		return fmt.Errorf("failed to unmarshal JSON: %s", err)
 	}
 
+	// The tag names come from an annotation or a label set on the workload
+	// itself, so they go through the denylist.
 	for key, value := range result {
 		switch v := value.(type) {
 		case string:
-			tags.AddAuto(key, v)
+			tags.AddAutoFromWorkload(key, v)
 		case float64:
-			tags.AddAuto(key, fmt.Sprint(v))
+			tags.AddAutoFromWorkload(key, fmt.Sprint(v))
 		case int64:
-			tags.AddAuto(key, strconv.FormatInt(v, 10))
+			tags.AddAutoFromWorkload(key, strconv.FormatInt(v, 10))
 		case bool:
-			tags.AddAuto(key, strconv.FormatBool(v))
+			tags.AddAutoFromWorkload(key, strconv.FormatBool(v))
 		case []interface{}:
 			for _, tag := range v {
-				tags.AddAuto(key, fmt.Sprint(tag))
+				tags.AddAutoFromWorkload(key, fmt.Sprint(tag))
 			}
 		default:
 			log.Debugf("Tag value %s is not valid, must be a string, int, float, bool or an array, skipping", v)
@@ -1538,6 +1541,6 @@ func parseContainerADTagsLabels(tags *taglist.TagList, labelValue string) {
 			log.Debugf("Tag '%s' is not in k:v format", tag)
 			continue
 		}
-		tags.AddHigh(tagParts[0], tagParts[1])
+		tags.AddHighFromWorkload(tagParts[0], tagParts[1])
 	}
 }

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -975,7 +975,7 @@ func TestHandleKubePod(t *testing.T) {
 					},
 					LowCardTags: []string{
 						"kube_namespace:" + podNamespace,
-						"pod_name:" + podName,
+						// no pod_name: it is in the default workload_tags_denylist
 						"pod_namespace:" + podNamespace,
 						"static:value",
 					},
@@ -1091,6 +1091,92 @@ func TestHandleKubePod(t *testing.T) {
 			actual := collector.handleKubePod(workloadmeta.Event{
 				Type:   workloadmeta.EventTypeSet,
 				Entity: &tt.pod,
+			})
+
+			assertTagInfoListEqual(t, tt.expected, actual)
+		})
+	}
+}
+
+// TestHandleKubePodDeniedAnnotationTags checks that a pod cannot forge the tags
+// listed in workload_tags_denylist through the ad.datadoghq.com/tags annotation.
+func TestHandleKubePodDeniedAnnotationTags(t *testing.T) {
+	podEntityID := workloadmeta.EntityID{
+		Kind: workloadmeta.KindKubernetesPod,
+		ID:   "foobar",
+	}
+
+	pod := workloadmeta.KubernetesPod{
+		EntityID: podEntityID,
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:      "datadog-agent-foobar",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"ad.datadoghq.com/tags": `{"host":"victim-host","pod_name":"victim-pod","+pod_name":"victim-pod","team":"attacker"}`,
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		denylist []string
+		expected []*types.TagInfo
+	}{
+		{
+			name: "default denylist",
+			expected: []*types.TagInfo{
+				{
+					Source:               podSource,
+					EntityID:             types.NewEntityID(types.KubernetesPodUID, podEntityID.ID),
+					HighCardTags:         []string{},
+					OrchestratorCardTags: []string{"pod_name:datadog-agent-foobar"},
+					LowCardTags: []string{
+						"kube_namespace:default",
+						"team:attacker",
+					},
+					StandardTags: []string{},
+				},
+			},
+		},
+		{
+			name:     "denylist disabled",
+			denylist: []string{},
+			expected: []*types.TagInfo{
+				{
+					Source:               podSource,
+					EntityID:             types.NewEntityID(types.KubernetesPodUID, podEntityID.ID),
+					HighCardTags:         []string{"pod_name:victim-pod"},
+					OrchestratorCardTags: []string{"pod_name:datadog-agent-foobar"},
+					LowCardTags: []string{
+						"kube_namespace:default",
+						"host:victim-host",
+						"pod_name:victim-pod",
+						"team:attacker",
+					},
+					StandardTags: []string{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+				fx.Provide(func() log.Component { return logmock.New(t) }),
+				fx.Provide(func() config.Component { return config.NewMock(t) }),
+				fx.Supply(context.Background()),
+				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+			))
+
+			cfg := configmock.New(t)
+			if tt.denylist != nil {
+				cfg.SetInTest("workload_tags_denylist", tt.denylist)
+			}
+			collector := NewWorkloadMetaCollector(context.Background(), cfg, store, nil)
+
+			actual := collector.handleKubePod(workloadmeta.Event{
+				Type:   workloadmeta.EventTypeSet,
+				Entity: &pod,
 			})
 
 			assertTagInfoListEqual(t, tt.expected, actual)
@@ -3176,6 +3262,33 @@ func TestHandleContainer(t *testing.T) {
 						"owner_team:container-integrations",
 					},
 					StandardTags: []string{},
+				},
+			},
+		},
+		{
+			name: "denied tags from labels",
+			container: workloadmeta.Container{
+				EntityID: entityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: containerName,
+					Labels: map[string]string{
+						// custom tags from label
+						"com.datadoghq.ad.tags": `["host:victim-host","pod_name:victim-pod","app_name:datadog-agent"]`,
+					},
+				},
+			},
+			expected: []*types.TagInfo{
+				{
+					Source:   containerSource,
+					EntityID: taggerEntityID,
+					HighCardTags: []string{
+						"container_name:" + containerName,
+						"container_id:" + entityID.ID,
+						"app_name:datadog-agent",
+					},
+					OrchestratorCardTags: []string{},
+					LowCardTags:          []string{},
+					StandardTags:         []string{},
 				},
 			},
 		},

--- a/comp/core/tagger/k8s_metadata/k8s_metadata.go
+++ b/comp/core/tagger/k8s_metadata/k8s_metadata.go
@@ -38,8 +38,22 @@ func InitMetadataAsTags(metadataAsTags map[string]string) (map[string]string, ma
 	return metadataAsTags, globMap
 }
 
-// AddMetadataAsTags converts name and value into tags based on the metadata as tags configuration and patterns
+// AddMetadataAsTags converts name and value into tags based on the metadata as tags configuration and patterns.
+// Use it for metadata the cluster administrator controls, such as node or namespace labels.
 func AddMetadataAsTags(name, value string, metadataAsTags map[string]string, glob map[string]glob.Glob, tags *taglist.TagList) {
+	addMetadataAsTags(name, value, metadataAsTags, glob, tags, false)
+}
+
+// AddWorkloadMetadataAsTags is AddMetadataAsTags for metadata the workload itself controls, such as
+// pod labels and annotations or container labels and environment variables. A tag whose name is
+// derived from the metadata name through a %%label%%, %%annotation%% or %%env%% template is dropped
+// when that name is denied, so that a workload cannot name its own tags after the reserved ones.
+// Tag names the administrator hardcoded in the mapping are kept as-is.
+func AddWorkloadMetadataAsTags(name, value string, metadataAsTags map[string]string, glob map[string]glob.Glob, tags *taglist.TagList) {
+	addMetadataAsTags(name, value, metadataAsTags, glob, tags, true)
+}
+
+func addMetadataAsTags(name, value string, metadataAsTags map[string]string, glob map[string]glob.Glob, tags *taglist.TagList, fromWorkload bool) {
 	for pattern, tmplStr := range metadataAsTags {
 		n := strings.ToLower(name)
 		if g, ok := glob[pattern]; ok {
@@ -51,7 +65,12 @@ func AddMetadataAsTags(name, value string, metadataAsTags map[string]string, glo
 		}
 		tagTmplList := splitTags(tmplStr)
 		for _, tmpl := range tagTmplList {
-			tags.AddAuto(resolveTag(tmpl, name), value)
+			tagName, fromMetadata := resolveTag(tmpl, name)
+			if fromWorkload && fromMetadata {
+				tags.AddAutoFromWorkload(tagName, value)
+				continue
+			}
+			tags.AddAuto(tagName, value)
 		}
 	}
 }
@@ -71,16 +90,20 @@ var templateVariables = map[string]struct{}{
 	"env":        {},
 }
 
-// resolveTag replaces %%label%%, %%annotation%% and %%env%% by their values
-func resolveTag(tmpl, label string) string {
+// resolveTag replaces %%label%%, %%annotation%% and %%env%% by their values.
+// It also reports whether the resulting tag name embeds the metadata name,
+// meaning the workload has a say in how the tag is named.
+func resolveTag(tmpl, label string) (string, bool) {
 	vars := tmplvar.ParseString(tmpl)
 	tagName := tmpl
+	fromMetadata := false
 	for _, v := range vars {
 		if _, ok := templateVariables[string(v.Name)]; ok {
 			tagName = strings.ReplaceAll(tagName, string(v.Raw), label)
+			fromMetadata = true
 			continue
 		}
 		tagName = strings.ReplaceAll(tagName, string(v.Raw), "")
 	}
-	return tagName
+	return tagName, fromMetadata
 }

--- a/comp/core/tagger/k8s_metadata/k8s_metadata_test.go
+++ b/comp/core/tagger/k8s_metadata/k8s_metadata_test.go
@@ -132,6 +132,60 @@ func TestMetadataAsTags(t *testing.T) {
 	}
 }
 
+func TestWorkloadMetadataAsTags(t *testing.T) {
+	tests := []struct {
+		name           string
+		k              string
+		v              string
+		metadataAsTags map[string]string
+		want           []string
+	}{
+		{
+			// the workload names the tag through the template, so the denylist applies
+			name:           "denied tpl var",
+			k:              "pod_name",
+			v:              "forged",
+			metadataAsTags: map[string]string{"*": "%%label%%"},
+			want:           []string{},
+		},
+		{
+			// the administrator names the tag, so it is kept as-is
+			name:           "denied name hardcoded in the mapping",
+			k:              "foo",
+			v:              "bar",
+			metadataAsTags: map[string]string{"foo": "pod_name"},
+			want:           []string{"pod_name:bar"},
+		},
+		{
+			name:           "allowed tpl var",
+			k:              "team",
+			v:              "backend",
+			metadataAsTags: map[string]string{"*": "%%label%%"},
+			want:           []string{"team:backend"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tagList := taglist.NewTagList()
+			m, g := InitMetadataAsTags(tt.metadataAsTags)
+			AddWorkloadMetadataAsTags(tt.k, tt.v, m, g, tagList)
+			tags, _, _, _ := tagList.Compute()
+			assert.ElementsMatch(t, tt.want, tags)
+		})
+	}
+}
+
+// TestMetadataAsTagsIgnoresDenylist checks that administrator-controlled
+// metadata, such as node or namespace labels, is not filtered.
+func TestMetadataAsTagsIgnoresDenylist(t *testing.T) {
+	tagList := taglist.NewTagList()
+	m, g := InitMetadataAsTags(map[string]string{"*": "%%label%%"})
+	AddMetadataAsTags("host", "node-1", m, g, tagList)
+
+	tags, _, _, _ := tagList.Compute()
+	assert.ElementsMatch(t, []string{"host:node-1"}, tags)
+}
+
 func TestResolveTag(t *testing.T) {
 	testCases := []struct {
 		tmpl, label, expected string
@@ -164,7 +218,7 @@ func TestResolveTag(t *testing.T) {
 
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
-			tagName := resolveTag(testCase.tmpl, testCase.label)
+			tagName, _ := resolveTag(testCase.tmpl, testCase.label)
 			assert.Equal(t, testCase.expected, tagName)
 		})
 	}

--- a/comp/core/tagger/taglist/BUILD.bazel
+++ b/comp/core/tagger/taglist/BUILD.bazel
@@ -6,12 +6,18 @@ go_library(
     srcs = ["taglist.go"],
     importpath = "github.com/DataDog/datadog-agent/comp/core/tagger/taglist",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/config/setup"],
+    deps = [
+        "//pkg/config/setup",
+        "//pkg/util/log",
+    ],
 )
 
 dd_agent_go_test(
     name = "taglist_test",
     srcs = ["taglist_test.go"],
     embed = [":taglist"],
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "//pkg/config/mock",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/comp/core/tagger/taglist/taglist.go
+++ b/comp/core/tagger/taglist/taglist.go
@@ -8,11 +8,18 @@ package taglist
 
 import (
 	"maps"
+	"slices"
 	"strings"
+	"sync/atomic"
 	"unique"
 
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+// denylistSetting lists the tag names that must never be built out of
+// workload-controlled metadata.
+const denylistSetting = "workload_tags_denylist"
 
 // TagList allows collector to incremental build a tag list
 // then export it easily to []string format
@@ -22,6 +29,10 @@ type TagList struct {
 	highCardTags         map[string]bool
 	standardTags         map[string]bool
 	splitList            map[string]string
+	// denylist is a read-only set of tag names refused from workload-controlled
+	// metadata, shared between tag lists. Only the Add*FromWorkload methods
+	// honor it: the tags the Agent computes itself are never filtered out.
+	denylist map[string]struct{}
 }
 
 // NewTagList creates a new object ready to use
@@ -32,7 +43,59 @@ func NewTagList() *TagList {
 		highCardTags:         make(map[string]bool),
 		standardTags:         make(map[string]bool),
 		splitList:            pkgconfigsetup.Datadog().GetStringMapString("tag_value_split_separator"),
+		denylist:             deniedTagNames(),
 	}
+}
+
+// deniedTagNamesCache memoizes the parsed denylist: NewTagList runs for every
+// workloadmeta event, so the set is only rebuilt when the setting changes.
+var deniedTagNamesCache atomic.Pointer[denylistCache]
+
+type denylistCache struct {
+	raw []string
+	set map[string]struct{}
+}
+
+// deniedTagNames returns the configured denylist as a set, for O(1) lookups.
+// The returned map is shared and must not be modified.
+func deniedTagNames() map[string]struct{} {
+	raw := pkgconfigsetup.Datadog().GetStringSlice(denylistSetting)
+
+	if cached := deniedTagNamesCache.Load(); cached != nil && slices.Equal(cached.raw, raw) {
+		return cached.set
+	}
+
+	set := make(map[string]struct{}, len(raw))
+	for _, name := range raw {
+		if name := normalizeTagName(name); name != "" {
+			set[name] = struct{}{}
+		}
+	}
+
+	deniedTagNamesCache.Store(&denylistCache{raw: raw, set: set})
+
+	return set
+}
+
+// normalizeTagName reduces a tag name to what consumers actually read as the
+// tag name, so that the denylist matches whichever form the workload used: the
+// '+' high cardinality prefix is stripped, the name is lowercased, and anything
+// from the first ':' on is dropped, since tags are serialized as "name:value"
+// and split on their first ':'.
+func normalizeTagName(name string) string {
+	name = strings.TrimPrefix(strings.TrimSpace(name), "+")
+	name, _, _ = strings.Cut(name, ":")
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+// IsDenied reports whether name is refused from workload-controlled metadata.
+func (l *TagList) IsDenied(name string) bool {
+	if len(l.denylist) == 0 {
+		return false
+	}
+
+	_, denied := l.denylist[normalizeTagName(name)]
+	return denied
 }
 
 func addTags(target map[string]bool, name string, value string, splits map[string]string) {
@@ -92,6 +155,43 @@ func (l *TagList) AddAuto(name, value string) {
 	l.AddLow(name, value)
 }
 
+// AddLowFromWorkload behaves like AddLow for a tag name coming from
+// workload-controlled metadata, dropping the denied ones.
+func (l *TagList) AddLowFromWorkload(name string, value string) {
+	if l.denied(name) {
+		return
+	}
+	l.AddLow(name, value)
+}
+
+// AddHighFromWorkload behaves like AddHigh for a tag name coming from
+// workload-controlled metadata, dropping the denied ones.
+func (l *TagList) AddHighFromWorkload(name string, value string) {
+	if l.denied(name) {
+		return
+	}
+	l.AddHigh(name, value)
+}
+
+// AddAutoFromWorkload behaves like AddAuto for a tag name coming from
+// workload-controlled metadata, dropping the denied ones.
+func (l *TagList) AddAutoFromWorkload(name string, value string) {
+	if l.denied(name) {
+		return
+	}
+	l.AddAuto(name, value)
+}
+
+// denied reports whether the tag must be dropped, and logs it when it is.
+func (l *TagList) denied(name string) bool {
+	if !l.IsDenied(name) {
+		return false
+	}
+
+	log.Debugf("Ignoring tag %q from workload metadata: it is listed in %s", name, denylistSetting)
+	return true
+}
+
 // Compute returns four string arrays in the format "tag:value"
 // - low cardinality
 // - orchestrator cardinality
@@ -119,6 +219,7 @@ func (l *TagList) Copy() *TagList {
 		highCardTags:         deepCopyMap(l.highCardTags),
 		standardTags:         deepCopyMap(l.standardTags),
 		splitList:            l.splitList, // constant, can be shared
+		denylist:             l.denylist,  // read-only, can be shared
 	}
 }
 

--- a/comp/core/tagger/taglist/taglist_test.go
+++ b/comp/core/tagger/taglist/taglist_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 )
 
 func TestNewTagList(t *testing.T) {
@@ -121,6 +123,62 @@ func TestAddStandard(t *testing.T) {
 	require.Contains(t, list.standardTags, "values:1")
 	require.Contains(t, list.standardTags, "values:2")
 	require.Contains(t, list.standardTags, "values:3")
+}
+
+func TestAddFromWorkload(t *testing.T) {
+	// host and pod_name are the default denylist
+	list := NewTagList()
+	list.AddLowFromWorkload("host", "forged")
+	list.AddHighFromWorkload("pod_name", "forged")
+	list.AddAutoFromWorkload("+POD_NAME", "forged")
+	list.AddAutoFromWorkload(" host ", "forged")
+	// tags are serialized as "name:value" and split on their first ':', so a
+	// name holding a ':' must not be a way around the denylist
+	list.AddAutoFromWorkload("host:forged", "1")
+	list.AddAutoFromWorkload("team", "backend")
+	list.AddLowFromWorkload("kube_namespace", "kube-system")
+
+	require.Empty(t, list.highCardTags)
+	require.Len(t, list.lowCardTags, 2)
+	require.True(t, list.lowCardTags["team:backend"])
+	require.True(t, list.lowCardTags["kube_namespace:kube-system"])
+
+	// the Agent's own tags are never filtered out
+	list.AddLow("host", "node-1")
+	list.AddOrchestrator("pod_name", "redis-0")
+	require.True(t, list.lowCardTags["host:node-1"])
+	require.True(t, list.orchestratorCardTags["pod_name:redis-0"])
+}
+
+func TestAddFromWorkloadCustomDenylist(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.SetInTest("workload_tags_denylist", []string{"Team", " kube_namespace "})
+
+	list := NewTagList()
+	list.AddAutoFromWorkload("team", "forged")
+	list.AddAutoFromWorkload("kube_namespace", "forged")
+	// no longer denied now that the default has been overridden
+	list.AddAutoFromWorkload("host", "10.0.0.1")
+
+	require.Len(t, list.lowCardTags, 1)
+	require.True(t, list.lowCardTags["host:10.0.0.1"])
+}
+
+func TestAddFromWorkloadEmptyDenylist(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.SetInTest("workload_tags_denylist", []string{})
+
+	list := NewTagList()
+	require.False(t, list.IsDenied("host"))
+
+	list.AddAutoFromWorkload("host", "forged")
+	require.True(t, list.lowCardTags["host:forged"])
+}
+
+func TestCopyKeepsDenylist(t *testing.T) {
+	list := NewTagList().Copy()
+	list.AddAutoFromWorkload("host", "forged")
+	require.Empty(t, list.lowCardTags)
 }
 
 func TestCompute(t *testing.T) {

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -3477,6 +3477,33 @@ properties:
         <HIGH_CARDINALITY_LABEL_NAME>: +<TAG_KEY>
     tags:
     - template_section:KubernetesTagging
+  workload_tags_denylist:
+    node_type: setting
+    type: array
+    default:
+    - host
+    - pod_name
+    items:
+      type: string
+    env_parser: comma_separated
+    visibility: public
+    description: |-
+      List of tag names the Agent never accepts from workload-controlled metadata, so that a
+      workload cannot override a tag the Agent computes itself. It applies to the tag names read
+      from the `ad.datadoghq.com/tags` (and `ad.datadoghq.com/<CONTAINER_NAME>.tags`) pod
+      annotations, the `com.datadoghq.ad.tags` container label, the tracer process tags, and the
+      pod labels, pod annotations, container labels or container environment variables mapped to a
+      tag name with a `%%label%%`, `%%annotation%%` or `%%env%%` template.
+      Node and namespace metadata, tag names hardcoded in a `*_labels_as_tags` mapping, and the
+      tags the Agent computes itself are not affected.
+      Matching is case-insensitive and ignores the `+` high cardinality prefix. Set it to an empty
+      list to accept every tag name.
+    example: |2-
+
+        - host
+        - pod_name
+    tags:
+    - template_section:KubernetesTagging
   ecs_agent_container_name:
     node_type: setting
     title: ECS integration Configuration

--- a/releasenotes/notes/workload-tags-denylist-6b0d24a5f4c1e7a9.yaml
+++ b/releasenotes/notes/workload-tags-denylist-6b0d24a5f4c1e7a9.yaml
@@ -1,0 +1,27 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+security:
+  - |
+    The tagger no longer lets a workload name its own tags ``host`` or ``pod_name``.
+    Previously any tag name found in the ``ad.datadoghq.com/tags`` pod annotation, the
+    ``com.datadoghq.ad.tags`` container label, the tracer process tags, or a
+    ``%%label%%``/``%%annotation%%``/``%%env%%`` tag template applied to pod or container
+    metadata was accepted as-is, so a workload could override tags the Agent assigns
+    itself. The new ``workload_tags_denylist`` setting lists the tag names refused from
+    those sources, and defaults to ``["host", "pod_name"]``. Node and namespace metadata,
+    tag names hardcoded in a ``*_labels_as_tags`` mapping, and the tags the Agent computes
+    itself are unaffected.
+upgrade:
+  - |
+    Tags named ``host`` or ``pod_name`` coming from a pod annotation, a container label, or
+    a tag template are now dropped by the new ``workload_tags_denylist`` setting. This
+    notably affects the ``ad.datadoghq.com/tags`` annotation used to add a low cardinality
+    ``pod_name`` tag, for example ``{"pod_name":"%%kube_pod_name%%"}``. Remove ``pod_name``
+    from ``workload_tags_denylist``, or set it to an empty list, to keep the previous
+    behavior.


### PR DESCRIPTION
### What does this PR do?

Adds a `workload_tags_denylist` setting (default `["host", "pod_name"]`) listing tag names the tagger refuses to build out of workload-controlled metadata. It is resolved once into a set held by the `TagList` for O(1) lookups, and honored by the new `AddLow/AddHigh/AddAutoFromWorkload` methods, which are used on the paths where the workload names the tag:

- the `ad.datadoghq.com/tags` and `ad.datadoghq.com/<container>.tags` pod annotations (`parseJSONValue`)
- the `com.datadoghq.ad.tags` container label
- tracer process tags on process entities
- pod labels/annotations and container labels/env vars mapped to a tag name via a `%%label%%`/`%%annotation%%`/`%%env%%` template (`AddWorkloadMetadataAsTags`)

Matching is case-insensitive, ignores the `+` high-cardinality prefix, and cuts at the first `:` — otherwise `{"host:attacker": "1"}` would serialize to `host:attacker:1` and still be read as the `host` tag downstream.

Deliberately **not** filtered, since the tag name there is not the workload's to choose: the tags the Agent computes itself, node/namespace/deployment metadata (`AddMetadataAsTags` is unchanged, so node labels as host tags keep working), and tag names an administrator hardcoded in a `*_labels_as_tags` mapping.

### Motivation

VULN-92370 / CONTP-108: a tenant with `edit` on its own namespace could inject reserved infrastructure tags on its own workload and have the DCA ship them, poisoning cross-tenant tag attribution, monitor scoping and billing-by-tag. Confirmed as real — reproduced in a unit test that asserts the forged tags land on the entity when the denylist is empty.

### Describe how you validated your changes

`go test -tags test ./comp/core/tagger/...` — all green. New coverage:

- `taglist`: default denylist, custom/empty denylist, `+` prefix, casing, `:` in the tag name, `Copy` keeping the set, and that the Agent's own `AddLow`/`AddOrchestrator` are unaffected
- `k8s_metadata`: template-named tag denied, admin-hardcoded name kept, admin-controlled `AddMetadataAsTags` unfiltered
- `collectors`: end-to-end pod with a forged `ad.datadoghq.com/tags`, both with the default denylist (dropped) and with it disabled (the pre-fix behavior, i.e. the repro)

Also ran the schema linter and `go vet` on the changed packages.

### Additional Notes

- One behavior change to flag: `{"pod_name":"%%kube_pod_name%%"}` in `ad.datadoghq.com/tags` — the documented way to get `pod_name` at low cardinality — now drops that tag. Covered in the upgrade release note; admins can remove `pod_name` from the list.
- The setting name is easy to change if you'd prefer something else.
- Follow-up worth its own PR: in `labelsToTags`, `extractFromMapNormalizedWithFn(labels, containerLabelsAsTags, tags.AddAuto)` re-processes container labels a second time without resolving templates, emitting a literal `%%label%%:<value>` tag. Pre-existing and unrelated to this fix, so left alone.
- Coordinate with CONTP-1959, which extends the same annotation path.
