### PR TITLE
fix(autoscaling): stop informer in test fixture to fix TestPodAutoscalerLocalOwnerObjectsLimit flake

### DIFF
--- a/pkg/clusteragent/autoscaling/controller_fake.go
+++ b/pkg/clusteragent/autoscaling/controller_fake.go
@@ -98,10 +98,13 @@ func (f *ControllerFixture) newController(leader bool) (*Controller, dynamicinfo
 // RunControllerSync runs the controller sync loop and checks the expected actions.
 func (f *ControllerFixture) RunControllerSync(leader bool, objectID string) {
 	f.t.Helper()
-	controller, informer := f.newController(leader)
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	informer.Start(stopCh)
+	// Do NOT start the informer. Starting it spawns goroutines that fire AddFunc
+	// for every pre-seeded indexer object, enqueueing them concurrently with the
+	// explicit Add below and causing process() to dequeue the wrong item.
+	// The indexer is already seeded via GetIndexer().Add() in newController so
+	// the lister works without the informer running, and alwaysReady bypasses
+	// the cache-sync gate.
+	controller, _ := f.newController(leader)
 
 	controller.Workqueue.Add(objectID)
 	assert.True(f.t, controller.process())


### PR DESCRIPTION
### What does this PR do?

Removes the `informer.Start(stopCh)` call from `RunControllerSync` in the autoscaling controller test fixture (`pkg/clusteragent/autoscaling/controller_fake.go`).

### Motivation

`TestPodAutoscalerLocalOwnerObjectsLimit` (and `TestPodAutoscalerRemoteOwnerObjectsLimit`) have been [flaking](https://app.datadoghq.com/ci/ci-cd/explorer?query=test_level%3Atest%20%40test.status%3Afail%20%40test.name%3ATestPodAutoscalerLocalOwnerObjectsLimit&agg_m=count&agg_m_source=base&agg_t=count&ci_cd_explorer_tab=tests&citest_explorer_sort=%40duration%2Cdesc&cols=%40test.status%2C%40test.name%2C%40test.suite%2C%40test.is_known_flaky%2C%40duration%2C%40test.service%2Cerror.type&currentTab=overview&eventStack=&fromUser=false&index=citest&refresh_mode=sliding&start=1785920759493&end=1786525559493&paused=false) on `tests_macos_gitlab_amd64` with two symptoms:

1. Assertion failure at `controller_test.go:681`: expected `default/dpa-2` at heap top, got `default/dpa-1`
2. Immediate panic: `mock: I don't know what to return because the method call was unexpected` for `GetPodsForOwner`

**Root cause**: `RunControllerSync` called `informer.Start(stopCh)`, which spawns background goroutines that fire `AddFunc` for every object already in the indexer. These callbacks call `c.enqueue(obj)` → `Workqueue.Add(key)` concurrently with the test's own `Workqueue.Add(objectID)`. Since `process()` dequeues exactly one item, it could pick up a background-enqueued key (e.g. `dpa-0`) instead of the intended target (e.g. `dpa-2`). Consequences:

- The intended object (`dpa-2`) is never synced → never upserted → never inserted into the heap
- Heap state assertions fail (`dpa-1` is at top instead of `dpa-2`)
- The wrong object (`dpa-0`) is processed, reaches `validateAutoscaler` (passes, since it was just inserted into the heap), then calls `GetPodsForOwner` for which no mock was set up → panic

**Fix**: do not start the informer. The indexer is already pre-seeded via `GetIndexer().Add()` in `newController`, so the lister works correctly without the informer running. The `alwaysReady` synced gate bypasses the cache-sync check. No background goroutines → no concurrent enqueues → deterministic `process()` behavior.

### Describe how you validated your changes

- Ran `TestPodAutoscalerLocalOwnerObjectsLimit` 5× with `-count=5`: all pass
- Ran the full `./pkg/clusteragent/autoscaling/...` test suite: all green