### PR TITLE
Debug-log and collect Agent logs on failure in domain-controller upgrade test

### DIFF
--- a/test/new-e2e/tests/windows/domain-test/domain_test.go
+++ b/test/new-e2e/tests/windows/domain-test/domain_test.go
@@ -16,7 +16,6 @@ import (
 
 	scenwindows "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2/windows"
 	awsHostWindows "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host/windows"
-	agentclient "github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/e2e/client/agentclient"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
 
 	"github.com/stretchr/testify/assert"
@@ -126,19 +125,19 @@ func (suite *testUpgradeSuite) TestGivenDomainUserCanUpgradeAgent() {
 		windowsAgent.WithAgentUserPassword(fmt.Sprintf("\"%s\"", TestPassword)),
 		windowsAgent.WithValidAPIKey(),
 		windowsAgent.WithFakeIntake(suite.Env().FakeIntake),
+		windowsAgent.WithLogLevel("debug"),
 		windowsAgent.WithInstallLogFile(filepath.Join(suite.SessionOutputDir(), "TC-UPG-DC-001_install_last_stable.log")))
 
 	suite.Require().NoError(err, "should succeed to install Agent on a Domain Controller with a valid domain account & password")
 
 	tc := suite.NewTestClientForHost(suite.Env().RemoteHost)
-	suite.setLogLevelDebug(tc)
 	platformCommon.CheckAgentBehaviour(suite.T(), tc)
 
 	_, err = suite.InstallAgent(host,
 		windowsAgent.WithPackage(suite.AgentPackage),
+		windowsAgent.WithLogLevel("debug"),
 		windowsAgent.WithInstallLogFile(filepath.Join(suite.SessionOutputDir(), "TC-UPG-DC-001_upgrade.log")))
 	suite.Require().NoError(err, "should succeed to upgrade an Agent on a Domain Controller")
-	suite.setLogLevelDebug(tc)
 
 	tc.CheckAgentVersion(suite.T(), suite.AgentPackage.AgentVersion())
 	platformCommon.CheckAgentBehaviour(suite.T(), tc)
@@ -147,14 +146,6 @@ func (suite *testUpgradeSuite) TestGivenDomainUserCanUpgradeAgent() {
 		assert.NoError(c, err)
 		assert.NotEmpty(c, stats)
 	}, 5*time.Minute, 10*time.Second)
-}
-
-// setLogLevelDebug sets the running Agent's log level to debug, to get more detail in the
-// collected agent logs if this test fails (see AfterTest below). This is a runtime setting,
-// so it must be re-applied after the Agent process restarts (e.g. after the upgrade step).
-func (suite *testUpgradeSuite) setLogLevelDebug(tc *platformCommon.TestClient) {
-	_, err := tc.AgentClient.ConfigWithError(agentclient.WithArgs([]string{"set", "log_level", "debug"}))
-	suite.Require().NoError(err, "should set log_level to debug")
 }
 
 // AfterTest collects the Agent logs when the test fails, to help debug issues like the

--- a/test/new-e2e/tests/windows/domain-test/domain_test.go
+++ b/test/new-e2e/tests/windows/domain-test/domain_test.go
@@ -127,6 +127,7 @@ func (suite *testUpgradeSuite) TestGivenDomainUserCanUpgradeAgent() {
 		windowsAgent.WithInstallLogFile(filepath.Join(suite.SessionOutputDir(), "TC-UPG-DC-001_install_last_stable.log")))
 
 	suite.Require().NoError(err, "should succeed to install Agent on a Domain Controller with a valid domain account & password")
+	suite.Env().FakeIntake.Client().FlushServerAndResetAggregators() // flush to reset memory usage and avoid OOM
 
 	tc := suite.NewTestClientForHost(suite.Env().RemoteHost)
 	platformCommon.CheckAgentBehaviour(suite.T(), tc)
@@ -135,6 +136,7 @@ func (suite *testUpgradeSuite) TestGivenDomainUserCanUpgradeAgent() {
 		windowsAgent.WithPackage(suite.AgentPackage),
 		windowsAgent.WithInstallLogFile(filepath.Join(suite.SessionOutputDir(), "TC-UPG-DC-001_upgrade.log")))
 	suite.Require().NoError(err, "should succeed to upgrade an Agent on a Domain Controller")
+	suite.Env().FakeIntake.Client().FlushServerAndResetAggregators() // flush to reset memory usage and avoid OOM
 
 	tc.CheckAgentVersion(suite.T(), suite.AgentPackage.AgentVersion())
 	platformCommon.CheckAgentBehaviour(suite.T(), tc)

