### PR TITLE
[EBPF] gpu: Skip unsupported vGPU max-clock queries

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -490,8 +490,25 @@ func clockThrottleReasonMetrics(reasons uint64) []Metric {
 	return allMetrics
 }
 
+// maxClockInfoSample handles max clock metrics, which are not supported for vGPU devices.
+// Returning an unsupported API error lets filterSupportedAPIs remove this API from the
+// collector during initialization, so it is not retried on every collection cycle.
+func maxClockInfoSample(device ddnvml.Device, clockType nvml.ClockType, metricName string) ([]Metric, uint64, error) {
+	virtMode, err := device.GetVirtualizationMode()
+	if err == nil && virtMode == nvml.GPU_VIRTUALIZATION_MODE_VGPU {
+		return nil, 0, ddnvml.NewNvmlAPIErrorOrNil("GetMaxClockInfo", nvml.ERROR_NOT_SUPPORTED)
+	}
+
+	clock, err := device.GetMaxClockInfo(clockType)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return []Metric{{Name: metricName, Value: float64(clock), Type: metrics.GaugeType}}, 0, nil
+}
+
 // createStatelessAPIs creates API call definitions for all stateless metrics on demand
-func createStatelessAPIs(deps *CollectorDependencies, includeMaxClockInfo bool) []apiCallInfo {
+func createStatelessAPIs(deps *CollectorDependencies) []apiCallInfo {
 	apis := []apiCallInfo{
 		// Memory collector APIs
 		{
@@ -685,6 +702,30 @@ func createStatelessAPIs(deps *CollectorDependencies, includeMaxClockInfo bool) 
 			},
 		},
 		{
+			Name: "max_clock_speed_sm",
+			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
+				return maxClockInfoSample(device, nvml.CLOCK_SM, "clock.speed.sm.max")
+			},
+		},
+		{
+			Name: "max_clock_speed_memory",
+			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
+				return maxClockInfoSample(device, nvml.CLOCK_MEM, "clock.speed.memory.max")
+			},
+		},
+		{
+			Name: "max_clock_speed_graphics",
+			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
+				return maxClockInfoSample(device, nvml.CLOCK_GRAPHICS, "clock.speed.graphics.max")
+			},
+		},
+		{
+			Name: "max_clock_speed_video",
+			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
+				return maxClockInfoSample(device, nvml.CLOCK_VIDEO, "clock.speed.video.max")
+			},
+		},
+		{
 			Name: "energy_consumption",
 			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
 				energy, err := device.GetTotalEnergyConsumption()
@@ -802,53 +843,6 @@ func createStatelessAPIs(deps *CollectorDependencies, includeMaxClockInfo bool) 
 		},
 	}
 
