### PR TITLE
[ACTP][IR-59050] Use DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION instead of RC fake intake to prevent test PAR E2E test flakiness

### DIFF
--- a/test/new-e2e/tests/privateactionrunner/private_action_runner_executor_nix_test.go
+++ b/test/new-e2e/tests/privateactionrunner/private_action_runner_executor_nix_test.go
@@ -6,24 +6,17 @@
 package privateactionrunner
 
 import (
-	"crypto/ed25519"
-	"crypto/rand"
-	"crypto/x509"
-	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
 	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
 	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -34,16 +27,7 @@ const (
 
 	executorListeningLogLine = "Private action runner executor listening on"
 	executorReadyLogLine     = "Private action runner executor ready to accept actions"
-
-	// pkg/remoteconfig/state.ProductActionPlatformRunnerKeys
-	runnerKeysRCProduct = "AP_RUNNER_KEYS"
 )
-
-// mirrors pkg/privateactionrunner/types.RawKey's JSON shape
-type rawRCKey struct {
-	KeyType string `json:"keyType"`
-	Key     []byte `json:"key"`
-}
 
 type linuxPrivateActionRunnerExecutorSuite struct {
 	e2e.BaseSuite[environments.Host]
@@ -63,31 +47,11 @@ func TestLinuxPrivateActionRunnerExecutorSuite(t *testing.T) {
 	))
 }
 
-func (s *linuxPrivateActionRunnerExecutorSuite) pushFakeRunnerKeysConfig() {
-	t := s.T()
-
-	pub, _, err := ed25519.GenerateKey(rand.Reader)
-	require.NoError(t, err, "failed to generate fake runner key")
-
-	pubDER, err := x509.MarshalPKIXPublicKey(pub)
-	require.NoError(t, err, "failed to marshal fake runner public key")
-
-	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
-
-	payload, err := json.Marshal(rawRCKey{KeyType: "ED25519", Key: pubPEM})
-	require.NoError(t, err, "failed to marshal fake runner key config payload")
-
-	err = s.Env().FakeIntake.Client().RCAddConfig("", runnerKeysRCProduct, "fake-runner-key", "fake-runner-key", payload)
-	require.NoError(t, err, "failed to push fake runner key config to fakeintake")
-}
-
 // TestExecutorStartsAndListens launches the on-demand executor subcommand and
 // asserts it comes up: the process runs, the gRPC unix socket is created, and
 // the log reports the server listening and ready.
 func (s *linuxPrivateActionRunnerExecutorSuite) TestExecutorStartsAndListens() {
 	host := s.Env().RemoteHost
-
-	s.pushFakeRunnerKeysConfig()
 
 	// run-executor is a foreground subcommand, not the packaged systemd service.
 	// Launch it detached as dd-agent so it can bind its socket under
@@ -96,7 +60,7 @@ func (s *linuxPrivateActionRunnerExecutorSuite) TestExecutorStartsAndListens() {
 	// matches on the full command line, so it would also match the very shell
 	// invocation used to search for it.
 	launch := fmt.Sprintf(
-		`sudo -u dd-agent bash -c 'nohup %s run-executor --cfgpath=%s </dev/null >/dev/null 2>&1 & echo $!'`,
+		`sudo -u dd-agent bash -c 'DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION=true nohup %s run-executor --cfgpath=%s </dev/null >/dev/null 2>&1 & echo $!'`,
 		privateActionRunnerBinary, privateActionRunnerConfigPath,
 	)
 	pid := strings.TrimSpace(host.MustExecute(launch))
@@ -121,11 +85,6 @@ func (s *linuxPrivateActionRunnerExecutorSuite) TestExecutorStartsAndListens() {
 		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -F %q %s", executorListeningLogLine, privateActionRunnerLogFile))
 	}, 2*time.Minute, 5*time.Second, "executor log should report listening")
 
-	// Readiness depends on the KeysManager receiving its first AP_RUNNER_KEYS
-	// remote-config update. The backend director's first fetch of a brand-new
-	// product can take well over 2 minutes regardless of the client's poll
-	// interval (observed ~2m10s in CI), so this needs a longer budget than the
-	// other checks in this test.
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
 		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -F %q %s", executorReadyLogLine, privateActionRunnerLogFile))
 	}, 5*time.Minute, 5*time.Second, "executor log should report ready")


### PR DESCRIPTION
### What does this PR do?

Use DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION instead of RC fake intake to reduce flakiness

### Motivation

Fix flakiness until we find a proper way to prevent the flakiness

### Describe how you validated your changes

CI

### Additional Notes

[#incident-59050](https://dd.enterprise.slack.com/archives/C0BPAUK98F7)