### PR TITLE
tasks/schema: use shutil.copy instead of shelling out to cp

### DIFF
--- a/tasks/schema/generate.py
+++ b/tasks/schema/generate.py
@@ -376,7 +376,7 @@ def schema_codegen(ctx, keep_orig_order=False, check=False, fix=False, keeptmp=F
             destination_dir = os.path.dirname(destination)
             if not os.path.isdir(destination_dir):
                 raise Exit(f"Cannot copy generated file {source}: {destination_dir} does not exist", code=1)
-            ctx.run(f"cp {source} {destination}")
+            shutil.copy(source, destination)
 
     if not keeptmp and not display:
         shutil.rmtree(tmpdir)


### PR DESCRIPTION
## Summary
`schema_codegen(fix=True)` shells out to `cp` to copy generated files. CI's Windows build image has Git's `usr\bin` (MSYS2 coreutils, e.g. `C:\devtools\git\usr\bin\cp.exe`) on PATH, so this works there. A bare Windows dev machine only gets `Git\cmd` / `Git\mingw64\bin` on PATH by default, not `Git\usr\bin`, so `cp` isn't found and the build fails with `'cp' is not recognized`. Switched to `shutil.copy` so this doesn't depend on PATH contents.

xref IR-59017 (https://app.datadoghq.com/incidents/59017)