### PR TITLE
chore(devx): clean up and align CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -605,6 +605,7 @@
 /pkg/config/schema/yaml/compliance_config.yaml                        @DataDog/agent-cspm @DataDog/agent-security @DataDog/fleet-automation
 /pkg/config/schema/yaml/container_image.yaml                          @DataDog/container-integrations @DataDog/fleet-automation
 /pkg/config/schema/yaml/container_lifecycle.yaml                      @DataDog/container-integrations @DataDog/fleet-automation
+/pkg/config/schema/yaml/network_devices.yaml                          @DataDog/network-device-monitoring-core @DataDog/fleet-automation
 /pkg/config/schema/yaml/external_metrics_provider.yaml                @DataDog/container-autoscaling @DataDog/fleet-automation
 /pkg/config/schema/yaml/gpu.yaml                                      @DataDog/ebpf-platform @DataDog/gpu-monitoring-agent @DataDog/fleet-automation
 /pkg/config/schema/yaml/internal_profiling.yaml                       @DataDog/agent-runtimes @DataDog/fleet-automation
@@ -878,12 +879,12 @@
 /tasks/unit_tests/build_tags_tests.py                           @DataDog/agent-build
 /tasks/unit_tests/libs/build/                                   @DataDog/agent-build
 /tasks/unit_tests/omnibus_tests.py                              @DataDog/agent-build
-/tasks/unit_tests/schema_*                                      @DataDog/agent-configuration
+/tasks/unit_tests/schema_*                                      @DataDog/fleet-automation
 /tasks/unit_tests/testdata/components_src/                      @DataDog/agent-runtimes
 /tasks/unit_tests/testdata/collector/                           @DataDog/opentelemetry-agent
 /tasks/unit_tests/experimental_gates_tests.py                   @DataDog/agent-build
 /tasks/unit_tests/static_quality_gates/                         @DataDog/agent-build
-/tasks/unit_tests/testdata/schema_codegen/                      @DataDog/agent-configuration
+/tasks/unit_tests/testdata/schema_codegen/                      @DataDog/fleet-automation
 /tasks/installer.py                                             @DataDog/fleet
 /tasks/host_profiler.py                                         @DataDog/opentelemetry-agent @DataDog/profiling-full-host
 /test/                                                          @DataDog/agent-devx

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -425,6 +425,7 @@
 /comp/logonduration @DataDog/windows-products
 /comp/metriclookback @DataDog/q-branch
 /comp/networkconfigmanagement @DataDog/ndm-integrations
+/comp/networkdevices @DataDog/network-device-monitoring-core
 /comp/notableevents @DataDog/windows-products
 /comp/offlinereporter @DataDog/agent-metric-pipelines
 /comp/privateactionrunner @DataDog/action-platform
@@ -648,6 +649,7 @@
 /pkg/privateactionrunner/                                             @DataDog/action-platform
 /pkg/privateactionrunner/bundles/remoteaction/rshell                  @DataDog/action-platform @DataDog/dd-agent-mcp @DataDog/fleet-remediation
 /pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement @DataDog/action-platform @DataDog/ndm-integrations
+/pkg/privateactionrunner/bundles/remoteaction/networkdevices          @DataDog/action-platform @DataDog/network-device-monitoring-core
 /pkg/privateactionrunner/bundles/remoteaction/networks                @DataDog/action-platform @Datadog/network-path
 /pkg/proto/                                                           @DataDog/agent-runtimes
 /pkg/proto/datadog/dogstatsdhttp                                      @DataDog/agent-metric-pipelines
@@ -782,6 +784,7 @@
 /pkg/kubestatemetrics                                                 @DataDog/container-integrations
 /pkg/security/                                                        @DataDog/agent-security
 /pkg/networkdevice/                                                   @DataDog/network-device-monitoring-core
+/pkg/networkdevices/                                                  @DataDog/network-device-monitoring-core
 /pkg/snmp/                                                            @DataDog/network-device-monitoring-core
 /pkg/ssi/                                                             @DataDog/injection-platform
 /pkg/tagger/                                                          @DataDog/container-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,103 +13,105 @@
 # a slack channel in tasks/libs/pipeline_notifications.py
 
 # Config files for various CI systems / tasks
