### PR TITLE
fix(review): Remove unnecessary usage of `ask-review`

### DIFF
--- a/.github/workflows/upgrade-python-patch-version.yml
+++ b/.github/workflows/upgrade-python-patch-version.yml
@@ -89,4 +89,4 @@ jobs:
             ### Describe how you validated your changes
             CI is considered enough to validate changes.
           team-reviewers: agent-integrations
-          labels: team/agent-integrations,changelog/no-changelog,ask-review
+          labels: team/agent-integrations,changelog/no-changelog


### PR DESCRIPTION
The slack review request are automatically created when a PR is opened, so using the `ask-review` label here is redundant

