### PR TITLE
AGTMETRICS-572 Integrate filterlist into dogstatsd http server

### DIFF
--- a/comp/dogstatsd/http/impl/BUILD.bazel
+++ b/comp/dogstatsd/http/impl/BUILD.bazel
@@ -24,10 +24,12 @@ go_library(
         "//comp/dogstatsd/constants",
         "//comp/dogstatsd/http/def",
         "//comp/dogstatsd/http/impl/internal/reader",
+        "//comp/filterlist/def",
         "//pkg/metrics",
         "//pkg/proto/pbgo/dogstatsdhttp",
         "//pkg/tagger/types",
         "//pkg/tagset",
+        "//pkg/util/strings",
     ],
 )
 
@@ -44,6 +46,7 @@ dd_agent_go_test(
         "//pkg/metrics",
         "//pkg/proto/pbgo/dogstatsdhttp",
         "//pkg/tagset",
+        "//pkg/util/strings",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/comp/dogstatsd/http/impl/fx.go
+++ b/comp/dogstatsd/http/impl/fx.go
@@ -13,16 +13,18 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	comp "github.com/DataDog/datadog-agent/comp/def"
 	def "github.com/DataDog/datadog-agent/comp/dogstatsd/http/def"
+	filterlist "github.com/DataDog/datadog-agent/comp/filterlist/def"
 )
 
 // Requires declares the inputs for NewComponent
 type Requires struct {
-	Lc       comp.Lifecycle
-	Log      log.Component
-	Config   config.Component
-	Tagger   tagger.Component
-	Hostname hostname.Component
-	Demux    demultiplexer.Component
+	Lc         comp.Lifecycle
+	Log        log.Component
+	Config     config.Component
+	Tagger     tagger.Component
+	Hostname   hostname.Component
+	Demux      demultiplexer.Component
+	FilterList filterlist.Component
 }
 
 // Provides defines the output of this component
