### PR TITLE
[ACTP] [PAR split deployment] shut down idle private action executor

### DIFF
--- a/comp/privateactionrunner/def/component.go
+++ b/comp/privateactionrunner/def/component.go
@@ -29,6 +29,7 @@ const (
 	PARUrn                    = "private_action_runner.urn"
 	PARActionsAllowlist       = "private_action_runner.actions_allowlist"
 	PARDefaultActionsEnabled  = "private_action_runner.default_actions_enabled"
+	PARIdleTimeoutSeconds     = "private_action_runner.idle_timeout_seconds"
 
 	PARExecutorSocketPath = "private_action_runner.executor.socket_path"
 )

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -65,6 +65,7 @@ type Requires struct {
 	Config        config.Component
 	Log           log.Component
 	Lifecycle     compdef.Lifecycle
+	Shutdowner    compdef.Shutdowner
 	RcClient      rcclient.Component
 	Hostname      hostname.Component
 	Tagger        tagger.Component
@@ -102,6 +103,7 @@ type PrivateActionRunner struct {
 	executorServer  *executor.Server
 	encryptionStore *encryptioncontext.Store
 	executorDone    chan struct{}
+	shutdowner      compdef.Shutdowner
 
 	telemetry *telemetry.Telemetry
 
@@ -160,6 +162,7 @@ func NewExecutorComponent(reqs Requires) (Provides, error) {
 		return Provides{}, err
 	}
 	runner.ownsMetricsClient = true
+	runner.shutdowner = reqs.Shutdowner
 	reqs.Lifecycle.Append(compdef.Hook{
 		OnStart: runner.StartExecutor,
 		OnStop:  runner.StopExecutor,
@@ -314,13 +317,19 @@ func (p *PrivateActionRunner) startExecutor(ctx context.Context) error {
 	p.logger.Info("Private action runner executor listening on " + socketPath)
 
 	p.executorDone = make(chan struct{})
-	// Drain bounded by the task timeout: that's the longest an in-flight action can run.
 	drainTimeout := 60 * time.Second
 	if cfg.TaskTimeoutSeconds != nil {
 		drainTimeout = time.Duration(*cfg.TaskTimeoutSeconds) * time.Second
 	}
 	serveOpts := executor.ServeOptions{
 		DrainTimeout: drainTimeout,
+		IdleTimeout:  executorIdleTimeout(p.coreConfig),
+		OnIdleTimeout: func() {
+			p.logger.Info("Private action runner executor idle timeout elapsed; shutting down")
+			if err := p.shutdowner.Shutdown(); err != nil {
+				p.logger.Errorf("Private action runner executor failed to initiate shutdown: %v", err)
+			}
+		},
 	}
 	// mTLS via the agent IPC cert: only a client with a CA-signed cert can dispatch.
 	tlsConfig := p.ipc.GetTLSServerConfig()
@@ -334,6 +343,17 @@ func (p *PrivateActionRunner) startExecutor(ctx context.Context) error {
 		}
 	}()
 	return nil
+}
+
+// Keep self-termination behind the control plane's normal idle stop.
+const executorIdleTimeoutFactor = 3
+
+func executorIdleTimeout(cfg model.Reader) time.Duration {
+	idle := cfg.GetInt(privateactionrunner.PARIdleTimeoutSeconds)
+	if idle <= 0 {
+		return 0
+	}
+	return time.Duration(idle) * executorIdleTimeoutFactor * time.Second
 }
 
 // StopExecutor gracefully stops the executor gRPC server and releases resources.

--- a/pkg/config/schema/yaml/private_action_runner.yaml
+++ b/pkg/config/schema/yaml/private_action_runner.yaml
@@ -117,6 +117,14 @@ properties:
     node_type: setting
     type: boolean
     default: true
+  idle_timeout_seconds:
+    node_type: setting
+    type: integer
+    default: 60
+    description: |-
+      Sets the split-mode control plane's executor idle timeout in seconds. The
+      executor uses three times this value as a self-termination watchdog;
+      values of zero or less disable the watchdog.
   log_file:
     node_type: setting
     type: string

--- a/pkg/config/setup/privateactionrunner.go
+++ b/pkg/config/setup/privateactionrunner.go
@@ -22,6 +22,7 @@ const (
 	// General config
 	PARTaskConcurrency       = "private_action_runner.task_concurrency"
 	PARTaskTimeoutSeconds    = "private_action_runner.task_timeout_seconds"
+	PARIdleTimeoutSeconds    = "private_action_runner.idle_timeout_seconds"
 	PARActionsAllowlist      = "private_action_runner.actions_allowlist"
 	PARDefaultActionsEnabled = "private_action_runner.default_actions_enabled"
 

--- a/pkg/privateactionrunner/executor/BUILD.bazel
+++ b/pkg/privateactionrunner/executor/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/privateactionrunner/util",
         "//pkg/proto/pbgo/privateactionrunner/errorcode",
         "//pkg/proto/pbgo/privateactionrunner/executor",
+        "@com_github_benbjohnson_clock//:clock",
         "@org_golang_google_grpc//:grpc",
     ] + select({
         "@rules_go//go/platform:windows": [
@@ -40,6 +41,7 @@ dd_agent_go_test(
         "//pkg/privateactionrunner/util",
         "//pkg/proto/pbgo/privateactionrunner/errorcode",
         "//pkg/proto/pbgo/privateactionrunner/executor",
+        "@com_github_benbjohnson_clock//:clock",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:grpc",

--- a/pkg/privateactionrunner/executor/server.go
+++ b/pkg/privateactionrunner/executor/server.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"google.golang.org/grpc"
 
 	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
@@ -40,14 +41,31 @@ type Server struct {
 
 	ready  atomic.Bool
 	active atomic.Int32
+
+	lastActivity atomic.Int64
+	clock        clock.Clock
 }
 
 // NewServer builds a gRPC server that dispatches actions to the given core.
 func NewServer(executor actionExecutor, version string) *Server {
-	return &Server{
+	s := &Server{
 		executor: executor,
 		version:  version,
+		clock:    clock.New(),
 	}
+	s.touch()
+	return s
+}
+
+func (s *Server) touch() {
+	s.lastActivity.Store(s.clock.Now().UnixNano())
+}
+
+func (s *Server) idleFor() time.Duration {
+	if s.active.Load() > 0 {
+		return 0
+	}
+	return s.clock.Since(time.Unix(0, s.lastActivity.Load()))
 }
 
 // SetReady marks the executor ready (or not) to accept actions.
@@ -77,8 +95,12 @@ func (s *Server) RunAction(req *pb.RunActionRequest, stream pb.Executor_RunActio
 		))
 	}
 
+	s.touch()
 	s.active.Add(1)
-	defer s.active.Add(-1)
+	defer func() {
+		s.touch()
+		s.active.Add(-1)
+	}()
 
 	// Raw bytes must stay unmodified for signature verification.
 	task := &types.Task{Raw: req.GetTask()}
@@ -128,10 +150,14 @@ func sendError(stream pb.Executor_RunActionServer, parErr util.PARError) error {
 	})
 }
 
-// ServeOptions tunes drain behavior; zero value waits forever.
+// ServeOptions tunes server shutdown.
 type ServeOptions struct {
-	DrainTimeout time.Duration // bounds graceful drain on stop; 0 waits forever
+	DrainTimeout  time.Duration
+	IdleTimeout   time.Duration
+	OnIdleTimeout func()
 }
+
+const idleCheckDivisor = 10
 
 // Serve serves the Executor on lis until ctx is cancelled, then stops gracefully
 // bounded by the drain timeout. Pass grpcOpts to secure the socket.
@@ -144,12 +170,34 @@ func Serve(ctx context.Context, lis net.Listener, srv *Server, opts ServeOptions
 		errCh <- grpcServer.Serve(lis)
 	}()
 
-	select {
-	case <-ctx.Done():
-		stopGracefully(grpcServer, opts.DrainTimeout)
-		return nil
-	case err := <-errCh:
-		return err
+	var idleCheck <-chan time.Time
+	if opts.IdleTimeout > 0 {
+		interval := opts.IdleTimeout / idleCheckDivisor
+		if interval == 0 {
+			interval = opts.IdleTimeout
+		}
+		ticker := srv.clock.Ticker(interval)
+		defer ticker.Stop()
+		idleCheck = ticker.C
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			stopGracefully(grpcServer, opts.DrainTimeout)
+			return nil
+		case <-idleCheck:
+			if srv.idleFor() < opts.IdleTimeout {
+				continue
+			}
+			stopGracefully(grpcServer, opts.DrainTimeout)
+			if opts.OnIdleTimeout != nil {
+				opts.OnIdleTimeout()
+			}
+			return nil
+		case err := <-errCh:
+			return err
+		}
 	}
 }
 

--- a/pkg/privateactionrunner/executor/server_test.go
+++ b/pkg/privateactionrunner/executor/server_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -392,4 +393,69 @@ func TestServeMTLSRequiresValidClientCert(t *testing.T) {
 	defer shortCancel()
 	_, err = anon.Health(shortCtx, &pb.HealthRequest{})
 	require.Error(t, err, "client without a valid cert must be rejected")
+}
+
+func TestServeExitsWhenIdle(t *testing.T) {
+	mockClock := clock.NewMock()
+	srv := NewServer(&fakeExecutor{}, "test-version")
+	srv.clock = mockClock
+	srv.touch()
+	srv.SetReady(true)
+
+	socketPath := testListenAddr(t)
+	lis, err := Listen(socketPath)
+	require.NoError(t, err)
+
+	served := make(chan error, 1)
+	idleTimedOut := false
+	const idleTimeout = time.Minute
+	go func() {
+		served <- Serve(context.Background(), lis, srv, ServeOptions{
+			DrainTimeout: 2 * time.Second,
+			IdleTimeout:  idleTimeout,
+			OnIdleTimeout: func() {
+				idleTimedOut = true
+			},
+		})
+	}()
+
+	for range 2 * idleCheckDivisor {
+		mockClock.Add(idleTimeout / idleCheckDivisor)
+		select {
+		case err := <-served:
+			require.NoError(t, err, "an idle exit is a clean exit, so procmgr leaves it down")
+			require.True(t, idleTimedOut)
+			return
+		default:
+		}
+	}
+	t.Fatal("idle executor did not exit")
+}
+
+func TestIdleTracking(t *testing.T) {
+	mockClock := clock.NewMock()
+	srv := NewServer(&fakeExecutor{}, "test-version")
+	srv.clock = mockClock
+	srv.touch()
+
+	const timeout = time.Minute
+	mockClock.Add(timeout - time.Second)
+	assert.Equal(t, timeout-time.Second, srv.idleFor())
+
+	srv.touch()
+	assert.Zero(t, srv.idleFor(), "dispatch activity should reset the idle clock")
+
+	_, err := srv.Health(context.Background(), &pb.HealthRequest{})
+	require.NoError(t, err)
+	mockClock.Add(time.Second)
+	assert.Equal(t, time.Second, srv.idleFor(), "health checks should not count as activity")
+
+	srv.active.Add(1)
+	mockClock.Add(2 * timeout)
+	assert.Zero(t, srv.idleFor(), "an active action should suppress the idle state")
+	srv.active.Add(-1)
+	srv.touch()
+
+	mockClock.Add(timeout)
+	assert.Equal(t, timeout, srv.idleFor())
 }


### PR DESCRIPTION
### What does this PR do?

Adds a self-termination watchdog to the on-demand Go executor. Dispatch activity resets the idle timer; health checks do not, and active actions suppress idle shutdown.

The watchdog uses three times `private_action_runner.idle_timeout_seconds` (60 seconds by default) so `par-control` remains the primary owner of idle shutdown. It applies only to executor mode; the monolithic runner is unchanged.

### Validation

- `bazel test //pkg/privateactionrunner/executor:executor_test`
- `bazel test //comp/privateactionrunner/impl:impl_test`
- `bazel test //cmd/privateactionrunner/subcommands/runexecutor:runexecutor_test`

_Stack 1 of 9; followed by #54589._
