### PR TITLE
[SBOM] Derive image inUse from workloadmeta

### DIFF
--- a/pkg/collector/corechecks/sbom/batch_refresher.go
+++ b/pkg/collector/corechecks/sbom/batch_refresher.go
@@ -41,7 +41,9 @@ func (br *batchRefresher) tick() <-chan time.Time {
 
 // step performs a single refresh step
 func (br *batchRefresher) step() {
+	running := runningImages(br.wmStore)
+
 	for _, img := range br.wmStore.ListImages() {
-		br.proc.processImageSBOM(img)
+		br.proc.processImageSBOM(img, running)
 	}
 }

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -51,8 +51,8 @@ type processor struct {
 	workloadmetaStore     workloadmeta.Component
 	containerFilter       workloadfilter.FilterBundle
 	tagger                tagger.Component
-	imageRepoDigests      map[string]string              // Map where keys are image repo digest and values are image ID
-	imageUsers            map[string]map[string]struct{} // Map where keys are image repo digest and values are set of container IDs
+	imageRepoDigests      map[string]string   // Map where keys are image repo digest and values are image ID
+	imagesInUse           map[string]struct{} // Set of image IDs the back end was last told are in use
 	sbomScanner           *sbomscanner.Scanner
 	contImageSBOM         bool
 	hostSBOM              bool
@@ -101,7 +101,7 @@ func newProcessor(workloadmetaStore workloadmeta.Component, filterStore workload
 		containerFilter:       filterStore.GetContainerSBOMFilters(),
 		tagger:                tagger,
 		imageRepoDigests:      make(map[string]string),
-		imageUsers:            make(map[string]map[string]struct{}),
+		imagesInUse:           make(map[string]struct{}),
 		sbomScanner:           sbomScanner,
 		contImageSBOM:         contImageSBOM,
 		hostSBOM:              hostSBOM,
@@ -117,17 +117,24 @@ func isProcfsSBOMEnabled(cfg config.Component) bool {
 }
 
 func (p *processor) processContainerImagesEvents(evBundle workloadmeta.EventBundle) {
+	// The store already reflects the events in this bundle, so ask it which
+	// images are in use rather than tracking container events ourselves. Ask
+	// before acknowledging: the store hands the next bundle to the next
+	// subscriber as soon as this one acknowledges, and would then answer for a
+	// later moment than the bundle being processed describes.
+	running := runningImages(p.workloadmetaStore)
+
 	evBundle.Acknowledge()
 
 	log.Tracef("Processing %d events", len(evBundle.Events))
 
-	// Separate events by kind and type so we can process them in an order that
-	// keeps imageUsers accurate when SBOMs are computed.
+	// Separate events by kind and type. Image events are handled first so that
+	// imageRepoDigests is up to date when the identifiers the containers use
+	// are resolved below.
 	var (
-		imageSetEvents       []workloadmeta.Event
-		imageUnsetEvents     []workloadmeta.Event
-		containerSetEvents   []workloadmeta.Event
-		containerUnsetEvents []workloadmeta.Event
+		imageSetEvents     []workloadmeta.Event
+		imageUnsetEvents   []workloadmeta.Event
+		containerSetEvents []workloadmeta.Event
 	)
 
 	for _, event := range evBundle.Events {
@@ -141,42 +148,49 @@ func (p *processor) processContainerImagesEvents(evBundle workloadmeta.EventBund
 		case workloadmeta.KindContainer:
 			if event.Type == workloadmeta.EventTypeSet {
 				containerSetEvents = append(containerSetEvents, event)
-			} else {
-				containerUnsetEvents = append(containerUnsetEvents, event)
 			}
 		}
 	}
 
-	// 1. Unregister removed containers first so imageUsers is up to date before
-	//    we compute inUse below. Processing image Set events before these removals
-	//    would cause false-positive inUse=true on the emitted SBOM.
-	for _, event := range containerUnsetEvents {
-		p.unregisterContainer(event.Entity.(*workloadmeta.Container))
-	}
+	// Images reported in this bundle, so that an image and the container that
+	// just started it don't each produce an SBOM.
+	reported := make(map[string]struct{}, len(imageSetEvents))
 
-	// 2. Unregister removed images.
 	for _, event := range imageUnsetEvents {
 		p.unregisterImage(event.Entity.(*workloadmeta.ContainerImageMetadata))
 		// Let the SBOM expire on back-end side
 	}
 
-	// 3. Register updated images and emit SBOMs; inUse now reflects the
-	//    current set of running containers.
 	for _, event := range imageSetEvents {
-		filterableContainerImage := workloadfilter.CreateContainerImage(event.Entity.(*workloadmeta.ContainerImageMetadata).Name)
+		img := event.Entity.(*workloadmeta.ContainerImageMetadata)
+
+		filterableContainerImage := workloadfilter.CreateContainerImage(img.Name)
 		if p.containerFilter.IsExcluded(filterableContainerImage) {
 			continue
 		}
 
-		p.registerImage(event.Entity.(*workloadmeta.ContainerImageMetadata))
-		p.processImageSBOM(event.Entity.(*workloadmeta.ContainerImageMetadata))
+		p.registerImage(img)
+		p.processImageSBOM(img, running)
+		reported[img.ID] = struct{}{}
 	}
 
-	// 4. Register new/updated containers. registerContainer may emit a second
-	//    SBOM for an image that just gained its first running container.
+	// Report images that gained their first running container, so that the
+	// back end learns about them without waiting for the periodic refresh.
+	// Containers name the same image in more than one way, so compare resolved
+	// image IDs rather than the identifiers they use.
+	imagesInUse := make(map[string]struct{}, len(running))
+	for id := range running {
+		imgID := p.resolveImageID(id)
+		imagesInUse[imgID] = struct{}{}
+
+		if _, found := p.imagesInUse[imgID]; !found {
+			p.reportImage(imgID, running, reported)
+		}
+	}
+	p.imagesInUse = imagesInUse
+
 	for _, event := range containerSetEvents {
 		container := event.Entity.(*workloadmeta.Container)
-		p.registerContainer(container)
 
 		filterableContainer := workloadmetafilter.CreateContainer(container, nil)
 		if p.containerFilter.IsExcluded(filterableContainer) {
@@ -199,52 +213,71 @@ func (p *processor) registerImage(img *workloadmeta.ContainerImageMetadata) {
 
 func (p *processor) unregisterImage(img *workloadmeta.ContainerImageMetadata) {
 	for _, repoDigest := range img.RepoDigests {
-		delete(p.imageUsers, repoDigest)
 		if p.imageRepoDigests[repoDigest] == img.ID {
 			delete(p.imageRepoDigests, repoDigest)
 		}
 	}
 }
 
-func (p *processor) registerContainer(ctr *workloadmeta.Container) {
-	imgID := ctr.Image.ID
-	ctrID := ctr.ID
+// runningImages returns the identifiers of the images that have at least one
+// running container. Depending on the runtime and on which workloadmeta
+// sources describe it, a container names its image either by image ID or by
+// repo digest, so the identifiers are returned as the containers spell them.
+func runningImages(store workloadmeta.Component) map[string]struct{} {
+	containers := store.ListContainersWithFilter(workloadmeta.GetRunningContainers)
 
-	if !ctr.State.Running {
-		// Container is no longer running. Remove it from imageUsers so that a
-		// subsequent SBOM computation does not incorrectly set inUse=true for
-		// an image that has no running containers.
-		p.unregisterContainer(ctr)
+	images := make(map[string]struct{}, len(containers))
+	for _, ctr := range containers {
+		if ctr.Image.ID != "" {
+			images[ctr.Image.ID] = struct{}{}
+		}
+	}
+
+	return images
+}
+
+// imageInUse reports whether one of the running images is img, named either by
+// its ID or by one of its repo digests.
+func imageInUse(img *workloadmeta.ContainerImageMetadata, running map[string]struct{}) bool {
+	if _, found := running[img.ID]; found {
+		return true
+	}
+
+	for _, repoDigest := range img.RepoDigests {
+		if _, found := running[repoDigest]; found {
+			return true
+		}
+	}
+
+	return false
+}
+
+// resolveImageID maps the identifier a container uses to name its image to the
+// ID of the corresponding image entity. Identifiers that are already image IDs
+// are returned unchanged.
+func (p *processor) resolveImageID(id string) string {
+	if imgID, found := p.imageRepoDigests[id]; found {
+		return imgID
+	}
+
+	return id
+}
+
+// reportImage emits the SBOM of the image named by imgID, unless it has already
+// been reported for the event bundle being processed.
+func (p *processor) reportImage(imgID string, running, reported map[string]struct{}) {
+	if _, found := reported[imgID]; found {
 		return
 	}
 
-	if _, found := p.imageUsers[imgID]; found {
-		p.imageUsers[imgID][ctrID] = struct{}{}
-	} else {
-		p.imageUsers[imgID] = map[string]struct{}{
-			ctrID: {},
-		}
-
-		if realImgID, found := p.imageRepoDigests[imgID]; found {
-			imgID = realImgID
-		}
-
-		if img, err := p.workloadmetaStore.GetImage(imgID); err != nil {
-			log.Infof("Couldn’t find image %s in workloadmeta whereas it’s used by container %s: %v", imgID, ctrID, err)
-		} else {
-			p.processImageSBOM(img)
-		}
+	img, err := p.workloadmetaStore.GetImage(imgID)
+	if err != nil {
+		log.Infof("Couldn't find image %s in workloadmeta although a container runs it: %v", imgID, err)
+		return
 	}
-}
 
-func (p *processor) unregisterContainer(ctr *workloadmeta.Container) {
-	imgID := ctr.Image.ID
-	ctrID := ctr.ID
-
-	delete(p.imageUsers[imgID], ctrID)
-	if len(p.imageUsers[imgID]) == 0 {
-		delete(p.imageUsers, imgID)
-	}
+	p.processImageSBOM(img, running)
+	reported[imgID] = struct{}{}
 }
 
 func (p *processor) processHostScanResult(result sbom.ScanResult) {
@@ -361,7 +394,7 @@ func (p *processor) processProcfsScanResult(result sbom.ScanResult) {
 	p.queue <- sbom
 }
 
-func (p *processor) processImageSBOM(img *workloadmeta.ContainerImageMetadata) {
+func (p *processor) processImageSBOM(img *workloadmeta.ContainerImageMetadata, running map[string]struct{}) {
 	if !p.contImageSBOM {
 		return
 	}
@@ -394,17 +427,14 @@ func (p *processor) processImageSBOM(img *workloadmeta.ContainerImageMetadata) {
 		repos[strings.SplitN(repoTag, ":", 2)[0]] = struct{}{}
 	}
 
-	inUse := false
-	for _, repoDigest := range img.RepoDigests {
-		if _, found := p.imageUsers[repoDigest]; found {
-			inUse = true
-			break
-		}
-	}
-	// Fallback for runtimes (e.g. containerd) where ctr.Image.ID is the image
-	// config digest rather than a repo digest, so imageUsers is keyed by img.ID.
+	inUse := imageInUse(img, running)
 	if !inUse {
-		_, inUse = p.imageUsers[img.ID]
+		// A periodic refresh reaches this with no event bundle behind it, so
+		// forget the image here rather than only when a bundle rebuilds the
+		// set. Otherwise the back end is told the image is not in use while
+		// the set still says it is, and a container starting it again is
+		// taken for one that changes nothing and goes unreported.
+		delete(p.imagesInUse, img.ID)
 	}
 
 	cyclosbom, err := sbomutil.UncompressSBOM(img.SBOM)

--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -420,33 +420,9 @@ func TestProcessEvents(t *testing.T) {
 					},
 				},
 			},
+			// A single SBOM is emitted: the store already knows about the
+			// running container when the image event is processed.
 			expectedSBOMs: []*model.SBOMEntity{
-				{
-					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
-					Id:   "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-					DdTags: []string{
-						"image_id:datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
-						"image_name:datadog/agent",
-						"short_image:agent",
-						"image_tag:7-rc",
-					},
-					RepoTags: []string{
-						"7-rc",
-					},
-					RepoDigests: []string{
-						"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
-					},
-					InUse:              false,
-					GeneratedAt:        timestamppb.New(sbomGenerationTime),
-					GenerationDuration: durationpb.New(10 * time.Second),
-					Sbom: &model.SBOMEntity_Cyclonedx{
-						Cyclonedx: &cyclonedx_v1_4.Bom{
-							SpecVersion: "1.4",
-							Version:     pointer.Ptr(int32(42)),
-						},
-					},
-					Status: model.SBOMStatus_SUCCESS,
-				},
 				{
 					Type: model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 					Id:   "datadog/agent@sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
@@ -750,13 +726,20 @@ func TestProcessEvents(t *testing.T) {
 	}
 }
 
-// TestInUseFlagAccuracy covers three scenarios that previously caused incorrect inUse values:
-//  1. Event ordering: container removal and image SBOM update arrive in the same bundle.
+// TestInUseFlagAccuracy covers scenarios that previously caused incorrect inUse values:
+//  1. Same bundle: a container removal and an image SBOM update arrive together.
 //     The SBOM should be emitted with inUse=false because the container was removed.
 //  2. Container stopped (not yet removed): a container transitions to Running=false and
 //     then a new SBOM update arrives. The SBOM should reflect inUse=false.
 //  3. Containerd-style image ID: ctr.Image.ID is the raw image config digest rather than
 //     a repo digest. The image should still be reported as inUse=true when a container runs it.
+//  4. Image ID changing shape: a container is first described by the runtime alone, which
+//     names its image by config digest, then also by the kubelet, which names it by repo
+//     digest. Both spellings must stop being in use when the container stops.
+//  5. Missed event: the container disappears from the store without the check being told.
+//     The next SBOM must still report inUse=false.
+//  6. Periodic refresh reporting inUse=false: a container starting the image again must
+//     be reported, rather than taken for one that changes nothing.
 func TestInUseFlagAccuracy(t *testing.T) {
 	const (
 		imageID     = "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd"
@@ -765,23 +748,31 @@ func TestInUseFlagAccuracy(t *testing.T) {
 	)
 	sbomTime := time.Now()
 
-	imageEntity := &workloadmeta.ContainerImageMetadata{
-		EntityID: workloadmeta.EntityID{
-			Kind: workloadmeta.KindContainerImageMetadata,
-			ID:   imageID,
-		},
-		RepoTags:    []string{"datadog/agent:7-rc"},
-		RepoDigests: []string{repoDigest},
-		SBOM: mustCompressSBOM(t, &workloadmeta.SBOM{
-			CycloneDXBOM: &cyclonedx_v1_4.Bom{
-				SpecVersion: cyclonedx.SpecVersion1_4.String(),
-				Version:     pointer.Ptr(int32(1)),
+	// The SBOM version tells the payloads emitted for the initial image apart
+	// from those emitted after it is rescanned, so that an assertion on the
+	// second cannot be satisfied by the first.
+	imageWithSBOMVersion := func(version int32) *workloadmeta.ContainerImageMetadata {
+		return &workloadmeta.ContainerImageMetadata{
+			EntityID: workloadmeta.EntityID{
+				Kind: workloadmeta.KindContainerImageMetadata,
+				ID:   imageID,
 			},
-			GenerationTime:     sbomTime,
-			GenerationDuration: time.Second,
-			Status:             workloadmeta.Success,
-		}),
+			RepoTags:    []string{"datadog/agent:7-rc"},
+			RepoDigests: []string{repoDigest},
+			SBOM: mustCompressSBOM(t, &workloadmeta.SBOM{
+				CycloneDXBOM: &cyclonedx_v1_4.Bom{
+					SpecVersion: cyclonedx.SpecVersion1_4.String(),
+					Version:     pointer.Ptr(version),
+				},
+				GenerationTime:     sbomTime,
+				GenerationDuration: time.Second,
+				Status:             workloadmeta.Success,
+			}),
+		}
 	}
+
+	imageEntity := imageWithSBOMVersion(1)
+	rescannedImageEntity := imageWithSBOMVersion(2)
 
 	runningContainer := &workloadmeta.Container{
 		EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainer, ID: containerID},
@@ -794,7 +785,7 @@ func TestInUseFlagAccuracy(t *testing.T) {
 		State:    workloadmeta.ContainerState{Running: false},
 	}
 
-	makeExpectedSBOM := func(inUse bool) *model.SBOMEntity {
+	makeExpectedSBOM := func(inUse bool, version int32) *model.SBOMEntity {
 		return &model.SBOMEntity{
 			Type:               model.SBOMSourceType_CONTAINER_IMAGE_LAYERS,
 			Id:                 "datadog/agent@" + imageID,
@@ -806,7 +797,7 @@ func TestInUseFlagAccuracy(t *testing.T) {
 			GenerationDuration: durationpb.New(time.Second),
 			Sbom: &model.SBOMEntity_Cyclonedx{Cyclonedx: &cyclonedx_v1_4.Bom{
 				SpecVersion: "1.4",
-				Version:     pointer.Ptr(int32(1)),
+				Version:     pointer.Ptr(version),
 			}},
 			Status: model.SBOMStatus_SUCCESS,
 		}
@@ -818,6 +809,23 @@ func TestInUseFlagAccuracy(t *testing.T) {
 		"sbom.container_image.enabled":                  true,
 		"sbom.container_image.allow_missing_repodigest": true,
 	})
+
+	assertSBOMSent := func(t *testing.T, sender *mocksender.MockSender, entity *model.SBOMEntity) {
+		t.Helper()
+
+		hname, _ := hostname.Get(context.TODO())
+		envVarEnv := cfg.GetString("env")
+		encoded, err := proto.Marshal(&model.SBOMPayload{
+			Version:  1,
+			Host:     hname,
+			Source:   &sourceAgent,
+			Entities: []*model.SBOMEntity{entity},
+			DdEnv:    &envVarEnv,
+		})
+		assert.Nil(t, err)
+		sender.AssertEventPlatformEvent(t, encoded, eventplatform.EventTypeContainerSBOM)
+	}
+
 	if sbomscanner.GetGlobalScanner() == nil {
 		wmeta := fxutil.Test[option.Option[workloadmeta.Component]](t, fx.Options(
 			core.MockBundle(),
@@ -853,7 +861,7 @@ func TestInUseFlagAccuracy(t *testing.T) {
 	}
 
 	// Test 1: container removal and image SBOM update in the same bundle
-	t.Run("event ordering: container removal before image SBOM emission", func(t *testing.T) {
+	t.Run("container removed in the same bundle as the image SBOM", func(t *testing.T) {
 		p, sender, counter, store := newTestSetup(t)
 
 		// Establish initial state: running container.
@@ -863,78 +871,57 @@ func TestInUseFlagAccuracy(t *testing.T) {
 			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: imageEntity},
 			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: runningContainer},
 		))
-		// Wait for the two SBOMs from the setup phase (inUse=false, then inUse=true).
-		assert.Eventually(t, func() bool { return counter.Load() == 2 }, time.Second, 5*time.Millisecond)
+		// Wait for the single SBOM from the setup phase (inUse=true).
+		assert.Eventually(t, func() bool { return counter.Load() == 1 }, time.Second, 5*time.Millisecond)
 		counter.Store(0)
 
 		// The container is removed AND a fresh SBOM arrives in the same bundle.
-		// Without the event-ordering fix the SBOM would be emitted with inUse=true
-		// because the image Set was processed before the container Unset.
+		// The order the two events are handled in must not matter: the store
+		// has already dropped the container by the time the bundle arrives.
 		store.Unset(runningContainer)
-		store.Set(imageEntity)
+		store.Set(rescannedImageEntity)
 		p.processContainerImagesEvents(makeBundle(
-			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: imageEntity},
+			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: rescannedImageEntity},
 			workloadmeta.Event{Type: workloadmeta.EventTypeUnset, Entity: runningContainer},
 		))
 		p.stop()
 
 		assert.Eventually(t, func() bool { return counter.Load() == 1 }, time.Second, 5*time.Millisecond)
 
-		hname, _ := hostname.Get(context.TODO())
-		envVarEnv := cfg.GetString("env")
-		encoded, err := proto.Marshal(&model.SBOMPayload{
-			Version:  1,
-			Host:     hname,
-			Source:   &sourceAgent,
-			Entities: []*model.SBOMEntity{makeExpectedSBOM(false)},
-			DdEnv:    &envVarEnv,
-		})
-		assert.Nil(t, err)
-		sender.AssertEventPlatformEvent(t, encoded, eventplatform.EventTypeContainerSBOM)
+		assertSBOMSent(t, sender, makeExpectedSBOM(false, 2))
 	})
 
 	// Test 2: container transitions stopped then image SBOM updates
 	t.Run("stopped container does not keep inUse=true", func(t *testing.T) {
 		p, sender, counter, store := newTestSetup(t)
 
-		// Step 1: image + running container → two SBOMs (inUse=false then inUse=true).
+		// Step 1: image + running container → one SBOM with inUse=true.
 		store.Set(imageEntity)
 		store.Set(runningContainer)
 		p.processContainerImagesEvents(makeBundle(
 			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: imageEntity},
 			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: runningContainer},
 		))
-		assert.Eventually(t, func() bool { return counter.Load() == 2 }, time.Second, 5*time.Millisecond)
+		assert.Eventually(t, func() bool { return counter.Load() == 1 }, time.Second, 5*time.Millisecond)
 		counter.Store(0)
 
 		// Step 2: container stops (Running=false) and a new image SBOM arrives.
-		// Without the registerContainer fix the container remains in imageUsers and
-		// the SBOM is incorrectly emitted with inUse=true.
+		// The stopped container must no longer count as a user of the image.
 		store.Set(stoppedContainer)
-		store.Set(imageEntity)
+		store.Set(rescannedImageEntity)
 		p.processContainerImagesEvents(makeBundle(
 			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: stoppedContainer},
-			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: imageEntity},
+			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: rescannedImageEntity},
 		))
 		p.stop()
 
 		assert.Eventually(t, func() bool { return counter.Load() == 1 }, time.Second, 5*time.Millisecond)
 
-		hname, _ := hostname.Get(context.TODO())
-		envVarEnv := cfg.GetString("env")
-		encoded, err := proto.Marshal(&model.SBOMPayload{
-			Version:  1,
-			Host:     hname,
-			Source:   &sourceAgent,
-			Entities: []*model.SBOMEntity{makeExpectedSBOM(false)},
-			DdEnv:    &envVarEnv,
-		})
-		assert.Nil(t, err)
-		sender.AssertEventPlatformEvent(t, encoded, eventplatform.EventTypeContainerSBOM)
+		assertSBOMSent(t, sender, makeExpectedSBOM(false, 2))
 	})
 
 	// Test 3: containerd-style image ID (raw sha256, not repo digest)
-	t.Run("containerd image ID key fallback", func(t *testing.T) {
+	t.Run("container names its image by config digest", func(t *testing.T) {
 		p, sender, counter, store := newTestSetup(t)
 
 		// Container uses the raw image config digest as its Image.ID (containerd style).
@@ -952,21 +939,127 @@ func TestInUseFlagAccuracy(t *testing.T) {
 		))
 		p.stop()
 
-		// Expect two SBOMs: first from image Set (inUse=false, no containers yet),
-		// second from registerContainer (inUse=true via img.ID fallback).
-		assert.Eventually(t, func() bool { return counter.Load() == 2 }, time.Second, 5*time.Millisecond)
+		// The image is matched by its ID rather than by a repo digest.
+		assert.Eventually(t, func() bool { return counter.Load() == 1 }, time.Second, 5*time.Millisecond)
 
-		hname, _ := hostname.Get(context.TODO())
-		envVarEnv := cfg.GetString("env")
-		encoded, err := proto.Marshal(&model.SBOMPayload{
-			Version:  1,
-			Host:     hname,
-			Source:   &sourceAgent,
-			Entities: []*model.SBOMEntity{makeExpectedSBOM(true)},
-			DdEnv:    &envVarEnv,
-		})
-		assert.Nil(t, err)
-		sender.AssertEventPlatformEvent(t, encoded, eventplatform.EventTypeContainerSBOM)
+		assertSBOMSent(t, sender, makeExpectedSBOM(true, 1))
+	})
+
+	// Test 4: on Kubernetes the merged container entity names its image by
+	// config digest while the runtime is its only source, then by repo digest
+	// once the kubelet describes it too. A check tracking container events
+	// registers the container under both spellings but only ever removes it
+	// from the last one, leaving the image in use forever.
+	t.Run("image ID changing shape does not leave the image in use", func(t *testing.T) {
+		p, sender, counter, store := newTestSetup(t)
+
+		// The runtime is the only source: Image.ID is the config digest.
+		runtimeOnly := &workloadmeta.Container{
+			EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainer, ID: containerID},
+			Image:    workloadmeta.ContainerImage{ID: imageID},
+			State:    workloadmeta.ContainerState{Running: true},
+		}
+
+		store.Set(imageEntity)
+		store.Set(runtimeOnly)
+		p.processContainerImagesEvents(makeBundle(
+			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: imageEntity},
+			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: runtimeOnly},
+		))
+
+		// The kubelet describes the container too and wins the merge, so
+		// Image.ID becomes the repo digest.
+		store.Set(runningContainer)
+		p.processContainerImagesEvents(makeBundle(
+			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: runningContainer},
+		))
+
+		assert.Eventually(t, func() bool { return counter.Load() == 1 }, time.Second, 5*time.Millisecond)
+		counter.Store(0)
+
+		// The container goes away and a fresh SBOM arrives for the image.
+		store.Unset(runningContainer)
+		store.Set(rescannedImageEntity)
+		p.processContainerImagesEvents(makeBundle(
+			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: rescannedImageEntity},
+			workloadmeta.Event{Type: workloadmeta.EventTypeUnset, Entity: runningContainer},
+		))
+		p.stop()
+
+		assert.Eventually(t, func() bool { return counter.Load() == 1 }, time.Second, 5*time.Millisecond)
+
+		assertSBOMSent(t, sender, makeExpectedSBOM(false, 2))
+	})
+
+	// Test 5: workloadmeta drops a whole event bundle when a subscriber is too
+	// slow to read it, so the container removal is never delivered. The state
+	// of the store is still the truth.
+	t.Run("missed container event does not leave the image in use", func(t *testing.T) {
+		p, sender, counter, store := newTestSetup(t)
+
+		store.Set(imageEntity)
+		store.Set(runningContainer)
+		p.processContainerImagesEvents(makeBundle(
+			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: imageEntity},
+			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: runningContainer},
+		))
+		assert.Eventually(t, func() bool { return counter.Load() == 1 }, time.Second, 5*time.Millisecond)
+		counter.Store(0)
+
+		// The container is removed but the event never reaches the check.
+		store.Unset(runningContainer)
+		store.Set(rescannedImageEntity)
+		p.processContainerImagesEvents(makeBundle(
+			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: rescannedImageEntity},
+		))
+		p.stop()
+
+		assert.Eventually(t, func() bool { return counter.Load() == 1 }, time.Second, 5*time.Millisecond)
+
+		assertSBOMSent(t, sender, makeExpectedSBOM(false, 2))
+	})
+
+	// Test 6: a periodic refresh emits SBOMs without an event bundle behind it,
+	// so it is the only thing that tells the back end an image whose container
+	// stop was never delivered is no longer in use. The set of images last
+	// reported in use has to follow, or the container that starts the image
+	// again looks like one that changes nothing and is never reported.
+	t.Run("container starting an image a refresh reported idle is reported", func(t *testing.T) {
+		p, sender, counter, store := newTestSetup(t)
+
+		store.Set(imageEntity)
+		store.Set(runningContainer)
+		p.processContainerImagesEvents(makeBundle(
+			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: imageEntity},
+			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: runningContainer},
+		))
+		assert.Eventually(t, func() bool { return counter.Load() == 1 }, time.Second, 5*time.Millisecond)
+		counter.Store(0)
+
+		// The container goes away and the bundle saying so is dropped, so the
+		// refresh is what reports inUse=false. It is rescanned meanwhile, which
+		// tells the payloads emitted before and after this point apart.
+		store.Unset(runningContainer)
+		store.Set(rescannedImageEntity)
+
+		refresher := newBatchRefresher(time.Hour, store, p)
+		defer refresher.stop()
+		refresher.step()
+
+		assert.Eventually(t, func() bool { return counter.Load() == 1 }, time.Second, 5*time.Millisecond)
+		assertSBOMSent(t, sender, makeExpectedSBOM(false, 2))
+		counter.Store(0)
+
+		// A container starts the image again.
+		store.Set(runningContainer)
+		p.processContainerImagesEvents(makeBundle(
+			workloadmeta.Event{Type: workloadmeta.EventTypeSet, Entity: runningContainer},
+		))
+		p.stop()
+
+		assert.Eventually(t, func() bool { return counter.Load() == 1 }, time.Second, 5*time.Millisecond)
+
+		assertSBOMSent(t, sender, makeExpectedSBOM(true, 2))
 	})
 }
 

--- a/pkg/collector/corechecks/sbom/spread_refresher.go
+++ b/pkg/collector/corechecks/sbom/spread_refresher.go
@@ -69,9 +69,10 @@ func (br *spreadRefresher) step() {
 	})
 
 	// second step: we process the oldest images
+	running := runningImages(br.wmStore)
 	amountOfImagesToProcess := len(images) / spreadSteps
 	for _, img := range workingSet[:amountOfImagesToProcess] {
-		br.proc.processImageSBOM(img.image)
+		br.proc.processImageSBOM(img.image, running)
 		img.refreshTime = time.Now()
 	}
 

--- a/releasenotes/notes/sbom-inuse-from-workloadmeta-4f2a6c1d9e8b7a35.yaml
+++ b/releasenotes/notes/sbom-inuse-from-workloadmeta-4f2a6c1d9e8b7a35.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed container image SBOMs being reported as in use after their last
+    container had stopped. On Kubernetes nodes, an image that had run a
+    container once kept that flag until the Agent was restarted.


### PR DESCRIPTION
### What does this PR do?

The SBOM check computed inUse from imageUsers, a map of image identifier
to running container IDs that it maintained from workloadmeta container
events. The map was keyed by the Image.ID of the merged container entity,
and that field changes shape over a container's lifetime. On Kubernetes
the containerd collector reports the image config digest and the kubelet
reports the repo digest, and workloadmeta merges its sources in
alphabetical order, so the kubelet value wins as soon as it appears. A
container starting on a containerd node is therefore registered first
under the config digest, a moment later under the repo digest once the
kubelet describes it too, and removed only from the second. The config
digest entry stayed behind, and that is exactly the key the img.ID
fallback looks up, so the image reported inUse=true until the Agent
restarted. Nothing reconciled the map, so a dropped event bundle left the
same residue.

Ask workloadmeta which images have a running container instead. The store
is already up to date when an event bundle is handed to the check, and
the question is the one the container check behind Live Containers asks,
so the two agree by construction and no cache can drift from either. What
is left of the old map is the set of images reported in use by the
previous bundle, used only to decide when to push an update, so a stale
entry can now delay an emission but never produce a wrong inUse.

This drops the event ordering and the stopped container cleanup added in
#48586, which the store makes unnecessary. Matching a container against
the image entity ID, from the same change, stays: it is how a container
on containerd names its image.

When an image and the container that just started it are described by
the same event bundle, they no longer produce an SBOM each. The first
of the two used to carry inUse=false, because the container had not
been registered yet, and the second corrected it.
