### PR TITLE
fix(remoteagent): avoid /dev/vsock dependency in RAR vsock listener

### DIFF
--- a/comp/core/remoteagent/helper/serverhelper.go
+++ b/comp/core/remoteagent/helper/serverhelper.go
@@ -81,8 +81,12 @@ func NewUnimplementedRemoteAgentServer(ipcComp ipc.Component, log log.Component,
 	// remote agent runs in a separate guest VM from the core agent, so the callback listener
 	// (used for status/flare/telemetry pulls) must also be reachable over AF_VSOCK.
 	listenURI := "https://127.0.0.1:0"
-	if config.GetString("vsock_addr") != "" {
-		listenURI = "vsock://0"
+	if vsockAddr := config.GetString("vsock_addr"); vsockAddr != "" {
+		cid, err := discoverLocalVSockCID(vsockAddr, agentIpcAddress)
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine local vsock context ID: %w", err)
+		}
+		listenURI = fmt.Sprintf("vsock://%d:0", cid)
 	}
 	ral, err := buildRemoteAgentListener(listenURI)
 	if err != nil {
@@ -273,6 +277,37 @@ type remoteAgentListener struct {
 	cleanupSocketPath string
 }
 
+// discoverLocalVSockCID learns our own vsock context ID without opening /dev/vsock. AF_VSOCK's
+// CID is fixed per-VM, so a successful outbound connection to the core agent (which we need to
+// reach anyway to register) reports our real CID via getsockname() on the resulting *vsock.Conn.
+func discoverLocalVSockCID(vsockAddr, agentIpcAddress string) (uint32, error) {
+	peerCID, err := socket.ParseVSockAddress(vsockAddr)
+	if err != nil {
+		return 0, err
+	}
+
+	_, portStr, err := net.SplitHostPort(agentIpcAddress)
+	if err != nil {
+		return 0, err
+	}
+	port, err := strconv.ParseUint(portStr, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid vsock port %q: %w", portStr, err)
+	}
+
+	conn, err := vsock.Dial(peerCID, uint32(port), &vsock.Config{})
+	if err != nil {
+		return 0, err
+	}
+	defer conn.Close()
+
+	addr, ok := conn.LocalAddr().(*vsock.Addr)
+	if !ok {
+		return 0, fmt.Errorf("unexpected vsock local address type %T", conn.LocalAddr())
+	}
+	return addr.ContextID, nil
+}
+
 // buildRemoteAgentListener creates the inbound listener for a remote agent and computes
 // the api_endpoint_uri that should be advertised to the Core Agent.
 //
@@ -316,13 +351,24 @@ func buildRemoteAgentListener(listenURI string) (*remoteAgentListener, error) {
 		// so we refuse to set up a server that advertises plaintext to the registry.
 		return nil, errors.New("http:// scheme is not supported on the remote agent server side (use https:// or unix://)")
 	case "vsock":
-		port, err := strconv.ParseUint(rest, 10, 32)
+		cidStr, portStr, err := net.SplitHostPort(rest)
+		if err != nil {
+			return nil, fmt.Errorf("invalid vsock listen URI %q: %w", listenURI, err)
+		}
+		cid, err := strconv.ParseUint(cidStr, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid vsock listen URI %q: invalid context ID: %w", listenURI, err)
+		}
+		port, err := strconv.ParseUint(portStr, 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("invalid vsock listen URI %q: invalid port: %w", listenURI, err)
 		}
-		l, err := vsock.Listen(uint32(port), &vsock.Config{})
+		// ListenContextID with an explicit CID never opens /dev/vsock (unlike Listen, which
+		// auto-detects the CID via that device); the CID here is the caller's real, already
+		// known context ID, obtained by discoverLocalVSockCID.
+		l, err := vsock.ListenContextID(uint32(cid), uint32(port), &vsock.Config{})
 		if err != nil {
-			return nil, fmt.Errorf("failed to listen on vsock port %d: %w", port, err)
+			return nil, fmt.Errorf("failed to listen on vsock cid %d port %d: %w", cid, port, err)
 		}
 		addr, ok := l.Addr().(*vsock.Addr)
 		if !ok {

--- a/comp/core/remoteagent/helper/serverhelper_test.go
+++ b/comp/core/remoteagent/helper/serverhelper_test.go
@@ -138,7 +138,7 @@ func TestBuildRemoteAgentListener(t *testing.T) {
 	})
 
 	t.Run("vsock", func(t *testing.T) {
-		ral, err := buildRemoteAgentListener("vsock://0")
+		ral, err := buildRemoteAgentListener("vsock://3:0")
 		if err != nil {
 			t.Skipf("AF_VSOCK not available in this environment: %v", err)
 		}
@@ -146,11 +146,22 @@ func TestBuildRemoteAgentListener(t *testing.T) {
 
 		assert.Empty(t, ral.cleanupSocketPath)
 		assert.True(t, strings.HasPrefix(ral.apiEndpointURI, "vsock://"), "got %q", ral.apiEndpointURI)
-		assert.NotEqual(t, "vsock://0", ral.apiEndpointURI, "random port should be resolved")
+		assert.NotEqual(t, "vsock://3:0", ral.apiEndpointURI, "random port should be resolved")
+	})
+
+	t.Run("vsock_missing_cid", func(t *testing.T) {
+		_, err := buildRemoteAgentListener("vsock://0")
+		require.Error(t, err)
+	})
+
+	t.Run("vsock_invalid_cid", func(t *testing.T) {
+		_, err := buildRemoteAgentListener("vsock://not-a-cid:0")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid context ID")
 	})
 
 	t.Run("vsock_invalid_port", func(t *testing.T) {
-		_, err := buildRemoteAgentListener("vsock://not-a-port")
+		_, err := buildRemoteAgentListener("vsock://3:not-a-port")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid port")
 	})


### PR DESCRIPTION
## What does this PR do?

The Remote Agent Registry's vsock listener called `vsock.Listen()`, which auto-detects the local context ID by opening `/dev/vsock` and issuing an ioctl. On kata/microVM clusters where `/dev/vsock` isn't exposed to the system-probe container, this crashes RAR startup with `failed to listen on vsock port 0: listen vsock: open /dev/vsock: no such file or directory`.

This switches to `vsock.ListenContextID` with an explicit context ID, the same pattern already used by `pkg/security/utils/grpc/grpc.go` for CWS's vsock gRPC server — that function also avoids `Listen()`'s device-based auto-detection in favor of passing a known CID directly to `ListenContextID`. The difference here is where that CID comes from: CWS's server runs on the VM host, so it can just use the well-known `vsock.Host` constant. RAR's listener runs on the guest side (system-probe), so there's no equivalent well-known constant for "myself" — instead, a short-lived `vsock.Dial()` to the core agent (the same peer RAR already needs to reach to register) is used to learn the real local context ID via `getsockname()`, since a successful `Dial` populates that without ever touching `/dev/vsock`. That real CID is then used both to bind the listener and to compute the `api_endpoint_uri` advertised to the core agent, so status/flare/telemetry callbacks stay reachable.

## Motivation

Fix system-probe crashing on vsock-enabled clusters where `/dev/vsock` isn't exposed to its container:
https://ddstaging.datadoghq.com/logs?query=%22Error%3A%20failed%20to%20listen%20on%20vsock%20port%200%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ_xyDZd8if5WQAAABhBWl94eUVZb0FBQlJXWGFCc2RYM2dBQTcAAAAkZjE5ZmYxY2ItZWE5Ny00YmU1LTk0OGEtYTQyZTg5NTU5ZTViAAk6PA&fromUser=true&index=datadog-agent&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1786453461070&to_ts=1786467861070&live=false

## Describe how you validated your changes

- Validated the underlying `ListenContextID`/`Dial` mechanics on a Linux VM (colima): confirmed `ListenContextID` with both `VMADDR_CID_ANY` and a specific real CID succeeds inside a container lacking `/dev/vsock` (with a seccomp profile permitting `AF_VSOCK`), and confirmed `vsock.Dial()` populates the real local CID via `getsockname()` on a successful connect without opening `/dev/vsock`.
