### PR TITLE
Sort build tags to hit cache

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -290,7 +290,8 @@ def get_build_tags(include, exclude):
     for tag in unknown_exclude:
         print(f"Warning: unknown build tag '{tag}' was filtered out from excluded tags list.", file=sys.stderr)
 
-    return list(known_include - known_exclude)
+    # sort build tags to have the same order and ensure caching hits properly
+    return sorted(known_include - known_exclude)
 
 
 def compute_config_build_tags(

--- a/tasks/libs/common/go.py
+++ b/tasks/libs/common/go.py
@@ -172,7 +172,8 @@ def go_build(
     if echo:
         cmd += " -x"
     if build_tags:
-        cmd += f" -tags \"{','.join(build_tags)}\""
+        # sort build tags to have the same order and ensure caching hits properly
+        cmd += f" -tags \"{','.join(sorted(build_tags))}\""
     if bin_path:
         cmd += f" -o {bin_path}"
     if gcflags:


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Sort Go build tags when needed.

### Motivation
Fix cache miss.
Running `dda inv test` twice in a row would re-run everything because the tags are not in the same order and so it results in different cache keys.

### Describe how you validated your changes
Ran `dda inv test --targets=./cmd/agent` twice in a row and observed everything was cached as expected.

### Additional Notes
