### PR TITLE
[ABLD-419]  Only install bazelisk with dda inv install-tools on macos

### DIFF
--- a/tasks/install_tasks.py
+++ b/tasks/install_tasks.py
@@ -12,7 +12,6 @@ from tasks.libs.common.go import download_go_dependencies
 from tasks.libs.common.utils import environ, get_gobin, gitlab_section, link_or_copy
 
 TOOL_LIST = [
-    'github.com/bazelbuild/bazelisk',
     'github.com/frapposelli/wwhrd',
     'github.com/go-enry/go-license-detector/v4/cmd/license-detector',
     'github.com/golangci/golangci-lint/v2/cmd/golangci-lint',
@@ -23,6 +22,11 @@ TOOL_LIST = [
     'github.com/uber-go/gopatch',
     'github.com/aarzilli/whydeadcode',
 ]
+
+# TODO: Fix the build images.
+# For some reason, bazelisk is not pre-installed on our macos images.
+if sys.platform.startswith('darwin'):
+    TOOL_LIST.append('github.com/bazelbuild/bazelisk')
 
 TOOLS = {
     'internal/tools': TOOL_LIST,


### PR DESCRIPTION
### What does this PR do?
Cuts bazelisk out of tasks/install_tools. Except on mac, because for some reason it is not in the build image.

### Motivation
We should not be installing bazelisk from tasks. That muddies the chain to source of trust because bazel is the root of the trusted tools. Bazelisk should come with the build image or be installed in some other trusted way.

### Describe how you validated your changes
CI

### Additional notes
Related: ABLD-306

This may break some individual users where bazelisk is not installed on the developer machine.
That is desired. I want to find those cases and find ways to better manage their environment.
