### PR TITLE
[autoscaling] Filter Preview DPAs from pod patcher

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/pod_patcher.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
@@ -150,13 +151,11 @@ func (pa podPatcher) findAutoscaler(pod *corev1.Pod) (*model.PodAutoscalerIntern
 
 	// TODO: Implementation is slow
 	podAutoscalers := pa.store.List(func(podAutoscaler model.PodAutoscalerInternal) bool {
-		if podAutoscaler.Namespace() == pod.Namespace &&
+		return podAutoscaler.Namespace() == pod.Namespace &&
 			podAutoscaler.Spec().TargetRef.Name == ownerRef.Name &&
 			podAutoscaler.Spec().TargetRef.Kind == ownerRef.Kind &&
-			podAutoscaler.Spec().TargetRef.APIVersion == ownerRef.APIVersion {
-			return true
-		}
-		return false
+			podAutoscaler.Spec().TargetRef.APIVersion == ownerRef.APIVersion &&
+			(podAutoscaler.Spec().ApplyPolicy == nil || podAutoscaler.Spec().ApplyPolicy.Mode != datadoghq.DatadogPodAutoscalerApplyModePreview)
 	})
 
 	if len(podAutoscalers) == 0 {

--- a/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
@@ -179,6 +179,38 @@ func patcherTestStoreWithData() *store {
 		},
 	}.Build(), "")
 
+	// In ns5, autoscaler-apply and autoscaler-preview both target "mixed-mode-target".
+	item, _ = store.Get("ns5/autoscaler-apply")
+	item.Upsert(model.FakePodAutoscalerInternal{
+		Namespace: "ns5",
+		Name:      "autoscaler-apply",
+		Spec: &datadoghq.DatadogPodAutoscalerSpec{
+			TargetRef: autoscalingv2.CrossVersionObjectReference{
+				Kind:       "ReplicaSet",
+				APIVersion: "apps/v1",
+				Name:       "mixed-mode-target",
+			},
+			ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
+				Mode: datadoghq.DatadogPodAutoscalerApplyModeApply,
+			},
+		},
+	}.Build(), "")
+	item, _ = store.Get("ns5/autoscaler-preview")
+	item.Upsert(model.FakePodAutoscalerInternal{
+		Namespace: "ns5",
+		Name:      "autoscaler-preview",
+		Spec: &datadoghq.DatadogPodAutoscalerSpec{
+			TargetRef: autoscalingv2.CrossVersionObjectReference{
+				Kind:       "ReplicaSet",
+				APIVersion: "apps/v1",
+				Name:       "mixed-mode-target",
+			},
+			ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
+				Mode: datadoghq.DatadogPodAutoscalerApplyModePreview,
+			},
+		},
+	}.Build(), "")
+
 	// ns1/autoscaler-burstable targets "burstable-deployment" in burstable mode.
 	// applyVerticalConstraints has already stamped removeLimitSentinel (-1) on CPU limit in the
 	// stored ScalingValues (so patchContainerResources will remove the CPU limit).
@@ -1093,6 +1125,24 @@ func TestFindAutoscaler(t *testing.T) {
 			},
 			expectedAutoscalerID: "",
 			expectedError:        errors.New("Multiple autoscaler found for POD ns2/pod2, ownerRef: ReplicaSet/duplicate-target, cannot update POD"),
+		},
+		{
+			name: "Pod with owner and multiple matching autoscalers with different apply policies should return the Apply autoscaler",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns5",
+					Name:      "pod5",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "ReplicaSet",
+							Name:       "mixed-mode-target",
+							APIVersion: "apps/v1",
+						},
+					},
+				},
+			},
+			expectedAutoscalerID: "ns5/autoscaler-apply",
+			expectedError:        nil,
 		},
 		{
 			name: "Pod without owner",


### PR DESCRIPTION
### What does this PR do?
Updates findAutoscaler in pod_patcher.go to filter out DatadogPodAutoscaler resources whose ApplyPolicy.Mode is set to Preview. Only autoscalers in `Apply` mode (or with no ApplyPolicy set) are considered when patching pods.

### Motivation

It is valid to have multiple DPAs targeting the same workload - for example, one in Preview mode for observing recommendations and one in Apply mode for actually applying them. Previously, the pod patcher would find both and error out with "Multiple autoscaler found", preventing any patching from occurring. This fix allows Preview DPAs to coexist with an Apply DPA on the same target.

### Describe how you validated your changes

Tested locally with a kind cluster running two DPAs targeting the same deployment.