--- a/test/new-e2e/tests/windows/domain-test/domain_test.go
+++ b/test/new-e2e/tests/windows/domain-test/domain_test.go
@@ -16,9 +16,11 @@ import (
 
 	scenwindows "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2/windows"
 	awsHostWindows "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host/windows"
+	agentclient "github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/e2e/client/agentclient"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
 
 	"github.com/stretchr/testify/assert"
+	testifysuite "github.com/stretchr/testify/suite"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
@@ -127,16 +129,16 @@ func (suite *testUpgradeSuite) TestGivenDomainUserCanUpgradeAgent() {
 		windowsAgent.WithInstallLogFile(filepath.Join(suite.SessionOutputDir(), "TC-UPG-DC-001_install_last_stable.log")))
 
 	suite.Require().NoError(err, "should succeed to install Agent on a Domain Controller with a valid domain account & password")
-	suite.Env().FakeIntake.Client().FlushServerAndResetAggregators() // flush to reset memory usage and avoid OOM
 
 	tc := suite.NewTestClientForHost(suite.Env().RemoteHost)
+	suite.setLogLevelDebug(tc)
 	platformCommon.CheckAgentBehaviour(suite.T(), tc)
 
 	_, err = suite.InstallAgent(host,
 		windowsAgent.WithPackage(suite.AgentPackage),
 		windowsAgent.WithInstallLogFile(filepath.Join(suite.SessionOutputDir(), "TC-UPG-DC-001_upgrade.log")))
 	suite.Require().NoError(err, "should succeed to upgrade an Agent on a Domain Controller")
-	suite.Env().FakeIntake.Client().FlushServerAndResetAggregators() // flush to reset memory usage and avoid OOM
+	suite.setLogLevelDebug(tc)
 
 	tc.CheckAgentVersion(suite.T(), suite.AgentPackage.AgentVersion())
 	platformCommon.CheckAgentBehaviour(suite.T(), tc)
@@ -145,4 +147,52 @@ func (suite *testUpgradeSuite) TestGivenDomainUserCanUpgradeAgent() {
 		assert.NoError(c, err)
 		assert.NotEmpty(c, stats)
 	}, 5*time.Minute, 10*time.Second)
+}
+
+// setLogLevelDebug sets the running Agent's log level to debug, to get more detail in the
+// collected agent logs if this test fails (see AfterTest below). This is a runtime setting,
+// so it must be re-applied after the Agent process restarts (e.g. after the upgrade step).
+func (suite *testUpgradeSuite) setLogLevelDebug(tc *platformCommon.TestClient) {
+	_, err := tc.AgentClient.ConfigWithError(agentclient.WithArgs([]string{"set", "log_level", "debug"}))
+	suite.Require().NoError(err, "should set log_level to debug")
+}
+
+// AfterTest collects the Agent logs when the test fails, to help debug issues like the
+// fakeintake connectivity failures tracked in WINA-3019.
+func (suite *testUpgradeSuite) AfterTest(suiteName, testName string) {
+	if afterTest, ok := any(&suite.BaseAgentInstallerSuite).(testifysuite.AfterTest); ok {
+		afterTest.AfterTest(suiteName, testName)
+	}
+
+	if suite.T().Failed() {
+		suite.collectAgentLogs()
+	}
+}
+
+// collectAgentLogs downloads the agent log folder from the remote host into the session
+// output dir. Best-effort: missing logs are surfaced as assertion failures but do not
+// abort test cleanup.
+func (suite *testUpgradeSuite) collectAgentLogs() {
+	vm := suite.Env().RemoteHost
+	suite.T().Logf("Collecting agent logs")
+
+	logsFolder, err := vm.GetLogsFolder()
+	if !suite.Assert().NoError(err, "should get logs folder") {
+		return
+	}
+	entries, err := vm.ReadDir(logsFolder)
+	if !suite.Assert().NoError(err, "should read log folder") {
+		return
+	}
+	for _, entry := range entries {
+		sourcePath := filepath.Join(logsFolder, entry.Name())
+		destPath := filepath.Join(suite.SessionOutputDir(), entry.Name())
+
+		if entry.IsDir() {
+			err = vm.GetFolder(sourcePath, destPath)
+		} else {
+			err = vm.GetFile(sourcePath, destPath)
+		}
+		suite.Assert().NoError(err, "should download %s", entry.Name())
+	}
 }


### PR DESCRIPTION
@
## Summary
- Install the Agent with `DD_LOG_LEVEL=debug` (via the new `windowsAgent.WithLogLevel` option) in `testUpgradeSuite.TestGivenDomainUserCanUpgradeAgent`, instead of a runtime `agent config set log_level debug` after each install step.
- Add an `AfterTest` hook that downloads the Agent log folder from the remote host into the session output dir when the test fails.

## Motivation
https://datadoghq.atlassian.net/browse/WINA-3019

Note: the first install step uses the last stable package, whose MSI predates `DD_LOG_LEVEL` (#54741), so the property is ignored there; the upgraded Agent runs at debug.

## Test plan
- [ ] Run `TestInstallsOnDomainController/testUpgradeSuite` in CI and check the fakeintake dashboard for this run's stack to confirm memory usage stays under ~500MB across the install/upgrade flow.
- [ ] On a failing run, confirm the Agent logs are collected as job artifacts under the suite's session output dir.
@