### PR TITLE
Run system-probe config fixups after BuildSchema

### DIFF
--- a/pkg/config/setup/BUILD.bazel
+++ b/pkg/config/setup/BUILD.bazel
@@ -84,6 +84,7 @@ go_library(
 dd_agent_go_test(
     name = "setup_test",
     srcs = [
+        "config_init_test.go",
         "config_secret_test.go",
         "config_test.go",
         "privateactionrunner_test.go",

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -133,9 +133,6 @@ func InitConfigObjects() {
 	// Build the environment variable layer
 	datadog.(pkgconfigmodel.BuildableConfig).BuildSchema()
 	systemProbe.(pkgconfigmodel.BuildableConfig).BuildSchema()
-
-	// Fixups that need to read config values must run after BuildSchema(), once the config is ready for use.
-	fixupPostBuildConfig()
 }
 
 // InitConfig initializes the config defaults on a config used by all agents
@@ -461,6 +458,8 @@ func LoadDatadog(config pkgconfigmodel.Config, secretResolver secrets.Component,
 	}
 
 	useHostEtc(config)
+
+	postProcessSystemProbe(SystemProbe())
 
 	err = checkConflictingOptions(config)
 	if err != nil {

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -133,6 +133,9 @@ func InitConfigObjects() {
 	// Build the environment variable layer
 	datadog.(pkgconfigmodel.BuildableConfig).BuildSchema()
 	systemProbe.(pkgconfigmodel.BuildableConfig).BuildSchema()
+
+	// Fixups that need to read config values must run after BuildSchema(), once the config is ready for use.
+	fixupPostBuildConfig()
 }
 
 // InitConfig initializes the config defaults on a config used by all agents

--- a/pkg/config/setup/config_init.go
+++ b/pkg/config/setup/config_init.go
@@ -20,10 +20,3 @@ func fixupInitConfig() {
 	fixupInitCommonConfigComponents(ddcfg)
 	fixupInitFullAgentOnlyComponents(ddcfg)
 }
-
-// fixupPostBuildConfig runs fixups that need to read config values, so they must run after
-// BuildSchema() has marked the config ready for use (unlike fixupInitConfig, which only
-// registers override funcs and declares defaults before the config is ready).
-func fixupPostBuildConfig() {
-	fixupInitSystemProbe(SystemProbe())
-}

--- a/pkg/config/setup/config_init.go
+++ b/pkg/config/setup/config_init.go
@@ -19,7 +19,11 @@ func fixupInitConfig() {
 	ddcfg := Datadog()
 	fixupInitCommonConfigComponents(ddcfg)
 	fixupInitFullAgentOnlyComponents(ddcfg)
+}
 
-	sysprobe := SystemProbe()
-	fixupInitSystemProbe(sysprobe)
+// fixupPostBuildConfig runs fixups that need to read config values, so they must run after
+// BuildSchema() has marked the config ready for use (unlike fixupInitConfig, which only
+// registers override funcs and declares defaults before the config is ready).
+func fixupPostBuildConfig() {
+	fixupInitSystemProbe(SystemProbe())
 }

--- a/pkg/config/setup/config_init_serverless.go
+++ b/pkg/config/setup/config_init_serverless.go
@@ -23,9 +23,6 @@ func fixupInitConfig() {
 	fixupInitServerlessOnlyComponents(ddcfg)
 }
 
-// fixupPostBuildConfig is a no-op in serverless builds, which have no system-probe config.
-func fixupPostBuildConfig() {}
-
 // called only for full-agent, ONLY for serverless, after declaring settings
 func fixupInitServerlessOnlyComponents(_ pkgconfigmodel.Config) { // nolint:unused,deadcode this is only used by serverless
 	// Do not extend this list !

--- a/pkg/config/setup/config_init_serverless.go
+++ b/pkg/config/setup/config_init_serverless.go
@@ -23,6 +23,9 @@ func fixupInitConfig() {
 	fixupInitServerlessOnlyComponents(ddcfg)
 }
 
+// fixupPostBuildConfig is a no-op in serverless builds, which have no system-probe config.
+func fixupPostBuildConfig() {}
+
 // called only for full-agent, ONLY for serverless, after declaring settings
 func fixupInitServerlessOnlyComponents(_ pkgconfigmodel.Config) { // nolint:unused,deadcode this is only used by serverless
 	// Do not extend this list !

--- a/pkg/config/setup/config_init_test.go
+++ b/pkg/config/setup/config_init_test.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test && !serverless
+
+package setup
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+// TestFixupInitSystemProbeRunsAfterConfigIsReady is a regression test for a bug where
+// fixupInitSystemProbe read/wrote system-probe config keys before BuildSchema() marked the
+// config ready for use. Under HOST_ETC (any containerized deployment), the guarded getters
+// silently no-op instead of applying the HOST_ETC path rewrite, so apt/yum/zypper repo dirs
+// were never adjusted to point under the host filesystem.
+func TestFixupInitSystemProbeRunsAfterConfigIsReady(t *testing.T) {
+	origDatadog := Datadog().(pkgconfigmodel.BuildableConfig)
+	origSystemProbe := SystemProbe().(pkgconfigmodel.BuildableConfig)
+	t.Cleanup(func() {
+		SetDatadog(origDatadog)         // nolint: forbidigo // restoring the singleton after the test
+		SetSystemProbe(origSystemProbe) // nolint: forbidigo // restoring the singleton after the test
+	})
+
+	t.Setenv("HOST_ETC", "/host/etc")
+
+	InitConfigObjects()
+
+	for _, name := range []string{
+		"system_probe_config.apt_config_dir",
+		"system_probe_config.yum_repos_dir",
+		"system_probe_config.zypper_repos_dir",
+	} {
+		val := SystemProbe().GetString(name)
+		require.True(t, strings.HasPrefix(val, "/host/etc"), "expected %s to be rooted under HOST_ETC, got %q", name, val)
+	}
+}

--- a/pkg/config/setup/config_init_test.go
+++ b/pkg/config/setup/config_init_test.go
@@ -8,20 +8,21 @@
 package setup
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	delegatedauthmock "github.com/DataDog/datadog-agent/comp/core/delegatedauth/mock"
+	secretsmock "github.com/DataDog/datadog-agent/comp/core/secrets/mock"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
-// TestFixupInitSystemProbeRunsAfterConfigIsReady is a regression test for a bug where
-// fixupInitSystemProbe read/wrote system-probe config keys before BuildSchema() marked the
-// config ready for use. Under HOST_ETC (any containerized deployment), the guarded getters
-// silently no-op instead of applying the HOST_ETC path rewrite, so apt/yum/zypper repo dirs
-// were never adjusted to point under the host filesystem.
-func TestFixupInitSystemProbeRunsAfterConfigIsReady(t *testing.T) {
+// Regression test: the HOST_ETC repo dir rewrite used to run before the config was ready
+// (and before HOST_ETC auto-detection), so it silently never applied.
+func TestPostProcessSystemProbeRunsAfterConfigIsReady(t *testing.T) {
 	origDatadog := Datadog().(pkgconfigmodel.BuildableConfig)
 	origSystemProbe := SystemProbe().(pkgconfigmodel.BuildableConfig)
 	t.Cleanup(func() {
@@ -29,9 +30,16 @@ func TestFixupInitSystemProbeRunsAfterConfigIsReady(t *testing.T) {
 		SetSystemProbe(origSystemProbe) // nolint: forbidigo // restoring the singleton after the test
 	})
 
+	InitConfigObjects()
+
 	t.Setenv("HOST_ETC", "/host/etc")
 
-	InitConfigObjects()
+	configPath := filepath.Join(t.TempDir(), "empty_conf.yaml")
+	require.NoError(t, os.WriteFile(configPath, nil, 0o600))
+	Datadog().(pkgconfigmodel.BuildableConfig).SetConfigFile(configPath)
+
+	err := LoadDatadog(Datadog(), secretsmock.New(t), delegatedauthmock.New(t), nil)
+	require.NoError(t, err)
 
 	for _, name := range []string{
 		"system_probe_config.apt_config_dir",

--- a/pkg/config/setup/fixup_init.go
+++ b/pkg/config/setup/fixup_init.go
@@ -117,8 +117,9 @@ func fixupInitFullAgentOnlyComponents(_ pkgconfigmodel.Config) {
 	pkgconfigmodel.AddOverrideFunc(sanitizeExternalMetricsProviderChunkSize)
 }
 
-// called only for system-probe, after declaring settings
-func fixupInitSystemProbe(config pkgconfigmodel.Config) {
+// postProcessSystemProbe rewrites system-probe repo dir defaults to live under HOST_ETC.
+// Called from LoadDatadog, after the config is ready and HOST_ETC has been determined.
+func postProcessSystemProbe(config pkgconfigmodel.Config) {
 	if value, _ := os.LookupEnv("HOST_ETC"); value != "" {
 		for _, name := range []string{
 			"system_probe_config.apt_config_dir",


### PR DESCRIPTION
### What does this PR do?

Renames `fixupInitSystemProbe` to `postProcessSystemProbe` and moves the call from `fixupInitConfig` into `LoadDatadog`, right after `useHostEtc`.

### Motivation

`postProcessSystemProbe` reads and writes system-probe config keys (`apt_config_dir`, `yum_repos_dir`, `zypper_repos_dir`) to rewrite them under `HOST_ETC`. It was being called too early on two counts:

- Before `BuildSchema()` marks the config ready, so the readiness guard in the getters kicks in and `GetSource`/`GetString` silently no-op. Agents logged `attempt to read key before config is constructed: system_probe_config.apt_config_dir` (and the yum/zypper equivalents) on every start, and the rewrite never applied since `GetSource` returns `SourceUnknown` instead of `SourceDefault` while the config isn't ready.
- Before `useHostEtc` runs, so even once that readiness issue is fixed, auto-detected `HOST_ETC` (as opposed to one set in the env ahead of time) still wouldn't be picked up.

This was introduced in #53983, which changed the function from a no-op into a real implementation without accounting for either ordering constraint.

### Describe how you validated your changes

Added a regression test (`TestPostProcessSystemProbeRunsAfterConfigIsReady`) that runs the real `InitConfigObjects()` + `LoadDatadog()` flow with `HOST_ETC` set and asserts the three keys get rewritten. Confirmed it fails against the old code (reproducing the exact error messages seen in the field) and passes with the fix. Also ran the full `pkg/config/setup` test suite and linter, no regressions.

### Additional Notes

Serverless builds don't call this at all, since they have no system-probe config.