### PR TITLE
[CONS-8490] - Fix missing kubernetes_state.configmap.count metric

### DIFF
--- a/pkg/kubestatemetrics/builder/builder.go
+++ b/pkg/kubestatemetrics/builder/builder.go
@@ -478,6 +478,8 @@ func createConfigMapListWatch(metadataClient metadata.Interface, gvr schema.Grou
 						Namespace:       item.GetNamespace(),
 						UID:             item.GetUID(),
 						ResourceVersion: item.GetResourceVersion(),
+						Labels:          item.GetLabels(),
+						Annotations:     item.GetAnnotations(),
 					},
 				})
 			}
@@ -506,6 +508,8 @@ func createConfigMapListWatch(metadataClient metadata.Interface, gvr schema.Grou
 						Namespace:       partialObject.GetNamespace(),
 						UID:             partialObject.GetUID(),
 						ResourceVersion: partialObject.GetResourceVersion(),
+						Labels:          partialObject.GetLabels(),
+						Annotations:     partialObject.GetAnnotations(),
 					},
 				}
 

--- a/releasenotes/notes/ksm-configmap-count-fix-2e67f322295885a0.yaml
+++ b/releasenotes/notes/ksm-configmap-count-fix-2e67f322295885a0.yaml
@@ -1,0 +1,17 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    KSM core check: Fixed a bug where the ``kubernetes_state.configmap.count`` metric could
+    stop being reported. ConfigMaps are collected using a metadata-only Kubernetes client, and
+    the conversion of watch events into ConfigMap objects was dropping annotations, including
+    the ``k8s.io/initial-events-end`` bookmark annotation used by newer versions of client-go's
+    watch-list feature to signal that the initial list has finished syncing. Without that
+    signal, the underlying reflector would wait indefinitely and the metric would never be
+    reported.


### PR DESCRIPTION
### What does this PR do?
Fix an issue where `kubernetes_state.configmap.count` goes missing in cluster agent versions 7.79.0+.

Caused by this PR upgraded the Kubernetes Go libraries (client-go, apimachinery, etc.) from v0.34.1 to v0.35.3: https://github.com/DataDog/datadog-agent/pull/48796 

The raw watch event's [*v1.PartialObjectMetadata](https://github.com/kubernetes/apimachinery/blob/v0.35.6/pkg/apis/meta/v1/types.go#L1553-L1559) does carry the bookmark's `k8s.io/initial-events-end: "true"` annotation when the API server sends it, but prior to this fix, it's never read via `partialObject.GetAnnotations()` and never assigned onto the reconstructed `configMap.ObjectMeta.Annotations` field before `event.Object = configMap` overwrites the original object.

Starting at 1.35, Kubernetes flipped it on by default. Since PR #48796 bumped client-go's version straight across that 1.34→1.35 line, it silently turned this feature on for every reflector in the agent, including the ConfigMap watcher, with zero code changes needed to "activate" it.

The fix just adds the two missing lines to that conversion function so [Annotations](https://github.com/kubernetes/apimachinery/blob/v0.35.6/pkg/apis/meta/v1/types.go#L230) (and [Labels](https://github.com/kubernetes/apimachinery/blob/v0.35.6/pkg/apis/meta/v1/types.go#L223)) get copied from the [PartialObjectMetadata](https://github.com/kubernetes/apimachinery/blob/v0.35.6/pkg/apis/meta/v1/types.go#L1553) object onto the reconstructed `corev1.ConfigMap`.

In addition, adding `partialObject.GetLabels()` may fix an issue with the `kube_configmap_labels` metric integrity. As in the kube-state-metrics library, the `kube_configmap_labels` family generator reads c.Labels directly: https://github.com/kubernetes/kube-state-metrics/blob/main/internal/store/configmap.go#L72. If we did not include `partialObject.GetLabels()`, that label joins capability for ConfigMaps might be silently broken for anyone using it, with no error, just missing tags. So I think it doesn't hurt to add Labels as well.

### Motivation
CONS-8490

### Describe how you validated your changes
Built a local image with the changes and, using a kind cluster, tested it by installing the agent with Helm with the local image. The Datadog Helm Chart already deploys a bunch of ConfigMaps for certain agent features so the metric should naturally report already.