### PR TITLE
[ABLD-471] Map external `datadog-agent` imports with `gazelle:resolve_regexp`

### DIFF
--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -23,53 +23,9 @@ go_deps.gazelle_default_attributes(
         # We don't want to generate code from protos from dependencies, as this most often fails
         # and is different behavior from the default with go tooling
         "gazelle:proto disable",
-        # ABLD-471: third-party modules that import datadog-agent submodules would
-        # otherwise generate `@com_github_datadog_datadog_agent_*` labels (because
-        # go_deps materializes our local go.work modules as external repos),
-        # while the same Go package is also reachable in-tree at `//<path>`. The linker
-        # then sees two copies of the package. Redirect every such import to the in-tree
-        # label so both build contexts agree. The list grows as new third-party imports
-        # surface — long-term fix is unifying label spaces.
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace @@//pkg/proto/pbgo/trace:trace",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/trace/traceutil/normalize @@//pkg/trace/traceutil/normalize:normalize",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/metrics/event @@//pkg/metrics/event:event",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/metrics/servicecheck @@//pkg/metrics/servicecheck:servicecheck",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes/source @@//pkg/opentelemetry-mapping-go/otlp/attributes/source:source",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/serializer/marshaler @@//pkg/serializer/marshaler:marshaler",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/serializer/types @@//pkg/serializer/types:types",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/util/hostname/validate @@//pkg/util/hostname/validate:validate",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/comp/core/config @@//comp/core/config:config",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/comp/core/log/def @@//comp/core/log/def:def",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/comp/core/tagger/types @@//comp/core/tagger/types:types",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder @@//comp/forwarder/defaultforwarder:defaultforwarder",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/comp/logs/agent/config @@//comp/logs/agent/config:config",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient @@//comp/otelcol/otlp/components/metricsclient:metricsclient",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil @@//comp/otelcol/otlp/testutil:testutil",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/config/create @@//pkg/config/create:create",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/config/model @@//pkg/config/model:model",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/config/setup @@//pkg/config/setup:setup",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/config/utils @@//pkg/config/utils:utils",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry @@//pkg/fleet/installer/telemetry:telemetry",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/metrics @@//pkg/metrics:metrics",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/obfuscate @@//pkg/obfuscate:obfuscate",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata @@//pkg/opentelemetry-mapping-go/inframetadata:inframetadata",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata/gohai @@//pkg/opentelemetry-mapping-go/inframetadata/gohai:gohai",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata/payload @@//pkg/opentelemetry-mapping-go/inframetadata/payload:payload",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes @@//pkg/opentelemetry-mapping-go/otlp/attributes:attributes",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes/azure @@//pkg/opentelemetry-mapping-go/otlp/attributes/azure:azure",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes/ec2 @@//pkg/opentelemetry-mapping-go/otlp/attributes/ec2:ec2",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes/gcp @@//pkg/opentelemetry-mapping-go/otlp/attributes/gcp:gcp",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/metrics @@//pkg/opentelemetry-mapping-go/otlp/metrics:metrics",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/serializer @@//pkg/serializer:serializer",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/tagset @@//pkg/tagset:tagset",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/trace/config @@//pkg/trace/config:config",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/trace/log @@//pkg/trace/log:log",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/trace/otel/stats @@//pkg/trace/otel/stats:stats",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/trace/stats @@//pkg/trace/stats:stats",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/util/compression/impl-zlib @@//pkg/util/compression/impl-zlib:impl-zlib",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/util/option @@//pkg/util/option:option",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/remoteconfig/state @@//pkg/remoteconfig/state:state",
-        "gazelle:resolve go github.com/DataDog/datadog-agent/pkg/network/driver @@//pkg/network/driver:driver",
+        # Map external imports of datadog-agent submodules to in-tree labels: as for any override, last match wins
+        "gazelle:resolve_regexp go ^github[.]com/DataDog/datadog-agent/(.+)$ @@//$1",  # general
+        "gazelle:resolve_regexp go ^github[.]com/DataDog/datadog-agent/(.+/([^/]+)/v[0-9]+)$ @@//$1:$2",  # versioned
     ],
 )
 go_deps.gazelle_override(


### PR DESCRIPTION
### What does this PR do?
Replace the ~40 individual `gazelle:resolve` lines in `deps/go.MODULE.bazel` with 2 `gazelle:resolve_regexp` directives:
1. a general rule,
2. a rule specific to versioned modules.

Together they cover every current and future datadog-agent submodule import from external Go modules.

### Motivation
[ABLD-471](https://datadoghq.atlassian.net/browse/ABLD-471): external modules that import a `datadog-agent` submodule end up depending on two copies of the same Go package:
- our in-tree `//<path>` target,
- a `go_deps`-generated external repo.

The Go linker rightfully rejects the duplicate.

This is by design: `go_deps` Gazelle directives run inside each external module's own, **separate Gazelle invocation**, which never sees the main repository: directives in the root `BUILD.bazel` (`prefix`, `resolve`, etc.) only scope our own `//:gazelle` invocation.

Each occurrence had its own `gazelle:resolve` line redirecting the import to the in-tree target, growing by one entry every time a new external importer surfaced.

This is the kind of repetition bazel-contrib/bazel-gazelle#1542 introduced `resolve_regexp` to avoid.

Every entry follows one of two shapes, though:
1. in the general case, the target name is just the last path segment, so Bazel's `//x/y/z` == `//x/y/z:z` shorthand covers it,
3. but, when a package's own directory is a bare major-version suffix, Gazelle then names the `go_library` after the parent directory instead, e.g. `.../installers/v2` gets target `:installers`, not `:v2`.

### Describe how you validated your changes
A full `bazel build //...` passes with no `datadog-agent`-related or Gazelle resolution failures.

### Additional Notes
As for any Gazelle override, last encountered matching definition wins: the general case is therefore defined first, and the more specific version-suffix case next.

[ABLD-471]: https://datadoghq.atlassian.net/browse/ABLD-471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