### PR TITLE
fix(logs): score timestamps on window density, not run average

### DIFF
--- a/pkg/logs/internal/decoder/preprocessor/BUILD.bazel
+++ b/pkg/logs/internal/decoder/preprocessor/BUILD.bazel
@@ -94,6 +94,7 @@ dd_agent_go_test(
         "sampler_test.go",
         "stack_trace_aggregator_test.go",
         "timestamp_detector_test.go",
+        "token_graph_benchmark_test.go",
         "token_graph_test.go",
         "tokenizer_benchmark_test.go",
         "tokenizer_test.go",

--- a/pkg/logs/internal/decoder/preprocessor/timestamp_detector_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/timestamp_detector_test.go
@@ -52,6 +52,16 @@ var inputs = []testInput{
 	// A case where the timestamp has a non-matching token in the midddle of it.
 	{startGroup, "acb def 10:10:10 foo 2024-05-15 hijk lmop"},
 
+	// IIS W3C extended log format. Every record is a complete single-line entry prefixed
+	// with a timestamp, so each one must start its own group. What makes these interesting
+	// is the client address field: an address tokenizing to DD.D.DD.DD keeps the largest
+	// subsequence growing well past the timestamp, so averaging over that subsequence
+	// scores the line at exactly the 0.5 default threshold instead of 1.0.
+	{startGroup, "2026-08-11 10:34:49 W3SVC1 10.1.48.10 GET /ZenIT/Service/v13/core/Consent land=DE 443 ndl\\SVC-Zenit-NDL0167 10.1.48.122 Mozilla/5.0 200 0 0 19571 1051"},
+	{startGroup, "2026-08-11 10:34:50 W3SVC1 10.1.48.10 POST /ZenIT/Service/v13/core/Logger - 443 ndl\\SVC-Zenit-NDL0167 10.1.48.122 Mozilla/5.0 204 0 0 504 6"},
+	{startGroup, "2026-08-11 10:34:49 W3SVC1 fe80::b045:52da:3136:3f1c%3 GET /ZenIT/Service/v13/colibriApi/api/Auftrag/Reklamation 443 NDL\\SVC-Zenit-NDL0167 - 200 0 0 945 7"},
+	{startGroup, "2026-08-11 10:34:51 W3SVC1 192.168.1.1 GET /ZenIT/Service/v13/core/Consent - 443 ndl\\SVC-Zenit-NDL0167 10.1.48.122 Mozilla/5.0 200 0 0 1586 51"},
+
 	// Likely do not contain timestamps for aggreagtion
 	{aggregate, "12:30:2017 - info App started successfully"},
 	{aggregate, "12:30:20 - info App started successfully"},

--- a/pkg/logs/internal/decoder/preprocessor/token_graph.go
+++ b/pkg/logs/internal/decoder/preprocessor/token_graph.go
@@ -51,27 +51,37 @@ func (m *TokenGraph) MatchProbability(ts []Token) MatchContext {
 		return MatchContext{}
 	}
 
-	lastToken := ts[0]
-	// A function used by maxSubsequence to look up a match in the graph for a pair of tokens.
+	// A function used to look up a match in the graph for the pair of tokens at idx. The
+	// transition at idx is fully determined by ts, so this is free of position state and may
+	// be called for any index, in any order, as many times as needed.
 	matchForIndex := func(idx int) int {
-		match := -1
-		if m.adjacencies[lastToken] != nil && m.adjacencies[lastToken][ts[idx+1]] {
-			match = 1
+		if m.adjacencies[ts[idx]] != nil && m.adjacencies[ts[idx]][ts[idx+1]] {
+			return 1
 		}
-		lastToken = ts[idx+1]
-		return match
+		return -1
 	}
 
 	// Look up each token transition and mark it with a 1 (match) or -1 (no match). From this
-	// we must compute the subsequences that have the highest probability of being a match.
+	// we must compute the subsequence that has the highest probability of being a match.
 	// This code may seem overcomplicated but it's designed this way to avoid allocating an additional buffer to
 	// store the matches while remaining testable and clear.
-	avg, start, end := maxSubsequence(len(ts)-1, matchForIndex)
+	//
+	// Scoring happens in two steps. The largest subsequence establishes that the input holds a
+	// run of transitions long enough, and matching enough, to be worth scoring at all. The
+	// density of the best window inside that run is then the probability. Reporting the
+	// average over the largest subsequence itself conflates the two: because the largest
+	// subsequence maximises the sum, it keeps absorbing stretches that sum positive even
+	// though they lower the average, so a perfectly matching timestamp is scored down by
+	// whatever happens to follow it on the line.
+	sumStart, sumEnd := maxSumSubsequence(len(ts)-1, matchForIndex)
 
-	// Reject sequences of tokens that are less than the minimum token length.
-	if end-start < m.minimumTokenLength {
+	// Reject sequences of tokens that are less than the minimum token length. The floor of 1
+	// keeps the window handed to maxAverageSubsequence non-empty when there is no minimum.
+	if sumEnd-sumStart < max(m.minimumTokenLength, 1) {
 		return MatchContext{}
 	}
+
+	avg, start, end := maxAverageSubsequence(sumStart, sumEnd, m.minimumTokenLength, matchForIndex)
 
 	return MatchContext{
 		probability: avg,
@@ -80,11 +90,12 @@ func (m *TokenGraph) MatchProbability(ts []Token) MatchContext {
 	}
 }
 
-// maxSubsequence is a modified Kadane’s Algorithm that returns the average, start, and end of the largest subsequence.
-// It takes a length of the target input, and a function used to look up values for each index.
-func maxSubsequence(length int, matchForIndex func(idx int) int) (float64, int, int) {
-	if length == 0 {
-		return 0, 0, 0
+// maxSumSubsequence is a modified Kadane’s Algorithm that returns the start and end (exclusive)
+// of the largest subsequence. It takes a length of the target input, and a function used to look
+// up values for each index.
+func maxSumSubsequence(length int, matchForIndex func(idx int) int) (int, int) {
+	if length <= 0 {
+		return 0, 0
 	}
 	maxSum := matchForIndex(0)
 	currentSum := maxSum
@@ -108,5 +119,81 @@ func maxSubsequence(length int, matchForIndex func(idx int) int) (float64, int, 
 		}
 	}
 	end++
-	return float64(maxSum) / float64(end-start), start, end
+	return start, end
+}
+
+// prefixRingCapacity is the stack allocated capacity of the prefix sum ring in
+// maxAverageSubsequence. A minLength past half of this falls back to the heap, which no caller
+// does today: minimumTokenLength is 8, needing 16 entries.
+const prefixRingCapacity = 64
+
+// maxAverageSubsequence returns the average, start, and end (exclusive) of the window within
+// [from, to) with the highest average value, among those at least minLength long. It takes a
+// function used to look up values for each index, called at most once per index in ascending
+// order, and every value it returns must be 1 or -1. If the range is shorter than minLength
+// there is no such window and it returns 0, from, to.
+//
+// Only windows shorter than 2*minLength are searched. Any longer window splits into two parts
+// that each satisfy the minimum, and a weighted average never exceeds both of its parts, so one
+// part always scores at least as high.
+func maxAverageSubsequence(from, to, minLength int, matchForIndex func(idx int) int) (float64, int, int) {
+	if minLength < 1 {
+		minLength = 1
+	}
+
+	// ring[i&mask] holds the sum of the values in [from, i). Windows reach back at most
+	// 2*minLength-1 values, so only the trailing 2*minLength sums are ever read, and the entry
+	// each iteration overwrites is always one older than that. The ring is rounded up to a
+	// power of two so that wrapping an index is a mask rather than an integer division.
+	size := 1
+	for size < 2*minLength {
+		size <<= 1
+	}
+	var scratch [prefixRingCapacity]int
+	var ring []int
+	if size <= prefixRingCapacity {
+		ring = scratch[:size]
+	} else {
+		ring = make([]int, size)
+	}
+	mask := size - 1
+	ring[from&mask] = 0
+
+	// The best window so far is kept as a sum over a length rather than a float so that
+	// comparing two candidates stays in integer arithmetic. Dividing once at the end instead of
+	// once per candidate matters: this runs for every log line that reaches the detector.
+	bestSum := 0
+	bestLen := 0
+	start := from
+	end := to
+	sum := 0
+
+	for i := from + 1; i <= to; i++ {
+		sum += matchForIndex(i - 1)
+		ring[i&mask] = sum
+
+		for windowLen := minLength; windowLen < 2*minLength && windowLen <= i-from; windowLen++ {
+			windowStart := i - windowLen
+			windowSum := sum - ring[windowStart&mask]
+			// windowSum/windowLen > bestSum/bestLen, without the division.
+			if bestLen == 0 || windowSum*bestLen > bestSum*windowLen {
+				bestSum = windowSum
+				bestLen = windowLen
+				start = windowStart
+				end = i
+			}
+		}
+
+		// Every value is 1 or -1, so an all-match window is the highest average there is and
+		// no later window can displace it. Most real timestamps are one, at the head of the
+		// line, which is exactly where stopping early saves the most.
+		if bestLen != 0 && bestSum == bestLen {
+			break
+		}
+	}
+
+	if bestLen == 0 {
+		return 0, from, to
+	}
+	return float64(bestSum) / float64(bestLen), start, end
 }

--- a/pkg/logs/internal/decoder/preprocessor/token_graph_benchmark_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/token_graph_benchmark_test.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package automultilinedetection contains auto multiline detection and aggregation logic.
+package preprocessor
+
+import "testing"
+
+// BenchmarkMatchProbability covers the shapes MatchProbability sees in the log pipeline: a
+// line rejected before it is scored, a line that is scored, and the longest input the
+// default tokenizer_max_input_bytes allows.
+func BenchmarkMatchProbability(b *testing.B) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"NoTimestamp", "[INFO] App started successfully"},
+		{"Timestamp", "2024-05-15 17:04:12,369 - root - DEBUG - handled the request"},
+		{"TimestampFollowedByAddress", "2026-08-11 10:34:49 W3SVC1 10.1.48.10 GET /svc/v13/core/Consent 443 - 200"},
+		{"MaxInputBytes", "1234567890 1234567890 1234567890 1234567890 1234567890 12345"},
+	}
+
+	tokenizer := NewTokenizer(60)
+	graph := makeStaticTokenGraph()
+
+	for _, c := range cases {
+		tokens, _ := tokenizer.Tokenize([]byte(c.input))
+		b.Run(c.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				graph.MatchProbability(tokens)
+			}
+		})
+	}
+}

