### PR TITLE
Keep injected redacted_compat.h file out of the windows python's build inputs

### DIFF
--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -55,7 +55,13 @@ run_binary(
     srcs = (
         glob(
             ["**"],
-            exclude = ["**/*.pyc", "BUILD.bazel"],
+            exclude = [
+                "**/*.pyc",
+                "BUILD.bazel",
+                # Unix-only build helper injected into the CPython repository.
+                # Keep it out of the Windows action key; the Windows build does not use it.
+                "redacted_compat.h",
+            ],
         ) + [
             "bzip2_win_dir",
             "mpdecimal_win_dir",


### PR DESCRIPTION
### What does this PR do?

It removes the `redacted_compat.h` file out of the sources for the Python build on Windows, such that it doesn't get used for cache computation.

### Motivation

I didn't get remote cache hits on a local checkout with git core.autocrlf disabled (see also https://github.com/DataDog/datadog-agent/pull/54776) due to this specific file. Since the file is only intended for the `configure_make` rule that builds Python on Linux / macOS, we can simply remove the file from inputs to mitigate the problem (regardless of whether we go with https://github.com/DataDog/datadog-agent/pull/54776 or any other similar more general solution).

### Describe how you validated your changes

CI.

### Additional Notes

Due to the lack of windows sandboxing, the excluded sources for the rule are actually visible to the build action, so there's no guarantee that it doesn't get used by it. However, given that it's a file that we introduce ourselves and not looked at by Python's build system, it's fairly safe to assume that in practice this file doesn't cause any difference to the build outputs.