### PR TITLE
Fix trailing comma in devcontainer.json runArgs

### DIFF
--- a/.devcontainer/datadog/default/devcontainer.json
+++ b/.devcontainer/datadog/default/devcontainer.json
@@ -21,6 +21,6 @@
     "-v",
     "/sys/kernel/debug:/sys/kernel/debug",
     "-v",
-    "/etc/os-release:/etc/os-release",
-  ],
+    "/etc/os-release:/etc/os-release"
+  ]
 }


### PR DESCRIPTION
### What does this PR do?

Removes trailing commas in `.devcontainer/datadog/default/devcontainer.json`'s `runArgs` array (after `"/etc/os-release:/etc/os-release"` and after the array's closing `]`), introduced by #53862.

### Motivation

Trailing commas make the file invalid strict JSON. The `workspaces` CLI's devcontainer builder uses a strict JSON parser and fails with:

```
error: code = Unknown desc = error running devcontainer, got: failed to create builder: error reading config '.../.devcontainer/datadog/default/devcontainer.json': invalid character ']' looking for beginning of value (type: wrapError, retryable: true)
```

This blocked creating new workspaces from this devcontainer config entirely.

### Describe how you validated your changes

Verified `.devcontainer/datadog/default/devcontainer.json` is now valid JSON (comments aside, which the JSONC-tolerant parts of the config already support) with no trailing commas remaining.

### Additional Notes