### PR TITLE
[SBOM] Refresh every image when spreading the refresh

### DIFF
--- a/pkg/collector/corechecks/sbom/BUILD.bazel
+++ b/pkg/collector/corechecks/sbom/BUILD.bazel
@@ -536,6 +536,7 @@ dd_agent_go_test(
     srcs = [
         "check_test.go",
         "processor_test.go",
+        "spread_refresher_test.go",
     ],
     embed = [":sbom"],
     gotags_sets = [["trivy"]],

--- a/pkg/collector/corechecks/sbom/spread_refresher.go
+++ b/pkg/collector/corechecks/sbom/spread_refresher.go
@@ -68,9 +68,11 @@ func (br *spreadRefresher) step() {
 		return a.refreshTime.Compare(b.refreshTime)
 	})
 
-	// second step: we process the oldest images
+	// second step: we process the oldest images. Rounding up covers every
+	// image within one period, at the cost of at most spreadSteps-1 extra
+	// refreshes per period.
 	running := runningImages(br.wmStore)
-	amountOfImagesToProcess := len(images) / spreadSteps
+	amountOfImagesToProcess := (len(images) + spreadSteps - 1) / spreadSteps
 	for _, img := range workingSet[:amountOfImagesToProcess] {
 		br.proc.processImageSBOM(img.image, running)
 		img.refreshTime = time.Now()

--- a/pkg/collector/corechecks/sbom/spread_refresher_test.go
+++ b/pkg/collector/corechecks/sbom/spread_refresher_test.go
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+//go:build trivy || windows
+
+package sbom
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	configcomp "github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	workloadfilterfxmock "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx-mock"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	sbomscanner "github.com/DataDog/datadog-agent/pkg/sbom/scanner"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+// TestSpreadRefresherCoversEveryImage checks that spreading the refresh over
+// spreadSteps steps still refreshes every image once per period. Dividing the
+// image count by spreadSteps used to truncate, so a node with fewer than
+// spreadSteps images refreshed nothing at all and inUse never became false
+// again once a container had stopped.
+func TestSpreadRefresherCoversEveryImage(t *testing.T) {
+	cfg := configcomp.NewMockWithOverrides(t, map[string]interface{}{
+		"sbom.cache_directory": t.TempDir(),
+	})
+	if sbomscanner.GetGlobalScanner() == nil {
+		wmeta := fxutil.Test[option.Option[workloadmeta.Component]](t, fx.Options(
+			core.MockBundle(),
+			workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+		))
+		_, err := sbomscanner.CreateGlobalScanner(cfg, wmeta)
+		assert.Nil(t, err)
+	}
+
+	for _, imageCount := range []int{0, 1, 9, 10, 15, 100} {
+		t.Run(fmt.Sprintf("%d images", imageCount), func(t *testing.T) {
+			store := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+				fx.Provide(func() log.Component { return logmock.New(t) }),
+				fx.Provide(func() configcomp.Component { return configcomp.NewMock(t) }),
+				fx.Supply(context.Background()),
+				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+			))
+
+			for i := 0; i < imageCount; i++ {
+				store.Set(&workloadmeta.ContainerImageMetadata{
+					EntityID: workloadmeta.EntityID{
+						Kind: workloadmeta.KindContainerImageMetadata,
+						ID:   fmt.Sprintf("sha256:%064d", i),
+					},
+				})
+			}
+
+			p, err := newProcessor(store, workloadfilterfxmock.SetupMockFilter(t), mocksender.NewMockSender(t, ""), taggerfxmock.SetupFakeTagger(t), cfg, 1, 50*time.Millisecond, time.Second)
+			assert.Nil(t, err)
+			defer p.stop()
+
+			refresher := newSpreadRefresher(time.Hour, store, p)
+			defer refresher.stop()
+
+			for i := 0; i < spreadSteps; i++ {
+				refresher.step()
+			}
+
+			refreshed := 0
+			for _, at := range refresher.refreshTimes {
+				if !at.IsZero() {
+					refreshed++
+				}
+			}
+			assert.Equal(t, imageCount, refreshed, "every image should be refreshed within one period")
+		})
+	}
+}

--- a/releasenotes/notes/sbom-spread-refresher-rounding-2b9c7e40a1d6f853.yaml
+++ b/releasenotes/notes/sbom-spread-refresher-rounding-2b9c7e40a1d6f853.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed ``sbom.container_image.use_spread_refresher`` never refreshing
+    container image SBOMs on hosts with fewer than ten images, and refreshing
+    them more slowly than ``periodic_refresh_seconds`` on other hosts.


### PR DESCRIPTION
### What does this PR do?

The spread refresher divides the image count by the number of steps it
spreads a period over to decide how many images to refresh per step. The
division truncates, so a host with fewer than ten images refreshed none
of them, ever. An image SBOM was then sent only when the image changed
or when a container first ran it, so inUse stayed true after the last
container stopped. Above ten, unless the count was a multiple of ten,
the refresh was merely slower than configured. Fifteen images took one
and a half periods to cycle.

Round the count up. Every image is then covered within one period, at
the cost of at most nine extra refreshes per period. That overhead only
matters where images are few, and a host with a single image now sends
it once per step rather than once per period.

The refresher is off by default, so this only affects hosts that set
sbom.container_image.use_spread_refresher.
