### PR TITLE
add skeletal authored script action

### DIFF
--- a/pkg/privateactionrunner/adapters/actions/BUILD.bazel
+++ b/pkg/privateactionrunner/adapters/actions/BUILD.bazel
@@ -1,8 +1,16 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "actions",
     srcs = ["actions_adapter.go"],
     importpath = "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/actions",
     visibility = ["//visibility:public"],
+)
+
+dd_agent_go_test(
+    name = "actions_test",
+    srcs = ["actions_adapter_test.go"],
+    embed = [":actions"],
+    deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/pkg/privateactionrunner/adapters/actions/actions_adapter.go
+++ b/pkg/privateactionrunner/adapters/actions/actions_adapter.go
@@ -16,6 +16,15 @@ func SplitFQN(fqn string) (string, string) {
 	}
 	return fqn[:index], fqn[index+1:]
 }
+
+func GetRootBundle(bundleID string) string {
+	parts := strings.SplitN(bundleID, ".", 4)
+	if len(parts) < 3 {
+		return bundleID
+	}
+	return strings.Join(parts[:3], ".")
+}
+
 func IsHttpBundle(bundleId string) bool {
 	return bundleId == "com.datadoghq.http"
 }

--- a/pkg/privateactionrunner/adapters/actions/actions_adapter_test.go
+++ b/pkg/privateactionrunner/adapters/actions/actions_adapter_test.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRootBundle(t *testing.T) {
+	tests := []struct {
+		name     string
+		bundleID string
+		expected string
+	}{
+		{
+			name:     "returns three-part bundle unchanged",
+			bundleID: "com.datadoghq.http",
+			expected: "com.datadoghq.http",
+		},
+		{
+			name:     "returns root of nested bundle",
+			bundleID: "com.datadoghq.authoredscripts.helm",
+			expected: "com.datadoghq.authoredscripts",
+		},
+		{
+			name:     "returns short bundle unchanged",
+			bundleID: "com.datadoghq",
+			expected: "com.datadoghq",
+		},
+		{
+			name:     "returns empty bundle unchanged",
+			bundleID: "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, GetRootBundle(tt.bundleID))
+		})
+	}
+}

--- a/pkg/privateactionrunner/bundles/BUILD.bazel
+++ b/pkg/privateactionrunner/bundles/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "bundles",
@@ -13,7 +14,9 @@ go_library(
         "//comp/forwarder/eventplatform/def",
         "//comp/kubeactions/helmactions/def",
         "//comp/networkpath/traceroute/def",
+        "//pkg/privateactionrunner/adapters/actions",
         "//pkg/privateactionrunner/adapters/config",
+        "//pkg/privateactionrunner/bundles/authoredscripts",
         "//pkg/privateactionrunner/bundles/gitlab/branches",
         "//pkg/privateactionrunner/bundles/gitlab/commits",
         "//pkg/privateactionrunner/bundles/gitlab/customattributes",
@@ -54,5 +57,22 @@ go_library(
         "//pkg/privateactionrunner/bundles/temporal",
         "//pkg/privateactionrunner/libs/encryptioncontext",
         "//pkg/privateactionrunner/types",
+    ],
+)
+
+dd_agent_go_test(
+    name = "bundles_test",
+    srcs = ["registry_test.go"],
+    embed = [":bundles"],
+    gotags_sets = [[
+        "cel",
+        "clusterchecks",
+        "kubeapiserver",
+        "kubelet",
+        "orchestrator",
+    ]],
+    deps = [
+        "//pkg/privateactionrunner/types",
+        "@com_github_stretchr_testify//assert",
     ],
 )

