### PR TITLE
[CONTP-1773] Fix(workloadmeta): signal initialization when no collector is applicable

### DIFF
--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -93,7 +93,7 @@ func (w *workloadmeta) start(ctx context.Context) {
 		// but also don't block on full startCandidatesWithRetry.
 		select {
 		case <-w.firstCollectorReady:
-			w.log.Debug("at least one workloadmeta collector ready, starting pull loop")
+			w.log.Debug("collector startup resolved, starting pull loop")
 		case <-time.After(firstPullWaitTimeout):
 			w.log.Warnf("no workloadmeta collector ready after %s, starting pull loop anyway", firstPullWaitTimeout)
 		case <-ctx.Done():
@@ -724,6 +724,14 @@ func (w *workloadmeta) startCandidatesWithRetry(ctx context.Context) error {
 		}
 
 		if w.startCandidates(ctx) {
+			// All candidates have been processed (started successfully or failed
+			// with a non-retriable error). If none of them actually started,
+			// unblock the pull goroutine so it can proceed with an empty first
+			// pull and signal that the store is initialized, instead of waiting
+			// for firstPullWaitTimeout. This avoids autodiscovery logging a
+			// spurious "Workloadmeta collectors are not ready" error on every
+			// startup in environments with no applicable collector.
+			w.firstCollectorReadyOnce.Do(func() { close(w.firstCollectorReady) })
 			return nil, nil
 		}
 

--- a/comp/core/workloadmeta/impl/store_test.go
+++ b/comp/core/workloadmeta/impl/store_test.go
@@ -8,10 +8,13 @@
 package workloadmetaimpl
 
 import (
+	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -2241,4 +2244,91 @@ func TestHandleEvents_completeness(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, actual)
+}
+
+// failingCollector is a workloadmeta collector that always fails to start with a
+// non-retriable error, simulating a collector that is not applicable to the
+// current environment (e.g. docker/containerd when no socket is present).
+type failingCollector struct {
+	id string
+}
+
+func (c *failingCollector) Start(context.Context, wmdef.Component) error {
+	return errors.NewDisabled(c.id, "not applicable to this environment")
+}
+
+func (c *failingCollector) Pull(context.Context) error { return nil }
+
+func (c *failingCollector) GetID() string { return c.id }
+
+func (c *failingCollector) GetTargetCatalog() wmdef.AgentType { return wmdef.NodeAgent }
+
+func newWorkloadmetaWithCollectors(t *testing.T, collectors ...wmdef.Collector) *workloadmeta {
+	deps := Dependencies{
+		Lc:      compdef.NewTestLifecycle(t),
+		Log:     logmock.New(t),
+		Config:  config.NewMock(t),
+		Params:  wmdef.NewParams(),
+		Catalog: wmdef.CollectorList(collectors),
+	}
+	return NewComponent(deps).Comp.(*workloadmeta)
+}
+
+// TestStartCandidatesWithRetryClosesFirstCollectorReadyWhenNoneStart verifies
+// that when all candidates fail to start with non-retriable errors (i.e. no
+// collector is applicable to the environment), startCandidatesWithRetry unblocks
+// the pull goroutine by closing firstCollectorReady instead of leaving it to
+// wait for firstPullWaitTimeout.
+func TestStartCandidatesWithRetryClosesFirstCollectorReadyWhenNoneStart(t *testing.T) {
+	w := newWorkloadmetaWithCollectors(t,
+		&failingCollector{id: "docker"},
+		&failingCollector{id: "containerd"},
+		&failingCollector{id: "kubelet"},
+	)
+	w.firstCollectorReady = make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, w.startCandidatesWithRetry(ctx))
+
+	select {
+	case <-w.firstCollectorReady:
+		// expected: pull goroutine is unblocked even though no collector started
+	case <-time.After(5 * time.Second):
+		t.Fatal("firstCollectorReady was not closed when all candidates failed non-retriably")
+	}
+}
+
+// TestStartSignalsInitializedWhenNoCollectorApplicable verifies the end-to-end
+// behavior: when no collector is applicable, the store becomes initialized
+// quickly (well before firstPullWaitTimeout), so autodiscovery does not log a
+// spurious "Workloadmeta collectors are not ready" error on every startup.
+func TestStartSignalsInitializedWhenNoCollectorApplicable(t *testing.T) {
+	w := newWorkloadmetaWithCollectors(t,
+		&failingCollector{id: "docker"},
+		&failingCollector{id: "containerd"},
+	)
+	w.firstCollectorReady = make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, w.startCandidatesWithRetry(ctx))
+
+	// Deterministic signal: firstCollectorReady is closed when no collector
+	// is applicable, unblocking the pull goroutine so it proceeds with the
+	// first (empty) pull instead of waiting for firstPullWaitTimeout.
+	select {
+	case <-w.firstCollectorReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("firstCollectorReady was not closed when no collector is applicable")
+	}
+
+	// The pull goroutine reacts to the closed signal by running the first
+	// (empty) pull and marking the store initialized. Drive those steps
+	// deterministically to verify the store becomes initialized.
+	w.pull(ctx)
+	w.updateCollectorStatus(wmdef.CollectorsInitialized)
+	require.True(t, w.IsInitialized())
 }

--- a/comp/core/workloadmeta/impl/workloadmeta.go
+++ b/comp/core/workloadmeta/impl/workloadmeta.go
@@ -53,7 +53,9 @@ type workloadmeta struct {
 	// startWg tracks background goroutines spawned by start() so OnStop can wait for them to exit.
 	startWg sync.WaitGroup
 
-	// firstCollectorReady is closed when at least one collector has been started.
+	// firstCollectorReady is closed when collector startup is resolved: at least
+	// one collector has started, or all candidates have been processed without any
+	// starting (e.g. no collector is applicable to the environment).
 	firstCollectorReady     chan struct{}
 	firstCollectorReadyOnce sync.Once
 

--- a/releasenotes/notes/fix-workloadmeta-init-no-collector-d159a448f9d6b5c0.yaml
+++ b/releasenotes/notes/fix-workloadmeta-init-no-collector-d159a448f9d6b5c0.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix an issue where the Agent logged a spurious error about
+    Workloadmeta collectors not being ready on every startup in
+    environments where no container runtime or orchestrator is
+    detected, such as container sidecars.


### PR DESCRIPTION
### What does this PR do?

Fixes GH issue #49480 / CONTP-1773: the Agent logs a spurious ERROR on every startup in environments where no workloadmeta collector is applicable (e.g. a container sidecar with no Kubernetes, no container runtime socket, no ECS, no GPU).

Root cause: when all collector candidates fail to start with non-retriable "disabled" errors, `startCandidatesWithRetry` never closes `firstCollectorReady`, so the pull goroutine waits the full `firstPullWaitTimeout` (30s) before marking the store initialized. Autodiscovery only waits 10s, so it logs the ERROR first.

Fix: close `firstCollectorReady` once all candidates have been processed, even when none started, so the pull goroutine proceeds immediately and signals initialization.

### Motivation

Spurious startup ERROR alarms users and trips log-based alerts on every pod restart.

### Describe how you validated your changes

Unit tests (`dda inv test --targets=./comp/core/workloadmeta/impl/...` and `./comp/core/autodiscovery/impl/...`).

### Additional Notes

Regression introduced by #47178 (AGENTCFG-650). This fix restores prompt initialization when no collector is applicable without reintroducing that PR's race.
