### PR TITLE
feat(snmp): add ignore_network_and_broadcast_addresses autodiscovery option

### DIFF
--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -4331,6 +4331,19 @@ properties:
             visibility: public
             description: Enable collection of VPN tunnels and route table data
             example: 'true'
+          ignore_network_and_broadcast_addresses:
+            node_type: setting
+            type: boolean
+            default: false
+            visibility: public
+            description: |-
+              When enabled, the network and broadcast addresses of each scanned subnet
+              are skipped during autodiscovery. These addresses are often assigned to
+              floating/virtual IPs (such as HSRP/VRRP gateways) that multiple devices can
+              answer on, which corrupts per-device metrics such as interface bandwidth
+              usage. Can be overridden per subnet in `configs`. Only applies to IPv4
+              subnets with a prefix of /30 or larger.
+            example: 'true'
           ping:
             node_type: section
             type: object
@@ -4464,6 +4477,13 @@ properties:
                   ignored_ip_addresses:
                     - <IP_ADDRESS_1>
                     - <IP_ADDRESS_2>
+
+                  # @param ignore_network_and_broadcast_addresses - boolean - optional - default: false
+                  # When enabled, skip the network and broadcast addresses of this subnet
+                  # during discovery. Overrides the top-level autodiscovery setting.
+                  # Only applies to IPv4 subnets with a prefix of /30 or larger.
+
+                  # ignore_network_and_broadcast_addresses: true
 
                   # @param port - integer - optional - default: 161
                   # The UDP port to use when connecting to SNMP devices.

--- a/pkg/config/schema/yaml/snmp_listener.yaml
+++ b/pkg/config/schema/yaml/snmp_listener.yaml
@@ -29,6 +29,10 @@ properties:
     node_type: setting
     type: integer
     default: 3600