-/.*                                              @DataDog/agent-devx
-/.claude/settings.json                           @DataDog/agent-devx
-/.claude/agents/tend.md                          @DataDog/single-machine-performance
-/.claude/agents/weed.md                          @DataDog/single-machine-performance
-/.claude/rules/allium.md                         @DataDog/single-machine-performance
-/.claude/rules/bazel.md                          @DataDog/agent-build
-/.claude/rules/msi.md                            @DataDog/windows-products
-/.agents/*                                       @DataDog/agent-devx
-/.agents/skills/*                                @DataDog/agent-devx
-/.agents/skills/allium/                          @DataDog/single-machine-performance
-/.agents/skills/agent-supply-chain-newsletter/   @DataDog/agent-devx
-/.agents/skills/auto-jira/                       @DataDog/agent-devx
-/.agents/skills/create-component/                @DataDog/agent-runtimes
-/.agents/skills/create-core-check/               @DataDog/agent-runtimes
-/.agents/skills/create-epic-recap/               @DataDog/opentelemetry-agent
-/.agents/skills/create-go-module/                @DataDog/agent-runtimes
-/.agents/skills/create-invoke-task/              @DataDog/agent-devx
-/.agents/skills/create-pr/                       @DataDog/agent-devx
-/.agents/skills/create-release-note/             @DataDog/agent-devx
-/.agents/skills/create-config-field/SKILL.md     @DataDog/fleet-automation
-/.agents/skills/create-status-provider/SKILL.md  @DataDog/fleet-remediation
-/.agents/skills/create-subcommand/SKILL.md       @DataDog/fleet-remediation
-/.agents/skills/locate-config-setting/SKILL.md   @DataDog/fleet-automation
-/.agents/skills/create-runtime-setting/SKILL.md  @DataDog/agent-runtimes @DataDog/fleet-automation
-/.agents/skills/create-runtime-setting/SKILL.md  @DataDog/agent-runtimes @DataDog/fleet-automation
-/.agents/skills/cws-iouring-coverage/            @DataDog/agent-security
-/.agents/skills/explain-lading-config            @DataDog/single-machine-performance
-/.agents/skills/injector-dev                     @Datadog/container-platform
-/.agents/skills/quality-gate-size-analysis/      @DataDog/agent-build
-/.agents/skills/review-pr-comments/              @DataDog/agent-devx
-/.agents/skills/run-e2e/                         @DataDog/agent-devx
-/.agents/skills/run-jira/                        @DataDog/agent-devx
-/.agents/skills/run-windows-e2e/                 @DataDog/windows-products
-/.agents/skills/update-3rd-party-libs            @DataDog/agent-build
-/.agents/skills/update-otel-deps/                @DataDog/opentelemetry-agent
-/.agents/skills/write-e2e/                       @DataDog/agent-devx
-/.agents/skills/locate-config-setting/           @DataDog/fleet-automation
+/.*                                             @DataDog/agent-devx
+/.claude/settings.json                          @DataDog/agent-devx
+/.claude/agents/tend.md                         @DataDog/single-machine-performance
+/.claude/agents/weed.md                         @DataDog/single-machine-performance
+/.claude/rules/allium.md                        @DataDog/single-machine-performance
+/.claude/rules/bazel.md                         @DataDog/agent-build
+/.claude/rules/msi.md                           @DataDog/windows-products
+/.agents/*                                      @DataDog/agent-devx
+/.agents/skills/*                               @DataDog/agent-devx
+/.agents/skills/allium/                         @DataDog/single-machine-performance
+/.agents/skills/agent-supply-chain-newsletter/  @DataDog/agent-devx
+/.agents/skills/auto-jira/                      @DataDog/agent-devx
+/.agents/skills/create-component/               @DataDog/agent-runtimes
+/.agents/skills/create-core-check/              @DataDog/agent-runtimes
+/.agents/skills/create-epic-recap/              @DataDog/opentelemetry-agent
+/.agents/skills/create-go-module/               @DataDog/agent-runtimes
+/.agents/skills/create-invoke-task/             @DataDog/agent-devx
+/.agents/skills/create-pr/                      @DataDog/agent-devx
+/.agents/skills/create-release-note/            @DataDog/agent-devx
+/.agents/skills/create-config-field/SKILL.md    @DataDog/fleet-automation
+/.agents/skills/create-status-provider/SKILL.md @DataDog/fleet-remediation
+/.agents/skills/create-subcommand/SKILL.md      @DataDog/fleet-remediation
+/.agents/skills/locate-config-setting/SKILL.md  @DataDog/fleet-automation
+/.agents/skills/create-runtime-setting/SKILL.md @DataDog/agent-runtimes @DataDog/fleet-automation
+/.agents/skills/cws-iouring-coverage/           @DataDog/agent-security
+/.agents/skills/explain-lading-config           @DataDog/single-machine-performance
+/.agents/skills/injector-dev                    @Datadog/container-platform
+/.agents/skills/quality-gate-size-analysis/     @DataDog/agent-build
+/.agents/skills/review-pr-comments/             @DataDog/agent-devx
+/.agents/skills/run-e2e/                        @DataDog/agent-devx
+/.agents/skills/run-jira/                       @DataDog/agent-devx
+/.agents/skills/run-windows-e2e/                @DataDog/windows-products
+/.agents/skills/update-3rd-party-libs           @DataDog/agent-build
+/.agents/skills/update-otel-deps/               @DataDog/opentelemetry-agent
+/.agents/skills/write-e2e/                      @DataDog/agent-devx
+/.agents/skills/locate-config-setting/          @DataDog/fleet-automation
 # changing the config of mockery will regenerate the mocks, so owners will have to review anyway
-/.mockery.yaml                          # do not notify anyone
-/.go-version                            @DataDog/agent-runtimes @DataDog/agent-build
+/.mockery.yaml                                  # do not notify anyone
+/.go-version                                    @DataDog/agent-runtimes @DataDog/agent-build
 # Go linters and pre-commit config
-/.golangci.yml                          @DataDog/agent-devx
-/.pre-commit-config.yaml                @DataDog/agent-devx
-/.vscode/                               @DataDog/agent-devx
+/.golangci.yml                                  @DataDog/agent-devx
+/.pre-commit-config.yaml                        @DataDog/agent-devx
+/.vscode/                                       @DataDog/agent-devx
+/.run                                           @DataDog/agent-devx
+/.run/docker/                                   @DataDog/container-integrations @DataDog/container-platform
+/skaffold.yaml                                  @DataDog/agent-devx @DataDog/container-platform
+/.run/skaffold/                                 @DataDog/agent-devx @DataDog/container-platform
+/CHANGELOG.rst                                  @DataDog/agent-delivery
+/CHANGELOG-DCA.rst                              @DataDog/container-integrations @DataDog/container-platform
+/CHANGELOG-INSTALLSCRIPT.rst                    @DataDog/agent-delivery
+/*.md                                           @DataDog/agent-devx
+/CHANGELOG-AIX.md                               @DataDog/agent-runtimes
+/AGENTS.md                                      @DataDog/agent-devx
+/CLAUDE.md                                      @DataDog/agent-devx
+/NOTICE                                         @DataDog/agent-delivery
+/mkdocs.yml                                     @DataDog/agent-devx
+/release.json                                   @DataDog/agent-build @DataDog/agent-delivery @DataDog/agent-integrations
+/renovate.json                                  @DataDog/agent-build
+/pyproject.toml                                 @DataDog/agent-devx
+/agents.toml                                    @DataDog/agent-devx
+/mise.toml                                      @DataDog/agent-devx
+/repository.datadog.yml                         @DataDog/agent-devx
+/code-coverage.datadog.yml                      @DataDog/agent-devx
+/service.datadog.yaml                           @DataDog/agent-delivery @DataDog/agent-devx
+/static-analysis.datadog.yml                    @DataDog/agent-devx
+/rust-toolchain.toml                            @DataDog/agent-build @DataDog/agent-devx
+/Cargo.toml                                     @DataDog/agent-build @DataDog/agent-devx
+/Cargo.lock                                     @DataDog/agent-build @DataDog/agent-devx
+/datadog-agent.map                              @DataDog/agent-log-pipelines
+/flakes.yaml                                    @DataDog/agent-devx
+/k8s_versions.json                              @DataDog/container-integrations
+/modules.yml                                    @DataDog/agent-runtimes
+# if go.work changes then either .go-version or modules.yml changed too, so ASC might as well own it
+/go.work                                        @DataDog/agent-runtimes
 
 # Bazel configuration
-/*.bazel*                               @DataDog/agent-build
-/.adms/                                 @DataDog/agent-build @DataDog/agent-devx
-/.bazel*                                @DataDog/agent-build
-/.buildifier.json                       @DataDog/agent-build
-/bazel/                                 @DataDog/agent-build
-/bazel/configs/rust.bazelrc             @DataDog/agent-discovery @DataDog/agent-runtimes @DataDog/agent-build
-/deps/                                  @DataDog/agent-build
-/deps/agent_data_plane/                 @DataDog/agent-data-plane @DataDog/agent-build
+/*.bazel*                   @DataDog/agent-build
+/.adms/                     @DataDog/agent-build @DataDog/agent-devx
+/.bazel*                    @DataDog/agent-build
+/.buildifier.json           @DataDog/agent-build
+/bazel/                     @DataDog/agent-build
+/bazel/configs/rust.bazelrc @DataDog/agent-discovery @DataDog/agent-runtimes @DataDog/agent-build
+/deps/                      @DataDog/agent-build
+/deps/agent_data_plane/     @DataDog/agent-data-plane @DataDog/agent-build
 
 # The owner should really be to a team that does not exist yet. It would cover supply chain in general.
 # For now, agent-build are the experts in that.
-/compliance/                            @DataDog/agent-build
-/third_party/                           @DataDog/agent-build
-/.copyright-overrides.yml               @DataDog/agent-build @DataDog/agent-devx
-/LICENSE*                               # do not notify anyone
-/rust/LICENSE*				# do not notify anyone
-/rust/deny.toml                         @DataDog/agent-build
+/compliance/              @DataDog/agent-build
+/third_party/             @DataDog/agent-build
+/.copyright-overrides.yml @DataDog/agent-build @DataDog/agent-devx
+/LICENSE*                 # do not notify anyone
+/rust/LICENSE*            # do not notify anyone
+/rust/license-tool.toml   # do not notify anyone
+/rust/deny.toml           @DataDog/agent-build
 
-/CHANGELOG.rst                          @DataDog/agent-delivery
-/CHANGELOG-DCA.rst                      @DataDog/container-integrations @DataDog/container-platform
-/CHANGELOG-INSTALLSCRIPT.rst            @DataDog/agent-delivery
-
-/*.md                                   @DataDog/agent-devx
-/CHANGELOG-AIX.md                       @DataDog/agent-runtimes
-/AGENTS.md                              @DataDog/agent-devx
-/CLAUDE.md                              @DataDog/agent-devx
-/NOTICE                                 @DataDog/agent-delivery
-
-/mkdocs.yml                             @DataDog/agent-devx
-/release.json                           @DataDog/agent-build @DataDog/agent-delivery @DataDog/agent-integrations
-/renovate.json                          @DataDog/agent-build
-/pyproject.toml                         @DataDog/agent-devx
-/agents.toml                            @DataDog/agent-devx
-/mise.toml                              @DataDog/agent-devx
-/repository.datadog.yml                 @DataDog/agent-devx
-/code-coverage.datadog.yml              @DataDog/agent-devx
-/service.datadog.yaml                   @DataDog/agent-delivery @DataDog/agent-devx
-/static-analysis.datadog.yml            @DataDog/agent-devx
-/rust-toolchain.toml                    @DataDog/agent-build @DataDog/agent-devx
-/Cargo.toml                             @DataDog/agent-build @DataDog/agent-devx
-/Cargo.lock                             @DataDog/agent-build @DataDog/agent-devx
-
-/modules.yml                            @DataDog/agent-runtimes
-# if go.work changes then either .go-version or modules.yml changed too, so ASC might as well own it
-/go.work                                @DataDog/agent-runtimes
 
 /.github/CODEOWNERS                                  # do not notify anyone
 /.github/*_TEMPLATE.md                               @DataDog/agent-devx
 /.github/chainguard/**                               @DataDog/agent-devx
-# Removed temporarily
-# /.github/dependabot.yaml                             @DataDog/agent-devx
 /.github/workflows/cws-btfhub-sync.yml               @DataDog/agent-security @DataDog/agent-devx
 /.github/workflows/gohai.yml                         @DataDog/fleet-automation @DataDog/agent-devx
 /.github/workflows/go-update-commenter.yml           @DataDog/agent-runtimes @DataDog/agent-devx
@@ -119,212 +121,182 @@
 /.github/workflows/collector-generate-and-update.yml @DataDog/opentelemetry-agent @DataDog/agent-devx
 /.github/workflows/update-kubernetes-versions.yml    @DataDog/container-integrations @DataDog/agent-devx
 
-
-/.run                                                @DataDog/agent-devx
-/.run/docker/                                        @DataDog/container-integrations @DataDog/container-platform
-
-/skaffold.yaml                                       @DataDog/agent-devx @DataDog/container-platform
-/.run/skaffold/                                      @DataDog/agent-devx @DataDog/container-platform
-
 # Gitlab files
 # Files containing job contents are owned by teams in charge of the jobs + agent-devx or agent-delivery or agent-build
 # Files that only describe structure (eg. includes, rules) are owned by agent-devx
 
-/.gitlab/.ci-linters.yml                             @DataDog/agent-devx @DataDog/agent-build
-/.gitlab/.pre/*                                      @DataDog/agent-devx
-/.gitlab/.post/*                                     @DataDog/agent-devx
-/.gitlab/build/bazel/*                                     @DataDog/agent-build
-/.gitlab/deploy/check_deploy/*                              @DataDog/agent-delivery
-/.gitlab/.post/do_not_merge.yml                               @DataDog/agent-devx
-/.gitlab/deploy*/*                                   @DataDog/agent-delivery
-/.gitlab/.pre/deps_fetch/*                                @DataDog/agent-devx
-/.gitlab/test/e2e/*                                       @DataDog/agent-devx
-/.gitlab/deploy/e2e_testing_deploy/*                        @DataDog/agent-devx
-/.gitlab/test/e2e_pre_test/*                              @DataDog/agent-devx
-/.gitlab/test/kernel_matrix_testing/*                     @DataDog/agent-devx @DataDog/ebpf-platform
-/.gitlab/build/lint/*                                      @DataDog/agent-devx
-/.gitlab/.pre/maintenance_jobs/*                          @DataDog/agent-devx
-/.gitlab/.post/notify/*                                    @DataDog/agent-devx
-/.gitlab/build/pkg_metrics/*                               @DataDog/agent-devx
-/.gitlab/.pre/setup/*                                     @DataDog/agent-devx
-/.gitlab/deploy/trigger_distribution.yml                      @DataDog/agent-delivery
-/.gitlab/distribute/trigger_release/*                           @DataDog/agent-devx @DataDog/agent-delivery
-/.gitlab/build/binary_build/cws_instrumentation.yml        @DataDog/agent-devx @DataDog/agent-security
-/.gitlab/build/binary_build/linux.yml                      @DataDog/agent-devx @DataDog/agent-build
-/.gitlab/test/functional_test/static_quality_gate.yml     @DataDog/agent-build
-/.gitlab/test/functional_test/files_inventory_check.yml   @DataDog/agent-build
-/.gitlab/test/install_script_testing/install_script_testing.yml          @DataDog/agent-build
-/.gitlab/test/integration_test/dogstatsd.yml              @DataDog/agent-devx @DataDog/agent-metric-pipelines
-/.gitlab/test/integration_test/linux.yml                  @DataDog/agent-devx
-/.gitlab/test/integration_test/otel.yml                   @DataDog/agent-devx @DataDog/opentelemetry-agent
-/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml            @DataDog/agent-delivery
-/.gitlab/deploy/internal_kubernetes_deploy/internal_kubernetes_deploy.yml  @DataDog/agent-delivery
-/.gitlab/build/package_deps_build/package_deps_build.yml   @DataDog/agent-devx @DataDog/ebpf-platform
-/.gitlab/build/source_test/golang_deps_diff.yml            @DataDog/agent-runtimes
-/.gitlab/build/source_test/*                               @DataDog/agent-devx
-/.gitlab/build/source_test/linux.yml                       @DataDog/agent-devx @Datadog/agent-build
-/.gitlab/build/source_test/macos.yml                       @DataDog/agent-devx @Datadog/agent-build @DataDog/windows-products
-/.gitlab/build/source_test/notify.yml                      @DataDog/agent-devx
-/.gitlab/build/source_test/slack.yml                       @DataDog/agent-devx
-/.gitlab/build/source_test/tooling_unit_tests.yml          @DataDog/agent-devx
-/.gitlab/build/source_test/kmt_tasks.yml                   @DataDog/ebpf-platform
+/.gitlab/.ci-linters.yml                                                  @DataDog/agent-devx @DataDog/agent-build
+/.gitlab/.pre/*                                                           @DataDog/agent-devx
+/.gitlab/.post/*                                                          @DataDog/agent-devx
+/.gitlab/build/bazel/*                                                    @DataDog/agent-build
+/.gitlab/deploy/check_deploy/*                                            @DataDog/agent-delivery
+/.gitlab/.post/do_not_merge.yml                                           @DataDog/agent-devx
+/.gitlab/deploy*/*                                                        @DataDog/agent-delivery
+/.gitlab/.pre/deps_fetch/*                                                @DataDog/agent-devx
+/.gitlab/test/e2e/*                                                       @DataDog/agent-devx
+/.gitlab/deploy/e2e_testing_deploy/*                                      @DataDog/agent-devx
+/.gitlab/test/e2e_pre_test/*                                              @DataDog/agent-devx
+/.gitlab/test/kernel_matrix_testing/*                                     @DataDog/agent-devx @DataDog/ebpf-platform
+/.gitlab/build/lint/*                                                     @DataDog/agent-devx
+/.gitlab/.pre/maintenance_jobs/*                                          @DataDog/agent-devx
+/.gitlab/.post/notify/*                                                   @DataDog/agent-devx
+/.gitlab/build/pkg_metrics/*                                              @DataDog/agent-devx
+/.gitlab/.pre/setup/*                                                     @DataDog/agent-devx
+/.gitlab/deploy/trigger_distribution.yml                                  @DataDog/agent-delivery
+/.gitlab/distribute/trigger_release/*                                     @DataDog/agent-devx @DataDog/agent-delivery
+/.gitlab/build/binary_build/cws_instrumentation.yml                       @DataDog/agent-devx @DataDog/agent-security
+/.gitlab/build/binary_build/linux.yml                                     @DataDog/agent-devx @DataDog/agent-build
+/.gitlab/test/functional_test/static_quality_gate.yml                     @DataDog/agent-build
+/.gitlab/test/functional_test/files_inventory_check.yml                   @DataDog/agent-build
+/.gitlab/test/install_script_testing/install_script_testing.yml           @DataDog/agent-build
+/.gitlab/test/integration_test/dogstatsd.yml                              @DataDog/agent-devx @DataDog/agent-metric-pipelines
+/.gitlab/test/integration_test/linux.yml                                  @DataDog/agent-devx
+/.gitlab/test/integration_test/otel.yml                                   @DataDog/agent-devx @DataDog/opentelemetry-agent
+/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml           @DataDog/agent-delivery
+/.gitlab/deploy/internal_kubernetes_deploy/internal_kubernetes_deploy.yml @DataDog/agent-delivery
+/.gitlab/build/package_deps_build/package_deps_build.yml                  @DataDog/agent-devx @DataDog/ebpf-platform
+/.gitlab/build/source_test/golang_deps_diff.yml                           @DataDog/agent-runtimes
+/.gitlab/build/source_test/*                                              @DataDog/agent-devx
+/.gitlab/build/source_test/linux.yml                                      @DataDog/agent-devx @Datadog/agent-build
+/.gitlab/build/source_test/macos.yml                                      @DataDog/agent-devx @Datadog/agent-build @DataDog/windows-products
+/.gitlab/build/source_test/notify.yml                                     @DataDog/agent-devx
+/.gitlab/build/source_test/slack.yml                                      @DataDog/agent-devx
+/.gitlab/build/source_test/tooling_unit_tests.yml                         @DataDog/agent-devx
+/.gitlab/build/source_test/kmt_tasks.yml                                  @DataDog/ebpf-platform
+/.gitlab/build/binary_build/cluster_agent_cloudfoundry.yml                @DataDog/agent-integrations @DataDog/agent-build
+/.gitlab/build/binary_build/cluster_agent.yml                             @DataDog/container-platform @DataDog/agent-build
+/.gitlab/build/binary_build/fakeintake.yml                                @DataDog/agent-devx
+/.gitlab/build/binary_build/host_profiler.yml                             @DataDog/opentelemetry-agent @DataDog/profiling-full-host @DataDog/agent-build
+/.gitlab/build/binary_build/system_probe.yml                              @DataDog/ebpf-platform @DataDog/agent-build
+/.gitlab/windows/build/binary_build/windows.yml                           @DataDog/agent-build @DataDog/windows-products
+/.gitlab/build/source_test/codeql_scan.yml                                @DataDog/sdlc-security
+/.gitlab/test/benchmarks/                                                 @DataDog/agent-devx @DataDog/apm-ecosystems-performance @DataDog/agent-apm
+/.gitlab/distribute/                                                      @DataDog/container-integrations @DataDog/agent-delivery
+/.gitlab/deploy/deploy_packages/                                          @DataDog/agent-delivery
+/.gitlab/deploy/deploy_packages/oci.yml                                   @DataDog/agent-delivery @DataDog/fleet
+/.gitlab/windows/deploy/deploy_packages/windows.yml                       @DataDog/agent-delivery @DataDog/windows-products
+/.gitlab/windows/distribute/winget/windows.yml                            @DataDog/agent-delivery @DataDog/windows-products
+/.gitlab/deploy/deploy_packages/cluster_agent_cloudfoundry.yml            @DataDog/agent-integrations @DataDog/agent-devx
+/.gitlab/deploy/deploy_packages/e2e.yml                                   @DataDog/agent-devx  @DataDog/fleet
+/.gitlab/.pre/deps_build/                                                 @DataDog/ebpf-platform @DataDog/agent-build @DataDog/windows-products
+/.gitlab/windows/test/e2e_install_packages/windows.yml                    @DataDog/windows-products
+/.gitlab/.pre/common/                                                     @DataDog/agent-devx
+/.gitlab/test/e2e/e2e.yml                                                 @DataDog/container-integrations @DataDog/agent-devx @DataDog/fleet
+/.gitlab/deploy/container_build/fakeintake.yml                            @DataDog/agent-devx
+/.gitlab/build/binary_build/fakeintake.yml                                @DataDog/agent-devx
+/.gitlab/test/functional_test/oracle.yml                                  @DataDog/agent-devx @DataDog/database-monitoring
+/.gitlab/windows/deploy/choco_build/windows.yml                           @DataDog/agent-build @DataDog/windows-products
+/.gitlab/windows/test/integration_test/windows.yml                        @DataDog/agent-devx @DataDog/windows-products
+/.gitlab/test/kernel_matrix_testing                                       @DataDog/ebpf-platform
+/.gitlab/test/kernel_matrix_testing/security_agent.yml                    @DataDog/agent-security
+/.gitlab/.pre/common/container_publish_job_templates.yml                  @DataDog/container-integrations @DataDog/agent-delivery
+/.gitlab/deploy/container_build/                                          @DataDog/container-platform @DataDog/agent-build
+/.gitlab/windows/deploy/container_build/*                                 @DataDog/agent-build @DataDog/windows-products
+/.gitlab/deploy/dev_container_deploy/                                     @DataDog/container-integrations @DataDog/agent-delivery
+/.gitlab/deploy/dev_container_deploy/fakeintake.yml                       @DataDog/agent-devx
+/.gitlab/deploy/dev_container_deploy/e2e.yml                              @DataDog/agent-devx
+/.gitlab/windows/deploy/dev_container_deploy/windows.yml                  @DataDog/agent-delivery @DataDog/windows-products
+/.gitlab/deploy/container_scan/container_scan.yml                         @DataDog/container-integrations @DataDog/agent-delivery
+/.gitlab/.pre/maintenance_jobs/docker.yml                                 @DataDog/container-integrations @DataDog/agent-delivery
+/.gitlab/build/source_test/ebpf.yml                                       @DataDog/ebpf-platform @DataDog/agent-devx
+/.gitlab/windows/build/source_test/windows.yml                            @DataDog/agent-devx @DataDog/agent-build @DataDog/windows-products
+/.gitlab/build/source_test/go_generate_check.yml                          @DataDog/agent-security
+/.gitlab/build/package_build/                                             @DataDog/agent-build
+/.gitlab/windows/build/package_build/windows.yml                          @DataDog/agent-build @DataDog/windows-products
+/.gitlab/build/package_build/installer.yml                                @DataDog/agent-build @DataDog/fleet
+/.gitlab/build/packaging/                                                 @DataDog/agent-build
+/.gitlab/deploy/network_device_build/                                     @DataDog/agent-delivery
+/.gitlab/test/benchmarks/benchmarks.yml                                   @DataDog/agent-apm
+/.gitlab/test/functional_test/regression_detector.yml                     @DataDog/single-machine-performance
 
-/.gitlab/build/binary_build/cluster_agent_cloudfoundry.yml @DataDog/agent-integrations @DataDog/agent-build
-/.gitlab/build/binary_build/cluster_agent.yml              @DataDog/container-platform @DataDog/agent-build
-/.gitlab/build/binary_build/fakeintake.yml                 @DataDog/agent-devx
-/.gitlab/build/binary_build/host_profiler.yml              @DataDog/opentelemetry-agent @DataDog/profiling-full-host @DataDog/agent-build
-/.gitlab/build/binary_build/system_probe.yml               @DataDog/ebpf-platform @DataDog/agent-build
-/.gitlab/windows/build/binary_build/windows.yml            @DataDog/agent-build @DataDog/windows-products
+/chocolatey/ @DataDog/windows-products
 
-/.gitlab/build/source_test/codeql_scan.yml                 @DataDog/sdlc-security
-
-/.gitlab/test/benchmarks/                                 @DataDog/agent-devx @DataDog/apm-ecosystems-performance @DataDog/agent-apm
-
-/.gitlab/distribute/                                 @DataDog/container-integrations @DataDog/agent-delivery
-
-/.gitlab/deploy/deploy_packages/                               @DataDog/agent-delivery
-/.gitlab/deploy/deploy_packages/oci.yml                        @DataDog/agent-delivery @DataDog/fleet
-/.gitlab/windows/deploy/deploy_packages/windows.yml           @DataDog/agent-delivery @DataDog/windows-products
-/.gitlab/windows/distribute/winget/windows.yml              @DataDog/agent-delivery @DataDog/windows-products
-/.gitlab/deploy/deploy_packages/cluster_agent_cloudfoundry.yml @DataDog/agent-integrations @DataDog/agent-devx
-/.gitlab/deploy/deploy_packages/e2e.yml                        @DataDog/agent-devx  @DataDog/fleet
-
-/.gitlab/.pre/deps_build/                                 @DataDog/ebpf-platform @DataDog/agent-build @DataDog/windows-products
-
-/.gitlab/windows/test/e2e_install_packages/windows.yml   @DataDog/windows-products
-
-/.gitlab/.pre/common/                                     @DataDog/agent-devx
-
-/.gitlab/test/e2e/e2e.yml                                 @DataDog/container-integrations @DataDog/agent-devx @DataDog/fleet
-/.gitlab/deploy/container_build/fakeintake.yml               @DataDog/agent-devx
-/.gitlab/build/binary_build/fakeintake.yml                  @DataDog/agent-devx
-
-/.gitlab/test/functional_test/oracle.yml                  @DataDog/agent-devx @DataDog/database-monitoring
-
-/.gitlab/windows/deploy/choco_build/windows.yml             @DataDog/agent-build @DataDog/windows-products
-
-/.gitlab/windows/test/integration_test/windows.yml        @DataDog/agent-devx @DataDog/windows-products
-
-/.gitlab/test/kernel_matrix_testing                       @DataDog/ebpf-platform
-/.gitlab/test/kernel_matrix_testing/security_agent.yml    @DataDog/agent-security
-
-/.gitlab/.pre/common/container_publish_job_templates.yml  @DataDog/container-integrations @DataDog/agent-delivery
-/.gitlab/deploy/container_build/                            @DataDog/container-platform @DataDog/agent-build
-/.gitlab/windows/deploy/container_build/*                   @DataDog/agent-build @DataDog/windows-products
-
-/.gitlab/deploy/dev_container_deploy/                       @DataDog/container-integrations @DataDog/agent-delivery
-/.gitlab/deploy/dev_container_deploy/fakeintake.yml         @DataDog/agent-devx
-/.gitlab/deploy/dev_container_deploy/e2e.yml                @DataDog/agent-devx
-/.gitlab/windows/deploy/dev_container_deploy/windows.yml    @DataDog/agent-delivery @DataDog/windows-products
-
-/.gitlab/deploy/container_scan/container_scan.yml           @DataDog/container-integrations @DataDog/agent-delivery
-
-
-/.gitlab/.pre/maintenance_jobs/docker.yml                 @DataDog/container-integrations @DataDog/agent-delivery
-
-/.gitlab/build/source_test/ebpf.yml                        @DataDog/ebpf-platform @DataDog/agent-devx
-/.gitlab/windows/build/source_test/windows.yml             @DataDog/agent-devx @DataDog/agent-build @DataDog/windows-products
-/.gitlab/build/source_test/go_generate_check.yml           @DataDog/agent-security
-
-/.gitlab/build/package_build/                              @DataDog/agent-build
-/.gitlab/windows/build/package_build/windows.yml           @DataDog/agent-build @DataDog/windows-products
-/.gitlab/build/package_build/installer.yml                 @DataDog/agent-build @DataDog/fleet
-/.gitlab/build/packaging/                                  @DataDog/agent-build
-
-/.gitlab/deploy/network_device_build/                       @DataDog/agent-delivery
-
-/.gitlab/test/benchmarks/benchmarks.yml                   @DataDog/agent-apm
-
-/.gitlab/test/functional_test/regression_detector.yml     @DataDog/single-machine-performance
-
-
-
-/chocolatey/                            @DataDog/windows-products
-
-/cmd/                                   @DataDog/fleet-remediation
-/cmd/trace-agent/                       @DataDog/agent-apm
-/cmd/agent/subcommands/controlsvc       @DataDog/windows-products
-/cmd/agent/subcommands/otel             @DataDog/opentelemetry-agent
-/cmd/agent/subcommands/check            @DataDog/agent-runtimes @DataDog/agent-integrations
-/cmd/agent/subcommands/dogstatsd*       @DataDog/agent-metric-pipelines
-/cmd/agent/subcommands/integrations     @DataDog/agent-integrations @DataDog/agent-runtimes
-/cmd/agent/subcommands/hostname         @DataDog/agent-runtimes
-/cmd/agent/subcommands/version          @DataDog/agent-runtimes
-/cmd/agent/subcommands/processchecks    @DataDog/container-experiences
-/cmd/agent/subcommands/remoteconfig     @DataDog/remote-config
-/cmd/agent/subcommands/snmp             @DataDog/network-device-monitoring-core
-/cmd/agent/subcommands/streamlogs       @DataDog/agent-log-pipelines
-/cmd/agent/subcommands/analyzelogs      @DataDog/agent-log-pipelines
-/cmd/agent/subcommands/streamep         @DataDog/container-integrations
-/cmd/agent/subcommands/taggerlist       @DataDog/container-platform
-/cmd/agent/subcommands/workloadlist     @DataDog/container-platform
-/cmd/agent/subcommands/run/             @DataDog/agent-runtimes
-/cmd/agent/subcommands/run/internal/clcrunnerapi/       @DataDog/container-platform
-/cmd/agent/windows                      @DataDog/windows-products
-/cmd/agent/windows_resources            @DataDog/windows-products
-/cmd/agent/dist/conf.d/                 @DataDog/agent-integrations
-/cmd/agent/dist/conf.d/container.d/     @DataDog/container-integrations
-/cmd/agent/dist/conf.d/containerd.d/    @DataDog/container-integrations
-/cmd/agent/dist/conf.d/container_image.d/      @DataDog/container-integrations
-/cmd/agent/dist/conf.d/container_lifecycle.d/  @DataDog/container-integrations
-/cmd/agent/dist/conf.d/discovery.d/          @DataDog/agent-discovery
-/cmd/agent/dist/conf.d/jetson.d/        @DataDog/agent-runtimes
-/cmd/agent/dist/conf.d/oracle.d/    @DataDog/database-monitoring
-/cmd/agent/dist/conf.d/oracle-dbm.d/    @DataDog/database-monitoring
-/cmd/agent/dist/conf.d/network_path.d/  @DataDog/network-path
-/cmd/agent/dist/conf.d/network_config_management.d/  @DataDog/ndm-integrations
-/cmd/agent/dist/conf.d/orchestrator_ecs.d/  @DataDog/ecs-experiences
-/cmd/agent/dist/conf.d/sbom.d/          @DataDog/agent-security @DataDog/container-integrations
-/cmd/agent/dist/conf.d/snmp.d/          @DataDog/network-device-monitoring-core
-/cmd/agent/dist/conf.d/win32_event_log.d/ @DataDog/windows-products
-/cmd/agent/dist/conf.d/windows_certificate.d/ @DataDog/windows-products
-/cmd/agent/install*.sh                  @DataDog/agent-build
-/cmd/agent/macos/                       @DataDog/windows-products
-/cmd/ai_prompt_logger/                  @DataDog/windows-products
-/cmd/cluster-agent/                     @DataDog/container-platform
-/cmd/cluster-agent/subcommands/autoscalerlist   @DataDog/container-autoscaling @DataDog/container-integrations
-/cmd/cluster-agent/subcommands/rotateparidentity   @Datadog/action-platform
-/cmd/cluster-agent/subcommands/start/agent_task.go @DataDog/container-platform @DataDog/fleet
-/cmd/cluster-agent-cloudfoundry/        @DataDog/agent-integrations
-/cmd/cluster-agent/api/v1/cloudfoundry_metadata.go        @DataDog/agent-integrations
-/cmd/cws-instrumentation/               @DataDog/agent-security
-/cmd/dogstatsd/                         @DataDog/agent-metric-pipelines
-/cmd/loader/                            @DataDog/agent-runtimes @DataDog/agent-apm
-/cmd/otel-agent/                        @DataDog/opentelemetry-agent
-/cmd/privateactionrunner                @DataDog/action-platform
-/cmd/process-agent/                     @DataDog/container-experiences
-/cmd/serverless-init/                   @DataDog/serverless-azure-gcp
-/cmd/sbomgen/                           @DataDog/agent-security
-/cmd/system-probe/                      @DataDog/ebpf-platform
-/cmd/system-probe/modules/usm*          @DataDog/universal-service-monitoring
-/cmd/system-probe/modules/network_tracer*  @DataDog/cloud-network-monitoring
-/cmd/system-probe/modules/oom_kill_probe*   @DataDog/container-integrations
-/cmd/system-probe/modules/process*      @DataDog/container-experiences
-/cmd/system-probe/modules/eventmonitor* @DataDog/agent-security
-/cmd/system-probe/modules/compliance*   @DataDog/agent-cspm @DataDog/agent-security
-/cmd/system-probe/modules/tcp_queue_tracer* @DataDog/container-integrations
-/cmd/system-probe/modules/traceroute*   @DataDog/network-path
-/cmd/system-probe/modules/ping*         @DataDog/network-device-monitoring-core
-/cmd/system-probe/modules/language_detection* @DataDog/container-experiences @DataDog/agent-discovery
-/cmd/system-probe/modules/dynamic_instrumentation* @DataDog/debugger-go
-/cmd/system-probe/modules/noisy_neighbor* @DataDog/container-experiences
-/cmd/system-probe/windows/              @DataDog/windows-products
-/cmd/system-probe/windows_resources/    @DataDog/windows-products
-/cmd/system-probe/main_windows*.go      @DataDog/windows-products
+/cmd/                                               @DataDog/fleet-remediation
+/cmd/trace-agent/                                   @DataDog/agent-apm
+/cmd/agent/subcommands/controlsvc                   @DataDog/windows-products
+/cmd/agent/subcommands/otel                         @DataDog/opentelemetry-agent
+/cmd/agent/subcommands/check                        @DataDog/agent-runtimes @DataDog/agent-integrations
+/cmd/agent/subcommands/dogstatsd*                   @DataDog/agent-metric-pipelines
+/cmd/agent/subcommands/integrations                 @DataDog/agent-integrations @DataDog/agent-runtimes
+/cmd/agent/subcommands/hostname                     @DataDog/agent-runtimes
+/cmd/agent/subcommands/version                      @DataDog/agent-runtimes
+/cmd/agent/subcommands/processchecks                @DataDog/container-experiences
+/cmd/agent/subcommands/remoteconfig                 @DataDog/remote-config
+/cmd/agent/subcommands/snmp                         @DataDog/network-device-monitoring-core
+/cmd/agent/subcommands/streamlogs                   @DataDog/agent-log-pipelines
+/cmd/agent/subcommands/analyzelogs                  @DataDog/agent-log-pipelines
+/cmd/agent/subcommands/streamep                     @DataDog/container-integrations
+/cmd/agent/subcommands/taggerlist                   @DataDog/container-platform
+/cmd/agent/subcommands/workloadlist                 @DataDog/container-platform
+/cmd/agent/subcommands/run/                         @DataDog/agent-runtimes
+/cmd/agent/subcommands/run/internal/clcrunnerapi/   @DataDog/container-platform
+/cmd/agent/windows                                  @DataDog/windows-products
+/cmd/agent/windows_resources                        @DataDog/windows-products
+/cmd/agent/dist/conf.d/                             @DataDog/agent-integrations
+/cmd/agent/dist/conf.d/container.d/                 @DataDog/container-integrations
+/cmd/agent/dist/conf.d/containerd.d/                @DataDog/container-integrations
+/cmd/agent/dist/conf.d/container_image.d/           @DataDog/container-integrations
+/cmd/agent/dist/conf.d/container_lifecycle.d/       @DataDog/container-integrations
+/cmd/agent/dist/conf.d/discovery.d/                 @DataDog/agent-discovery
+/cmd/agent/dist/conf.d/jetson.d/                    @DataDog/agent-runtimes
+/cmd/agent/dist/conf.d/oracle.d/                    @DataDog/database-monitoring
+/cmd/agent/dist/conf.d/oracle-dbm.d/                @DataDog/database-monitoring
+/cmd/agent/dist/conf.d/network_path.d/              @DataDog/network-path
+/cmd/agent/dist/conf.d/network_config_management.d/ @DataDog/ndm-integrations
+/cmd/agent/dist/conf.d/orchestrator_ecs.d/          @DataDog/ecs-experiences
+/cmd/agent/dist/conf.d/sbom.d/                      @DataDog/agent-security @DataDog/container-integrations
+/cmd/agent/dist/conf.d/snmp.d/                      @DataDog/network-device-monitoring-core
+/cmd/agent/dist/conf.d/win32_event_log.d/           @DataDog/windows-products
+/cmd/agent/dist/conf.d/windows_certificate.d/       @DataDog/windows-products
+/cmd/agent/install*.sh                              @DataDog/agent-build
+/cmd/agent/macos/                                   @DataDog/windows-products
+/cmd/ai_prompt_logger/                              @DataDog/windows-products
+/cmd/cluster-agent/                                 @DataDog/container-platform
+/cmd/cluster-agent/subcommands/autoscalerlist       @DataDog/container-autoscaling @DataDog/container-integrations
+/cmd/cluster-agent/subcommands/rotateparidentity    @Datadog/action-platform
+/cmd/cluster-agent/subcommands/start/agent_task.go  @DataDog/container-platform @DataDog/fleet
+/cmd/cluster-agent-cloudfoundry/                    @DataDog/agent-integrations
+/cmd/cluster-agent/api/v1/cloudfoundry_metadata.go  @DataDog/agent-integrations
+/cmd/cws-instrumentation/                           @DataDog/agent-security
+/cmd/dogstatsd/                                     @DataDog/agent-metric-pipelines
+/cmd/loader/                                        @DataDog/agent-runtimes @DataDog/agent-apm
+/cmd/otel-agent/                                    @DataDog/opentelemetry-agent
+/cmd/privateactionrunner                            @DataDog/action-platform
+/cmd/process-agent/                                 @DataDog/container-experiences
+/cmd/serverless-init/                               @DataDog/serverless-azure-gcp
+/cmd/sbomgen/                                       @DataDog/agent-security
+/cmd/system-probe/                                  @DataDog/ebpf-platform
+/cmd/system-probe/modules/usm*                      @DataDog/universal-service-monitoring
+/cmd/system-probe/modules/network_tracer*           @DataDog/cloud-network-monitoring
+/cmd/system-probe/modules/oom_kill_probe*           @DataDog/container-integrations
+/cmd/system-probe/modules/process*                  @DataDog/container-experiences
+/cmd/system-probe/modules/eventmonitor*             @DataDog/agent-security
+/cmd/system-probe/modules/compliance*               @DataDog/agent-cspm @DataDog/agent-security
+/cmd/system-probe/modules/tcp_queue_tracer*         @DataDog/container-integrations
+/cmd/system-probe/modules/traceroute*               @DataDog/network-path
+/cmd/system-probe/modules/ping*                     @DataDog/network-device-monitoring-core
+/cmd/system-probe/modules/language_detection*       @DataDog/container-experiences @DataDog/agent-discovery
+/cmd/system-probe/modules/dynamic_instrumentation*  @DataDog/debugger-go
+/cmd/system-probe/modules/noisy_neighbor*           @DataDog/container-experiences
+/cmd/system-probe/windows/                          @DataDog/windows-products
+/cmd/system-probe/windows_resources/                @DataDog/windows-products
+/cmd/system-probe/main_windows*.go                  @DataDog/windows-products
 /cmd/system-probe/subcommands/run/command_windows*  @DataDog/windows-products
-/cmd/system-probe/subcommands/runtime/  @DataDog/agent-security
-/cmd/system-probe/subcommands/usm/      @DataDog/universal-service-monitoring
-/cmd/system-probe/subcommands/ebpf/     @DataDog/ebpf-platform @DataDog/universal-service-monitoring
-/cmd/system-probe/subcommands/compliance/     @DataDog/agent-cspm @DataDog/agent-security
-/cmd/systray/                           @DataDog/windows-products
-/cmd/secret-generic-connector/          @DataDog/fleet-automation
-/cmd/security-agent/                    @DataDog/agent-security
-/cmd/security-agent/subcommands/compliance/ @DataDog/agent-cspm @DataDog/agent-security
-/cmd/installer/                         @DataDog/fleet @DataDog/windows-products
-/cmd/host-profiler/                     @DataDog/opentelemetry-agent @DataDog/profiling-full-host
+/cmd/system-probe/subcommands/runtime/              @DataDog/agent-security
+/cmd/system-probe/subcommands/usm/                  @DataDog/universal-service-monitoring
+/cmd/system-probe/subcommands/ebpf/                 @DataDog/ebpf-platform @DataDog/universal-service-monitoring
+/cmd/system-probe/subcommands/compliance/           @DataDog/agent-cspm @DataDog/agent-security
+/cmd/systray/                                       @DataDog/windows-products
+/cmd/secret-generic-connector/                      @DataDog/fleet-automation
+/cmd/security-agent/                                @DataDog/agent-security
+/cmd/security-agent/subcommands/compliance/         @DataDog/agent-cspm @DataDog/agent-security
+/cmd/installer/                                     @DataDog/fleet @DataDog/windows-products
+/cmd/host-profiler/                                 @DataDog/opentelemetry-agent @DataDog/profiling-full-host
 
-/dev/                                   @DataDog/agent-devx
-/devenv/                                @DataDog/agent-devx
+/dev/    @DataDog/agent-devx
+/devenv/ @DataDog/agent-devx
+
+/examples/ # do not notify anyone
 
 /Dockerfiles/                            @DataDog/agent-build
 /Dockerfiles/agent/entrypoint.d.windows/ @DataDog/agent-build @DataDog/windows-products
@@ -334,11 +306,10 @@
 /Dockerfiles/agent/bouncycastle-fips     @DataDog/agent-metric-pipelines
 /Dockerfiles/manifests/                  @DataDog/container-integrations
 
-/docs/                                  @DataDog/agent-devx
-/docs/dev/agent_api.md                  @DataDog/agent-runtimes
-/docs/dev/checks/                       @DataDog/agent-runtimes
-/docs/cloud-workload-security/          @DataDog/documentation @DataDog/agent-security
-
+/docs/                                                       @DataDog/agent-devx
+/docs/dev/agent_api.md                                       @DataDog/agent-runtimes
+/docs/dev/checks/                                            @DataDog/agent-runtimes
+/docs/cloud-workload-security/                               @DataDog/documentation @DataDog/agent-security
 /docs/public/components/                                     @DataDog/agent-runtimes
 /docs/public/hostname/                                       @DataDog/agent-runtimes
 /docs/public/architecture/dogstatsd/                         @DataDog/agent-metric-pipelines
@@ -347,29 +318,29 @@
 # These files are owned by all teams, but assigning them to @DataDog/agent-community-eng causes a lot of spam
 # Assigning them to a group that doesn't exist means nobody will receive notifications for them, but
 # that should be fine since rarely we make PRs that only change those files alone.
-/go.mod                                 # do not notify anyone
-/go.sum                                 # do not notify anyone
+/go.mod # do not notify anyone
+/go.sum # do not notify anyone
 
-/omnibus/                               @DataDog/agent-build
-/omnibus/package-scripts/agent-rpm/     @DataDog/agent-build @DataDog/fleet
-/omnibus/package-scripts/agent-deb/     @DataDog/agent-build @DataDog/fleet
-/omnibus/package-scripts/agent-dmg/     @DataDog/agent-build @DataDog/windows-products
-/omnibus/package-scripts/installer-deb/ @DataDog/agent-build @DataDog/fleet
-/omnibus/package-scripts/installer-rpm/ @DataDog/agent-build @DataDog/fleet
-/omnibus/python-scripts/                @DataDog/agent-integrations @DataDog/windows-products
-/deps/openscap/                         @DataDog/agent-build @DataDog/agent-cspm @DataDog/agent-security
-/omnibus/config/software/datadog-agent-integrations-*.rb  @DataDog/agent-integrations
-/deps/agent_integrations/               @DataDog/agent-build @DataDog/agent-integrations
-/omnibus/resources/*/msi/                                 @DataDog/windows-products
+/omnibus/                                                @DataDog/agent-build
+/omnibus/package-scripts/agent-rpm/                      @DataDog/agent-build @DataDog/fleet
+/omnibus/package-scripts/agent-deb/                      @DataDog/agent-build @DataDog/fleet
+/omnibus/package-scripts/agent-dmg/                      @DataDog/agent-build @DataDog/windows-products
+/omnibus/package-scripts/installer-deb/                  @DataDog/agent-build @DataDog/fleet
+/omnibus/package-scripts/installer-rpm/                  @DataDog/agent-build @DataDog/fleet
+/omnibus/python-scripts/                                 @DataDog/agent-integrations @DataDog/windows-products
+/deps/openscap/                                          @DataDog/agent-build @DataDog/agent-cspm @DataDog/agent-security
+/omnibus/config/software/datadog-agent-integrations-*.rb @DataDog/agent-integrations
+/deps/agent_integrations/                                @DataDog/agent-build @DataDog/agent-integrations
+/omnibus/resources/*/msi/                                @DataDog/windows-products
 
-/packages/                              @DataDog/agent-build
-/packages/debian/                       @DataDog/agent-build @DataDog/fleet
-/packages/redhat/                       @DataDog/agent-build @DataDog/fleet
-/packages/macos                         @DataDog/agent-build @DataDog/windows-products
-/packages/windows                       @DataDog/agent-build @DataDog/windows-products
+/packages/        @DataDog/agent-build
+/packages/debian/ @DataDog/agent-build @DataDog/fleet
+/packages/redhat/ @DataDog/agent-build @DataDog/fleet
+/packages/macos   @DataDog/agent-build @DataDog/windows-products
+/packages/windows @DataDog/agent-build @DataDog/windows-products
 
 # AIX
-/packaging/aix/                         @DataDog/agent-build
+/packaging/aix/ @DataDog/agent-build
 
 # The following is managed by `dda inv lint-components` -- DO NOT EDIT
 # BEGIN COMPONENTS
@@ -454,7 +425,6 @@
 /comp/logonduration @DataDog/windows-products
 /comp/metriclookback @DataDog/q-branch
 /comp/networkconfigmanagement @DataDog/ndm-integrations
-/comp/networkdevices @DataDog/network-device-monitoring-core
 /comp/notableevents @DataDog/windows-products
 /comp/offlinereporter @DataDog/agent-metric-pipelines
 /comp/privateactionrunner @DataDog/action-platform
@@ -472,21 +442,21 @@
 # Per-team ownership of individual event platform pipeline descriptor files.
 # Each file holds the passthroughPipelineDesc entries for one owning team so
 # that teams can merge pipeline config changes without Logs team review.
-/comp/forwarder/eventplatform/impl/pipelines_agentdiscovery.go         @DataDog/agent-discovery
-/comp/forwarder/eventplatform/impl/pipelines_dbm.go                    @DataDog/database-monitoring
-/comp/forwarder/eventplatform/impl/pipelines_ndm_core.go               @DataDog/network-device-monitoring-core
-/comp/forwarder/eventplatform/impl/pipelines_ndm_integrations.go       @DataDog/ndm-integrations
-/comp/forwarder/eventplatform/impl/pipelines_networkpath.go            @DataDog/network-path
-/comp/forwarder/eventplatform/impl/pipelines_container.go              @DataDog/container-integrations
-/comp/forwarder/eventplatform/impl/pipelines_sbom.go                   @DataDog/agent-security
-/comp/forwarder/eventplatform/impl/pipelines_synthetics.go             @DataDog/synthetics-executing
-/comp/forwarder/eventplatform/impl/pipelines_eventmanagement.go        @DataDog/windows-products
-/comp/forwarder/eventplatform/impl/pipelines_datastreams.go            @DataDog/data-streams-monitoring
-/comp/forwarder/eventplatform/impl/pipelines_dataobservability.go      @DataDog/data-observability
-/comp/forwarder/eventplatform/impl/pipelines_datasecurity.go           @DataDog/sensitive-data-scanner
-/comp/forwarder/eventplatform/impl/pipelines_softwareinventory.go      @DataDog/windows-products
+/comp/forwarder/eventplatform/impl/pipelines_agentdiscovery.go    @DataDog/agent-discovery
+/comp/forwarder/eventplatform/impl/pipelines_dbm.go               @DataDog/database-monitoring
+/comp/forwarder/eventplatform/impl/pipelines_ndm_core.go          @DataDog/network-device-monitoring-core
+/comp/forwarder/eventplatform/impl/pipelines_ndm_integrations.go  @DataDog/ndm-integrations
+/comp/forwarder/eventplatform/impl/pipelines_networkpath.go       @DataDog/network-path
+/comp/forwarder/eventplatform/impl/pipelines_container.go         @DataDog/container-integrations
+/comp/forwarder/eventplatform/impl/pipelines_sbom.go              @DataDog/agent-security
+/comp/forwarder/eventplatform/impl/pipelines_synthetics.go        @DataDog/synthetics-executing
+/comp/forwarder/eventplatform/impl/pipelines_eventmanagement.go   @DataDog/windows-products
+/comp/forwarder/eventplatform/impl/pipelines_datastreams.go       @DataDog/data-streams-monitoring
+/comp/forwarder/eventplatform/impl/pipelines_dataobservability.go @DataDog/data-observability
+/comp/forwarder/eventplatform/impl/pipelines_datasecurity.go      @DataDog/sensitive-data-scanner
+/comp/forwarder/eventplatform/impl/pipelines_softwareinventory.go @DataDog/windows-products
 
-/comp/core/agenttelemetry               @DataDog/fleet-remediation
+/comp/core/agenttelemetry @DataDog/fleet-remediation
 
 # ebpf-platform also owns the stat wrappers in telemetry (previously pkg/telemetry/stat_*_wrapper.go)
 /comp/core/telemetry/def/stat_gauge_wrapper.go   @DataDog/agent-runtimes @DataDog/ebpf-platform
@@ -496,579 +466,565 @@
 /comp/core/log/impl-trace @DataDog/agent-apm
 
 # remoteagent implementation should also notify their respective teams
-/comp/core/remoteagent/impl-systemprobe @DataDog/agent-runtimes @DataDog/ebpf-platform
-/comp/core/remoteagent/impl-trace @DataDog/agent-runtimes @DataDog/agent-apm
+/comp/core/remoteagent/impl-systemprobe   @DataDog/agent-runtimes @DataDog/ebpf-platform
+/comp/core/remoteagent/impl-trace         @DataDog/agent-runtimes @DataDog/agent-apm
 /comp/core/remoteagent/impl-securityagent @DataDog/agent-runtimes @DataDog/agent-security
 
 # pkg
-/pkg/                                   @DataDog/agent-runtimes
-/pkg/metriclookback/                    @DataDog/q-branch
-/pkg/metriclookback/dogstatsd/          @DataDog/q-branch @DataDog/agent-metric-pipelines
-/pkg/api/                               @DataDog/agent-runtimes
-/pkg/api/security/cert/cert_getter_dca.go   @DataDog/agent-runtimes @DataDog/container-platform
-/pkg/aggregator/                        @DataDog/agent-metric-pipelines
-/pkg/collector/                         @DataDog/agent-runtimes
-/pkg/commonchecks/                      @DataDog/agent-runtimes
-/pkg/cli/                               @DataDog/fleet-remediation
-/pkg/cli/subcommands/check              @DataDog/agent-runtimes @DataDog/agent-integrations
-/pkg/cli/subcommands/version            @DataDog/agent-runtimes
-/pkg/cli/subcommands/clusterchecks      @DataDog/container-platform
-/pkg/cli/subcommands/workloadfilter     @DataDog/container-platform
-/pkg/cli/subcommands/autoscalerlist     @DataDog/container-autoscaling @DataDog/container-integrations
-/pkg/cli/subcommands/processchecks      @DataDog/container-experiences
-/pkg/discovery/                         @DataDog/agent-discovery
-/pkg/errors/                            @DataDog/agent-runtimes
-/pkg/privileged-logs/                        @DataDog/agent-discovery @DataDog/agent-log-pipelines
-/pkg/fips                               @DataDog/agent-runtimes
-/pkg/gohai                              @DataDog/fleet-automation
-/pkg/gpu/                               @DataDog/ebpf-platform @DataDog/gpu-monitoring-agent
-/pkg/hosttags/                          @DataDog/agent-runtimes
-/pkg/jmxfetch/                          @DataDog/agent-metric-pipelines
-/pkg/metrics/                           @DataDog/agent-metric-pipelines
-/pkg/metrics/metricsource.go            @DataDog/agent-metric-pipelines @DataDog/agent-integrations
-/pkg/notableevents/                     @DataDog/windows-products
-/pkg/serializer/                        @DataDog/agent-metric-pipelines
-/pkg/serializer/internal/metrics/origin_mapping.go  @DataDog/agent-metric-pipelines @DataDog/agent-integrations
-/pkg/serverless/                        @DataDog/serverless-azure-gcp
-/pkg/status/                            @DataDog/fleet-remediation
-/pkg/status/health                      @DataDog/agent-runtimes
-/pkg/status/collector                   @DataDog/agent-runtimes
-/pkg/status/clusteragent                @DataDog/container-platform
-/pkg/template/                          @DataDog/agent-runtimes
-/pkg/version/                           @DataDog/agent-runtimes
-/pkg/obfuscate/                         @DataDog/agent-apm
-
-/pkg/trace/                             @DataDog/agent-apm
-
-/pkg/trace/api/otlp*.go                 @DataDog/opentelemetry
-
-/pkg/trace/api/loader/                  @DataDog/agent-runtimes
-
-/pkg/trace/api/loader/listeners.go      @DataDog/agent-apm
-
-/pkg/trace/traceutil/                   @DataDog/agent-apm
-
-/pkg/trace/stats/                       @DataDog/agent-apm
-
-/pkg/trace/otel/                        @DataDog/opentelemetry
-
-/pkg/trace/telemetry/                   @DataDog/apm-trace-storage
-
-/pkg/trace/transform/                   @DataDog/opentelemetry
-
-/pkg/trace/semantics/mappings.json       @DataDog/agent-apm @DataDog/semantic-core
-/comp/core/autodiscovery/listeners/           @DataDog/container-platform
-/comp/core/autodiscovery/listeners/cloudfoundry*.go  @DataDog/agent-integrations
-/comp/core/autodiscovery/listeners/snmp*.go   @DataDog/network-device-monitoring-core
-/comp/core/autodiscovery/providers/           @DataDog/container-platform
-/comp/core/autodiscovery/providers/file*.go   @DataDog/agent-log-pipelines
-/comp/core/autodiscovery/providers/config_reader*.go @DataDog/container-platform @DataDog/agent-log-pipelines
-/comp/core/autodiscovery/providers/cloudfoundry*.go  @DataDog/agent-integrations
-/comp/core/autodiscovery/providers/process_log*.go @DataDog/agent-discovery @DataDog/agent-log-pipelines
-/comp/core/autodiscovery/providers/remote_config*.go  @DataDog/fleet
-/comp/core/autodiscovery/providers/datastreams @DataDog/data-streams-monitoring
-/comp/core/autodiscovery/providers/datasecurity @DataDog/sensitive-data-scanner
-/comp/core/autodiscovery/providers/networkpath @DataDog/network-path @DataDog/container-platform
-/comp/core/gui/impl/systray/ @DataDog/windows-products @DataDog/fleet-remediation
-/comp/healthplatform/issues/ad-misconfiguration @DataDog/container-platform @DataDog/fleet-remediation
-/comp/healthplatform/issues/gpuenvironment @DataDog/gpu-monitoring-agent @DataDog/ebpf-platform @DataDog/fleet-remediation
-/comp/healthplatform/issues/rofspermissions @DataDog/container-platform @DataDog/fleet-remediation
-/pkg/cloudfoundry                       @DataDog/agent-integrations
-/pkg/clusteragent/                      @DataDog/container-platform
-/pkg/clusteragent/autoscaling/          @DataDog/container-autoscaling
-/pkg/clusteragent/kubeactions/          @DataDog/container-integrations
-/pkg/clusteragent/evictor/              @DataDog/container-platform @DataDog/container-integrations
-/pkg/clusteragent/metricsstore/         @DataDog/container-autoscaling
-/pkg/clusteragent/admission/mutate/autoscaling          @DataDog/container-integrations
-/pkg/clusteragent/admission/mutate/appsec               @DataDog/container-platform @DataDog/asm-go
-/pkg/clusteragent/admission/mutate/autoinstrumentation/ @DataDog/container-platform @DataDog/injection-platform
-/pkg/clusteragent/admission/mutate/cwsinstrumentation    @DataDog/agent-security
-/pkg/clusteragent/appsec/               @DataDog/asm-go @DataDog/container-platform
-/pkg/clusteragent/orchestrator/         @DataDog/kubernetes-experiences
-/pkg/clusteragent/telemetry/            @DataDog/apm-trace-storage
-/pkg/collector/                         @DataDog/agent-runtimes
-/pkg/collector/corechecks/cluster/      @DataDog/container-integrations
-/pkg/collector/corechecks/cluster/orchestrator  @DataDog/kubernetes-experiences
-/pkg/collector/corechecks/cluster/orchestrator/collectors/ecs/    @DataDog/ecs-experiences
-/pkg/collector/corechecks/cluster/orchestrator/processors/ecs/    @DataDog/ecs-experiences
-/pkg/collector/corechecks/cluster/orchestrator/transformers/ecs/  @DataDog/ecs-experiences
-/pkg/collector/corechecks/containers/   @DataDog/container-integrations
-/pkg/collector/corechecks/containers/csi_driver/   @DataDog/container-platform
-/pkg/collector/corechecks/containerimage/       @DataDog/container-integrations
-/pkg/collector/corechecks/containerlifecycle/   @DataDog/container-integrations
-/pkg/collector/corechecks/discovery/ @DataDog/agent-discovery
-/pkg/collector/corechecks/ebpf/                       @DataDog/container-integrations
-/pkg/collector/corechecks/ebpf/ebpf*                  @DataDog/ebpf-platform
-/pkg/collector/corechecks/ebpf/noisyneighbor/         @DataDog/container-experiences
-/pkg/collector/corechecks/ebpf/probe/ebpfcheck/       @DataDog/ebpf-platform
-/pkg/collector/corechecks/ebpf/probe/noisyneighbor/   @DataDog/container-experiences
-/pkg/collector/corechecks/ebpf/c/runtime/ebpf*        @DataDog/ebpf-platform
-/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor*    @DataDog/container-experiences
-/pkg/collector/corechecks/embed/                   @DataDog/agent-delivery
-/pkg/collector/corechecks/embed/apm/               @DataDog/agent-apm
-/pkg/collector/corechecks/embed/process/           @DataDog/container-experiences
-/pkg/collector/corechecks/gpu/                     @DataDog/ebpf-platform @DataDog/gpu-monitoring-agent
-/pkg/collector/corechecks/networkconfigmanagement/ @DataDog/ndm-integrations
-/pkg/collector/corechecks/network-devices/         @DataDog/ndm-integrations
-/pkg/collector/corechecks/orchestrator/   @DataDog/kubernetes-experiences
-/pkg/collector/corechecks/orchestrator/ecs/   @DataDog/ecs-experiences
-/pkg/collector/corechecks/net/          @DataDog/agent-runtimes
-/pkg/collector/corechecks/net/wlan/     @DataDog/windows-products
-/pkg/collector/corechecks/oracle        @DataDog/database-monitoring
-/pkg/collector/corechecks/sbom/         @DataDog/agent-security @DataDog/container-integrations
-/pkg/collector/corechecks/snmp/         @DataDog/network-device-monitoring-core
-/pkg/collector/corechecks/system/                 @DataDog/agent-runtimes
-/pkg/collector/corechecks/system/**/*_windows*.go @DataDog/agent-runtimes @DataDog/windows-products
-/pkg/collector/corechecks/system/battery/     @DataDog/windows-products
-/pkg/collector/corechecks/system/thermal/     @DataDog/windows-products
-/pkg/collector/corechecks/system/wincrashdetect/  @DataDog/windows-products
-/pkg/collector/corechecks/system/windowscertificate/ @DataDog/windows-products
-/pkg/collector/corechecks/system/winkmem/         @DataDog/windows-products
-/pkg/collector/corechecks/system/winproc/         @DataDog/windows-products
-/pkg/collector/corechecks/systemd/      @DataDog/agent-integrations
-/pkg/collector/corechecks/nvidia/       @DataDog/agent-runtimes
-/pkg/config/                            @DataDog/fleet-automation
-/pkg/config/settings/runtime_setting_profiling_period*.go  @DataDog/agent-runtimes
-/pkg/config/example/application_monitoring.yaml.example @DataDog/agent-apm
-/pkg/config/autodiscovery/              @DataDog/container-integrations @DataDog/container-platform @DataDog/fleet-automation
-/pkg/config/env                         @DataDog/container-integrations @DataDog/container-platform @DataDog/fleet-automation
-/pkg/config/setup                               @DataDog/fleet-automation
-/pkg/config/setup/privateactionrunner*.go       @DataDog/action-platform @DataDog/fleet-automation
-/pkg/config/setup/process*.go                   @DataDog/container-experiences @DataDog/fleet-automation
-/pkg/config/setup/system_probe*.go              @DataDog/ebpf-platform @DataDog/agent-security @DataDog/universal-service-monitoring @DataDog/fleet-automation
-/pkg/config/schema/yaml/                                    @DataDog/fleet-automation
-/pkg/config/schema/yaml/admission_controller.yaml           @DataDog/container-platform @DataDog/fleet-automation
-/pkg/config/schema/yaml/agent_telemetry.yaml                @DataDog/fleet-remediation @DataDog/fleet-automation
-/pkg/config/schema/yaml/apm_config.yaml                     @DataDog/agent-apm @DataDog/fleet-automation
-/pkg/config/schema/yaml/cluster_agent.yaml                  @DataDog/container-platform @DataDog/fleet-automation
-/pkg/config/schema/yaml/cluster_checks.yaml                 @DataDog/container-platform @DataDog/fleet-automation
-/pkg/config/schema/yaml/compliance_config.yaml              @DataDog/agent-cspm @DataDog/agent-security @DataDog/fleet-automation
-/pkg/config/schema/yaml/container_image.yaml                @DataDog/container-integrations @DataDog/fleet-automation
-/pkg/config/schema/yaml/container_lifecycle.yaml            @DataDog/container-integrations @DataDog/fleet-automation
-/pkg/config/schema/yaml/network_devices.yaml                @DataDog/network-device-monitoring-core @DataDog/fleet-automation
-/pkg/config/schema/yaml/external_metrics_provider.yaml      @DataDog/container-autoscaling @DataDog/fleet-automation
-/pkg/config/schema/yaml/gpu.yaml                            @DataDog/ebpf-platform @DataDog/gpu-monitoring-agent @DataDog/fleet-automation
-/pkg/config/schema/yaml/internal_profiling.yaml             @DataDog/agent-runtimes @DataDog/fleet-automation
-/pkg/config/schema/yaml/logs_config*.yaml                   @DataDog/agent-log-pipelines @DataDog/fleet-automation
-/pkg/config/schema/yaml/orchestrator_explorer.yaml          @DataDog/kubernetes-experiences @DataDog/fleet-automation
-/pkg/config/schema/yaml/otelcollector.yaml                  @DataDog/opentelemetry-agent @DataDog/fleet-automation
-/pkg/config/schema/yaml/private_action_runner.yaml          @DataDog/action-platform @DataDog/fleet-automation
-/pkg/config/schema/yaml/process_config.yaml                 @DataDog/container-experiences @DataDog/fleet-automation
-/pkg/config/schema/yaml/remote_configuration.yaml           @DataDog/remote-config @DataDog/fleet-automation
-/pkg/config/schema/yaml/runtime_security_config.yaml        @DataDog/agent-security @DataDog/fleet-automation
-/pkg/config/schema/yaml/sbom.yaml                           @DataDog/agent-security @DataDog/container-integrations @DataDog/fleet-automation
-/pkg/config/schema/yaml/snmp_listener.yaml                  @DataDog/network-device-monitoring-core @DataDog/fleet-automation
-/pkg/config/schema/yaml/system-probe_schema.yaml            @DataDog/ebpf-platform @DataDog/agent-security @DataDog/universal-service-monitoring @DataDog/fleet-automation
-/pkg/config/schema/yaml/system-probe-cws.yaml               @DataDog/agent-security @DataDog/fleet-automation
-/pkg/config/schema/yaml/system-probe-usm.yaml               @DataDog/universal-service-monitoring @DataDog/fleet-automation
-/pkg/config/remote/                     @DataDog/remote-config
-/pkg/config/remote/meta/                @DataDog/remote-config
-/pkg/configstreambootstrap              @DataDog/fleet-automation
-/pkg/containerlifecycle/                @DataDog/container-integrations
-/pkg/diagnose/                          @DataDog/fleet-remediation
-/pkg/diagnose/connectivity/             @DataDog/fleet-remediation
-/pkg/diagnose/firewallscanner/          @DataDog/network-device-monitoring-core
-/pkg/diagnose/ports/                    @DataDog/fleet-remediation
-/pkg/diagnose/ports/*windows*.go        @DataDog/windows-products
-/pkg/eventmonitor/                      @DataDog/ebpf-platform @DataDog/agent-security
-/pkg/dyninst/                           @DataDog/debugger-go
-/pkg/flare/                             @DataDog/fleet-remediation
-/pkg/flare/*_win.go                     @DataDog/windows-products @DataDog/fleet-remediation
-/pkg/flare/*_windows.go                 @DataDog/windows-products @DataDog/fleet-remediation
-/pkg/flare/*_windows_test.go            @DataDog/windows-products @DataDog/fleet-remediation
-/pkg/fleet/                             @DataDog/fleet @DataDog/windows-products
-/pkg/fleet/installer/setup/djm/         @DataDog/fleet @DataDog/data-observability
-/pkg/inventory/                         @DataDog/windows-products
-/pkg/inventory/software/                @DataDog/windows-products
-/pkg/inventory/systeminfo/              @DataDog/windows-products
-/pkg/opentelemetry-mapping-go           @DataDog/opentelemetry-agent
-/pkg/pidfile/                           @DataDog/agent-runtimes
-/pkg/persistentcache/                   @DataDog/agent-runtimes
-/pkg/procmgr/                           @DataDog/agent-runtimes
-/pkg/procmgr/rust/src/platform/windows.rs          @DataDog/agent-runtimes @DataDog/windows-products
-/pkg/procmgr/rust/src/transport/named_pipe.rs       @DataDog/agent-runtimes @DataDog/windows-products
-/pkg/privateactionrunner/               @DataDog/action-platform
-/pkg/privateactionrunner/bundles/remoteaction/rshell  @DataDog/action-platform @DataDog/dd-agent-mcp @DataDog/fleet-remediation
-/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement  @DataDog/action-platform @DataDog/ndm-integrations
-/pkg/privateactionrunner/bundles/remoteaction/networkdevices  @DataDog/action-platform @DataDog/network-device-monitoring-core
-/pkg/privateactionrunner/bundles/remoteaction/networks  @DataDog/action-platform @Datadog/network-path
-/pkg/proto/                             @DataDog/agent-runtimes
-/pkg/proto/datadog/dogstatsdhttp        @DataDog/agent-metric-pipelines
-/pkg/proto/datadog/kubemetadata         @DataDog/container-platform
-/pkg/proto/datadog/languagedetection    @DataDog/container-experiences
-/pkg/proto/datadog/privateactionrunner  @DataDog/action-platform
-/pkg/proto/datadog/process              @DataDog/container-experiences
-/pkg/proto/datadog/sds                  @DataDog/sensitive-data-scanner
-/pkg/proto/datadog/trace                @DataDog/agent-apm
-/pkg/proto/datadog/workloadmeta         @DataDog/container-platform
-/pkg/remoteconfig/                      @DataDog/remote-config
-/pkg/remoteflags/                       @DataDog/fleet-remediation
-/pkg/runtime/                           @DataDog/agent-runtimes
-/pkg/redact/                            @DataDog/kubernetes-experiences
-/pkg/system-probe/                      @DataDog/ebpf-platform
-/pkg/system-probe/api/client/client_windows.go      @DataDog/windows-products
-/pkg/system-probe/api/server/listener_windows.go    @DataDog/windows-products
-/pkg/system-probe/config/adjust_npm.go  @DataDog/ebpf-platform @DataDog/cloud-network-monitoring
-/pkg/system-probe/config/adjust_usm.go  @DataDog/ebpf-platform @DataDog/universal-service-monitoring
-/pkg/system-probe/config/adjust_security.go  @DataDog/ebpf-platform @DataDog/agent-security
-/pkg/tagset/                            @DataDog/agent-runtimes
-/pkg/util/                              @DataDog/agent-runtimes
-/pkg/util/aggregatingqueue              @DataDog/container-integrations @DataDog/container-platform
-/pkg/util/aws/creds/                    @DataDog/credential-management
-/pkg/util/cloudproviders/cloudfoundry/  @DataDog/agent-integrations
-/pkg/util/clusteragent/                 @DataDog/container-platform
-/pkg/util/confmaputils                       @DataDog/opentelemetry-agent @DataDog/profiling-full-host
-/pkg/util/containerd/                   @DataDog/container-integrations
-/pkg/util/containers/                   @DataDog/container-integrations
-/pkg/util/containers/metrics/ecsfargate/          @DataDog/ecs-experiences @DataDog/container-integrations
-/pkg/util/containers/metrics/ecsmanagedinstances/ @DataDog/ecs-experiences @DataDog/container-integrations
-/pkg/util/crio/                         @DataDog/container-integrations
-/pkg/util/docker/                       @DataDog/container-integrations
-/pkg/util/ecs/                          @DataDog/ecs-experiences
-/pkg/util/fargate/                      @DataDog/ecs-experiences
-/pkg/util/filesystem/                   @DataDog/agent-runtimes
-/pkg/util/filesystem/rights_*.go        @DataDog/fleet-automation
-/pkg/util/funcs/                        @DataDog/ebpf-platform
-/pkg/util/gpu/                          @DataDog/container-platform @DataDog/gpu-monitoring-agent
-/pkg/util/installinfo/                  @DataDog/fleet-automation
-/pkg/util/kernel/                       @DataDog/ebpf-platform
-/pkg/util/safeelf/                      @DataDog/ebpf-platform
-/pkg/util/slices/                       @DataDog/ebpf-platform
-/pkg/util/ktime                         @DataDog/agent-security
-/pkg/util/kubelet/                      @DataDog/container-integrations @DataDog/container-platform @DataDog/kubernetes-experiences
-/pkg/util/kubernetes/                   @DataDog/container-integrations @DataDog/container-platform @DataDog/kubernetes-experiences
-/pkg/util/podman/                       @DataDog/container-integrations
-/pkg/util/port/                         @DataDog/agent-runtimes
-/pkg/util/port/portlist/*windows*.go    @DataDog/windows-products
-/pkg/util/prometheus                    @DataDog/container-integrations
-/pkg/util/quantile/                     @DataDog/opentelemetry-agent
-/pkg/util/tags/                         @DataDog/container-platform
-/pkg/util/tmplvar/                      @DataDog/container-platform
-/pkg/util/trivy/                        @DataDog/agent-security @DataDog/container-integrations
-/pkg/util/uuid/                         @DataDog/agent-runtimes
-/pkg/util/cgroups/                      @DataDog/container-integrations
-/pkg/util/retry/                        @DataDog/container-platform
-/pkg/util/intern/                       @DataDog/ebpf-platform
-/pkg/util/crashreport/                  @DataDog/windows-products
-/pkg/util/pdhutil/                      @DataDog/windows-products
-/pkg/util/winutil/                      @DataDog/windows-products
-/pkg/util/winutil/iisconfig             @DataDog/windows-products @DataDog/universal-service-monitoring
-/pkg/util/testutil/flake                @DataDog/agent-devx
-/pkg/util/testutil/patternscanner.go    @DataDog/universal-service-monitoring @DataDog/ebpf-platform
-/pkg/util/testutil/docker               @DataDog/universal-service-monitoring @DataDog/ebpf-platform
-/pkg/util/trie                          @DataDog/container-integrations
-/pkg/languagedetection                  @DataDog/container-experiences @DataDog/agent-discovery
-/pkg/logonduration                      @DataDog/windows-products
-/pkg/logs/                              @DataDog/agent-log-pipelines
-/pkg/logs/launchers/container           @DataDog/agent-log-pipelines @DataDog/container-integrations
-/pkg/logs/tailers/container             @DataDog/agent-log-pipelines @DataDog/container-integrations
-/pkg/logs/launchers/windowsevent        @DataDog/agent-log-pipelines @DataDog/windows-products
-/pkg/logs/tailers/windowsevent          @DataDog/agent-log-pipelines @DataDog/windows-products
-/pkg/logs/util/windowsevent             @DataDog/agent-log-pipelines @DataDog/windows-products
-/comp/logs-library/diagnostic           @DataDog/agent-log-pipelines
-/pkg/logs/message                       @DataDog/agent-log-pipelines
-/pkg/process/                           @DataDog/container-experiences
-/pkg/process/util/address*.go           @DataDog/cloud-network-monitoring
-/pkg/process/checks/net*.go             @DataDog/cloud-network-monitoring
-/pkg/process/metadata/parser/           @DataDog/universal-service-monitoring @DataDog/container-experiences @DataDog/cloud-network-monitoring
-/pkg/process/metadata/parser/*windows*  @DataDog/universal-service-monitoring @DataDog/container-experiences @DataDog/cloud-network-monitoring @DataDog/windows-products
-/pkg/process/monitor/                   @DataDog/universal-service-monitoring
-/pkg/process/net/                       @DataDog/universal-service-monitoring @DataDog/cloud-network-monitoring
-/pkg/proto/datadog/remoteconfig/        @DataDog/remote-config
-/pkg/proto/pbgo/                        # do not notify anyone
-/pkg/proto/pbgo/trace                   @DataDog/agent-apm
-/pkg/proto/pbgo/languagedetection       @DataDog/agent-apm
-/pkg/proto/pbgo/process                 @DataDog/container-experiences
-/pkg/proto/pbgo/core                    @DataDog/agent-runtimes
-/pkg/proto/pbgo/core/kubemetadata.pb.go @DataDog/container-platform
-/pkg/proto/pbgo/core/remoteconfig.pb.go       @DataDog/remote-config
-/pkg/proto/pbgo/core/remoteconfig_gen.go      @DataDog/remote-config
-/pkg/proto/pbgo/core/remoteconfig_gen_test.go @DataDog/remote-config
-/pkg/proto/pbgo/core/workloadfilter.pb.go     @DataDog/container-platform
-/pkg/proto/pbgo/core/workloadmeta.pb.go       @DataDog/container-platform
-/pkg/proto/pbgo/mocks/core              @DataDog/agent-runtimes
-/pkg/proto/pbgo/privateactionrunner     @DataDog/action-platform
-/pkg/orchestrator/                      @DataDog/kubernetes-experiences
-/pkg/network/                           @DataDog/cloud-network-monitoring
-/pkg/network/*usm*                      @DataDog/universal-service-monitoring
-/pkg/network/*_windows*.go              @DataDog/windows-products
-/pkg/network/*usm*windows*.go           @DataDog/windows-products @DataDog/universal-service-monitoring
-/pkg/network/config/config_test.go      @DataDog/cloud-network-monitoring @DataDog/universal-service-monitoring @DataDog/windows-products
-/pkg/network/config/usm*.go             @DataDog/universal-service-monitoring
-/pkg/network/driver_*.go                @DataDog/windows-products
-/pkg/network/dns/*_windows*.go          @DataDog/windows-products
-/pkg/network/driver/                    @DataDog/windows-products
-/pkg/network/ebpf/c/prebuilt/usm*      @DataDog/universal-service-monitoring
-/pkg/network/ebpf/c/runtime/usm*       @DataDog/universal-service-monitoring
-/pkg/network/ebpf/c/prebuilt/shared-libraries*  @DataDog/universal-service-monitoring
-/pkg/network/ebpf/c/runtime/shared-libraries*   @DataDog/universal-service-monitoring
-/pkg/network/ebpf/c/shared-libraries/           @DataDog/universal-service-monitoring
-/pkg/network/ebpf/c/protocols/          @DataDog/universal-service-monitoring
-/pkg/network/ebpf/c/protocols/tls       @DataDog/cloud-network-monitoring @DataDog/universal-service-monitoring
-/pkg/network/encoding/marshal/*usm*     @DataDog/universal-service-monitoring
-/pkg/network/encoding/marshal/*_windows*.go  @DataDog/windows-products
-/pkg/network/encoding/marshal/*usm*windows*.go  @DataDog/windows-products @DataDog/universal-service-monitoring
-/pkg/network/go/                        @DataDog/universal-service-monitoring
-/pkg/network/protocols/                 @DataDog/universal-service-monitoring
-/pkg/network/protocols/http/driver_*.go         @DataDog/windows-products @DataDog/universal-service-monitoring
-/pkg/network/protocols/http/etw*.go             @DataDog/windows-products @DataDog/universal-service-monitoring
-/pkg/network/protocols/http/*_windows*.go       @DataDog/windows-products @DataDog/universal-service-monitoring
-/pkg/network/tracer/testutil/proxy/              @DataDog/universal-service-monitoring
-/pkg/network/tracer/*_windows*.go               @DataDog/windows-products
-/pkg/network/usm/                       @DataDog/universal-service-monitoring
-/pkg/network/usm/tests/*_windows*.go    @DataDog/windows-products @DataDog/universal-service-monitoring
-/pkg/networkconfigmanagement/           @DataDog/ndm-integrations
-/pkg/ebpf/                              @DataDog/ebpf-platform
-/pkg/ebpf/map_cleaner*.go               @DataDog/universal-service-monitoring
-/pkg/compliance/                        @DataDog/agent-cspm @DataDog/agent-security
-/pkg/databasemonitoring                 @DataDog/database-monitoring
-/pkg/kubestatemetrics                   @DataDog/container-integrations
-/pkg/security/                          @DataDog/agent-security
-/pkg/networkdevice/                     @DataDog/network-device-monitoring-core
-/pkg/networkdevices/                    @DataDog/network-device-monitoring-core
-/pkg/snmp/                              @DataDog/network-device-monitoring-core
-/pkg/ssi/                               @DataDog/injection-platform
-/pkg/tagger/                            @DataDog/container-platform
-/pkg/windowsdriver/                     @DataDog/windows-products
-/comp/core/workloadmeta/collectors/internal/cloudfoundry     @DataDog/agent-integrations
-/comp/core/workloadmeta/collectors/internal/containerd       @DataDog/container-platform @DataDog/container-integrations
-/comp/core/workloadmeta/collectors/internal/crio             @DataDog/container-platform @DataDog/container-integrations
-/comp/core/workloadmeta/collectors/internal/docker           @DataDog/container-platform @DataDog/container-integrations
-/comp/core/workloadmeta/collectors/internal/ecs              @DataDog/ecs-experiences
-/comp/core/workloadmeta/collectors/internal/kubeapiserver    @DataDog/container-platform @DataDog/container-integrations
-/comp/core/workloadmeta/collectors/internal/kubelet          @DataDog/container-platform @DataDog/container-integrations
-/comp/core/workloadmeta/collectors/internal/kubemetadata     @DataDog/container-platform @DataDog/container-integrations
-/comp/core/workloadmeta/collectors/internal/nvml             @DataDog/ebpf-platform @DataDog/gpu-monitoring-agent
-/comp/core/workloadmeta/collectors/internal/podman           @DataDog/container-platform @DataDog/container-integrations
-/comp/core/workloadmeta/collectors/internal/process          @DataDog/container-experiences @DataDog/container-platform
-/comp/core/tagger/collectors            @DataDog/container-platform @DataDog/container-integrations
-/pkg/sbom/                              @DataDog/agent-security @DataDog/container-integrations
-/pkg/networkpath/                       @DataDog/network-path
-/pkg/networkpath/traceroute/            @DataDog/windows-products @DataDog/network-path
-/pkg/collector/corechecks/networkpath/  @DataDog/network-path
-/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/ @DataDog/sensitive-data-scanner
+/pkg/                                                                 @DataDog/agent-runtimes
+/pkg/metriclookback/                                                  @DataDog/q-branch
+/pkg/metriclookback/dogstatsd/                                        @DataDog/q-branch @DataDog/agent-metric-pipelines
+/pkg/api/                                                             @DataDog/agent-runtimes
+/pkg/api/security/cert/cert_getter_dca.go                             @DataDog/agent-runtimes @DataDog/container-platform
+/pkg/aggregator/                                                      @DataDog/agent-metric-pipelines
+/pkg/collector/                                                       @DataDog/agent-runtimes
+/pkg/commonchecks/                                                    @DataDog/agent-runtimes
+/pkg/cli/                                                             @DataDog/fleet-remediation
+/pkg/cli/subcommands/check                                            @DataDog/agent-runtimes @DataDog/agent-integrations
+/pkg/cli/subcommands/version                                          @DataDog/agent-runtimes
+/pkg/cli/subcommands/clusterchecks                                    @DataDog/container-platform
+/pkg/cli/subcommands/workloadfilter                                   @DataDog/container-platform
+/pkg/cli/subcommands/autoscalerlist                                   @DataDog/container-autoscaling @DataDog/container-integrations
+/pkg/cli/subcommands/processchecks                                    @DataDog/container-experiences
+/pkg/discovery/                                                       @DataDog/agent-discovery
+/pkg/errors/                                                          @DataDog/agent-runtimes
+/pkg/privileged-logs/                                                 @DataDog/agent-discovery @DataDog/agent-log-pipelines
+/pkg/fips                                                             @DataDog/agent-runtimes
+/pkg/gohai                                                            @DataDog/fleet-automation
+/pkg/gpu/                                                             @DataDog/ebpf-platform @DataDog/gpu-monitoring-agent
+/pkg/hosttags/                                                        @DataDog/agent-runtimes
+/pkg/jmxfetch/                                                        @DataDog/agent-metric-pipelines
+/pkg/metrics/                                                         @DataDog/agent-metric-pipelines
+/pkg/metrics/metricsource.go                                          @DataDog/agent-metric-pipelines @DataDog/agent-integrations
+/pkg/notableevents/                                                   @DataDog/windows-products
+/pkg/serializer/                                                      @DataDog/agent-metric-pipelines
+/pkg/serializer/internal/metrics/origin_mapping.go                    @DataDog/agent-metric-pipelines @DataDog/agent-integrations
+/pkg/serverless/                                                      @DataDog/serverless-azure-gcp
+/pkg/status/                                                          @DataDog/fleet-remediation
+/pkg/status/health                                                    @DataDog/agent-runtimes
+/pkg/status/collector                                                 @DataDog/agent-runtimes
+/pkg/status/clusteragent                                              @DataDog/container-platform
+/pkg/template/                                                        @DataDog/agent-runtimes
+/pkg/version/                                                         @DataDog/agent-runtimes
+/pkg/obfuscate/                                                       @DataDog/agent-apm
+/pkg/trace/                                                           @DataDog/agent-apm
+/pkg/trace/api/otlp*.go                                               @DataDog/opentelemetry
+/pkg/trace/api/loader/                                                @DataDog/agent-runtimes
+/pkg/trace/api/loader/listeners.go                                    @DataDog/agent-apm
+/pkg/trace/traceutil/                                                 @DataDog/agent-apm
+/pkg/trace/stats/                                                     @DataDog/agent-apm
+/pkg/trace/otel/                                                      @DataDog/opentelemetry
+/pkg/trace/telemetry/                                                 @DataDog/apm-trace-storage
+/pkg/trace/transform/                                                 @DataDog/opentelemetry
+/pkg/trace/semantics/mappings.json                                    @DataDog/agent-apm @DataDog/semantic-core
+/comp/core/autodiscovery/listeners/                                   @DataDog/container-platform
+/comp/core/autodiscovery/listeners/cloudfoundry*.go                   @DataDog/agent-integrations
+/comp/core/autodiscovery/listeners/snmp*.go                           @DataDog/network-device-monitoring-core
+/comp/core/autodiscovery/providers/                                   @DataDog/container-platform
+/comp/core/autodiscovery/providers/file*.go                           @DataDog/agent-log-pipelines
+/comp/core/autodiscovery/providers/config_reader*.go                  @DataDog/container-platform @DataDog/agent-log-pipelines
+/comp/core/autodiscovery/providers/cloudfoundry*.go                   @DataDog/agent-integrations
+/comp/core/autodiscovery/providers/process_log*.go                    @DataDog/agent-discovery @DataDog/agent-log-pipelines
+/comp/core/autodiscovery/providers/remote_config*.go                  @DataDog/fleet
+/comp/core/autodiscovery/providers/datastreams                        @DataDog/data-streams-monitoring
+/comp/core/autodiscovery/providers/datasecurity                       @DataDog/sensitive-data-scanner
+/comp/core/autodiscovery/providers/networkpath                        @DataDog/network-path @DataDog/container-platform
+/comp/core/gui/impl/systray/                                          @DataDog/windows-products @DataDog/fleet-remediation
+/comp/healthplatform/issues/ad-misconfiguration                       @DataDog/container-platform @DataDog/fleet-remediation
+/comp/healthplatform/issues/gpuenvironment                            @DataDog/gpu-monitoring-agent @DataDog/ebpf-platform @DataDog/fleet-remediation
+/comp/healthplatform/issues/rofspermissions                           @DataDog/container-platform @DataDog/fleet-remediation
+/pkg/cloudfoundry                                                     @DataDog/agent-integrations
+/pkg/clusteragent/                                                    @DataDog/container-platform
+/pkg/clusteragent/autoscaling/                                        @DataDog/container-autoscaling
+/pkg/clusteragent/kubeactions/                                        @DataDog/container-integrations
+/pkg/clusteragent/evictor/                                            @DataDog/container-platform @DataDog/container-integrations
+/pkg/clusteragent/metricsstore/                                       @DataDog/container-autoscaling
+/pkg/clusteragent/admission/mutate/autoscaling                        @DataDog/container-integrations
+/pkg/clusteragent/admission/mutate/appsec                             @DataDog/container-platform @DataDog/asm-go
+/pkg/clusteragent/admission/mutate/autoinstrumentation/               @DataDog/container-platform @DataDog/injection-platform
+/pkg/clusteragent/admission/mutate/cwsinstrumentation                 @DataDog/agent-security
+/pkg/clusteragent/appsec/                                             @DataDog/asm-go @DataDog/container-platform
+/pkg/clusteragent/orchestrator/                                       @DataDog/kubernetes-experiences
+/pkg/clusteragent/telemetry/                                          @DataDog/apm-trace-storage
+/pkg/collector/corechecks/cluster/                                    @DataDog/container-integrations
+/pkg/collector/corechecks/cluster/orchestrator                        @DataDog/kubernetes-experiences
+/pkg/collector/corechecks/cluster/orchestrator/collectors/ecs/        @DataDog/ecs-experiences
+/pkg/collector/corechecks/cluster/orchestrator/processors/ecs/        @DataDog/ecs-experiences
+/pkg/collector/corechecks/cluster/orchestrator/transformers/ecs/      @DataDog/ecs-experiences
+/pkg/collector/corechecks/containers/                                 @DataDog/container-integrations
+/pkg/collector/corechecks/containers/csi_driver/                      @DataDog/container-platform
+/pkg/collector/corechecks/containerimage/                             @DataDog/container-integrations
+/pkg/collector/corechecks/containerlifecycle/                         @DataDog/container-integrations
+/pkg/collector/corechecks/discovery/                                  @DataDog/agent-discovery
+/pkg/collector/corechecks/ebpf/                                       @DataDog/container-integrations
+/pkg/collector/corechecks/ebpf/ebpf*                                  @DataDog/ebpf-platform
+/pkg/collector/corechecks/ebpf/noisyneighbor/                         @DataDog/container-experiences
+/pkg/collector/corechecks/ebpf/probe/ebpfcheck/                       @DataDog/ebpf-platform
+/pkg/collector/corechecks/ebpf/probe/noisyneighbor/                   @DataDog/container-experiences
+/pkg/collector/corechecks/ebpf/c/runtime/ebpf*                        @DataDog/ebpf-platform
+/pkg/collector/corechecks/ebpf/c/runtime/noisy-neighbor*              @DataDog/container-experiences
+/pkg/collector/corechecks/embed/                                      @DataDog/agent-delivery
+/pkg/collector/corechecks/embed/apm/                                  @DataDog/agent-apm
+/pkg/collector/corechecks/embed/process/                              @DataDog/container-experiences
+/pkg/collector/corechecks/gpu/                                        @DataDog/ebpf-platform @DataDog/gpu-monitoring-agent
+/pkg/collector/corechecks/networkconfigmanagement/                    @DataDog/ndm-integrations
+/pkg/collector/corechecks/network-devices/                            @DataDog/ndm-integrations
+/pkg/collector/corechecks/orchestrator/                               @DataDog/kubernetes-experiences
+/pkg/collector/corechecks/orchestrator/ecs/                           @DataDog/ecs-experiences
+/pkg/collector/corechecks/net/                                        @DataDog/agent-runtimes
+/pkg/collector/corechecks/net/wlan/                                   @DataDog/windows-products
+/pkg/collector/corechecks/oracle                                      @DataDog/database-monitoring
+/pkg/collector/corechecks/sbom/                                       @DataDog/agent-security @DataDog/container-integrations
+/pkg/collector/corechecks/snmp/                                       @DataDog/network-device-monitoring-core
+/pkg/collector/corechecks/system/                                     @DataDog/agent-runtimes
+/pkg/collector/corechecks/system/**/*_windows*.go                     @DataDog/agent-runtimes @DataDog/windows-products
+/pkg/collector/corechecks/system/battery/                             @DataDog/windows-products
+/pkg/collector/corechecks/system/thermal/                             @DataDog/windows-products
+/pkg/collector/corechecks/system/wincrashdetect/                      @DataDog/windows-products
+/pkg/collector/corechecks/system/windowscertificate/                  @DataDog/windows-products
+/pkg/collector/corechecks/system/winkmem/                             @DataDog/windows-products
+/pkg/collector/corechecks/system/winproc/                             @DataDog/windows-products
+/pkg/collector/corechecks/systemd/                                    @DataDog/agent-integrations
+/pkg/collector/corechecks/nvidia/                                     @DataDog/agent-runtimes
+/pkg/config/                                                          @DataDog/fleet-automation
+/pkg/config/settings/runtime_setting_profiling_period*.go             @DataDog/agent-runtimes
+/pkg/config/example/application_monitoring.yaml.example               @DataDog/agent-apm
+/pkg/config/autodiscovery/                                            @DataDog/container-integrations @DataDog/container-platform @DataDog/fleet-automation
+/pkg/config/env                                                       @DataDog/container-integrations @DataDog/container-platform @DataDog/fleet-automation
+/pkg/config/setup                                                     @DataDog/fleet-automation
+/pkg/config/setup/privateactionrunner*.go                             @DataDog/action-platform @DataDog/fleet-automation
+/pkg/config/setup/process*.go                                         @DataDog/container-experiences @DataDog/fleet-automation
+/pkg/config/setup/system_probe*.go                                    @DataDog/ebpf-platform @DataDog/agent-security @DataDog/universal-service-monitoring @DataDog/fleet-automation
+/pkg/config/schema/yaml/                                              @DataDog/fleet-automation
+/pkg/config/schema/yaml/admission_controller.yaml                     @DataDog/container-platform @DataDog/fleet-automation
+/pkg/config/schema/yaml/agent_telemetry.yaml                          @DataDog/fleet-remediation @DataDog/fleet-automation
+/pkg/config/schema/yaml/apm_config.yaml                               @DataDog/agent-apm @DataDog/fleet-automation
+/pkg/config/schema/yaml/cluster_agent.yaml                            @DataDog/container-platform @DataDog/fleet-automation
+/pkg/config/schema/yaml/cluster_checks.yaml                           @DataDog/container-platform @DataDog/fleet-automation
+/pkg/config/schema/yaml/compliance_config.yaml                        @DataDog/agent-cspm @DataDog/agent-security @DataDog/fleet-automation
+/pkg/config/schema/yaml/container_image.yaml                          @DataDog/container-integrations @DataDog/fleet-automation
+/pkg/config/schema/yaml/container_lifecycle.yaml                      @DataDog/container-integrations @DataDog/fleet-automation
+/pkg/config/schema/yaml/external_metrics_provider.yaml                @DataDog/container-autoscaling @DataDog/fleet-automation
+/pkg/config/schema/yaml/gpu.yaml                                      @DataDog/ebpf-platform @DataDog/gpu-monitoring-agent @DataDog/fleet-automation
+/pkg/config/schema/yaml/internal_profiling.yaml                       @DataDog/agent-runtimes @DataDog/fleet-automation
+/pkg/config/schema/yaml/logs_config*.yaml                             @DataDog/agent-log-pipelines @DataDog/fleet-automation
+/pkg/config/schema/yaml/orchestrator_explorer.yaml                    @DataDog/kubernetes-experiences @DataDog/fleet-automation
+/pkg/config/schema/yaml/otelcollector.yaml                            @DataDog/opentelemetry-agent @DataDog/fleet-automation
+/pkg/config/schema/yaml/private_action_runner.yaml                    @DataDog/action-platform @DataDog/fleet-automation
+/pkg/config/schema/yaml/process_config.yaml                           @DataDog/container-experiences @DataDog/fleet-automation
+/pkg/config/schema/yaml/remote_configuration.yaml                     @DataDog/remote-config @DataDog/fleet-automation
+/pkg/config/schema/yaml/runtime_security_config.yaml                  @DataDog/agent-security @DataDog/fleet-automation
+/pkg/config/schema/yaml/sbom.yaml                                     @DataDog/agent-security @DataDog/container-integrations @DataDog/fleet-automation
+/pkg/config/schema/yaml/snmp_listener.yaml                            @DataDog/network-device-monitoring-core @DataDog/fleet-automation
+/pkg/config/schema/yaml/system-probe_schema.yaml                      @DataDog/ebpf-platform @DataDog/agent-security @DataDog/universal-service-monitoring @DataDog/fleet-automation
+/pkg/config/schema/yaml/system-probe-cws.yaml                         @DataDog/agent-security @DataDog/fleet-automation
+/pkg/config/schema/yaml/system-probe-usm.yaml                         @DataDog/universal-service-monitoring @DataDog/fleet-automation
+/pkg/config/remote/                                                   @DataDog/remote-config
+/pkg/config/remote/meta/                                              @DataDog/remote-config
+/pkg/configstreambootstrap                                            @DataDog/fleet-automation
+/pkg/containerlifecycle/                                              @DataDog/container-integrations
+/pkg/diagnose/                                                        @DataDog/fleet-remediation
+/pkg/diagnose/connectivity/                                           @DataDog/fleet-remediation
+/pkg/diagnose/firewallscanner/                                        @DataDog/network-device-monitoring-core
+/pkg/diagnose/ports/                                                  @DataDog/fleet-remediation
+/pkg/diagnose/ports/*windows*.go                                      @DataDog/windows-products
+/pkg/eventmonitor/                                                    @DataDog/ebpf-platform @DataDog/agent-security
+/pkg/dyninst/                                                         @DataDog/debugger-go
+/pkg/flare/                                                           @DataDog/fleet-remediation
+/pkg/flare/*_win.go                                                   @DataDog/windows-products @DataDog/fleet-remediation
+/pkg/flare/*_windows.go                                               @DataDog/windows-products @DataDog/fleet-remediation
+/pkg/flare/*_windows_test.go                                          @DataDog/windows-products @DataDog/fleet-remediation
+/pkg/fleet/                                                           @DataDog/fleet @DataDog/windows-products
+/pkg/fleet/installer/setup/djm/                                       @DataDog/fleet @DataDog/data-observability
+/pkg/inventory/                                                       @DataDog/windows-products
+/pkg/inventory/software/                                              @DataDog/windows-products
+/pkg/inventory/systeminfo/                                            @DataDog/windows-products
+/pkg/opentelemetry-mapping-go                                         @DataDog/opentelemetry-agent
+/pkg/pidfile/                                                         @DataDog/agent-runtimes
+/pkg/persistentcache/                                                 @DataDog/agent-runtimes
+/pkg/procmgr/                                                         @DataDog/agent-runtimes
+/pkg/procmgr/rust/src/platform/windows.rs                             @DataDog/agent-runtimes @DataDog/windows-products
+/pkg/procmgr/rust/src/transport/named_pipe.rs                         @DataDog/agent-runtimes @DataDog/windows-products
+/pkg/privateactionrunner/                                             @DataDog/action-platform
+/pkg/privateactionrunner/bundles/remoteaction/rshell                  @DataDog/action-platform @DataDog/dd-agent-mcp @DataDog/fleet-remediation
+/pkg/privateactionrunner/bundles/remoteaction/networkconfigmanagement @DataDog/action-platform @DataDog/ndm-integrations
+/pkg/privateactionrunner/bundles/remoteaction/networks                @DataDog/action-platform @Datadog/network-path
+/pkg/proto/                                                           @DataDog/agent-runtimes
+/pkg/proto/datadog/dogstatsdhttp                                      @DataDog/agent-metric-pipelines
+/pkg/proto/datadog/kubemetadata                                       @DataDog/container-platform
+/pkg/proto/datadog/languagedetection                                  @DataDog/container-experiences
+/pkg/proto/datadog/privateactionrunner                                @DataDog/action-platform
+/pkg/proto/datadog/process                                            @DataDog/container-experiences
+/pkg/proto/datadog/sds                                                @DataDog/sensitive-data-scanner
+/pkg/proto/datadog/trace                                              @DataDog/agent-apm
+/pkg/proto/datadog/workloadmeta                                       @DataDog/container-platform
+/pkg/remoteconfig/                                                    @DataDog/remote-config
+/pkg/remoteflags/                                                     @DataDog/fleet-remediation
+/pkg/runtime/                                                         @DataDog/agent-runtimes
+/pkg/redact/                                                          @DataDog/kubernetes-experiences
+/pkg/system-probe/                                                    @DataDog/ebpf-platform
+/pkg/system-probe/api/client/client_windows.go                        @DataDog/windows-products
+/pkg/system-probe/api/server/listener_windows.go                      @DataDog/windows-products
+/pkg/system-probe/config/adjust_npm.go                                @DataDog/ebpf-platform @DataDog/cloud-network-monitoring
+/pkg/system-probe/config/adjust_usm.go                                @DataDog/ebpf-platform @DataDog/universal-service-monitoring
+/pkg/system-probe/config/adjust_security.go                           @DataDog/ebpf-platform @DataDog/agent-security
+/pkg/tagset/                                                          @DataDog/agent-runtimes
+/pkg/util/                                                            @DataDog/agent-runtimes
+/pkg/util/aggregatingqueue                                            @DataDog/container-integrations @DataDog/container-platform
+/pkg/util/aws/creds/                                                  @DataDog/credential-management
+/pkg/util/cloudproviders/cloudfoundry/                                @DataDog/agent-integrations
+/pkg/util/clusteragent/                                               @DataDog/container-platform
+/pkg/util/confmaputils                                                @DataDog/opentelemetry-agent @DataDog/profiling-full-host
+/pkg/util/containerd/                                                 @DataDog/container-integrations
+/pkg/util/containers/                                                 @DataDog/container-integrations
+/pkg/util/containers/metrics/ecsfargate/                              @DataDog/ecs-experiences @DataDog/container-integrations
+/pkg/util/containers/metrics/ecsmanagedinstances/                     @DataDog/ecs-experiences @DataDog/container-integrations
+/pkg/util/crio/                                                       @DataDog/container-integrations
+/pkg/util/docker/                                                     @DataDog/container-integrations
+/pkg/util/ecs/                                                        @DataDog/ecs-experiences
+/pkg/util/fargate/                                                    @DataDog/ecs-experiences
+/pkg/util/filesystem/                                                 @DataDog/agent-runtimes
+/pkg/util/filesystem/rights_*.go                                      @DataDog/fleet-automation
+/pkg/util/funcs/                                                      @DataDog/ebpf-platform
+/pkg/util/gpu/                                                        @DataDog/container-platform @DataDog/gpu-monitoring-agent
+/pkg/util/installinfo/                                                @DataDog/fleet-automation
+/pkg/util/kernel/                                                     @DataDog/ebpf-platform
+/pkg/util/safeelf/                                                    @DataDog/ebpf-platform
+/pkg/util/slices/                                                     @DataDog/ebpf-platform
+/pkg/util/ktime                                                       @DataDog/agent-security
+/pkg/util/kubelet/                                                    @DataDog/container-integrations @DataDog/container-platform @DataDog/kubernetes-experiences
+/pkg/util/kubernetes/                                                 @DataDog/container-integrations @DataDog/container-platform @DataDog/kubernetes-experiences
+/pkg/util/podman/                                                     @DataDog/container-integrations
+/pkg/util/port/                                                       @DataDog/agent-runtimes
+/pkg/util/port/portlist/*windows*.go                                  @DataDog/windows-products
+/pkg/util/prometheus                                                  @DataDog/container-integrations
+/pkg/util/quantile/                                                   @DataDog/opentelemetry-agent
+/pkg/util/tags/                                                       @DataDog/container-platform
+/pkg/util/tmplvar/                                                    @DataDog/container-platform
+/pkg/util/trivy/                                                      @DataDog/agent-security @DataDog/container-integrations
+/pkg/util/uuid/                                                       @DataDog/agent-runtimes
+/pkg/util/cgroups/                                                    @DataDog/container-integrations
+/pkg/util/retry/                                                      @DataDog/container-platform
+/pkg/util/intern/                                                     @DataDog/ebpf-platform
+/pkg/util/crashreport/                                                @DataDog/windows-products
+/pkg/util/pdhutil/                                                    @DataDog/windows-products
+/pkg/util/winutil/                                                    @DataDog/windows-products
+/pkg/util/winutil/iisconfig                                           @DataDog/windows-products @DataDog/universal-service-monitoring
+/pkg/util/testutil/flake                                              @DataDog/agent-devx
+/pkg/util/testutil/patternscanner.go                                  @DataDog/universal-service-monitoring @DataDog/ebpf-platform
+/pkg/util/testutil/docker                                             @DataDog/universal-service-monitoring @DataDog/ebpf-platform
+/pkg/util/trie                                                        @DataDog/container-integrations
+/pkg/languagedetection                                                @DataDog/container-experiences @DataDog/agent-discovery
+/pkg/logonduration                                                    @DataDog/windows-products
+/pkg/logs/                                                            @DataDog/agent-log-pipelines
+/pkg/logs/launchers/container                                         @DataDog/agent-log-pipelines @DataDog/container-integrations
+/pkg/logs/tailers/container                                           @DataDog/agent-log-pipelines @DataDog/container-integrations
+/pkg/logs/launchers/windowsevent                                      @DataDog/agent-log-pipelines @DataDog/windows-products
+/pkg/logs/tailers/windowsevent                                        @DataDog/agent-log-pipelines @DataDog/windows-products
+/pkg/logs/util/windowsevent                                           @DataDog/agent-log-pipelines @DataDog/windows-products
+/comp/logs-library/diagnostic                                         @DataDog/agent-log-pipelines
+/pkg/logs/message                                                     @DataDog/agent-log-pipelines
+/pkg/process/                                                         @DataDog/container-experiences
+/pkg/process/util/address*.go                                         @DataDog/cloud-network-monitoring
+/pkg/process/checks/net*.go                                           @DataDog/cloud-network-monitoring
+/pkg/process/metadata/parser/                                         @DataDog/universal-service-monitoring @DataDog/container-experiences @DataDog/cloud-network-monitoring
+/pkg/process/metadata/parser/*windows*                                @DataDog/universal-service-monitoring @DataDog/container-experiences @DataDog/cloud-network-monitoring @DataDog/windows-products
+/pkg/process/monitor/                                                 @DataDog/universal-service-monitoring
+/pkg/process/net/                                                     @DataDog/universal-service-monitoring @DataDog/cloud-network-monitoring
+/pkg/proto/datadog/remoteconfig/                                      @DataDog/remote-config
+/pkg/proto/pbgo/                                                      # do not notify anyone
+/pkg/proto/pbgo/trace                                                 @DataDog/agent-apm
+/pkg/proto/pbgo/languagedetection                                     @DataDog/agent-apm
+/pkg/proto/pbgo/process                                               @DataDog/container-experiences
+/pkg/proto/pbgo/core                                                  @DataDog/agent-runtimes
+/pkg/proto/pbgo/core/kubemetadata.pb.go                               @DataDog/container-platform
+/pkg/proto/pbgo/core/remoteconfig.pb.go                               @DataDog/remote-config
+/pkg/proto/pbgo/core/remoteconfig_gen.go                              @DataDog/remote-config
+/pkg/proto/pbgo/core/remoteconfig_gen_test.go                         @DataDog/remote-config
+/pkg/proto/pbgo/core/workloadfilter.pb.go                             @DataDog/container-platform
+/pkg/proto/pbgo/core/workloadmeta.pb.go                               @DataDog/container-platform
+/pkg/proto/pbgo/mocks/core                                            @DataDog/agent-runtimes
+/pkg/proto/pbgo/privateactionrunner                                   @DataDog/action-platform
+/pkg/orchestrator/                                                    @DataDog/kubernetes-experiences
+/pkg/network/                                                         @DataDog/cloud-network-monitoring
+/pkg/network/*usm*                                                    @DataDog/universal-service-monitoring
+/pkg/network/*_windows*.go                                            @DataDog/windows-products
+/pkg/network/*usm*windows*.go                                         @DataDog/windows-products @DataDog/universal-service-monitoring
+/pkg/network/config/config_test.go                                    @DataDog/cloud-network-monitoring @DataDog/universal-service-monitoring @DataDog/windows-products
+/pkg/network/config/usm*.go                                           @DataDog/universal-service-monitoring
+/pkg/network/driver_*.go                                              @DataDog/windows-products
+/pkg/network/dns/*_windows*.go                                        @DataDog/windows-products
+/pkg/network/driver/                                                  @DataDog/windows-products
+/pkg/network/ebpf/c/prebuilt/usm*                                     @DataDog/universal-service-monitoring
+/pkg/network/ebpf/c/runtime/usm*                                      @DataDog/universal-service-monitoring
+/pkg/network/ebpf/c/prebuilt/shared-libraries*                        @DataDog/universal-service-monitoring
+/pkg/network/ebpf/c/runtime/shared-libraries*                         @DataDog/universal-service-monitoring
+/pkg/network/ebpf/c/shared-libraries/                                 @DataDog/universal-service-monitoring
+/pkg/network/ebpf/c/protocols/                                        @DataDog/universal-service-monitoring
+/pkg/network/ebpf/c/protocols/tls                                     @DataDog/cloud-network-monitoring @DataDog/universal-service-monitoring
+/pkg/network/encoding/marshal/*usm*                                   @DataDog/universal-service-monitoring
+/pkg/network/encoding/marshal/*_windows*.go                           @DataDog/windows-products
+/pkg/network/encoding/marshal/*usm*windows*.go                        @DataDog/windows-products @DataDog/universal-service-monitoring
+/pkg/network/go/                                                      @DataDog/universal-service-monitoring
+/pkg/network/protocols/                                               @DataDog/universal-service-monitoring
+/pkg/network/protocols/http/driver_*.go                               @DataDog/windows-products @DataDog/universal-service-monitoring
+/pkg/network/protocols/http/etw*.go                                   @DataDog/windows-products @DataDog/universal-service-monitoring
+/pkg/network/protocols/http/*_windows*.go                             @DataDog/windows-products @DataDog/universal-service-monitoring
+/pkg/network/tracer/testutil/proxy/                                   @DataDog/universal-service-monitoring
+/pkg/network/tracer/*_windows*.go                                     @DataDog/windows-products
+/pkg/network/usm/                                                     @DataDog/universal-service-monitoring
+/pkg/network/usm/tests/*_windows*.go                                  @DataDog/windows-products @DataDog/universal-service-monitoring
+/pkg/networkconfigmanagement/                                         @DataDog/ndm-integrations
+/pkg/ebpf/                                                            @DataDog/ebpf-platform
+/pkg/ebpf/map_cleaner*.go                                             @DataDog/universal-service-monitoring
+/pkg/compliance/                                                      @DataDog/agent-cspm @DataDog/agent-security
+/pkg/databasemonitoring                                               @DataDog/database-monitoring
+/pkg/kubestatemetrics                                                 @DataDog/container-integrations
+/pkg/security/                                                        @DataDog/agent-security
+/pkg/networkdevice/                                                   @DataDog/network-device-monitoring-core
+/pkg/snmp/                                                            @DataDog/network-device-monitoring-core
+/pkg/ssi/                                                             @DataDog/injection-platform
+/pkg/tagger/                                                          @DataDog/container-platform
+/pkg/windowsdriver/                                                   @DataDog/windows-products
+/comp/core/workloadmeta/collectors/internal/cloudfoundry              @DataDog/agent-integrations
+/comp/core/workloadmeta/collectors/internal/containerd                @DataDog/container-platform @DataDog/container-integrations
+/comp/core/workloadmeta/collectors/internal/crio                      @DataDog/container-platform @DataDog/container-integrations
+/comp/core/workloadmeta/collectors/internal/docker                    @DataDog/container-platform @DataDog/container-integrations
+/comp/core/workloadmeta/collectors/internal/ecs                       @DataDog/ecs-experiences
+/comp/core/workloadmeta/collectors/internal/kubeapiserver             @DataDog/container-platform @DataDog/container-integrations
+/comp/core/workloadmeta/collectors/internal/kubelet                   @DataDog/container-platform @DataDog/container-integrations
+/comp/core/workloadmeta/collectors/internal/kubemetadata              @DataDog/container-platform @DataDog/container-integrations
+/comp/core/workloadmeta/collectors/internal/nvml                      @DataDog/ebpf-platform @DataDog/gpu-monitoring-agent
+/comp/core/workloadmeta/collectors/internal/podman                    @DataDog/container-platform @DataDog/container-integrations
+/comp/core/workloadmeta/collectors/internal/process                   @DataDog/container-experiences @DataDog/container-platform
+/comp/core/tagger/collectors                                          @DataDog/container-platform @DataDog/container-integrations
+/pkg/sbom/                                                            @DataDog/agent-security @DataDog/container-integrations
+/pkg/networkpath/                                                     @DataDog/network-path
+/pkg/networkpath/traceroute/                                          @DataDog/windows-products @DataDog/network-path
+/pkg/collector/corechecks/networkpath/                                @DataDog/network-path
+/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/          @DataDog/sensitive-data-scanner
 
 # release notes accompany code changes, so code owners will review anyway
-/releasenotes/                          # do not notify anyone
-/releasenotes-dca/                      # do not notify anyone
+/releasenotes/     # do not notify anyone
+/releasenotes-dca/ # do not notify anyone
 
-/rtloader/                              @DataDog/agent-runtimes
+/rtloader/ @DataDog/agent-runtimes
 
-/tasks/                                 @DataDog/agent-devx
-/tasks/macos.py                         @DataDog/windows-products
-/tasks/msi.py                           @DataDog/windows-products
-/tasks/agent.py                         @DataDog/agent-runtimes
-/tasks/bazel.py                         @DataDog/agent-build
-/tasks/build_tags.py                    @DataDog/agent-build
-/tasks/build_tags.bzl                   @DataDog/agent-build
-/tasks/anomalydetection.py              @DataDog/q-branch
-/tasks/unit_tests/anomalydetection*.py  @DataDog/q-branch
-/tasks/loader.py                        @DataDog/agent-runtimes
-/tasks/go_deps.py                       @DataDog/agent-runtimes
-/tasks/gotest.py                        @DataDog/agent-devx @DataDog/agent-build
-/tasks/dogstatsd.py                     @DataDog/agent-metric-pipelines
-/tasks/update_go.py                     @DataDog/agent-runtimes
-/tasks/python_version.py                @DataDog/agent-integrations
-/tasks/unit_tests/update_go_tests.py    @DataDog/agent-runtimes
-/tasks/unit_tests/python_version_tests.py @DataDog/agent-integrations
-/tasks/unit_tests/kmt_tests.py          @DataDog/ebpf-platform
-/tasks/unit_tests/macos_tests.py        @DataDog/windows-products
-/tasks/unit_tests/winbuild_tests.py     @DataDog/windows-products
-/tasks/cluster_agent_cloudfoundry.py    @DataDog/agent-integrations
-/tasks/devcontainer.py                  @DataDog/agent-devx @DataDog/container-platform
-/tasks/skaffold.py                      @DataDog/agent-devx @DataDog/container-platform
-/tasks/new_e2e_tests.py                  @DataDog/agent-devx
-/tasks/process_agent.py                 @DataDog/container-experiences
-/tasks/privateactionrunner.py           @DataDog/action-platform
-/tasks/system_probe.py                  @DataDog/ebpf-platform
-/tasks/ebpf.py                          @DataDog/ebpf-platform
-/tasks/kmt.py                           @DataDog/ebpf-platform
-/tasks/gpu.py                           @DataDog/ebpf-platform @DataDog/gpu-monitoring-agent
-/tasks/kernel_matrix_testing/           @DataDog/ebpf-platform
-/tasks/ebpf_verifier/                   @DataDog/ebpf-platform
-/tasks/trace_agent.py                   @DataDog/agent-apm
-/tasks/protobuf.py                      @DataDog/agent-build
-/tasks/quality_gates.py                 @DataDog/agent-build
-/tasks/static_quality_gates/            @DataDog/agent-build
-/tasks/files_inventory.py               @DataDog/agent-build
-/tasks/rtloader.py                      @DataDog/agent-runtimes
-/tasks/secret_generic_connector.py      @DataDog/fleet-automation
-/tasks/security_agent.py                @DataDog/agent-security
-/tasks/sbomgen.py                       @DataDog/agent-security
-/tasks/libs/anomalydetection/           @DataDog/q-branch
-/tasks/libs/build/                      @DataDog/agent-build
-/tasks/libs/cws/                        @DataDog/agent-security
-/tasks/libs/gpu/                        @DataDog/ebpf-platform @DataDog/gpu-monitoring-agent
-/tasks/systray.py                       @DataDog/windows-products
-/tasks/winbuildscripts/                 @DataDog/windows-products
-/tasks/winbuild.py                      @DataDog/windows-products
-/tasks/windows_resources.py             @DataDog/windows-products
-/tasks/virustotal.py                    @DataDog/windows-products
-/tasks/collector.py                     @DataDog/opentelemetry-agent
-/tasks/components.py                    @DataDog/agent-runtimes
-/tasks/components_templates             @DataDog/agent-runtimes
-/tasks/libs/ciproviders/                @DataDog/agent-devx
-/tasks/libs/common/omnibus.py           @DataDog/agent-build
-/tasks/omnibus.py                       @DataDog/agent-build
-/tasks/release.py                       @DataDog/agent-delivery
-/tasks/release_metrics/                 @DataDog/agent-delivery
-/tasks/libs/releasing/                  @DataDog/agent-delivery
-/tasks/schema/                          @DataDog/fleet-automation
-/tasks/unit_tests/bazel_tests.py        @DataDog/agent-build
-/tasks/unit_tests/components_tests.py   @DataDog/agent-runtimes
-/tasks/unit_tests/build_tags_tests.py   @DataDog/agent-build
-/tasks/unit_tests/libs/build/           @DataDog/agent-build
-/tasks/unit_tests/omnibus_tests.py      @DataDog/agent-build
-/tasks/unit_tests/schema_*              @DataDog/fleet-automation
-/tasks/unit_tests/testdata/components_src/ @DataDog/agent-runtimes
-/tasks/unit_tests/testdata/collector/   @DataDog/opentelemetry-agent
-/tasks/unit_tests/experimental_gates_tests.py @DataDog/agent-build
-/tasks/unit_tests/static_quality_gates/    @DataDog/agent-build
-/tasks/unit_tests/testdata/schema_codegen/ @DataDog/fleet-automation
-/tasks/installer.py                     @DataDog/fleet
-/tasks/host_profiler.py                 @DataDog/opentelemetry-agent @DataDog/profiling-full-host
-/test/                                  @DataDog/agent-devx
-/test/benchmarks/                       @DataDog/agent-metric-pipelines
-/test/benchmarks/kubernetes_state/      @DataDog/container-integrations
-/test/integration/                      @DataDog/serverless-azure-gcp
-/test/integration/docker/               @DataDog/opentelemetry-agent
-/test/e2e-framework/AGENTS.md                           @DataDog/agent-devx
-/test/e2e-framework/CLAUDE.md                          @DataDog/agent-devx
-/test/e2e-framework/testing/testcommon/check            @DataDog/agent-runtimes
-/test/e2e-framework/testing/utils/e2e/client/ecs/       @DataDog/ecs-experiences
-/test/e2e-framework/testing/provisioners/aws/ecs/       @DataDog/ecs-experiences
-/test/e2e-framework/testing/environments/ecs.go         @DataDog/ecs-experiences
-/test/e2e-framework/scenarios/aws/ecs/                  @DataDog/ecs-experiences
-/test/e2e-framework/scenarios/aws/integrations/        @DataDog/agent-integrations
-/tasks/e2e_framework/aws/integrations/                  @DataDog/agent-integrations
-/test/e2e-framework/resources/aws/ecs/                  @DataDog/ecs-experiences
-/test/e2e-framework/components/ecs/                     @DataDog/ecs-experiences
-/test/e2e-framework/components/datadog/agent/ecs.go     @DataDog/ecs-experiences
-/test/e2e-framework/components/datadog/agent/ecsFargate.go @DataDog/ecs-experiences
-/test/e2e-framework/components/datadog/ecsagentparams/  @DataDog/ecs-experiences
-/test/e2e-framework/components/datadog/otel-standalone/ @DataDog/opentelemetry-agent
-/test/e2e-framework/components/windows/                @DataDog/windows-products
-/test/fakeintake/                              @DataDog/agent-devx
-/test/fakeintake/version/VERSION               # do not notify anyone
-/test/fakeintake/aggregator/ndmAggregator.go @DataDog/network-device-monitoring-core
-/test/fakeintake/aggregator/ndmAggregator_test.go @DataDog/network-device-monitoring-core
-/test/fakeintake/aggregator/ndmflowAggregator.go @DataDog/ndm-integrations
-/test/fakeintake/aggregator/ndmflowAggregator_test.go @DataDog/ndm-integrations
-/test/fakeintake/aggregator/agenthealthAggregator.go @DataDog/fleet-remediation
-/test/fakeintake/aggregator/agenthealthAggregator_test.go @DataDog/fleet-remediation
-/test/fakeintake/client/fixtures/api_v2_agenthealth_response @DataDog/fleet-remediation
-/test/new-e2e/                                 @DataDog/agent-devx
-/test/new-e2e/system-probe                    @DataDog/ebpf-platform
-/test/new-e2e/system-probe/config/vmconfig-security-agent.json @DataDog/ebpf-platform @DataDog/agent-security
-/test/new-e2e/scenarios/system-probe          @DataDog/ebpf-platform
-/test/new-e2e/tests/anomalydetection          @DataDog/q-branch
-/test/new-e2e/tests/agent-platform            @DataDog/agent-devx
-/test/new-e2e/tests/agent-platform/common/agent_integration.go @DataDog/agent-integrations
-/test/new-e2e/tests/agent-platform/tests/macos*      @DataDog/windows-products
-/test/new-e2e/tests/agent-runtimes            @DataDog/agent-runtimes
-/test/new-e2e/tests/agent-data-plane          @DataDog/agent-data-plane
-/test/new-e2e/tests/agent-configuration       @DataDog/fleet-automation
-/test/new-e2e/tests/agent-health              @DataDog/fleet-remediation
-/test/new-e2e/tests/agent-metric-pipelines    @DataDog/agent-metric-pipelines
-/test/new-e2e/tests/agent-subcommands                @DataDog/fleet-remediation
-/test/new-e2e/tests/agent-subcommands/config*         @DataDog/fleet-automation
-/test/new-e2e/tests/agent-subcommands/check*          @DataDog/agent-runtimes
-/test/new-e2e/tests/agent-subcommands/health*        @DataDog/agent-runtimes
-/test/new-e2e/tests/agent-subcommands/hostname*      @DataDog/agent-runtimes
-/test/new-e2e/tests/agent-subcommands/configcheck*   @DataDog/agent-runtimes @DataDog/agent-integrations
-/test/new-e2e/tests/agent-subcommands/run*           @DataDog/agent-runtimes
-/test/new-e2e/tests/agent-subcommands/flare*          @DataDog/fleet-remediation
-/test/new-e2e/tests/agent-subcommands/status*         @DataDog/fleet-remediation
-/test/new-e2e/tests/agent-telemetry           @DataDog/fleet-remediation
-/test/new-e2e/tests/autoscaling               @DataDog/container-autoscaling
-/test/new-e2e/tests/containers                @DataDog/container-integrations @DataDog/container-platform
-/test/new-e2e/tests/containers/cluster_agent_sgc_binary_test.go    @DataDog/fleet-automation
-/test/new-e2e/tests/containers/ecs_test.go    @DataDog/ecs-experiences
-/test/new-e2e/tests/cspm                      @DataDog/agent-cspm @DataDog/agent-security
-/test/new-e2e/tests/discovery                 @DataDog/agent-discovery
-/test/new-e2e/tests/ddot                      @DataDog/agent-runtimes
-/test/new-e2e/tests/fips-compliance           @DataDog/agent-runtimes
-/test/new-e2e/tests/ha-agent                  @DataDog/network-device-monitoring-core
-/test/new-e2e/tests/language-detection        @DataDog/container-experiences
-/test/new-e2e/tests/ndm                       @DataDog/network-device-monitoring-core
-/test/new-e2e/tests/ndm/netflow               @DataDog/ndm-integrations
-/test/new-e2e/tests/netpath                   @DataDog/windows-products @DataDog/network-path
-/test/new-e2e/tests/npm                       @DataDog/cloud-network-monitoring
-/test/new-e2e/tests/npm/ec2_1host_wkit_test.go @DataDog/cloud-network-monitoring @DataDog/windows-products
-/test/new-e2e/tests/npm/ecs_1host_test.go    @DataDog/ecs-experiences
-/test/new-e2e/tests/orchestrator              @DataDog/kubernetes-experiences
-/test/new-e2e/tests/orchestrator/ecs_test.go @DataDog/ecs-experiences
-/test/new-e2e/tests/otel                      @DataDog/opentelemetry-agent
-/test/new-e2e/tests/privateactionrunner       @DataDog/action-platform
-/test/new-e2e/tests/process                   @DataDog/container-experiences
-/test/new-e2e/tests/process/ecs_test.go      @DataDog/ecs-experiences @DataDog/container-experiences
-/test/new-e2e/tests/process/fargate_test.go  @DataDog/ecs-experiences @DataDog/container-experiences
-/test/new-e2e/tests/sysprobe-functional     @DataDog/windows-products
-/test/new-e2e/tests/security-agent-functional     @DataDog/windows-products @DataDog/agent-security
-/test/new-e2e/tests/cws                       @DataDog/agent-security
-/test/new-e2e/tests/cws/fargate_test.go       @DataDog/agent-security @DataDog/ecs-experiences
-/test/new-e2e/tests/agent-log-pipelines       @DataDog/agent-log-pipelines
-/test/new-e2e/tests/windows                   @DataDog/windows-products @DataDog/windows-products
-/test/new-e2e/tests/apm                       @DataDog/agent-apm
-/test/new-e2e/tests/remote-config             @DataDog/remote-config
-/test/new-e2e/tests/ssi                       @DataDog/injection-platform
-/test/new-e2e/tests/ssi-gradual-rollout       @DataDog/apm-release-platform
-/test/new-e2e/tests/fleet                     @DataDog/fleet @DataDog/windows-products
-/test/new-e2e/tests/installer                 @DataDog/fleet @DataDog/windows-products
-/test/new-e2e/tests/installer/script          @DataDog/fleet @DataDog/data-observability
-/test/new-e2e/tests/sbom                      @DataDog/agent-security
+/tasks/                                                         @DataDog/agent-devx
+/tasks/macos.py                                                 @DataDog/windows-products
+/tasks/msi.py                                                   @DataDog/windows-products
+/tasks/agent.py                                                 @DataDog/agent-runtimes
+/tasks/bazel.py                                                 @DataDog/agent-build
+/tasks/build_tags.py                                            @DataDog/agent-build
+/tasks/build_tags.bzl                                           @DataDog/agent-build
+/tasks/anomalydetection.py                                      @DataDog/q-branch
+/tasks/unit_tests/anomalydetection*.py                          @DataDog/q-branch
+/tasks/loader.py                                                @DataDog/agent-runtimes
+/tasks/go_deps.py                                               @DataDog/agent-runtimes
+/tasks/gotest.py                                                @DataDog/agent-devx @DataDog/agent-build
+/tasks/dogstatsd.py                                             @DataDog/agent-metric-pipelines
+/tasks/update_go.py                                             @DataDog/agent-runtimes
+/tasks/python_version.py                                        @DataDog/agent-integrations
+/tasks/unit_tests/update_go_tests.py                            @DataDog/agent-runtimes
+/tasks/unit_tests/python_version_tests.py                       @DataDog/agent-integrations
+/tasks/unit_tests/kmt_tests.py                                  @DataDog/ebpf-platform
+/tasks/unit_tests/macos_tests.py                                @DataDog/windows-products
+/tasks/unit_tests/winbuild_tests.py                             @DataDog/windows-products
+/tasks/cluster_agent_cloudfoundry.py                            @DataDog/agent-integrations
+/tasks/devcontainer.py                                          @DataDog/agent-devx @DataDog/container-platform
+/tasks/skaffold.py                                              @DataDog/agent-devx @DataDog/container-platform
+/tasks/new_e2e_tests.py                                         @DataDog/agent-devx
+/tasks/process_agent.py                                         @DataDog/container-experiences
+/tasks/privateactionrunner.py                                   @DataDog/action-platform
+/tasks/system_probe.py                                          @DataDog/ebpf-platform
+/tasks/ebpf.py                                                  @DataDog/ebpf-platform
+/tasks/kmt.py                                                   @DataDog/ebpf-platform
+/tasks/gpu.py                                                   @DataDog/ebpf-platform @DataDog/gpu-monitoring-agent
+/tasks/kernel_matrix_testing/                                   @DataDog/ebpf-platform
+/tasks/ebpf_verifier/                                           @DataDog/ebpf-platform
+/tasks/trace_agent.py                                           @DataDog/agent-apm
+/tasks/protobuf.py                                              @DataDog/agent-build
+/tasks/quality_gates.py                                         @DataDog/agent-build
+/tasks/static_quality_gates/                                    @DataDog/agent-build
+/tasks/files_inventory.py                                       @DataDog/agent-build
+/tasks/rtloader.py                                              @DataDog/agent-runtimes
+/tasks/secret_generic_connector.py                              @DataDog/fleet-automation
+/tasks/security_agent.py                                        @DataDog/agent-security
+/tasks/sbomgen.py                                               @DataDog/agent-security
+/tasks/libs/anomalydetection/                                   @DataDog/q-branch
+/tasks/libs/build/                                              @DataDog/agent-build
+/tasks/libs/cws/                                                @DataDog/agent-security
+/tasks/libs/gpu/                                                @DataDog/ebpf-platform @DataDog/gpu-monitoring-agent
+/tasks/systray.py                                               @DataDog/windows-products
+/tasks/winbuildscripts/                                         @DataDog/windows-products
+/tasks/winbuild.py                                              @DataDog/windows-products
+/tasks/windows_resources.py                                     @DataDog/windows-products
+/tasks/virustotal.py                                            @DataDog/windows-products
+/tasks/collector.py                                             @DataDog/opentelemetry-agent
+/tasks/components.py                                            @DataDog/agent-runtimes
+/tasks/components_templates                                     @DataDog/agent-runtimes
+/tasks/libs/ciproviders/                                        @DataDog/agent-devx
+/tasks/libs/common/omnibus.py                                   @DataDog/agent-build
+/tasks/omnibus.py                                               @DataDog/agent-build
+/tasks/release.py                                               @DataDog/agent-delivery
+/tasks/release_metrics/                                         @DataDog/agent-delivery
+/tasks/libs/releasing/                                          @DataDog/agent-delivery
+/tasks/schema/                                                  @DataDog/fleet-automation
+/tasks/unit_tests/bazel_tests.py                                @DataDog/agent-build
+/tasks/unit_tests/components_tests.py                           @DataDog/agent-runtimes
+/tasks/unit_tests/build_tags_tests.py                           @DataDog/agent-build
+/tasks/unit_tests/libs/build/                                   @DataDog/agent-build
+/tasks/unit_tests/omnibus_tests.py                              @DataDog/agent-build
+/tasks/unit_tests/schema_*                                      @DataDog/agent-configuration
+/tasks/unit_tests/testdata/components_src/                      @DataDog/agent-runtimes
+/tasks/unit_tests/testdata/collector/                           @DataDog/opentelemetry-agent
+/tasks/unit_tests/experimental_gates_tests.py                   @DataDog/agent-build
+/tasks/unit_tests/static_quality_gates/                         @DataDog/agent-build
+/tasks/unit_tests/testdata/schema_codegen/                      @DataDog/agent-configuration
+/tasks/installer.py                                             @DataDog/fleet
+/tasks/host_profiler.py                                         @DataDog/opentelemetry-agent @DataDog/profiling-full-host
+/test/                                                          @DataDog/agent-devx
+/test/benchmarks/                                               @DataDog/agent-metric-pipelines
+/test/benchmarks/kubernetes_state/                              @DataDog/container-integrations
+/test/integration/                                              @DataDog/serverless-azure-gcp
+/test/integration/docker/                                       @DataDog/opentelemetry-agent
+/test/e2e-framework/AGENTS.md                                   @DataDog/agent-devx
+/test/e2e-framework/CLAUDE.md                                   @DataDog/agent-devx
+/test/e2e-framework/testing/testcommon/check                    @DataDog/agent-runtimes
+/test/e2e-framework/testing/utils/e2e/client/ecs/               @DataDog/ecs-experiences
+/test/e2e-framework/testing/provisioners/aws/ecs/               @DataDog/ecs-experiences
+/test/e2e-framework/testing/environments/ecs.go                 @DataDog/ecs-experiences
+/test/e2e-framework/scenarios/aws/ecs/                          @DataDog/ecs-experiences
+/test/e2e-framework/scenarios/aws/integrations/                 @DataDog/agent-integrations
+/tasks/e2e_framework/aws/integrations/                          @DataDog/agent-integrations
+/test/e2e-framework/resources/aws/ecs/                          @DataDog/ecs-experiences
+/test/e2e-framework/components/ecs/                             @DataDog/ecs-experiences
+/test/e2e-framework/components/datadog/agent/ecs.go             @DataDog/ecs-experiences
+/test/e2e-framework/components/datadog/agent/ecsFargate.go      @DataDog/ecs-experiences
+/test/e2e-framework/components/datadog/ecsagentparams/          @DataDog/ecs-experiences
+/test/e2e-framework/components/datadog/otel-standalone/         @DataDog/opentelemetry-agent
+/test/e2e-framework/components/windows/                         @DataDog/windows-products
+/test/fakeintake/                                               @DataDog/agent-devx
+/test/fakeintake/version/VERSION                                # do not notify anyone
+/test/fakeintake/aggregator/ndmAggregator.go                    @DataDog/network-device-monitoring-core
+/test/fakeintake/aggregator/ndmAggregator_test.go               @DataDog/network-device-monitoring-core
+/test/fakeintake/aggregator/ndmflowAggregator.go                @DataDog/ndm-integrations
+/test/fakeintake/aggregator/ndmflowAggregator_test.go           @DataDog/ndm-integrations
+/test/fakeintake/aggregator/agenthealthAggregator.go            @DataDog/fleet-remediation
+/test/fakeintake/aggregator/agenthealthAggregator_test.go       @DataDog/fleet-remediation
+/test/fakeintake/client/fixtures/api_v2_agenthealth_response    @DataDog/fleet-remediation
+/test/new-e2e/                                                  @DataDog/agent-devx
+/test/new-e2e/system-probe                                      @DataDog/ebpf-platform
+/test/new-e2e/system-probe/config/vmconfig-security-agent.json  @DataDog/ebpf-platform @DataDog/agent-security
+/test/new-e2e/scenarios/system-probe                            @DataDog/ebpf-platform
+/test/new-e2e/tests/anomalydetection                            @DataDog/q-branch
+/test/new-e2e/tests/agent-platform                              @DataDog/agent-devx
+/test/new-e2e/tests/agent-platform/common/agent_integration.go  @DataDog/agent-integrations
+/test/new-e2e/tests/agent-platform/tests/macos*                 @DataDog/windows-products
+/test/new-e2e/tests/agent-runtimes                              @DataDog/agent-runtimes
+/test/new-e2e/tests/agent-data-plane                            @DataDog/agent-data-plane
+/test/new-e2e/tests/agent-configuration                         @DataDog/fleet-automation
+/test/new-e2e/tests/agent-health                                @DataDog/fleet-remediation
+/test/new-e2e/tests/agent-metric-pipelines                      @DataDog/agent-metric-pipelines
+/test/new-e2e/tests/agent-subcommands                           @DataDog/fleet-remediation
+/test/new-e2e/tests/agent-subcommands/config*                   @DataDog/fleet-automation
+/test/new-e2e/tests/agent-subcommands/check*                    @DataDog/agent-runtimes
+/test/new-e2e/tests/agent-subcommands/health*                   @DataDog/agent-runtimes
+/test/new-e2e/tests/agent-subcommands/hostname*                 @DataDog/agent-runtimes
+/test/new-e2e/tests/agent-subcommands/configcheck*              @DataDog/agent-runtimes @DataDog/agent-integrations
+/test/new-e2e/tests/agent-subcommands/run*                      @DataDog/agent-runtimes
+/test/new-e2e/tests/agent-subcommands/flare*                    @DataDog/fleet-remediation
+/test/new-e2e/tests/agent-subcommands/status*                   @DataDog/fleet-remediation
+/test/new-e2e/tests/agent-telemetry                             @DataDog/fleet-remediation
+/test/new-e2e/tests/autoscaling                                 @DataDog/container-autoscaling
+/test/new-e2e/tests/containers                                  @DataDog/container-integrations @DataDog/container-platform
+/test/new-e2e/tests/containers/cluster_agent_sgc_binary_test.go @DataDog/fleet-automation
+/test/new-e2e/tests/containers/ecs_test.go                      @DataDog/ecs-experiences
+/test/new-e2e/tests/cspm                                        @DataDog/agent-cspm @DataDog/agent-security
+/test/new-e2e/tests/discovery                                   @DataDog/agent-discovery
+/test/new-e2e/tests/ddot                                        @DataDog/agent-runtimes
+/test/new-e2e/tests/fips-compliance                             @DataDog/agent-runtimes
+/test/new-e2e/tests/ha-agent                                    @DataDog/network-device-monitoring-core
+/test/new-e2e/tests/language-detection                          @DataDog/container-experiences
+/test/new-e2e/tests/ndm                                         @DataDog/network-device-monitoring-core
+/test/new-e2e/tests/ndm/netflow                                 @DataDog/ndm-integrations
+/test/new-e2e/tests/netpath                                     @DataDog/windows-products @DataDog/network-path
+/test/new-e2e/tests/npm                                         @DataDog/cloud-network-monitoring
+/test/new-e2e/tests/npm/ec2_1host_wkit_test.go                  @DataDog/cloud-network-monitoring @DataDog/windows-products
+/test/new-e2e/tests/npm/ecs_1host_test.go                       @DataDog/ecs-experiences
+/test/new-e2e/tests/orchestrator                                @DataDog/kubernetes-experiences
+/test/new-e2e/tests/orchestrator/ecs_test.go                    @DataDog/ecs-experiences
+/test/new-e2e/tests/otel                                        @DataDog/opentelemetry-agent
+/test/new-e2e/tests/privateactionrunner                         @DataDog/action-platform
+/test/new-e2e/tests/process                                     @DataDog/container-experiences
+/test/new-e2e/tests/process/ecs_test.go                         @DataDog/ecs-experiences @DataDog/container-experiences
+/test/new-e2e/tests/process/fargate_test.go                     @DataDog/ecs-experiences @DataDog/container-experiences
+/test/new-e2e/tests/sysprobe-functional                         @DataDog/windows-products
+/test/new-e2e/tests/security-agent-functional                   @DataDog/windows-products @DataDog/agent-security
+/test/new-e2e/tests/cws                                         @DataDog/agent-security
+/test/new-e2e/tests/cws/fargate_test.go                         @DataDog/agent-security @DataDog/ecs-experiences
+/test/new-e2e/tests/agent-log-pipelines                         @DataDog/agent-log-pipelines
+/test/new-e2e/tests/windows                                     @DataDog/windows-products @DataDog/windows-products
+/test/new-e2e/tests/apm                                         @DataDog/agent-apm
+/test/new-e2e/tests/remote-config                               @DataDog/remote-config
+/test/new-e2e/tests/ssi                                         @DataDog/injection-platform
+/test/new-e2e/tests/ssi-gradual-rollout                         @DataDog/apm-release-platform
+/test/new-e2e/tests/fleet                                       @DataDog/fleet @DataDog/windows-products
+/test/new-e2e/tests/installer                                   @DataDog/fleet @DataDog/windows-products
+/test/new-e2e/tests/installer/script                            @DataDog/fleet @DataDog/data-observability
+/test/new-e2e/tests/sbom                                        @DataDog/agent-security
 # windows-products primary owner for windows tests so we get failure notifications
-/test/new-e2e/tests/installer/windows         @DataDog/windows-products @DataDog/fleet
-/test/new-e2e/tests/gpu                       @DataDog/ebpf-platform @DataDog/gpu-monitoring-agent
-/test/new-e2e/tests/usm                       @DataDog/universal-service-monitoring
-/test/new-e2e/examples/ecs_test.go           @DataDog/ecs-experiences
-/test/otel/                                   @DataDog/opentelemetry-agent
-/test/static/                                 @DataDog/agent-build
+/test/new-e2e/tests/installer/windows                           @DataDog/windows-products @DataDog/fleet
+/test/new-e2e/tests/gpu                                         @DataDog/ebpf-platform @DataDog/gpu-monitoring-agent
+/test/new-e2e/tests/usm                                         @DataDog/universal-service-monitoring
+/test/new-e2e/examples/ecs_test.go                              @DataDog/ecs-experiences
+/test/otel/                                                     @DataDog/opentelemetry-agent
+/test/static/                                                   @DataDog/agent-build
 # Also change the run-time check for approver at: tasks/static_quality_gates/decisions.py:EXCEPTION_APPROVERS
-/test/static/static_quality_gates.yml        @DataDog/agent-build @DataDog/container-platform @cmourot @aiuto @quentinus95
-/test/benchmarks/apm_scripts/                 @DataDog/agent-apm
-/test/regression/                             @DataDog/single-machine-performance
-/test/regression/ebpf                         @DataDog/single-machine-performance @DataDog/ebpf-platform
-/test/regression/cases/quality_gate_security_* @DataDog/single-machine-performance @DataDog/agent-security
-/test/regression/cases/quality_gate_private_action_runner* @DataDog/single-machine-performance @DataDog/action-platform
+/test/static/static_quality_gates.yml                           @DataDog/agent-build @DataDog/container-platform @cmourot @aiuto @quentinus95
+/test/benchmarks/apm_scripts/                                   @DataDog/agent-apm
+/test/regression/                                               @DataDog/single-machine-performance
+/test/regression/ebpf                                           @DataDog/single-machine-performance @DataDog/ebpf-platform
+/test/regression/cases/quality_gate_security_*                  @DataDog/single-machine-performance @DataDog/agent-security
+/test/regression/cases/quality_gate_private_action_runner*      @DataDog/single-machine-performance @DataDog/action-platform
 
-/tools/                                 @DataDog/agent-devx
-/tools/host-profiler/                   @DataDog/profiling-full-host
-/tools/bazel*                           @DataDog/agent-build
-/tools/ci                               @DataDog/agent-devx
-/tools/ci/*bazel*                       @DataDog/agent-build
-/tools/ebpf/                            @DataDog/ebpf-platform
-/tools/gdb/                             @DataDog/agent-runtimes
-/tools/go-update/                       @DataDog/agent-runtimes
-/tools/NamedPipeCmd/                    @DataDog/windows-products
-/tools/retry_file_dump/                 @DataDog/agent-metric-pipelines
-/tools/windows/                         @DataDog/windows-products
+/tools/                                                              @DataDog/agent-devx
+/tools/host-profiler/                                                @DataDog/profiling-full-host
+/tools/bazel*                                                        @DataDog/agent-build
+/tools/ci                                                            @DataDog/agent-devx
+/tools/ci/*bazel*                                                    @DataDog/agent-build
+/tools/ebpf/                                                         @DataDog/ebpf-platform
+/tools/gdb/                                                          @DataDog/agent-runtimes
+/tools/go-update/                                                    @DataDog/agent-runtimes
+/tools/NamedPipeCmd/                                                 @DataDog/windows-products
+/tools/retry_file_dump/                                              @DataDog/agent-metric-pipelines
+/tools/windows/                                                      @DataDog/windows-products
 /tools/windows/DatadogAgentInstaller/WixSetup/localization-en-us.wxl @DataDog/windows-products @DataDog/documentation
-/tools/agent_QA/                        @DataDog/agent-devx
-/tools/build-ddot-byoc/                 @DataDog/opentelemetry-agent
+/tools/agent_QA/                                                     @DataDog/agent-devx
+/tools/build-ddot-byoc/                                              @DataDog/opentelemetry-agent
 
-/internal/remote-agent                  @DataDog/agent-runtimes
-/internal/tools/                        @DataDog/agent-devx
-/internal/third_party/client-go         @DataDog/container-platform
-/internal/third_party/kubernetes        @DataDog/container-integrations
-/internal/third_party/golang/           @DataDog/container-integrations
+/internal/remote-agent           @DataDog/agent-runtimes
+/internal/tools/                 @DataDog/agent-devx
+/internal/third_party/client-go  @DataDog/container-platform
+/internal/third_party/kubernetes @DataDog/container-integrations
+/internal/third_party/golang/    @DataDog/container-integrations
 
-/q_branch/                               @DataDog/q-branch
-/internal/qbranch/                       @DataDog/q-branch
-/comp/anomalydetection/                  @DataDog/q-branch # Useful for AGENTS.md files etc. at the root of all AD components
+/q_branch/              @DataDog/q-branch
+/internal/qbranch/      @DataDog/q-branch
+/comp/anomalydetection/ @DataDog/q-branch # Useful for AGENTS.md files etc. at the root of all AD components
 
 # With the introduction of go.work, dependencies bump modify go.mod and go.sum in a lot of file.
 # Which bring a lot of team in the review each time. To make it smoother we no longer consider go.mod and go.sum owned by teams.
 # Each team can individually decide to update CODEOWNERS to be requested for a review on each modification of their go.mod/sum
-/**/go.mod                              # do not notify anyone
-/**/go.sum                              # do not notify anyone
-/deps/go.MODULE.bazel                   # do not notify anyone
+/**/go.mod            # do not notify anyone
+/**/go.sum            # do not notify anyone
+/deps/go.MODULE.bazel # do not notify anyone
 
 # Add here modules that need explicit review from the team owning them
