### PR TITLE
[ABLD-366] Fix build file for cmd/loader so it can also build for macos.

### DIFF
--- a/bazel/rules/go/go_binary.bzl
+++ b/bazel/rules/go/go_binary.bzl
@@ -142,7 +142,8 @@ def dd_agent_go_binary(name, gc_linkopts = None, gotags = None, exact_gotags = N
     })
 
     if exact_gotags:
-        kwargs["gotags"] = sorted(exact_gotags)
+        # this might be select()'ed by platform. It is up to the user to sort it.
+        kwargs["gotags"] = exact_gotags
     else:
         gotags = gotags or set()
         kwargs["gotags"] = select({

--- a/cmd/loader/BUILD.bazel
+++ b/cmd/loader/BUILD.bazel
@@ -1,16 +1,20 @@
 """The trace loader."""
 
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 load(
     "@rules_pkg//pkg:mappings.bzl",
     "pkg_attributes",
     "pkg_files",
 )
+load("//bazel/rules/go:go_binary.bzl", "dd_agent_go_binary")
+load("//tasks:build_tags.bzl", "LOADER_TAGS")
 
 package(default_visibility = ["//packages:__subpackages__"])
 
 pkg_files(
-    name = "trace_loader",
+    name = "trace_loader_all_files",
+    # Temporary: Point to prebuilt trace_loader. When we can stamp module deps
+    # in the file, swap to :next_loader and rename that as trace-loader.
     srcs = select({
         "//packages/agent:linux_default": [
             "@trace_loader_binary//:trace_loader",
@@ -23,6 +27,9 @@ pkg_files(
         "//packages/agent:linux_heroku": [
             "main_noop.sh",
         ],
+        "@platforms//os:macos": [
+            "@trace_loader_binary//:trace_loader",
+        ],
         "//conditions:default": [],
     }),
     attributes = pkg_attributes(mode = "755"),
@@ -31,7 +38,6 @@ pkg_files(
         "//packages/agent:linux_heroku": {":main_noop.sh": "trace-loader"},
         "//conditions:default": {},
     }),
-    target_compatible_with = ["@platforms//os:linux"],
 )
 
 go_library(
@@ -108,13 +114,17 @@ go_library(
     }),
 )
 
-go_binary(
-    name = "loader",
+# This is what we will use in the
+dd_agent_go_binary(
+    name = "next_loader",
     embed = [":loader_lib"],
-    gotags = ["linux_bpf"],  # keep
-    # keep
+    # LOADER_TAGS is actually empty. We're including it to keep a consistent style.
+    exact_gotags = list(LOADER_TAGS) + select({
+        "@platforms//os:linux": ["linux_bpf"],
+        "//conditions:default": [],
+    }),
     target_compatible_with = select({
-        "@platforms//os:linux": [],
-        "//conditions:default": ["@platforms//:incompatible"],
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
     }),
 )

--- a/cmd/loader/BUILD.bazel
+++ b/cmd/loader/BUILD.bazel
@@ -14,7 +14,7 @@ package(default_visibility = ["//packages:__subpackages__"])
 pkg_files(
     name = "trace_loader_all_files",
     # Temporary: Point to prebuilt trace_loader. When we can stamp module deps
-    # in the file, swap to :next_loader and rename that as trace-loader.
+    # in the file, swap to :loader and rename that as trace-loader.
     srcs = select({
         "//packages/agent:linux_default": [
             "@trace_loader_binary//:trace_loader",
@@ -114,9 +114,9 @@ go_library(
     }),
 )
 
-# This is what we will use in the
+# TODO(ABLD-294): Rename to trace-loader and use this instead of @trace_loader_binary//:trace_loader
 dd_agent_go_binary(
-    name = "next_loader",
+    name = "loader",
     embed = [":loader_lib"],
     # LOADER_TAGS is actually empty. We're including it to keep a consistent style.
     exact_gotags = list(LOADER_TAGS) + select({

--- a/packages/agent/product/BUILD.bazel
+++ b/packages/agent/product/BUILD.bazel
@@ -37,7 +37,6 @@ pkg_filegroup(
         # TODO: sysprobe - windows
         # TODO: systray - windows
         # TODO: installer
-        "//cmd/loader:trace_loader",
         ":dda_built_trace_agent_binary",
         ":dda_built_process_agent_binary",
         ":dda_built_privateactionrunner_binary",
@@ -62,10 +61,13 @@ pkg_filegroup(
             "//pkg/procmgr/rust:all_files_linux",
         ],
         "//packages/agent:linux_heroku": [],
-        "//conditions:default": [
-        ],
+        "//conditions:default": [],
     }) + select({
+        "@platforms//os:linux": [
+            "//cmd/loader:trace_loader_all_files",
+        ],
         "@platforms//os:macos": [
+            "//cmd/loader:trace_loader_all_files",
             "//packages/macos/app:all_files",
             # TODO: systray
         ],


### PR DESCRIPTION
### What does this PR do?

Fix build file for cmd/loader so it can also build for macos.
- Remove unneeded target_compatible_with
- Adjust packaging to include it for macos.
- Fix dd_agent_go_binary so we can select() `exact_gotags`

We are blocked on ABLD-294 for using the loader in the real package, so we just have it named "loader" for now. We can build and verify that it works.

### Describe how you validated your changes
Make sure the loader builds and runs on mac.  Running it is subtle.
```
$ bazel build //cmd/trace-agent:trace-agent
Target //cmd/trace-agent:trace-agent up-to-date:
  bazel-bin/cmd/trace-agent/trace-agent_/trace-agent
INFO: Build completed successfully, 1 total action
$ cp bazel-bin/cmd/trace-agent/trace-agent_/trace-agent /tmp
$ bazel build //cmd/loader:loader
Target //cmd/loader:loader up-to-date:
  bazel-bin/cmd/loader/loader_/loader
$ bazel-bin/cmd/loader/loader_/loader /opt/datadog-agent/etc/datadog.yaml /tmp/trace-agent
...
2026-08-11 14:45:52 EDT | TRACE-LOADER | INFO | (pkg/util/log/log.go:734 in func1) | Starting to load the configuration
2026-08-11 14:45:52 EDT | TRACE-LOADER | ERROR | (pkg/util/log/log.go:815 in func1) | warning reading config
...
### Additional Notes