### PR TITLE
fix(cws): collect mount fields from `make_visible` to support kernels >= 6.18

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/mount.h
+++ b/pkg/security/ebpf/c/include/hooks/mount.h
@@ -340,14 +340,23 @@ int hook_mnt_change_mountpoint(ctx_t *ctx)
 
 HOOK_ENTRY("make_visible")
 int hook_make_visible(ctx_t *ctx) {
-    struct syscall_cache_t *syscall = peek_syscall_with(unshare_or_open_tree_or_move_mount);
+    struct syscall_cache_t *syscall = peek_syscall_with(mountpoint_predicate);
     if (!syscall) {
         return 0;
     }
 
     struct mount *newmnt = (struct mount *)CTX_PARM1(ctx);
-    // check if this mount has already been processed by another hook
-    if (syscall->mount.newmnt == newmnt) {
+
+    if (syscall->type == EVENT_MOUNT) {
+        // attach_recursive_mnt is the only other hook covering plain mounts and it cannot be trusted
+        // since 6.18: its arguments were replaced by a pinned_mountpoint and the compiler usually
+        // leaves only an ISRA clone of it. commit_tree calls us once per propagated copy, the first
+        // one being the mount the syscall was issued for, so take it and re-read its fields here.
+        if (syscall->mount.newmnt && syscall->mount.newmnt != newmnt) {
+            return 0;
+        }
+    } else if (syscall->mount.newmnt && syscall->mount.newmnt == newmnt) {
+        // check if this mount has already been processed by another hook
         return 0;
     }
 
@@ -357,7 +366,10 @@ int hook_make_visible(ctx_t *ctx) {
     struct mountpoint *mp  = get_mount_mountpoint(newmnt);
     syscall->mount.mountpoint_dentry = get_mountpoint_dentry(mp);
 
-    handle_new_mount(ctx, syscall, KPROBE_OR_FENTRY_TYPE, false);
+    // plain mounts are sent from the mount syscall return hook, once the syscall is known to succeed
+    if (syscall->type != EVENT_MOUNT) {
+        handle_new_mount(ctx, syscall, KPROBE_OR_FENTRY_TYPE, false);
+    }
 
     return 0;
 }

--- a/pkg/security/ebpf/c/include/hooks/mount.h
+++ b/pkg/security/ebpf/c/include/hooks/mount.h
@@ -346,12 +346,18 @@ int hook_make_visible(ctx_t *ctx) {
     }
 
     struct mount *newmnt = (struct mount *)CTX_PARM1(ctx);
+    u32 ns_inum = get_mount_mount_ns_inum(newmnt);
 
     if (syscall->type == EVENT_MOUNT) {
-        // attach_recursive_mnt is the only other hook covering plain mounts and it cannot be trusted
+        // copy_tree attaches the copies of a recursive bind mount before the mount itself is made visible, so
+        // we skip these copies here, commit_tree will call us again with the mount the syscall was issued for,
+        // once it joined the namespace. (ns_inum == 0 because the copies aren't part of any namespace at this point).
+        if (!ns_inum) {
+            return 0;
+        }
+        // attach_recursive_mnt is the only other hook covering regular mount syscalls and it cannot be trusted
         // since 6.18: its arguments were replaced by a pinned_mountpoint and the compiler usually
-        // leaves only an ISRA clone of it. commit_tree calls us once per propagated copy, the first
-        // one being the mount the syscall was issued for, so take it and re-read its fields here.
+        // leaves an ISRA clone of it. It records the same mount as we do here, but only a older kernel versions (< 6.18).
         if (syscall->mount.newmnt && syscall->mount.newmnt != newmnt) {
             return 0;
         }
@@ -360,7 +366,7 @@ int hook_make_visible(ctx_t *ctx) {
         return 0;
     }
 
-    syscall->mount.ns_inum = get_mount_mount_ns_inum(newmnt);
+    syscall->mount.ns_inum = ns_inum;
     syscall->mount.newmnt  = newmnt;
     syscall->mount.parent  = get_mount_parent(newmnt);
     struct mountpoint *mp  = get_mount_mountpoint(newmnt);


### PR DESCRIPTION
### What does this PR do?

Collects the fields of a mount syscall event from `make_visible` instead of `attach_recursive_mnt`.

### Motivation

Kernel 6.18 changed how `attach_recursive_mnt` receives its destination, and compilers usually emit it as an ISRA optimized function, so the hook either reads the wrong arguments or is not called at all. It is the only hook covering plain mounts, so CWS stops reporting them entirely: no mount event, no mount resolution, and paths on those mounts can no longer be resolved from events.

`make_visible` is reached on the same code path, takes a single argument and exposes the parent mount and the mountpoint through the new mount itself. It exists since 6.17, which covers every kernel affected by the change, and older kernels keep using the existing hook.

### Describe how you validated your changes

Existing functional tests (TestMount* and TestUmount tests) running on Ubuntu 26.04 that this PR fixes.

### Additional Notes