--- a/pkg/logs/internal/decoder/preprocessor/token_graph_test.go
+++ b/pkg/logs/internal/decoder/preprocessor/token_graph_test.go
@@ -30,9 +30,15 @@ func TestExpectedMatch(t *testing.T) {
 
 	graph = NewTokenGraph(0, [][]Token{{1, 2, 3, 4, 5, 6}})
 	assert.Equal(t, float64(1), graph.MatchProbability([]Token{7, 2, 3, 4, 5, 8}).probability, "Input should match because unmatch tokens are trimmed")
+
+	// The transitions here are 1, 1, 1, 1, 1, -1, 1, 1, -1. Every one of them is inside the
+	// largest subsequence because the trailing run is net positive, so averaging over that
+	// subsequence reports 0.66 for an input that opens with a perfect match.
+	graph = NewTokenGraph(3, [][]Token{{1, 2, 3, 1}})
+	assert.Equal(t, float64(1), graph.MatchProbability([]Token{1, 2, 3, 1, 2, 3, 2, 3, 1, 3}).probability, "A perfect match should not be scored down by a net-positive suffix")
 }
 
-func TestMaxSubsequence(t *testing.T) {
+func TestMaxSumSubsequence(t *testing.T) {
 	tests := []struct {
 		input    []int
 		expected []int
@@ -49,10 +55,65 @@ func TestMaxSubsequence(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		_, start, end := maxSubsequence(len(test.input), func(idx int) int {
+		start, end := maxSumSubsequence(len(test.input), func(idx int) int {
 			return test.input[idx]
 		})
 
 		assert.Equal(t, test.expected, test.input[start:end])
 	}
+}
+
+func TestMaxAverageSubsequence(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []int
+		minLength   int
+		expected    []int
+		expectedAvg float64
+	}{
+		{"whole input is the only candidate", []int{1, 1, 1, 1, 1}, 5, []int{1, 1, 1, 1, 1}, 1},
+		{"no minimum picks the single best value", []int{-1, -1, 1, -1, -1}, 1, []int{1}, 1},
+		{"all values negative", []int{-1, -1, -1, -1}, 2, []int{-1, -1}, -1},
+
+		// The largest subsequence here is the whole input, because the trailing run is net
+		// positive. Its average is 0.66, which is not the density of the best window in it.
+		{"perfect prefix is not scored down by a net-positive suffix",
+			[]int{1, 1, 1, 1, 1, -1, -1, 1, 1, 1, 1, 1}, 5, []int{1, 1, 1, 1, 1}, 1},
+
+		// The largest subsequence bridges the two runs of ones through the negative values
+		// between them, for an average of 0.4. The second run on its own is the better window.
+		{"two runs are not bridged through the gap between them",
+			[]int{-1, 1, 1, 1, -1, -1, -1, 1, 1, 1, 1, -1, -1, -1, 1, 1}, 4, []int{1, 1, 1, 1}, 1},
+
+		// No window of the minimum length is a perfect match, so the best average is a
+		// fraction and the window that achieves it is longer than the minimum.
+		{"best window can be longer than the minimum",
+			[]int{1, 1, -1, 1, 1, -1, 1, 1, -1}, 4, []int{1, 1, -1, 1, 1}, 0.6},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			avg, start, end := maxAverageSubsequence(0, len(test.input), test.minLength, func(idx int) int {
+				return test.input[idx]
+			})
+
+			assert.Equal(t, test.expected, test.input[start:end])
+			assert.Equal(t, test.expectedAvg, avg)
+		})
+	}
+}
+
+func TestMaxAverageSubsequenceSearchesOnlyTheGivenRange(t *testing.T) {
+	// A perfect run sits outside [from, to) on both sides. Only the range handed in, which
+	// is the largest subsequence when this is called for real, may be considered.
+	input := []int{1, 1, 1, 1, -1, -1, 1, -1, -1, 1, 1, 1, 1}
+
+	avg, start, end := maxAverageSubsequence(4, 9, 3, func(idx int) int {
+		assert.GreaterOrEqual(t, idx, 4, "looked up an index before the start of the range")
+		assert.Less(t, idx, 9, "looked up an index past the end of the range")
+		return input[idx]
+	})
+
+	assert.Equal(t, []int{-1, -1, 1}, input[start:end])
+	assert.InDelta(t, -1.0/3.0, avg, 1e-9)
 }

--- a/releasenotes/notes/fix-timestamp-detector-score-dilution-4f8a1d92c705b6e3.yaml
+++ b/releasenotes/notes/fix-timestamp-detector-score-dilution-4f8a1d92c705b6e3.yaml
@@ -1,0 +1,26 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Auto multi-line detection no longer scores a log line's timestamp down based on the
+    text that follows it. The timestamp detector picked the highest-scoring run of token
+    transitions in a line by maximizing its sum, then reported the average over that run
+    as the match probability. Because extending a run by a stretch that sums positive
+    raises its sum while lowering its average, a line whose timestamp matched perfectly
+    could be reported well below 1.0, fall under
+    ``logs_config.auto_multi_line.timestamp_detector_match_threshold``, and be treated as
+    a continuation of the preceding log rather than the start of a new one. The
+    probability is now the density of the best window inside that run.
+
+    This was reported on IIS W3C extended format access logs, which are single-line by
+    specification. A record whose client address tokenizes to ``DD.D.DD.DD`` (for example
+    ``10.1.48.10``) extended the run far enough past the timestamp to land the probability
+    on exactly the ``0.5`` default threshold, so consecutive records were concatenated
+    into a single log. Because the outcome depends on the shape of the fields that follow
+    the timestamp, records from the same file could be affected intermittently.


### PR DESCRIPTION
### What does this PR do?

Changes how the auto multi-line timestamp detector turns a token-transition match into a probability.

`MatchProbability` marks every token transition in a line as `1` (the graph has that edge) or `-1` (it does not), runs Kadane's algorithm to find the highest-*sum* run, and then reports the **average over that run** as the probability. Those are answers to two different questions. Extending a run by a stretch that sums positive raises its sum while lowering its average, so Kadane's keeps growing the window past a perfect match and the score that comes back is the diluted one.

This PR splits the two roles apart:

- `maxSumSubsequence` (Kadane's, unchanged logic) still finds the run and still acts as the gate. A line only gets scored at all if that run is at least `minimumTokenLength` long. This is the check that holds false positives down, so it is kept exactly as-is.
- `maxAverageSubsequence` then reports the density of the best window inside that run, which is the probability.

The new search only looks at windows shorter than `2*minLength`. Any longer window splits into two parts that each satisfy the minimum, and a weighted average never exceeds both of its parts, so one part always scores at least as high. Comparisons stay in integer arithmetic (`windowSum*bestLen > bestSum*windowLen`) with a single division at the end, the prefix sums live in a stack-allocated power-of-two ring, and the loop stops as soon as an all-match window is found because with `1`/`-1` values nothing can beat it.

One incidental cleanup that the split required: the `matchForIndex` closure carried a `lastToken` variable that made it single-pass and order-dependent. The transition at `idx` is fully determined by `ts[idx]` and `ts[idx+1]`, so that state was redundant. Removing it is what lets the two passes share one lookup function.

### Motivation

Reported on IIS W3C extended format access logs, which are single-line by specification. Consecutive records were being concatenated into one log and tagged `auto_multiline_detected:true`, which broke the downstream IIS pipeline: grok-parsed fields such as `server_name` and `status_code` received a concatenated block of raw log text instead of extracted values.

The mechanism is the dilution above. For a record like:

```
2026-08-11 10:34:49 W3SVC1 10.1.48.10 GET /svc/v13/core/Consent 443 - 200 0 0 19571 1051
```

the timestamp matches perfectly, but the client address tokenizes to `DD.D.DD.DD`, which extends the highest-sum run well past the timestamp. The average over that longer run comes to exactly `0.5`, the default `logs_config.auto_multi_line.timestamp_detector_match_threshold`. The comparison is strictly greater-than, so the line is not labelled `startGroup`, falls through to the labeler's default `aggregate`, and is appended to the log before it.

Two things about this made it hard to spot from the outside:

- It is shape-specific, not format-specific. In the same file, a record with `fe80::b045:52da:3136:3f1c%3` or `192.168.1.1` in that field scores `1.00` and behaves correctly. Only the `DD.D.DD.DD` shape lands on the boundary, so records from one file are affected intermittently.
- Landing on exactly `0.5` is a coincidence of this input. The underlying defect scores down any line whose timestamp is followed by a net-positive but imperfect stretch, and other inputs will land elsewhere below the threshold.

### Verification

**The pre-existing accuracy dataset is unchanged, line for line.** `TestCorrectLabelIsAssigned` prints a probability per input. I captured that output on `main` and on this branch and diffed the 49 pre-existing rows:

```
lines: before=49 after=49
(no diff)
```

Every true positive still scores what it scored before, and every negative still scores `0.00`. That last part is the load-bearing one: on `main` all 26 negatives score exactly `0.00`, meaning they are rejected by the length gate rather than by a low score. Keeping the gate on the highest-sum run is what preserves that.

**The four IIS cases added to the dataset, before and after:**

| Input (client address field) | `main` | this PR |
|---|---|---|
| `10.1.48.10` | 0.50, wrong label | 1.00 |
| `10.1.48.10` (second record) | 0.50, wrong label | 1.00 |
| `fe80::b045:52da:3136:3f1c%3` | 1.00 | 1.00 |
| `192.168.1.1` | 1.00 | 1.00 |

On `main` the two `DD.D.DD.DD` rows fail `TestCorrectLabelIsAssigned` with `probability: 0.500000`; with this change all four pass.

**New unit tests.** `TestMaxAverageSubsequence` covers the window search directly, including two cases built so that maximizing the sum gives a demonstrably worse answer (a perfect prefix followed by a net-positive suffix, and two runs of matches bridged through the gap between them). `TestMaxAverageSubsequenceSearchesOnlyTheGivenRange` asserts the search never reads outside the run it was handed. `TestExpectedMatch` gains a case at the `MatchProbability` level whose transitions are `1 1 1 1 1 -1 1 1 -1`: averaging over the largest subsequence reports `0.66`, the new path reports `1.00`. `TestMaxSumSubsequence` is the old `TestMaxSubsequence` with its expectations untouched, since Kadane's behaviour is unchanged.

**Performance.** This is a per-log-line path, so I added `BenchmarkMatchProbability` and measured both sides (Apple M3 Max, `-benchtime 2000000x -count 5`, mean ns/op):

| Case | `main` | this PR |
|---|---|---|
| `NoTimestamp` (rejected at the gate) | 20 | 18 |
| `MaxInputBytes` (rejected at the gate) | 23 | 23 |
| `Timestamp` | 67 | 92 |
| `TimestampFollowedByAddress` | 82 | 108 |

Zero allocations in every case, same as before. Lines rejected at the gate, which is the common case for non-log-start lines, are unaffected. Lines that get scored cost about a third more. The first draft of this was 4-10x slower; the integer comparison, power-of-two ring, and perfect-window early exit are what brought it down, and each is exact rather than approximate.

**Full package suite:** `go test ./pkg/logs/internal/decoder/...` fails on `TestUserPatternsJSON` and `TestSingleLineHandlerProcess/Base_case`. Both reproduce identically on a pristine `main` checkout in my environment, so they are pre-existing and unrelated. Everything else passes.

### Additional Notes

**Relationship to #54753.** #54753 is a one-character minimal fix for the same customer report: it makes the threshold comparison inclusive (`>=`), so a line landing exactly on the threshold counts as a match. That resolves the IIS symptom because this input happens to land on exactly `0.5`, but it does not address why a perfectly matching timestamp scored `0.5` in the first place. This PR does. **They are alternatives, not a stack** (both touch the same test file), and I would take this one and close #54753. The boundary question #54753 raises is real and independent, though, so it may be worth keeping as a separate follow-up on its own merits.

**Not addressed here.** IIS `u_ex*.log` files open with W3C header comment lines (`#Software:`, `#Version:`, `#Date:`, `#Fields:`) that carry no timestamp. Those still get the labeler's default `aggregate` label and are folded into the first real record. That is a separate concern from this scoring defect and is out of scope for this PR.

**Threshold semantics unchanged.** `timestamp_detector_match_threshold` keeps its `0.5` default and its meaning. This PR changes what the probability measures, not how it is compared.