-	// GetMaxClockInfo can return errors other than ERROR_NOT_SUPPORTED for vGPU devices,
-	// so gate these API calls directly on the device type.
-	if includeMaxClockInfo {
-		apis = append(apis,
-			apiCallInfo{
-				Name: "max_clock_speed_sm",
-				Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-					clock, err := device.GetMaxClockInfo(nvml.CLOCK_SM)
-					if err != nil {
-						return nil, 0, err
-					}
-					return []Metric{{Name: "clock.speed.sm.max", Value: float64(clock), Type: metrics.GaugeType}}, 0, nil
-				},
-			},
-			apiCallInfo{
-				Name: "max_clock_speed_memory",
-				Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-					clock, err := device.GetMaxClockInfo(nvml.CLOCK_MEM)
-					if err != nil {
-						return nil, 0, err
-					}
-					return []Metric{{Name: "clock.speed.memory.max", Value: float64(clock), Type: metrics.GaugeType}}, 0, nil
-				},
-			},
-			apiCallInfo{
-				Name: "max_clock_speed_graphics",
-				Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-					clock, err := device.GetMaxClockInfo(nvml.CLOCK_GRAPHICS)
-					if err != nil {
-						return nil, 0, err
-					}
-					return []Metric{{Name: "clock.speed.graphics.max", Value: float64(clock), Type: metrics.GaugeType}}, 0, nil
-				},
-			},
-			apiCallInfo{
-				Name: "max_clock_speed_video",
-				Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-					clock, err := device.GetMaxClockInfo(nvml.CLOCK_VIDEO)
-					if err != nil {
-						return nil, 0, err
-					}
-					return []Metric{{Name: "clock.speed.video.max", Value: float64(clock), Type: metrics.GaugeType}}, 0, nil
-				},
-			},
-		)
-	}
-
 	// Create APIs for corrected and uncorrected ECC errors.
 	for errorType, errorTypeName := range eccErrorTypeToName {
 		// Handlers close over these values and run after the loops finish, so rebind
@@ -896,12 +890,5 @@ var statelessAPIFactory = createStatelessAPIs
 
 // newStatelessCollector creates a collector that consolidates all stateless collector types
 func newStatelessCollector(device ddnvml.Device, deps *CollectorDependencies) (Collector, error) {
-	physicalDevice := device
-	if migDevice, ok := device.(*ddnvml.MIGDevice); ok {
-		physicalDevice = migDevice.Parent
-	}
-
-	virtMode, err := physicalDevice.GetVirtualizationMode()
-	includeMaxClockInfo := err != nil || virtMode != nvml.GPU_VIRTUALIZATION_MODE_VGPU
-	return NewBaseCollector(stateless, device, statelessAPIFactory(deps, includeMaxClockInfo))
+	return NewBaseCollector(stateless, device, statelessAPIFactory(deps))
 }

--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -490,6 +490,23 @@ func clockThrottleReasonMetrics(reasons uint64) []Metric {
 	return allMetrics
 }
 
+// maxClockInfoSample handles max clock metrics, which are not supported for vGPU devices.
+// Returning an unsupported API error lets filterSupportedAPIs remove this API from the
+// collector during initialization, so it is not retried on every collection cycle.
+func maxClockInfoSample(device ddnvml.Device, clockType nvml.ClockType, metricName string) ([]Metric, uint64, error) {
+	virtMode, err := device.GetVirtualizationMode()
+	if err == nil && virtMode == nvml.GPU_VIRTUALIZATION_MODE_VGPU {
+		return nil, 0, ddnvml.NewNvmlAPIErrorOrNil("GetMaxClockInfo", nvml.ERROR_NOT_SUPPORTED)
+	}
+
+	clock, err := device.GetMaxClockInfo(clockType)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return []Metric{{Name: metricName, Value: float64(clock), Type: metrics.GaugeType}}, 0, nil
+}
+
 // createStatelessAPIs creates API call definitions for all stateless metrics on demand
 func createStatelessAPIs(deps *CollectorDependencies) []apiCallInfo {
 	apis := []apiCallInfo{
@@ -687,41 +704,25 @@ func createStatelessAPIs(deps *CollectorDependencies) []apiCallInfo {
 		{
 			Name: "max_clock_speed_sm",
 			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-				smClock, err := device.GetMaxClockInfo(nvml.CLOCK_SM)
-				if err != nil {
-					return nil, 0, err
-				}
-				return []Metric{{Name: "clock.speed.sm.max", Value: float64(smClock), Type: metrics.GaugeType}}, 0, nil
+				return maxClockInfoSample(device, nvml.CLOCK_SM, "clock.speed.sm.max")
 			},
 		},
 		{
 			Name: "max_clock_speed_memory",
 			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-				memoryClock, err := device.GetMaxClockInfo(nvml.CLOCK_MEM)
-				if err != nil {
-					return nil, 0, err
-				}
-				return []Metric{{Name: "clock.speed.memory.max", Value: float64(memoryClock), Type: metrics.GaugeType}}, 0, nil
+				return maxClockInfoSample(device, nvml.CLOCK_MEM, "clock.speed.memory.max")
 			},
 		},
 		{
 			Name: "max_clock_speed_graphics",
 			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-				graphicsClock, err := device.GetMaxClockInfo(nvml.CLOCK_GRAPHICS)
-				if err != nil {
-					return nil, 0, err
-				}
-				return []Metric{{Name: "clock.speed.graphics.max", Value: float64(graphicsClock), Type: metrics.GaugeType}}, 0, nil
+				return maxClockInfoSample(device, nvml.CLOCK_GRAPHICS, "clock.speed.graphics.max")
 			},
 		},
 		{
 			Name: "max_clock_speed_video",
 			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-				videoClock, err := device.GetMaxClockInfo(nvml.CLOCK_VIDEO)
-				if err != nil {
-					return nil, 0, err
-				}
-				return []Metric{{Name: "clock.speed.video.max", Value: float64(videoClock), Type: metrics.GaugeType}}, 0, nil
+				return maxClockInfoSample(device, nvml.CLOCK_VIDEO, "clock.speed.video.max")
 			},
 		},
 		{

--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -490,25 +490,8 @@ func clockThrottleReasonMetrics(reasons uint64) []Metric {
 	return allMetrics
 }
 
-// maxClockInfoSample handles max clock metrics, which are not supported for vGPU devices.
-// Returning an unsupported API error lets filterSupportedAPIs remove this API from the
-// collector during initialization, so it is not retried on every collection cycle.
-func maxClockInfoSample(device ddnvml.Device, clockType nvml.ClockType, metricName string) ([]Metric, uint64, error) {
-	virtMode, err := device.GetVirtualizationMode()
-	if err == nil && virtMode == nvml.GPU_VIRTUALIZATION_MODE_VGPU {
-		return nil, 0, ddnvml.NewNvmlAPIErrorOrNil("GetMaxClockInfo", nvml.ERROR_NOT_SUPPORTED)
-	}
-
-	clock, err := device.GetMaxClockInfo(clockType)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	return []Metric{{Name: metricName, Value: float64(clock), Type: metrics.GaugeType}}, 0, nil
-}
-
 // createStatelessAPIs creates API call definitions for all stateless metrics on demand
-func createStatelessAPIs(deps *CollectorDependencies) []apiCallInfo {
+func createStatelessAPIs(deps *CollectorDependencies, includeMaxClockInfo bool) []apiCallInfo {
 	apis := []apiCallInfo{
 		// Memory collector APIs
 		{
@@ -702,30 +685,6 @@ func createStatelessAPIs(deps *CollectorDependencies) []apiCallInfo {
 			},
 		},
 		{
-			Name: "max_clock_speed_sm",
-			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-				return maxClockInfoSample(device, nvml.CLOCK_SM, "clock.speed.sm.max")
-			},
-		},
-		{
-			Name: "max_clock_speed_memory",
-			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-				return maxClockInfoSample(device, nvml.CLOCK_MEM, "clock.speed.memory.max")
-			},
-		},
-		{
-			Name: "max_clock_speed_graphics",
-			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-				return maxClockInfoSample(device, nvml.CLOCK_GRAPHICS, "clock.speed.graphics.max")
-			},
-		},
-		{
-			Name: "max_clock_speed_video",
-			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-				return maxClockInfoSample(device, nvml.CLOCK_VIDEO, "clock.speed.video.max")
-			},
-		},
-		{
 			Name: "energy_consumption",
 			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
 				energy, err := device.GetTotalEnergyConsumption()
@@ -843,6 +802,53 @@ func createStatelessAPIs(deps *CollectorDependencies) []apiCallInfo {
 		},
 	}
 
