### PR TITLE
Manage MSYS2 via Bazel

### DIFF
--- a/.adms/bazel/adms.mirror.cfg
+++ b/.adms/bazel/adms.mirror.cfg
@@ -25,6 +25,7 @@ allow golang.google.cn
 # Depot's pull-through cache (unlike the static.crates.io .crate downloads
 # rewritten below), so it must be fetched directly.
 allow index.crates.io
+allow repo.msys2.org
 
 # Our windows filters are not stored on an internal host.
 allow s3.amazonaws.com
@@ -77,6 +78,7 @@ rewrite (github.com)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (raw.githubusercontent.com)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (cdn.jsdelivr.net)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (dl.google.com)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
+rewrite (repo.msys2.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (agent-int-packages.datadoghq.com)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 
 # Taken from https://blog.aspect.build/configuring-bazels-downloader

--- a/.bazelrc
+++ b/.bazelrc
@@ -80,6 +80,8 @@ common:windows --repo_env=PIP_CACHE_DIR # https://pip.pypa.io/en/stable/topics/c
 common:windows --repo_env=SYSTEMDRIVE # needed by vswhere to locate the VS installer instance database
 common:windows --repo_env=SYSTEMROOT # used by COM to load system DLLs, needed by vswhere
 common:windows --repo_env=USERPROFILE # used by MSYS2 bash to emulate HOME, needed by git to fetch repositories
+common:windows --repo_env=MSYS2_FORCE_INSTALL # opt-in full MSYS2 reinstall via @msys2_base (see bazel/toolchains/msys2/README.md)
+common:windows --repo_env=MSYS2_INSTALL_ROOT # override default C:/tools/msys64 install location
 common:windows --repo_env=VSTUDIO_ROOT # visual_studio(path_variable) in MODULE.bazel
 common:windows --run_env=__COMPAT_LAYER=RunAsInvoker # install*.exe may otherwise fail claiming unneeded admin elevation
 common:windows --test_env=__COMPAT_LAYER=RunAsInvoker # same, for bazel test

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -361,12 +361,77 @@ winlibs_mingw_repository(
     url = "https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-19.1.7-12.0.0-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-14.2.0-mingw-w64msvcrt-12.0.0-r3.zip",
 )
 
+# Pinned MSYS2 base + autotools overlays for Windows bash/configure/make workloads.
+# See bazel/toolchains/msys2/README.md for install policy and follow-up work.
+msys2_base_repository = use_repo_rule(
+    "//bazel/toolchains/msys2:msys2.bzl",
+    "msys2_base_repository",
+)
+
+msys2_base_repository(
+    name = "msys2_base",
+    overlay_packages = {
+        "make": [
+            "https://repo.msys2.org/msys/x86_64/make-4.4.1-2-x86_64.pkg.tar.zst",
+            "2408af61717dae87b00c855b132769a125c708907fc94a46bb16dae076113e5c",
+        ],
+        "m4": [
+            "https://repo.msys2.org/msys/x86_64/m4-1.4.21-1-x86_64.pkg.tar.zst",
+            "b561e8871c7599502d9fae7196ee965b3fed3d7af09154eb8d2f5e4d9e5e5106",
+        ],
+        "libtool": [
+            "https://repo.msys2.org/msys/x86_64/libtool-2.5.4-4-x86_64.pkg.tar.zst",
+            "c8e812a9a32dd86c53d6e9bd5ec94977a5fc66d2ce3e691d92196aa06f616775",
+        ],
+        "pkgconf": [
+            "https://repo.msys2.org/msys/x86_64/pkgconf-2.5.1-1-x86_64.pkg.tar.zst",
+            "38efd4928ac0cb06e9bd558baa533fc923c0592115bf9bd44970250f3ae2cb7e",
+        ],
+        "autoconf-wrapper": [
+            "https://repo.msys2.org/msys/x86_64/autoconf-wrapper-20260320-1-any.pkg.tar.zst",
+            "84c1f93d4450b3bf1ef567110b51c15ffb3f13670d656cc48fea70a01371b20c",
+        ],
+        "autoconf2.72": [
+            "https://repo.msys2.org/msys/x86_64/autoconf2.72-2.72-4-any.pkg.tar.zst",
+            "65b3a37edf8bb4221d38db910ce1acc1ed879c7bcba33faa058066d06d35e7b0",
+        ],
+        "automake-wrapper": [
+            "https://repo.msys2.org/msys/x86_64/automake-wrapper-20260320-1-any.pkg.tar.zst",
+            "693817c288c81bb9f94ac92e5b6f914402735b80bb33e326ccddd7c89cc6a719",
+        ],
+        "automake1.18": [
+            "https://repo.msys2.org/msys/x86_64/automake1.18-1.18.1-1-any.pkg.tar.zst",
+            "c045d9eddf900dbacae06d9e0e19e250cc32d849def7d06b833253f85e3fc941",
+        ],
+        "libiconv-devel": [
+            "https://repo.msys2.org/msys/x86_64/libiconv-devel-1.19-1-x86_64.pkg.tar.zst",
+            "b4836f02199a2ae02d5a836d5a6dc4a174a055da79c30e256635e638b52e2c5d",
+        ],
+        "perl": [
+            "https://repo.msys2.org/msys/x86_64/perl-5.42.2-1-x86_64.pkg.tar.zst",
+            "7c96ef91b7395c12cfbd967ebf7daa8d3f950d1c0be23bb1dc2a635c95a07c01",
+        ],
+        "libcrypt": [
+            "https://repo.msys2.org/msys/x86_64/libcrypt-2.1-5-x86_64.pkg.tar.zst",
+            "3e7822d392eed281cd6019b80078ab201eefa7c83fff2d5bab0491b01088f674",
+        ],
+        "libxcrypt": [
+            "https://repo.msys2.org/msys/x86_64/libxcrypt-4.5.2-1-x86_64.pkg.tar.zst",
+            "e63db0aa2b708359e25f61f506e2d2c92c315febf5f88cc9f386e4ec0bdf4fa5",
+        ],
+    },
+    sha256 = "7a3e5c0a728ebefd24dca6da179fe569dc98d6c7d20ce80981d8dc33fb15f7fc",
+    url = "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20260322.tar.zst",
+    version = "20260322",
+)
+
 # TODO{agent-build}: Find a way to register platform-specific toolchains dynamically
 register_toolchains(
     "@gcc_toolchain_x86_64//:cc_toolchain",
     "@gcc_toolchain_aarch64//:cc_toolchain",
     "@gcc_toolchain_armv7//:cc_toolchain",
     "@winlibs_mingw64//:mingw_cc_toolchain",
+    "@msys2_base//:sh_toolchain",
     "@llvm_toolchain//:all",  # last to avoid taking precedence over GCC toolchains
 )
 

--- a/bazel/AGENTS.md
+++ b/bazel/AGENTS.md
@@ -761,8 +761,10 @@ In `genrule` or test `args`, use the `$(rlocationpath :target)` Make variable, n
 `genrule`, `sh_binary`, `sh_test`, and `ctx.actions.run_shell()` all require Bash. Since Bazel 1.0, every other rule
 type is Bash-free. Bash is the single biggest portability hazard in Bazel builds:
 
-- **Windows**: Bash is not installed by default. Building those rules requires MSYS2, configured via `BAZEL_SH` /
-  `--shell_executable` in `.bazelrc`. This dependency is increasingly absent on developer machines.
+- **Windows**: Bash is not installed by default. Building those rules requires MSYS2 at `C:/tools/msys64`
+  (`BAZEL_SH`, `--shell_executable` in `.bazelrc`). `tools/bazel.bat` fetches `@msys2_base` when bash is
+  missing; see `bazel/toolchains/msys2/README.md`. TODO: version-locked reinstall and hermetic foreign_cc
+  toolchains.
 - **macOS**: the system shell (`/bin/bash`) is version 3.2 (2007, last GPLv2 release — Apple does not ship later
   versions for licensing reasons). It lacks `declare -A` (associative arrays), `mapfile`/`readarray`, and many features
   added in Bash 4/5. Users may have Homebrew Bash 5.x, but that is not guaranteed and must not be assumed.
@@ -902,8 +904,9 @@ Minimize action environments — env vars are part of the cache key.
 not executable on Windows and cannot be used as `ctx.actions.run`'s `executable`. Empty `.bat` files cannot be executed
 — write at least one space if you need a no-op script.
 
-**Bash.** The `.bazelrc` configures MSYS2 bash (`BAZEL_SH`, `--shell_executable`) for the rules that require it. Avoid
-those rules — see the [Shell portability](#shell-portability--use-bash-as-a-last-resort) section above.
+**Bash.** MSYS2 bash at `C:/tools/msys64` (`BAZEL_SH`, `--shell_executable`). `tools/bazel.bat` installs it via
+`@msys2_base` when missing. Avoid shell rules where possible — see
+[Shell portability](#shell-portability--use-bash-as-a-last-resort).
 
 **Run from `cmd.exe` or PowerShell**, not MSYS2/Git Bash. MSYS2 auto-converts path arguments like `//foo:bar` to Windows
 paths, breaking Bazel label syntax.

--- a/bazel/repo/prebuilt_file.bzl
+++ b/bazel/repo/prebuilt_file.bzl
@@ -62,7 +62,7 @@ def _prebuilt_file(rctx):
     target_path = rctx.path(actual_label)
 
     # Windows will probably have a .exe extension, so we can fall back to that.
-    if not target_path.exists and rctx.os.name == "windows":
+    if not target_path.exists and rctx.os.name.startswith("windows"):
         actual_label = rctx.attr.target_label.same_package_label(rctx.attr.target_label.name + ".exe")
         target_path = rctx.path(actual_label)
     rctx.watch(target_path)

--- a/bazel/toolchains/msys2/BUILD.bazel
+++ b/bazel/toolchains/msys2/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "msys2.BUILD.bazel",
+    "install.ps1",
+])

--- a/bazel/toolchains/msys2/README.md
+++ b/bazel/toolchains/msys2/README.md
@@ -4,25 +4,29 @@ Bazel on Windows needs MSYS2 bash for `genrule`, `run_shell`, and `rules_foreign
 configure/make actions. The repo expects the tree at `C:/tools/msys64` (see
 `.bazelrc`: `BAZEL_SH`, `--shell_executable`).
 
-`@msys2_base` downloads a pinned MSYS2 base archive plus overlay pacman packages
-(autotools stack). On Windows it installs under `MSYS2_INSTALL_ROOT` when bash is
-missing or when a force install is requested.
+`@msys2_base` is a `local` repository rule that:
+
+1. Downloads a pinned MSYS2 base archive plus overlay pacman packages (autotools stack)
+2. On **native Windows Bazel** (`ctx.os.name == "windows"`), copies the tree to
+   `MSYS2_INSTALL_ROOT` (default `C:/tools/msys64`) via `install.ps1`
+
+Run Bazel from **cmd.exe or PowerShell**, not Git Bash or WSL — those report a
+non-Windows OS to repository rules, so the host install step is skipped even though
+`bazel fetch` succeeds.
 
 ## Current policy (relaxed)
 
-- If `C:/tools/msys64/usr/bin/bash.exe` already exists, keep using it (no download,
-  no reinstall).
-- If bash is missing, `tools/bazel.bat` runs `bazel fetch @msys2_base//:bash_files`
-  which downloads and installs the pinned tree.
-- To replace the install entirely: `DD_BAZEL_MSYS2_FORCE_INSTALL=1` then `bazel build //...`
-  (wrapper runs `bazel fetch --force @msys2_base//:bash_files --repo_env=MSYS2_FORCE_INSTALL=1`).
-  Or manually:
+- If `C:/tools/msys64/usr/bin/bash.exe` already exists, keep using it (no fetch).
+- If bash is missing, `tools/bazel.bat` runs `bazel fetch --force @msys2_base//:bash_files`
+  which triggers the repository rule install.
+- Force reinstall: `DD_BAZEL_MSYS2_FORCE_INSTALL=1` then `bazel build //...`, or:
 
 ```powershell
 bazel fetch --force @msys2_base//:bash_files --repo_env=MSYS2_FORCE_INSTALL=1
 ```
 
-If install still fails, check write access to `C:\tools` (admin / corporate policy).
+If install fails, the repository rule fails the fetch with stdout/stderr from
+`install.ps1` (permissions, robocopy, missing archive, etc.).
 
 ## TODO
 

--- a/bazel/toolchains/msys2/README.md
+++ b/bazel/toolchains/msys2/README.md
@@ -14,19 +14,18 @@ missing or when a force install is requested.
   no reinstall).
 - If bash is missing, `tools/bazel.bat` runs `bazel fetch @msys2_base//:bash_files`
   which downloads and installs the pinned tree.
