### PR TITLE
[NETPATH-1108] Remove flaky RC re-poll gate from Dynamic Path e2e test Setup

### DIFF
--- a/test/new-e2e/tests/netpath/dynamic-tests/host_traffic_dynamic_path_test.go
+++ b/test/new-e2e/tests/netpath/dynamic-tests/host_traffic_dynamic_path_test.go
@@ -158,26 +158,18 @@ func (s *hostTrafficDynamicPathSuite) SetupSuite() {
 	s.BaseSuite.SetupSuite()
 	defer s.CleanupOnSetupFailure()
 
+	// Add the config before the rest of setup. Fakeintake returns 404 when the
+	// Agent polls an empty RC repository, and those responses increase the
+	// Agent's retry backoff while the host dependencies are being prepared.
+	fakeintake := s.Env().FakeIntake.Client()
+	require.NoError(s.T(), fakeintake.RCAddConfig("", hostTrafficRCProduct, hostTrafficRCConfigID, hostTrafficRCConfigName, hostTrafficDynamicRCConfig))
+	s.remoteConfigAdded = true
+
 	s.ensureCurlInstalled()
 	s.startHostTrafficDNSServer()
 	s.configureAgentResolver()
 	s.assertHostTrafficDomainResolves()
 
-	fakeintake := s.Env().FakeIntake.Client()
-	s.EventuallyWithT(func(c *assert.CollectT) {
-		stats, err := fakeintake.RCStats()
-		assert.NoError(c, err)
-		assert.NotZero(c, stats.Polls, "agent did not poll fakeintake Remote Config")
-	}, 2*time.Minute, 5*time.Second)
-	require.NoError(s.T(), fakeintake.RCAddConfig("", hostTrafficRCProduct, hostTrafficRCConfigID, hostTrafficRCConfigName, hostTrafficDynamicRCConfig))
-	s.remoteConfigAdded = true
-
-	// We deliberately don't gate setup on the agent re-polling Remote Config here.
-	// The agent's RC refresh cadence is defaultRefreshInterval (1m) plus exponential
-	// backoff on transient errors, so the next poll can legitimately land beyond a
-	// short deadline and would flake this gate. TestHostTrafficDynamicNetworkPath
-	// already waits for the RC-admitted network path to appear, which inherently
-	// proves the agent polled and applied this config.
 	require.NoError(s.T(), fakeintake.FlushServerAndResetAggregators())
 }
 
@@ -199,7 +191,9 @@ func (s *hostTrafficDynamicPathSuite) AfterTest(suiteName, testName string) {
 
 func (s *hostTrafficDynamicPathSuite) TestHostTrafficDynamicNetworkPath() {
 	fakeintake := s.Env().FakeIntake.Client()
-	s.startHostTrafficGenerator(4 * time.Minute)
+	// Keep producing matching connections for longer than the assertion window
+	// so a delayed RC application still has traffic to admit.
+	s.startHostTrafficGenerator(6 * time.Minute)
 
 	var remoteConfigMatch *aggregator.Netpath
 	s.EventuallyWithT(func(c *assert.CollectT) {

--- a/test/new-e2e/tests/netpath/dynamic-tests/host_traffic_dynamic_path_test.go
+++ b/test/new-e2e/tests/netpath/dynamic-tests/host_traffic_dynamic_path_test.go
@@ -171,14 +171,13 @@ func (s *hostTrafficDynamicPathSuite) SetupSuite() {
 	}, 2*time.Minute, 5*time.Second)
 	require.NoError(s.T(), fakeintake.RCAddConfig("", hostTrafficRCProduct, hostTrafficRCConfigID, hostTrafficRCConfigName, hostTrafficDynamicRCConfig))
 	s.remoteConfigAdded = true
-	statsAfterAdd, err := fakeintake.RCStats()
-	require.NoError(s.T(), err)
-	s.EventuallyWithT(func(c *assert.CollectT) {
-		stats, err := fakeintake.RCStats()
-		assert.NoError(c, err)
-		assert.Greater(c, stats.Polls, statsAfterAdd.Polls, "agent did not poll Remote Config after the dynamic config was added")
-	}, 2*time.Minute, 5*time.Second)
 
+	// We deliberately don't gate setup on the agent re-polling Remote Config here.
+	// The agent's RC refresh cadence is defaultRefreshInterval (1m) plus exponential
+	// backoff on transient errors, so the next poll can legitimately land beyond a
+	// short deadline and would flake this gate. TestHostTrafficDynamicNetworkPath
+	// already waits for the RC-admitted network path to appear, which inherently
+	// proves the agent polled and applied this config.
 	require.NoError(s.T(), fakeintake.FlushServerAndResetAggregators())
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes the synchronization in `TestHostTrafficDynamicPathSuite` without relying on fakeintake's global Remote Config poll counter.

- Adds the `NETWORK_PATH` Remote Config document immediately after `BaseSuite.SetupSuite`, before curl, DNS, and resolver setup.
- Removes both `RCStats().Polls` gates.
- Keeps the traffic generator running for 6 minutes so it outlives the test's 5-minute eventual assertion.

JIRA: [NETPATH-1108](https://datadoghq.atlassian.net/browse/NETPATH-1108)

### Motivation

The suite has intermittently failed on `main` in `SetupSuite` with:

> `agent did not poll Remote Config after the dynamic config was added`

The E2E framework configures the Agent to poll fakeintake every 5 seconds, so the production default 1-minute cadence was not the cause. The flake came from the interaction between the test's setup order and fakeintake's empty Remote Config behavior:

1. The suite performed package, DNS, and resolver setup before adding its first `NETWORK_PATH` config.
2. During that time, the Agent polled fakeintake's empty RC repository.
3. Fakeintake records those requests in `RCStats().Polls` but returns HTTP 404 when no requested product has a config.
4. Those responses increased the Agent's exponential retry backoff, so the next poll could fall outside the setup gate's 2-minute deadline.

The poll counter was also not a reliable synchronization signal: it increments before fakeintake knows whether the request can be served and therefore does not prove that this config was fetched or applied. Taking the counter baseline after `RCAddConfig` also allowed a successful fetch between those two calls to be missed, forcing the test to wait for an unnecessary additional poll.

The test's existing payload assertion is the stronger end-to-end proof. Local configuration excludes all destinations, and the expected Network Path event must contain the exact remote `test_config_id`, `test_config_source`, and tags. Observing that event proves the config was fetched, applied by the deployed Agent, exercised by matching host traffic, and forwarded to fakeintake.

Adding the config first minimizes empty-repository polling during setup. Keeping traffic active beyond the full assertion window ensures a delayed RC application still receives matching connections to admit.

### Describe how you validated your changes

- `git diff --check`
- Confirmed the existing `new-e2e-netpath` CI job covers `./tests/netpath`.
- Local live E2E was intentionally skipped; `new-e2e-netpath` will exercise the change in CI.

No production code is changed.


[NETPATH-1108]: https://datadoghq.atlassian.net/browse/NETPATH-1108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