### PR TITLE
Add DD_LOG_LEVEL install-time option

### DIFF
--- a/pkg/fleet/installer/setup/common/setup.go
+++ b/pkg/fleet/installer/setup/common/setup.go
@@ -104,6 +104,7 @@ Running the %s installation script (https://github.com/DataDog/datadog-agent/tre
 				APIKey:   os.Getenv("DD_API_KEY"),
 				Hostname: os.Getenv("DD_HOSTNAME"),
 				Site:     os.Getenv("DD_SITE"),
+				LogLevel: os.Getenv("DD_LOG_LEVEL"),
 				Proxy: config.DatadogConfigProxy{
 					HTTP:    os.Getenv("DD_PROXY_HTTP"),
 					HTTPS:   os.Getenv("DD_PROXY_HTTPS"),

--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -81,6 +81,7 @@ type DatadogConfig struct {
 	APIKey               string                     `yaml:"api_key,omitempty"`
 	Hostname             string                     `yaml:"hostname,omitempty"`
 	Site                 string                     `yaml:"site,omitempty"`
+	LogLevel             string                     `yaml:"log_level,omitempty"`
 	Proxy                DatadogConfigProxy         `yaml:"proxy,omitempty"`
 	Env                  string                     `yaml:"env,omitempty"`
 	Tags                 []string                   `yaml:"tags,omitempty"`

--- a/pkg/fleet/installer/setup/defaultscript/default_script.go
+++ b/pkg/fleet/installer/setup/defaultscript/default_script.go
@@ -52,6 +52,7 @@ var (
 	supportedEnvVars = []string{
 		"DD_ENV",
 		"DD_SITE",
+		"DD_LOG_LEVEL",
 		"DD_TAGS",
 		"DD_HOST_TAGS",
 		"DD_URL",

--- a/releasenotes/notes/add-msi-dd-log-level-4f98815e4ac5ccb1.yaml
+++ b/releasenotes/notes/add-msi-dd-log-level-4f98815e4ac5ccb1.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The Datadog installer's setup script now accepts a ``DD_LOG_LEVEL``
+    environment variable to set the ``log_level`` option in ``datadog.yaml``
+    at install time. On Windows, the Agent MSI installer also exposes a
+    ``DD_LOG_LEVEL`` property and passes it through to the Datadog installer.

--- a/test/e2e-framework/components/datadog/agentparams/msi/install_params.go
+++ b/test/e2e-framework/components/datadog/agentparams/msi/install_params.go
@@ -20,6 +20,7 @@ type InstallAgentParams struct {
 	Site              string `installer_arg:"SITE"`
 	InstallPath       string `installer_arg:"PROJECTLOCATION"`
 	InstallLogFile    string `installer_arg:"/log"`
+	LogLevel          string `installer_arg:"DD_LOG_LEVEL"`
 }
 
 // InstallAgentOption is an optional function parameter type for InstallAgentParams options
@@ -106,5 +107,12 @@ func WithFakeIntake(fakeIntake *fakeintake.FakeintakeOutput) InstallAgentOption 
 func WithCustomInstallPath(installPath string) InstallAgentOption {
 	return func(i *InstallAgentParams) {
 		i.InstallPath = installPath
+	}
+}
+
+// WithLogLevel specifies the DD_LOG_LEVEL parameter.
+func WithLogLevel(logLevel string) InstallAgentOption {
+	return func(i *InstallAgentParams) {
+		i.LogLevel = logLevel
 	}
 }

--- a/test/new-e2e/tests/windows/common/agent/agent_install_params.go
+++ b/test/new-e2e/tests/windows/common/agent/agent_install_params.go
@@ -366,3 +366,11 @@ func WithInstallOnly(installOnly string) InstallAgentOption {
 		return nil
 	}
 }
+
+// WithLogLevel specifies the DD_LOG_LEVEL parameter.
+func WithLogLevel(logLevel string) InstallAgentOption {
+	return func(i *InstallAgentParams) error {
+		i.InstallAgentParams.LogLevel = logLevel
+		return nil
+	}
+}

--- a/tools/windows/DatadogAgentInstaller/CustomActions/InstallOciPackages.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/InstallOciPackages.cs
@@ -19,6 +19,7 @@ namespace Datadog.CustomActions
         private readonly string _overrideRegistryUrl;
         private readonly string _remoteUpdates;
         private readonly string _infrastructureMode;
+        private readonly string _logLevel;
         private readonly RollbackDataStore _rollbackDataStore;
 
         public InstallOciPackages(ISession session)
@@ -30,6 +31,7 @@ namespace Datadog.CustomActions
             _overrideRegistryUrl = session.Property("DD_INSTALLER_REGISTRY_URL");
             _remoteUpdates = session.Property("DD_REMOTE_UPDATES");
             _infrastructureMode = session.Property("DD_INFRASTRUCTURE_MODE");
+            _logLevel = session.Property("DD_LOG_LEVEL");
             _installerExecutable = System.IO.Path.Combine(installDir, "bin", "datadog-installer.exe");
             _rollbackDataStore = new RollbackDataStore(session, "InstallOciPackages", new FileSystemServices(), new ServiceController());
         }
@@ -100,6 +102,11 @@ namespace Datadog.CustomActions
             if (!string.IsNullOrEmpty(_infrastructureMode))
             {
                 env["DD_INFRASTRUCTURE_MODE"] = _infrastructureMode;
+            }
+
+            if (!string.IsNullOrEmpty(_logLevel))
+            {
+                env["DD_LOG_LEVEL"] = _logLevel;
             }
 
             var appKey = _session.Property("DD_APP_KEY");

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -537,6 +537,7 @@ namespace WixSetup.Datadog_Agent
             .SetProperties("PROJECTLOCATION=[PROJECTLOCATION]," +
                            "APIKEY=[APIKEY]," +
                            "SITE=[SITE]," +
+                           "DD_LOG_LEVEL=[DD_LOG_LEVEL]," +
                            "DD_INSTALLER_REGISTRY_URL=[DD_INSTALLER_REGISTRY_URL]," +
                            "DD_APM_INSTRUMENTATION_ENABLED=[DD_APM_INSTRUMENTATION_ENABLED]," +
                            "DD_APM_INSTRUMENTATION_LIBRARIES=[DD_APM_INSTRUMENTATION_LIBRARIES]," +

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
@@ -104,6 +104,10 @@ namespace WixSetup.Datadog_Agent
                 {
                     AttributesDefinition = "Secure=yes"
                 },
+                new Property("DD_LOG_LEVEL")
+                {
+                    AttributesDefinition = "Secure=yes"
+                },
                 // Custom WindowsBuild property since MSI caps theirs at 9600
                 new Property("DDAGENT_WINDOWSBUILD")
                 {


### PR DESCRIPTION
### What does this PR do?

Adds a `DD_LOG_LEVEL` install-time option to set the initial `log_level` in `datadog.yaml`:
- The Datadog installer's setup script now maps a `DD_LOG_LEVEL` environment variable to `datadog.yaml`'s `log_level` (cross-platform, in `pkg/fleet/installer/setup`).
- On Windows, the Agent MSI installer exposes a `DD_LOG_LEVEL` property (declared secure so it survives into the elevated deferred custom action) that's passed through to the Datadog installer.
- Adds matching `WithLogLevel` e2e test install options in both `msi.InstallAgentParams` and `windowsAgent.InstallAgentParams`.

### Motivation

https://datadoghq.atlassian.net/browse/WINA-3019

Windows E2E tests currently have no easy way to run the installed Agent at `debug` log level for better diagnostics when a test fails. This gives tests (and customers) a one-shot way to set it at install time instead of editing `datadog.yaml` or using a runtime `agent config set` call after the fact.

### Describe how you validated your changes
