### PR TITLE
Clean bazelignore from invalid folder path

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -6,4 +6,3 @@
 # inside of arm64 Linux containers.
 bazel-datadog-agent/
 bazel-testlogs/
-hard-coded-generation


### PR DESCRIPTION
### What does this PR do?
This path was added by mistake in previous PR and correspond to a local git worktree.
