### PR TITLE
Deflake `TestRequestScan` with `synctest`

### DIFF
--- a/comp/snmpscanmanager/impl/snmpscanmanager_test.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
@@ -265,7 +266,7 @@ func TestRequestScan(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		syncTestRequestScan := func(t *testing.T) {
 			testDir := t.TempDir()
 			mockConfig := configmock.New(t)
 			mockConfig.SetInTest("run_path", testDir)
@@ -302,15 +303,18 @@ func TestRequestScan(t *testing.T) {
 				provides.Comp.RequestScan(req, false)
 			}
 
-			assert.EventuallyWithT(t, func(t *assert.CollectT) {
-				assertDeviceScans(t, tt.expectedDeviceScans, scanManager)
-			}, 2*time.Second, 100*time.Millisecond)
+			synctest.Wait()
+			assertDeviceScans(t, tt.expectedDeviceScans, scanManager)
 
 			err = mockLifecycle.Stop(context.Background())
 			assert.NoError(t, err)
 
 			mockScanner.AssertExpectations(t)
 			mockConfigProvider.AssertExpectations(t)
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, syncTestRequestScan)
 		})
 	}
 }
@@ -803,36 +807,30 @@ func TestWriteCache(t *testing.T) {
 }
 
 func TestQueueDueScans(t *testing.T) {
-	now := time.Now()
-
 	tests := []struct {
 		name                    string
-		scanTasks               []scanTask
+		buildScanTasks          func(now time.Time) []scanTask
 		buildMockConfigProvider func() *snmpConfigProviderMock
 		buildMockScanner        func() *snmpscanmock.SnmpScanMock
 		expectedDeviceScans     deviceScansByIP
 	}{
 		{
 			name: "due scans are queued",
-			scanTasks: []scanTask{
-				{
-					req: snmpscanmanager.ScanRequest{
-						DeviceIP: "10.0.0.1",
+			buildScanTasks: func(now time.Time) []scanTask {
+				return []scanTask{
+					{
+						req:        snmpscanmanager.ScanRequest{DeviceIP: "10.0.0.1"},
+						nextScanTs: now.Add(999 * time.Hour), // Not a due scan
 					},
-					nextScanTs: now.Add(999 * time.Hour), // Not a due scan
-				},
-				{
-					req: snmpscanmanager.ScanRequest{
-						DeviceIP: "127.0.0.1",
+					{
+						req:        snmpscanmanager.ScanRequest{DeviceIP: "127.0.0.1"},
+						nextScanTs: now.Add(-1 * time.Minute), // Due scan
 					},
-					nextScanTs: now.Add(-1 * time.Minute), // Due scan
-				},
-				{
-					req: snmpscanmanager.ScanRequest{
-						DeviceIP: "127.0.0.2",
+					{
+						req:        snmpscanmanager.ScanRequest{DeviceIP: "127.0.0.2"},
+						nextScanTs: now.Add(-2 * time.Minute), // Due scan
 					},
-					nextScanTs: now.Add(-2 * time.Minute), // Due scan
-				},
+				}
 			},
 			buildMockConfigProvider: func() *snmpConfigProviderMock {
 				mockConfigProvider := newSnmpConfigProviderMock()
@@ -888,7 +886,7 @@ func TestQueueDueScans(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		syncTestQueueDueScans := func(t *testing.T) {
 			testDir := t.TempDir()
 			mockConfig := configmock.New(t)
 			mockConfig.SetInTest("run_path", testDir)
@@ -916,7 +914,7 @@ func TestQueueDueScans(t *testing.T) {
 			mockConfigProvider := tt.buildMockConfigProvider()
 			scanManager.snmpConfigProvider = mockConfigProvider
 
-			for _, st := range tt.scanTasks {
+			for _, st := range tt.buildScanTasks(time.Now()) {
 				scanManager.scanScheduler.QueueScanTask(st)
 			}
 
@@ -925,15 +923,18 @@ func TestQueueDueScans(t *testing.T) {
 			err = mockLifecycle.Start(context.Background())
 			assert.NoError(t, err)
 
-			assert.EventuallyWithT(t, func(t *assert.CollectT) {
-				assertDeviceScans(t, tt.expectedDeviceScans, scanManager)
-			}, 2*time.Second, 100*time.Millisecond)
+			synctest.Wait()
+			assertDeviceScans(t, tt.expectedDeviceScans, scanManager)
 
 			err = mockLifecycle.Stop(context.Background())
 			assert.NoError(t, err)
 
 			mockScanner.AssertExpectations(t)
 			mockConfigProvider.AssertExpectations(t)
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, syncTestQueueDueScans)
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?
Wrap `TestRequestScan` and `TestQueueDueScans` in `synctest` "bubbles", replacing `assert.EventuallyWithT`'s real-clock polling with `synctest.Wait()`.

### Motivation
Stumbled upon the following flake when running tests locally through `bazel` with flake detection:
```
    --- FAIL: TestRequestScan/default_scan_is_enabled_via_config (4.44s)
        mock.go:28: 2026-08-07 15:06:43 UTC | WARN | (pkg/api/util/util_dca.go:67 in SetCrossNodeClientTLSConfig) | Cross-node client TLS configuration is already set, ignoring the new configuration
        mock.go:28: 2026-08-07 15:06:43 UTC | INFO | (comp/snmpscanmanager/impl/snmpscanmanager.go:184 in RequestScan) | Queued default scan request for device 192.168.0.1
        mock.go:28: 2026-08-07 15:06:43 UTC | INFO | (comp/snmpscanmanager/impl/snmpscanmanager.go:184 in RequestScan) | Queued default scan request for device 192.168.0.2
        mock.go:28: 2026-08-07 15:06:43 UTC | INFO | (comp/snmpscanmanager/impl/snmpscanmanager.go:184 in RequestScan) | Queued default scan request for device 10.0.0.1
        mock.go:28: 2026-08-07 15:06:43 UTC | INFO | (comp/snmpscanmanager/impl/snmpscanmanager.go:184 in RequestScan) | Queued default scan request for device 10.0.0.2
        mock.go:28: 2026-08-07 15:06:43 UTC | WARN | (comp/snmpscanmanager/impl/snmpscanmanager.go:270 in onDeviceScanFailure) | Default scan for device 192.168.0.2 failed with a non-retryable error, will not be retried
        mock.go:28: 2026-08-07 15:06:43 UTC | INFO | (comp/snmpscanmanager/impl/snmpscanmanager.go:244 in processScanRequest) | Successfully processed default scan request for device '192.168.0.1'
        mock.go:28: 2026-08-07 15:06:43 UTC | ERROR | (comp/snmpscanmanager/impl/snmpscanmanager.go:204 in scanWorker) | Error processing default scan request for device '192.168.0.2': some error
        snmpscanmanager_test.go:305:
            	Error Trace:	comp/snmpscanmanager/impl/snmpscanmanager_test.go:944
            	            				comp/snmpscanmanager/impl/snmpscanmanager_test.go:306
            	            				src/runtime/asm_amd64.s:1771
            	Error:      	Not equal:
            	            	expected: 4
            	            	actual  : 2
        snmpscanmanager_test.go:305:
            	Error Trace:	comp/snmpscanmanager/impl/snmpscanmanager_test.go:305
            	Error:      	Condition never satisfied
            	Test:       	TestRequestScan/default_scan_is_enabled_via_config
```
It turns out the flake also triggers at times in CI ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1688602361#L1819)).

`scanWorkers = 2` and nothing in the scan chain sleeps, so 4 queued devices need 2 waves, and a contended runner can occasionally make the second wave outlast `EventuallyWithT`'s fixed 2 seconds.

`TestQueueDueScans` shares the same worker pool and queuing code, hence the same theoretical exposure, though its 2 due scans against 2 workers never actually need a second wave.

With `synctest` faking `time`, the bubble's clock advances once every goroutine is durably blocked, so the completion check can no longer time out against wall clock.

### Describe how you validated your changes
40/40 tests in the package pass under `-race`, both tests pass 30/30 repeated `-race` runs, and timing improves as a side effect: the same passing subtest averages ~130ms before this change versus ~35ms after.