### PR TITLE
[Cisco SD-WAN] Fix BGP neighbor field parsing for real-time endpoint

### DIFF
--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/client_test.go
@@ -618,10 +618,14 @@ func TestGetBGPNeighbors(t *testing.T) {
 
 	require.Equal(t, "10.10.1.11", neighbors[0].VmanageSystemIP)
 	require.Equal(t, "ipv4-unicast", neighbors[0].Afi)
-	require.Equal(t, float64(1), neighbors[0].VpnID)
+	require.Equal(t, "1", neighbors[0].VpnID)
 	require.Equal(t, "10.60.1.1", neighbors[0].PeerAddr)
-	require.Equal(t, float64(2024), neighbors[0].AS)
+	require.Equal(t, "2024", neighbors[0].AS)
 	require.Equal(t, "established", neighbors[0].State)
+
+	// A non-numeric VRF name (vpn-id) must deserialize as a string, not be dropped
+	require.Equal(t, "default", neighbors[1].VpnID)
+	require.Equal(t, "10.60.1.2", neighbors[1].PeerAddr)
 
 	// Ensure endpoint has been called once per device
 	require.Equal(t, 1, handler.numberOfCalls())
@@ -657,10 +661,10 @@ func TestGetBGPNeighborsPartialFailureAndBackfill(t *testing.T) {
 	const bgpNeighborNoSystemIP = `
 [
 	{
-		"afi": "ipv4-unicast",
-		"vpn-id": 1,
+		"afi-safi": "ipv4-unicast",
+		"vpn-id": "1",
 		"peer-addr": "10.60.1.1",
-		"as": 2024,
+		"as": "2024",
 		"vmanage-system-ip": "",
 		"state": "established"
 	}

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/fixtures/payloads.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/fixtures/payloads.go
@@ -438,24 +438,41 @@ const GetCloudExpressMetrics = `
 `
 
 // GetBGPNeighbors /dataservice/device/bgp/neighbors
+//
+// The real-time endpoint returns vpn-id and as as strings (vpn-id is a VRF name
+// and may be non-numeric, e.g. "default") and reports the address family as
+// afi-safi. The second entry exercises the non-numeric VRF case.
 const GetBGPNeighbors = `
 [
 	{
-		"recordId": "0:BGPNeighborNode:1000:500",
 		"vdevice-name": "10.10.1.11",
-		"afi": "ipv4-unicast",
-		"createTimeStamp": 1707919131595,
-		"last-uptime": "Thu Jul 25 13:48:17 2024",
-		"vpn-id": 1,
+		"afi-safi": "ipv4-unicast",
+		"vpn-id": "1",
 		"vdevice-host-name": "DC-cEdge01",
 		"peer-addr": "10.60.1.1",
-		"as": 2024,
-		"vdevice-dataKey": "10.10.1.11-10.60.1.1",
-		"@rid": 100,
+		"as": "2024",
+		"sent-opens": 1,
+		"rcvd-opens": 1,
+		"outq-depth": 0,
+		"vdevice-dataKey": "10.10.1.11-1-10.60.1.1",
 		"vmanage-system-ip": "10.10.1.11",
-		"afi-id": 0,
 		"lastupdated": 1708940180703,
 		"state": "established"
+	},
+	{
+		"vdevice-name": "10.10.1.11",
+		"afi-safi": "ipv4-unicast",
+		"vpn-id": "default",
+		"vdevice-host-name": "DC-cEdge01",
+		"peer-addr": "10.60.1.2",
+		"as": "2024",
+		"sent-opens": 0,
+		"rcvd-opens": 0,
+		"outq-depth": 0,
+		"vdevice-dataKey": "10.10.1.11-default-10.60.1.2",
+		"vmanage-system-ip": "10.10.1.11",
+		"lastupdated": 1708940180703,
+		"state": "closed"
 	}
 ]
 `

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/client/types.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/client/types.go
@@ -471,19 +471,20 @@ type CloudXStatistics struct {
 }
 
 // BGPNeighbor /dataservice/device/bgp/neighbors
+//
+// The real-time per-device endpoint returns a different schema than the legacy
+// /dataservice/data/device/state/BGPNeighbor state table: vpn-id and as are
+// strings (vpn-id is a VRF name and may be non-numeric, e.g. "default"), and
+// the address family is reported as afi-safi rather than afi.
 type BGPNeighbor struct {
-	RecordID        string  `json:"recordId"`
 	VdeviceName     string  `json:"vdevice-name"`
-	Afi             string  `json:"afi"`
-	CreateTimeStamp float64 `json:"createTimeStamp"`
-	VpnID           float64 `json:"vpn-id"`
+	Afi             string  `json:"afi-safi"`
+	VpnID           string  `json:"vpn-id"`
 	VdeviceHostName string  `json:"vdevice-host-name"`
 	PeerAddr        string  `json:"peer-addr"`
-	AS              float64 `json:"as"`
+	AS              string  `json:"as"`
 	VdeviceDataKey  string  `json:"vdevice-dataKey"`
-	Rid             float64 `json:"@rid"`
 	VmanageSystemIP string  `json:"vmanage-system-ip"`
-	AfiID           float64 `json:"afi-id"`
 	Lastupdated     float64 `json:"lastupdated"`
 	State           string  `json:"state"`
 }

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics.go
@@ -293,11 +293,8 @@ func (ms *SDWanSender) SendCloudApplicationMetrics(cloudApplications []client.Cl
 // SendBGPNeighborMetrics sends hardware metrics
 func (ms *SDWanSender) SendBGPNeighborMetrics(bgpNeighbors []client.BGPNeighbor) {
 	for _, entry := range bgpNeighbors {
-		as := strconv.Itoa(int(entry.AS))
-		vpnID := strconv.Itoa(int(entry.VpnID))
-
 		tags := ms.getDeviceTags(entry.VmanageSystemIP)
-		tags = append(tags, "peer_state:"+entry.State, "remote_as:"+as, "neighbor:"+entry.PeerAddr, "vpn_id:"+vpnID, "afi:"+entry.Afi)
+		tags = append(tags, "peer_state:"+entry.State, "remote_as:"+entry.AS, "neighbor:"+entry.PeerAddr, "vpn_id:"+entry.VpnID, "afi:"+entry.Afi)
 
 		ms.sender.Gauge(ciscoSDWANMetricPrefix+"bgp.neighbor", float64(1), "", tags)
 	}

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics_test.go
@@ -1301,16 +1301,18 @@ func TestSendBGPNeighborMetrics(t *testing.T) {
 			bgpNeighbor: []client.BGPNeighbor{
 				{
 					VmanageSystemIP: "10.0.0.1",
-					AS:              1,
-					VpnID:           1,
+					AS:              "1",
+					VpnID:           "1",
 					State:           "established",
 					PeerAddr:        "10.60.1.11",
 					Afi:             "ipv4-unicast",
 				},
 				{
+					// vpn-id is a VRF name on the real-time endpoint and may be
+					// non-numeric (e.g. "default"); it must survive as a string.
 					VmanageSystemIP: "10.0.0.2",
-					AS:              2,
-					VpnID:           1,
+					AS:              "2",
+					VpnID:           "default",
 					State:           "established",
 					PeerAddr:        "10.60.2.11",
 					Afi:             "ipv4-unicast",
@@ -1367,7 +1369,7 @@ func TestSendBGPNeighborMetrics(t *testing.T) {
 						"peer_state:established",
 						"remote_as:2",
 						"neighbor:10.60.2.11",
-						"vpn_id:1",
+						"vpn_id:default",
 						"afi:ipv4-unicast",
 					},
 				},

--- a/releasenotes/notes/fix-cisco-sdwan-bgp-neighbor-metrics-4be356c787ff9150.yaml
+++ b/releasenotes/notes/fix-cisco-sdwan-bgp-neighbor-metrics-4be356c787ff9150.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fix missing BGP neighbor metrics in the Cisco SD-WAN integration. The
+    ``cisco_sdwan.bgp.neighbor`` metric now populates its ``neighbor``,
+    ``remote_as``, ``peer_state``, ``vpn_id`` and ``afi`` tags correctly. The
+    integration previously failed to parse the response from vManage, which
+    reports ``vpn-id`` and ``as`` as strings (``vpn-id`` may be a non-numeric
+    VRF name such as ``default``), silently dropping the affected neighbors.


### PR DESCRIPTION
### What does this PR do?

Fixes deserialization of BGP neighbor data from the real-time per-device
vManage endpoint so that `cisco_sdwan.bgp.neighbor` metrics carry correct
per-neighbor tags (`neighbor`, `remote_as`, `peer_state`, `vpn_id`, `afi`).

Stacked on the BGP real-time endpoint change (#52880). That PR switched the
BGP query from the global state table to the per-device real-time endpoint but
kept the old response struct, so neighbor rows failed to parse.

### Motivation

AGENT-15988. A customer upgraded and saw interface/tunnel/BFD metrics return,
but BGP neighbors were still missing. Root cause: the real-time endpoint
(`/dataservice/device/bgp/neighbors`) returns a different schema than the
legacy state table (`/dataservice/data/device/state/BGPNeighbor`):

| Field | State table | Real-time endpoint | Old struct expected |
|-------|-------------|--------------------|---------------------|
| `vpn-id` | number | **string** (VRF name, e.g. `"default"`) | `float64` ❌ |
| `as` | number | **string** | `float64` ❌ |
| address family | `afi` | **`afi-safi`** | `afi` ❌ |

`json.Unmarshal` errors on the first string→float64 mismatch, and because the
whole per-device response is unmarshalled in one call, every neighbor for that
device is dropped with no warning. Devices with zero neighbors "succeed" empty,
which is why the customer saw BGP present but with no neighbor detail.

Because `vpn-id` is a VRF name that can be non-numeric (`"default"`), the
correct type is `string`, not a numeric-tolerant type — a `FlexFloat64` would
still drop the `"default"` rows.

### Describe how you validated your changes

- Verified the endpoint schema against the Cisco DevNet sandbox and the
  customer's production payload (12 neighbors, `vpn-id` values `"10"` and
  `"default"`): the old struct errors, the fixed struct parses all 12 cleanly.
- Added a `vpn-id: "default"` neighbor to the fixture and assertions so the
  non-numeric VRF case is covered at both the deserialization layer
  (`client_test.go`) and the emission layer (`metrics_test.go`).
- `dda inv test --targets=./pkg/collector/corechecks/network-devices/cisco-sdwan/...`
  → 133 passed.

Note: a live end-to-end run producing real BGP metrics was not possible — the
DevNet sandbox has no BGP neighbors configured. Confidence rests on the schema
+ customer payload run through the actual structs.

### Possible drawbacks / trade-offs

`vpn_id` tag values are now VRF names (e.g. `default`) rather than numeric
strings, matching what vManage actually reports for this endpoint.

### Additional Notes

Should ship together with / after #52880.