### PR TITLE
fix(agent-integrations): bump AIX embedded Python version in patch upgrade task

### DIFF
--- a/.github/workflows/upgrade-python-patch-version.yml
+++ b/.github/workflows/upgrade-python-patch-version.yml
@@ -76,6 +76,7 @@ jobs:
             - Updated `omnibus/config/software/python3.rb` with new version and SHA256
             - Updated `deps/cpython/cpython.MODULE.bazel` with new version and SHA256
             - Updated `test/new-e2e/tests/agent-platform/common/agent_behaviour.go` with expected version
+            - Updated `packaging/aix/lib/env.sh` with new version
             - Created release note documenting the upgrade
             
             ### Motivation

--- a/tasks/python_version.py
+++ b/tasks/python_version.py
@@ -89,6 +89,7 @@ def update(
         updates.append(_prepare_omnibus_update(target_version))
         updates.append(_prepare_bazel_update(target_version, sha256_hash))
         updates.append(_prepare_test_update(target_version))
+        updates.append(_prepare_aix_update(target_version))
     except Exit:
         # If any validation fails, don't write anything
         raise
@@ -288,6 +289,24 @@ def _prepare_test_update(version: str) -> tuple[Path, str]:
 
     if count != 1:
         raise Exit(f"Expected 1 version match in {file_path}, found {count}")
+
+    return (file_path, new_content)
+
+
+def _prepare_aix_update(version: str) -> tuple[Path, str]:
+    """Prepare Python version update for the AIX packaging scripts.
+
+    Returns:
+        Tuple of (file_path, new_content) ready to write
+    """
+    file_path = Path("packaging/aix/lib/env.sh")
+    content = file_path.read_text()
+
+    pattern = r'^(PYTHON_VERSION=")([0-9.]+)(")$'
+    new_content, count = re.subn(pattern, rf'\g<1>{version}\g<3>', content, flags=re.MULTILINE)
+
+    if count != 1:
+        raise Exit(f"Expected 1 PYTHON_VERSION match in {file_path}, found {count}")
 
     return (file_path, new_content)
 

--- a/tasks/unit_tests/python_version_tests.py
+++ b/tasks/unit_tests/python_version_tests.py
@@ -202,6 +202,32 @@ const (
         self.assertIn('ExpectedPythonVersion2 = "2.7.18"', new_content)
 
 
+class TestAixUpdate(unittest.TestCase):
+    @unittest.mock.patch('tasks.python_version.Path')
+    def test_update_aix_python_version(self, mock_path):
+        """Test preparing version update for AIX packaging env.sh."""
+        from tasks.python_version import _prepare_aix_update
+
+        original_content = '''# lib/env.sh — shared environment sourced by every stage script
+
+PYTHON_VERSION="3.13.7"
+PYTHON_MAJ_MIN="${PYTHON_VERSION%.*}"
+export PYTHON_VERSION PYTHON_MAJ_MIN
+'''
+
+        # Mock file operations
+        mock_file = unittest.mock.MagicMock()
+        mock_file.read_text.return_value = original_content
+        mock_path.return_value = mock_file
+
+        # Prepare update to new version
+        file_path, new_content = _prepare_aix_update("3.13.9")
+
+        # Verify version was updated
+        self.assertIn('PYTHON_VERSION="3.13.9"', new_content)
+        self.assertNotIn('PYTHON_VERSION="3.13.7"', new_content)
+
+
 class TestGetPythonSha256Hash(unittest.TestCase):
     VALID_SBOM = json.dumps(
         {


### PR DESCRIPTION
### What does this PR do?

Adds a new `_prepare_aix_update` step to `tasks/python_version.py` so the `python-version.update` task also bumps `PYTHON_VERSION` in `packaging/aix/lib/env.sh`. Also updates the `upgrade-python-patch-version` workflow's PR description to mention this file, and adds a unit test covering the new function.

### Motivation

PR #54696 (the automated Python patch bump) only updated the Omnibus and Bazel Python references. As flagged in [review feedback](https://github.com/DataDog/datadog-agent/pull/54696#discussion_r3755248597), the AIX packaging path (`packaging/aix/lib/env.sh`, sourced by `packaging/aix/stages/02-python.sh`) has its own `PYTHON_VERSION` variable that was left out of sync, so AIX Agent builds continued embedding the old patch version.

### Describe how you validated your changes

Ran the existing unit test suite plus the new `TestAixUpdate` test via `dda inv invoke-unit-tests.run --tests python_version` — all 17 tests pass.