### PR TITLE
CONTINT-5539 - use correct kind version for latest k8s test job

### DIFF
--- a/k8s_versions.json
+++ b/k8s_versions.json
@@ -18,18 +18,18 @@
     "tag": "v1.36.2",
     "digest": "sha256:0ce766f2c31c54771255f79445cce3e3097ea293304227c792c60e3cd14365d6",
     "rc": false,
-    "kind_version": "v0.31.0"
+    "kind_version": "v0.32.0"
   },
   "v1.36.3": {
     "tag": "v1.36.3",
     "digest": "sha256:a16e7786dbb06083ddd49e59a17f9cb36e75e85491b192d6977a674d5364b720",
     "rc": false,
-    "kind_version": "v0.31.0"
+    "kind_version": "v0.32.0"
   },
   "v1.37.0-rc.0": {
     "tag": "v1.37.0-rc.0",
     "digest": "sha256:a11b5b8063555e8ef8a5e1100459cad9e100543f61e37cb7fd722ec576c9be89",
     "rc": true,
-    "kind_version": "v0.31.0"
+    "kind_version": "v0.32.0"
   }
 }

--- a/test/e2e-framework/common/config/environment.go
+++ b/test/e2e-framework/common/config/environment.go
@@ -237,7 +237,7 @@ func (e *CommonEnvironment) KubernetesVersion() string {
 }
 
 func (e *CommonEnvironment) KindVersion() string {
-	return e.GetStringWithDefault(e.InfraConfig, DDInfraKindVersion, "v0.31.0")
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraKindVersion, "v0.32.0")
 }
 
 func (e *CommonEnvironment) KubeNodeURL() string {

--- a/test/e2e-framework/components/kubernetes/kind_versions.json
+++ b/test/e2e-framework/components/kubernetes/kind_versions.json
@@ -1,6 +1,6 @@
 {
   "1.37": {
-    "kind_version": "v0.31.0",
+    "kind_version": "v0.32.0",
     "node_image_version": "v1.37.0-rc.0@sha256:a11b5b8063555e8ef8a5e1100459cad9e100543f61e37cb7fd722ec576c9be89"
   },
   "1.36": {


### PR DESCRIPTION
### What does this PR do?

Kubernetes v1.36+ requires kubeadm API version v1beta4 at least to run.

In order to provide it, we must use kind v0.32.0 as minimum version for
any kubernetes version above 1.36.

All kind test jobs have a pinned version of kind to use.

Any new job will use the default value for kind version, set that
default to v0.32 so any new job will provide the kubeadm v1beta4.

### Motivation

fix flaky test

### Describe how you validated your changes

run the latest job with kube v1.37.0-rc.0 ✅ 
run the latest job with kube v1.19 ✅ 

### Additional Notes