-- To replace the install entirely: `DD_BAZEL_MSYS2_FORCE_INSTALL=1` (sets
-  `MSYS2_FORCE_INSTALL=1` for the fetch) or pass
-  `--repo_env=MSYS2_FORCE_INSTALL=1` to Bazel directly.
+- To replace the install entirely: `DD_BAZEL_MSYS2_FORCE_INSTALL=1` then `bazel build //...`
+  (wrapper runs `bazel fetch --force @msys2_base//:bash_files --repo_env=MSYS2_FORCE_INSTALL=1`).
+  Or manually:
+
+```powershell
+bazel fetch --force @msys2_base//:bash_files --repo_env=MSYS2_FORCE_INSTALL=1
+```
+
+If install still fails, check write access to `C:\tools` (admin / corporate policy).
 
 ## TODO
 
 - Managed sentinel + auto-reinstall when the MODULE.bazel pin changes.
 - Windows `rules_foreign_cc` toolchains backed by `@msys2_base` filegroups so
   make/autoconf/m4/etc. are action inputs (remote-cache correctness).
-
-## Manual fetch
-
-```powershell
-bazel fetch @msys2_base//:bash_files
-bazel fetch @msys2_base//:bash_files --repo_env=MSYS2_FORCE_INSTALL=1
-```