--- a/pkg/privateactionrunner/bundles/authoredscripts/BUILD.bazel
+++ b/pkg/privateactionrunner/bundles/authoredscripts/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+
+go_library(
+    name = "authoredscripts",
+    srcs = [
+        "entrypoint.go",
+        "run_authored_script.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/authoredscripts",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/privateactionrunner/libs/privateconnection",
+        "//pkg/privateactionrunner/types",
+    ],
+)
+
+dd_agent_go_test(
+    name = "authoredscripts_test",
+    srcs = ["entrypoint_test.go"],
+    embed = [":authoredscripts"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/pkg/privateactionrunner/bundles/authoredscripts/entrypoint.go
+++ b/pkg/privateactionrunner/bundles/authoredscripts/entrypoint.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_authoredscripts
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
+)
+
+type AuthoredScripts struct {
+	runAuthoredScript types.Action
+}
+
+func NewAuthoredScripts() *AuthoredScripts {
+	return &AuthoredScripts{
+		runAuthoredScript: NewRunAuthoredScriptHandler(),
+	}
+}
+
+func (h *AuthoredScripts) GetAction(actionName string) types.Action {
+	if actionName == "" {
+		return nil
+	}
+	return h.runAuthoredScript
+}

--- a/pkg/privateactionrunner/bundles/authoredscripts/entrypoint_test.go
+++ b/pkg/privateactionrunner/bundles/authoredscripts/entrypoint_test.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_authoredscripts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthoredScriptsGetAction(t *testing.T) {
+	bundle := NewAuthoredScripts()
+	handler := bundle.GetAction("addRepo")
+
+	assert.IsType(t, &RunAuthoredScriptHandler{}, handler)
+	assert.Same(t, handler, bundle.GetAction("restartService"))
+	assert.Nil(t, bundle.GetAction(""))
+}

--- a/pkg/privateactionrunner/bundles/authoredscripts/run_authored_script.go
+++ b/pkg/privateactionrunner/bundles/authoredscripts/run_authored_script.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_authoredscripts
+
+import (
+	"context"
+	"errors"
+
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
+)
+
+type RunAuthoredScriptHandler struct {
+}
+
+func NewRunAuthoredScriptHandler() *RunAuthoredScriptHandler {
+	return &RunAuthoredScriptHandler{}
+}
+
+func (h *RunAuthoredScriptHandler) Run(
+	_ context.Context,
+	_ *types.Task,
+	_ *privateconnection.PrivateCredentials,
+) (interface{}, error) {
+	return nil, errors.New("authored script execution is not implemented")
+}

--- a/pkg/privateactionrunner/bundles/registry.go
+++ b/pkg/privateactionrunner/bundles/registry.go
@@ -12,7 +12,9 @@ import (
 	eventplatform "github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/def"
 	helmactions "github.com/DataDog/datadog-agent/comp/kubeactions/helmactions/def"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/actions"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
+	com_datadoghq_authoredscripts "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/authoredscripts"
 	com_datadoghq_gitlab_branches "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/branches"
 	com_datadoghq_gitlab_commits "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/commits"
 	com_datadoghq_gitlab_customattributes "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/customattributes"
@@ -55,6 +57,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
 )
 
+var rootRoutedBundles = map[string]struct{}{
+	"com.datadoghq.authoredscripts": {},
+}
+
 type Registry struct {
 	Bundles map[string]types.Bundle
 }
@@ -62,6 +68,7 @@ type Registry struct {
 func NewRegistry(configuration *config.Config, traceroute traceroute.Component, eventPlatform eventplatform.Component, ipcClient ipc.HTTPClient, encryptionStore *encryptioncontext.Store, helmactions helmactions.Component) *Registry {
 	return &Registry{
 		Bundles: map[string]types.Bundle{
+			"com.datadoghq.authoredscripts":                      com_datadoghq_authoredscripts.NewAuthoredScripts(),
 			"com.datadoghq.gitlab.branches":                      com_datadoghq_gitlab_branches.NewGitlabBranches(),
 			"com.datadoghq.gitlab.commits":                       com_datadoghq_gitlab_commits.NewGitlabCommits(),
 			"com.datadoghq.gitlab.customattributes":              com_datadoghq_gitlab_customattributes.NewGitlabCustomAttributes(),
@@ -104,6 +111,14 @@ func NewRegistry(configuration *config.Config, traceroute traceroute.Component, 
 	}
 }
 
-func (r *Registry) GetBundle(fqn string) types.Bundle {
-	return r.Bundles[fqn]
+func (r *Registry) GetBundle(bundleID string) types.Bundle {
+	if bundle := r.Bundles[bundleID]; bundle != nil {
+		return bundle
+	}
+
+	rootBundleID := actions.GetRootBundle(bundleID)
+	if _, ok := rootRoutedBundles[rootBundleID]; !ok {
+		return nil
+	}
+	return r.Bundles[rootBundleID]
 }

--- a/pkg/privateactionrunner/bundles/registry_test.go
+++ b/pkg/privateactionrunner/bundles/registry_test.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build !kubeapiserver
+
+package privatebundles
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
+)
+
+type testBundle struct {
+	name string
+}
+
+func (b *testBundle) GetAction(string) types.Action {
+	return nil
+}
+
+func TestRegistryGetBundle(t *testing.T) {
+	rootBundle := &testBundle{name: "root"}
+	gitlabBranchesBundle := &testBundle{name: "gitlab-branches"}
+	nonRootRoutedBundle := &testBundle{name: "non-root-routed"}
+	registry := &Registry{
+		Bundles: map[string]types.Bundle{
+			"com.datadoghq.authoredscripts": rootBundle,
+			"com.datadoghq.gitlab.branches": gitlabBranchesBundle,
+			"com.datadoghq.http":            nonRootRoutedBundle,
+		},
+	}
+
+	tests := []struct {
+		name     string
+		bundleID string
+		expected types.Bundle
+	}{
+		{
+			name:     "returns exact root bundle",
+			bundleID: "com.datadoghq.authoredscripts",
+			expected: rootBundle,
+		},
+		{
+			name:     "returns exact nested bundle",
+			bundleID: "com.datadoghq.gitlab.branches",
+			expected: gitlabBranchesBundle,
+		},
+		{
+			name:     "returns root-routed bundle for nested bundle",
+			bundleID: "com.datadoghq.authoredscripts.helm",
+			expected: rootBundle,
+		},
+		{
+			name:     "does not route nested bundle for non-root-routed bundle",
+			bundleID: "com.datadoghq.http.extra",
+			expected: nil,
+		},
+		{
+			name:     "returns nil for unknown bundle",
+			bundleID: "com.datadoghq.unknown.extra",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := registry.GetBundle(tt.bundleID)
+			if tt.expected == nil {
+				assert.Nil(t, actual)
+				return
+			}
+			assert.Same(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Adds skeletal implemenation for authored script actions. This is not available to users as the action is behind a feature flag. [This PR](https://github.com/ddoghq/dd-source/pull/48812)

### Motivation
We will be supporting authored scripts where new scripts can be added without needing a new agent release. This is to add a skeletal handler to support it. Further details in [Datadog Authored Script](https://docs.google.com/document/d/1qB2R__ZUkL2xjCDLybJGoaKl5EhpJ-rpy907h0qlRm4/edit?tab=t.0#heading=h.qjl27megtr2p) and [Authored script download and storage RFC](https://datadoghq.atlassian.net/wiki/spaces/ACT/pages/7060063493/RFC+Authored+script+download+storage+and+isolation)

### Describe how you validated your changes
Ran an authorized script action from a local agent. Screenshot attached

<img width="1353" height="771" alt="Screenshot 2026-08-13 at 12 46 44 PM" src="https://github.com/user-attachments/assets/5d729838-3aa4-4f8e-a7d0-ac6057dba557" />


### Additional Notes
