### PR TITLE
[EBPF] gpu: Support ARM64 NVML library discovery

### DIFF
--- a/pkg/config/env/environment_containers.go
+++ b/pkg/config/env/environment_containers.go
@@ -407,8 +407,10 @@ func getDefaultNvmlPaths() []string {
 	}
 
 	systemPaths := []string{
-		"/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1",                   // default system install
-		"/run/nvidia/driver/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1", // nvidia-gpu-operator install
+		"/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1",                    // default system install
+		"/run/nvidia/driver/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1",  // nvidia-gpu-operator install
+		"/usr/lib/aarch64-linux-gnu/libnvidia-ml.so.1",                   // default system install on ARM64
+		"/run/nvidia/driver/usr/lib/aarch64-linux-gnu/libnvidia-ml.so.1", // nvidia-gpu-operator install on ARM64
 	}
 
 	hostRoot := os.Getenv("HOST_ROOT")

--- a/pkg/config/env/environment_containers_test.go
+++ b/pkg/config/env/environment_containers_test.go
@@ -10,6 +10,7 @@ package env
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -65,6 +66,21 @@ func Test_merge(t *testing.T) {
 			assert.EqualValues(t, tt.want, merge(tt.s1, tt.s2))
 		})
 	}
+}
+
+func TestGetDefaultNvmlPathsIncludesSupportedLinuxArchitectures(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("NVML default paths are only defined on Linux")
+	}
+
+	t.Setenv("HOST_ROOT", "/host")
+
+	assert.Equal(t, []string{
+		"/host/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1",
+		"/host/run/nvidia/driver/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1",
+		"/host/usr/lib/aarch64-linux-gnu/libnvidia-ml.so.1",
+		"/host/run/nvidia/driver/usr/lib/aarch64-linux-gnu/libnvidia-ml.so.1",
+	}, getDefaultNvmlPaths())
 }
 
 func TestDetectPodmanInHomeDir(t *testing.T) {

--- a/pkg/gpu/safenvml/lib.go
+++ b/pkg/gpu/safenvml/lib.go
@@ -436,8 +436,10 @@ func GetSafeNvmlLib() (SafeNVML, error) {
 // is imported by nearly every binary in the repo.
 func generateDefaultNvmlPaths() []string {
 	systemPaths := []string{
-		"/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1",                   // default system install
-		"/run/nvidia/driver/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1", // nvidia-gpu-operator install
+		"/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1",                    // default system install
+		"/run/nvidia/driver/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1",  // nvidia-gpu-operator install
+		"/usr/lib/aarch64-linux-gnu/libnvidia-ml.so.1",                   // default system install on ARM64
+		"/run/nvidia/driver/usr/lib/aarch64-linux-gnu/libnvidia-ml.so.1", // nvidia-gpu-operator install on ARM64
 	}
 
 	hostRoot := os.Getenv("HOST_ROOT")

--- a/pkg/gpu/safenvml/lib_test.go
+++ b/pkg/gpu/safenvml/lib_test.go
@@ -104,6 +104,17 @@ func TestPopulateCapabilities(t *testing.T) {
 	}
 }
 
+func TestGenerateDefaultNvmlPathsIncludesSupportedLinuxArchitectures(t *testing.T) {
+	t.Setenv("HOST_ROOT", "/host")
+
+	require.Equal(t, []string{
+		"/host/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1",
+		"/host/run/nvidia/driver/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1",
+		"/host/usr/lib/aarch64-linux-gnu/libnvidia-ml.so.1",
+		"/host/run/nvidia/driver/usr/lib/aarch64-linux-gnu/libnvidia-ml.so.1",
+	}, generateDefaultNvmlPaths())
+}
+
 // Tests for the NvmlAPIError type
 func TestNvmlAPIError(t *testing.T) {
 	// Define test cases with different error codes and API names


### PR DESCRIPTION
<!-- dd-meta {"pullId":"df13230b-a434-451b-972e-ac9007c02168","source":"chat","resourceId":"86800824-17f2-4a85-9551-be5b7bf8a830","workflowId":"2ce581a4-a03e-4c0a-a1a1-dda5b27f5a0c","codeChangeId":"2ce581a4-a03e-4c0a-a1a1-dda5b27f5a0c","sourceType":"bits_ai_sre"} -->
### What does this PR do?

Bits AI SRE Investigation • [View in Bits AI SRE Investigation](https://ddstaging.datadoghq.com/bits-ai/investigations/8418dc69-efd2-44d3-ad70-91e14223f69d)

Add standard ARM64 (`aarch64-linux-gnu`) NVML library paths for host and NVIDIA GPU Operator installations.

### Motivation

GPU checks on ARM64 GPU nodes fail because NVML discovery searches only x86_64 library directories. This causes all GPU metrics to fail on affected ARM64 nodes and can trigger incorrect health responses.

### Describe how you validated your changes

Unit tests added

### Additional Notes

---

PR by Bits - [View session in Datadog](https://ddstaging.datadoghq.com/code/86800824-17f2-4a85-9551-be5b7bf8a830)

Comment @datadog to request changes