### PR TITLE
[Backport 7.83.x] fix typo in OTEL semantic convention labels (#54518)

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/attributes/attributes.go
+++ b/pkg/opentelemetry-mapping-go/otlp/attributes/attributes.go
@@ -110,7 +110,7 @@ var (
 		"app.kubernetes.io/name":       "kube_app_name",
 		"app.kubernetes.io/instance":   "kube_app_instance",
 		"app.kubernetes.io/version":    "kube_app_version",
-		"app.kuberenetes.io/component": "kube_app_component",
+		"app.kubernetes.io/component":  "kube_app_component",
 		"app.kubernetes.io/part-of":    "kube_app_part_of",
 		"app.kubernetes.io/managed-by": "kube_app_managed_by",
 	}


### PR DESCRIPTION
Backport of #54518 to 7.83.x.

## Original PR description

### What does this PR do?

Fix a typo in the OTEL semantic convention labels.

### Describe how you validated your changes

The label is correctly defined here: https://github.com/DataDog/datadog-agent/blob/e081bed/pkg/util/kubernetes/const.go#L23

Cherry-picked from 882f470a9b9e5187641ca5a6a177efed3f41d7f5.