+	// GetMaxClockInfo can return errors other than ERROR_NOT_SUPPORTED for vGPU devices,
+	// so gate these API calls directly on the device type.
+	if includeMaxClockInfo {
+		apis = append(apis,
+			apiCallInfo{
+				Name: "max_clock_speed_sm",
+				Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
+					clock, err := device.GetMaxClockInfo(nvml.CLOCK_SM)
+					if err != nil {
+						return nil, 0, err
+					}
+					return []Metric{{Name: "clock.speed.sm.max", Value: float64(clock), Type: metrics.GaugeType}}, 0, nil
+				},
+			},
+			apiCallInfo{
+				Name: "max_clock_speed_memory",
+				Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
+					clock, err := device.GetMaxClockInfo(nvml.CLOCK_MEM)
+					if err != nil {
+						return nil, 0, err
+					}
+					return []Metric{{Name: "clock.speed.memory.max", Value: float64(clock), Type: metrics.GaugeType}}, 0, nil
+				},
+			},
+			apiCallInfo{
+				Name: "max_clock_speed_graphics",
+				Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
+					clock, err := device.GetMaxClockInfo(nvml.CLOCK_GRAPHICS)
+					if err != nil {
+						return nil, 0, err
+					}
+					return []Metric{{Name: "clock.speed.graphics.max", Value: float64(clock), Type: metrics.GaugeType}}, 0, nil
+				},
+			},
+			apiCallInfo{
+				Name: "max_clock_speed_video",
+				Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
+					clock, err := device.GetMaxClockInfo(nvml.CLOCK_VIDEO)
+					if err != nil {
+						return nil, 0, err
+					}
+					return []Metric{{Name: "clock.speed.video.max", Value: float64(clock), Type: metrics.GaugeType}}, 0, nil
+				},
+			},
+		)
+	}
+
 	// Create APIs for corrected and uncorrected ECC errors.
 	for errorType, errorTypeName := range eccErrorTypeToName {
 		// Handlers close over these values and run after the loops finish, so rebind
@@ -890,5 +896,12 @@ var statelessAPIFactory = createStatelessAPIs
 
 // newStatelessCollector creates a collector that consolidates all stateless collector types
 func newStatelessCollector(device ddnvml.Device, deps *CollectorDependencies) (Collector, error) {
-	return NewBaseCollector(stateless, device, statelessAPIFactory(deps))
+	physicalDevice := device
+	if migDevice, ok := device.(*ddnvml.MIGDevice); ok {
+		physicalDevice = migDevice.Parent
+	}
+
+	virtMode, err := physicalDevice.GetVirtualizationMode()
+	includeMaxClockInfo := err != nil || virtMode != nvml.GPU_VIRTUALIZATION_MODE_VGPU
+	return NewBaseCollector(stateless, device, statelessAPIFactory(deps, includeMaxClockInfo))
 }

--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -490,12 +490,10 @@ func clockThrottleReasonMetrics(reasons uint64) []Metric {
 	return allMetrics
 }
 
-// maxClockInfoSample handles max clock metrics, which are not supported for vGPU devices.
-// Returning an unsupported API error lets filterSupportedAPIs remove this API from the
-// collector during initialization, so it is not retried on every collection cycle.
+// vGPU environments may return an error other than ERROR_NOT_SUPPORTED from GetMaxClockInfo,
+// so check the cached device virtualization mode before calling it.
 func maxClockInfoSample(device ddnvml.Device, clockType nvml.ClockType, metricName string) ([]Metric, uint64, error) {
-	virtMode, err := device.GetVirtualizationMode()
-	if err == nil && virtMode == nvml.GPU_VIRTUALIZATION_MODE_VGPU {
+	if device.GetDeviceInfo().VirtualizationMode == nvml.GPU_VIRTUALIZATION_MODE_VGPU {
 		return nil, 0, ddnvml.NewNvmlAPIErrorOrNil("GetMaxClockInfo", nvml.ERROR_NOT_SUPPORTED)
 	}
 

--- a/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
@@ -214,7 +214,7 @@ func TestAllECCAPIHandlers(t *testing.T) {
 				testutil.WithCustomHook(configureEccAPIs),
 			)
 
-			apis := createStatelessAPIs(&CollectorDependencies{})
+			apis := createStatelessAPIs(&CollectorDependencies{}, true)
 			var metricsOut []Metric
 			for _, api := range apis {
 				if api.Name != "sram_ecc_error_status" && !strings.HasPrefix(api.Name, "ecc_errors.") {
@@ -256,10 +256,14 @@ func TestNewStatelessCollector(t *testing.T) {
 }
 
 func TestStatelessCollectorSkipsMaxClockInfoForVGPU(t *testing.T) {
-	var maxClockInfoCalls int
+	var maxClockInfoCalls, virtualizationModeCalls int
 	device := setupMockDevice(t,
 		testutil.WithDeviceFeatureMode(testutil.DeviceFeatureVGPU),
 		testutil.WithCustomHook(func(device *mock.Device) {
+			device.GetVirtualizationModeFunc = func() (nvml.GpuVirtualizationMode, nvml.Return) {
+				virtualizationModeCalls++
+				return nvml.GPU_VIRTUALIZATION_MODE_VGPU, nvml.SUCCESS
+			}
 			device.GetMaxClockInfoFunc = func(nvml.ClockType) (uint32, nvml.Return) {
 				maxClockInfoCalls++
 				return 0, nvml.ERROR_UNKNOWN
@@ -269,6 +273,7 @@ func TestStatelessCollectorSkipsMaxClockInfoForVGPU(t *testing.T) {
 
 	collector, err := newStatelessCollector(device, &CollectorDependencies{})
 	require.NoError(t, err)
+	require.Equal(t, 1, virtualizationModeCalls, "vGPU status should be queried once during collector initialization")
 	require.Zero(t, maxClockInfoCalls, "vGPU collector should not probe max clock info")
 
 	baseCollector := collector.(*baseCollector)
@@ -324,7 +329,7 @@ func TestCollectProcessMemory(t *testing.T) {
 			originalFactory := statelessAPIFactory
 			defer func() { statelessAPIFactory = originalFactory }()
 
-			statelessAPIFactory = func(_ *CollectorDependencies) []apiCallInfo {
+			statelessAPIFactory = func(_ *CollectorDependencies, _ bool) []apiCallInfo {
 				return []apiCallInfo{
 					{
 						Name: "process_memory_usage",
@@ -353,7 +358,7 @@ func TestCollectProcessMemory_Error(t *testing.T) {
 	originalFactory := statelessAPIFactory
 	defer func() { statelessAPIFactory = originalFactory }()
 
-	statelessAPIFactory = func(_ *CollectorDependencies) []apiCallInfo {
+	statelessAPIFactory = func(_ *CollectorDependencies, _ bool) []apiCallInfo {
 		return []apiCallInfo{
 			{
 				Name: "process_memory_usage",
@@ -382,7 +387,7 @@ func TestProcessMemoryMetricTags(t *testing.T) {
 	originalFactory := statelessAPIFactory
 	defer func() { statelessAPIFactory = originalFactory }()
 
-	statelessAPIFactory = func(_ *CollectorDependencies) []apiCallInfo {
+	statelessAPIFactory = func(_ *CollectorDependencies, _ bool) []apiCallInfo {
 		return []apiCallInfo{
 			{
 				Name: "process_memory_usage",
@@ -465,7 +470,7 @@ func TestNVLinkCollector_Initialization(t *testing.T) {
 			originalFactory := statelessAPIFactory
 			defer func() { statelessAPIFactory = originalFactory }()
 
-			statelessAPIFactory = func(_ *CollectorDependencies) []apiCallInfo {
+			statelessAPIFactory = func(_ *CollectorDependencies, _ bool) []apiCallInfo {
 				return []apiCallInfo{
 					{
 						Name: "nvlink_metrics",
@@ -555,7 +560,7 @@ func TestNVLinkCollector_Collection(t *testing.T) {
 			originalFactory := statelessAPIFactory
 			defer func() { statelessAPIFactory = originalFactory }()
 
-			statelessAPIFactory = func(_ *CollectorDependencies) []apiCallInfo {
+			statelessAPIFactory = func(_ *CollectorDependencies, _ bool) []apiCallInfo {
 				return []apiCallInfo{
 					{
 						Name: "nvlink_metrics",
@@ -672,7 +677,7 @@ func TestProcessMemoryMetricValues(t *testing.T) {
 			originalFactory := statelessAPIFactory
 			defer func() { statelessAPIFactory = originalFactory }()
 
-			statelessAPIFactory = func(_ *CollectorDependencies) []apiCallInfo {
+			statelessAPIFactory = func(_ *CollectorDependencies, _ bool) []apiCallInfo {
 				return []apiCallInfo{
 					{
 						Name: "process_memory_usage",
@@ -810,7 +815,7 @@ func TestDeviceUnhealthyMetricFeatureGate(t *testing.T) {
 
 			device := setupMockDevice(t)
 			wmeta := testutil.GetWorkloadMetaMockWithDefaultGPUs(t)
-			apis := createStatelessAPIs(&CollectorDependencies{Workloadmeta: wmeta})
+			apis := createStatelessAPIs(&CollectorDependencies{Workloadmeta: wmeta}, true)
 			deviceUnhealthyAPI := findAPICallByName(t, apis, "device_unhealthy_count")
 
 			gotMetrics, _, err := deviceUnhealthyAPI.Handler(device, 0)

--- a/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
@@ -214,7 +214,7 @@ func TestAllECCAPIHandlers(t *testing.T) {
 				testutil.WithCustomHook(configureEccAPIs),
 			)
 
-			apis := createStatelessAPIs(&CollectorDependencies{}, true)
+			apis := createStatelessAPIs(&CollectorDependencies{})
 			var metricsOut []Metric
 			for _, api := range apis {
 				if api.Name != "sram_ecc_error_status" && !strings.HasPrefix(api.Name, "ecc_errors.") {
@@ -256,14 +256,10 @@ func TestNewStatelessCollector(t *testing.T) {
 }
 
 func TestStatelessCollectorSkipsMaxClockInfoForVGPU(t *testing.T) {
-	var maxClockInfoCalls, virtualizationModeCalls int
+	var maxClockInfoCalls int
 	device := setupMockDevice(t,
 		testutil.WithDeviceFeatureMode(testutil.DeviceFeatureVGPU),
 		testutil.WithCustomHook(func(device *mock.Device) {
-			device.GetVirtualizationModeFunc = func() (nvml.GpuVirtualizationMode, nvml.Return) {
-				virtualizationModeCalls++
-				return nvml.GPU_VIRTUALIZATION_MODE_VGPU, nvml.SUCCESS
-			}
 			device.GetMaxClockInfoFunc = func(nvml.ClockType) (uint32, nvml.Return) {
 				maxClockInfoCalls++
 				return 0, nvml.ERROR_UNKNOWN
@@ -273,7 +269,6 @@ func TestStatelessCollectorSkipsMaxClockInfoForVGPU(t *testing.T) {
 
 	collector, err := newStatelessCollector(device, &CollectorDependencies{})
 	require.NoError(t, err)
-	require.Equal(t, 1, virtualizationModeCalls, "vGPU status should be queried once during collector initialization")
 	require.Zero(t, maxClockInfoCalls, "vGPU collector should not probe max clock info")
 
 	baseCollector := collector.(*baseCollector)
@@ -329,7 +324,7 @@ func TestCollectProcessMemory(t *testing.T) {
 			originalFactory := statelessAPIFactory
 			defer func() { statelessAPIFactory = originalFactory }()
 
-			statelessAPIFactory = func(_ *CollectorDependencies, _ bool) []apiCallInfo {
+			statelessAPIFactory = func(_ *CollectorDependencies) []apiCallInfo {
 				return []apiCallInfo{
 					{
 						Name: "process_memory_usage",
@@ -358,7 +353,7 @@ func TestCollectProcessMemory_Error(t *testing.T) {
 	originalFactory := statelessAPIFactory
 	defer func() { statelessAPIFactory = originalFactory }()
 
-	statelessAPIFactory = func(_ *CollectorDependencies, _ bool) []apiCallInfo {
+	statelessAPIFactory = func(_ *CollectorDependencies) []apiCallInfo {
 		return []apiCallInfo{
 			{
 				Name: "process_memory_usage",
@@ -387,7 +382,7 @@ func TestProcessMemoryMetricTags(t *testing.T) {
 	originalFactory := statelessAPIFactory
 	defer func() { statelessAPIFactory = originalFactory }()
 
-	statelessAPIFactory = func(_ *CollectorDependencies, _ bool) []apiCallInfo {
+	statelessAPIFactory = func(_ *CollectorDependencies) []apiCallInfo {
 		return []apiCallInfo{
 			{
 				Name: "process_memory_usage",
@@ -470,7 +465,7 @@ func TestNVLinkCollector_Initialization(t *testing.T) {
 			originalFactory := statelessAPIFactory
 			defer func() { statelessAPIFactory = originalFactory }()
 
-			statelessAPIFactory = func(_ *CollectorDependencies, _ bool) []apiCallInfo {
+			statelessAPIFactory = func(_ *CollectorDependencies) []apiCallInfo {
 				return []apiCallInfo{
 					{
 						Name: "nvlink_metrics",
@@ -560,7 +555,7 @@ func TestNVLinkCollector_Collection(t *testing.T) {
 			originalFactory := statelessAPIFactory
 			defer func() { statelessAPIFactory = originalFactory }()
 
-			statelessAPIFactory = func(_ *CollectorDependencies, _ bool) []apiCallInfo {
+			statelessAPIFactory = func(_ *CollectorDependencies) []apiCallInfo {
 				return []apiCallInfo{
 					{
 						Name: "nvlink_metrics",
@@ -677,7 +672,7 @@ func TestProcessMemoryMetricValues(t *testing.T) {
 			originalFactory := statelessAPIFactory
 			defer func() { statelessAPIFactory = originalFactory }()
 
-			statelessAPIFactory = func(_ *CollectorDependencies, _ bool) []apiCallInfo {
+			statelessAPIFactory = func(_ *CollectorDependencies) []apiCallInfo {
 				return []apiCallInfo{
 					{
 						Name: "process_memory_usage",
@@ -815,7 +810,7 @@ func TestDeviceUnhealthyMetricFeatureGate(t *testing.T) {
 
 			device := setupMockDevice(t)
 			wmeta := testutil.GetWorkloadMetaMockWithDefaultGPUs(t)
-			apis := createStatelessAPIs(&CollectorDependencies{Workloadmeta: wmeta}, true)
+			apis := createStatelessAPIs(&CollectorDependencies{Workloadmeta: wmeta})
 			deviceUnhealthyAPI := findAPICallByName(t, apis, "device_unhealthy_count")
 
 			gotMetrics, _, err := deviceUnhealthyAPI.Handler(device, 0)

--- a/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
@@ -256,16 +256,22 @@ func TestNewStatelessCollector(t *testing.T) {
 }
 
 func TestStatelessCollectorSkipsMaxClockInfoForVGPU(t *testing.T) {
-	var maxClockInfoCalls int
+	var maxClockInfoCalls, virtualizationModeCalls int
 	device := setupMockDevice(t,
 		testutil.WithDeviceFeatureMode(testutil.DeviceFeatureVGPU),
 		testutil.WithCustomHook(func(device *mock.Device) {
+			device.GetVirtualizationModeFunc = func() (nvml.GpuVirtualizationMode, nvml.Return) {
+				virtualizationModeCalls++
+				return nvml.GPU_VIRTUALIZATION_MODE_VGPU, nvml.SUCCESS
+			}
 			device.GetMaxClockInfoFunc = func(nvml.ClockType) (uint32, nvml.Return) {
 				maxClockInfoCalls++
 				return 0, nvml.ERROR_UNKNOWN
 			}
 		}),
 	)
+	require.Equal(t, 1, virtualizationModeCalls, "virtualization mode should be cached during device initialization")
+	require.Equal(t, nvml.GPU_VIRTUALIZATION_MODE_VGPU, device.GetDeviceInfo().VirtualizationMode)
 
 	collector, err := newStatelessCollector(device, &CollectorDependencies{})
 	require.NoError(t, err)

--- a/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
@@ -255,6 +255,39 @@ func TestNewStatelessCollector(t *testing.T) {
 	require.NotEmpty(t, metrics) // Should have some metrics
 }
 
+func TestStatelessCollectorSkipsMaxClockInfoForVGPU(t *testing.T) {
+	var maxClockInfoCalls int
+	device := setupMockDevice(t,
+		testutil.WithDeviceFeatureMode(testutil.DeviceFeatureVGPU),
+		testutil.WithCustomHook(func(device *mock.Device) {
+			device.GetMaxClockInfoFunc = func(nvml.ClockType) (uint32, nvml.Return) {
+				maxClockInfoCalls++
+				return 0, nvml.ERROR_UNKNOWN
+			}
+		}),
+	)
+
+	collector, err := newStatelessCollector(device, &CollectorDependencies{})
+	require.NoError(t, err)
+	require.Zero(t, maxClockInfoCalls, "vGPU collector should not probe max clock info")
+
+	baseCollector := collector.(*baseCollector)
+	for _, apiName := range []string{
+		"max_clock_speed_sm",
+		"max_clock_speed_memory",
+		"max_clock_speed_graphics",
+		"max_clock_speed_video",
+	} {
+		for _, api := range baseCollector.supportedAPIs {
+			require.NotEqual(t, apiName, api.Name, "vGPU collector should not include %s", apiName)
+		}
+	}
+
+	_, err = collector.Collect()
+	require.NoError(t, err)
+	require.Zero(t, maxClockInfoCalls, "vGPU collector should not collect max clock info")
+}
+
 // TestCollectProcessMemory tests the process memory collection with different process scenarios
 func TestCollectProcessMemory(t *testing.T) {
 	tests := []struct {

--- a/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
@@ -259,6 +259,7 @@ func TestStatelessCollectorSkipsMaxClockInfoForVGPU(t *testing.T) {
 	var maxClockInfoCalls, virtualizationModeCalls int
 	device := setupMockDevice(t,
 		testutil.WithDeviceFeatureMode(testutil.DeviceFeatureVGPU),
+		testutil.WithMockAllFunctions(),
 		testutil.WithCustomHook(func(device *mock.Device) {
 			device.GetVirtualizationModeFunc = func() (nvml.GpuVirtualizationMode, nvml.Return) {
 				virtualizationModeCalls++

--- a/pkg/gpu/safenvml/device.go
+++ b/pkg/gpu/safenvml/device.go
@@ -143,11 +143,12 @@ type DeviceEventData struct {
 
 // DeviceInfo holds common cached properties for a GPU device
 type DeviceInfo struct {
-	SMVersion    uint32
-	UUID         string
-	Name         string
-	CoreCount    int
-	Architecture nvml.DeviceArchitecture
+	SMVersion          uint32
+	UUID               string
+	Name               string
+	CoreCount          int
+	Architecture       nvml.DeviceArchitecture
+	VirtualizationMode nvml.GpuVirtualizationMode
 
 	// Index of the device in the host. For MIG devices, this is the index of the MIG device in the parent device.
 	Index int
@@ -360,6 +361,10 @@ func (d *DeviceInfo) fillBasicDataFromNVML(dev SafeDevice) error {
 	d.Index, err = dev.GetIndex()
 	if err != nil {
 		return err
+	}
+
+	if virtualizationMode, err := dev.GetVirtualizationMode(); err == nil {
+		d.VirtualizationMode = virtualizationMode
 	}
 
 	return nil

--- a/pkg/gpu/safenvml/device.go
+++ b/pkg/gpu/safenvml/device.go
@@ -365,12 +365,6 @@ func (d *DeviceInfo) fillBasicDataFromNVML(dev SafeDevice) error {
 		return err
 	}
 
-	if virtualizationMode, err := dev.GetVirtualizationMode(); err == nil {
-		d.VirtualizationMode = virtualizationMode
-	} else if logLimiter.ShouldLog() {
-		log.Errorf("error getting device virtualization mode: %v", err)
-	}
-
 	return nil
 }
 
@@ -387,6 +381,12 @@ func (d *DeviceInfo) fillPhysicalDeviceData(dev SafeDevice) error {
 		return fmt.Errorf("error getting CUDA compute capability: %w", err)
 	}
 	d.SMVersion = uint32(major*10 + minor)
+
+	if virtualizationMode, err := dev.GetVirtualizationMode(); err == nil {
+		d.VirtualizationMode = virtualizationMode
+	} else if logLimiter.ShouldLog() {
+		log.Warnf("cannot get virtualization mode: %v", err)
+	}
 
 	return nil
 }

--- a/pkg/gpu/safenvml/device.go
+++ b/pkg/gpu/safenvml/device.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // SafeDevice represents a safe wrapper around NVML device operations.
@@ -365,6 +367,8 @@ func (d *DeviceInfo) fillBasicDataFromNVML(dev SafeDevice) error {
 
 	if virtualizationMode, err := dev.GetVirtualizationMode(); err == nil {
 		d.VirtualizationMode = virtualizationMode
+	} else if logLimiter.ShouldLog() {
+		log.Errorf("error getting device virtualization mode: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- dd-meta {"pullId":"00000000-0000-0000-0000-000000000000","source":"chat","resourceId":"b6950850-80dc-4801-bc2f-895d5b466cca","workflowId":"c63cfe10-11dd-4bbc-800e-23188cad9c50","codeChangeId":"c63cfe10-11dd-4bbc-800e-23188cad9c50","sourceType":"bits_ai_sre"} -->
### What does this PR do?

Bits AI SRE Investigation • [View in Bits AI SRE Investigation](https://app.datadoghq.com/bits-ai/investigations/54d64295-b38b-44f1-85fa-fb1948786cba)

- Detect vGPU devices in the NVIDIA stateless max-clock handlers.
- Cache each device's NVML virtualization mode in `safenvml.DeviceInfo` during device initialization, so max-clock collection does not query NVML repeatedly.
- Return the repository's typed unsupported-API error so all four max-clock handlers are filtered during collector initialization.
- Log an error when the virtualization-mode lookup fails during device initialization.
- Add regression coverage that makes vGPU max-clock calls return `ERROR_UNKNOWN`, verifies the cached mode, and confirms max-clock calls are never invoked or reported as collection errors.

### Motivation

NVIDIA vGPU devices such as the A10-24Q configuration in the zekrom cluster do not support NVML `GetMaxClockInfo`. The API returns `Unknown Error` rather than `ERROR_NOT_SUPPORTED`, so the stateless collector previously retried the calls on every collection cycle and generated recurring collection-error noise. This fix suppresses those unsupported calls while preserving max-clock metrics for physical GPUs, caches the virtualization capability query used to make that decision, and reports failures to determine the mode.

### Describe how you validated your changes

- Formatted the modified Go file with `gofmt` and ran `git diff --check`.
- Verified the vGPU regression test observes one virtualization-mode query during device initialization and zero max-clock queries.

### Additional Notes

The change is limited to the NVIDIA stateless collector, safenvml device metadata and logging, and regression coverage.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b6950850-80dc-4801-bc2f-895d5b466cca)

Comment @datadog to request changes