+  ignore_network_and_broadcast_addresses:
+    node_type: setting
+    type: boolean
+    default: false
   loader:
     node_type: setting
     type: string

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -29,22 +29,25 @@ const (
 
 // ListenerConfig holds global configuration for SNMP discovery
 type ListenerConfig struct {
-	Workers                 int                        `mapstructure:"workers"`
-	DiscoveryInterval       int                        `mapstructure:"discovery_interval"`
-	AllowedFailures         int                        `mapstructure:"discovery_allowed_failures"`
-	Loader                  string                     `mapstructure:"loader"`
-	CollectDeviceMetadata   bool                       `mapstructure:"collect_device_metadata"`
-	CollectTopology         bool                       `mapstructure:"collect_topology"`
-	CollectVPN              bool                       `mapstructure:"collect_vpn"`
-	MinCollectionInterval   uint                       `mapstructure:"min_collection_interval"`
-	Namespace               string                     `mapstructure:"namespace"`
-	UseDeviceISAsHostname   bool                       `mapstructure:"use_device_id_as_hostname"`
-	PingConfig              snmpintegration.PingConfig `mapstructure:"ping"`
-	Deduplicate             bool                       `mapstructure:"use_deduplication"`
-	UseRemoteConfigProfiles bool                       `mapstructure:"use_remote_config_profiles"`
-	OidBatchSize            int                        `mapstructure:"oid_batch_size"`
-	Timeout                 int                        `mapstructure:"timeout"`
-	Retries                 int                        `mapstructure:"retries"`
+	Workers               int    `mapstructure:"workers"`
+	DiscoveryInterval     int    `mapstructure:"discovery_interval"`
+	AllowedFailures       int    `mapstructure:"discovery_allowed_failures"`
+	Loader                string `mapstructure:"loader"`
+	CollectDeviceMetadata bool   `mapstructure:"collect_device_metadata"`
+	CollectTopology       bool   `mapstructure:"collect_topology"`
+	CollectVPN            bool   `mapstructure:"collect_vpn"`
+	// IgnoreNetworkAndBroadcastAddresses, when true, skips the network and broadcast
+	// address of each scanned subnet during autodiscovery (IPv4, prefix <= /30).
+	IgnoreNetworkAndBroadcastAddresses bool                       `mapstructure:"ignore_network_and_broadcast_addresses"`
+	MinCollectionInterval              uint                       `mapstructure:"min_collection_interval"`
+	Namespace                          string                     `mapstructure:"namespace"`
+	UseDeviceISAsHostname              bool                       `mapstructure:"use_device_id_as_hostname"`
+	PingConfig                         snmpintegration.PingConfig `mapstructure:"ping"`
+	Deduplicate                        bool                       `mapstructure:"use_deduplication"`
+	UseRemoteConfigProfiles            bool                       `mapstructure:"use_remote_config_profiles"`
+	OidBatchSize                       int                        `mapstructure:"oid_batch_size"`
+	Timeout                            int                        `mapstructure:"timeout"`
+	Retries                            int                        `mapstructure:"retries"`
 
 	// legacy
 	AllowedFailuresLegacy int `mapstructure:"allowed_failures"`
@@ -57,33 +60,34 @@ type ListenerConfig struct {
 
 // UnmarshalledConfig is used to read each item of the array in datadog.yaml
 type UnmarshalledConfig struct {
-	ADIdentifier          string                                       `mapstructure:"ad_identifier"`
-	AuthKey               string                                       `mapstructure:"authKey"`
-	AuthProtocol          string                                       `mapstructure:"authProtocol"`
-	Authentications       []Authentication                             `mapstructure:"authentications"`
-	CollectDeviceMetadata *bool                                        `mapstructure:"collect_device_metadata"`
-	CollectTopology       *bool                                        `mapstructure:"collect_topology"`
-	CollectVPN            *bool                                        `mapstructure:"collect_vpn"`
-	Community             string                                       `mapstructure:"community_string"`
-	ContextEngineID       string                                       `mapstructure:"context_engine_id"`
-	ContextName           string                                       `mapstructure:"context_name"`
-	IgnoredIPAddresses    []string                                     `mapstructure:"ignored_ip_addresses"`
-	InterfaceConfigs      map[string][]snmpintegration.InterfaceConfig `mapstructure:"interface_configs"`
-	Loader                string                                       `mapstructure:"loader"`
-	MinCollectionInterval uint                                         `mapstructure:"min_collection_interval"`
-	Namespace             string                                       `mapstructure:"namespace"`
-	Network               string                                       `mapstructure:"network_address"`
-	OidBatchSize          int                                          `mapstructure:"oid_batch_size"`
-	PingConfig            snmpintegration.PingConfig                   `mapstructure:"ping"`
-	Port                  uint16                                       `mapstructure:"port"`
-	PrivKey               string                                       `mapstructure:"privKey"`
-	PrivProtocol          string                                       `mapstructure:"privProtocol"`
-	Retries               int                                          `mapstructure:"retries"`
-	Tags                  []string                                     `mapstructure:"tags"`
-	Timeout               int                                          `mapstructure:"timeout"`
-	UseDeviceIDAsHostname *bool                                        `mapstructure:"use_device_id_as_hostname"`
-	User                  string                                       `mapstructure:"user"`
-	Version               string                                       `mapstructure:"snmp_version"`
+	ADIdentifier                       string                                       `mapstructure:"ad_identifier"`
+	AuthKey                            string                                       `mapstructure:"authKey"`
+	AuthProtocol                       string                                       `mapstructure:"authProtocol"`
+	Authentications                    []Authentication                             `mapstructure:"authentications"`
+	CollectDeviceMetadata              *bool                                        `mapstructure:"collect_device_metadata"`
+	CollectTopology                    *bool                                        `mapstructure:"collect_topology"`
+	CollectVPN                         *bool                                        `mapstructure:"collect_vpn"`
+	Community                          string                                       `mapstructure:"community_string"`
+	ContextEngineID                    string                                       `mapstructure:"context_engine_id"`
+	ContextName                        string                                       `mapstructure:"context_name"`
+	IgnoredIPAddresses                 []string                                     `mapstructure:"ignored_ip_addresses"`
+	IgnoreNetworkAndBroadcastAddresses *bool                                        `mapstructure:"ignore_network_and_broadcast_addresses"`
+	InterfaceConfigs                   map[string][]snmpintegration.InterfaceConfig `mapstructure:"interface_configs"`
+	Loader                             string                                       `mapstructure:"loader"`
+	MinCollectionInterval              uint                                         `mapstructure:"min_collection_interval"`
+	Namespace                          string                                       `mapstructure:"namespace"`
+	Network                            string                                       `mapstructure:"network_address"`
+	OidBatchSize                       int                                          `mapstructure:"oid_batch_size"`
+	PingConfig                         snmpintegration.PingConfig                   `mapstructure:"ping"`
+	Port                               uint16                                       `mapstructure:"port"`
+	PrivKey                            string                                       `mapstructure:"privKey"`
+	PrivProtocol                       string                                       `mapstructure:"privProtocol"`
+	Retries                            int                                          `mapstructure:"retries"`
+	Tags                               []string                                     `mapstructure:"tags"`
+	Timeout                            int                                          `mapstructure:"timeout"`
+	UseDeviceIDAsHostname              *bool                                        `mapstructure:"use_device_id_as_hostname"`
+	User                               string                                       `mapstructure:"user"`
+	Version                            string                                       `mapstructure:"snmp_version"`
 
 	// Legacy
 	NetworkLegacy      string `mapstructure:"network"`
@@ -97,33 +101,34 @@ type UnmarshalledConfig struct {
 
 // Config holds configuration for a particular subnet
 type Config struct {
-	ADIdentifier            string
-	AuthKey                 string
-	AuthProtocol            string
-	Authentications         []Authentication
-	Community               string
-	ContextEngineID         string
-	ContextName             string
-	Loader                  string
-	MinCollectionInterval   uint
-	Namespace               string
-	Network                 string
-	OidBatchSize            int
-	Port                    uint16
-	PrivKey                 string
-	PrivProtocol            string
-	Retries                 int
-	Tags                    []string
-	Timeout                 int
-	User                    string
-	Version                 string
-	CollectDeviceMetadata   bool
-	CollectTopology         bool
-	CollectVPN              bool
-	IgnoredIPAddresses      map[string]bool
-	UseDeviceIDAsHostname   bool
-	UseRemoteConfigProfiles bool
-	PingConfig              snmpintegration.PingConfig
+	ADIdentifier                       string
+	AuthKey                            string
+	AuthProtocol                       string
+	Authentications                    []Authentication
+	Community                          string
+	ContextEngineID                    string
+	ContextName                        string
+	Loader                             string
+	MinCollectionInterval              uint
+	Namespace                          string
+	Network                            string
+	OidBatchSize                       int
+	Port                               uint16
+	PrivKey                            string
+	PrivProtocol                       string
+	Retries                            int
+	Tags                               []string
+	Timeout                            int
+	User                               string
+	Version                            string
+	CollectDeviceMetadata              bool
+	CollectTopology                    bool
+	CollectVPN                         bool
+	IgnoredIPAddresses                 map[string]bool
+	IgnoreNetworkAndBroadcastAddresses bool
+	UseDeviceIDAsHostname              bool
+	UseRemoteConfigProfiles            bool
+	PingConfig                         snmpintegration.PingConfig
 
 	// InterfaceConfigs is a map of IP to a list of snmpintegration.InterfaceConfig
 	InterfaceConfigs map[string][]snmpintegration.InterfaceConfig
@@ -254,6 +259,12 @@ func NewListenerConfig() (ListenerConfig, error) {
 			config.UseDeviceIDAsHostname = snmpConfig.UseDeviceISAsHostname
 		}
 
+		if unmarshalledConfig.IgnoreNetworkAndBroadcastAddresses != nil {
+			config.IgnoreNetworkAndBroadcastAddresses = *unmarshalledConfig.IgnoreNetworkAndBroadcastAddresses
+		} else {
+			config.IgnoreNetworkAndBroadcastAddresses = snmpConfig.IgnoreNetworkAndBroadcastAddresses
+		}
+
 		if config.Loader == "" {
 			config.Loader = snmpConfig.Loader
 		}
@@ -313,6 +324,16 @@ func NewListenerConfig() (ListenerConfig, error) {
 		config.IgnoredIPAddresses = make(map[string]bool, len(unmarshalledConfig.IgnoredIPAddresses))
 		for _, ip := range unmarshalledConfig.IgnoredIPAddresses {
 			config.IgnoredIPAddresses[ip] = true
+		}
+
+		// When enabled, skip the network and broadcast address of the subnet. These
+		// are commonly assigned to floating/virtual IPs (e.g. HSRP/VRRP gateways) that
+		// several devices can answer on, which corrupts per-device rate calculations.
+		if config.IgnoreNetworkAndBroadcastAddresses {
+			if network, broadcast, ok := networkAndBroadcastAddresses(config.Network); ok {
+				config.IgnoredIPAddresses[network.String()] = true
+				config.IgnoredIPAddresses[broadcast.String()] = true
+			}
 		}
 	}
 
@@ -388,6 +409,32 @@ func (c *Config) Digest(address string) string {
 	}
 
 	return strconv.FormatUint(h.Sum64(), 16)
+}
+
+// networkAndBroadcastAddresses returns the network and broadcast addresses for the
+// given IPv4 CIDR. The second return value is false when the addresses should not be
+// skipped: a parse error, a non-IPv4 network, or a prefix of /31 or /32 where every
+// address is a usable host (RFC 3021 point-to-point and single-host cases).
+func networkAndBroadcastAddresses(cidr string) (net.IP, net.IP, bool) {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, nil, false
+	}
+	network := ipNet.IP.To4()
+	if network == nil {
+		// Only IPv4 has a broadcast address; skip IPv6.
+		return nil, nil, false
+	}
+	ones, bits := ipNet.Mask.Size()
+	if bits-ones < 2 {
+		// /31 and /32 have no distinct network/broadcast host addresses to skip.
+		return nil, nil, false
+	}
+	broadcast := make(net.IP, len(network))
+	for i := range network {
+		broadcast[i] = network[i] | ^ipNet.Mask[i]
+	}
+	return network, broadcast, true
 }
 
 // IsIPIgnored checks the given IP against IgnoredIPAddresses

--- a/pkg/snmp/snmp_test.go
+++ b/pkg/snmp/snmp_test.go
@@ -1050,3 +1050,106 @@ network_devices:
 
 	assert.False(t, conf.Deduplicate)
 }
+
+func Test_IgnoreNetworkAndBroadcastAddresses(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		configmock.NewFromYAML(t, `
+network_devices:
+  autodiscovery:
+    configs:
+     - network: 10.0.0.0/24
+`)
+		conf, err := snmp.NewListenerConfig()
+		assert.NoError(t, err)
+		assert.False(t, conf.Configs[0].IgnoreNetworkAndBroadcastAddresses)
+		assert.NotContains(t, conf.Configs[0].IgnoredIPAddresses, "10.0.0.0")
+		assert.NotContains(t, conf.Configs[0].IgnoredIPAddresses, "10.0.0.255")
+	})
+
+	t.Run("top-level enabled adds network and broadcast", func(t *testing.T) {
+		configmock.NewFromYAML(t, `
+network_devices:
+  autodiscovery:
+    ignore_network_and_broadcast_addresses: true
+    configs:
+     - network: 10.0.0.0/24
+`)
+		conf, err := snmp.NewListenerConfig()
+		assert.NoError(t, err)
+		assert.True(t, conf.Configs[0].IgnoreNetworkAndBroadcastAddresses)
+		assert.Contains(t, conf.Configs[0].IgnoredIPAddresses, "10.0.0.0")
+		assert.Contains(t, conf.Configs[0].IgnoredIPAddresses, "10.0.0.255")
+	})
+
+	t.Run("per-config overrides top-level", func(t *testing.T) {
+		configmock.NewFromYAML(t, `
+network_devices:
+  autodiscovery:
+    ignore_network_and_broadcast_addresses: true
+    configs:
+     - network: 10.0.0.0/24
+       ignore_network_and_broadcast_addresses: false
+     - network: 10.0.1.0/24
+`)
+		conf, err := snmp.NewListenerConfig()
+		assert.NoError(t, err)
+		// overridden off: network/broadcast not added
+		assert.False(t, conf.Configs[0].IgnoreNetworkAndBroadcastAddresses)
+		assert.NotContains(t, conf.Configs[0].IgnoredIPAddresses, "10.0.0.0")
+		assert.NotContains(t, conf.Configs[0].IgnoredIPAddresses, "10.0.0.255")
+		// inherits top-level true
+		assert.True(t, conf.Configs[1].IgnoreNetworkAndBroadcastAddresses)
+		assert.Contains(t, conf.Configs[1].IgnoredIPAddresses, "10.0.1.0")
+		assert.Contains(t, conf.Configs[1].IgnoredIPAddresses, "10.0.1.255")
+	})
+
+	t.Run("preserves explicitly ignored addresses", func(t *testing.T) {
+		configmock.NewFromYAML(t, `
+network_devices:
+  autodiscovery:
+    ignore_network_and_broadcast_addresses: true
+    configs:
+     - network: 10.0.0.0/24
+       ignored_ip_addresses:
+         - 10.0.0.42
+`)
+		conf, err := snmp.NewListenerConfig()
+		assert.NoError(t, err)
+		assert.Contains(t, conf.Configs[0].IgnoredIPAddresses, "10.0.0.42")
+		assert.Contains(t, conf.Configs[0].IgnoredIPAddresses, "10.0.0.0")
+		assert.Contains(t, conf.Configs[0].IgnoredIPAddresses, "10.0.0.255")
+	})
+
+	t.Run("skipped for /31 and /32", func(t *testing.T) {
+		configmock.NewFromYAML(t, `
+network_devices:
+  autodiscovery:
+    ignore_network_and_broadcast_addresses: true
+    configs:
+     - network: 10.0.0.0/31
+     - network: 10.0.1.5/32
+`)
+		conf, err := snmp.NewListenerConfig()
+		assert.NoError(t, err)
+		// /31: both addresses are usable hosts (RFC 3021), nothing skipped
+		assert.Empty(t, conf.Configs[0].IgnoredIPAddresses)
+		// /32: single host, nothing skipped
+		assert.Empty(t, conf.Configs[1].IgnoredIPAddresses)
+	})
+
+	t.Run("larger subnet uses true network and broadcast", func(t *testing.T) {
+		configmock.NewFromYAML(t, `
+network_devices:
+  autodiscovery:
+    ignore_network_and_broadcast_addresses: true
+    configs:
+     - network: 10.0.0.0/23
+`)
+		conf, err := snmp.NewListenerConfig()
+		assert.NoError(t, err)
+		// network is 10.0.0.0, broadcast is 10.0.1.255; the .0 host 10.0.1.0 is NOT skipped
+		assert.Contains(t, conf.Configs[0].IgnoredIPAddresses, "10.0.0.0")
+		assert.Contains(t, conf.Configs[0].IgnoredIPAddresses, "10.0.1.255")
+		assert.NotContains(t, conf.Configs[0].IgnoredIPAddresses, "10.0.1.0")
+	})
+}

--- a/releasenotes/notes/snmp-ignore-network-broadcast-6c1f0a2b9d4e7f83.yaml
+++ b/releasenotes/notes/snmp-ignore-network-broadcast-6c1f0a2b9d4e7f83.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    SNMP autodiscovery: add ``ignore_network_and_broadcast_addresses`` (settable
+    under ``network_devices.autodiscovery`` and overridable per subnet). When
+    enabled, the network and broadcast addresses of each scanned IPv4 subnet
+    (prefix ``/30`` or larger) are skipped during discovery. Disabled by default.


### PR DESCRIPTION
### What does this PR do?

Adds a new SNMP autodiscovery option `ignore_network_and_broadcast_addresses`. When enabled, the network and broadcast addresses of each scanned IPv4 subnet (prefix `/30` or larger) are excluded from discovery. It is settable at the top level under `network_devices.autodiscovery` and overridable per subnet config. Disabled by default.

Implementation reuses the existing `IgnoredIPAddresses` path: when the flag is set, the computed network and broadcast addresses of the subnet CIDR are injected into the ignore map, so no scan-loop change is required.

### Motivation

Floating/virtual gateway IPs (HSRP/VRRP) are commonly assigned to the network address (`.0`) of a subnet. These VIPs can be answered by different physical devices over time as the active router flaps between members. NDM autodiscovery picks up the VIP as a device, and the bandwidth calculation then computes deltas across two different physical counters, producing nonsensical `ifBandwidthInUsage.rate` values (billions of percent).

Excluding network and broadcast addresses lets operators avoid discovering these addresses without hand-maintaining `ignored_ip_addresses` per subnet.

### Describe how you validated your changes

- Added `Test_IgnoreNetworkAndBroadcastAddresses` in `pkg/snmp/snmp_test.go` covering: disabled by default, top-level enable, per-config override, preserving explicit ignored addresses, correct handling for `/23` (true network + broadcast, no mid-subnet `.0`), and skip for `/31` and `/32`.
- `dda inv linter.go --targets=./pkg/snmp` clean.
- `dda inv schema.lint` clean.

### Additional Notes

Feature is opt-in and IPv4-only. Subnets smaller than `/30` (i.e. `/31`, `/32`) are skipped since there is no distinct network/broadcast pair to exclude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
