### PR TITLE
Bump AIX embedded Python to 3.13.15

### DIFF
--- a/packaging/aix/lib/env.sh
+++ b/packaging/aix/lib/env.sh
@@ -11,7 +11,7 @@
 # any variable before sourcing this file.
 
 # ── Python version ────────────────────────────────────────────────────────────
-PYTHON_VERSION="3.13.14"
+PYTHON_VERSION="3.13.15"
 PYTHON_MAJ_MIN="${PYTHON_VERSION%.*}"   # e.g. 3.13
 export PYTHON_VERSION PYTHON_MAJ_MIN
 


### PR DESCRIPTION
### What does this PR do?

Bumps the AIX embedded Python pin from 3.13.14 to 3.13.15 in `packaging/aix/lib/env.sh`.

### Motivation

The AIX packaging build pins the embedded Python version in `packaging/aix/lib/env.sh`, and `packaging/aix/stages/02-python.sh` downloads and builds CPython from that value. This file is **not** touched by `dda inv python-version.update`, so the 3.13.15 upgrade (#54723) left AIX on 3.13.14 — meaning the AIX artifact would ship the vulnerable patch version while the rest of the platforms move to 3.13.15. This was flagged by Codex review on #54723 and confirmed by @aiuto.

`02-python.sh` downloads the source tarball from python.org over `curl` with no pinned checksum and applies AIX patches via `sed` with graceful fallback, so the version string is the only change required for a patch bump.

### Describe how you validated your changes

- Verified `packaging/aix/stages/02-python.sh` derives the tarball name, URL, and source dir entirely from `$PYTHON_VERSION` and performs no checksum verification, so no hash needs updating.
- Confirmed `packaging/` has no other hardcoded `3.13.14` reference after the change.

### Additional Notes

Companion to the main 3.13.15 upgrade in #54723; the "embedded Python upgraded from 3.13.14 to 3.13.15" release note in that PR covers this change for the AIX platform, so no separate release note is added here.
