### PR TITLE
fix(ci): cancel previous pipelines based on pipeline id instead of commit ancestry

### DIFF
--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -2,7 +2,7 @@ import os
 import re
 import sys
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 import yaml
 from gitlab import GitlabError
@@ -101,11 +101,13 @@ def auto_cancel_previous_pipelines(ctx):
     if git_ref == "":
         raise Exit("CI_COMMIT_REF_NAME is empty, skipping pipeline cancellation", 0)
 
-    git_sha = os.getenv("CI_COMMIT_SHA")
+    current_pipeline_id = int(os.environ["CI_PIPELINE_ID"])
 
     repo = get_gitlab_repo()
     pipelines = get_running_pipelines_on_same_ref(repo, git_ref)
-    pipelines_without_current = [p for p in pipelines if p.sha != git_sha]
+    # A pipeline with a lower id than the current one was necessarily created earlier, so it is
+    # superseded by the current pipeline and can be cancelled, regardless of commit ancestry.
+    older_pipelines = [p for p in pipelines if p.id < current_pipeline_id]
     force_cancel_stages = [
         "package_build",
         # We want to cancel all KMT jobs to ensure proper cleanup of the KMT EC2 instances.
@@ -119,29 +121,9 @@ def auto_cancel_previous_pipelines(ctx):
         "kernel_matrix_testing_security_agent",
     ]
 
-    for pipeline in pipelines_without_current:
-        # We cancel pipeline only if it correspond to a commit that is an ancestor of the current commit
-        is_ancestor = ctx.run(f'git merge-base --is-ancestor {pipeline.sha} {git_sha}', warn=True, hide="both")
-        if is_ancestor.exited == 0:
-            print(f'Gracefully canceling jobs that are not canceled on pipeline {pipeline.id} ({pipeline.web_url})')
-            gracefully_cancel_pipeline(repo, pipeline, force_cancel_stages=force_cancel_stages)
-        elif is_ancestor.exited == 1:
-            print(f'{pipeline.sha} is not an ancestor of {git_sha}, not cancelling pipeline {pipeline.id}')
-        elif is_ancestor.exited == 128:
-            min_time_before_cancel = 5
-            print(
-                f'Could not determine if {pipeline.sha} is an ancestor of {git_sha}, probably because it has been deleted from the history because of force push'
-            )
-            if datetime.strptime(pipeline.created_at, "%Y-%m-%dT%H:%M:%S.%fZ") < datetime.now() - timedelta(
-                minutes=min_time_before_cancel
-            ):
-                print(
-                    f'Pipeline started earlier than {min_time_before_cancel} minutes ago, gracefully canceling pipeline {pipeline.id}'
-                )
-                gracefully_cancel_pipeline(repo, pipeline, force_cancel_stages=force_cancel_stages)
-        else:
-            print(is_ancestor.stderr)
-            raise Exit(code=1)
+    for pipeline in older_pipelines:
+        print(f'Gracefully canceling jobs that are not canceled on pipeline {pipeline.id} ({pipeline.web_url})')
+        gracefully_cancel_pipeline(repo, pipeline, force_cancel_stages=force_cancel_stages)
 
 
 @task


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Simplifies `auto_cancel_previous_pipelines` (used by the `cancel-prev-pipelines` `.pre` job) to cancel any other running pipeline on the same ref whose pipeline id is lower than the current pipeline's id, instead of using a `git merge-base --is-ancestor` check on commit history.

### Motivation
https://datadoghq.atlassian.net/browse/ACIX-1949

The previous mechanism only cancelled a running pipeline if its commit was a provable ancestor of the current commit. When ancestry couldn't be determined (`git merge-base` exit code 128), which mainly happens after a force-push rewrites history, the pipeline was only cancelled once it had been running for more than 5 minutes, as a fallback heuristic. This made cancellation slower and less aggressive in exactly the case it needs to be aggressive in: cleaning up stale/superseded pipelines after force-pushes.

Pipeline ids are monotonically increasing and assigned by GitLab at pipeline creation time, so comparing ids is a simpler and unambiguous way to determine that another running pipeline on the same branch was created earlier and is superseded by the current one. This removes the need for the `git merge-base` shell-out and the special-cased force-push handling entirely.

### Describe how you validated your changes

- Reviewed the existing behavior of `get_running_pipelines_on_same_ref`, `gracefully_cancel_pipeline`, and the `cancel-prev-pipelines` job to confirm the mechanism and its call site.
- Verified `CI_PIPELINE_ID` is a standard GitLab predefined variable already used elsewhere in `.gitlab/`.
- Ran `dda inv linter.python`, which passed (and auto-removed an unused import).