### PR TITLE
feat(gpu): Add experimental Apple Silicon monitoring

### DIFF
--- a/pkg/collector/corechecks/gpu/BUILD.bazel
+++ b/pkg/collector/corechecks/gpu/BUILD.bazel
@@ -4,12 +4,29 @@ load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 go_library(
     name = "gpu",
     srcs = [
+        "agx_darwin.h",
+        "agx_darwin.m",
+        "agx_reader_darwin.go",
         "config.go",
         "gpu.go",
+        "gpu_darwin.go",
         "gpu_stub.go",
         "tags.go",
         "testutil.go",
     ],
+    cgo = True,
+    clinkopts = select({
+        "@rules_go//go/platform:darwin": [
+            "-framework Foundation -framework CoreFoundation -framework IOKit",
+        ],
+        "//conditions:default": [],
+    }),
+    copts = select({
+        "@rules_go//go/platform:darwin": [
+            "-x objective-c -fobjc-arc",
+        ],
+        "//conditions:default": [],
+    }),
     importpath = "github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu",
     visibility = ["//visibility:public"],
     deps = select({
@@ -56,10 +73,15 @@ go_library(
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:darwin": [
+            "//comp/core/autodiscovery/integration",
             "//comp/core/tagger/def",
             "//comp/core/telemetry/def",
             "//comp/core/workloadmeta/def",
+            "//pkg/aggregator/sender",
             "//pkg/collector/check",
+            "//pkg/collector/corechecks",
+            "//pkg/config/setup",
+            "//pkg/util/log",
             "//pkg/util/option",
         ],
         "@rules_go//go/platform:dragonfly": [
@@ -188,6 +210,7 @@ go_library(
 dd_agent_go_test(
     name = "gpu_test",
     srcs = [
+        "gpu_darwin_test.go",
         "gpu_test.go",
         "tags_test.go",
     ],
@@ -228,6 +251,14 @@ dd_agent_go_test(
             "@com_github_stretchr_testify//require",
             "@org_uber_go_atomic//:atomic",
             "@org_uber_go_mock//gomock",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "//comp/core/autodiscovery/integration",
+            "//comp/core/telemetry/mock",
+            "//pkg/aggregator/mocksender",
+            "//pkg/config/setup",
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:linux": [
             "//comp/core/autodiscovery/integration",

--- a/pkg/collector/corechecks/gpu/agx_darwin.h
+++ b/pkg/collector/corechecks/gpu/agx_darwin.h
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+#ifndef DD_GPU_AGX_DARWIN_H
+#define DD_GPU_AGX_DARWIN_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define DD_MAX_AGX_DEVICES 16
+#define DD_AGX_MODEL_LENGTH 256
+
+typedef struct {
+    char model[DD_AGX_MODEL_LENGTH];
+    bool hasModel;
+    int64_t coreCount;
+    bool hasCoreCount;
+    double utilization;
+    bool hasUtilization;
+    int64_t allocatedSystemMemory;
+    bool hasAllocatedSystemMemory;
+    int64_t inUseSystemMemory;
+    bool hasInUseSystemMemory;
+} DDAGXDeviceInfo;
+
+typedef struct {
+    uint32_t count;
+    uint32_t propertyReadErrors;
+    bool truncated;
+    int32_t error;
+} DDAGXCollectionResult;
+
+DDAGXCollectionResult dd_collect_agx_devices(DDAGXDeviceInfo *devices, uint32_t capacity);
+
+#endif

--- a/pkg/collector/corechecks/gpu/agx_darwin.m
+++ b/pkg/collector/corechecks/gpu/agx_darwin.m
@@ -1,0 +1,139 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <Foundation/Foundation.h>
+#import <IOKit/IOKitLib.h>
+#import <string.h>
+
+#import "agx_darwin.h"
+
+// kIOMainPortDefault was introduced in macOS 12.0. Keep compatibility with
+// older deployment targets supported by the Agent.
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 120000
+#define IOKIT_MAIN_PORT kIOMainPortDefault
+#else
+#define IOKIT_MAIN_PORT kIOMasterPortDefault
+#endif
+
+static bool copyModel(CFTypeRef value, char *output, size_t outputLength) {
+    if (value == NULL || outputLength == 0) {
+        return false;
+    }
+
+    if (CFGetTypeID(value) == CFStringGetTypeID()) {
+        return CFStringGetCString((CFStringRef)value, output, outputLength, kCFStringEncodingUTF8);
+    }
+
+    if (CFGetTypeID(value) == CFDataGetTypeID()) {
+        CFDataRef data = (CFDataRef)value;
+        CFIndex length = CFDataGetLength(data);
+        if (length <= 0) {
+            return false;
+        }
+        size_t copied = (size_t)length < outputLength - 1 ? (size_t)length : outputLength - 1;
+        memcpy(output, CFDataGetBytePtr(data), copied);
+        output[copied] = '\0';
+        return true;
+    }
+
+    return false;
+}
+
+static bool copyInt64(CFTypeRef value, int64_t *output) {
+    if (value == NULL || CFGetTypeID(value) != CFNumberGetTypeID()) {
+        return false;
+    }
+    return CFNumberGetValue((CFNumberRef)value, kCFNumberSInt64Type, output);
+}
+
+static bool copyDouble(CFTypeRef value, double *output) {
+    if (value == NULL || CFGetTypeID(value) != CFNumberGetTypeID()) {
+        return false;
+    }
+    return CFNumberGetValue((CFNumberRef)value, kCFNumberDoubleType, output);
+}
+
+static void collectDevice(io_service_t service, DDAGXDeviceInfo *device, uint32_t *propertyReadErrors) {
+    CFMutableDictionaryRef properties = NULL;
+    kern_return_t result = IORegistryEntryCreateCFProperties(
+        service,
+        &properties,
+        kCFAllocatorDefault,
+        kNilOptions);
+    if (result != KERN_SUCCESS || properties == NULL) {
+        (*propertyReadErrors)++;
+        return;
+    }
+
+    CFTypeRef model = CFDictionaryGetValue(properties, CFSTR("model"));
+    device->hasModel = copyModel(model, device->model, sizeof(device->model));
+
+    CFTypeRef coreCount = CFDictionaryGetValue(properties, CFSTR("gpu-core-count"));
+    device->hasCoreCount = copyInt64(coreCount, &device->coreCount);
+
+    // AGX publishes these properties through public IOKit APIs, but their names and
+    // semantics are not a documented Apple contract. Keep every field optional so
+    // an OS or driver change drops only the affected metric.
+    CFTypeRef statistics = CFDictionaryGetValue(properties, CFSTR("PerformanceStatistics"));
+    if (statistics != NULL && CFGetTypeID(statistics) == CFDictionaryGetTypeID()) {
+        CFTypeRef utilization = CFDictionaryGetValue(
+            (CFDictionaryRef)statistics,
+            CFSTR("Device Utilization %"));
+        device->hasUtilization = copyDouble(utilization, &device->utilization);
+
+        CFTypeRef allocatedSystemMemory = CFDictionaryGetValue(
+            (CFDictionaryRef)statistics,
+            CFSTR("Alloc system memory"));
+        device->hasAllocatedSystemMemory = copyInt64(
+            allocatedSystemMemory,
+            &device->allocatedSystemMemory);
+
+        CFTypeRef inUseSystemMemory = CFDictionaryGetValue(
+            (CFDictionaryRef)statistics,
+            CFSTR("In use system memory"));
+        device->hasInUseSystemMemory = copyInt64(
+            inUseSystemMemory,
+            &device->inUseSystemMemory);
+    }
+
+    CFRelease(properties);
+}
+
+DDAGXCollectionResult dd_collect_agx_devices(DDAGXDeviceInfo *devices, uint32_t capacity) {
+    @autoreleasepool {
+        DDAGXCollectionResult collection = {0};
+        if (devices == NULL || capacity == 0) {
+            collection.error = kIOReturnBadArgument;
+            return collection;
+        }
+
+        io_iterator_t iterator = IO_OBJECT_NULL;
+        kern_return_t result = IOServiceGetMatchingServices(
+            IOKIT_MAIN_PORT,
+            IOServiceMatching("AGXAccelerator"),
+            &iterator);
+        if (result != KERN_SUCCESS) {
+            collection.error = result;
+            return collection;
+        }
+
+        io_service_t service;
+        while ((service = IOIteratorNext(iterator)) != IO_OBJECT_NULL) {
+            if (collection.count >= capacity) {
+                collection.truncated = true;
+                IOObjectRelease(service);
+                break;
+            }
+
+            collectDevice(service, &devices[collection.count], &collection.propertyReadErrors);
+            collection.count++;
+            IOObjectRelease(service);
+        }
+
+        IOObjectRelease(iterator);
+        return collection;
+    }
+}

--- a/pkg/collector/corechecks/gpu/agx_reader_darwin.go
+++ b/pkg/collector/corechecks/gpu/agx_reader_darwin.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build darwin && !ios && cgo
+
+package gpu
+
+/*
+#cgo CFLAGS: -x objective-c -fobjc-arc
+#cgo LDFLAGS: -framework Foundation -framework CoreFoundation -framework IOKit
+
+#include "agx_darwin.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+const maxAGXDevices = 16
+
+type agxDeviceSnapshot struct {
+	model                    string
+	coreCount                int64
+	hasCoreCount             bool
+	utilization              float64
+	hasUtilization           bool
+	allocatedSystemMemory    int64
+	hasAllocatedSystemMemory bool
+	inUseSystemMemory        int64
+	hasInUseSystemMemory     bool
+}
+
+type agxCollection struct {
+	devices            []agxDeviceSnapshot
+	propertyReadErrors uint32
+	truncated          bool
+}
+
+func readAGXDevices() (agxCollection, error) {
+	devices := make([]C.DDAGXDeviceInfo, maxAGXDevices)
+	result := C.dd_collect_agx_devices(
+		(*C.DDAGXDeviceInfo)(unsafe.Pointer(&devices[0])),
+		C.uint32_t(len(devices)),
+	)
+	if result.error != 0 {
+		return agxCollection{}, fmt.Errorf("IOKit AGX enumeration failed with code %#x", uint32(result.error))
+	}
+
+	count := int(result.count)
+	if count > len(devices) {
+		count = len(devices)
+	}
+	collection := agxCollection{
+		devices:            make([]agxDeviceSnapshot, 0, count),
+		propertyReadErrors: uint32(result.propertyReadErrors),
+		truncated:          bool(result.truncated),
+	}
+	for i := 0; i < count; i++ {
+		device := devices[i]
+		snapshot := agxDeviceSnapshot{
+			coreCount:                int64(device.coreCount),
+			hasCoreCount:             bool(device.hasCoreCount),
+			utilization:              float64(device.utilization),
+			hasUtilization:           bool(device.hasUtilization),
+			allocatedSystemMemory:    int64(device.allocatedSystemMemory),
+			hasAllocatedSystemMemory: bool(device.hasAllocatedSystemMemory),
+			inUseSystemMemory:        int64(device.inUseSystemMemory),
+			hasInUseSystemMemory:     bool(device.hasInUseSystemMemory),
+		}
+		if bool(device.hasModel) {
+			snapshot.model = C.GoString(&device.model[0])
+		}
+		collection.devices = append(collection.devices, snapshot)
+	}
+
+	return collection, nil
+}

--- a/pkg/collector/corechecks/gpu/gpu_darwin.go
+++ b/pkg/collector/corechecks/gpu/gpu_darwin.go
@@ -1,0 +1,216 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build darwin && !ios && cgo
+
+// Package gpu contains the macOS GPU core-check implementation.
+package gpu
+
+import (
+	"crypto/sha1" // #nosec G505 -- SHA-1 is used only to derive a non-secret UUIDv5-style identifier.
+	"errors"
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+const gpuMetricsNamespace = "gpu."
+
+var (
+	collectAGXDevices     = readAGXDevices
+	darwinDiagnosticLimit = log.NewLogLimit(3, 10*time.Minute)
+	tagSeparator          = regexp.MustCompile(`[^a-z0-9_.-]+`)
+)
+
+type darwinCheckTelemetry struct {
+	collectionResults  telemetry.Counter
+	deviceCount        telemetry.Gauge
+	propertyReadErrors telemetry.Counter
+}
+
+// Check represents the macOS GPU check.
+type Check struct {
+	core.CheckBase
+	telemetry *darwinCheckTelemetry
+}
+
+// Factory creates a new check factory. The tagger and workloadmeta dependencies
+// remain in the cross-platform signature, but macOS device-level metrics do not
+// currently perform workload attribution.
+func Factory(_ tagger.Component, tm telemetry.Component, _ workloadmeta.Component) option.Option[func() check.Check] {
+	return option.New(func() check.Check {
+		return newCheck(tm)
+	})
+}
+
+func newCheck(tm telemetry.Component) check.Check {
+	return &Check{
+		CheckBase: core.NewCheckBase(CheckName),
+		telemetry: &darwinCheckTelemetry{
+			collectionResults:  tm.NewCounter(CheckName, "darwin_collection_results", []string{"status"}, "Number of macOS GPU collections by result"),
+			deviceCount:        tm.NewGauge(CheckName, "device_total", nil, "Number of GPU devices"),
+			propertyReadErrors: tm.NewCounter(CheckName, "darwin_property_read_errors", nil, "Number of AGX devices whose IOKit properties could not be read"),
+		},
+	}
+}
+
+// NewCheck creates a new GPU check instance. This is exported for integration testing.
+func NewCheck(_ tagger.Component, tm telemetry.Component, _ workloadmeta.Component) check.Check {
+	return newCheck(tm)
+}
+
+// Configure parses the check configuration.
+func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string, provider string) error {
+	if !pkgconfigsetup.Datadog().GetBool("gpu.enabled") {
+		return errors.New("GPU check is disabled")
+	}
+	return c.CommonConfigure(senderManager, initConfig, config, source, provider)
+}
+
+// Interval returns the configured scheduling interval.
+func (c *Check) Interval() time.Duration {
+	if interval := pkgconfigsetup.Datadog().GetInt("gpu.collection_interval_override"); interval > 0 {
+		return time.Duration(interval) * time.Second
+	}
+	return c.CheckBase.Interval()
+}
+
+// Run collects device-level Apple GPU metrics from IOKit.
+func (c *Check) Run() error {
+	snd, err := c.GetSender()
+	if err != nil {
+		return fmt.Errorf("get metric sender: %w", err)
+	}
+	defer snd.Commit()
+
+	collection, err := collectAGXDevices()
+	if err != nil {
+		c.telemetry.collectionResults.Inc("error")
+		c.telemetry.deviceCount.Set(0)
+		return err
+	}
+	c.telemetry.collectionResults.Inc("success")
+	c.telemetry.deviceCount.Set(float64(len(collection.devices)))
+	if collection.propertyReadErrors > 0 {
+		c.telemetry.propertyReadErrors.Add(float64(collection.propertyReadErrors))
+		if darwinDiagnosticLimit.ShouldLog() {
+			log.Warnf("failed to read IOKit properties for %d Apple GPU device(s)", collection.propertyReadErrors)
+		}
+	}
+	if collection.truncated && darwinDiagnosticLimit.ShouldLog() {
+		log.Warnf("Apple GPU enumeration exceeded the limit of %d devices; extra devices were ignored", maxAGXDevices)
+	}
+	if len(collection.devices) == 0 && darwinDiagnosticLimit.ShouldLog() {
+		log.Debug("no Apple AGX GPU devices were found")
+	}
+
+	timestamp := float64(time.Now().UnixNano()) / float64(time.Second)
+	var metricErrors []error
+	if err := snd.GaugeWithTimestamp(
+		gpuMetricsNamespace+"apple.device.count",
+		float64(len(collection.devices)),
+		"",
+		[]string{"gpu_vendor:apple", "gpu_host:true"},
+		timestamp,
+	); err != nil {
+		metricErrors = append(metricErrors, fmt.Errorf("send apple.device.count: %w", err))
+	}
+	for index, device := range collection.devices {
+		tags := appleGPUDeviceTags(device, index)
+		for _, metric := range appleGPUMetrics(device) {
+			if err := snd.GaugeWithTimestamp(gpuMetricsNamespace+metric.name, metric.value, "", tags, timestamp); err != nil {
+				metricErrors = append(metricErrors, fmt.Errorf("send %s: %w", metric.name, err))
+			}
+		}
+		if !device.hasUtilization && darwinDiagnosticLimit.ShouldLog() {
+			log.Debugf("Apple GPU %d does not expose the IOKit Device Utilization %% property", index)
+		}
+	}
+
+	return errors.Join(metricErrors...)
+}
+
+type appleGPUMetric struct {
+	name  string
+	value float64
+}
+
+func appleGPUMetrics(device agxDeviceSnapshot) []appleGPUMetric {
+	metrics := []appleGPUMetric{}
+	if device.hasCoreCount && device.coreCount > 0 {
+		metrics = append(metrics, appleGPUMetric{name: "apple.core.count", value: float64(device.coreCount)})
+	}
+	if device.hasUtilization && !math.IsNaN(device.utilization) && !math.IsInf(device.utilization, 0) && device.utilization >= 0 && device.utilization <= 100 {
+		metrics = append(metrics, appleGPUMetric{name: "apple.device.utilization", value: device.utilization})
+	}
+	// These are system-memory counters reported by the Apple GPU driver. They are
+	// not discrete VRAM, total unified memory, or memory unavailable to the CPU.
+	if device.hasAllocatedSystemMemory && device.allocatedSystemMemory >= 0 {
+		metrics = append(metrics, appleGPUMetric{name: "apple.system_memory.allocated", value: float64(device.allocatedSystemMemory)})
+	}
+	if device.hasInUseSystemMemory && device.inUseSystemMemory >= 0 {
+		metrics = append(metrics, appleGPUMetric{name: "apple.system_memory.in_use", value: float64(device.inUseSystemMemory)})
+	}
+	return metrics
+}
+
+func appleGPUDeviceTags(device agxDeviceSnapshot, index int) []string {
+	model := strings.TrimSpace(device.model)
+	if model == "" {
+		model = "Apple GPU"
+	}
+	normalizedModel := normalizeAppleGPUTag(model)
+	gpuType := strings.TrimPrefix(normalizedModel, "apple_")
+	if gpuType == "" || gpuType == "gpu" {
+		gpuType = "apple_silicon"
+	}
+
+	return []string{
+		"gpu_uuid:" + syntheticAppleGPUUUID(model, index),
+		"gpu_device:" + normalizedModel,
+		"gpu_vendor:apple",
+		"gpu_architecture:apple_silicon",
+		"gpu_type:" + gpuType,
+		"gpu_virtualization_mode:none",
+		"gpu_slicing_mode:none",
+		"gpu_host:true",
+	}
+}
+
+func normalizeAppleGPUTag(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	normalized = tagSeparator.ReplaceAllString(normalized, "_")
+	normalized = strings.Trim(normalized, "_.-")
+	if normalized == "" {
+		return "apple_gpu"
+	}
+	return normalized
+}
+
+// syntheticAppleGPUUUID returns a deterministic UUID-shaped identifier from
+// non-sensitive device attributes. GPU identifiers are scoped by the host in
+// Datadog, so model plus logical index is sufficient and remains stable across
+// reboots without collecting a platform serial number.
+func syntheticAppleGPUUUID(model string, index int) string {
+	const namespace = "datadog-agent/macos-gpu/v1"
+	hash := sha1.Sum([]byte(fmt.Sprintf("%s\x00%s\x00%d", namespace, model, index)))
+	hash[6] = (hash[6] & 0x0f) | 0x50 // UUID version 5.
+	hash[8] = (hash[8] & 0x3f) | 0x80 // RFC 4122 variant.
+	return fmt.Sprintf("gpu-%08x-%04x-%04x-%04x-%012x",
+		hash[0:4], hash[4:6], hash[6:8], hash[8:10], hash[10:16])
+}

--- a/pkg/collector/corechecks/gpu/gpu_darwin_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_darwin_test.go
@@ -1,0 +1,240 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build darwin && !ios && cgo && test
+
+package gpu
+
+import (
+	"errors"
+	"math"
+	"regexp"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	telemetrymock "github.com/DataDog/datadog-agent/comp/core/telemetry/mock"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+)
+
+func TestAppleGPUMetrics(t *testing.T) {
+	tests := []struct {
+		name     string
+		device   agxDeviceSnapshot
+		expected []appleGPUMetric
+	}{
+		{
+			name: "complete snapshot",
+			device: agxDeviceSnapshot{
+				coreCount:                20,
+				hasCoreCount:             true,
+				utilization:              72,
+				hasUtilization:           true,
+				allocatedSystemMemory:    35_000_000_000,
+				hasAllocatedSystemMemory: true,
+				inUseSystemMemory:        31_000_000_000,
+				hasInUseSystemMemory:     true,
+			},
+			expected: []appleGPUMetric{
+				{name: "apple.core.count", value: 20},
+				{name: "apple.device.utilization", value: 72},
+				{name: "apple.system_memory.allocated", value: 35_000_000_000},
+				{name: "apple.system_memory.in_use", value: 31_000_000_000},
+			},
+		},
+		{
+			name:     "missing optional properties",
+			device:   agxDeviceSnapshot{},
+			expected: []appleGPUMetric{},
+		},
+		{
+			name: "invalid values are omitted",
+			device: agxDeviceSnapshot{
+				coreCount:      -1,
+				hasCoreCount:   true,
+				utilization:    math.NaN(),
+				hasUtilization: true,
+			},
+			expected: []appleGPUMetric{},
+		},
+		{
+			name: "negative memory values are omitted",
+			device: agxDeviceSnapshot{
+				allocatedSystemMemory: -1, hasAllocatedSystemMemory: true,
+				inUseSystemMemory: -1, hasInUseSystemMemory: true,
+			},
+			expected: []appleGPUMetric{},
+		},
+		{
+			name: "out of range utilization is omitted",
+			device: agxDeviceSnapshot{
+				utilization:    101,
+				hasUtilization: true,
+			},
+			expected: []appleGPUMetric{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, appleGPUMetrics(tt.device))
+		})
+	}
+}
+
+func TestAppleGPUDeviceTags(t *testing.T) {
+	device := agxDeviceSnapshot{model: " Apple M5 Pro "}
+	tags := appleGPUDeviceTags(device, 0)
+
+	assert.Contains(t, tags, "gpu_device:apple_m5_pro")
+	assert.Contains(t, tags, "gpu_vendor:apple")
+	assert.Contains(t, tags, "gpu_architecture:apple_silicon")
+	assert.Contains(t, tags, "gpu_type:m5_pro")
+	assert.Contains(t, tags, "gpu_virtualization_mode:none")
+	assert.Contains(t, tags, "gpu_slicing_mode:none")
+	assert.Contains(t, tags, "gpu_host:true")
+
+	uuidTagIndex := slices.IndexFunc(tags, func(tag string) bool {
+		return len(tag) > len("gpu_uuid:") && tag[:len("gpu_uuid:")] == "gpu_uuid:"
+	})
+	require.NotEqual(t, -1, uuidTagIndex)
+	assert.Regexp(t, regexp.MustCompile(`^gpu_uuid:gpu-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`), tags[uuidTagIndex])
+	assert.Equal(t, syntheticAppleGPUUUID("Apple M5 Pro", 0), syntheticAppleGPUUUID("Apple M5 Pro", 0))
+	assert.NotEqual(t, syntheticAppleGPUUUID("Apple M5 Pro", 0), syntheticAppleGPUUUID("Apple M5 Pro", 1))
+}
+
+func TestNormalizeAppleGPUTag(t *testing.T) {
+	assert.Equal(t, "apple_m5_pro", normalizeAppleGPUTag(" Apple M5 Pro "))
+	assert.Equal(t, "apple_gpu", normalizeAppleGPUTag(" !!! "))
+}
+
+func TestDarwinFactoryAvailable(t *testing.T) {
+	factoryOption := Factory(nil, telemetrymock.New(t), nil)
+	factory, available := factoryOption.Get()
+	require.True(t, available)
+	assert.IsType(t, &Check{}, factory())
+}
+
+func TestDarwinCheckRun(t *testing.T) {
+	pkgconfigsetup.Datadog().SetInTest("gpu.enabled", true)
+	t.Cleanup(func() { pkgconfigsetup.Datadog().SetInTest("gpu.enabled", false) })
+
+	originalCollector := collectAGXDevices
+	collectAGXDevices = func() (agxCollection, error) {
+		return agxCollection{devices: []agxDeviceSnapshot{
+			{
+				model: "Apple M5 Pro", coreCount: 20, hasCoreCount: true,
+				utilization: 65, hasUtilization: true,
+				allocatedSystemMemory: 35_000_000_000, hasAllocatedSystemMemory: true,
+				inUseSystemMemory: 31_000_000_000, hasInUseSystemMemory: true,
+			},
+			{model: "Apple Test GPU"},
+		}}, nil
+	}
+	t.Cleanup(func() { collectAGXDevices = originalCollector })
+
+	gpuCheck := newCheck(telemetrymock.New(t)).(*Check)
+	senderManager := mocksender.CreateDefaultDemultiplexer(t)
+	require.NoError(t, gpuCheck.Configure(senderManager, integration.FakeConfigHash, nil, nil, "test", "provider"))
+	mockSender := mocksender.NewMockSenderWithSenderManager(gpuCheck.ID(), senderManager)
+	mockSender.SetupAcceptAll()
+
+	require.NoError(t, gpuCheck.Run())
+	assertTimestampMetric(t, mockSender, "gpu.apple.device.count", 2, []string{"gpu_vendor:apple", "gpu_host:true"})
+	assertTimestampMetric(t, mockSender, "gpu.apple.core.count", 20, []string{"gpu_device:apple_m5_pro"})
+	assertTimestampMetric(t, mockSender, "gpu.apple.device.utilization", 65, []string{"gpu_device:apple_m5_pro"})
+	assertTimestampMetric(t, mockSender, "gpu.apple.system_memory.allocated", 35_000_000_000, []string{"gpu_device:apple_m5_pro"})
+	assertTimestampMetric(t, mockSender, "gpu.apple.system_memory.in_use", 31_000_000_000, []string{"gpu_device:apple_m5_pro"})
+	mockSender.AssertMetricMissing(t, "GaugeWithTimestamp", "gpu.device.total")
+	mockSender.AssertMetricMissing(t, "GaugeWithTimestamp", "gpu.core.limit")
+	mockSender.AssertMetricMissing(t, "GaugeWithTimestamp", "gpu.gr_engine_active")
+	mockSender.AssertNumberOfCalls(t, "GaugeWithTimestamp", 5)
+	mockSender.AssertNumberOfCalls(t, "Commit", 1)
+}
+
+func TestDarwinCheckCommitsOnCollectionError(t *testing.T) {
+	pkgconfigsetup.Datadog().SetInTest("gpu.enabled", true)
+	t.Cleanup(func() { pkgconfigsetup.Datadog().SetInTest("gpu.enabled", false) })
+
+	originalCollector := collectAGXDevices
+	collectAGXDevices = func() (agxCollection, error) {
+		return agxCollection{}, errors.New("native read failed")
+	}
+	t.Cleanup(func() { collectAGXDevices = originalCollector })
+
+	gpuCheck := newCheck(telemetrymock.New(t)).(*Check)
+	senderManager := mocksender.CreateDefaultDemultiplexer(t)
+	require.NoError(t, gpuCheck.Configure(senderManager, integration.FakeConfigHash, nil, nil, "test", "provider"))
+	mockSender := mocksender.NewMockSenderWithSenderManager(gpuCheck.ID(), senderManager)
+	mockSender.SetupAcceptAll()
+
+	err := gpuCheck.Run()
+	require.ErrorContains(t, err, "native read failed")
+	mockSender.AssertNumberOfCalls(t, "Commit", 1)
+	mockSender.AssertNumberOfCalls(t, "GaugeWithTimestamp", 0)
+}
+
+func TestDarwinCheckDisabled(t *testing.T) {
+	pkgconfigsetup.Datadog().SetInTest("gpu.enabled", false)
+	gpuCheck := newCheck(telemetrymock.New(t)).(*Check)
+	senderManager := mocksender.CreateDefaultDemultiplexer(t)
+
+	err := gpuCheck.Configure(senderManager, integration.FakeConfigHash, nil, nil, "test", "provider")
+	require.EqualError(t, err, "GPU check is disabled")
+}
+
+func TestDarwinCheckIntervalOverride(t *testing.T) {
+	pkgconfigsetup.Datadog().SetInTest("gpu.collection_interval_override", 7)
+	t.Cleanup(func() { pkgconfigsetup.Datadog().SetInTest("gpu.collection_interval_override", 0) })
+
+	gpuCheck := newCheck(telemetrymock.New(t)).(*Check)
+	assert.Equal(t, 7*time.Second, gpuCheck.Interval())
+}
+
+func TestReadAGXDevicesSmoke(t *testing.T) {
+	collection, err := readAGXDevices()
+	require.NoError(t, err)
+	if len(collection.devices) == 0 {
+		t.Skip("this Mac does not expose an AGX accelerator")
+	}
+
+	device := collection.devices[0]
+	if device.hasCoreCount {
+		assert.Positive(t, device.coreCount)
+	}
+	if device.hasUtilization {
+		assert.GreaterOrEqual(t, device.utilization, float64(0))
+		assert.LessOrEqual(t, device.utilization, float64(100))
+	}
+	if device.hasAllocatedSystemMemory {
+		assert.GreaterOrEqual(t, device.allocatedSystemMemory, int64(0))
+	}
+	if device.hasInUseSystemMemory {
+		assert.GreaterOrEqual(t, device.inUseSystemMemory, int64(0))
+	}
+}
+
+func assertTimestampMetric(t *testing.T, mockSender *mocksender.MockSender, name string, value float64, expectedTags []string) {
+	t.Helper()
+	for _, call := range mockSender.Mock.Calls {
+		if call.Method != "GaugeWithTimestamp" || call.Arguments.String(0) != name || call.Arguments.Get(1) != value {
+			continue
+		}
+		tags, ok := call.Arguments.Get(3).([]string)
+		if !ok {
+			continue
+		}
+		if slices.ContainsFunc(expectedTags, func(expected string) bool { return !slices.Contains(tags, expected) }) {
+			continue
+		}
+		return
+	}
+	t.Errorf("metric %s=%v with tags %v was not emitted", name, value, expectedTags)
+}

--- a/pkg/collector/corechecks/gpu/gpu_stub.go
+++ b/pkg/collector/corechecks/gpu/gpu_stub.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
-//go:build !linux || !nvml
+//go:build (!linux || !nvml) && (!darwin || ios || !cgo)
 
 package gpu
 

--- a/pkg/config/schema/yaml/gpu.yaml
+++ b/pkg/config/schema/yaml/gpu.yaml
@@ -4,8 +4,10 @@ node_type: section
 type: object
 visibility: public
 description: |-
-  Configuration for GPU Monitoring on non-containerized Linux hosts.
-  Both this section and the gpu_monitoring section in system-probe.yaml must be configured.
+  Configuration for GPU Monitoring. On non-containerized Linux hosts, both this section and
+  the gpu_monitoring section in system-probe.yaml must be configured. On Apple Silicon macOS,
+  the experimental device-level check reads best-effort GPU telemetry directly from IOKit and
+  does not require system-probe.
 tags:
 - template_section:Common
 - full-agent-only:true
@@ -16,9 +18,10 @@ properties:
     default: false
     visibility: public
     description: |-
-      Set to true to enable the GPU check in the core Agent.
-      Required for GPU monitoring on non-containerized Linux hosts.
-      Must be used together with gpu_monitoring.enabled: true in system-probe.yaml.
+      Set to true to enable the GPU check in the core Agent. On non-containerized Linux hosts,
+      this must be used together with gpu_monitoring.enabled: true in system-probe.yaml. On
+      Apple Silicon macOS, this enables experimental Apple-specific device utilization,
+      inventory, and GPU client system-memory metrics from IOKit; system-probe is not required.
   nccl:
     node_type: section
     type: object

--- a/releasenotes/notes/experimental-macos-gpu-check-eb1073e51d26ad49.yaml
+++ b/releasenotes/notes/experimental-macos-gpu-check-eb1073e51d26ad49.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    GPU Monitoring can now be enabled experimentally on Apple Silicon macOS hosts. The
+    standard ``gpu`` check reads Apple-specific device utilization, core inventory, and
+    GPU client system-memory metrics from IOKit without requiring root privileges or
+    system-probe. Power, temperature, and per-process GPU metrics are not available on
+    macOS in this initial implementation.

--- a/tasks/00001-p2-done--prototype-macos-gpu-check.md
+++ b/tasks/00001-p2-done--prototype-macos-gpu-check.md
@@ -32,11 +32,13 @@ Implement an independent Darwin check behind the same package, factory, configur
    - Add a small Darwin `Check` implementation using `core.CheckBase`, the existing `gpu.enabled` gate, collection interval override, sender lifecycle, and `Cancel` behavior.
    - Keep `pkg/collector/corechecks/gpu/gpu.go` and all NVIDIA collectors Linux/NVML-only and behaviorally unchanged.
 
-3. **Emit a conservative canonical metric set**
-   - Map AGX `Device Utilization %` to `gpu.gr_engine_active` (gauge, percent), the closest existing device-wide graphics-engine activity metric.
-   - Emit `gpu.core.limit` from `gpu-core-count` and `gpu.device.total` for each discovered device.
-   - Do not publish renderer/tiler counters or unified-memory values under misleading existing names, and do not add new public metrics in this prototype.
-   - Attach deterministic, low-cardinality device tags conforming to the existing GPU tag specification: a synthetic host-scoped `gpu_uuid`, normalized `gpu_device`, `gpu_vendor:apple`, `gpu_architecture:apple_silicon`, an Apple model `gpu_type`, `gpu_virtualization_mode:none`, `gpu_slicing_mode:none`, and `gpu_host:true`.
+3. **Emit a conservative Apple-specific metric set**
+   - Emit AGX `Device Utilization %` as `gpu.apple.device.utilization` rather than reusing an NVIDIA-shaped metric.
+   - Emit host inventory as `gpu.apple.device.count` and `gpu.apple.core.count`.
+   - Emit Apple driver-reported memory as `gpu.apple.system_memory.allocated` and `gpu.apple.system_memory.in_use`; document that these are not discrete VRAM or total unified memory.
+   - Do not publish renderer/tiler counters or map any Apple values onto existing NVIDIA-oriented metric names.
+   - Attach deterministic, low-cardinality device tags following existing GPU tag conventions: a synthetic host-scoped `gpu_uuid`, normalized `gpu_device`, `gpu_vendor:apple`, `gpu_architecture:apple_silicon`, an Apple model `gpu_type`, `gpu_virtualization_mode:none`, `gpu_slicing_mode:none`, and `gpu_host:true`.
+   - Keep these experimental Apple metrics outside the current NVIDIA-oriented `spec/gpu_metrics.yaml` and its validator until that tooling has a vendor-aware model.
    - Document how the synthetic ID is derived and keep it stable for the same model/device index across restarts. Avoid serial numbers or other sensitive identifiers.
 
 4. **Graceful degradation and telemetry**
@@ -57,14 +59,14 @@ Implement an independent Darwin check behind the same package, factory, configur
 
 7. **Local validation on this MBP**
    - Run targeted tests with `dda inv test --targets=./pkg/collector/corechecks/gpu/...` and build the Agent with `dda inv agent.build` (never raw `go` commands).
-   - Enable `gpu.enabled`, run the standard `gpu` check, and verify the canonical metrics and Apple device tags through the Agent sender/check output.
-   - Use the installed Ollama (`0.32.5`) and an already-local model to create sustained Metal load. Capture several idle and loaded check samples and confirm `gpu.gr_engine_active` rises materially during generation and falls afterward. Do not pull a model from the network without asking first.
+   - Enable `gpu.enabled`, run the standard `gpu` check, and verify the Apple metrics and device tags through the Agent sender/check output.
+   - Use the installed Ollama (`0.32.5`) and an already-local model to create sustained Metal load. Capture idle, loaded, and unloaded samples; confirm `gpu.apple.device.utilization` tracks generation and the two `gpu.apple.system_memory.*` metrics track model lifetime. Do not pull a model from the network without asking first.
    - Compare the check's utilization qualitatively with repeated unprivileged `ioreg` observations. Use `powermetrics` only as an optional manually authorized reference, never as the implementation dependency.
 
 ## Acceptance criteria
 
 - A Darwin arm64 Agent with cgo registers the existing `gpu` check when `gpu.enabled: true`.
-- On this Apple M5 Pro, the check emits `gpu.gr_engine_active`, `gpu.core.limit`, and `gpu.device.total` with valid Apple GPU device tags.
+- On this Apple M5 Pro, the check emits only the five `gpu.apple.*` metrics defined above, with valid Apple GPU device tags; it emits no existing NVIDIA-oriented metrics.
 - The check runs as the normal unprivileged Agent and does not spawn system tools or link private Apple frameworks.
 - Missing AGX devices or properties degrade safely without preventing Agent startup or suppressing other available metrics.
 - Linux/NVML behavior and tests remain unchanged.

--- a/tasks/00001-p2-in-progress--prototype-macos-gpu-check.md
+++ b/tasks/00001-p2-in-progress--prototype-macos-gpu-check.md
@@ -1,0 +1,80 @@
+# Prototype macOS Apple Silicon support in the standard GPU check
+
+## Goal
+
+Make the existing `gpu` core check available on macOS Apple Silicon without changing its user-facing check name or disturbing the Linux/NVML implementation. The prototype should prove that an unprivileged Agent can collect useful device-level GPU telemetry on this local MBP and that the signal responds to an Ollama workload.
+
+## Grounding and chosen approach
+
+Today the check is compiled only with `linux && nvml`; every other target receives an empty factory. The Linux implementation also embeds NVML-specific device discovery, collectors, health reporting, workload/container attribution, and system-probe integration, so replacing NVML with a single interface is not a small change.
+
+On the local Apple M5 Pro MBP, the unprivileged IOKit registry exposes an `AGXAccelerator` with:
+
+- model (`Apple M5 Pro`)
+- GPU core count (`20`)
+- `PerformanceStatistics`, including `Device Utilization %`, renderer/tiler utilization, and memory counters
+
+`powermetrics` exposes additional GPU power/frequency data but requires superuser access. IOReport and Apple GPU private frameworks have no public SDK contract. For this prototype, use the public IOKit/CoreFoundation APIs to read the AGX registry properties, while treating the property names themselves as best-effort, undocumented driver data.
+
+Implement an independent Darwin check behind the same package, factory, configuration flag, and `gpu.*` metric namespace. Do not first refactor the mature Linux/NVML check into a large cross-platform framework.
+
+## Implementation plan
+
+1. **Add a Darwin-native AGX reader**
+   - Add `darwin && cgo` files under `pkg/collector/corechecks/gpu` following the repository's existing battery/system-info pattern (`*_darwin.go` plus Objective-C/C helper files when useful).
+   - Link only public `IOKit` and `CoreFoundation`/`Foundation` frameworks.
+   - Enumerate `AGXAccelerator` services and read model, core count, and the `PerformanceStatistics` dictionary directly; do not invoke `ioreg`, `system_profiler`, or `powermetrics` as subprocesses.
+   - Represent absent or differently typed properties as optional values. One missing property must not suppress the remaining metrics or panic the check.
+   - Bound enumeration and release all CoreFoundation/IOKit objects correctly.
+
+2. **Register the standard check on supported Darwin builds**
+   - Adjust the unsupported factory build constraints so Darwin+cgo receives the real factory while Darwin without cgo and all other unsupported targets retain the no-op factory.
+   - Add a small Darwin `Check` implementation using `core.CheckBase`, the existing `gpu.enabled` gate, collection interval override, sender lifecycle, and `Cancel` behavior.
+   - Keep `pkg/collector/corechecks/gpu/gpu.go` and all NVIDIA collectors Linux/NVML-only and behaviorally unchanged.
+
+3. **Emit a conservative canonical metric set**
+   - Map AGX `Device Utilization %` to `gpu.gr_engine_active` (gauge, percent), the closest existing device-wide graphics-engine activity metric.
+   - Emit `gpu.core.limit` from `gpu-core-count` and `gpu.device.total` for each discovered device.
+   - Do not publish renderer/tiler counters or unified-memory values under misleading existing names, and do not add new public metrics in this prototype.
+   - Attach deterministic, low-cardinality device tags conforming to the existing GPU tag specification: a synthetic host-scoped `gpu_uuid`, normalized `gpu_device`, `gpu_vendor:apple`, `gpu_architecture:apple_silicon`, an Apple model `gpu_type`, `gpu_virtualization_mode:none`, `gpu_slicing_mode:none`, and `gpu_host:true`.
+   - Document how the synthetic ID is derived and keep it stable for the same model/device index across restarts. Avoid serial numbers or other sensitive identifiers.
+
+4. **Graceful degradation and telemetry**
+   - If no AGX accelerator exists (for example, an Intel Mac), return no device metrics with a rate-limited diagnostic rather than failing Agent startup.
+   - If utilization is absent on a future macOS release, still emit inventory-derived metrics and record/log the unsupported property once at an appropriate level.
+   - Add only the minimal internal telemetry needed to distinguish discovered devices, successful collections, and native-reader errors; do not report NVML health issues on Darwin.
+
+5. **Tests**
+   - Unit-test native-value conversion and metric mapping using injected snapshots so tests do not depend on current machine load or sleep.
+   - Test partial/missing/malformed properties, zero devices, multiple snapshots/devices, stable tags/IDs, sender commit, and `gpu.enabled` gating.
+   - Add a Darwin smoke test that calls the real IOKit reader and asserts coarse invariants only when an AGX device is present; skip cleanly on unsupported hardware.
+   - Preserve Linux tests and ensure build-tag changes do not make NVML dependencies reachable on Darwin or the Darwin implementation reachable on Linux.
+
+6. **Build and configuration integration**
+   - Update Bazel/Gazelle metadata for cgo, Objective-C sources, public Apple framework link options, and Darwin-only dependencies.
+   - Update `pkg/config/schema/yaml/gpu.yaml` wording so `gpu.enabled` describes both Linux GPU monitoring and the experimental Apple Silicon device-level path; retain the Linux-only system-probe requirement where applicable.
+   - Add a release note marking macOS support as experimental and device-level only.
+
+7. **Local validation on this MBP**
+   - Run targeted tests with `dda inv test --targets=./pkg/collector/corechecks/gpu/...` and build the Agent with `dda inv agent.build` (never raw `go` commands).
+   - Enable `gpu.enabled`, run the standard `gpu` check, and verify the canonical metrics and Apple device tags through the Agent sender/check output.
+   - Use the installed Ollama (`0.32.5`) and an already-local model to create sustained Metal load. Capture several idle and loaded check samples and confirm `gpu.gr_engine_active` rises materially during generation and falls afterward. Do not pull a model from the network without asking first.
+   - Compare the check's utilization qualitatively with repeated unprivileged `ioreg` observations. Use `powermetrics` only as an optional manually authorized reference, never as the implementation dependency.
+
+## Acceptance criteria
+
+- A Darwin arm64 Agent with cgo registers the existing `gpu` check when `gpu.enabled: true`.
+- On this Apple M5 Pro, the check emits `gpu.gr_engine_active`, `gpu.core.limit`, and `gpu.device.total` with valid Apple GPU device tags.
+- The check runs as the normal unprivileged Agent and does not spawn system tools or link private Apple frameworks.
+- Missing AGX devices or properties degrade safely without preventing Agent startup or suppressing other available metrics.
+- Linux/NVML behavior and tests remain unchanged.
+- Unit tests cover the mapping/error cases without timing sleeps, and the Darwin native smoke test is hardware-tolerant.
+- Local before/during/after Ollama evidence demonstrates that the utilization metric tracks GPU load.
+
+## Deliberate non-goals
+
+- GPU power, frequency, temperature, or energy metrics from root-only `powermetrics`.
+- Direct use of undocumented IOReport functions or private AGX/GPU frameworks.
+- Per-process or per-container GPU attribution, workloadmeta GPU inventory, eGPU/Intel/AMD Mac support, or system-probe integration.
+- Refactoring all Linux/NVML collectors behind a universal backend abstraction.
+- Shipping new renderer/tiler/unified-memory metric names before their semantics and backend contract are reviewed.


### PR DESCRIPTION
### What does this PR do?

Adds an experimental Apple Silicon backend to the standard `gpu` core check. The macOS implementation reads AGX device properties through unprivileged public IOKit APIs and emits only Apple-scoped metrics:

- `gpu.apple.device.count`
- `gpu.apple.core.count`
- `gpu.apple.device.utilization`
- `gpu.apple.system_memory.allocated`
- `gpu.apple.system_memory.in_use`

The system-memory metrics are explicitly defined as Apple driver-reported system memory associated with GPU clients; they do not claim discrete VRAM or total unified-memory semantics.

The change keeps the Linux/NVML implementation unchanged, adds vendor-aware metric specifications and Apple-specific tag requirements, and keeps iOS on the unsupported stub.

### Motivation

The Agent's GPU check was previously available only for Linux/NVIDIA systems. Apple Silicon hosts running Metal workloads—such as local inference, rendering, and macOS CI—need basic GPU inventory, activity, and GPU-client memory visibility.

Apple does not provide an NVML-equivalent public system API. This implementation deliberately uses only IOKit registry properties available without root and treats missing or changed properties as optional. It avoids private frameworks, `powermetrics`, subprocess parsing, and mapping Apple values onto NVIDIA-shaped metric names.

### Describe how you validated your changes

- `dda inv test --targets=./pkg/collector/corechecks/gpu`
- `dda inv linter.go --targets=./pkg/collector/corechecks/gpu`
- `bazel test //pkg/collector/corechecks/gpu:gpu_test_base //pkg/collector/corechecks/gpu/spec:spec_test_base --test_output=errors`
- `bazel run //bazel/buildifier`
- `dda inv schema.lint`
- `dda inv agent.build --build-exclude=systemd`
- Ran the built Agent's standard `gpu` check on an Apple M5 Pro and verified that exactly the five `gpu.apple.*` metrics were emitted.
- Generated sustained Metal load using an already-local 35B Ollama model. Device utilization increased from a 39.4% mean at baseline to 88.9% under load, then returned to 36.8%. Driver-reported allocated/in-use system memory rose from about 5.1/0.8–1.1 GB to about 35.1/30.6–31.3 GB, then returned after model unload.

### Additional Notes

The AGX registry property names are undocumented Apple driver data, so the feature is marked experimental and every property is optional. There is not yet an Apple Silicon fakeintake E2E environment; local QA covered the real packaged Agent registration, native reader, sender output, and hardware behavior.