--- a/bazel/toolchains/msys2/README.md
+++ b/bazel/toolchains/msys2/README.md
@@ -7,7 +7,7 @@ configure/make actions. The repo expects the tree at `C:/tools/msys64` (see
 `@msys2_base` is a `local` repository rule that:
 
 1. Downloads a pinned MSYS2 base archive plus overlay pacman packages (autotools stack)
-2. On **native Windows Bazel** (`ctx.os.name == "windows"`), copies the tree to
+2. On **native Windows Bazel** (`ctx.os.name` starts with `windows`), copies the tree to
    `MSYS2_INSTALL_ROOT` (default `C:/tools/msys64`) via `install.ps1`
 
 Run Bazel from **cmd.exe or PowerShell**, not Git Bash or WSL — those report a

--- a/bazel/toolchains/msys2/README.md
+++ b/bazel/toolchains/msys2/README.md
@@ -1,0 +1,32 @@
+# MSYS2 on Windows
+
+Bazel on Windows needs MSYS2 bash for `genrule`, `run_shell`, and `rules_foreign_cc`
+configure/make actions. The repo expects the tree at `C:/tools/msys64` (see
+`.bazelrc`: `BAZEL_SH`, `--shell_executable`).
+
+`@msys2_base` downloads a pinned MSYS2 base archive plus overlay pacman packages
+(autotools stack). On Windows it installs under `MSYS2_INSTALL_ROOT` when bash is
+missing or when a force install is requested.
+
+## Current policy (relaxed)
+
+- If `C:/tools/msys64/usr/bin/bash.exe` already exists, keep using it (no download,
+  no reinstall).
+- If bash is missing, `tools/bazel.bat` runs `bazel fetch @msys2_base//:bash_files`
+  which downloads and installs the pinned tree.
+- To replace the install entirely: `DD_BAZEL_MSYS2_FORCE_INSTALL=1` (sets
+  `MSYS2_FORCE_INSTALL=1` for the fetch) or pass
+  `--repo_env=MSYS2_FORCE_INSTALL=1` to Bazel directly.
+
+## TODO
+
+- Managed sentinel + auto-reinstall when the MODULE.bazel pin changes.
+- Windows `rules_foreign_cc` toolchains backed by `@msys2_base` filegroups so
+  make/autoconf/m4/etc. are action inputs (remote-cache correctness).
+
+## Manual fetch
+
+```powershell
+bazel fetch @msys2_base//:bash_files
+bazel fetch @msys2_base//:bash_files --repo_env=MSYS2_FORCE_INSTALL=1
+```

--- a/bazel/toolchains/msys2/install.ps1
+++ b/bazel/toolchains/msys2/install.ps1
@@ -1,0 +1,35 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Source,
+
+    [Parameter(Mandatory = $true)]
+    [string]$InstallRoot,
+
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+$bash = Join-Path $InstallRoot "usr\bin\bash.exe"
+if (-not $Force -and (Test-Path -LiteralPath $bash)) {
+    exit 0
+}
+
+if ($Force -and (Test-Path -LiteralPath $InstallRoot)) {
+    Remove-Item -LiteralPath $InstallRoot -Recurse -Force
+}
+
+New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
+
+# robocopy: exit codes 0-7 mean success.
+& robocopy $Source $InstallRoot /MIR /NFL /NDL /NJH /NJS /nc /ns /np | Out-Null
+$code = $LASTEXITCODE
+if ($code -ge 8) {
+    throw "robocopy failed with exit code $code"
+}
+
+if (-not (Test-Path -LiteralPath $bash)) {
+    throw "MSYS2 install finished but bash.exe is missing at $bash"
+}
+
+exit 0

--- a/bazel/toolchains/msys2/install.ps1
+++ b/bazel/toolchains/msys2/install.ps1
@@ -10,9 +10,23 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+$Source = (Resolve-Path -LiteralPath $Source).Path
+$InstallRoot = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($InstallRoot)
 $bash = Join-Path $InstallRoot "usr\bin\bash.exe"
+
 if (-not $Force -and (Test-Path -LiteralPath $bash)) {
     exit 0
+}
+
+# download_and_extract uses strip_prefix=msys64; tolerate a nested layout if not stripped.
+$sourceRoot = $Source
+$nested = Join-Path $Source "msys64"
+if (-not (Test-Path -LiteralPath (Join-Path $Source "usr\bin\bash.exe")) -and (Test-Path -LiteralPath (Join-Path $nested "usr\bin\bash.exe"))) {
+    $sourceRoot = $nested
+}
+
+if (-not (Test-Path -LiteralPath (Join-Path $sourceRoot "usr\bin\bash.exe"))) {
+    throw "MSYS2 source tree has no usr\bin\bash.exe under $sourceRoot"
 }
 
 if ($Force -and (Test-Path -LiteralPath $InstallRoot)) {
@@ -22,10 +36,10 @@ if ($Force -and (Test-Path -LiteralPath $InstallRoot)) {
 New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
 
 # robocopy: exit codes 0-7 mean success.
-& robocopy $Source $InstallRoot /MIR /NFL /NDL /NJH /NJS /nc /ns /np | Out-Null
+& robocopy $sourceRoot $InstallRoot /MIR /NFL /NDL /NJH /NJS /nc /ns /np | Out-Null
 $code = $LASTEXITCODE
 if ($code -ge 8) {
-    throw "robocopy failed with exit code $code"
+    throw "robocopy from $sourceRoot to $InstallRoot failed with exit code $code"
 }
 
 if (-not (Test-Path -LiteralPath $bash)) {

--- a/bazel/toolchains/msys2/msys2.BUILD.bazel
+++ b/bazel/toolchains/msys2/msys2.BUILD.bazel
@@ -1,0 +1,75 @@
+"""BUILD template instantiated by msys2_base_repository.
+
+%VERSION% is substituted at fetch time so the URL pin in MODULE.bazel stays the
+single source of truth for which MSYS2 archive we use.
+"""
+
+load("@rules_shell//shell/toolchains:sh_toolchain.bzl", "sh_toolchain")
+
+package(default_visibility = ["//visibility:public"])
+
+MSYS2_VERSION = "%VERSION%"
+MSYS2_INSTALL_ROOT = "%INSTALL_ROOT%"
+
+filegroup(
+    name = "all",
+    srcs = glob(
+        ["**"],
+        exclude = [
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+        ],
+        allow_empty = True,
+    ),
+)
+
+filegroup(
+    name = "bash_files",
+    srcs = glob(["usr/bin/bash.exe"], allow_empty = True) + glob(["usr/bin/msys-*.dll"], allow_empty = True),
+)
+
+# TODO{agent-build}: Wire rules_foreign_cc native toolchains to these filegroups so
+# make/autoconf/m4/etc. become action inputs (remote-cache-safe). Until then,
+# preinstalled_* toolchains resolve bare names like make.exe from PATH.
+filegroup(
+    name = "make",
+    srcs = glob(["usr/bin/make.exe"], allow_empty = True),
+)
+
+filegroup(
+    name = "m4",
+    srcs = glob(["usr/bin/m4.exe"], allow_empty = True),
+)
+
+filegroup(
+    name = "autoconf",
+    srcs = glob(["usr/bin/autoconf.exe"], allow_empty = True),
+)
+
+filegroup(
+    name = "automake",
+    srcs = glob(["usr/bin/automake.exe"], allow_empty = True),
+)
+
+filegroup(
+    name = "pkgconfig",
+    srcs = glob(["usr/bin/pkg-config.exe"], allow_empty = True),
+)
+
+sh_toolchain(
+    name = "msys2_bash",
+    path = MSYS2_INSTALL_ROOT + "/usr/bin/bash.exe",
+    launcher = "@bazel_tools//tools/launcher",
+    launcher_maker = "@bazel_tools//tools/launcher:launcher_maker",
+)
+
+toolchain(
+    name = "sh_toolchain",
+    target_compatible_with = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+    toolchain = ":msys2_bash",
+    toolchain_type = "@bazel_tools//tools/sh:toolchain_type",
+)

--- a/bazel/toolchains/msys2/msys2.bzl
+++ b/bazel/toolchains/msys2/msys2.bzl
@@ -1,7 +1,10 @@
 """Repository rule for a pinned MSYS2 base archive plus optional overlay packages.
 
-On Windows, materializes the tree under MSYS2_INSTALL_ROOT (default
-C:/tools/msys64) when bash is missing or MSYS2_FORCE_INSTALL=1.
+On Windows (native Bazel only — not Git Bash/WSL), extracts the archive into
+@msys2_base and copies the tree to MSYS2_INSTALL_ROOT (default C:/tools/msys64).
+
+Relaxed policy: skip the host install when bash already exists unless
+MSYS2_FORCE_INSTALL=1. tools/bazel.bat only triggers fetch; install happens here.
 
 TODO{agent-build}:
   - Require a managed sentinel version and auto-reinstall on pin bumps.
@@ -15,34 +18,59 @@ def _bash_path(install_root):
         install_root = install_root[:-1]
     return install_root + "/usr/bin/bash.exe"
 
+def _to_windows_path(p):
+    return p.replace("/", "\\")
+
+def _source_root(ctx):
+    if ctx.path("usr/bin/bash.exe").exists:
+        return "."
+    if ctx.path("msys64/usr/bin/bash.exe").exists:
+        return "msys64"
+    fail(
+        "MSYS2 archive extracted but usr/bin/bash.exe is missing " +
+        "(ctx.os.name=%r). Check strip_prefix and download logs." % ctx.os.name,
+    )
+
 def _install_msys2(ctx, install_root, force):
     bash = _bash_path(install_root)
     if not force and ctx.path(bash).exists:
         return
 
-    install_script = ctx.path(ctx.attr._install_script)
-    source = ctx.path(".")
-    result = ctx.execute(
-        [
-            "powershell.exe",
-            "-NoProfile",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-File",
-            install_script,
-            "-Source",
-            source,
-            "-InstallRoot",
-            install_root,
-        ] + (["-Force"] if force else []),
-        quiet = False,
-    )
+    install_script = str(ctx.path(ctx.attr._install_script))
+    source = str(ctx.path(_source_root(ctx)))
+    install_root_win = _to_windows_path(install_root)
+
+    args = [
+        "powershell.exe",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        install_script,
+        "-Source",
+        source,
+        "-InstallRoot",
+        install_root_win,
+    ]
+    if force:
+        args.append("-Force")
+
+    result = ctx.execute(args, quiet = False)
     if result.return_code != 0:
-        fail("MSYS2 install to %s failed:\n%s\n%s" % (
-            install_root,
-            result.stdout,
-            result.stderr,
-        ))
+        fail(
+            "MSYS2 install to %s failed (exit %d).\nstdout:\n%s\nstderr:\n%s" % (
+                install_root,
+                result.return_code,
+                result.stdout,
+                result.stderr,
+            ),
+        )
+
+    if not ctx.path(bash).exists:
+        fail(
+            "MSYS2 install reported success but bash is still missing at %s. " % bash +
+            "Check write access to %s (admin may be required)." % install_root,
+        )
 
 def _msys2_base_repository_impl(ctx):
     install_root = ctx.getenv("MSYS2_INSTALL_ROOT") or _DEFAULT_INSTALL_ROOT
@@ -61,23 +89,23 @@ def _msys2_base_repository_impl(ctx):
         return
 
     force = (ctx.getenv("MSYS2_FORCE_INSTALL") or "0") == "1"
+    bash = _bash_path(install_root)
+    need_archive = force or not ctx.path(bash).exists
 
-    # Relaxed "keep existing MSYS2" policy lives in tools/bazel.bat only. Do not
-    # short-circuit here: a cached repo rule skip prevents reinstall when bash is
-    # removed or MSYS2_FORCE_INSTALL is set later.
-    ctx.download_and_extract(
-        url = ctx.attr.url,
-        sha256 = ctx.attr.sha256,
-        stripPrefix = ctx.attr.strip_prefix,
-    )
-
-    for pkg_name, spec in ctx.attr.overlay_packages.items():
-        if len(spec) != 2:
-            fail("overlay_packages[%r] must be [url, sha256], got %r" % (pkg_name, spec))
+    if need_archive:
         ctx.download_and_extract(
-            url = spec[0],
-            sha256 = spec[1],
+            url = ctx.attr.url,
+            sha256 = ctx.attr.sha256,
+            stripPrefix = ctx.attr.strip_prefix,
         )
+
+        for pkg_name, spec in ctx.attr.overlay_packages.items():
+            if len(spec) != 2:
+                fail("overlay_packages[%r] must be [url, sha256], got %r" % (pkg_name, spec))
+            ctx.download_and_extract(
+                url = spec[0],
+                sha256 = spec[1],
+            )
 
     _install_msys2(ctx, install_root, force)
 
@@ -93,7 +121,7 @@ def _msys2_base_repository_impl(ctx):
 
 msys2_base_repository = repository_rule(
     implementation = _msys2_base_repository_impl,
-    doc = "Downloads a pinned MSYS2 base archive and, on Windows, installs it under MSYS2_INSTALL_ROOT.",
+    doc = "Downloads MSYS2 into @msys2_base and installs it under MSYS2_INSTALL_ROOT on Windows.",
     attrs = {
         "url": attr.string(
             mandatory = True,
@@ -127,4 +155,5 @@ msys2_base_repository = repository_rule(
         "MSYS2_FORCE_INSTALL",
         "MSYS2_INSTALL_ROOT",
     ],
+    local = True,
 )

--- a/bazel/toolchains/msys2/msys2.bzl
+++ b/bazel/toolchains/msys2/msys2.bzl
@@ -61,21 +61,10 @@ def _msys2_base_repository_impl(ctx):
         return
 
     force = (ctx.getenv("MSYS2_FORCE_INSTALL") or "0") == "1"
-    bash = _bash_path(install_root)
 
-    # Relaxed mode: keep an existing MSYS2 tree and skip downloading the archive.
-    if not force and ctx.path(bash).exists:
-        ctx.template(
-            "BUILD.bazel",
-            ctx.attr._build_file_template,
-            substitutions = {
-                "%VERSION%": ctx.attr.version,
-                "%INSTALL_ROOT%": install_root,
-            },
-            executable = False,
-        )
-        return
-
+    # Relaxed "keep existing MSYS2" policy lives in tools/bazel.bat only. Do not
+    # short-circuit here: a cached repo rule skip prevents reinstall when bash is
+    # removed or MSYS2_FORCE_INSTALL is set later.
     ctx.download_and_extract(
         url = ctx.attr.url,
         sha256 = ctx.attr.sha256,

--- a/bazel/toolchains/msys2/msys2.bzl
+++ b/bazel/toolchains/msys2/msys2.bzl
@@ -76,7 +76,8 @@ def _msys2_base_repository_impl(ctx):
     install_root = ctx.getenv("MSYS2_INSTALL_ROOT") or _DEFAULT_INSTALL_ROOT
     install_root = install_root.replace("\\", "/")
 
-    if ctx.os.name != "windows":
+    # repository_os.name is the lowercased Java os.name, e.g. "windows 11".
+    if not ctx.os.name.startswith("windows"):
         ctx.template(
             "BUILD.bazel",
             ctx.attr._build_file_template,

--- a/bazel/toolchains/msys2/msys2.bzl
+++ b/bazel/toolchains/msys2/msys2.bzl
@@ -1,0 +1,141 @@
+"""Repository rule for a pinned MSYS2 base archive plus optional overlay packages.
+
+On Windows, materializes the tree under MSYS2_INSTALL_ROOT (default
+C:/tools/msys64) when bash is missing or MSYS2_FORCE_INSTALL=1.
+
+TODO{agent-build}:
+  - Require a managed sentinel version and auto-reinstall on pin bumps.
+  - Register rules_foreign_cc toolchains against @msys2_base filegroups.
+"""
+
+_DEFAULT_INSTALL_ROOT = "C:/tools/msys64"
+
+def _bash_path(install_root):
+    if install_root.endswith("/"):
+        install_root = install_root[:-1]
+    return install_root + "/usr/bin/bash.exe"
+
+def _install_msys2(ctx, install_root, force):
+    bash = _bash_path(install_root)
+    if not force and ctx.path(bash).exists:
+        return
+
+    install_script = ctx.path(ctx.attr._install_script)
+    source = ctx.path(".")
+    result = ctx.execute(
+        [
+            "powershell.exe",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            install_script,
+            "-Source",
+            source,
+            "-InstallRoot",
+            install_root,
+        ] + (["-Force"] if force else []),
+        quiet = False,
+    )
+    if result.return_code != 0:
+        fail("MSYS2 install to %s failed:\n%s\n%s" % (
+            install_root,
+            result.stdout,
+            result.stderr,
+        ))
+
+def _msys2_base_repository_impl(ctx):
+    install_root = ctx.getenv("MSYS2_INSTALL_ROOT") or _DEFAULT_INSTALL_ROOT
+    install_root = install_root.replace("\\", "/")
+
+    if ctx.os.name != "windows":
+        ctx.template(
+            "BUILD.bazel",
+            ctx.attr._build_file_template,
+            substitutions = {
+                "%VERSION%": ctx.attr.version,
+                "%INSTALL_ROOT%": install_root,
+            },
+            executable = False,
+        )
+        return
+
+    force = (ctx.getenv("MSYS2_FORCE_INSTALL") or "0") == "1"
+    bash = _bash_path(install_root)
+
+    # Relaxed mode: keep an existing MSYS2 tree and skip downloading the archive.
+    if not force and ctx.path(bash).exists:
+        ctx.template(
+            "BUILD.bazel",
+            ctx.attr._build_file_template,
+            substitutions = {
+                "%VERSION%": ctx.attr.version,
+                "%INSTALL_ROOT%": install_root,
+            },
+            executable = False,
+        )
+        return
+
+    ctx.download_and_extract(
+        url = ctx.attr.url,
+        sha256 = ctx.attr.sha256,
+        stripPrefix = ctx.attr.strip_prefix,
+    )
+
+    for pkg_name, spec in ctx.attr.overlay_packages.items():
+        if len(spec) != 2:
+            fail("overlay_packages[%r] must be [url, sha256], got %r" % (pkg_name, spec))
+        ctx.download_and_extract(
+            url = spec[0],
+            sha256 = spec[1],
+        )
+
+    _install_msys2(ctx, install_root, force)
+
+    ctx.template(
+        "BUILD.bazel",
+        ctx.attr._build_file_template,
+        substitutions = {
+            "%VERSION%": ctx.attr.version,
+            "%INSTALL_ROOT%": install_root,
+        },
+        executable = False,
+    )
+
+msys2_base_repository = repository_rule(
+    implementation = _msys2_base_repository_impl,
+    doc = "Downloads a pinned MSYS2 base archive and, on Windows, installs it under MSYS2_INSTALL_ROOT.",
+    attrs = {
+        "url": attr.string(
+            mandatory = True,
+            doc = "Direct URL to the msys2-base-x86_64-*.tar.zst release asset.",
+        ),
+        "sha256": attr.string(
+            mandatory = True,
+            doc = "SHA256 of the archive, pinned for supply-chain integrity.",
+        ),
+        "strip_prefix": attr.string(
+            default = "msys64",
+            doc = "Top-level directory stripped from the archive (MSYS2 ships everything under msys64/).",
+        ),
+        "version": attr.string(
+            mandatory = True,
+            doc = "MSYS2 release date (e.g. 20260322); must match the URL.",
+        ),
+        "overlay_packages": attr.string_list_dict(
+            doc = "Pacman packages overlaid on the base tree, as name -> [url, sha256].",
+        ),
+        "_build_file_template": attr.label(
+            default = "//bazel/toolchains/msys2:msys2.BUILD.bazel",
+            allow_single_file = True,
+        ),
+        "_install_script": attr.label(
+            default = "//bazel/toolchains/msys2:install.ps1",
+            allow_single_file = True,
+        ),
+    },
+    environ = [
+        "MSYS2_FORCE_INSTALL",
+        "MSYS2_INSTALL_ROOT",
+    ],
+)

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -116,7 +116,7 @@ set "msys2_bash=!msys2_root!\usr\bin\bash.exe"
 if defined MSYS2_INSTALL_ROOT set "msys2_root=!MSYS2_INSTALL_ROOT!"
 if defined MSYS2_INSTALL_ROOT set "msys2_bash=!msys2_root!\usr\bin\bash.exe"
 
-set "msys2_fetch_args=fetch @msys2_base//:bash_files"
+set "msys2_fetch_args=fetch --force @msys2_base//:bash_files"
 if defined DD_BAZEL_MSYS2_FORCE_INSTALL set "MSYS2_FORCE_INSTALL=!DD_BAZEL_MSYS2_FORCE_INSTALL!"
 if /i "!MSYS2_FORCE_INSTALL!" == "1" (
   set "msys2_fetch_args=!msys2_fetch_args! --repo_env=MSYS2_FORCE_INSTALL=1"
@@ -125,11 +125,18 @@ if /i "!MSYS2_FORCE_INSTALL!" == "1" (
 if exist "!msys2_bash!" exit /b 0
 
 :do_msys2_fetch
-"%BAZEL_REAL%" !startup_options! !msys2_fetch_args!
+if defined MSYS2_INSTALL_ROOT set "msys2_fetch_args=!msys2_fetch_args! --repo_env=MSYS2_INSTALL_ROOT=!MSYS2_INSTALL_ROOT!"
+if defined extra_args (
+  "%BAZEL_REAL%" !startup_options! !msys2_fetch_args! !extra_args!
+) else (
+  "%BAZEL_REAL%" !startup_options! !msys2_fetch_args!
+)
 if !errorlevel! neq 0 exit /b !errorlevel!
 if not exist "!msys2_bash!" (
   >&2 echo 🔴 MSYS2 bash was not installed at !msys2_bash!
-  >&2 echo     Set DD_BAZEL_MSYS2_FORCE_INSTALL=1 to replace an existing install.
+  >&2 echo     Retry: set DD_BAZEL_MSYS2_FORCE_INSTALL=1
+  >&2 echo     Manual: bazel fetch --force @msys2_base//:bash_files --repo_env=MSYS2_FORCE_INSTALL=1
+  >&2 echo     Check write access to !msys2_root! ^(admin may be required for C:\tools^).
   exit /b 2
 )
 exit /b 0

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -79,9 +79,60 @@ for %%i in ("!more_than_8dot3_chars!") do if "%%~nxi"=="%%~snxi" (
 )
 
 set "args=%*"
+call :find_bazel_command
+set "needs_msys2_sync="
+if /i "!bazel_cmd!" == "build" set "needs_msys2_sync=1"
+if /i "!bazel_cmd!" == "test" set "needs_msys2_sync=1"
+if /i "!bazel_cmd!" == "run" set "needs_msys2_sync=1"
+if /i "!bazel_cmd!" == "coverage" set "needs_msys2_sync=1"
+if defined needs_msys2_sync call :sync_msys2_if_needed
+if !errorlevel! neq 0 exit /b !errorlevel!
+
 if defined args if defined extra_args call :insert_extra_args
 "%BAZEL_REAL%" !startup_options! !args!
 exit /b !errorlevel!
+
+:: Find the Bazel command after startup options.
+:find_bazel_command
+set "bazel_cmd="
+set "next_args=!args!"
+:find_next_arg
+for /f "tokens=1* delims= " %%i in ("!next_args!") do (
+  set "arg=%%~i"
+  if "!arg:~0,1!" equ "-" (
+    set "next_args=%%j"
+  ) else (
+    set "bazel_cmd=%%i"
+    exit /b 0
+  )
+)
+if not defined bazel_cmd if defined next_args goto :find_next_arg
+exit /b 0
+
+:: Install pinned MSYS2 when bash is missing, or when force install is requested.
+:sync_msys2_if_needed
+set "msys2_root=C:\tools\msys64"
+set "msys2_bash=!msys2_root!\usr\bin\bash.exe"
+if defined MSYS2_INSTALL_ROOT set "msys2_root=!MSYS2_INSTALL_ROOT!"
+if defined MSYS2_INSTALL_ROOT set "msys2_bash=!msys2_root!\usr\bin\bash.exe"
+
+set "msys2_fetch_args=fetch @msys2_base//:bash_files"
+if defined DD_BAZEL_MSYS2_FORCE_INSTALL set "MSYS2_FORCE_INSTALL=!DD_BAZEL_MSYS2_FORCE_INSTALL!"
+if /i "!MSYS2_FORCE_INSTALL!" == "1" (
+  set "msys2_fetch_args=!msys2_fetch_args! --repo_env=MSYS2_FORCE_INSTALL=1"
+  goto :do_msys2_fetch
+)
+if exist "!msys2_bash!" exit /b 0
+
+:do_msys2_fetch
+"%BAZEL_REAL%" !startup_options! !msys2_fetch_args!
+if !errorlevel! neq 0 exit /b !errorlevel!
+if not exist "!msys2_bash!" (
+  >&2 echo 🔴 MSYS2 bash was not installed at !msys2_bash!
+  >&2 echo     Set DD_BAZEL_MSYS2_FORCE_INSTALL=1 to replace an existing install.
+  exit /b 2
+)
+exit /b 0
 
 :: "--startup cmd ..." -> "--startup cmd --config=ci ..."
 :insert_extra_args

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -136,7 +136,7 @@ if not exist "!msys2_bash!" (
   >&2 echo 🔴 MSYS2 bash was not installed at !msys2_bash!
   >&2 echo     Retry: set DD_BAZEL_MSYS2_FORCE_INSTALL=1
   >&2 echo     Manual: bazel fetch --force @msys2_base//:bash_files --repo_env=MSYS2_FORCE_INSTALL=1
-  >&2 echo     Check write access to !msys2_root! ^(admin may be required for C:\tools^).
+  >&2 echo     Run Bazel from cmd.exe/PowerShell ^(not Git Bash/WSL^). Check write access to !msys2_root!
   exit /b 2
 )
 exit /b 0


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Let Bazel manage MSYS2 installation. By default, Bazel will check if `bash` exists in `C:\tools\msys64`. In this case Bazel will just keep using it as is. If `bash` hasn't been found there or force install is requested via envvar Bazel will download MSYS2 and autotools stack and install it in `C:\tools\msys64` unless the install location is overwritten. 

There are 2 reasons why we decided to use `C:\tools` as a default installation path:
- That's what we already use in build images. This way our happy path keeps working and has no effect on cache hit rate, meaning that rebuilding openssl or python on Windows with Bazel managed MSYS2 will utilize the same cache regardless of currently installed MSYS2 version. This is somewhat incorrect but acceptable, given Windows has no sandboxing at all and everything is running `local`.
- If users have an installation os MSYS2 already they can keep using it (as `C:\tools` isn't a default installation path), Bazel will use its own copy that can, however, be used outside of Bazel for other activities.

#### Things to keep in mind

- As mentioned above, it is not technically correct to let Bazel use whatever MSYS2 is already present in `C:\tools`, because in this case we don't treat autotools as build inputs, therefore, potentially introducing cache poisoning issues. This is, however, more of a hypothetical risk rather than the real one. We will make `rules_foreign_cc` make aware of `make` and co as action inputs in one of the follow ups. In the meantime we allow everyone to use the layout that they currently have with no action required.

- We will enforce MSYS2 installation later on, so this should be properly documented and communicated to the users before rollout.