### PR TITLE
fix(config): suppress false-positive unknown-key warnings for sysprobe

### DIFF
--- a/pkg/config/buildschema/config.go
+++ b/pkg/config/buildschema/config.go
@@ -74,6 +74,10 @@ func (b *builder) BindEnvAndSetDefault(key string, val interface{}, env ...strin
 	b.addToSchema(key, val, env, false)
 }
 
+func (b *builder) SetKnown(_ string) {
+	// no-op: the schema builder does not need to track known keys separately
+}
+
 func (b *builder) BuildSchema() {
 }
 

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -264,6 +264,11 @@ type Setup interface {
 	// config key
 	BindEnvAndSetDefault(key string, val interface{}, env ...string)
 
+	// SetKnown marks a key as known without setting a default value or env binding.
+	// Use this to suppress false-positive "unknown key" warnings for keys that are
+	// valid in a sibling process config (e.g. system-probe keys read by the core agent).
+	SetKnown(key string)
+
 	AddConfigPath(in string)
 	AddExtraConfigPaths(in []string) error
 	SetConfigName(in string)

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -453,6 +453,13 @@ func (c *ntmConfig) parentOfNode(node *nodeImpl, key string) (*nodeImpl, string,
 	return node, lastPart, nil
 }
 
+// SetKnown marks a key as known without setting a default value or env binding.
+func (c *ntmConfig) SetKnown(key string) {
+	c.Lock()
+	defer c.Unlock()
+	c.addToKnownKeys(strings.ToLower(key))
+}
+
 func (c *ntmConfig) addToKnownKeys(key string) {
 	if _, ok := c.knownKeys[key]; ok {
 		return

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -2057,6 +2057,29 @@ func TestSetDefaultAfterRevertToBuilder(t *testing.T) {
 	assert.Equal(t, "v2", cfg.GetString("ns.new"))
 }
 
+func TestSetKnown(t *testing.T) {
+	cfg := NewNodeTreeConfig("test", "TEST", nil)
+	cfg.SetDefault("has_default", 42)
+	cfg.SetKnown("known_only")
+	cfg.SetKnown("known_only.nested")
+	cfg.BuildSchema()
+
+	// SetKnown key is recognised
+	assert.True(t, cfg.IsKnown("known_only"))
+	assert.True(t, cfg.IsKnown("known_only.nested"))
+
+	// SetKnown does not set a default value
+	assert.Nil(t, cfg.Get("known_only"))
+	assert.Nil(t, cfg.Get("known_only.nested"))
+
+	// SetKnown key does not appear in AllSettings (no value in any layer)
+	_, found := cfg.AllSettings()["known_only"]
+	assert.False(t, found)
+
+	// Regular default key is unaffected
+	assert.Equal(t, 42, cfg.Get("has_default"))
+}
+
 func BenchmarkMaybeRebuildUnchangedEnv(b *testing.B) {
 	cfg := NewNodeTreeConfig("test", "TEST", nil)
 	cfg.SetTestOnlyDynamicSchema(true)

--- a/pkg/config/setup/BUILD.bazel
+++ b/pkg/config/setup/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "config_windows.go",
         "constants_compat.go",
         "fixup_init.go",
+        "known_only_setup.go",
         "otlp.go",
         "privateactionrunner.go",
         "process.go",

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -142,6 +142,10 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	initCommonBase(config)
 	// Settings just for the full agent in general
 	initCoreAgentFull(config)
+	// Register system-probe keys as known so that checkKnownKey does not emit
+	// false-positive warnings when the core agent reads a datadog.yaml that
+	// contains system_probe_config.*, network_config.*, etc. sections.
+	InitSystemProbeConfig(&knownOnlySetup{inner: config})
 
 	processesAddOverrideOnce.Do(func() {
 		pkgconfigmodel.AddOverrideFunc(loadProcessTransforms)

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -1625,6 +1625,42 @@ func TestServerlessConfigInit(t *testing.T) {
 	assert.Equal(t, 2, conf.GetInt("ol_proxy_config.api_version"))
 }
 
+// TestInitConfigRegistersSystemProbeKeysAsKnown verifies that InitConfig registers
+// system-probe schema keys as known in the core agent config so that checkKnownKey
+// does not emit false-positive warnings when the core agent reads a datadog.yaml
+// that contains system_probe_config.*, network_config.*, etc. sections.
+// Regression test for https://github.com/DataDog/datadog-agent/issues/54747.
+func TestInitConfigRegistersSystemProbeKeysAsKnown(t *testing.T) {
+	conf := newEmptyMockConf(t)
+	InitConfig(conf)
+
+	// Keys from the bug report must be known after InitConfig.
+	for _, key := range []string{
+		"system_probe_config.enable_oom_kill",
+		"system_probe_config.enable_co_re",
+		"system_probe_config.enable_runtime_compiler",
+		"system_probe_config.enable_kernel_header_download",
+		"system_probe_config.allow_prebuilt_fallback",
+		"system_probe_config.telemetry_enabled",
+		"system_probe_config.max_conns_per_message",
+		"network_config.collect_tcp_v4",
+		"network_config.collect_tcp_v6",
+		"network_config.collect_udp_v4",
+		"network_config.collect_udp_v6",
+		"network_config.enable_protocol_classification",
+		"network_config.enable_gateway_lookup",
+		"network_config.enable_root_netns",
+		"runtime_security_config.enabled",
+		"service_monitoring_config.enabled",
+	} {
+		assert.True(t, conf.IsKnown(key), "expected system-probe key %q to be known in core agent config", key)
+	}
+
+	// System-probe keys must not have defaults set in the core agent config.
+	assert.Nil(t, conf.Get("system_probe_config.enable_oom_kill"))
+	assert.Nil(t, conf.Get("network_config.collect_tcp_v4"))
+}
+
 func TestDisableCoreAgent(t *testing.T) {
 	pkgconfigmodel.CleanOverride(t)
 	conf := newEmptyMockConf(t)

--- a/pkg/config/setup/known_only_setup.go
+++ b/pkg/config/setup/known_only_setup.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package setup
+
+import (
+	"strings"
+
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+// knownOnlySetup wraps a Setup and forwards only SetKnown calls, ignoring
+// defaults, env bindings, and all other schema-building operations.
+// It is used to register system-probe config keys as known in the core agent
+// config so that checkKnownKey does not emit false-positive warnings when the
+// core agent reads a datadog.yaml that contains system-probe sections.
+type knownOnlySetup struct {
+	inner pkgconfigmodel.Setup
+}
+
+func (k *knownOnlySetup) SetDefault(key string, _ interface{}) {
+	k.inner.SetKnown(strings.ToLower(key))
+}
+
+func (k *knownOnlySetup) BindEnvAndSetDefault(key string, _ interface{}, _ ...string) {
+	k.inner.SetKnown(strings.ToLower(key))
+}
+
+func (k *knownOnlySetup) SetKnown(key string)                                                      { k.inner.SetKnown(key) }
+func (k *knownOnlySetup) BuildSchema()                                                              {}
+func (k *knownOnlySetup) SetEnvPrefix(_ string)                                                    {}
+func (k *knownOnlySetup) SetEnvKeyReplacer(_ *strings.Replacer)                                    {}
+func (k *knownOnlySetup) ParseEnvSplitComma(_ string)                                              {}
+func (k *knownOnlySetup) ParseEnvSplitSpace(_ string)                                              {}
+func (k *knownOnlySetup) ParseEnvJSON(_ string, _ any)                                             {}
+func (k *knownOnlySetup) ParseEnvAsStringSlice(_ string, _ func(string) []string)                 {}
+func (k *knownOnlySetup) ParseEnvAsMapStringInterface(_ string, _ func(string) map[string]interface{}) {
+}
+func (k *knownOnlySetup) AddConfigPath(_ string)               {}
+func (k *knownOnlySetup) AddExtraConfigPaths(_ []string) error { return nil }
+func (k *knownOnlySetup) SetConfigName(_ string)               {}
+func (k *knownOnlySetup) SetConfigFile(_ string)               {}
+func (k *knownOnlySetup) SetConfigType(_ string)               {}


### PR DESCRIPTION
The core agent's ntmConfig emits WARN log lines for config keys that are fully valid and schema-registered, but are only declared via InitSystemProbeConfig (called on the systemProbe config instance, not on the datadog config instance). When the core agent reads a datadog.yaml that contains system_probe_config.*, network_config.*, runtime_security_config.*, or service_monitoring_config.* sections, every Get* call on those keys triggers checkKnownKey to log a false-positive warning.

Fix:
- Add SetKnown(key string) to the model.Setup interface and implement it on ntmConfig (calls addToKnownKeys without setting a default or env binding) and on the buildschema builder (no-op).
- Add knownOnlySetup, a thin Setup wrapper that forwards SetDefault and BindEnvAndSetDefault as SetKnown calls, discarding defaults and env bindings.
- In InitConfig, call InitSystemProbeConfig(&knownOnlySetup{inner: config}) so that every key declared by the system-probe schema is registered as known in the core agent config without polluting its defaults tree.

Tests:
- TestSetKnown: unit test for the new SetKnown method on ntmConfig.
- TestInitConfigRegistersSystemProbeKeysAsKnown: regression test that would have caught the bug; asserts all keys from issue #54747 are known after InitConfig and that none have defaults set.

Fixes #54747

<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Adds SetKnown(key string) to the model.Setup interface and registers all system-probe schema keys as known in the core agent config during InitConfig, via a thin knownOnlySetup wrapper that discards defaults and env bindings.

### Motivation

Fixes #54747. The core agent logs false-positive WARN | config key X is unknown messages for keys such as system_probe_config.enable_oom_kill, network_config.collect_tcp_v4, runtime_security_config.enabled, and service_monitoring_config.enabled on every start, even with no system-probe.yaml present. These keys are fully valid and present in pkg/config/schema/yaml/system-probe_schema.yaml, but checkKnownKey only consults knownKeys, which is populated by BindEnvAndSetDefault/SetDefault. Because InitSystemProbeConfig is only called on the systemProbe config instance, the core agent's ntmConfig has no entries for any system-probe-owned key.

### Describe how you validated your changes

- TestInitConfigRegistersSystemProbeKeysAsKnown (new): calls InitConfig and asserts every key from the bug report is known and has no default set in the core agent config. This test would have failed before this fix.
- TestSetKnown (new): unit-tests the new SetKnown method on ntmConfig directly.
- Existing TestAgentConfigInit, TestServerlessConfigInit, and the full pkg/config/setup, pkg/config/nodetreemodel, and pkg/config/buildschema test suites were run locally and pass.

### Additional Notes

knownOnlySetup is intentionally not exported. It is a one-call-site adapter whose only purpose is to translate InitSystemProbeConfig's schema-building calls into SetKnown calls on the core agent config. The system-probe defaults tree is not affected.
