### PR TITLE
[EBPF] Collect NVLink fields per port

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/helpers.go
+++ b/pkg/collector/corechecks/gpu/nvidia/helpers.go
@@ -262,14 +262,12 @@ func portIsAlwaysSupported(_ int) ([]*Metric, error) {
 func getSupportedNvlinkPorts(device ddnvml.Device, metricCollector func(int) ([]*Metric, error)) ([]int, error) {
 	totalPorts, err := GetNVLinkCount(device)
 	if err != nil {
-		if ddnvml.IsAPIUnsupportedOnDevice(err, device) || errors.Is(err, errUnsupportedDevice) {
-			return nil, fmt.Errorf("%w: get NVLink link count: %w", errUnsupportedDevice, err)
-		}
-		return nil, fmt.Errorf("get NVLink link count: %w", err)
+		log.Warnf("failed to get NVLink link count on device %s: %s", device.GetDeviceInfo().UUID, err)
+		totalPorts = 1
 	}
 
 	if totalPorts <= 0 {
-		return nil, fmt.Errorf("%w: no NVLink ports found", errUnsupportedDevice)
+		log.Warnf("no NVLink ports found on device %s", device.GetDeviceInfo().UUID)
 	}
 
 	var ports []int

--- a/pkg/collector/corechecks/gpu/nvidia/helpers.go
+++ b/pkg/collector/corechecks/gpu/nvidia/helpers.go
@@ -262,12 +262,14 @@ func portIsAlwaysSupported(_ int) ([]*Metric, error) {
 func getSupportedNvlinkPorts(device ddnvml.Device, metricCollector func(int) ([]*Metric, error)) ([]int, error) {
 	totalPorts, err := GetNVLinkCount(device)
 	if err != nil {
-		log.Warnf("failed to get NVLink link count on device %s: %s", device.GetDeviceInfo().UUID, err)
-		totalPorts = 1
+		if ddnvml.IsAPIUnsupportedOnDevice(err, device) || errors.Is(err, errUnsupportedDevice) {
+			return nil, fmt.Errorf("%w: get NVLink link count: %w", errUnsupportedDevice, err)
+		}
+		return nil, fmt.Errorf("get NVLink link count: %w", err)
 	}
 
 	if totalPorts <= 0 {
-		log.Warnf("no NVLink ports found on device %s", device.GetDeviceInfo().UUID)
+		return nil, fmt.Errorf("%w: no NVLink ports found", errUnsupportedDevice)
 	}
 
 	var ports []int

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
@@ -83,10 +83,10 @@ var nvlinkFieldsMetrics = map[uint32]nvlinkFieldValueMetric{
 }
 
 type nvlinkFieldsCollector struct {
-	device  ddnvml.Device
-	metrics map[uint32]nvlinkFieldValueMetric
-	ports   []int
-	totals  map[uint32]float64
+	device         ddnvml.Device
+	ports          []int
+	metricsPerPort map[int]map[uint32]nvlinkFieldValueMetric
+	totals         map[uint32]float64
 }
 
 func newNVLinkFieldsCollector(device ddnvml.Device, _ *CollectorDependencies) (Collector, error) {
@@ -95,7 +95,7 @@ func newNVLinkFieldsCollector(device ddnvml.Device, _ *CollectorDependencies) (C
 		totals: make(map[uint32]float64),
 	}
 
-	c.metrics = maps.Clone(nvlinkFieldsMetrics) // copy all metrics to avoid modifying the original map
+	c.metricsPerPort = make(map[int]map[uint32]nvlinkFieldValueMetric)
 
 	var err error
 	c.ports, err = getSupportedNvlinkPorts(device, c.getPortMetrics)
@@ -132,7 +132,7 @@ func (c *nvlinkFieldsCollector) Collect() ([]*Metric, error) {
 		metrics = append(metrics, portMetrics...)
 	}
 
-	for fieldValueID, metric := range c.metrics {
+	for fieldValueID, metric := range nvlinkFieldsMetrics {
 		if !metric.addTotalMetric {
 			continue
 		}
@@ -160,14 +160,21 @@ func (c *nvlinkFieldsCollector) Collect() ([]*Metric, error) {
 }
 
 func (c *nvlinkFieldsCollector) getPortMetrics(port int) ([]*Metric, error) {
+	// Initialize the metrics for the port if they don't exist.
+	portMetrics, ok := c.metricsPerPort[port]
+	if !ok {
+		portMetrics = maps.Clone(nvlinkFieldsMetrics)
+		c.metricsPerPort[port] = portMetrics
+	}
+
 	// Metrics might have been removed in the previous run, so we check if there are any metrics to collect.
-	if len(c.metrics) == 0 {
+	if len(portMetrics) == 0 {
 		return nil, fmt.Errorf("%w: no metrics to collect", errUnsupportedDevice)
 	}
 
-	fields := make([]nvml.FieldValue, len(c.metrics))
+	fields := make([]nvml.FieldValue, len(portMetrics))
 	fieldIdx := 0
-	for fieldValueID, metric := range c.metrics {
+	for fieldValueID, metric := range portMetrics {
 		fields[fieldIdx].FieldId = fieldValueID
 
 		if metric.forceScopeIDValue != nil {
@@ -186,7 +193,7 @@ func (c *nvlinkFieldsCollector) getPortMetrics(port int) ([]*Metric, error) {
 	var metrics []*Metric
 	var errs []error
 	for _, val := range fields {
-		fieldValueMetric, ok := c.metrics[val.FieldId]
+		fieldValueMetric, ok := portMetrics[val.FieldId]
 		if !ok {
 			errs = append(errs, fmt.Errorf("unexpected field value ID %d", val.FieldId))
 			continue
@@ -196,9 +203,8 @@ func (c *nvlinkFieldsCollector) getPortMetrics(port int) ([]*Metric, error) {
 		// this metric from the collector, even if it's after a later run. The assumption here
 		// is that unsupported fields are returned from the start, and their status does not change.
 		// This way, we avoid having different functions to collect metrics and to check for support.
-		// We also assume that if a field is not supported for a port, it's not supported for any other port.
 		if val.NvmlReturn == uint32(nvml.ERROR_NOT_SUPPORTED) || (val.NvmlReturn == uint32(nvml.ERROR_INVALID_ARGUMENT) && fieldValueMetric.markUnsupportedOnInvalidArgument) {
-			delete(c.metrics, val.FieldId)
+			delete(portMetrics, val.FieldId)
 			log.Warnf("nvlink: fields collector removing metric %s for port %d because it's not supported, error: %s", fieldValueMetric.name, port, nvml.ErrorString(nvml.Return(val.NvmlReturn)))
 			continue
 		} else if val.NvmlReturn != uint32(nvml.SUCCESS) {
@@ -226,7 +232,7 @@ func (c *nvlinkFieldsCollector) getPortMetrics(port int) ([]*Metric, error) {
 		}
 	}
 
-	if len(c.metrics) == 0 {
+	if len(portMetrics) == 0 {
 		// All metrics were removed, so we return an error to indicate that the device is unsupported.
 		return nil, fmt.Errorf("%w: no metrics to collect", errUnsupportedDevice)
 	}

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
@@ -222,7 +222,7 @@ func (c *nvlinkFieldsCollector) getPortMetrics(port int) ([]*Metric, error) {
 		})
 
 		if fieldValueMetric.addTotalMetric {
-			c.totals[fieldValueMetric.fieldValueID] += value
+			c.totals[val.FieldId] += value
 		}
 	}
 

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields.go
@@ -10,7 +10,7 @@ package nvidia
 import (
 	"errors"
 	"fmt"
-	"slices"
+	"maps"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
@@ -22,8 +22,7 @@ import (
 // nvlinkFieldValueMetric represents a metric that can be retrieved using the NVML
 // FieldValues API for NVLink-specific metrics.
 type nvlinkFieldValueMetric struct {
-	name         string
-	fieldValueID uint32 // No specific type, but these are constants prefixed with FI_DEV in the nvml package
+	name string
 	// Some fields on older architectures return INVALID_ARGUMENT immediately
 	// instead of cleanly reporting ERROR_NOT_SUPPORTED. Mark those fields here
 	// so collector initialization can treat INVALID_ARGUMENT as unsupported.
@@ -39,50 +38,53 @@ func intToPointer(i uint32) *uint32 {
 	return &i
 }
 
-var nvlinkFieldsMetrics = []nvlinkFieldValueMetric{
+// nvlinkFieldsMetrics is a map of field value IDs to nvlinkFieldValueMetric.
+// Field value IDs have no specific type, but they are constants prefixed with
+// FI_DEV in the nvml package
+var nvlinkFieldsMetrics = map[uint32]nvlinkFieldValueMetric{
 	// -- NVLink throughput --
 	// Despite NVIDIA calling these "throughput", they report cumulative bytes transferred,
 	// so we compute the rate ourselves.
-	{name: "nvlink.throughput.data.rx", fieldValueID: nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX, addTotalMetric: true, metricType: metrics.GaugeType, rateCalculationMode: PerSecondRateCalculation},
-	{name: "nvlink.throughput.data.tx", fieldValueID: nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_TX, addTotalMetric: true, metricType: metrics.GaugeType, rateCalculationMode: PerSecondRateCalculation},
-	{name: "nvlink.throughput.raw.rx", fieldValueID: nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_RX, addTotalMetric: true, metricType: metrics.GaugeType, rateCalculationMode: PerSecondRateCalculation},
-	{name: "nvlink.throughput.raw.tx", fieldValueID: nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_TX, addTotalMetric: true, metricType: metrics.GaugeType, rateCalculationMode: PerSecondRateCalculation},
+	nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX: {name: "nvlink.throughput.data.rx", addTotalMetric: true, metricType: metrics.GaugeType, rateCalculationMode: PerSecondRateCalculation},
+	nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_TX: {name: "nvlink.throughput.data.tx", addTotalMetric: true, metricType: metrics.GaugeType, rateCalculationMode: PerSecondRateCalculation},
+	nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_RX:  {name: "nvlink.throughput.raw.rx", addTotalMetric: true, metricType: metrics.GaugeType, rateCalculationMode: PerSecondRateCalculation},
+	nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_TX:  {name: "nvlink.throughput.raw.tx", addTotalMetric: true, metricType: metrics.GaugeType, rateCalculationMode: PerSecondRateCalculation},
 
 	// Alternative throughput fields
-	{name: "nvlink.throughput.data.rx", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_RCV_BYTES, addTotalMetric: true, metricType: metrics.GaugeType, priority: Medium, rateCalculationMode: PerSecondRateCalculation},
-	{name: "nvlink.throughput.data.tx", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_BYTES, addTotalMetric: true, metricType: metrics.GaugeType, priority: Medium, rateCalculationMode: PerSecondRateCalculation},
+	nvml.FI_DEV_NVLINK_COUNT_RCV_BYTES:  {name: "nvlink.throughput.data.rx", addTotalMetric: true, metricType: metrics.GaugeType, priority: Medium, rateCalculationMode: PerSecondRateCalculation},
+	nvml.FI_DEV_NVLINK_COUNT_XMIT_BYTES: {name: "nvlink.throughput.data.tx", addTotalMetric: true, metricType: metrics.GaugeType, priority: Medium, rateCalculationMode: PerSecondRateCalculation},
 
 	// -- NVLink speed --
 	// MediumLow: newer field (164), uses per-link speeds. Older field return the same per-link speed for all links, lower priority (default).
-	{name: "nvlink.speed", fieldValueID: nvml.FI_DEV_NVLINK_GET_SPEED, priority: MediumLow, metricType: metrics.GaugeType},
-	{name: "nvlink.speed", fieldValueID: nvml.FI_DEV_NVLINK_SPEED_MBPS_COMMON, metricType: metrics.GaugeType, forceScopeIDValue: intToPointer(0)},
+	nvml.FI_DEV_NVLINK_GET_SPEED:         {name: "nvlink.speed", priority: MediumLow, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_SPEED_MBPS_COMMON: {name: "nvlink.speed", metricType: metrics.GaugeType, forceScopeIDValue: intToPointer(0)},
 
 	// -- NVLink error counters --
-	{name: "nvlink.errors.crc.data", fieldValueID: nvml.FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.crc.flit", fieldValueID: nvml.FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.ecc", fieldValueID: nvml.FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.recovery", fieldValueID: nvml.FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.replay", fieldValueID: nvml.FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL, metricType: metrics.GaugeType},
-	{name: "nvlink.rx.packets", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_RCV_PACKETS, metricType: metrics.GaugeType},
-	{name: "nvlink.tx.packets", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_PACKETS, metricType: metrics.GaugeType},
-	{name: "nvlink.tx.discards", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.malformed.packet", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_MALFORMED_PACKET_ERRORS, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.buffer.overrun", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_BUFFER_OVERRUN_ERRORS, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.rx", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_RCV_ERRORS, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.rx.remote", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_RCV_REMOTE_ERRORS, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.rx.general", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_RCV_GENERAL_ERRORS, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.local.link.integrity", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS, metricType: metrics.GaugeType},
-	{name: "nvlink.recovery.events.successful", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS, metricType: metrics.GaugeType},
-	{name: "nvlink.recovery.events.failed", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.effective", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS, markUnsupportedOnInvalidArgument: true, metricType: metrics.GaugeType},
-	{name: "nvlink.ber.effective", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_EFFECTIVE_BER, metricType: metrics.GaugeType},
-	{name: "nvlink.errors.symbol", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_SYMBOL_ERRORS, metricType: metrics.GaugeType},
-	{name: "nvlink.ber.symbol", fieldValueID: nvml.FI_DEV_NVLINK_COUNT_SYMBOL_BER, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL:            {name: "nvlink.errors.crc.data", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL:            {name: "nvlink.errors.crc.flit", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL:            {name: "nvlink.errors.ecc", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL:            {name: "nvlink.errors.recovery", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL:              {name: "nvlink.errors.replay", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_RCV_PACKETS:                     {name: "nvlink.rx.packets", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_XMIT_PACKETS:                    {name: "nvlink.tx.packets", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS:                   {name: "nvlink.tx.discards", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_MALFORMED_PACKET_ERRORS:         {name: "nvlink.errors.malformed.packet", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_BUFFER_OVERRUN_ERRORS:           {name: "nvlink.errors.buffer.overrun", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_RCV_ERRORS:                      {name: "nvlink.errors.rx", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_RCV_REMOTE_ERRORS:               {name: "nvlink.errors.rx.remote", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_RCV_GENERAL_ERRORS:              {name: "nvlink.errors.rx.general", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS:     {name: "nvlink.errors.local.link.integrity", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS: {name: "nvlink.recovery.events.successful", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS:     {name: "nvlink.recovery.events.failed", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS:                {name: "nvlink.errors.effective", markUnsupportedOnInvalidArgument: true, metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_EFFECTIVE_BER:                   {name: "nvlink.ber.effective", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_SYMBOL_ERRORS:                   {name: "nvlink.errors.symbol", metricType: metrics.GaugeType},
+	nvml.FI_DEV_NVLINK_COUNT_SYMBOL_BER:                      {name: "nvlink.ber.symbol", metricType: metrics.GaugeType},
 }
 
 type nvlinkFieldsCollector struct {
 	device  ddnvml.Device
-	metrics []nvlinkFieldValueMetric
+	metrics map[uint32]nvlinkFieldValueMetric
 	ports   []int
 	totals  map[uint32]float64
 }
@@ -93,7 +95,7 @@ func newNVLinkFieldsCollector(device ddnvml.Device, _ *CollectorDependencies) (C
 		totals: make(map[uint32]float64),
 	}
 
-	c.metrics = append(c.metrics, nvlinkFieldsMetrics...) // copy all metrics to avoid modifying the original slice
+	c.metrics = maps.Clone(nvlinkFieldsMetrics) // copy all metrics to avoid modifying the original map
 
 	var err error
 	c.ports, err = getSupportedNvlinkPorts(device, c.getPortMetrics)
@@ -130,12 +132,12 @@ func (c *nvlinkFieldsCollector) Collect() ([]*Metric, error) {
 		metrics = append(metrics, portMetrics...)
 	}
 
-	for _, metric := range c.metrics {
+	for fieldValueID, metric := range c.metrics {
 		if !metric.addTotalMetric {
 			continue
 		}
 
-		total, ok := c.totals[metric.fieldValueID]
+		total, ok := c.totals[fieldValueID]
 		if !ok {
 			// No value got added to this metric, so we skip it for consistency. That way,
 			// we only emit the total metric if there's any value. If there was a temporary
@@ -164,14 +166,16 @@ func (c *nvlinkFieldsCollector) getPortMetrics(port int) ([]*Metric, error) {
 	}
 
 	fields := make([]nvml.FieldValue, len(c.metrics))
-	for i, metric := range c.metrics {
-		fields[i].FieldId = metric.fieldValueID
+	fieldIdx := 0
+	for fieldValueID, metric := range c.metrics {
+		fields[fieldIdx].FieldId = fieldValueID
 
 		if metric.forceScopeIDValue != nil {
-			fields[i].ScopeId = *metric.forceScopeIDValue
+			fields[fieldIdx].ScopeId = *metric.forceScopeIDValue
 		} else {
-			fields[i].ScopeId = uint32(port - 1)
+			fields[fieldIdx].ScopeId = uint32(port - 1)
 		}
+		fieldIdx++
 	}
 
 	if err := c.device.GetFieldValues(fields); err != nil {
@@ -182,15 +186,11 @@ func (c *nvlinkFieldsCollector) getPortMetrics(port int) ([]*Metric, error) {
 	var metrics []*Metric
 	var errs []error
 	for _, val := range fields {
-		metricIdx := slices.IndexFunc(c.metrics, func(m nvlinkFieldValueMetric) bool {
-			return m.fieldValueID == val.FieldId
-		})
-		if metricIdx == -1 {
+		fieldValueMetric, ok := c.metrics[val.FieldId]
+		if !ok {
 			errs = append(errs, fmt.Errorf("unexpected field value ID %d", val.FieldId))
 			continue
 		}
-
-		fieldValueMetric := c.metrics[metricIdx]
 
 		// Check first if the field returned unsupported. If it's not supported, we remove
 		// this metric from the collector, even if it's after a later run. The assumption here
@@ -198,7 +198,7 @@ func (c *nvlinkFieldsCollector) getPortMetrics(port int) ([]*Metric, error) {
 		// This way, we avoid having different functions to collect metrics and to check for support.
 		// We also assume that if a field is not supported for a port, it's not supported for any other port.
 		if val.NvmlReturn == uint32(nvml.ERROR_NOT_SUPPORTED) || (val.NvmlReturn == uint32(nvml.ERROR_INVALID_ARGUMENT) && fieldValueMetric.markUnsupportedOnInvalidArgument) {
-			c.metrics = slices.Delete(c.metrics, metricIdx, metricIdx+1)
+			delete(c.metrics, val.FieldId)
 			log.Warnf("nvlink: fields collector removing metric %s for port %d because it's not supported, error: %s", fieldValueMetric.name, port, nvml.ErrorString(nvml.Return(val.NvmlReturn)))
 			continue
 		} else if val.NvmlReturn != uint32(nvml.SUCCESS) {

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
@@ -37,10 +37,24 @@ func TestNVLinkFieldsCollectorQueriesAllConfiguredPorts(t *testing.T) {
 	collector := &nvlinkFieldsCollector{
 		device: device,
 		ports:  []int{1, 2, 3},
-		metrics: map[uint32]nvlinkFieldValueMetric{
-			nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
-				name:       "nvlink.tx.discards",
-				metricType: metrics.GaugeType,
+		metricsPerPort: map[int]map[uint32]nvlinkFieldValueMetric{
+			1: {
+				nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
+					name:       "nvlink.tx.discards",
+					metricType: metrics.GaugeType,
+				},
+			},
+			2: {
+				nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
+					name:       "nvlink.tx.discards",
+					metricType: metrics.GaugeType,
+				},
+			},
+			3: {
+				nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
+					name:       "nvlink.tx.discards",
+					metricType: metrics.GaugeType,
+				},
 			},
 		},
 	}
@@ -75,23 +89,10 @@ func TestNVLinkFieldsCollectorAddsTotals(t *testing.T) {
 	collector := &nvlinkFieldsCollector{
 		device: device,
 		ports:  []int{1, 2, 3},
-		metrics: map[uint32]nvlinkFieldValueMetric{
-			nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX: {
-				name:                "nvlink.throughput.data.rx",
-				addTotalMetric:      true,
-				metricType:          metrics.GaugeType,
-				rateCalculationMode: PerSecondRateCalculation,
-			},
-			nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_TX: {
-				name:                "nvlink.throughput.raw.tx",
-				addTotalMetric:      true,
-				metricType:          metrics.GaugeType,
-				rateCalculationMode: PerSecondRateCalculation,
-			},
-			nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
-				name:       "nvlink.tx.discards",
-				metricType: metrics.GaugeType,
-			},
+		metricsPerPort: map[int]map[uint32]nvlinkFieldValueMetric{
+			1: nvlinkFieldMetricsWithTotals(),
+			2: nvlinkFieldMetricsWithTotals(),
+			3: nvlinkFieldMetricsWithTotals(),
 		},
 	}
 
@@ -127,13 +128,34 @@ func TestNVLinkFieldsCollectorAddsTotals(t *testing.T) {
 	require.ElementsMatch(t, []float64{100, 200, 300}, discardValues)
 }
 
+func nvlinkFieldMetricsWithTotals() map[uint32]nvlinkFieldValueMetric {
+	return map[uint32]nvlinkFieldValueMetric{
+		nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX: {
+			name:                "nvlink.throughput.data.rx",
+			addTotalMetric:      true,
+			metricType:          metrics.GaugeType,
+			rateCalculationMode: PerSecondRateCalculation,
+		},
+		nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_TX: {
+			name:                "nvlink.throughput.raw.tx",
+			addTotalMetric:      true,
+			metricType:          metrics.GaugeType,
+			rateCalculationMode: PerSecondRateCalculation,
+		},
+		nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
+			name:       "nvlink.tx.discards",
+			metricType: metrics.GaugeType,
+		},
+	}
+}
+
 func TestNVLinkFieldsCollectorDiscardsUnsupportedFieldMetrics(t *testing.T) {
 	var requestedFieldsByScope = make(map[uint32][]uint32)
 	device := setupMockDevice(t, testutil.WithCustomHook(func(d *mock.Device) {
 		d.GetFieldValuesFunc = func(fv []nvml.FieldValue) nvml.Return {
 			for i := range fv {
 				requestedFieldsByScope[fv[i].ScopeId] = append(requestedFieldsByScope[fv[i].ScopeId], fv[i].FieldId)
-				if fv[i].FieldId == nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS {
+				if fv[i].FieldId == nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS && fv[i].ScopeId == 0 {
 					fv[i].NvmlReturn = uint32(nvml.ERROR_NOT_SUPPORTED)
 					continue
 				}
@@ -147,16 +169,30 @@ func TestNVLinkFieldsCollectorDiscardsUnsupportedFieldMetrics(t *testing.T) {
 	collector := &nvlinkFieldsCollector{
 		device: device,
 		ports:  []int{1, 2},
-		metrics: map[uint32]nvlinkFieldValueMetric{
-			nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX: {
-				name:                "nvlink.throughput.data.rx",
-				addTotalMetric:      true,
-				metricType:          metrics.GaugeType,
-				rateCalculationMode: PerSecondRateCalculation,
+		metricsPerPort: map[int]map[uint32]nvlinkFieldValueMetric{
+			1: {
+				nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX: {
+					name:                "nvlink.throughput.data.rx",
+					addTotalMetric:      true,
+					metricType:          metrics.GaugeType,
+					rateCalculationMode: PerSecondRateCalculation,
+				},
+				nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
+					name:       "nvlink.tx.discards",
+					metricType: metrics.GaugeType,
+				},
 			},
-			nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_TX: {
-				name:       "nvlink.tx.discards",
-				metricType: metrics.GaugeType,
+			2: {
+				nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX: {
+					name:                "nvlink.throughput.data.rx",
+					addTotalMetric:      true,
+					metricType:          metrics.GaugeType,
+					rateCalculationMode: PerSecondRateCalculation,
+				},
+				nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
+					name:       "nvlink.tx.discards",
+					metricType: metrics.GaugeType,
+				},
 			},
 		},
 	}
@@ -164,14 +200,13 @@ func TestNVLinkFieldsCollectorDiscardsUnsupportedFieldMetrics(t *testing.T) {
 	collected, err := collector.Collect()
 	require.NoError(t, err)
 
-	for _, metric := range collected {
-		require.NotEqual(t, "nvlink.tx.discards", metric.Name)
-	}
-
-	require.Len(t, collector.metrics, 1)
-	require.Contains(t, collector.metrics, uint32(nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX))
+	require.Contains(t, collected, &Metric{Name: "nvlink.tx.discards", Value: 2, Type: metrics.GaugeType, Tags: []string{nvlinkPortTag(2)}})
+	require.Len(t, collector.metricsPerPort[1], 1)
+	require.Contains(t, collector.metricsPerPort[1], uint32(nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX))
+	require.Len(t, collector.metricsPerPort[2], 2)
+	require.Contains(t, collector.metricsPerPort[2], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
 	require.Contains(t, requestedFieldsByScope[0], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
-	require.NotContains(t, requestedFieldsByScope[1], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
+	require.Contains(t, requestedFieldsByScope[1], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
 }
 
 func TestNVLinkFieldsCollectorCollectDoesNotPanicWhenMetricsBecomeEmpty(t *testing.T) {
@@ -190,10 +225,18 @@ func TestNVLinkFieldsCollectorCollectDoesNotPanicWhenMetricsBecomeEmpty(t *testi
 	collector := &nvlinkFieldsCollector{
 		device: device,
 		ports:  []int{1, 2},
-		metrics: map[uint32]nvlinkFieldValueMetric{
-			nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
-				name:       "nvlink.tx.discards",
-				metricType: metrics.GaugeType,
+		metricsPerPort: map[int]map[uint32]nvlinkFieldValueMetric{
+			1: {
+				nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
+					name:       "nvlink.tx.discards",
+					metricType: metrics.GaugeType,
+				},
+			},
+			2: {
+				nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
+					name:       "nvlink.tx.discards",
+					metricType: metrics.GaugeType,
+				},
 			},
 		},
 	}
@@ -281,13 +324,9 @@ func TestNVlinkFieldsCollectorTreatsInvalidArgumentAsUnsupportedOnlyWhenConfigur
 	fc, ok := collector.(*nvlinkFieldsCollector)
 	require.True(t, ok, "expected *nvlinkFieldsCollector")
 
-	foundNvlinkEffective := false
-	for _, metric := range fc.metrics {
-		switch metric.name {
-		case "nvlink.errors.effective":
-			foundNvlinkEffective = true
+	for port, metrics := range fc.metricsPerPort {
+		for _, metric := range metrics {
+			require.NotEqualf(t, "nvlink.errors.effective", metric.name, "metric should be removed for port %d", port)
 		}
 	}
-
-	require.False(t, foundNvlinkEffective, "nvlink.errors.effective should be removed when INVALID_ARGUMENT is explicitly mapped to unsupported")
 }

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_fields_test.go
@@ -8,6 +8,8 @@
 package nvidia
 
 import (
+	"maps"
+	"slices"
 	"testing"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
@@ -35,11 +37,10 @@ func TestNVLinkFieldsCollectorQueriesAllConfiguredPorts(t *testing.T) {
 	collector := &nvlinkFieldsCollector{
 		device: device,
 		ports:  []int{1, 2, 3},
-		metrics: []nvlinkFieldValueMetric{
-			{
-				name:         "nvlink.tx.discards",
-				fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS,
-				metricType:   metrics.GaugeType,
+		metrics: map[uint32]nvlinkFieldValueMetric{
+			nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
+				name:       "nvlink.tx.discards",
+				metricType: metrics.GaugeType,
 			},
 		},
 	}
@@ -74,25 +75,22 @@ func TestNVLinkFieldsCollectorAddsTotals(t *testing.T) {
 	collector := &nvlinkFieldsCollector{
 		device: device,
 		ports:  []int{1, 2, 3},
-		metrics: []nvlinkFieldValueMetric{
-			{
+		metrics: map[uint32]nvlinkFieldValueMetric{
+			nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX: {
 				name:                "nvlink.throughput.data.rx",
-				fieldValueID:        nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX,
 				addTotalMetric:      true,
 				metricType:          metrics.GaugeType,
 				rateCalculationMode: PerSecondRateCalculation,
 			},
-			{
+			nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_TX: {
 				name:                "nvlink.throughput.raw.tx",
-				fieldValueID:        nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_TX,
 				addTotalMetric:      true,
 				metricType:          metrics.GaugeType,
 				rateCalculationMode: PerSecondRateCalculation,
 			},
-			{
-				name:         "nvlink.tx.discards",
-				fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS,
-				metricType:   metrics.GaugeType,
+			nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
+				name:       "nvlink.tx.discards",
+				metricType: metrics.GaugeType,
 			},
 		},
 	}
@@ -149,18 +147,16 @@ func TestNVLinkFieldsCollectorDiscardsUnsupportedFieldMetrics(t *testing.T) {
 	collector := &nvlinkFieldsCollector{
 		device: device,
 		ports:  []int{1, 2},
-		metrics: []nvlinkFieldValueMetric{
-			{
+		metrics: map[uint32]nvlinkFieldValueMetric{
+			nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX: {
 				name:                "nvlink.throughput.data.rx",
-				fieldValueID:        nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX,
 				addTotalMetric:      true,
 				metricType:          metrics.GaugeType,
 				rateCalculationMode: PerSecondRateCalculation,
 			},
-			{
-				name:         "nvlink.tx.discards",
-				fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS,
-				metricType:   metrics.GaugeType,
+			nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_TX: {
+				name:       "nvlink.tx.discards",
+				metricType: metrics.GaugeType,
 			},
 		},
 	}
@@ -173,7 +169,7 @@ func TestNVLinkFieldsCollectorDiscardsUnsupportedFieldMetrics(t *testing.T) {
 	}
 
 	require.Len(t, collector.metrics, 1)
-	require.Equal(t, uint32(nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX), collector.metrics[0].fieldValueID)
+	require.Contains(t, collector.metrics, uint32(nvml.FI_DEV_NVLINK_THROUGHPUT_DATA_RX))
 	require.Contains(t, requestedFieldsByScope[0], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
 	require.NotContains(t, requestedFieldsByScope[1], uint32(nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS))
 }
@@ -194,11 +190,10 @@ func TestNVLinkFieldsCollectorCollectDoesNotPanicWhenMetricsBecomeEmpty(t *testi
 	collector := &nvlinkFieldsCollector{
 		device: device,
 		ports:  []int{1, 2},
-		metrics: []nvlinkFieldValueMetric{
-			{
-				name:         "nvlink.tx.discards",
-				fieldValueID: nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS,
-				metricType:   metrics.GaugeType,
+		metrics: map[uint32]nvlinkFieldValueMetric{
+			nvml.FI_DEV_NVLINK_COUNT_XMIT_DISCARDS: {
+				name:       "nvlink.tx.discards",
+				metricType: metrics.GaugeType,
 			},
 		},
 	}
@@ -209,6 +204,13 @@ func TestNVLinkFieldsCollectorCollectDoesNotPanicWhenMetricsBecomeEmpty(t *testi
 	})
 	require.ErrorIs(t, err, errUnsupportedDevice)
 	require.ErrorContains(t, err, "no metrics to collect")
+}
+
+func TestNVlinkFieldsIsDisabledWhenNoMetricsAreSupported(t *testing.T) {
+	allFields := slices.Collect(maps.Keys(nvlinkFieldsMetrics))
+	device := setupMockDevice(t, testutil.WithUnsupportedFields(allFields...))
+	_, err := newNVLinkFieldsCollector(device, nil)
+	require.ErrorIs(t, err, errUnsupportedDevice)
 }
 
 func TestFieldsCollector_NvlinkSpeedPriority(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?
Collects NVLink field values independently for each port.

### Motivation
A field unsupported on one port should not suppress metrics from supported ports.

### Describe how you validated your changes
`dda inv test --targets=./pkg/collector/corechecks/gpu/nvidia`

### Additional Notes