### PR TITLE
Upgrade embedded Python patch version to 3.13.15

### DIFF
--- a/deps/cpython/cpython.MODULE.bazel
+++ b/deps/cpython/cpython.MODULE.bazel
@@ -2,7 +2,7 @@ http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "ht
 
 constants_repo = use_repo_rule("//bazel/repo:constants_repo.bzl", "constants_repo")
 
-PYTHON_VERSION = "3.13.14"
+PYTHON_VERSION = "3.13.15"
 
 PYTHON_MAJOR_MINOR = ".".join(PYTHON_VERSION.split(".")[:2])
 
@@ -32,7 +32,7 @@ http_archive(
         "//deps/cpython:0004-Skip-bytecode-compilation-during-install.patch",
         "//deps/cpython:0005-Honor-explicit-libffi-flags-on-Darwin.patch",
     ],
-    sha256 = "5ae535a36af0ebca6fca176ecb8197f5db9c1cb8c8f0cd12cdf1787046db1f41",
+    sha256 = "c28d9d213c09b5b5ab2c29812950e12f746999e099b82894231be954b26baed9",
     strip_prefix = "Python-{}".format(PYTHON_VERSION),
     url = "https://python.org/ftp/python/{0}/Python-{0}.tgz".format(PYTHON_VERSION),
 )

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -1,6 +1,6 @@
 name "python3"
 
-default_version "3.13.14"
+default_version "3.13.15"
 
 
 relative_path "Python-#{version}"

--- a/releasenotes/notes/Bump-embedded-Python-to-3.13.15-8e2c1fb460be861e.yaml
+++ b/releasenotes/notes/Bump-embedded-Python-to-3.13.15-8e2c1fb460be861e.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+- |
+    The Agent's embedded Python has been upgraded from 3.13.14 to 3.13.15

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -228,7 +228,7 @@ const (
 	ExpectedPythonVersion2 = "2.7.18"
 	// ExpectedPythonVersion3 is the expected python 3 version
 	// Bump this version when the version in omnibus/config/software/python3.rb changes
-	ExpectedPythonVersion3 = "3.13.14"
+	ExpectedPythonVersion3 = "3.13.15"
 	// ExpectedUnloadedPython is the status value for uninitialized lazy loaded python runtime
 	ExpectedUnloadedPython = "unused"
 )


### PR DESCRIPTION
### What does this PR do?

Upgrades the Agent's embedded CPython interpreter from **3.13.14** to **3.13.15** (patch version update).

- Updated `omnibus/config/software/python3.rb` with the new version
- Updated `deps/cpython/cpython.MODULE.bazel` with the new version and SHA256
- Updated `test/new-e2e/tests/agent-platform/common/agent_behaviour.go` with the expected version
- Created a release note documenting the upgrade

SHA256 hash automatically fetched and verified against the official Python.org SBOM file. See the [official Python release page](https://www.python.org/downloads/release/python-31315/) for details.

### Motivation

Keep the embedded Python up to date with bug fixes and security patches. 3.13.15 (released 2026-08-05) remediates several CVEs tracked in the agent-integrations VULN queue, including tarfile symlink/hardlink filter issues (CVE-2026-11940, CVE-2026-4360), a tarfile DoS (CVE-2026-11972), an html.parser quadratic DoS (CVE-2026-15308), a configparser CR write injection (CVE-2026-0864), and an xml.etree findall DoS (CVE-2026-6879).

### Describe how you validated your changes

CI is considered enough to validate changes. The E2E `ExpectedPythonVersion3` constant is updated in lockstep so the agent-platform behaviour tests assert the new version.

### Additional Notes

Generated with `dda inv python-version.update`, mirroring the previous automated bump (#52085).