### PR TITLE
[procmgr] Extract shared Rust client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,19 +708,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "dd-procmgr-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hyper-util",
+ "prost",
+ "protoc-gen-prost",
+ "protoc-gen-tonic",
+ "tempfile",
+ "tokio",
+ "tonic",
+ "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tower",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dd-procmgrd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
  "dd-agent-log",
- "hyper-util",
+ "dd-procmgr-client",
  "log",
  "nix",
- "prost",
- "prost-types",
- "protoc-gen-prost",
- "protoc-gen-tonic",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -728,11 +743,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tonic-build",
- "tonic-prost",
- "tonic-prost-build",
  "tonic-reflection",
- "tower",
  "uuid",
  "windows-registry",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "pkg/discovery/module/rust",
     "pkg/privateactionrunner/par-control",
     "pkg/procmgr/rust",
+    "pkg/procmgr/rust/client",
 ]
 
 [workspace.package]
@@ -47,6 +48,7 @@ serde = { version = "1.0.219", features = ["derive", "std"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 dd-agent-log = { path = "comp/core/log/rust" }
+dd-procmgr-client = { path = "pkg/procmgr/rust/client" }
 time = { version = "0.3", features = ["formatting", "macros"] }
 thiserror = "2.0.12"
 tokio = "1"

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -1,32 +1,12 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
-
-# ============================================================================
-# Protobuf / gRPC
-# ============================================================================
-#
-# Rust prost codegen lives next to the canonical .proto in
-# //pkg/proto/datadog/procmgr (same package as go_proto_library).
 
 _LINUX_OR_WINDOWS = select({
     "@platforms//os:linux": [],
     "@platforms//os:windows": [],
     "//conditions:default": ["@platforms//:incompatible"],
 })
-
-# rust_prost_library propagates CcInfo from proto_library, which transitively
-# includes abseil-cpp (C++). The Rust linker does not add libstdc++ by default,
-# so we provide it explicitly. On Windows the MinGW toolchain links C++ runtime
-# automatically.
-cc_library(
-    name = "cpp_stdlib",
-    linkopts = select({
-        "@platforms//os:windows": [],
-        "//conditions:default": ["-lstdc++"],
-    }),
-)
 
 # ============================================================================
 # Library
@@ -38,11 +18,9 @@ _LIB_SRCS = glob(
 )
 
 _LIB_DEPS = [
-    "//pkg/proto/datadog/procmgr:procmgr_rust_proto",
+    "//pkg/procmgr/rust/client:dd-procmgr-client",
     "@crates//:anyhow",
-    "@crates//:hyper-util",
     "@crates//:log",
-    "@crates//:prost",
     "@crates//:serde",
     "@crates//:serde_json",
     "@crates//:serde_yaml",
@@ -50,7 +28,6 @@ _LIB_DEPS = [
     "@crates//:tokio-stream",
     "@crates//:tonic",
     "@crates//:tonic-reflection",
-    "@crates//:tower",
     "@crates//:uuid",
 ] + select({
     "@platforms//os:linux": [
@@ -69,7 +46,6 @@ rust_library(
     srcs = _LIB_SRCS,
     crate_name = "dd_procmgrd",
     edition = "2024",
-    link_deps = [":cpp_stdlib"],
     rustc_flags = ["--cfg=bazel"],
     target_compatible_with = _LINUX_OR_WINDOWS,
     visibility = ["//visibility:public"],
@@ -83,7 +59,6 @@ rust_library(
     crate_features = ["test-helpers"],
     crate_name = "dd_procmgrd",
     edition = "2024",
-    link_deps = [":cpp_stdlib"],
     rustc_flags = ["--cfg=bazel"],
     target_compatible_with = _LINUX_OR_WINDOWS,
     deps = _LIB_DEPS,
@@ -125,7 +100,7 @@ rust_binary(
     target_compatible_with = _LINUX_OR_WINDOWS,
     visibility = ["//visibility:public"],
     deps = [
-        ":dd-procmgrd-lib",
+        "//pkg/procmgr/rust/client:dd-procmgr-client",
         "@crates//:clap",
         "@crates//:serde_json",
         "@crates//:tokio",
@@ -178,11 +153,7 @@ rust_test(
     edition = "2024",
     rustc_flags = ["--cfg=bazel"],
     target_compatible_with = _LINUX_OR_WINDOWS,
-    deps = [
-        "@crates//:hyper-util",
-        "@crates//:tempfile",
-        "@crates//:tower",
-    ],
+    deps = ["@crates//:tempfile"],
 )
 
 rust_test(

--- a/pkg/procmgr/rust/Cargo.toml
+++ b/pkg/procmgr/rust/Cargo.toml
@@ -24,20 +24,16 @@ path = "src/bins/dd-procmgr.rs"
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
-hyper-util = { workspace = true, features = ["tokio"] }
 log.workspace = true
-prost.workspace = true
-prost-types.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_yaml.workspace = true
 dd-agent-log.workspace = true
+dd-procmgr-client.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "process", "fs", "time", "sync"] }
 tokio-stream = { workspace = true, features = ["net"] }
 tonic = { workspace = true, features = ["transport"] }
-tonic-prost.workspace = true
 tonic-reflection.workspace = true
-tower.workspace = true
 uuid.workspace = true
 
 [target.'cfg(unix)'.dependencies]
@@ -66,9 +62,3 @@ tempfile.workspace = true
 [[test]]
 name = "e2e"
 required-features = ["test-helpers"]
-
-[build-dependencies]
-protoc-gen-prost.workspace = true
-protoc-gen-tonic.workspace = true
-tonic-build.workspace = true
-tonic-prost-build.workspace = true

--- a/pkg/procmgr/rust/build.rs
+++ b/pkg/procmgr/rust/build.rs
@@ -4,6 +4,5 @@
 // Copyright 2026-present Datadog, Inc.
 
 fn main() {
-    // Tests use this cfg to omit reflection from Bazel's generated service.
     println!("cargo::rustc-check-cfg=cfg(bazel)");
 }

--- a/pkg/procmgr/rust/client/BUILD.bazel
+++ b/pkg/procmgr/rust/client/BUILD.bazel
@@ -1,0 +1,51 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+_LINUX_OR_WINDOWS = select({
+    "@platforms//os:linux": [],
+    "@platforms//os:windows": [],
+    "//conditions:default": ["@platforms//:incompatible"],
+})
+
+# rust_prost_library propagates CcInfo from proto_library, which transitively
+# includes abseil-cpp. The Rust linker needs the C++ runtime explicitly on Linux.
+cc_library(
+    name = "cpp_stdlib",
+    linkopts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["-lstdc++"],
+    }),
+)
+
+rust_library(
+    name = "dd-procmgr-client",
+    srcs = glob(["src/**/*.rs"]),
+    crate_name = "dd_procmgr_client",
+    edition = "2024",
+    link_deps = [":cpp_stdlib"],
+    rustc_flags = ["--cfg=bazel"],
+    target_compatible_with = _LINUX_OR_WINDOWS,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/proto/datadog/procmgr:procmgr_rust_proto",
+        "@crates//:anyhow",
+        "@crates//:hyper-util",
+        "@crates//:prost",
+        "@crates//:tokio",
+        "@crates//:tonic",
+        "@crates//:tonic-prost",
+        "@crates//:tower",
+    ] + select({
+        "@platforms//os:windows": ["@crates//:windows-sys"],
+        "//conditions:default": [],
+    }),
+)
+
+rust_test(
+    name = "dd-procmgr-client_test",
+    crate = ":dd-procmgr-client",
+    edition = "2024",
+    rustc_flags = ["--cfg=bazel"],
+    target_compatible_with = _LINUX_OR_WINDOWS,
+    deps = ["@crates//:tempfile"],
+)

--- a/pkg/procmgr/rust/client/BUILD.bazel
+++ b/pkg/procmgr/rust/client/BUILD.bazel
@@ -19,7 +19,7 @@ cc_library(
 
 rust_library(
     name = "dd-procmgr-client",
-    srcs = glob(["src/**/*.rs"]),
+    srcs = glob(["src/*.rs"]),
     crate_name = "dd_procmgr_client",
     edition = "2024",
     link_deps = [":cpp_stdlib"],

--- a/pkg/procmgr/rust/client/Cargo.toml
+++ b/pkg/procmgr/rust/client/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "dd-procmgr-client"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "Shared Rust client transport for dd-procmgrd"
+
+[dependencies]
+anyhow.workspace = true
+hyper-util = { workspace = true, features = ["tokio"] }
+prost.workspace = true
+tokio = { workspace = true, features = ["net", "time"] }
+tonic = { workspace = true, features = ["transport"] }
+tonic-prost.workspace = true
+tower.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_Foundation"] }
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[build-dependencies]
+# Keep the generators in Cargo.lock for the repository's Bazel prost toolchain.
+protoc-gen-prost.workspace = true
+protoc-gen-tonic.workspace = true
+tonic-build.workspace = true
+tonic-prost-build.workspace = true

--- a/pkg/procmgr/rust/client/build.rs
+++ b/pkg/procmgr/rust/client/build.rs
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Bazel builds use the generated Rust crate from
+// `//pkg/proto/datadog/procmgr:procmgr_rust_proto`.
+// This script exists only for Cargo and IDE workflows outside Bazel.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo::rustc-check-cfg=cfg(bazel)");
+
+    let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR")?);
+    tonic_prost_build::configure()
+        .file_descriptor_set_path(out_dir.join("process_manager_descriptor.bin"))
+        .compile_protos(
+            &["../../../proto/datadog/procmgr/process_manager.proto"],
+            &["../../../proto"],
+        )?;
+    Ok(())
+}

--- a/pkg/procmgr/rust/client/src/lib.rs
+++ b/pkg/procmgr/rust/client/src/lib.rs
@@ -1,0 +1,138 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//! Rust client plumbing for the local dd-procmgrd gRPC API.
+//!
+//! This crate owns the process-manager protobuf bindings, endpoint resolution,
+//! and platform connector. Daemon server transport and process supervision stay
+//! in `dd-procmgrd`.
+
+use anyhow::{Context as _, Result};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[cfg(windows)]
+mod named_pipe;
+#[cfg(unix)]
+mod uds;
+
+#[cfg(not(bazel))]
+pub mod proto {
+    tonic::include_proto!("datadog.procmgr");
+
+    pub const FILE_DESCRIPTOR_SET: &[u8] =
+        tonic::include_file_descriptor_set!("process_manager_descriptor");
+}
+
+#[cfg(bazel)]
+pub mod proto {
+    pub use procmgr_proto::datadog::procmgr::*;
+    pub const FILE_DESCRIPTOR_SET: &[u8] = procmgr_proto::datadog::procmgr::FILE_DESCRIPTOR_SET;
+}
+
+#[cfg(windows)]
+pub use named_pipe::IpcStream;
+#[cfg(unix)]
+pub use uds::IpcStream;
+
+#[cfg(unix)]
+const DEFAULT_IPC_PATH: &str = "/var/run/datadog-procmgrd/dd-procmgrd.sock";
+#[cfg(windows)]
+const DEFAULT_IPC_PATH: &str = r"\\.\pipe\datadog-procmgrd";
+
+const DUMMY_ENDPOINT: &str = "http://[::]:50051";
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Resolve the daemon endpoint from `DD_PM_SOCKET_PATH`, falling back to the
+/// platform default.
+pub fn ipc_path() -> PathBuf {
+    std::env::var("DD_PM_SOCKET_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(DEFAULT_IPC_PATH))
+}
+
+/// Open the platform-local stream used by dd-procmgrd.
+pub async fn connect_stream(path: &Path) -> std::io::Result<IpcStream> {
+    connect_platform(path).await
+}
+
+/// Connect eagerly to dd-procmgrd at `path`.
+pub async fn connect(path: &Path) -> Result<tonic::transport::Channel> {
+    let endpoint = path.to_path_buf();
+    let display_path = endpoint.clone();
+    tonic::transport::Endpoint::from_static(DUMMY_ENDPOINT)
+        .connect_with_connector(tower::service_fn(move |_| {
+            let endpoint = endpoint.clone();
+            async move {
+                connect_platform(&endpoint)
+                    .await
+                    .map(hyper_util::rt::TokioIo::new)
+            }
+        }))
+        .await
+        .with_context(|| {
+            format!(
+                "failed to connect to local endpoint {}",
+                display_path.display()
+            )
+        })
+}
+
+/// Build a channel that connects on the first RPC and reconnects after the
+/// daemon restarts.
+pub fn connect_lazy(path: &Path) -> tonic::transport::Channel {
+    let path = path.to_path_buf();
+    tonic::transport::Endpoint::from_static(DUMMY_ENDPOINT)
+        .connect_timeout(CONNECT_TIMEOUT)
+        .connect_with_connector_lazy(tower::service_fn(move |_| {
+            let path = path.clone();
+            async move {
+                connect_platform(&path)
+                    .await
+                    .map(hyper_util::rt::TokioIo::new)
+            }
+        }))
+}
+
+#[cfg(unix)]
+async fn connect_platform(path: &Path) -> std::io::Result<IpcStream> {
+    uds::connect(path).await
+}
+
+#[cfg(windows)]
+async fn connect_platform(path: &Path) -> std::io::Result<IpcStream> {
+    named_pipe::connect(path).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn connects_to_unix_listener() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("procmgr.sock");
+        let listener = tokio::net::UnixListener::bind(&path).unwrap();
+
+        let accept = tokio::spawn(async move { listener.accept().await.unwrap() });
+        connect_stream(&path).await.unwrap();
+        accept.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn missing_endpoint_reports_an_os_error() {
+        let error = connect_stream(Path::new(MISSING_ENDPOINT))
+            .await
+            .expect_err("connecting to a nonexistent endpoint should fail");
+        assert_ne!(error.kind(), std::io::ErrorKind::Unsupported);
+        assert!(error.raw_os_error().is_some(), "{error:?}");
+    }
+
+    #[cfg(unix)]
+    const MISSING_ENDPOINT: &str = "/tmp/dd-procmgr-client-does-not-exist.sock";
+    #[cfg(windows)]
+    const MISSING_ENDPOINT: &str = r"\\.\pipe\dd-procmgr-client-does-not-exist";
+}

--- a/pkg/procmgr/rust/client/src/lib.rs
+++ b/pkg/procmgr/rust/client/src/lib.rs
@@ -45,12 +45,17 @@ const DEFAULT_IPC_PATH: &str = r"\\.\pipe\datadog-procmgrd";
 const DUMMY_ENDPOINT: &str = "http://[::]:50051";
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Return the platform's default dd-procmgrd endpoint.
+pub fn default_ipc_path() -> PathBuf {
+    PathBuf::from(DEFAULT_IPC_PATH)
+}
+
 /// Resolve the daemon endpoint from `DD_PM_SOCKET_PATH`, falling back to the
 /// platform default.
 pub fn ipc_path() -> PathBuf {
     std::env::var("DD_PM_SOCKET_PATH")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from(DEFAULT_IPC_PATH))
+        .unwrap_or_else(|_| default_ipc_path())
 }
 
 /// Open the platform-local stream used by dd-procmgrd.

--- a/pkg/procmgr/rust/client/src/lib.rs
+++ b/pkg/procmgr/rust/client/src/lib.rs
@@ -60,6 +60,7 @@ pub async fn connect(path: &Path) -> Result<tonic::transport::Channel> {
     let endpoint = path.to_path_buf();
     let display_path = endpoint.clone();
     tonic::transport::Endpoint::from_static(TONIC_PLACEHOLDER_URI)
+        .connect_timeout(CONNECT_TIMEOUT)
         .connect_with_connector(tower::service_fn(move |_| {
             let endpoint = endpoint.clone();
             async move {

--- a/pkg/procmgr/rust/client/src/lib.rs
+++ b/pkg/procmgr/rust/client/src/lib.rs
@@ -4,10 +4,6 @@
 // Copyright 2026-present Datadog, Inc.
 
 //! Rust client plumbing for the local dd-procmgrd gRPC API.
-//!
-//! This crate owns the process-manager protobuf bindings, endpoint resolution,
-//! and platform connector. Daemon server transport and process supervision stay
-//! in `dd-procmgrd`.
 
 use anyhow::{Context as _, Result};
 use std::path::{Path, PathBuf};
@@ -42,32 +38,28 @@ const DEFAULT_IPC_PATH: &str = "/var/run/datadog-procmgrd/dd-procmgrd.sock";
 #[cfg(windows)]
 const DEFAULT_IPC_PATH: &str = r"\\.\pipe\datadog-procmgrd";
 
-const DUMMY_ENDPOINT: &str = "http://[::]:50051";
+const TONIC_PLACEHOLDER_URI: &str = "http://[::]:50051";
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Return the platform's default dd-procmgrd endpoint.
 pub fn default_ipc_path() -> PathBuf {
     PathBuf::from(DEFAULT_IPC_PATH)
 }
 
-/// Resolve the daemon endpoint from `DD_PM_SOCKET_PATH`, falling back to the
-/// platform default.
 pub fn ipc_path() -> PathBuf {
     std::env::var("DD_PM_SOCKET_PATH")
         .map(PathBuf::from)
         .unwrap_or_else(|_| default_ipc_path())
 }
 
-/// Open the platform-local stream used by dd-procmgrd.
 pub async fn connect_stream(path: &Path) -> std::io::Result<IpcStream> {
     connect_platform(path).await
 }
 
-/// Connect eagerly to dd-procmgrd at `path`.
+/// Connect eagerly to dd-procmgrd.
 pub async fn connect(path: &Path) -> Result<tonic::transport::Channel> {
     let endpoint = path.to_path_buf();
     let display_path = endpoint.clone();
-    tonic::transport::Endpoint::from_static(DUMMY_ENDPOINT)
+    tonic::transport::Endpoint::from_static(TONIC_PLACEHOLDER_URI)
         .connect_with_connector(tower::service_fn(move |_| {
             let endpoint = endpoint.clone();
             async move {
@@ -85,11 +77,10 @@ pub async fn connect(path: &Path) -> Result<tonic::transport::Channel> {
         })
 }
 
-/// Build a channel that connects on the first RPC and reconnects after the
-/// daemon restarts.
+/// Connect lazily to dd-procmgrd and reconnect if it restarted.
 pub fn connect_lazy(path: &Path) -> tonic::transport::Channel {
     let path = path.to_path_buf();
-    tonic::transport::Endpoint::from_static(DUMMY_ENDPOINT)
+    tonic::transport::Endpoint::from_static(TONIC_PLACEHOLDER_URI)
         .connect_timeout(CONNECT_TIMEOUT)
         .connect_with_connector_lazy(tower::service_fn(move |_| {
             let path = path.clone();

--- a/pkg/procmgr/rust/client/src/named_pipe.rs
+++ b/pkg/procmgr/rust/client/src/named_pipe.rs
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use std::ffi::OsStr;
+use std::io;
+use std::path::Path;
+use std::time::Duration;
+use tokio::net::windows::named_pipe::ClientOptions;
+use windows_sys::Win32::Foundation::ERROR_PIPE_BUSY;
+
+pub type IpcStream = tokio::net::windows::named_pipe::NamedPipeClient;
+
+const PIPE_BUSY_RETRIES: u32 = 5;
+const PIPE_BUSY_BACKOFF_MS: u64 = 50;
+
+pub async fn connect(path: &Path) -> io::Result<IpcStream> {
+    open_with_retry(path.as_os_str()).await
+}
+
+/// Open a named-pipe client, retrying when every server instance is busy.
+async fn open_with_retry(name: &OsStr) -> io::Result<IpcStream> {
+    let mut backoff = PIPE_BUSY_BACKOFF_MS;
+    for attempt in 0..PIPE_BUSY_RETRIES {
+        match ClientOptions::new().open(name) {
+            Ok(client) => return Ok(client),
+            Err(error)
+                if error.raw_os_error() == Some(ERROR_PIPE_BUSY as i32)
+                    && attempt + 1 < PIPE_BUSY_RETRIES =>
+            {
+                tokio::time::sleep(Duration::from_millis(backoff)).await;
+                backoff *= 2;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!()
+}

--- a/pkg/procmgr/rust/client/src/named_pipe.rs
+++ b/pkg/procmgr/rust/client/src/named_pipe.rs
@@ -19,7 +19,6 @@ pub async fn connect(path: &Path) -> io::Result<IpcStream> {
     open_with_retry(path.as_os_str()).await
 }
 
-/// Open a named-pipe client, retrying when every server instance is busy.
 async fn open_with_retry(name: &OsStr) -> io::Result<IpcStream> {
     let mut backoff = PIPE_BUSY_BACKOFF_MS;
     for attempt in 0..PIPE_BUSY_RETRIES {

--- a/pkg/procmgr/rust/client/src/uds.rs
+++ b/pkg/procmgr/rust/client/src/uds.rs
@@ -3,7 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
-fn main() {
-    // Tests use this cfg to omit reflection from Bazel's generated service.
-    println!("cargo::rustc-check-cfg=cfg(bazel)");
+use std::path::Path;
+
+pub type IpcStream = tokio::net::UnixStream;
+
+pub async fn connect(path: &Path) -> std::io::Result<IpcStream> {
+    IpcStream::connect(path).await
 }

--- a/pkg/procmgr/rust/src/bins/dd-procmgr.rs
+++ b/pkg/procmgr/rust/src/bins/dd-procmgr.rs
@@ -4,9 +4,8 @@
 // Copyright 2026-present Datadog, Inc.
 
 use clap::{Parser, Subcommand};
-use dd_procmgrd::grpc::proto;
-use dd_procmgrd::grpc::proto::process_manager_client::ProcessManagerClient;
-use dd_procmgrd::transport;
+use dd_procmgr_client::proto;
+use dd_procmgr_client::proto::process_manager_client::ProcessManagerClient;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -115,9 +114,9 @@ async fn main() -> ExitCode {
 async fn connect(socket_override: Option<&str>) -> Result<ProcessManagerClient<Channel>, String> {
     let path: PathBuf = match socket_override {
         Some(s) => PathBuf::from(s),
-        None => transport::ipc_path(),
+        None => dd_procmgr_client::ipc_path(),
     };
-    let channel = transport::connect(&path)
+    let channel = dd_procmgr_client::connect(&path)
         .await
         .map_err(|e| format!("failed to connect to {}: {e}", path.display()))?;
     Ok(ProcessManagerClient::new(channel))

--- a/pkg/procmgr/rust/src/grpc/mod.rs
+++ b/pkg/procmgr/rust/src/grpc/mod.rs
@@ -6,19 +6,10 @@
 pub mod server;
 pub mod service;
 
-#[cfg(not(bazel))]
+/// Process-manager protobuf and gRPC bindings are owned by the shared client
+/// crate so daemon and client consumers compile against one generated API.
 pub mod proto {
-    tonic::include_proto!("datadog.procmgr");
-
-    pub const FILE_DESCRIPTOR_SET: &[u8] =
-        tonic::include_file_descriptor_set!("process_manager_descriptor");
-}
-
-#[cfg(bazel)]
-pub mod proto {
-    // Crate name from //pkg/proto/datadog/procmgr:procmgr_rust_proto (rules_rust_prost).
-    pub use procmgr_proto::datadog::procmgr::*;
-    pub const FILE_DESCRIPTOR_SET: &[u8] = procmgr_proto::datadog::procmgr::FILE_DESCRIPTOR_SET;
+    pub use dd_procmgr_client::proto::*;
 }
 
 #[cfg(all(test, unix))]
@@ -29,13 +20,11 @@ mod tests {
     use crate::command::Command;
     use crate::config::{ProcessConfig, ProcessDefinition, RestartPolicy, StaticConfigLoader};
     use crate::manager::ProcessManager;
-    use hyper_util::rt::TokioIo;
     use std::sync::Arc;
     use tokio::net::UnixListener;
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::UnixListenerStream;
-    use tonic::transport::{Channel, Endpoint};
-    use tower::service_fn;
+    use tonic::transport::Channel;
 
     use crate::test_helpers;
 
@@ -122,17 +111,7 @@ mod tests {
             }
         });
 
-        let channel = Endpoint::from_static(crate::transport::DUMMY_ENDPOINT)
-            .connect_with_connector(service_fn(move |_| {
-                let path = sock_path.clone();
-                async move {
-                    tokio::net::UnixStream::connect(path)
-                        .await
-                        .map(TokioIo::new)
-                }
-            }))
-            .await
-            .unwrap();
+        let channel = dd_procmgr_client::connect(&sock_path).await.unwrap();
 
         let client = ProcessManagerClient::new(channel);
         (client, shutdown_tx)

--- a/pkg/procmgr/rust/src/grpc/mod.rs
+++ b/pkg/procmgr/rust/src/grpc/mod.rs
@@ -6,8 +6,6 @@
 pub mod server;
 pub mod service;
 
-/// Process-manager protobuf and gRPC bindings are owned by the shared client
-/// crate so daemon and client consumers compile against one generated API.
 pub mod proto {
     pub use dd_procmgr_client::proto::*;
 }

--- a/pkg/procmgr/rust/src/transport/named_pipe.rs
+++ b/pkg/procmgr/rust/src/transport/named_pipe.rs
@@ -12,20 +12,11 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeServer, ServerOptions};
-use windows_sys::Win32::Foundation::ERROR_PIPE_BUSY;
-
-const DEFAULT_PIPE_PATH: &str = r"\\.\pipe\datadog-procmgrd";
+use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
 const DEFAULT_PIPE_INSTANCES: usize = 4;
 
-/// Placeholder URI for tonic Endpoint when connecting over Named Pipes.
-/// The actual address is irrelevant because `connect_with_connector` bypasses it.
-pub const DUMMY_ENDPOINT: &str = "http://[::]:50051";
-
 pub fn ipc_path() -> PathBuf {
-    std::env::var("DD_PM_SOCKET_PATH")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from(DEFAULT_PIPE_PATH))
+    dd_procmgr_client::ipc_path()
 }
 
 /// Named pipes don't require filesystem preparation.
@@ -162,47 +153,4 @@ async fn accept_loop(
     }
 
     Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// Client
-// ---------------------------------------------------------------------------
-
-pub async fn connect(path: &Path) -> Result<tonic::transport::Channel> {
-    let pipe_name = path.as_os_str().to_os_string();
-    let channel = tonic::transport::Endpoint::from_static(DUMMY_ENDPOINT)
-        .connect_with_connector(tower::service_fn(move |_| {
-            let name = pipe_name.clone();
-            async move { open_pipe_with_retry(&name).await }
-        }))
-        .await
-        .with_context(|| format!("failed to connect to named pipe {}", path.display()))?;
-    Ok(channel)
-}
-
-const PIPE_BUSY_RETRIES: u32 = 5;
-const PIPE_BUSY_BACKOFF_MS: u64 = 50;
-
-/// Open a named pipe client, retrying on `ERROR_PIPE_BUSY`.
-///
-/// All server instances may be occupied when the client calls `open()`.
-/// Windows named pipe clients are expected to wait and retry in this case.
-async fn open_pipe_with_retry(
-    name: &std::ffi::OsStr,
-) -> io::Result<hyper_util::rt::TokioIo<tokio::net::windows::named_pipe::NamedPipeClient>> {
-    let mut backoff = PIPE_BUSY_BACKOFF_MS;
-    for attempt in 0..PIPE_BUSY_RETRIES {
-        match ClientOptions::new().open(name) {
-            Ok(client) => return Ok(hyper_util::rt::TokioIo::new(client)),
-            Err(e)
-                if e.raw_os_error() == Some(ERROR_PIPE_BUSY as i32)
-                    && attempt + 1 < PIPE_BUSY_RETRIES =>
-            {
-                tokio::time::sleep(std::time::Duration::from_millis(backoff)).await;
-                backoff *= 2;
-            }
-            Err(e) => return Err(e),
-        }
-    }
-    unreachable!()
 }

--- a/pkg/procmgr/rust/src/transport/uds.rs
+++ b/pkg/procmgr/rust/src/transport/uds.rs
@@ -10,17 +10,10 @@ use std::path::{Path, PathBuf};
 use tokio::net::UnixListener;
 use tokio_stream::wrappers::UnixListenerStream;
 
-const DEFAULT_SOCKET_PATH: &str = "/var/run/datadog-procmgrd/dd-procmgrd.sock";
 const SOCKET_PERMISSIONS: u32 = 0o660;
 
-/// Placeholder URI for tonic Endpoint when connecting over UDS.
-/// The actual address is irrelevant because `connect_with_connector` bypasses it.
-pub const DUMMY_ENDPOINT: &str = "http://[::]:50051";
-
 pub fn ipc_path() -> PathBuf {
-    std::env::var("DD_PM_SOCKET_PATH")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from(DEFAULT_SOCKET_PATH))
+    dd_procmgr_client::ipc_path()
 }
 
 pub fn prepare(path: &Path) -> Result<()> {
@@ -70,22 +63,6 @@ where
     info!("gRPC server stopped");
     cleanup(&path);
     Ok(())
-}
-
-pub async fn connect(path: &Path) -> Result<tonic::transport::Channel> {
-    let path = path.to_path_buf();
-    let channel = tonic::transport::Endpoint::from_static(DUMMY_ENDPOINT)
-        .connect_with_connector(tower::service_fn(move |_| {
-            let p = path.clone();
-            async move {
-                tokio::net::UnixStream::connect(p)
-                    .await
-                    .map(hyper_util::rt::TokioIo::new)
-            }
-        }))
-        .await
-        .context("failed to connect to Unix socket")?;
-    Ok(channel)
 }
 
 pub fn cleanup(path: &Path) {


### PR DESCRIPTION
### What does this PR do?

Extracts a `dd-procmgr-client` Rust crate from client code in `dd-procmgrd`:

- process-manager protobuf/gRPC bindings;
- default endpoint and `DD_PM_SOCKET_PATH` handling;
- Unix socket and Windows named-pipe connections;
- Windows busy-pipe retry behavior.

The `dd-procmgr` CLI now uses this crate. The daemon reuses its bindings and endpoint resolution, but keeps all server transport, process supervision, and lifecycle code.

This is a code move and dependency cleanup. It does not change the protocol, endpoint defaults, retry policy, or process-manager behavior.

### Why?

A later PR in the Private Action Runner split-mode stack (#54589) adds a second Rust client of `dd-procmgrd`. Without this crate, that client would either depend on the full daemon implementation or copy its platform-specific connection code.

### Validation

```text
dda env dev run -- bazel test //pkg/procmgr/rust/...
dda env dev run -- cargo clippy --manifest-path pkg/procmgr/rust/client/Cargo.toml --all-targets -- -D warnings
dda env dev run -- cargo clippy --manifest-path pkg/procmgr/rust/Cargo.toml --all-targets --features test-helpers -- -D warnings
```

The Bazel suite covers the client, daemon, CLI, and CLI/daemon E2E tests.