@@ -32,10 +34,11 @@ type Provides struct {
 
 func NewComponent(req Requires) (Provides, error) {
 	s := &server{
-		config:   req.Config,
-		log:      req.Log,
-		tagger:   req.Tagger,
-		hostname: req.Hostname,
+		config:     req.Config,
+		log:        req.Log,
+		tagger:     req.Tagger,
+		hostname:   req.Hostname,
+		filterList: req.FilterList,
 
 		out: req.Demux.Serializer(),
 	}

--- a/comp/dogstatsd/http/impl/handler.go
+++ b/comp/dogstatsd/http/impl/handler.go
@@ -12,6 +12,7 @@ import (
 
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	filterlist "github.com/DataDog/datadog-agent/comp/filterlist/def"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/dogstatsdhttp"
 )
 
@@ -36,10 +37,11 @@ func (ctx *requestCtx) respond(status int, format string, args ...any) {
 }
 
 type handlerBase struct {
-	log      log.Component
-	tagger   tagger.Component
-	hostname string
-	out      serializer
+	log        log.Component
+	tagger     tagger.Component
+	hostname   string
+	filterList filterlist.Component
+	out        serializer
 }
 
 func (h *handlerBase) handle(
@@ -86,7 +88,7 @@ type seriesHandler struct {
 
 func (h *seriesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.handle(w, r, func(origin origin, payload *pb.Payload) error {
-		it, err := newSeriesIterator(payload, origin, h.hostname)
+		it, err := newSeriesIterator(payload, origin, h.hostname, h.filterList.GetMetricFilterList())
 		if err != nil {
 			return err
 		}
@@ -104,7 +106,7 @@ type sketchesHandler struct {
 
 func (h *sketchesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.handle(w, r, func(origin origin, payload *pb.Payload) error {
-		it, err := newSketchIterator(payload, origin, h.hostname)
+		it, err := newSketchIterator(payload, origin, h.hostname, h.filterList.GetMetricFilterList())
 		if err != nil {
 			return err
 		}

--- a/comp/dogstatsd/http/impl/iterator.go
+++ b/comp/dogstatsd/http/impl/iterator.go
@@ -15,13 +15,41 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/dogstatsdhttp"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
+	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 )
 
 type iteratorCommon struct {
-	reader   *reader.MetricDataReader
-	origin   origin
-	hostname string
-	err      error
+	reader     *reader.MetricDataReader
+	origin     origin
+	hostname   string
+	filterList utilstrings.Matcher
+	err        error
+}
+
+// nextUnfilteredMetric advances the reader to the next metric that is not in
+// the filter list. It returns false once the payload is exhausted or the reader
+// fails.
+func (it *iteratorCommon) nextUnfilteredMetric() bool {
+	for {
+		if it.err != nil {
+			return false
+		}
+
+		if !it.reader.HaveMoreMetrics() {
+			return false
+		}
+
+		it.err = it.reader.NextMetric()
+		if it.err != nil {
+			return false
+		}
+
+		// NextMetric drains any points left over from the previous metric, so
+		// skipping here keeps the reader's column indexes in sync.
+		if !it.filterList.Test(it.reader.Name()) {
+			return true
+		}
+	}
 }
 
 func (it *iteratorCommon) processTags() tagset.CompositeTags {
@@ -48,12 +76,13 @@ type seriesIterator struct {
 	buffer metrics.Serie
 }
 
-func newSeriesIterator(payload *pb.Payload, origin origin, hostname string) (*seriesIterator, error) {
+func newSeriesIterator(payload *pb.Payload, origin origin, hostname string, filterList utilstrings.Matcher) (*seriesIterator, error) {
 	it := &seriesIterator{
 		iteratorCommon: iteratorCommon{
-			reader:   reader.NewMetricDataReader(payload.MetricData),
-			origin:   origin,
-			hostname: hostname,
+			reader:     reader.NewMetricDataReader(payload.MetricData),
+			origin:     origin,
+			hostname:   hostname,
+			filterList: filterList,
 		},
 	}
 
@@ -62,16 +91,7 @@ func newSeriesIterator(payload *pb.Payload, origin origin, hostname string) (*se
 
 // MoveNext reads one entire metric record from the dogstatsd payload into the internal buffer.
 func (it *seriesIterator) MoveNext() bool {
-	if it.err != nil {
-		return false
-	}
-
-	if !it.reader.HaveMoreMetrics() {
-		return false
-	}
-
-	it.err = it.reader.NextMetric()
-	if it.err != nil {
+	if !it.nextUnfilteredMetric() {
 		return false
 	}
 

--- a/comp/dogstatsd/http/impl/iterator_test.go
+++ b/comp/dogstatsd/http/impl/iterator_test.go
@@ -16,10 +16,15 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/dogstatsdhttp"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
+	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 )
 
-func TestIterator(t *testing.T) {
-	payload := &pb.Payload{
+// seriesTestPayload builds a payload holding the count `foo` (1 point), the
+// rate `bar` (2 points) and the gauge `baz` (2 points). Timestamps and values
+// are shared across all three in delta-encoded columns, so skipping a metric
+// must not shift what the following one decodes.
+func seriesTestPayload() *pb.Payload {
+	return &pb.Payload{
 		MetricData: &pb.MetricData{
 			DictNameStr:      []byte("\x03foo\x03bar\x03baz"),
 			DictTagStr:       []byte("\x03ook\x15dd.internal.card:none\x15dd.internal.card:high"),
@@ -41,6 +46,10 @@ func TestIterator(t *testing.T) {
 			ValsSint64:         []int64{5, 6, 7, 8, 9},
 		},
 	}
+}
+
+func seriesTestOrigin(t *testing.T) origin {
+	t.Helper()
 
 	entityID := taggertypes.NewEntityID(taggertypes.ContainerID, "123456789")
 
@@ -55,7 +64,11 @@ func TestIterator(t *testing.T) {
 	origin, err := originFromHeader(header, tagger)
 	require.NoError(t, err)
 
-	it, err := newSeriesIterator(payload, origin, "default")
+	return origin
+}
+
+func TestIterator(t *testing.T) {
+	it, err := newSeriesIterator(seriesTestPayload(), seriesTestOrigin(t), "default", utilstrings.Matcher{})
 	require.NoError(t, err)
 	require.NotNil(t, it)
 
@@ -91,4 +104,51 @@ func TestIterator(t *testing.T) {
 		Source:   metrics.MetricSourceDogstatsd,
 		Points:   []metrics.Point{{Ts: 1000, Value: 8}, {Ts: 1010, Value: 9}},
 	}, it.Current())
+}
+
+func TestIteratorFilterList(t *testing.T) {
+	t.Run("exact match skips the metric", func(t *testing.T) {
+		it, err := newSeriesIterator(seriesTestPayload(), seriesTestOrigin(t), "default",
+			utilstrings.NewMatcher([]string{"bar"}, false))
+		require.NoError(t, err)
+
+		require.True(t, it.MoveNext())
+		require.Equal(t, "foo", it.Current().Name)
+
+		// baz must still decode the points that follow bar's in the payload.
+		require.True(t, it.MoveNext())
+		require.Equal(t, &metrics.Serie{
+			Name:     "baz",
+			Tags:     tagset.NewCompositeTags([]string{"low"}, []string{"ook"}),
+			Host:     "default",
+			MType:    metrics.APIGaugeType,
+			Interval: 10,
+			Source:   metrics.MetricSourceDogstatsd,
+			Points:   []metrics.Point{{Ts: 1000, Value: 8}, {Ts: 1010, Value: 9}},
+		}, it.Current())
+
+		require.False(t, it.MoveNext())
+		require.NoError(t, it.err)
+	})
+
+	t.Run("prefix match skips every matching metric", func(t *testing.T) {
+		it, err := newSeriesIterator(seriesTestPayload(), seriesTestOrigin(t), "default",
+			utilstrings.NewMatcher([]string{"ba"}, true))
+		require.NoError(t, err)
+
+		require.True(t, it.MoveNext())
+		require.Equal(t, "foo", it.Current().Name)
+
+		require.False(t, it.MoveNext())
+		require.NoError(t, it.err)
+	})
+
+	t.Run("everything filtered", func(t *testing.T) {
+		it, err := newSeriesIterator(seriesTestPayload(), seriesTestOrigin(t), "default",
+			utilstrings.NewMatcher([]string{"foo", "bar", "baz"}, false))
+		require.NoError(t, err)
+
+		require.False(t, it.MoveNext())
+		require.NoError(t, it.err)
+	})
 }

--- a/comp/dogstatsd/http/impl/server.go
+++ b/comp/dogstatsd/http/impl/server.go
@@ -16,15 +16,17 @@ import (
 	hostname "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	filterlist "github.com/DataDog/datadog-agent/comp/filterlist/def"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
 type server struct {
-	config   config.Component
-	log      log.Component
-	tagger   tagger.Component
-	hostname hostname.Component
-	out      serializer
+	config     config.Component
+	log        log.Component
+	tagger     tagger.Component
+	hostname   hostname.Component
+	filterList filterlist.Component
+	out        serializer
 
 	http *http.Server
 }
@@ -46,10 +48,11 @@ func (s *server) start(ctx context.Context) error {
 	}
 
 	base := handlerBase{
-		log:      s.log,
-		tagger:   s.tagger,
-		hostname: hostname,
-		out:      s.out,
+		log:        s.log,
+		tagger:     s.tagger,
+		hostname:   hostname,
+		filterList: s.filterList,
+		out:        s.out,
 	}
 
 	mux := &http.ServeMux{}

--- a/comp/dogstatsd/http/impl/sketch_iterator.go
+++ b/comp/dogstatsd/http/impl/sketch_iterator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/http/impl/internal/reader"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/dogstatsdhttp"
+	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 )
 
 // sketchData holds one sketch point's reader-provided columns and summary.
@@ -49,12 +50,13 @@ type sketchIterator struct {
 	buffer dogstatsdSketchSeries
 }
 
-func newSketchIterator(payload *pb.Payload, origin origin, hostname string) (*sketchIterator, error) {
+func newSketchIterator(payload *pb.Payload, origin origin, hostname string, filterList utilstrings.Matcher) (*sketchIterator, error) {
 	it := &sketchIterator{
 		iteratorCommon: iteratorCommon{
-			reader:   reader.NewMetricDataReader(payload.MetricData),
-			origin:   origin,
-			hostname: hostname,
+			reader:     reader.NewMetricDataReader(payload.MetricData),
+			origin:     origin,
+			hostname:   hostname,
+			filterList: filterList,
 		},
 	}
 	return it, it.reader.Initialize()
@@ -62,16 +64,7 @@ func newSketchIterator(payload *pb.Payload, origin origin, hostname string) (*sk
 
 // MoveNext reads one entire sketch metric record from the dogstatsd payload into the internal buffer.
 func (it *sketchIterator) MoveNext() bool {
-	if it.err != nil {
-		return false
-	}
-
-	if !it.reader.HaveMoreMetrics() {
-		return false
-	}
-
-	it.err = it.reader.NextMetric()
-	if it.err != nil {
+	if !it.nextUnfilteredMetric() {
 		return false
 	}
 

--- a/comp/dogstatsd/http/impl/sketch_iterator_test.go
+++ b/comp/dogstatsd/http/impl/sketch_iterator_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/dogstatsdhttp"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
+	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 )
 
 func TestSketchIterator(t *testing.T) {
@@ -43,7 +44,7 @@ func TestSketchIterator(t *testing.T) {
 	origin, err := originFromHeader(header, tagger)
 	require.NoError(t, err)
 
-	it, err := newSketchIterator(payload, origin, "default")
+	it, err := newSketchIterator(payload, origin, "default", utilstrings.Matcher{})
 	require.NoError(t, err)
 	require.NotNil(t, it)
 
@@ -94,6 +95,49 @@ func TestSketchIterator(t *testing.T) {
 	require.NoError(t, it.err)
 }
 
+func TestSketchIteratorFilterList(t *testing.T) {
+	payload := &pb.Payload{
+		MetricData: &pb.MetricData{
+			DictNameStr:        []byte("\x03foo\x03bar"),
+			Types:              []uint64{0x14, 0x04},
+			NameRefs:           []int64{1, 1},
+			TagsetRefs:         []int64{0, 0},
+			ResourcesRefs:      []int64{0, 0},
+			Intervals:          []uint64{0, 0},
+			NumPoints:          []uint64{2, 1},
+			SourceTypeNameRefs: []int64{0, 0},
+			OriginInfoRefs:     []int64{0, 0},
+			Timestamps:         []int64{1000, 1000, 1000},
+			ValsSint64:         []int64{4, 1, 3, 2, 6, 2, 4, 3, 5},
+			SketchNumBins:      []uint64{2, 1, 0},
+			SketchBinKeys:      []int32{0, 2, 1},
+			SketchBinCnts:      []uint32{1, 1, 3},
+		},
+	}
+
+	tagger := taggerfake.SetupFakeTagger(t)
+	origin, err := originFromHeader(http.Header{}, tagger)
+	require.NoError(t, err)
+
+	it, err := newSketchIterator(payload, origin, "default", utilstrings.NewMatcher([]string{"foo"}, false))
+	require.NoError(t, err)
+
+	// bar's summary and bins must not be shifted by foo's skipped points.
+	require.True(t, it.MoveNext())
+	s := it.Current().(*dogstatsdSketchSeries)
+	require.Equal(t, "bar", s.Name)
+	require.Len(t, s.Points, 1)
+
+	pt := s.Points[0]
+	require.Equal(t, int64(3000), pt.ts)
+	require.Empty(t, pt.k)
+	require.Empty(t, pt.n)
+	require.Equal(t, int64(5), pt.cnt)
+
+	require.False(t, it.MoveNext())
+	require.NoError(t, it.err)
+}
+
 func TestSketchIteratorTagMerging(t *testing.T) {
 	payload := &pb.Payload{
 		MetricData: &pb.MetricData{
@@ -126,7 +170,7 @@ func TestSketchIteratorTagMerging(t *testing.T) {
 	origin, err := originFromHeader(header, tagger)
 	require.NoError(t, err)
 
-	it, err := newSketchIterator(payload, origin, "default")
+	it, err := newSketchIterator(payload, origin, "default", utilstrings.Matcher{})
 	require.NoError(t, err)
 
 	require.True(t, it.MoveNext())
@@ -168,7 +212,7 @@ func TestSketchIteratorHostOverride(t *testing.T) {
 	header := http.Header{}
 	origin, err := originFromHeader(header, tagger)
 	require.NoError(t, err)
-	it, err := newSketchIterator(payload, origin, "default")
+	it, err := newSketchIterator(payload, origin, "default", utilstrings.Matcher{})
 	require.NoError(t, err)
 	require.True(t, it.MoveNext())
 	s := it.Current().(*dogstatsdSketchSeries)
@@ -198,7 +242,7 @@ func TestSketchIteratorWrongType(t *testing.T) {
 	header := http.Header{}
 	origin, err := originFromHeader(header, tagger)
 	require.NoError(t, err)
-	it, err := newSketchIterator(payload, origin, "default")
+	it, err := newSketchIterator(payload, origin, "default", utilstrings.Matcher{})
 	require.NoError(t, err)
 	require.False(t, it.MoveNext())
 	require.Error(t, it.err)


### PR DESCRIPTION
### What does this PR do?

Integrate filterlist into the dogstatsd http server.

### Motivation

Apply metrics filtering uniformly across UDS and HTTP dogstatsd versions.

### Describe how you validated your changes

Unit tests.

### Additional Notes
