### PR TITLE
fix(flare): mark newly-failing flare tests as flaky

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -46,8 +46,8 @@ on-log:
 # TODO: https://datadoghq.atlassian.net/browse/FLREM-153
 # TODO: https://datadoghq.atlassian.net/browse/FLREM-154
 test/new-e2e/tests/agent-subcommands:
-  - test: TestLinuxFlareSuite
-  - test: TestWindowsDiagnoseSuite
+  - test: TestLinuxFlareSuite/TestFlareDefaultFiles
+  - test: TestWindowsDiagnoseSuite/TestDiagnoseOtherCmdPort
 
 # TODO: https://datadoghq.atlassian.net/browse/FLREM-148
 # TODO: https://datadoghq.atlassian.net/browse/FLREM-155

--- a/flakes.yaml
+++ b/flakes.yaml
@@ -42,3 +42,15 @@ test/new-e2e/tests/installer/unix:
 
 on-log:
   - "panic: Expected to find a single pod" # K8s Agent Executor can be flaky with the current implementation
+
+# TODO: https://datadoghq.atlassian.net/browse/FLREM-153
+# TODO: https://datadoghq.atlassian.net/browse/FLREM-154
+test/new-e2e/tests/agent-subcommands:
+  - test: TestLinuxFlareSuite
+  - test: TestWindowsDiagnoseSuite
+
+# TODO: https://datadoghq.atlassian.net/browse/FLREM-148
+# TODO: https://datadoghq.atlassian.net/browse/FLREM-155
+comp/core/flare/helpers:
+  - test: TestSave
+  - test: TestNewFlareBuilder


### PR DESCRIPTION
### What does this PR do?

Mutes four flare-related tests in `flakes.yaml` that have started failing intermittently in CI.

### Motivation

The following tests have been reported failing via CI monitoring, with tracking tickets:

- `test/new-e2e/tests/agent-subcommands.TestLinuxFlareSuite/TestFlareDefaultFiles` — [FLREM-153](https://datadoghq.atlassian.net/browse/FLREM-153)
- `test/new-e2e/tests/agent-subcommands.TestWindowsDiagnoseSuite/TestDiagnoseOtherCmdPort` — [FLREM-154](https://datadoghq.atlassian.net/browse/FLREM-154)
- `comp/core/flare/helpers.TestSave` — [FLREM-148](https://datadoghq.atlassian.net/browse/FLREM-148)
- `comp/core/flare/helpers.TestNewFlareBuilder` — [FLREM-155](https://datadoghq.atlassian.net/browse/FLREM-155)

`TestLinuxFlareSuite` and `TestWindowsDiagnoseSuite` are testify suites with other subtests (`TestzzzFlareWithAllConfiguration`, `TestDiagnoseInclude`, `TestDiagnoseExclude`) that were never reported as flaky, so the entries are scoped to only the specific subtest confirmed failing in each linked Jira ticket, rather than muting the whole suite.

Muting them here unblocks other PRs from spurious CI failures while the underlying flakiness is investigated under those tickets.

### Describe how you validated your changes

Validated `flakes.yaml` parses correctly and follows the existing file's format/conventions. Confirmed via `tasks/testwasher.py`/`tasks/libs/testing/flakes.py` (and an empirical run of `consolidate_flaky_failures`) that muting a parent suite name would have also silenced its other subtests, which is why the two suite tests are scoped to their exact failing subtest paths instead.

### Additional Notes

[FLREM-153]: https://datadoghq.atlassian.net/browse/FLREM-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FLREM-154]: https://datadoghq.atlassian.net/browse/FLREM-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FLREM-148]: https://datadoghq.atlassian.net/browse/FLREM-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FLREM-155]: https://datadoghq.atlassian.net/browse/FLREM-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