### PR TITLE
fix(autoinstrumentation): scope namespace eligibility to policies

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/BUILD.bazel
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/BUILD.bazel
@@ -67,6 +67,7 @@ dd_agent_go_test(
         "mutators_test.go",
         "namespace_mutator_test.go",
         "policy_matcher_test.go",
+        "rc_policies_namespace_test.go",
         "rc_policies_test.go",
         "service_name_test.go",
         "target_matching_test.go",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/policy_matcher.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/policy_matcher.go
@@ -57,24 +57,11 @@ func (m *policyMatcher) matchIndex(pod *corev1.Pod) int {
 		Strings: map[string]string{policies.IDNamespaceName: pod.Namespace},
 		Labels:  map[string]map[string]string{policies.IDPodLabel: pod.Labels},
 	}
-	namespaceLabelsLoaded := false
-	namespaceLabelsUnavailable := false
+	loader := namespaceLabelLoader{wmeta: m.wmeta, namespace: pod.Namespace}
 
 	for i := range m.policies {
-		if nodeUsesNamespaceLabels(m.policies[i].Rules) && !namespaceLabelsLoaded {
-			if namespaceLabelsUnavailable || m.wmeta == nil {
-				namespaceLabelsUnavailable = true
-				continue
-			}
-
-			nsLabels, err := getNamespaceLabels(m.wmeta, pod.Namespace)
-			if err != nil {
-				log.Debugf("policy matcher: namespace labels unavailable for namespace %q, namespace-label rules will be skipped: %v", pod.Namespace, err)
-				namespaceLabelsUnavailable = true
-				continue
-			}
-			ctx.Labels[policies.IDNamespaceLabel] = nsLabels
-			namespaceLabelsLoaded = true
+		if nodeUsesNamespaceLabels(m.policies[i].Rules) && !loader.ensure(&ctx) {
+			continue
 		}
 
 		if policies.Evaluate(m.policies[i].Rules, ctx) == policies.ResultTrue {
@@ -82,6 +69,82 @@ func (m *policyMatcher) matchIndex(pod *corev1.Pod) int {
 		}
 	}
 	return -1
+}
+
+// namespaceCouldMatch reports whether any policy could match a workload in the
+// given namespace. It answers a strictly weaker question than matchIndex: only
+// the namespace facts are known here, so a rule reading pod labels evaluates to
+// ResultAbstain and keeps its policy a candidate. A namespace is ruled out only
+// when every policy is contradicted by the namespace facts (ResultFalse).
+//
+// This is what keeps namespace eligibility aligned with the policies actually in
+// effect, whether they come from the configuration targets or from remote config:
+// a namespace-scoped policy no longer makes unrelated namespaces eligible.
+//
+// Policies that deny injection are skipped: they never instrument anything, so
+// they must not make a namespace eligible on their own.
+func (m *policyMatcher) namespaceCouldMatch(namespace string) bool {
+	if m == nil {
+		return false
+	}
+
+	ctx := policies.Context{
+		Strings: map[string]string{policies.IDNamespaceName: namespace},
+		// Pod labels are deliberately absent rather than empty: an unavailable
+		// label source abstains, while an empty one would evaluate to false and
+		// wrongly rule out every pod-scoped policy.
+		Labels: map[string]map[string]string{},
+	}
+	loader := namespaceLabelLoader{wmeta: m.wmeta, namespace: namespace}
+
+	for i := range m.policies {
+		if !m.policies[i].Outcome.Inject {
+			continue
+		}
+
+		if nodeUsesNamespaceLabels(m.policies[i].Rules) && !loader.ensure(&ctx) {
+			continue
+		}
+
+		if policies.Evaluate(m.policies[i].Rules, ctx) != policies.ResultFalse {
+			return true
+		}
+	}
+	return false
+}
+
+// namespaceLabelLoader resolves a namespace's labels into an evaluation context
+// at most once. When they cannot be resolved, the policies that read them are
+// skipped rather than aborting the whole evaluation, so a namespace-name,
+// pod-only or catch-all policy keeps its chance to match.
+type namespaceLabelLoader struct {
+	wmeta       workloadmeta.Component
+	namespace   string
+	loaded      bool
+	unavailable bool
+}
+
+// ensure loads the namespace labels into ctx if they are not there yet, and
+// reports whether policies reading namespace labels can be evaluated.
+func (l *namespaceLabelLoader) ensure(ctx *policies.Context) bool {
+	if l.loaded {
+		return true
+	}
+	if l.unavailable || l.wmeta == nil {
+		l.unavailable = true
+		return false
+	}
+
+	nsLabels, err := getNamespaceLabels(l.wmeta, l.namespace)
+	if err != nil {
+		log.Debugf("policy matcher: namespace labels unavailable for namespace %q, namespace-label rules will be skipped: %v", l.namespace, err)
+		l.unavailable = true
+		return false
+	}
+
+	ctx.Labels[policies.IDNamespaceLabel] = nsLabels
+	l.loaded = true
+	return true
 }
 
 func nodeUsesNamespaceLabels(n *policies.Node) bool {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/rc_policies_namespace_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/rc_policies_namespace_test.go
@@ -1,0 +1,224 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+// This file pins down namespace eligibility for policy-driven matching. Pod
+// matching and namespace eligibility are two answers from the same policy set,
+// and a policy delivered by remote config must scope both: a policy targeting
+// one namespace must not turn the whole cluster into an SSI-eligible cluster,
+// because namespace eligibility gates the default library configuration, the
+// UST env vars and the language detection.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	"github.com/DataDog/dd-policy-engine/go/policies"
+)
+
+// nsNamePolicy builds a policy scoped to a single namespace name.
+func nsNamePolicy(name, namespace string, inject bool) policies.Policy {
+	return policies.Policy{
+		Name:    name,
+		Rules:   policies.StringLeaf(policies.IDNamespaceName, policies.CmpExact, namespace),
+		Outcome: policies.Outcome{Inject: inject, InjectSet: true},
+	}
+}
+
+// nsLabelPolicy builds a policy scoped to a namespace label.
+func nsLabelPolicy(name, key, value string) policies.Policy {
+	return policies.Policy{
+		Name:    name,
+		Rules:   policies.LabelLeaf(policies.IDNamespaceLabel, key, policies.CmpExact, value),
+		Outcome: policies.Outcome{Inject: true, InjectSet: true},
+	}
+}
+
+// TestRemotePolicies_NamespaceEligibilityIsScopedToPolicy verifies that the
+// namespace scope of a remote policy is honored by IsNamespaceEligible, and not
+// only by pod matching.
+func TestRemotePolicies_NamespaceEligibilityIsScopedToPolicy(t *testing.T) {
+	tests := map[string]struct {
+		policies []policies.Policy
+		want     map[string]bool
+	}{
+		"a namespace-scoped policy only makes its namespace eligible": {
+			policies: []policies.Policy{nsNamePolicy("remote-prod", "prod", true)},
+			want:     map[string]bool{"prod": true, "unrelated": false},
+		},
+		"a pod-scoped policy leaves every namespace eligible": {
+			// Nothing in the namespace facts can rule the policy out, so the
+			// namespace stays a candidate: eligibility is an over-approximation
+			// by design.
+			policies: []policies.Policy{podLabelPolicy("remote-db", "app", "db", true, nil)},
+			want:     map[string]bool{"prod": true, "unrelated": true},
+		},
+		"a deny policy makes no namespace eligible": {
+			policies: []policies.Policy{nsNamePolicy("remote-deny", "prod", false)},
+			want:     map[string]bool{"prod": false, "unrelated": false},
+		},
+		"a deny policy does not shadow the namespace scope of an allow policy": {
+			policies: []policies.Policy{
+				nsNamePolicy("remote-deny", "staging", false),
+				nsNamePolicy("remote-allow", "prod", true),
+			},
+			want: map[string]bool{"prod": true, "staging": false, "unrelated": false},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			wmeta := newMatchTestWmeta(t)
+			m := newMatchMutator(t, rcDisabledCfg, wmeta)
+
+			// Baseline: instrumentation is disabled, nothing is eligible.
+			for namespace := range test.want {
+				require.False(t, m.IsNamespaceEligible(namespace))
+			}
+
+			require.NoError(t, m.SetRemotePolicies(test.policies))
+			for namespace, want := range test.want {
+				require.Equal(t, want, m.IsNamespaceEligible(namespace), "namespace %q", namespace)
+			}
+
+			// Clearing the remote policies reverts to the disabled baseline.
+			m.ClearRemotePolicies()
+			for namespace := range test.want {
+				require.False(t, m.IsNamespaceEligible(namespace))
+			}
+		})
+	}
+}
+
+// TestRemotePolicies_NamespaceLabelEligibility verifies that a remote policy
+// scoped to namespace labels resolves them from workloadmeta, and that a
+// namespace whose metadata is unavailable is not eligible through that policy.
+func TestRemotePolicies_NamespaceLabelEligibility(t *testing.T) {
+	wmeta := newMatchTestWmeta(t,
+		newTestNamespace("instrumented", map[string]string{"instrument": "true"}),
+		newTestNamespace("not-instrumented", map[string]string{"instrument": "false"}),
+	)
+	m := newMatchMutator(t, rcDisabledCfg, wmeta)
+
+	require.NoError(t, m.SetRemotePolicies([]policies.Policy{
+		nsLabelPolicy("remote-labelled", "instrument", "true"),
+	}))
+
+	require.True(t, m.IsNamespaceEligible("instrumented"))
+	require.False(t, m.IsNamespaceEligible("not-instrumented"))
+	// Namespace metadata is unavailable: the policy cannot be evaluated and is
+	// skipped, exactly as it is skipped for pod matching.
+	require.False(t, m.IsNamespaceEligible("unknown-to-workloadmeta"))
+}
+
+// TestRemotePolicies_ConfigTargetsKeepTheirNamespaceScope verifies that layering
+// remote policies does not widen the namespace scope of the configuration
+// baseline, and that the config baseline does not widen the remote scope either.
+func TestRemotePolicies_ConfigTargetsKeepTheirNamespaceScope(t *testing.T) {
+	const cfg = `
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "config-billing"
+        namespaceSelector:
+          matchNames:
+            - "billing"
+        ddTraceVersions:
+          java: "default"
+`
+
+	wmeta := newMatchTestWmeta(t)
+	m := newMatchMutator(t, cfg, wmeta)
+
+	require.True(t, m.IsNamespaceEligible("billing"))
+	require.False(t, m.IsNamespaceEligible("prod"))
+	require.False(t, m.IsNamespaceEligible("unrelated"))
+
+	require.NoError(t, m.SetRemotePolicies([]policies.Policy{
+		nsNamePolicy("remote-prod", "prod", true),
+	}))
+
+	require.True(t, m.IsNamespaceEligible("billing"))
+	require.True(t, m.IsNamespaceEligible("prod"))
+	require.False(t, m.IsNamespaceEligible("unrelated"))
+}
+
+// TestRemotePolicies_NamespaceScopeGatesSSIDefaults is the user-visible side of
+// the same property: the exact same annotation-instrumented pod must only be
+// treated as an SSI pod (default library configuration, single-step install
+// type) inside the namespace the remote policy targets.
+func TestRemotePolicies_NamespaceScopeGatesSSIDefaults(t *testing.T) {
+	wmeta := newMatchTestWmeta(t)
+	m := newMatchMutator(t, rcDisabledCfg, wmeta)
+	require.NoError(t, m.SetRemotePolicies([]policies.Policy{
+		nsNamePolicy("remote-prod", "prod", true),
+	}))
+
+	annotatedPod := func(namespace string) *corev1.Pod {
+		return mutatecommon.FakePodSpec{
+			NS:          namespace,
+			Labels:      map[string]string{"admission.datadoghq.com/enabled": "true"},
+			Annotations: map[string]string{"admission.datadoghq.com/java-lib.version": "v1"},
+		}.Create()
+	}
+
+	tests := map[string]struct {
+		namespace       string
+		wantInstallType string
+		wantSSIDefaults bool
+	}{
+		"inside the policy scope the pod is an SSI pod": {
+			namespace:       "prod",
+			wantInstallType: "k8s_single_step",
+			wantSSIDefaults: true,
+		},
+		"outside the policy scope the pod is a local lib-injection pod": {
+			namespace:       "unrelated",
+			wantInstallType: "k8s_lib_injection",
+			wantSSIDefaults: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			pod := annotatedPod(test.namespace)
+			mutated, err := m.MutatePod(pod, test.namespace, nil)
+			require.NoError(t, err)
+			require.True(t, mutated, "the annotation must still drive the injection")
+
+			env := podEnvVars(t, pod)
+			require.Equal(t, test.wantInstallType, env["DD_INSTRUMENTATION_INSTALL_TYPE"])
+
+			// The default library configuration is injected for SSI-eligible
+			// namespaces only.
+			for _, name := range []string{
+				"DD_TRACE_ENABLED",
+				"DD_LOGS_INJECTION",
+				"DD_RUNTIME_METRICS_ENABLED",
+				"DD_TRACE_HEALTH_METRICS_ENABLED",
+			} {
+				_, found := env[name]
+				require.Equal(t, test.wantSSIDefaults, found, "env var %q", name)
+			}
+		})
+	}
+}
+
+func podEnvVars(t *testing.T, pod *corev1.Pod) map[string]string {
+	t.Helper()
+	require.Len(t, pod.Spec.Containers, 1)
+	env := make(map[string]string, len(pod.Spec.Containers[0].Env))
+	for _, e := range pod.Spec.Containers[0].Env {
+		env[e.Name] = e.Value
+	}
+	return env
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
@@ -15,7 +15,6 @@ import (
 
 	"go.uber.org/atomic"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/dynamic"
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
@@ -94,7 +93,7 @@ func NewTargetMutator(config *Config, wmeta workloadmeta.Component, imageResolve
 		}
 	}
 
-	internalTargets, err := buildInternalTargets(config, wmeta, targets, defaultLibVersions)
+	internalTargets, err := buildInternalTargets(config, targets, defaultLibVersions)
 	if err != nil {
 		return nil, err
 	}
@@ -133,38 +132,21 @@ func NewTargetMutator(config *Config, wmeta workloadmeta.Component, imageResolve
 	return m, nil
 }
 
-// buildInternalTargets converts configuration targets into the internal format used for matching and injection.
-func buildInternalTargets(config *Config, wmeta workloadmeta.Component, targets []Target, defaultLibVersions []libInfo) ([]targetInternal, error) {
+// buildInternalTargets converts configuration targets into the internal format used for injection. Matching is not
+// part of it: the selectors are lowered into policies by policiesFromTargets and evaluated by the policy engine.
+func buildInternalTargets(config *Config, targets []Target, defaultLibVersions []libInfo) ([]targetInternal, error) {
 	internalTargets := make([]targetInternal, len(targets))
 	for i, t := range targets {
-		// Convert the pod selector to a label selector.
-		podSelector := labels.Everything()
-		var err error
+		// The selectors are converted to k8s label selectors for validation only, so that an unsupported selector
+		// is still rejected at startup rather than silently abstaining at evaluation time.
 		if t.PodSelector != nil {
-			podSelector, err = t.PodSelector.AsLabelSelector()
-			if err != nil {
+			if _, err := t.PodSelector.AsLabelSelector(); err != nil {
 				return nil, fmt.Errorf("could not convert selector to label selector: %w", err)
 			}
 		}
-
-		// Determine if we should use the namespace selector or if we should use enabledNamespaces.
-		useNamespaceSelector := t.NamespaceSelector != nil && len(t.NamespaceSelector.MatchLabels)+len(t.NamespaceSelector.MatchExpressions) > 0
-
-		// Convert the namespace selector to a label selector.
-		namespaceSelector := labels.Everything()
-		if useNamespaceSelector && t.NamespaceSelector != nil {
-			namespaceSelector, err = t.NamespaceSelector.AsLabelSelector()
-			if err != nil {
+		if t.NamespaceSelector != nil {
+			if _, err := t.NamespaceSelector.AsLabelSelector(); err != nil {
 				return nil, fmt.Errorf("could not convert selector to label selector: %w", err)
-			}
-		}
-
-		// Create a map of enabled namespaces for quick lookups.
-		var enabledNamespaces map[string]bool
-		if !useNamespaceSelector && t.NamespaceSelector != nil {
-			enabledNamespaces = make(map[string]bool, len(t.NamespaceSelector.MatchNames))
-			for _, ns := range t.NamespaceSelector.MatchNames {
-				enabledNamespaces[ns] = true
 			}
 		}
 
@@ -194,16 +176,11 @@ func buildInternalTargets(config *Config, wmeta workloadmeta.Component, targets 
 
 		// Store the target in the internal format.
 		internalTargets[i] = targetInternal{
-			name:                 t.Name,
-			podSelector:          podSelector,
-			useNamespaceSelector: useNamespaceSelector,
-			nameSpaceSelector:    namespaceSelector,
-			wmeta:                wmeta,
-			enabledNamespaces:    enabledNamespaces,
-			libVersions:          libVersions,
-			envVars:              envVars,
-			json:                 createJSON(t),
-			usesDefaultLibs:      usesDefaultLibs,
+			name:            t.Name,
+			libVersions:     libVersions,
+			envVars:         envVars,
+			json:            createJSON(t),
+			usesDefaultLibs: usesDefaultLibs,
 		}
 	}
 
@@ -221,7 +198,7 @@ func (m *TargetMutator) activeSet() *policySet {
 // first (they take precedence), then the configuration policies, preserving
 // first-match-wins semantics.
 func (m *TargetMutator) SetRemotePolicies(ps []policies.Policy) error {
-	remoteTargets, err := buildInternalTargetsFromPolicies(m.core.config, m.core.wmeta, ps, m.defaultLibVersions)
+	remoteTargets, err := buildInternalTargetsFromPolicies(m.core.config, ps, m.defaultLibVersions)
 	if err != nil {
 		return err
 	}
@@ -249,7 +226,7 @@ func (m *TargetMutator) ClearRemotePolicies() {
 // buildInternalTargetsFromPolicies resolves each policy's outcome (tracer
 // versions and configs) into the internal injection format, mirroring
 // buildInternalTargets but sourced from policies rather than Targets.
-func buildInternalTargetsFromPolicies(config *Config, wmeta workloadmeta.Component, ps []policies.Policy, defaultLibVersions []libInfo) ([]targetInternal, error) {
+func buildInternalTargetsFromPolicies(config *Config, ps []policies.Policy, defaultLibVersions []libInfo) ([]targetInternal, error) {
 	internalTargets := make([]targetInternal, len(ps))
 	for i, p := range ps {
 		var libVersions []libInfo
@@ -273,7 +250,6 @@ func buildInternalTargetsFromPolicies(config *Config, wmeta workloadmeta.Compone
 
 		internalTargets[i] = targetInternal{
 			name:            p.Name,
-			wmeta:           wmeta,
 			libVersions:     libVersions,
 			envVars:         envVars,
 			json:            createPolicyJSON(p),
@@ -413,48 +389,32 @@ func (m *TargetMutator) ShouldMutatePod(pod *corev1.Pod) bool {
 }
 
 // IsNamespaceEligible returns true if a namespace is eligible for injection/mutation.
+//
+// Eligibility is decided by the same policy set that decides pod matching, so a
+// remote-config policy scoped to a namespace does not make unrelated namespaces
+// eligible. It is an over-approximation by construction: a policy that can only
+// be resolved with pod facts keeps every namespace eligible.
 func (m *TargetMutator) IsNamespaceEligible(namespace string) bool {
-	set := m.activeSet()
-
-	// If the namespace is disabled, we don't need to check the targets.
+	// If the namespace is disabled, we don't need to check the policies.
 	if _, ok := m.disabledNamespaces[namespace]; ok {
 		return false
 	}
 
-	// Check if the namespace matches any of the targets. A disabled mutator has
-	// no targets, so this naturally returns false.
-	for _, target := range set.targets {
-		matches, err := target.matchesNamespaceSelector(namespace)
-		if err != nil {
-			// Match the policy evaluator's behavior: a target whose namespace-label
-			// facts are unavailable cannot be evaluated, but it must not prevent a
-			// later namespace-name, pod-only, or catch-all target from making the
-			// namespace eligible.
-			log.Debugf("namespace metadata unavailable for target %q in namespace %q, skipping target: %v", target.name, namespace, err)
-			continue
-		}
-		if matches {
-			log.Debugf("Namespace %q matched target %q", namespace, target.name)
-			return true
-		}
-	}
-
-	// No target matched.
-	return false
+	// A disabled mutator with no remote policies has an empty set, so this
+	// naturally returns false.
+	return m.activeSet().matcher.namespaceCouldMatch(namespace)
 }
 
-// targetInternal is the struct we use to convert the config based target into something more performant.
+// targetInternal is the injection configuration a matched policy resolves to.
+// It carries no selector: matching (pods and namespaces alike) is delegated to
+// the policy engine, which is fed by policiesFromTargets for configuration
+// targets and by remote config for policies.
 type targetInternal struct {
-	name                 string
-	podSelector          labels.Selector
-	nameSpaceSelector    labels.Selector
-	useNamespaceSelector bool
-	enabledNamespaces    map[string]bool
-	libVersions          []libInfo
-	envVars              []corev1.EnvVar
-	wmeta                workloadmeta.Component
-	json                 string
-	usesDefaultLibs      bool
+	name            string
+	libVersions     []libInfo
+	envVars         []corev1.EnvVar
+	json            string
+	usesDefaultLibs bool
 	// fromPolicy is true when this internal target was derived from a policy
 	// (remote config) rather than a configuration target. It selects which
 	// annotation/env var carries the applied information.
@@ -552,28 +512,6 @@ func (m *TargetMutator) getMatchingTarget(pod *corev1.Pod) *targetInternal {
 
 	log.Debugf("Pod %q matched target %q", mutatecommon.PodString(pod), set.targets[idx].name)
 	return &set.targets[idx]
-}
-
-func (t targetInternal) matchesNamespaceSelector(namespace string) (bool, error) {
-	// If we are using the namespace selector, check if the namespace matches the selector.
-	if t.useNamespaceSelector {
-		nsLabels, err := getNamespaceLabels(t.wmeta, namespace)
-		if err != nil {
-			return false, fmt.Errorf("could not get labels to match: %w", err)
-		}
-
-		// Check if the namespace labels match the selector.
-		return t.nameSpaceSelector.Matches(labels.Set(nsLabels)), nil
-	}
-
-	// If there are no match names, we match all namespaces.
-	if len(t.enabledNamespaces) == 0 {
-		return true, nil
-	}
-
-	// Check if the pod namespace is in the match names.
-	_, ok := t.enabledNamespaces[namespace]
-	return ok, nil
 }
 
 // createDefaultTarget is used when there are no targets. If a user configures enabledNamespaces and libVersions, which


### PR DESCRIPTION
### What does this PR do?

Makes `IsNamespaceEligible` answer from the same policy set that decides pod
matching, so a remote-config SSI policy scoped to a namespace no longer makes
every namespace eligible.

- `policyMatcher.namespaceCouldMatch` evaluates each policy against the
  namespace facts only. The engine's tri-state does the work: a rule reading
  pod labels abstains (the label source is absent, not empty) and keeps the
  namespace a candidate, while a namespace fact that contradicts the policy
  yields `ResultFalse` and rules it out. Deny policies are skipped — they
  instrument nothing, so they must not make a namespace eligible on their own.
- The lazy namespace-label load is factored into a `namespaceLabelLoader`
  shared with `matchIndex`, so both paths skip an unresolvable policy
  identically (preserves #54462).
- `targetInternal` now carries only the injection payload. The selector fields
  (`podSelector`, which was already dead, `nameSpaceSelector`,
  `useNamespaceSelector`, `enabledNamespaces`, `wmeta`) and
  `matchesNamespaceSelector` are removed, which makes a second source of truth
  for matching structurally impossible. `AsLabelSelector()` is kept purely for
  startup validation of unsupported selectors.

### Motivation

Follow-up to #54476 (originally #52556). `buildInternalTargetsFromPolicies`
builds a `targetInternal` without any selector — a remote policy's scope lives
in `p.Rules` — and `matchesNamespaceSelector` reads "no selector" as "matches
every namespace". So pod matching was correctly scoped while namespace
eligibility was not:

```
policy scoped to NAMESPACE_NAME == "prod", instrumentation disabled in config

  IsNamespaceEligible("prod")      = true
  IsNamespaceEligible("unrelated") = true    <-- wrong
  pod in "prod" matches            = true
  pod in "unrelated" matches       = false   <-- correctly scoped
```

That is not cosmetic: eligibility gates `defaultLibConfigMutator`,
`ustEnvVarsPodMutator` and `initExtractedLibInfo`. A pod injected through
annotations in a namespace outside the policy's scope was silently promoted to
an SSI pod — it additionally received `DD_TRACE_ENABLED`, `DD_LOGS_INJECTION`,
`DD_RUNTIME_METRICS_ENABLED`, `DD_TRACE_HEALTH_METRICS_ENABLED`, the UST env
vars, and reported `k8s_single_step` instead of `k8s_lib_injection`. A
deny-only policy set had the same effect.

### Describe how you validated your changes

New `rc_policies_namespace_test.go`, five tests, all of which fail on `main`
and pass here:

- `TestRemotePolicies_NamespaceEligibilityIsScopedToPolicy` — namespace-scoped
  policy only makes its namespace eligible; pod-scoped policy keeps every
  namespace eligible (the intended over-approximation); deny-only policy makes
  none eligible; deny + allow each keep their own scope; `ClearRemotePolicies`
  reverts to the baseline.
- `TestRemotePolicies_NamespaceLabelEligibility` — namespace-label policy
  resolved through workloadmeta, and a namespace unknown to the store is not
  eligible through it (skip semantics).
- `TestRemotePolicies_ConfigTargetsKeepTheirNamespaceScope` — layering remote
  policies does not widen the config baseline's scope, nor the reverse.
- `TestRemotePolicies_NamespaceScopeGatesSSIDefaults` — the user-visible side:
  the same annotation-injected pod is an SSI pod inside the policy's namespace
  and a local lib-injection pod outside it.

Failure on `main` (fix stashed):

```
--- FAIL: .../a_namespace-scoped_policy_only_makes_its_namespace_eligible
      expected: false  actual: true   namespace "unrelated"
--- FAIL: .../a_deny_policy_makes_no_namespace_eligible
      expected: false  actual: true   namespace "prod"
--- FAIL: TestRemotePolicies_NamespaceScopeGatesSSIDefaults/outside_the_policy_scope...
      expected: "k8s_lib_injection"  actual: "k8s_single_step"
```

`go test -tags "kubeapiserver test" ./pkg/clusteragent/admission/...` is green,
including the untouched `TestIsNamespaceEligible` and
`TestIsNamespaceEligibleSkipsTargetWhenNamespaceMetadataIsUnavailable`.
`go build`, `go vet` and `gofmt` clean.

### Additional Notes

No behavior change for configuration targets. The two shapes that exist are
equivalent under both implementations (`matchNames` → `ResultFalse` elsewhere,
pod-selector-only → `ResultAbstain` → eligible), and `matchNames` combined with
`matchLabels`/`matchExpressions` on the same `namespaceSelector` is already
rejected at config load (`config.go:262`), so the corner where the old
eligibility ignored `matchNames` is unreachable.

No release note: the remote-config SSI path is gated behind
`apm_config.instrumentation.on_demand` and has not shipped.

Unrelated to this PR but spotted while reading #54476: the commit message
announces a `SubscribeWithInitialConfig` to remove the registration/initial
config race, but the merged code does `GetConfigs()` then `Subscribe()`
(`rc_policies.go:72-73`) and the helper is not in the diff — an update landing
between the two calls is lost. Possibly a rebase leftover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