-/pkg/util/scrubber/go.mod                @DataDog/agent-runtimes
-/pkg/util/scrubber/go.sum                @DataDog/agent-runtimes
+/pkg/util/scrubber/go.mod @DataDog/agent-runtimes
+/pkg/util/scrubber/go.sum @DataDog/agent-runtimes
 
 # Temporary during Bazel migration
 # This needs to go after all other rules that may include BUILD.bazel files, it otherwise gets overridden
-/**/BUILD.bazel                         @DataDog/agent-build
-/**/*.bzl                               @DataDog/agent-build
+/**/BUILD.bazel @DataDog/agent-build
+/**/*.bzl       @DataDog/agent-build


### PR DESCRIPTION
### What does this PR do?

Cleans up `.github/CODEOWNERS`:
- Removes two exact-duplicate rules (`/.agents/skills/create-runtime-setting/SKILL.md` and `/pkg/collector/`).
- Adds ownership for files that had no matching CODEOWNERS rule: `/datadog-agent.map` (`@DataDog/agent-log-pipelines`), `/flakes.yaml` (`@DataDog/agent-devx`), `/k8s_versions.json` (`@DataDog/container-integrations`), `/rust/license-tool.toml`, and `/examples/` (both marked "do not notify anyone", consistent with neighboring LICENSE-style entries).
- Aligns the owner columns within each blank-line-separated block for readability. The auto-generated `# BEGIN COMPONENTS` / `# END COMPONENTS` block (managed by `dda inv lint-components`) was left untouched, and the bottom-to-top match ordering of rules was preserved everywhere — no ownership semantics changed beyond the additions/removals above.

### Motivation

`.github/CODEOWNERS` had accumulated duplicate rules and a handful of files with no owning team, plus inconsistent spacing between owner columns that made the file harder to scan and diff.

### Describe how you validated your changes

- Verified every pattern in the file matches at least one path still present in the repo (no stale rules).
- Verified every tracked file in the repo now matches at least one CODEOWNERS rule (0 unmatched, down from 14).
- Diffed the file with all whitespace normalized to confirm the column-alignment pass didn't change any pattern or owner content.