### PR TITLE
[SBOM] Skip images whose SBOM cannot be uncompressed

### DIFF
--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -444,6 +444,7 @@ func (p *processor) processImageSBOM(img *workloadmeta.ContainerImageMetadata, r
 	cyclosbom, err := sbomutil.UncompressSBOM(img.SBOM)
 	if err != nil {
 		log.Errorf("Failed to uncompress SBOM for image %s: %v", img.ID, err)
+		return
 	}
 
 	for repo := range repos {

--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -1063,6 +1063,64 @@ func TestInUseFlagAccuracy(t *testing.T) {
 	})
 }
 
+// TestCorruptedSBOM checks that an image whose stored SBOM cannot be
+// uncompressed is skipped. Uncompressing returns no SBOM alongside its error,
+// so reading the SBOM anyway panicked, and the check runs on a goroutine that
+// nothing recovers.
+func TestCorruptedSBOM(t *testing.T) {
+	imageEntity := &workloadmeta.ContainerImageMetadata{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindContainerImageMetadata,
+			ID:   "sha256:9634b84c45c6ad220c3d0d2305aaa5523e47d6d43649c9bbeda46ff010b4aacd",
+		},
+		RepoTags:    []string{"datadog/agent:7-rc"},
+		RepoDigests: []string{"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
+		SBOM: &workloadmeta.CompressedSBOM{
+			Bom:    []byte("not a gzip stream"),
+			Status: workloadmeta.Success,
+		},
+	}
+
+	cacheDir := t.TempDir()
+	cfg := configcomp.NewMockWithOverrides(t, map[string]interface{}{
+		"sbom.cache_directory":         cacheDir,
+		"sbom.container_image.enabled": true,
+	})
+	if sbomscanner.GetGlobalScanner() == nil {
+		wmeta := fxutil.Test[option.Option[workloadmeta.Component]](t, fx.Options(
+			core.MockBundle(),
+			workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+		))
+		_, err := sbomscanner.CreateGlobalScanner(cfg, wmeta)
+		assert.Nil(t, err)
+	}
+
+	store := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		fx.Provide(func() log.Component { return logmock.New(t) }),
+		fx.Provide(func() configcomp.Component { return configcomp.NewMock(t) }),
+		fx.Supply(context.Background()),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+
+	sent := atomic.NewInt32(0)
+	sender := mocksender.NewMockSender(t, "")
+	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return().Run(func(_ mock.Arguments) {
+		sent.Inc()
+	})
+
+	p, err := newProcessor(store, workloadfilterfxmock.SetupMockFilter(t), sender, taggerfxmock.SetupFakeTagger(t), cfg, 1, 50*time.Millisecond, time.Second)
+	assert.Nil(t, err)
+
+	store.Set(imageEntity)
+	p.processContainerImagesEvents(workloadmeta.EventBundle{
+		Events: []workloadmeta.Event{{Type: workloadmeta.EventTypeSet, Entity: imageEntity}},
+		Ch:     make(chan struct{}),
+	})
+	p.stop()
+
+	assert.Never(t, func() bool { return sent.Load() > 0 }, 100*time.Millisecond, 5*time.Millisecond)
+}
+
 func mustCompressSBOM(t *testing.T, sbom *workloadmeta.SBOM) *workloadmeta.CompressedSBOM {
 	t.Helper()
 

--- a/releasenotes/notes/sbom-uncompress-error-crash-8d3e5b1a7c024f96.yaml
+++ b/releasenotes/notes/sbom-uncompress-error-crash-8d3e5b1a7c024f96.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed the Agent crashing when the stored SBOM of a container image could
+    not be uncompressed. The image is now skipped instead.


### PR DESCRIPTION
### What does this PR do?

processImageSBOM logged the error from UncompressSBOM and carried on,
but UncompressSBOM returns no SBOM alongside its error, so reading its
status a few lines later dereferenced a nil pointer. The check worker
recovers from a panic in Run, so that one misbehaving check cannot take
the process with it, but the long-running check wrapper returns from Run
as soon as it has started the goroutine the check really runs on, and
the recover never covers that goroutine. An image whose stored SBOM
cannot be uncompressed therefore brings the whole Agent down, and does
so again at every refresh for as long as workloadmeta holds it.

Skip the image instead. It is reported again once it is scanned anew.
