### PR TITLE
fix(cws): register connected sockets in the `flow_pid` map

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/network/connect.h
+++ b/pkg/security/ebpf/c/include/hooks/network/connect.h
@@ -4,6 +4,7 @@
 #include "constants/offsets/netns.h"
 #include "constants/syscall_macro.h"
 #include "helpers/discarders.h"
+#include "hooks/network/flow.h"
 
 int __attribute__((always_inline)) sys_connect(void *ctx, u64 pid_tgid) {
     struct policy_t policy = fetch_policy(EVENT_CONNECT);
@@ -37,6 +38,13 @@ int __attribute__((always_inline)) sys_connect_ret(void *ctx, int retval) {
 
     // EAGAIN may be returned on Fedora 37 (kernel 6.0.7-301.fc37.x86_64)
     if (IS_UNHANDLED_ERROR(retval) && retval != -EINPROGRESS && retval != -EAGAIN) {
+        return 0;
+    }
+
+    register_connecting_flow(syscall->connect.sk, syscall->connect.pid_tgid ? syscall->connect.pid_tgid : bpf_get_current_pid_tgid());
+
+    // these probes are also loaded with the network probes, only send the event when a rule asks for it
+    if (!is_event_enabled(EVENT_CONNECT)) {
         return 0;
     }
 
@@ -115,6 +123,7 @@ int hook_security_socket_connect(ctx_t *ctx) {
     
     struct sock *sk = get_sock_from_socket(sock);
     syscall->connect.protocol = get_protocol_from_sock(sk);
+    syscall->connect.sk = sk;
     return 0;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/network/flow.h
+++ b/pkg/security/ebpf/c/include/hooks/network/flow.h
@@ -695,16 +695,18 @@ __attribute__((always_inline)) int register_connected_flow(struct sock *sk, u64 
     return 0;
 }
 
-// Before Linux 7.0 an IPv6 socket was classified on its first transmit, once its source address and port
-// were known. Starting with Linux 7.0 inet6_csk_xmit only calls security_sk_classify_flow on a route miss.
+// Before Linux 7.0 an IPv6 socket was classified on its first transmit by security_sk_classify_flow.
+// Starting with Linux 7.0, security_sk_classify_flow is only called by inet6_csk_xmit on a route miss,
+// so IPv6 sockets need to call this helper to register the corresponding flow.
 __attribute__((always_inline)) int register_native_ipv6_flow(struct sock *sk, u64 pid_tgid) {
-    // IPv4 and ipv4 mapped addresses still reach security_sk_classify_flow with a usable flow
+    // IPv4 sockets still reach security_sk_classify_flow with a usable flow
     if (get_family_from_sock_common((void *)sk) != AF_INET6) {
         return 0;
     }
 
     u64 addr[2] = {};
     bpf_probe_read(&addr, sizeof(addr), &sk->__sk_common.skc_v6_rcv_saddr);
+    // IPv6 sockets using IPv4 mapped addresses still reach security_sk_classify_flow with a usable flow
     if (is_ipv4_mapped_ipv6_addr(addr)) {
         return 0;
     }

--- a/pkg/security/ebpf/c/include/hooks/network/flow.h
+++ b/pkg/security/ebpf/c/include/hooks/network/flow.h
@@ -695,26 +695,35 @@ __attribute__((always_inline)) int register_connected_flow(struct sock *sk, u64 
     return 0;
 }
 
-// The socket returned by accept() holds the concrete local address the connection landed on, which
-// the BIND_ENTRY of a wildcard listener doesn't cover. Before Linux 7.0 that IPv6 socket was classified
-// on its first transmit, causing security_sk_classify_flow to be called and classify the flow.
-// Starting with Linux 7.0 that security_sk_classify_flow call is only done on a route miss in inet6_csk_xmit,
-// this means that we miss the classification in the hit case.
-__attribute__((always_inline)) int register_accepted_flow(struct sock *sk) {
-    // Only native IPv6 sockets lost that classification with Linux 7.0, IPv4 always reaches
-    // security_sk_classify_flow, so the flow registration is already handled by the security_sk_classify_flow hook
+// Before Linux 7.0 an IPv6 socket was classified on its first transmit, once its source address and port
+// were known. Starting with Linux 7.0 inet6_csk_xmit only calls security_sk_classify_flow on a route miss.
+__attribute__((always_inline)) int register_native_ipv6_flow(struct sock *sk, u64 pid_tgid) {
+    // IPv4 and ipv4 mapped addresses still reach security_sk_classify_flow with a usable flow
     if (get_family_from_sock_common((void *)sk) != AF_INET6) {
         return 0;
     }
 
     u64 addr[2] = {};
     bpf_probe_read(&addr, sizeof(addr), &sk->__sk_common.skc_v6_rcv_saddr);
-    // ipv4 mapped addresses already go through the security_sk_classify_flow path
     if (is_ipv4_mapped_ipv6_addr(addr)) {
         return 0;
     }
 
-    return register_connected_flow(sk, bpf_get_current_pid_tgid());
+    return register_connected_flow(sk, pid_tgid);
+}
+
+// the BIND_ENTRY of a wildcard listener doesn't cover the local address the connection landed on
+__attribute__((always_inline)) int register_accepted_flow(struct sock *sk) {
+    return register_native_ipv6_flow(sk, bpf_get_current_pid_tgid());
+}
+
+// tcp_v6_connect classifies the flow before inet_hash_connect assigns the ephemeral port
+__attribute__((always_inline)) int register_connecting_flow(struct sock *sk, u64 pid_tgid) {
+    if (sk == NULL) {
+        return 0;
+    }
+
+    return register_native_ipv6_flow(sk, pid_tgid);
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/structs/syscalls.h
+++ b/pkg/security/ebpf/c/include/structs/syscalls.h
@@ -242,6 +242,7 @@ struct syscall_cache_t {
             u16 port;
             u16 protocol;
             u64 pid_tgid;
+            struct sock *sk;
         } connect;
 
          struct {

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -37,7 +37,7 @@ func NetworkVethSelectors() []manager.ProbesSelector {
 }
 
 // NetworkSelectors is the list of probes that should be activated when the network is enabled
-func NetworkSelectors(hasCgroupSocket bool) []manager.ProbesSelector {
+func NetworkSelectors(hasFentry, hasCgroupSocket, haveIOURing bool) []manager.ProbesSelector {
 	ps := []manager.ProbesSelector{
 		// flow classification probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
@@ -61,6 +61,9 @@ func NetworkSelectors(hasCgroupSocket bool) []manager.ProbesSelector {
 			hookFunc("hook_inet6_bind"),
 			hookFunc("rethook_inet6_bind"),
 		}},
+
+		// the connect exit is the only hook that sees the final source address and port of a connecting socket
+		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "connect", hasFentry, EntryAndExit)},
 
 		// network device probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
@@ -87,6 +90,13 @@ func NetworkSelectors(hasCgroupSocket bool) []manager.ProbesSelector {
 		ps = append(ps, &manager.BestEffort{Selectors: []manager.ProbesSelector{
 			hookFunc("hook_sock_create"),
 			hookFunc("hook_sock_release"),
+		}})
+	}
+
+	if haveIOURing {
+		ps = append(ps, &manager.BestEffort{Selectors: []manager.ProbesSelector{
+			hookFunc("hook_io_connect"),
+			hookFunc("rethook_io_connect"),
 		}})
 	}
 
@@ -147,10 +157,10 @@ func GetCapabilitiesMonitoringSelectors() []manager.ProbesSelector {
 // These probes must be loaded independently of the current ruleset or network filter actions as
 // these are used to track resources that are needed if we later dynamically load network rules
 // or network filter actions.
-func GetNetworkSelectors(hasCgroupSocket bool) []manager.ProbesSelector {
+func GetNetworkSelectors(hasFentry, hasCgroupSocket, haveIOURing bool) []manager.ProbesSelector {
 	selectors := []manager.ProbesSelector{
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.AllOf{Selectors: NetworkSelectors(hasCgroupSocket)},
+			&manager.AllOf{Selectors: NetworkSelectors(hasFentry, hasCgroupSocket, haveIOURing)},
 			&manager.AllOf{Selectors: NetworkVethSelectors()},
 		}},
 	}
@@ -683,6 +693,7 @@ func GetSelectorsPerEventType(hasFentry, haveIOURing bool) map[eval.EventType][]
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "bind", hasFentry, EntryAndExit)},
 		},
 		// List of probes required to capture connect events
+		// also part of NetworkSelectors, kept here so that connect events are captured when network tracking is off
 		"connect": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_security_socket_connect"),

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2352,7 +2352,7 @@ func (p *EBPFProbe) updateProbes(ruleSetEventTypes []eval.EventType, needRawSysc
 	// network filter actions as these are used to track resources that are needed if we later
 	// dynamically load network rules or network filter actions.
 	if p.config.Probe.NetworkEnabled {
-		activatedProbes = append(activatedProbes, probes.GetNetworkSelectors(p.kernelVersion.HasBpfGetSocketCookieForCgroupSocket())...)
+		activatedProbes = append(activatedProbes, probes.GetNetworkSelectors(p.useFentry, p.kernelVersion.HasBpfGetSocketCookieForCgroupSocket(), p.kernelVersion.HaveIOURing())...)
 	}
 
 	if p.config.Probe.CapabilitiesMonitoringEnabled {


### PR DESCRIPTION
### What does this PR do?

Registers the flow of a connecting IPv6 socket once `connect` returns.

### Motivation

`tcp_v6_connect` classifies the flow before the ephemeral source port and the source address are picked, so until Linux 7.0 the socket was classified on its first transmit, once both were known. Linux 7.0 only routes on a dst cache miss in `inet6_csk_xmit`, and a connecting socket always ends up holding a route, so that second classification never happens and those flows are left unattributed.

### Describe how you validated your changes

Existing functional tests running on Ubuntu 26.04 that this PR fixes.

### Additional Notes

IPv4 flows are unaffected as these are still registered as part of the `security_sk_classify_flow` hook.