### PR TITLE
AGNTLOG-706 Increase logging for fingerprinting tailing

### DIFF
--- a/pkg/logs/launchers/file/BUILD.bazel
+++ b/pkg/logs/launchers/file/BUILD.bazel
@@ -4,6 +4,7 @@ load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 go_library(
     name = "file",
     srcs = [
+        "fingerprint_tailer_diagnostics.go",
         "launcher.go",
         "position.go",
     ],
@@ -35,6 +36,7 @@ go_library(
 dd_agent_go_test(
     name = "file_test",
     srcs = [
+        "fingerprint_tailer_diagnostics_test.go",
         "launcher_privileged_logs_test.go",
         "launcher_test.go",
         "position_test.go",
@@ -64,6 +66,7 @@ dd_agent_go_test(
             "//pkg/logs/status",
             "//pkg/logs/tailers",
             "//pkg/logs/util/testutils",
+            "//pkg/util/log",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:android": [
@@ -81,6 +84,7 @@ dd_agent_go_test(
             "//pkg/logs/tailers",
             "//pkg/logs/util/testutils",
             "//pkg/privileged-logs/test",
+            "//pkg/util/log",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:darwin": [
@@ -97,6 +101,7 @@ dd_agent_go_test(
             "//pkg/logs/status",
             "//pkg/logs/tailers",
             "//pkg/logs/util/testutils",
+            "//pkg/util/log",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:dragonfly": [
@@ -113,6 +118,7 @@ dd_agent_go_test(
             "//pkg/logs/status",
             "//pkg/logs/tailers",
             "//pkg/logs/util/testutils",
+            "//pkg/util/log",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:freebsd": [
@@ -129,6 +135,7 @@ dd_agent_go_test(
             "//pkg/logs/status",
             "//pkg/logs/tailers",
             "//pkg/logs/util/testutils",
+            "//pkg/util/log",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:illumos": [
@@ -145,6 +152,7 @@ dd_agent_go_test(
             "//pkg/logs/status",
             "//pkg/logs/tailers",
             "//pkg/logs/util/testutils",
+            "//pkg/util/log",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:ios": [
@@ -161,6 +169,7 @@ dd_agent_go_test(
             "//pkg/logs/status",
             "//pkg/logs/tailers",
             "//pkg/logs/util/testutils",
+            "//pkg/util/log",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:js": [
@@ -177,6 +186,7 @@ dd_agent_go_test(
             "//pkg/logs/status",
             "//pkg/logs/tailers",
             "//pkg/logs/util/testutils",
+            "//pkg/util/log",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:linux": [
@@ -194,6 +204,7 @@ dd_agent_go_test(
             "//pkg/logs/tailers",
             "//pkg/logs/util/testutils",
             "//pkg/privileged-logs/test",
+            "//pkg/util/log",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:netbsd": [
@@ -210,6 +221,7 @@ dd_agent_go_test(
             "//pkg/logs/status",
             "//pkg/logs/tailers",
             "//pkg/logs/util/testutils",
+            "//pkg/util/log",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:openbsd": [
@@ -226,6 +238,7 @@ dd_agent_go_test(
             "//pkg/logs/status",
             "//pkg/logs/tailers",
             "//pkg/logs/util/testutils",
+            "//pkg/util/log",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:osx": [
@@ -242,6 +255,7 @@ dd_agent_go_test(
             "//pkg/logs/status",
             "//pkg/logs/tailers",
             "//pkg/logs/util/testutils",
+            "//pkg/util/log",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:plan9": [
@@ -258,6 +272,7 @@ dd_agent_go_test(
             "//pkg/logs/status",
             "//pkg/logs/tailers",
             "//pkg/logs/util/testutils",
+            "//pkg/util/log",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:qnx": [
@@ -274,6 +289,7 @@ dd_agent_go_test(
             "//pkg/logs/status",
             "//pkg/logs/tailers",
             "//pkg/logs/util/testutils",
+            "//pkg/util/log",
             "@com_github_stretchr_testify//suite",
         ],
         "@rules_go//go/platform:solaris": [
@@ -290,6 +306,7 @@ dd_agent_go_test(
             "//pkg/logs/status",
             "//pkg/logs/tailers",
             "//pkg/logs/util/testutils",
+            "//pkg/util/log",
             "@com_github_stretchr_testify//suite",
         ],
         "//conditions:default": [],

--- a/pkg/logs/launchers/file/fingerprint_tailer_diagnostics.go
+++ b/pkg/logs/launchers/file/fingerprint_tailer_diagnostics.go
@@ -1,0 +1,285 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package file
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	tailer "github.com/DataDog/datadog-agent/pkg/logs/tailers/file"
+	"github.com/DataDog/datadog-agent/pkg/logs/types"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// fingerprintSkipReason tells apart the two ways a fingerprint can end up unusable.
+type fingerprintSkipReason string
+
+const (
+	// fingerprintSkipInsufficientData means the file does not hold enough data to fingerprint yet,
+	// as happens right after a rotation. It resolves on its own once the application writes more.
+	fingerprintSkipInsufficientData fingerprintSkipReason = "insufficient_data"
+	// fingerprintSkipError means computing the fingerprint failed for any reason. eg permissions error
+	fingerprintSkipError fingerprintSkipReason = "error"
+)
+
+// fingerprintSkipOutcome picks the closing log line. The two outcomes mean opposite things, so they
+// cannot share one message: the file either started being tailed, or was never tailed at all.
+type fingerprintSkipOutcome string
+
+const (
+	// fingerprintSkipRecovered means a tailer was eventually started for the file.
+	fingerprintSkipRecovered fingerprintSkipOutcome = "recovered"
+	// fingerprintSkipAbandoned means the file stopped being expected, by deletion or by its source
+	// being removed, without ever being tailed.
+	fingerprintSkipAbandoned fingerprintSkipOutcome = "abandoned"
+)
+
+// fingerprintSkip records a file that got no tailer because its fingerprint was unusable. The
+// launcher retries every scan, so this exists to report the transitions, not the steady state.
+type fingerprintSkip struct {
+	// file is refreshed on every check so the paths that end the skip can name it and clear its
+	// status message. See recordFingerprintSkip.
+	file   *tailer.File
+	reason fingerprintSkipReason
+	// since is when we first declined to tail the file, for the duration on the closing line.
+	since time.Time
+	// warned latches the warning so a file that stays unfingerprintable is not reported every scan.
+	// It is keyed by reason rather than a single flag: a new reason is worth a fresh warning because
+	// the remediation differs, but a file alternating between the two must still warn once per
+	// reason rather than once per change.
+	warned map[fingerprintSkipReason]bool
+}
+
+// recordFingerprintSkip reports that file got no tailer because its fingerprint could not be used,
+// which means its logs are being lost. This runs on every scan and on every source addition, so the
+// warning is latched here and closed by closeFingerprintSkip.
+func (s *Launcher) recordFingerprintSkip(file *tailer.File, fingerprint *types.Fingerprint, err error) {
+	// A nil error means the file is only too short for now; anything else is a failure to read it.
+	reason := fingerprintSkipInsufficientData
+	if err != nil {
+		reason = fingerprintSkipError
+	}
+
+	scanKey := file.GetScanKey()
+	skip, isSkipped := s.fingerprintSkips[scanKey]
+	if !isSkipped {
+		// Set here as well as below so the field is never nil once stored: the paths that end the
+		// skip report skip.file.Path unguarded.
+		skip = &fingerprintSkip{
+			file:   file,
+			reason: reason,
+			since:  time.Now(),
+			warned: make(map[fingerprintSkipReason]bool, 1),
+		}
+		s.fingerprintSkips[scanKey] = skip
+	} else if skip.reason != reason {
+		// Still untailed, only failing differently, so keep the start time: resetting it would
+		// report one long gap as two shorter ones.
+		skip.reason = reason
+	}
+
+	// Adopt the File from this check rather than the first one: a source removed and re-added for
+	// the same path has to end up carrying the message. Hand the message over rather than copy it,
+	// because this is the last point that still knows about the source losing the file.
+	if previous := skip.file; fingerprintSkipMessages(previous) != fingerprintSkipMessages(file) {
+		removeFingerprintSkipMessage(previous)
+	}
+	skip.file = file
+	setFingerprintSkipMessage(file, reason, fingerprint, err)
+
+	if skip.warned[reason] {
+		return
+	}
+	skip.warned[reason] = true
+
+	// Remediation lives on the status page rather than here, so the log line stays scannable.
+	if reason == fingerprintSkipError {
+		log.Warnf("Unable to tail %s. Its fingerprint could not be computed: %v. Logs are not collected until this is resolved.",
+			file.Path, err)
+		return
+	}
+
+	log.Warnf("Unable to tail %s. %s is too short for fingerprinting (needs %s). Logs are not collected until the file grows.",
+		file.Path, fingerprintFileSize(file.Path, fingerprint), fingerprintRequirement(fingerprint))
+}
+
+// resolveFingerprintSkip stops tracking file as skipped, now that a tailer has been started for it.
+func (s *Launcher) resolveFingerprintSkip(file *tailer.File) {
+	scanKey := file.GetScanKey()
+	if skip, isSkipped := s.fingerprintSkips[scanKey]; isSkipped {
+		s.closeFingerprintSkip(scanKey, skip, fingerprintSkipRecovered)
+	}
+}
+
+// forgetVanishedFiles drops the state of files that are no longer expected to be tailed, so the map
+// does not grow with every path that rotates away.
+//
+// hitFileLimit says the scan result filled every slot, which means it may have left out files that
+// are still matched, so it cannot be read as the full set of what is expected. When the limit was
+// hit, a skipped file whose source is still active and still on disk may simply have been left out
+// of this scan rather than dropped; defer abandonment until one of those stops being true. Source
+// removal must end the skip even if the file remains, or stale state survives re-adds and the map
+// grows without bound under churning dynamic sources.
+func (s *Launcher) forgetVanishedFiles(expected map[string]bool, hitFileLimit bool) {
+	for scanKey, skip := range s.fingerprintSkips {
+		if expected[scanKey] {
+			continue
+		}
+		if hitFileLimit && fileStillExists(skip.file.Path) && skipSourceStillActive(s.activeSources, skip) {
+			continue
+		}
+		// Last chance to report the gap: we are about to lose track of these files.
+		s.closeFingerprintSkip(scanKey, skip, fingerprintSkipAbandoned)
+	}
+}
+
+// skipSourceStillActive reports whether the source that matched skip.file is still configured to
+// be tailed. Pointer identity matches removeSource.
+func skipSourceStillActive(activeSources []*sources.LogSource, skip *fingerprintSkip) bool {
+	if skip.file == nil || skip.file.Source == nil {
+		return false
+	}
+	source := skip.file.Source.UnderlyingSource()
+	if source == nil {
+		return false
+	}
+	for _, active := range activeSources {
+		if active == source {
+			return true
+		}
+	}
+	return false
+}
+
+// fileStillExists reports whether path is still on disk. Anything other than a missing file counts
+// as still there, since a file we cannot stat is one to keep retrying rather than give up on.
+func fileStillExists(path string) bool {
+	_, err := os.Stat(path)
+	return !os.IsNotExist(err)
+}
+
+// closeFingerprintSkip stops tracking a skipped file, however that came about. Routing both outcomes
+// through one function keeps them from drifting apart in what they clean up.
+func (s *Launcher) closeFingerprintSkip(scanKey string, skip *fingerprintSkip, outcome fingerprintSkipOutcome) {
+	delete(s.fingerprintSkips, scanKey)
+	removeFingerprintSkipMessage(skip.file)
+
+	// Only files we warned about get a closing line, so neither half of a gap appears on its own.
+	if len(skip.warned) == 0 {
+		return
+	}
+	waited := time.Since(skip.since).Truncate(time.Second)
+	if outcome == fingerprintSkipRecovered {
+		log.Infof("Now tailing %s, %v after it was first skipped for an unusable fingerprint (%s).",
+			skip.file.Path, waited, skip.reason)
+		return
+	}
+	log.Warnf("Stopped tracking %s, never tailed for %v because of an unusable fingerprint (%s). Logs written during that gap were not collected.",
+		skip.file.Path, waited, skip.reason)
+}
+
+// setFingerprintSkipMessage puts the reason on the status page of the source that matched the file,
+// next to the "N files tailed out of M files matching" message that reports the shortfall without
+// explaining it. Customers cannot query the Agent's telemetry, and status is where they look first.
+func setFingerprintSkipMessage(file *tailer.File, reason fingerprintSkipReason, fingerprint *types.Fingerprint, err error) {
+	messages := fingerprintSkipMessages(file)
+	if messages == nil {
+		return
+	}
+
+	if reason == fingerprintSkipError {
+		messages.AddMessage(fingerprintSkipMessageKey(file),
+			fmt.Sprintf("Not tailing %s: its fingerprint could not be computed (%v)", file.Path, err))
+		return
+	}
+
+	remediation := ""
+	if setting := fingerprintCountSetting(fingerprint); setting != "" {
+		remediation = fmt.Sprintf(". Lower %s if this persists", setting)
+	}
+	messages.AddMessage(fingerprintSkipMessageKey(file),
+		fmt.Sprintf("Not tailing %s: too short to fingerprint (needs %s)%s",
+			file.Path, fingerprintRequirement(fingerprint), remediation))
+}
+
+// fingerprintCountSetting names the count setting behind the threshold, or "" when no setting owns
+// it. A per-source fingerprint_config takes precedence over the global one, so naming logs_config
+// for those files would point at a setting that cannot change the outcome.
+func fingerprintCountSetting(fingerprint *types.Fingerprint) string {
+	if fingerprint == nil || fingerprint.Config == nil {
+		return ""
+	}
+	switch fingerprint.Config.Source {
+	case types.FingerprintConfigSourcePerSource:
+		return "this source's fingerprint_config.count"
+	case types.FingerprintConfigSourceDefault:
+		return ""
+	default:
+		return "logs_config.fingerprint_config.count"
+	}
+}
+
+// removeFingerprintSkipMessage clears the status message once the file stops being skipped, whether
+// it ended up being tailed or went away.
+func removeFingerprintSkipMessage(file *tailer.File) {
+	if messages := fingerprintSkipMessages(file); messages != nil {
+		messages.RemoveMessage(fingerprintSkipMessageKey(file))
+	}
+}
+
+// fingerprintSkipMessages returns the message set of the source that matched file, or nil when there
+// is no source to report against.
+func fingerprintSkipMessages(file *tailer.File) *config.Messages {
+	if file == nil || file.Source == nil {
+		return nil
+	}
+	source := file.Source.UnderlyingSource()
+	if source == nil {
+		return nil
+	}
+	return source.Messages
+}
+
+// fingerprintSkipMessageKey keys the message per file rather than per source, so a source matching
+// several files reports each of them.
+func fingerprintSkipMessageKey(file *tailer.File) string {
+	return "fingerprintSkip:" + file.GetScanKey()
+}
+
+// fingerprintFileSize renders what the file holds, as the subject of a sentence so the message still
+// reads when stat fails. Only byte_checksum gets a number: stat cannot count lines, and a size in
+// bytes against a threshold in lines would compare two different units.
+func fingerprintFileSize(path string, fingerprint *types.Fingerprint) string {
+	if fingerprint == nil || fingerprint.Config == nil ||
+		fingerprint.Config.FingerprintStrategy != types.FingerprintStrategyByteChecksum {
+		return "The file"
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "The file"
+	}
+	return fmt.Sprintf("%d bytes", info.Size())
+}
+
+// fingerprintRequirement renders the threshold, in the unit the strategy measures. count is read
+// only after seeking past count_to_skip, so when that is set the message says where the count starts
+// rather than letting the number read as a total the file already exceeds.
+func fingerprintRequirement(fingerprint *types.Fingerprint) string {
+	if fingerprint == nil || fingerprint.Config == nil {
+		return "more data"
+	}
+	unit := "lines"
+	if fingerprint.Config.FingerprintStrategy == types.FingerprintStrategyByteChecksum {
+		unit = "bytes"
+	}
+	if fingerprint.Config.CountToSkip > 0 {
+		return fmt.Sprintf("%d %s after the first %d", fingerprint.Config.Count, unit, fingerprint.Config.CountToSkip)
+	}
+	return fmt.Sprintf("%d %s", fingerprint.Config.Count, unit)
+}

--- a/pkg/logs/launchers/file/fingerprint_tailer_diagnostics_test.go
+++ b/pkg/logs/launchers/file/fingerprint_tailer_diagnostics_test.go
@@ -1,0 +1,604 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package file
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pipelinemock "github.com/DataDog/datadog-agent/comp/logs-library/pipeline/mock"
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	auditorMock "github.com/DataDog/datadog-agent/comp/logs/auditor/mock"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	"github.com/DataDog/datadog-agent/pkg/logs/status"
+	filetailer "github.com/DataDog/datadog-agent/pkg/logs/tailers/file"
+	"github.com/DataDog/datadog-agent/pkg/logs/types"
+	"github.com/DataDog/datadog-agent/pkg/logs/util/testutils"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// captureLauncherLogs redirects the Agent logger to a buffer for the duration of fn and returns
+// everything it emitted at or above minLevel, one "[LEVEL] message" line per entry.
+func captureLauncherLogs(t *testing.T, minLevel log.LogLevel, fn func()) string {
+	t.Helper()
+
+	var logBuffer bytes.Buffer
+	logWriter := bufio.NewWriter(&logBuffer)
+	logger, err := log.LoggerFromWriterWithMinLevelAndLvlMsgFormat(logWriter, minLevel)
+	require.NoError(t, err)
+
+	previousLogger := log.Default()
+	t.Cleanup(func() {
+		log.SetupLogger(previousLogger, "debug")
+	})
+	log.SetupLogger(logger, strings.ToLower(minLevel.String()))
+
+	fn()
+
+	require.NoError(t, logWriter.Flush())
+	return logBuffer.String()
+}
+
+// countLines returns the number of lines in logs that contain substr.
+func countLines(logs string, substr string) int {
+	count := 0
+	for _, line := range strings.Split(logs, "\n") {
+		if strings.Contains(line, substr) {
+			count++
+		}
+	}
+	return count
+}
+
+// fingerprintSkipTestSetup wires a launcher against a single fixed log path configured with the
+// byte_checksum strategy, mirroring the configuration of a customer whose files rotate to a size
+// smaller than the configured count.
+type fingerprintSkipTestSetup struct {
+	launcher *Launcher
+	source   *sources.LogSource
+	path     string
+	scan     func()
+}
+
+func setupFingerprintSkipTest(t *testing.T, count int) *fingerprintSkipTestSetup {
+	mockConfig := configmock.New(t)
+	path := t.TempDir() + "/fingerprint-skip.log"
+
+	fingerprintConfig := &types.FingerprintConfig{
+		FingerprintStrategy: types.FingerprintStrategyByteChecksum,
+		Count:               count,
+	}
+
+	launcher := createLauncher(t, launcherTestOptions{
+		openFilesLimit:    10,
+		fingerprintConfig: fingerprintConfig,
+	})
+	launcher.pipelineProvider = pipelinemock.NewMockProvider()
+	launcher.registry = auditorMock.NewMockRegistry()
+
+	source := sources.NewLogSource("", &config.LogsConfig{
+		Type:              config.FileType,
+		Path:              path,
+		FingerprintConfig: fingerprintConfig,
+	})
+	launcher.activeSources = append(launcher.activeSources, source)
+
+	status.Clear()
+	status.InitStatus(mockConfig, testutils.CreateSources([]*sources.LogSource{source}))
+	t.Cleanup(status.Clear)
+
+	return &fingerprintSkipTestSetup{
+		launcher: launcher,
+		source:   source,
+		path:     path,
+		scan: func() {
+			launcher.resolveActiveTailers(launcher.fileProvider.FilesToTail(
+				context.Background(), launcher.validatePodContainerID, launcher.activeSources, launcher.registry))
+		},
+	}
+}
+
+// writeFile writes size bytes to path, replacing whatever was there.
+func writeFile(t *testing.T, path string, size int) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(strings.Repeat("x", size)), 0644))
+}
+
+// That a file too short to fingerprint is not tailed is existing behaviour, covered by
+// TestLauncherDoesNotCreateTailerForRotatedUndersizedFile. What matters here is that the skip is
+// reported once when it starts rather than once per scan, since the launcher re-evaluates every
+// scan period.
+func TestLauncherWarnsOnceWhenFileIsTooShortToFingerprint(t *testing.T) {
+	const (
+		count = 2048
+		scans = 5
+	)
+	setup := setupFingerprintSkipTest(t, count)
+	writeFile(t, setup.path, count-1)
+
+	logs := captureLauncherLogs(t, log.WarnLvl, func() {
+		for i := 0; i < scans; i++ {
+			setup.scan()
+		}
+	})
+
+	// One warning for the whole time the file stays skipped, not one per scan.
+	assert.Equal(t, 1, countLines(logs, "is too short for fingerprinting"),
+		"the skip must be warned about exactly once while the condition persists, got:\n%s", logs)
+	assert.Contains(t, logs, setup.path, "the warning must name the file")
+	// The threshold has to carry its unit: count means bytes here, but lines under line_checksum.
+	assert.Contains(t, logs, "needs 2048 bytes", "the warning must report the threshold and its unit")
+
+	skip, isSkipped := setup.launcher.fingerprintSkips[setup.path]
+	require.True(t, isSkipped, "the launcher must remember it is skipping this file")
+	assert.Equal(t, fingerprintSkipInsufficientData, skip.reason)
+	assert.True(t, skip.warned[fingerprintSkipInsufficientData],
+		"the warning must stay latched so later scans stay silent")
+}
+
+// Once the file grows past the configured count it is tailed again, and the recovery is logged so
+// the collection gap can be bounded from the logs alone.
+func TestLauncherLogsRecoveryAfterFingerprintSkip(t *testing.T) {
+	const count = 2048
+	setup := setupFingerprintSkipTest(t, count)
+
+	writeFile(t, setup.path, 10000)
+	setup.scan()
+	require.NoError(t, os.Rename(setup.path, setup.path+".1"))
+	writeFile(t, setup.path, 100)
+
+	setup.scan()
+	setup.scan()
+	require.Equal(t, 0, setup.launcher.tailers.Count())
+
+	// The application keeps writing until the file is long enough to fingerprint.
+	writeFile(t, setup.path, count)
+
+	logs := captureLauncherLogs(t, log.InfoLvl, func() {
+		setup.scan()
+	})
+
+	assert.Equal(t, 1, setup.launcher.tailers.Count())
+	assert.Contains(t, logs, "Now tailing "+setup.path)
+	// Matched loosely because a unit test recovers in well under a second; what matters is that a
+	// duration is rendered at all, not its value.
+	assert.Regexp(t, `Now tailing .*, [0-9hms]+ after it was first skipped`, logs,
+		"the recovery must report how long the file went untailed")
+	assert.Empty(t, setup.launcher.fingerprintSkips, "the skip must be forgotten once the file is tailed")
+}
+
+// A fingerprint that could not be computed at all is reported differently from one that is merely
+// unavailable for now: the fingerprinter reports both as an invalid fingerprint, so the error is
+// what tells them apart.
+func TestLauncherWarnsWhenFingerprintComputationFails(t *testing.T) {
+	setup := setupFingerprintSkipTest(t, 2048)
+
+	// The mock fingerprinter returns an error for any file it has no fingerprint set for.
+	fingerprinter := filetailer.NewFingerprinterMock()
+	fingerprinter.SetShouldFileFingerprint(filetailer.NewFile(setup.path, setup.source, false), true)
+	setup.launcher.fingerprinter = fingerprinter
+	writeFile(t, setup.path, 10000)
+
+	logs := captureLauncherLogs(t, log.WarnLvl, func() {
+		setup.scan()
+		setup.scan()
+	})
+
+	assert.Equal(t, 0, setup.launcher.tailers.Count())
+	assert.Equal(t, 1, countLines(logs, "fingerprint could not be computed"),
+		"the failure must be warned about exactly once, got:\n%s", logs)
+
+	skip, isSkipped := setup.launcher.fingerprintSkips[setup.path]
+	require.True(t, isSkipped)
+	assert.Equal(t, fingerprintSkipError, skip.reason)
+}
+
+// Skip state must not outlive the files it refers to, otherwise a path that rotates away leaks an
+// entry on every scan. Losing track of a file also stops the skipping, which is the case worth
+// noticing: the file was never tailed at all.
+func TestLauncherForgetsFingerprintSkipsForVanishedFiles(t *testing.T) {
+	const count = 2048
+	setup := setupFingerprintSkipTest(t, count)
+
+	writeFile(t, setup.path, count-1)
+	setup.scan()
+	setup.scan()
+	require.Len(t, setup.launcher.fingerprintSkips, 1)
+
+	require.NoError(t, os.Remove(setup.path))
+	logs := captureLauncherLogs(t, log.WarnLvl, func() {
+		setup.scan()
+	})
+	assert.Empty(t, setup.launcher.fingerprintSkips)
+
+	// Giving up on a file needs a closing log line just like a recovery does, otherwise a file that
+	// was never tailed leaves no record of when its gap ended.
+	assert.Contains(t, logs, "Stopped tracking "+setup.path)
+	assert.Regexp(t, `Stopped tracking .*, never tailed for [0-9hms]+ because`, logs,
+		"the closing line must report how long the file went untailed")
+}
+
+// A shutdown is not the same event as a file we gave up on, so it is reported once for the whole
+// set rather than once per file: an Agent stopped while many files were too short to fingerprint
+// should not bury its own shutdown under a warning per file.
+func TestLauncherReportsStillSkippedFilesOnceOnCleanup(t *testing.T) {
+	const count = 2048
+	setup := setupFingerprintSkipTest(t, count)
+
+	writeFile(t, setup.path, count-1)
+	setup.scan()
+	require.Len(t, setup.launcher.fingerprintSkips, 1)
+
+	logs := captureLauncherLogs(t, log.WarnLvl, func() {
+		setup.launcher.cleanup()
+	})
+
+	assert.Empty(t, setup.launcher.fingerprintSkips, "shutdown must not leave skip state behind")
+	assert.Equal(t, 1, countLines(logs, "still not tailed because their fingerprint was unusable"),
+		"shutdown must report the outstanding files as a single line, got:\n%s", logs)
+	assert.NotContains(t, logs, "Stopped tracking "+setup.path,
+		"shutdown must not be reported as giving up on the file")
+}
+
+// A file whose fingerprint starts failing for a different reason is still the same uninterrupted
+// gap in collection, so the launcher carries on counting checks instead of starting over. Splitting
+// it would report one long gap as two shorter ones.
+func TestLauncherKeepsFingerprintSkipAcrossReasonChange(t *testing.T) {
+	const count = 2048
+	setup := setupFingerprintSkipTest(t, count)
+
+	// First scan: the file is simply too short to fingerprint.
+	writeFile(t, setup.path, count-1)
+	setup.scan()
+
+	skip, isSkipped := setup.launcher.fingerprintSkips[setup.path]
+	require.True(t, isSkipped)
+	require.Equal(t, fingerprintSkipInsufficientData, skip.reason)
+	since := skip.since
+
+	// The file now fails to be read at all. The mock errors for any file it has no fingerprint for.
+	fingerprinter := filetailer.NewFingerprinterMock()
+	fingerprinter.SetShouldFileFingerprint(filetailer.NewFile(setup.path, setup.source, false), true)
+	setup.launcher.fingerprinter = fingerprinter
+
+	logs := captureLauncherLogs(t, log.WarnLvl, func() {
+		setup.scan()
+	})
+
+	skip, isSkipped = setup.launcher.fingerprintSkips[setup.path]
+	require.True(t, isSkipped)
+	assert.Equal(t, fingerprintSkipError, skip.reason, "the new reason must be adopted")
+	assert.Equal(t, since, skip.since, "the start time must span the whole gap, not restart")
+
+	// The new reason is worth a fresh warning, since the remediation differs.
+	assert.Equal(t, 1, countLines(logs, "fingerprint could not be computed"),
+		"a new reason must be warned about, got:\n%s", logs)
+}
+
+// A new reason is worth a warning, but a file that keeps flipping between the two reasons must not
+// warn on every scan: an intermittent read failure on a file that is also too short would otherwise
+// defeat the latch entirely and report the same gap once per scan period.
+func TestLauncherWarnsOncePerReasonWhenFingerprintFlaps(t *testing.T) {
+	const (
+		count  = 2048
+		cycles = 3
+	)
+	setup := setupFingerprintSkipTest(t, count)
+	writeFile(t, setup.path, count-1)
+
+	// The real fingerprinter reports the short file as unusable with no error, while the mock
+	// reports an error for any file it has no fingerprint for. Alternating between the two flips the
+	// reason on every scan without the file ever becoming tailable.
+	tooShort := setup.launcher.fingerprinter
+	failing := filetailer.NewFingerprinterMock()
+	failing.SetShouldFileFingerprint(filetailer.NewFile(setup.path, setup.source, false), true)
+
+	logs := captureLauncherLogs(t, log.WarnLvl, func() {
+		for i := 0; i < cycles; i++ {
+			setup.launcher.fingerprinter = failing
+			setup.scan()
+			setup.launcher.fingerprinter = tooShort
+			setup.scan()
+		}
+	})
+
+	assert.Equal(t, 1, countLines(logs, "fingerprint could not be computed"),
+		"the error reason must be warned about once across every flip, got:\n%s", logs)
+	assert.Equal(t, 1, countLines(logs, "is too short for fingerprinting"),
+		"the too-short reason must be warned about once across every flip, got:\n%s", logs)
+}
+
+// A scan runs concurrently with the run loop against a copy of activeSources taken when it started,
+// so its result cannot mention files whose source was added while it was in flight. Those files must
+// not look like they vanished: reporting that we gave up on a file we are still retrying would split
+// one continuous gap into two and restart the duration we report for it.
+func TestLauncherKeepsFingerprintSkipOpenedDuringInFlightScan(t *testing.T) {
+	const count = 2048
+	setup := setupFingerprintSkipTest(t, count)
+	writeFile(t, setup.path, count-1)
+
+	// What FilesToTail returns for a scan that started before this source existed.
+	staleResult := setup.launcher.fileProvider.FilesToTail(
+		context.Background(), setup.launcher.validatePodContainerID, nil, setup.launcher.registry)
+	require.Empty(t, staleResult, "a scan predating the source must not report its files")
+
+	// The between-scans entry point, which addSource uses to evaluate a new source immediately
+	// rather than waiting for the next scan.
+	setup.launcher.launchTailers(setup.source)
+	skip := setup.launcher.fingerprintSkips[setup.path]
+	require.NotNil(t, skip, "the file must be skipped before the stale result lands")
+	since := skip.since
+
+	logs := captureLauncherLogs(t, log.WarnLvl, func() {
+		setup.launcher.resolveActiveTailers(staleResult)
+	})
+
+	require.Len(t, setup.launcher.fingerprintSkips, 1,
+		"the skip must survive a scan result that predates its source")
+	assert.NotContains(t, logs, "Stopped tracking",
+		"a file we are still retrying must not be reported as given up on, got:\n%s", logs)
+	assert.Equal(t, since, setup.launcher.fingerprintSkips[setup.path].since,
+		"the gap must stay continuous rather than restarting")
+
+	// And the file is still expired normally once it really does stop being expected.
+	require.NoError(t, os.Remove(setup.path))
+	setup.scan()
+	assert.Empty(t, setup.launcher.fingerprintSkips, "a genuinely vanished file must still be expired")
+}
+
+// A scan returns at most open_files_limit files, so a result that reached the limit may have left
+// out files that are still matched: a skipped file occupies one of those slots, and rotation renames
+// files, which moves them across the limit boundary at the same moment their fingerprints become
+// unusable. Reporting those as given up on would restart the gap we report for a file that every
+// scan is still retrying.
+func TestLauncherKeepsFingerprintSkipWhenScanHitFileLimit(t *testing.T) {
+	const count = 2048
+	setup := setupFingerprintSkipTest(t, count)
+
+	writeFile(t, setup.path, count-1)
+	setup.scan()
+	skip := setup.launcher.fingerprintSkips[setup.path]
+	require.NotNil(t, skip, "the file must be skipped first")
+	since := skip.since
+
+	// A result that filled every slot, and so cannot be read as everything that is matched.
+	setup.launcher.tailingLimit = 1
+	otherPath := t.TempDir() + "/other.log"
+	writeFile(t, otherPath, count)
+	otherSource := sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: otherPath})
+	atLimit := []*filetailer.File{filetailer.NewFile(otherPath, otherSource, false)}
+
+	logs := captureLauncherLogs(t, log.WarnLvl, func() {
+		setup.launcher.resolveActiveTailers(atLimit)
+	})
+
+	require.Len(t, setup.launcher.fingerprintSkips, 1,
+		"a file left out of a scan result that hit the limit must stay tracked")
+	assert.NotContains(t, logs, "Stopped tracking",
+		"a file we are still retrying must not be reported as given up on, got:\n%s", logs)
+	assert.Equal(t, since, setup.launcher.fingerprintSkips[setup.path].since,
+		"the gap must stay continuous rather than restarting")
+
+	// A file that really is gone is still forgotten, so the map stays bounded for an Agent that sits
+	// at its file limit for a long time.
+	require.NoError(t, os.Remove(setup.path))
+	setup.launcher.resolveActiveTailers(atLimit)
+	assert.Empty(t, setup.launcher.fingerprintSkips,
+		"a deleted file must be expired even from a scan result that hit the limit")
+}
+
+// When a scan hits open_files_limit, a skipped file left out of the result is kept only while its
+// source is still active. Removing the source while the physical file remains must still abandon the
+// skip, or the entry never clears, re-adds inherit stale duration and warning state, and dynamic
+// source churn can grow fingerprintSkips without bound.
+func TestLauncherAbandonsFingerprintSkipWhenSourceRemovedAtFileLimit(t *testing.T) {
+	const count = 2048
+	setup := setupFingerprintSkipTest(t, count)
+
+	writeFile(t, setup.path, count-1)
+	setup.scan()
+	skip := setup.launcher.fingerprintSkips[setup.path]
+	require.NotNil(t, skip, "the file must be skipped first")
+	since := skip.since
+
+	setup.launcher.tailingLimit = 1
+	otherPath := t.TempDir() + "/other.log"
+	writeFile(t, otherPath, count)
+	otherSource := sources.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: otherPath})
+	atLimit := []*filetailer.File{filetailer.NewFile(otherPath, otherSource, false)}
+
+	// Source goes away while the skipped file is still on disk and every scan is at the limit.
+	setup.launcher.activeSources = nil
+
+	logs := captureLauncherLogs(t, log.WarnLvl, func() {
+		setup.launcher.resolveActiveTailers(atLimit)
+	})
+
+	assert.Empty(t, setup.launcher.fingerprintSkips,
+		"removing the source must clear the skip even when the file still exists at the limit")
+	assert.Contains(t, logs, "Stopped tracking "+setup.path,
+		"source removal must close the gap, got:\n%s", logs)
+
+	// Re-adding the path must start fresh rather than inherit the old gap.
+	setup.launcher.activeSources = append(setup.launcher.activeSources, setup.source)
+	setup.scan()
+	freshSkip := setup.launcher.fingerprintSkips[setup.path]
+	require.NotNil(t, freshSkip, "the file must be tracked again once the source returns")
+	assert.True(t, freshSkip.since.After(since),
+		"a re-added source must start a new gap rather than inherit the previous start time")
+
+	logs = captureLauncherLogs(t, log.WarnLvl, func() {
+		setup.scan()
+		setup.scan()
+	})
+	assert.Equal(t, 0, countLines(logs, "is too short for fingerprinting"),
+		"a re-added source must not inherit the previous warning latch, got:\n%s", logs)
+}
+
+// Customers cannot query the Agent's internal telemetry, so the reason a file is not being tailed
+// has to reach them through `agent status`, next to the "N files tailed out of M matching" message
+// that otherwise reports the shortfall without explaining it.
+func TestLauncherReportsFingerprintSkipOnSourceStatus(t *testing.T) {
+	const count = 2048
+	setup := setupFingerprintSkipTest(t, count)
+
+	writeFile(t, setup.path, count-1)
+	setup.scan()
+
+	messages := setup.source.Messages.GetMessages()
+	require.Len(t, messages, 1, "the source must carry exactly one message for the skipped file")
+	assert.Contains(t, messages[0], setup.path, "the message must name the file")
+	assert.Contains(t, messages[0], "needs 2048 bytes", "the message must report the threshold and its unit")
+	// This source carries its own fingerprint_config, which wins over the global one, so the global
+	// setting is not what would make this file tailable.
+	assert.Contains(t, messages[0], "this source's fingerprint_config.count",
+		"the message must name the setting that actually applies")
+	assert.NotContains(t, messages[0], "logs_config.fingerprint_config.count",
+		"a per-source config cannot be fixed by changing the global setting")
+
+	// The message must not outlive the problem, or status would keep accusing a healthy file.
+	writeFile(t, setup.path, count)
+	setup.scan()
+	require.Equal(t, 1, setup.launcher.tailers.Count())
+	assert.Empty(t, setup.source.Messages.GetMessages(),
+		"the message must be cleared once the file is tailed")
+}
+
+// Remediation advice is only worth printing if it applies: the count a file fell short of can come
+// from the source, from the global config, or from a built-in fallback that answers to no setting.
+func TestFingerprintCountSetting(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   types.FingerprintConfigSource
+		expected string
+	}{
+		{"per-source wins over global", types.FingerprintConfigSourcePerSource, "this source's fingerprint_config.count"},
+		// GlobalFingerprintConfig unmarshals into a bare config, so the global case arrives unstamped.
+		{"global", types.FingerprintConfigSourceGlobal, "logs_config.fingerprint_config.count"},
+		{"unstamped global", "", "logs_config.fingerprint_config.count"},
+		{"built-in fallback has no setting", types.FingerprintConfigSourceDefault, ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fingerprint := &types.Fingerprint{Config: &types.FingerprintConfig{Source: test.source}}
+			assert.Equal(t, test.expected, fingerprintCountSetting(fingerprint))
+		})
+	}
+
+	// A file with no resolved config gives us nothing to point at, and a guess would be wrong.
+	assert.Empty(t, fingerprintCountSetting(nil), "a missing fingerprint must not name a setting")
+	assert.Empty(t, fingerprintCountSetting(&types.Fingerprint{}),
+		"a fingerprint with no config must not name a setting")
+}
+
+// count is read only after seeking past count_to_skip, so a file larger than count can still be too
+// short. Reporting count on its own would tell operators a file needs a size it already exceeds.
+func TestFingerprintRequirementReportsSkippedData(t *testing.T) {
+	requirement := func(strategy types.FingerprintStrategy, count, countToSkip int) string {
+		return fingerprintRequirement(&types.Fingerprint{Config: &types.FingerprintConfig{
+			FingerprintStrategy: strategy, Count: count, CountToSkip: countToSkip,
+		}})
+	}
+
+	// count_to_skip defaults to 0, so the common case says nothing about it.
+	assert.Equal(t, "2048 bytes", requirement(types.FingerprintStrategyByteChecksum, 2048, 0))
+	assert.Equal(t, "5 lines", requirement(types.FingerprintStrategyLineChecksum, 5, 0))
+
+	assert.Equal(t, "2048 bytes after the first 1000", requirement(types.FingerprintStrategyByteChecksum, 2048, 1000))
+	assert.Equal(t, "5 lines after the first 3", requirement(types.FingerprintStrategyLineChecksum, 5, 3))
+
+	assert.Equal(t, "more data", fingerprintRequirement(nil), "an unknown threshold must not invent a number")
+}
+
+// The file can only be measured with stat, which counts bytes. Reporting that size against a
+// threshold in lines would compare two different units and tell operators nothing.
+func TestFingerprintFileSizeMatchesThresholdUnit(t *testing.T) {
+	path := t.TempDir() + "/measured.log"
+	writeFile(t, path, 2047)
+
+	size := func(strategy types.FingerprintStrategy) string {
+		return fingerprintFileSize(path, &types.Fingerprint{
+			Config: &types.FingerprintConfig{FingerprintStrategy: strategy},
+		})
+	}
+
+	assert.Equal(t, "2047 bytes", size(types.FingerprintStrategyByteChecksum))
+	assert.Equal(t, "The file", size(types.FingerprintStrategyLineChecksum),
+		"a line threshold must not be measured against a byte count")
+
+	// Best effort throughout: an unreadable or unknown file still has to report as not tailed.
+	assert.Equal(t, "The file", fingerprintFileSize(path, nil))
+	assert.Equal(t, "The file", fingerprintFileSize(t.TempDir()+"/missing.log",
+		&types.Fingerprint{Config: &types.FingerprintConfig{FingerprintStrategy: types.FingerprintStrategyByteChecksum}}))
+}
+
+// A source can be removed and re-registered for the same path, by a config reload or by
+// autodiscovery, while the file is still being skipped. The file keeps being skipped throughout, so
+// the message has to follow onto the source that is now being displayed instead of staying on the
+// one that is gone.
+func TestLauncherMovesFingerprintSkipMessageToReplacementSource(t *testing.T) {
+	const count = 2048
+	setup := setupFingerprintSkipTest(t, count)
+
+	writeFile(t, setup.path, count-1)
+	setup.scan()
+	require.Len(t, setup.source.Messages.GetMessages(), 1)
+
+	// A second source for the same path takes over, as a config reload would produce.
+	replacement := sources.NewLogSource("", &config.LogsConfig{
+		Type:              config.FileType,
+		Path:              setup.path,
+		FingerprintConfig: &types.FingerprintConfig{FingerprintStrategy: types.FingerprintStrategyByteChecksum, Count: count},
+	})
+	setup.launcher.activeSources = []*sources.LogSource{replacement}
+
+	setup.scan()
+
+	require.Len(t, setup.launcher.fingerprintSkips, 1, "the file must still be tracked as skipped")
+	messages := replacement.Messages.GetMessages()
+	require.Len(t, messages, 1, "the replacement source must explain why the file is not tailed")
+	assert.Contains(t, messages[0], setup.path)
+	// The handover has to be a move, not a copy: a message left on the source that no longer matches
+	// the file claims it is not being tailed for as long as that source is displayed.
+	assert.Empty(t, setup.source.Messages.GetMessages(),
+		"the message must be taken off the source that no longer matches the file")
+
+	// And when the file stops being skipped, it must be cleared from the source that actually has it.
+	writeFile(t, setup.path, count)
+	setup.scan()
+	require.Equal(t, 1, setup.launcher.tailers.Count())
+	assert.Empty(t, replacement.Messages.GetMessages(),
+		"the message must be cleared from the replacement source once the file is tailed")
+}
+
+// A launcher does not only stop when the Agent does: switching transport stops the launchers and
+// keeps the sources, then builds new ones over them. The replacement launcher has no skip state to
+// clear, so anything left on a source at stop is left there for the lifetime of the process.
+func TestLauncherClearsFingerprintSkipMessagesOnStop(t *testing.T) {
+	const count = 2048
+	setup := setupFingerprintSkipTest(t, count)
+
+	writeFile(t, setup.path, count-1)
+	setup.scan()
+	require.Len(t, setup.source.Messages.GetMessages(), 1, "the file must be reported as skipped first")
+
+	setup.launcher.cleanup()
+
+	assert.Empty(t, setup.launcher.fingerprintSkips, "stopping must drop the skip state")
+	assert.Empty(t, setup.source.Messages.GetMessages(),
+		"stopping must take the message off the source that outlives the launcher")
+}

--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -63,11 +63,18 @@ type Launcher struct {
 	tagger                  tagger.Component
 	filesChan               chan []*tailer.File
 	filesTailedBetweenScans []*tailer.File
+	// Scan keys of files that started being skipped for an unusable fingerprint while a scan was in
+	// flight. Serves the same purpose as filesTailedBetweenScans, for files that got no tailer, and
+	// is cleared on the same schedule. See resolveActiveTailers.
+	filesSkippedBetweenScans []string
 	// Stores pertinent information about old tailer when rotation occurs and fingerprinting isn't possible
-	oldInfoMap    map[string]*oldTailerInfo
-	fileOpener    opener.FileOpener
-	fingerprinter tailer.Fingerprinter
-	stopOnce      sync.Once
+	oldInfoMap map[string]*oldTailerInfo
+	// Tracks the files we currently refuse to tail because their fingerprint is unusable, keyed by
+	// scan key. Only used to log the transitions instead of one line per scan, see recordFingerprintSkip.
+	fingerprintSkips map[string]*fingerprintSkip
+	fileOpener       opener.FileOpener
+	fingerprinter    tailer.Fingerprinter
+	stopOnce         sync.Once
 }
 
 const (
@@ -122,6 +129,7 @@ func NewLauncher(
 		tagger:                 tagger,
 		filesChan:              make(chan []*tailer.File, 1),
 		oldInfoMap:             make(map[string]*oldTailerInfo),
+		fingerprintSkips:       make(map[string]*fingerprintSkip),
 		fileOpener:             fileOpener,
 		fingerprinter:          fingerprinter,
 	}
@@ -169,8 +177,11 @@ func (s *Launcher) run() {
 			activeSourcesCopy := make([]*sources.LogSource, len(s.activeSources))
 			copy(activeSourcesCopy, s.activeSources)
 
-			// Clear files tailed between scans before starting new FilesToTail
+			// Clear the between-scans state before starting a new FilesToTail: the copy of
+			// activeSources it receives already covers the sources these files came from, so its
+			// result will mention them on its own.
 			s.filesTailedBetweenScans = s.filesTailedBetweenScans[:0]
+			s.filesSkippedBetweenScans = s.filesSkippedBetweenScans[:0]
 
 			scanTicker.Stop()
 			go func() {
@@ -208,6 +219,13 @@ func (s *Launcher) cleanup() {
 
 	// Clean up old info map to prevent memory leaks
 	s.oldInfoMap = make(map[string]*oldTailerInfo)
+	if stillSkipped := len(s.fingerprintSkips); stillSkipped > 0 {
+		log.Warnf("Stopping with %d file(s) still not tailed because their fingerprint was unusable.", stillSkipped)
+		for _, skip := range s.fingerprintSkips {
+			removeFingerprintSkipMessage(skip.file)
+		}
+		s.fingerprintSkips = make(map[string]*fingerprintSkip)
+	}
 }
 
 // resolveActiveTailers checks all the files we're expected to tail, compares them to the
@@ -225,9 +243,31 @@ func (s *Launcher) resolveActiveTailers(files []*tailer.File) {
 	// added during a concurrent scan.  In order to mitigate that possibility, any
 	// tailers started while FilesToTail() is running need to be merged with the
 	// result of FilesToTail() to prevent scan() from unscheudling them.
+	// FilesToTail returns at most tailingLimit files, so a result that reached the limit may have
+	// left out files that are still matched. Read before the merge below, which can push the count
+	// past the limit on its own.
+	hitFileLimit := len(files) >= s.tailingLimit
+
 	files = append(files, s.filesTailedBetweenScans...)
 	s.filesTailedBetweenScans = s.filesTailedBetweenScans[:0]
 	filesTailed := make(map[string]bool)
+
+	// Every file we are expected to tail during this scan, used to expire skip state for files that
+	// have gone away. Only worth building when there is skip state to expire, which is the
+	// exception: otherwise it costs a map insert per file on every scan and is never read. A file
+	// that starts being skipped later in this call is simply expired by the next scan instead.
+	expireSkips := len(s.fingerprintSkips) > 0
+	var filesExpected map[string]bool
+	if expireSkips {
+		filesExpected = make(map[string]bool, len(files)+len(s.filesSkippedBetweenScans))
+		// A scan already in flight cannot mention files whose source was added after it took its
+		// copy of activeSources, so they would look like they had vanished. This is the same
+		// mitigation the files slice gets above, for files that never got a tailer.
+		for _, scanKey := range s.filesSkippedBetweenScans {
+			filesExpected[scanKey] = true
+		}
+	}
+	s.filesSkippedBetweenScans = s.filesSkippedBetweenScans[:0]
 	var allFiles []string
 
 	log.Debugf("Scan - got %d files from FilesToTail and currently tailing %d files\n", len(files), s.tailers.Count())
@@ -247,9 +287,13 @@ func (s *Launcher) resolveActiveTailers(files []*tailer.File) {
 		// when a tailer for a dead container is still tailing the file, and another
 		// tailer is tailing the file for the new container).
 		scanKey := file.GetScanKey()
+		if expireSkips {
+			filesExpected[scanKey] = true
+		}
 		tailered, isTailed := s.tailers.Get(scanKey)
 		if isTailed && tailered.IsFinished() {
 			// skip this tailer as it must be stopped
+			log.Debugf("Tailer for %s has finished, it will be stopped and a new one started for this file", file.Path)
 			continue
 		}
 
@@ -261,6 +305,9 @@ func (s *Launcher) resolveActiveTailers(files []*tailer.File) {
 			if s.fingerprinter.ShouldFileFingerprint(file) {
 				didRotate, err = tailered.DidRotateViaFingerprint(s.fingerprinter)
 				if err != nil {
+					// Assuming no rotation keeps the existing tailer running, which is the safe
+					// choice for a check that usually fails only while a rotation is in flight.
+					log.Debugf("Could not check %s for log rotation: %v", file.Path, err)
 					didRotate = false
 				}
 				if didRotate {
@@ -325,6 +372,8 @@ func (s *Launcher) resolveActiveTailers(files []*tailer.File) {
 			fingerprint, err = s.fingerprinter.ComputeFingerprint(file)
 			// Skip files with invalid fingerprints (Value == 0)
 			if (fingerprint != nil && !fingerprint.ValidFingerprint()) || err != nil {
+				// Nothing tails this file until the fingerprint becomes usable, so make the gap visible.
+				s.recordFingerprintSkip(file, fingerprint, err)
 				// If fingerprint is invalid, persist the old info back into the map for future attempts
 				if hasOldInfo {
 					s.oldInfoMap[scanKey] = oldInfo
@@ -345,20 +394,29 @@ func (s *Launcher) resolveActiveTailers(files []*tailer.File) {
 			if s.startNewTailerWithStoredInfo(file, config.ForceBeginning, oldInfo, fingerprint) {
 				// hasOldInfo is true when restarting a tailer after a file rotation, so start tailer from the beginning
 				filesTailed[scanKey] = true
+				s.resolveFingerprintSkip(file)
 			}
 		} else {
 			// Normal case - no stored info
 			if s.startNewTailer(file, config.Beginning, fingerprint) {
 				filesTailed[scanKey] = true
+				s.resolveFingerprintSkip(file)
 			}
 		}
 	}
 	log.Debugf("After starting new tailers, there are %d tailers running. Limit is %d.\n", s.tailers.Count(), s.tailingLimit)
 
+	// Files that are no longer expected to be tailed can't recover, so drop their skip state.
+	if expireSkips {
+		s.forgetVanishedFiles(filesExpected, hitFileLimit)
+	}
+
 	// Check how many file handles the Agent process has open and log a warning if the process is coming close to the OS file limit
 	fileStats, err := procfilestats.GetProcessFileStats()
 	if err == nil {
 		CheckProcessTelemetry(fileStats)
+	} else {
+		log.Debugf("Could not read the Agent process file statistics, skipping the open file limit check: %v", err)
 	}
 }
 
@@ -394,6 +452,8 @@ func (s *Launcher) removeSource(source *sources.LogSource) {
 func (s *Launcher) launchTailers(source *sources.LogSource) {
 	// If we're at the limit already, no need to do a 'CollectFiles', just wait for the next 'scan'
 	if s.tailers.Count() >= s.tailingLimit {
+		log.Debugf("Not launching tailers for %s: already tailing %d files, which is the limit (logs_config.open_files_limit). Files for this source are picked up by the next scan.",
+			source.Config.Path, s.tailingLimit)
 		return
 	}
 	files, err := s.fileProvider.CollectFiles(source)
@@ -408,6 +468,8 @@ func (s *Launcher) launchTailers(source *sources.LogSource) {
 	symlinkResolver := fileprovider.NewContainerLogSymlinkResolver()
 	for _, file := range files {
 		if s.tailers.Count() >= s.tailingLimit {
+			log.Debugf("Reached the limit of %d tailed files (logs_config.open_files_limit) while launching tailers for %s, the remaining files are picked up by the next scan.",
+				s.tailingLimit, source.Config.Path)
 			return
 		}
 
@@ -428,6 +490,14 @@ func (s *Launcher) launchTailers(source *sources.LogSource) {
 		if s.fingerprinter.ShouldFileFingerprint(file) {
 			fingerprint, err = s.fingerprinter.ComputeFingerprint(file)
 			if err != nil || !fingerprint.ValidFingerprint() {
+				// Same silent drop as in the second pass of resolveActiveTailers: nothing tails this
+				// file until its fingerprint becomes usable.
+				s.recordFingerprintSkip(file, fingerprint, err)
+				// A scan running right now was handed a copy of activeSources that predates this
+				// source, so its result will not mention this file. Without this, that result
+				// expires the skip we just opened and we report giving up on a file we are still
+				// retrying, then open a second skip on the next scan.
+				s.filesSkippedBetweenScans = append(s.filesSkippedBetweenScans, file.GetScanKey())
 				continue
 			}
 		} else {
@@ -448,6 +518,7 @@ func (s *Launcher) launchTailers(source *sources.LogSource) {
 
 		newTailerStarted := s.startNewTailer(file, mode, fingerprint)
 		if newTailerStarted {
+			s.resolveFingerprintSkip(file)
 			s.filesTailedBetweenScans = append(s.filesTailedBetweenScans, file)
 		}
 	}
@@ -476,7 +547,7 @@ func (s *Launcher) startNewTailer(file *tailer.File, m config.TailingMode, finge
 	log.Infof("Starting a new tailer for: %s (offset: %d, whence: %d) for tailer key %s", file.Path, offset, whence, file.GetScanKey())
 	err = tailer.Start(offset, whence)
 	if err != nil {
-		log.Warn(err)
+		log.Warnf("Could not start the tailer for %s, this file is not being tailed and will be retried on the next scan: %v", file.Path, err)
 		return false
 	}
 
@@ -546,7 +617,7 @@ func (s *Launcher) startNewTailerWithStoredInfo(file *tailer.File, m config.Tail
 		oldInfo.Pattern != nil, file.Path, offset, whence)
 	err = tailer.Start(offset, whence)
 	if err != nil {
-		log.Warn(err)
+		log.Warnf("Could not start the tailer for %s after a log rotation, this file is not being tailed and will be retried on the next scan: %v", file.Path, err)
 		return false
 	}
 
@@ -622,7 +693,7 @@ func (s *Launcher) restartTailerAfterFileRotation(oldTailer *tailer.Tailer, file
 	// force reading file from beginning since it has been log-rotated
 	err := newTailer.StartFromBeginning()
 	if err != nil {
-		log.Warn(err)
+		log.Warnf("Could not start the replacement tailer for %s after a log rotation, this file is not being tailed and will be retried on the next scan: %v", file.Path, err)
 		return false
 	}
 

--- a/pkg/logs/launchers/file/provider/file_provider.go
+++ b/pkg/logs/launchers/file/provider/file_provider.go
@@ -221,6 +221,13 @@ func (p *FileProvider) FilesToTail(ctx context.Context, validatePodContainerID b
 				files, err := p.filesMatchingSource(source)
 				wildcardFileCounter.setTotal(source, len(files))
 				if err != nil {
+					// Same treatment as the non-wildcard branches above: without this the files of a
+					// wildcard source that stops matching are dropped without a trace, in the log and
+					// on the status page alike.
+					source.Status().Error(err)
+					if shouldLogErrors {
+						log.Warnf("Could not collect files: %v", err)
+					}
 					continue
 				}
 				wildcardFiles = append(wildcardFiles, files...)

--- a/pkg/logs/launchers/file/provider/file_provider_test.go
+++ b/pkg/logs/launchers/file/provider/file_provider_test.go
@@ -576,6 +576,37 @@ func TestFilesToTail(t *testing.T) {
 	})
 }
 
+// TestFilesToTailReportsWildcardMatchingNothing checks that a wildcard source resolving to no files is
+// reported rather than dropped. Both modes are covered because by_modification_time resolves wildcards
+// in a pass of its own, separate from the one every other source goes through, so it can regress alone.
+func TestFilesToTailReportsWildcardMatchingNothing(t *testing.T) {
+	modes := []struct {
+		name              string
+		wildcardSelection WildcardSelectionStrategy
+	}{
+		{"by_name", WildcardUseFileName},
+		{"by_modification_time", WildcardUseFileModTime},
+	}
+
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			fs := newTempFs(t)
+			// A directory the application has not written to yet, as opposed to a missing one, so the
+			// pattern is only unmatched rather than unreachable.
+			fs.mkDir("empty")
+
+			source := sources.NewLogSource("wildcard", &config.LogsConfig{Type: config.FileType, Path: fs.path("empty/*.log")})
+			fileProvider := NewFileProvider(2, mode.wildcardSelection)
+
+			files := fileProvider.FilesToTail(context.Background(), true, []*sources.LogSource{source}, auditor.NewMockAuditor())
+
+			assert.Empty(t, files)
+			assert.True(t, source.Status().IsError(), "a wildcard matching no files has to be reported on the status page")
+			assert.Contains(t, source.Status().GetError(), "could not find any file matching pattern")
+		})
+	}
+}
+
 func BenchmarkApplyOrdering(b *testing.B) {
 	b.Run("Mtime", func(b *testing.B) {
 		fs := newTempFs(b)

--- a/pkg/logs/tailers/file/fingerprint.go
+++ b/pkg/logs/tailers/file/fingerprint.go
@@ -146,6 +146,7 @@ func (f *fingerprinterImpl) ComputeFingerprint(file *File) (*types.Fingerprint, 
 // Note that the providedconfiguration can fallback to different default configuration if specific errors occur attempting to compute the fingerprint.
 func (f *fingerprinterImpl) ComputeFingerprintFromHandle(osFile afero.File, fingerprintConfig *types.FingerprintConfig) (*types.Fingerprint, error) {
 	if fingerprintConfig == nil {
+		log.Debug("no fingerprint configuration provided, returning an invalid fingerprint")
 		return newInvalidFingerprint(nil), nil
 	}
 
@@ -173,6 +174,7 @@ func (f *fingerprinterImpl) ComputeFingerprintFromHandle(osFile afero.File, fing
 // computeFingerprint computes the fingerprint for the given file path
 func (f *fingerprinterImpl) computeFingerprint(filePath string, fingerprintConfig *types.FingerprintConfig) (*types.Fingerprint, error) {
 	if fingerprintConfig == nil {
+		log.Debugf("no fingerprint configuration resolved for %q, returning an invalid fingerprint", filePath)
 		return newInvalidFingerprint(nil), nil
 	}
 
@@ -208,7 +210,10 @@ func computeFingerPrintByBytes(fpFile afero.File, filePath string, fingerprintCo
 		return newInvalidFingerprint(fingerprintConfig), err
 	}
 
-	// Check if we have enough bytes to create a meaningful fingerprint
+	// Check if we have enough bytes to create a meaningful fingerprint.
+	// Note that this is reported as an invalid fingerprint with a nil error: the file is not
+	// broken, it is simply too short for now. Callers that decide whether to tail a file
+	// distinguish this from a read failure by looking at whether the error is nil.
 	if bytesRead == 0 || bytesRead < maxBytes {
 		return newInvalidFingerprint(fingerprintConfig), nil
 	}
@@ -233,14 +238,12 @@ func computeFingerPrintByLines(fpFile afero.File, filePath string, fingerprintCo
 
 	// Single loop that handles both skipping and reading
 	var buffer []byte
-	linesRead := 0
 
 	for i := 0; i < linesToSkip+maxLines; i++ {
 		if scanner.Scan() {
 			if i >= linesToSkip {
 				line := scanner.Bytes()
 				buffer = append(buffer, line...)
-				linesRead++
 			}
 		} else {
 			/// Check if we need to fall back due to byte limits
@@ -263,7 +266,9 @@ func computeFingerPrintByLines(fpFile afero.File, filePath string, fingerprintCo
 				return newInvalidFingerprint(fingerprintConfig), err
 			}
 			// Check if we have enough data for fingerprinting
-			// We need either enough lines OR enough bytes to create a meaningful fingerprint
+			// We need either enough lines OR enough bytes to create a meaningful fingerprint.
+			// As in computeFingerPrintByBytes, this is an invalid fingerprint with a nil error:
+			// the file is simply too short for now.
 			return newInvalidFingerprint(fingerprintConfig), nil
 
 		}

--- a/releasenotes/notes/log-file-tailer-skip-observability-4c1f7a20b8de6931.yaml
+++ b/releasenotes/notes/log-file-tailer-skip-observability-4c1f7a20b8de6931.yaml
@@ -1,0 +1,26 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    ``agent status`` now reports why a file matched by a log configuration is not being tailed when
+    its fingerprint cannot be used, under the log source that matched it. The most common cause is a
+    file that holds less data than ``logs_config.fingerprint_config.count``, for instance right after
+    a log rotation replaced it with a smaller file, and the message names the setting to change. This
+    previously showed up only as a shortfall in the ``N files tailed out of M files matching`` line,
+    with no explanation.
+  - |
+    The Logs Agent now logs a warning when a file matched by a log configuration is not tailed
+    because its fingerprint cannot be used, which previously happened without any log line at any
+    level. The most common cause is a file that holds less data than ``logs_config.fingerprint_config.count``,
+    for instance right after a log rotation replaced it with a smaller file. The warning reports the
+    path, the current size of the file and how much data fingerprinting requires, and distinguishes a
+    file that is simply too short from a file whose fingerprint could not be computed at all. It is
+    emitted once when the file starts being skipped rather than once per check, and a closing
+    message is logged when it stops being skipped, whether the file started being tailed again or
+    was never tailed at all, so the collection gap can be measured from the Agent log alone.


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

A file that matches a log config but gets no tailer because its fingerprint is unusable used to be dropped silently, with no log line at any level. The only clue was an unexplained shortfall in `N files tailed out of M files matching`. This reports the gap when it opens, while it lasts, and when it closes.

#### What an operator sees

Setup: `byte_checksum` fingerprinting with `count` left at its default of 1024 bytes, a source matching `/var/log/app/*.log`, and `app.log` just rotated away to a 412-byte replacement. Scans run every second.

```
t=1s      WARN   Unable to tail /var/log/app/app.log. 412 bytes is too short for fingerprinting
                 (needs 1024 bytes). Logs are not collected until the file grows.

t=2..29s         (silent: the warning is latched, so a file that stays short cannot fill the log.
                  Every scan still shows the arithmetic at debug level.)

t=30s     INFO   Now tailing /var/log/app/app.log, 30s after it was first skipped for an
                 unusable fingerprint (insufficient_data).
```

While the gap is open, `agent status` carries it under the source whose pattern matched the file:

```
    - Type: file
      Path: /var/log/app/*.log
      Status: OK
        2 files tailed out of 3 files matching
        Not tailing /var/log/app/app.log: too short to fingerprint (needs 1024 bytes). Lower logs_config.fingerprint_config.count if this persists
```

The `2 files tailed out of 3` line already existed and was the whole of what an operator had to go on. The `Not tailing` line is new: which file, why, and the setting that governs it. It names `this source's fingerprint_config.count` instead when the source carries its own `fingerprint_config`, and names no setting at all when the threshold came from an internal fallback, so the suggestion always points at something that would change the outcome.

Recovery is a delay in collection rather than a hole in it: these tailers start at the beginning of the file, so the 412 bytes written while it waited are read and sent once tailing starts. What the file held is only lost if it is destroyed before a tailer ever reaches it.

Three variations on the ending:

- **The file goes away while still short** — deleted, or `count` set too high. The closing line is a WARN rather than an INFO, so the gap is bounded either way: `Stopped tracking /var/log/app/app.log, never tailed for 45s because of an unusable fingerprint (insufficient_data). Logs written during that gap were not collected.`
- **The Agent stops with skips outstanding** — one line: `Stopping with 1 file(s) still not tailed because their fingerprint was unusable.`
- **The fingerprint fails to compute** rather than coming up short, a permissions error say. The warning and the status message report that instead of blaming the file's size. A file alternating between the two reasons warns once per reason, keeping its original start time, so one gap is still reported as one gap.

### Motivation

The usual cause is benign and self-healing — a rotation leaving the file below `logs_config.fingerprint_config.count` — but collection stalls while it lasts, and a `count` set too high makes that permanent. Customers cannot query the Agent's telemetry, so this has to reach them through the log and `agent status`.

### Describe how you validated your changes

`dda inv test --targets=./pkg/logs/launchers/file/...` — 110 tests pass. New tests cover the warn-once latching (including a file alternating between reasons), both closing outcomes and their durations, the status message and its removal, the message following a source that gets replaced, and two ways a skip could be wrongly reported as given up on: a scan already in flight when the source was added, and one that hit `open_files_limit` and so may have left out files that are still matched.

`dda inv test --targets=./pkg/logs/launchers/file/provider/...` — 45 tests pass. The new one asserts that a wildcard matching no files is reported in both selection modes, which is the parity the provider fix restores: revert those six lines and only the `by_modification_time` case fails.

Also verified `gofmt` and `bazel test //bazel/buildifier:test`. No E2E test covers this.

### Additional Notes

- Inert by default: `logs_config.fingerprint_config.fingerprint_strategy` defaults to `disabled`.
- Drive-by fix in the file provider: under `file_wildcard_selection_mode: by_modification_time`, a wildcard source that resolves to no files now reports the error, as it already does under the default `by_name` mode. That mode resolves wildcards in a pass of its own, separate from the one every other source goes through, which is how it came to drop them. Not in the release note.
