### PR TITLE
Increase Quality Gate memory thresholds for ADP pre-flight mode

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -10,7 +10,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 30% higher than the memory_usage check value
-  memory_allotment: 200 MiB
+  memory_allotment: 232 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -38,7 +38,7 @@ checks:
     bounds:
       series: total_pss_bytes
       # When updating this, update the memory_allotment in the target section to 30% higher
-      upper_bound: "154 MiB"
+      upper_bound: "178 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -10,7 +10,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 30% higher than the memory_usage check value
-  memory_allotment: 666 MiB
+  memory_allotment: 700 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -64,7 +64,7 @@ checks:
       #
       # When updating this, update the memory_allotment in the target section to
       # 30% higher
-      upper_bound: "512 MiB"
+      upper_bound: "538 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -5,7 +5,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 20% higher than the memory_usage check value
-  memory_allotment: 234 MiB
+  memory_allotment: 275 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -31,7 +31,7 @@ checks:
     bounds:
       series: total_pss_bytes
       # When updating this, update the memory_allotment in the target section to 20% higher
-      upper_bound: "195 MiB"
+      upper_bound: "229 MiB"
 
   - name: missed_bytes
     description: "Allowable bytes not polled by log Agent"

--- a/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
@@ -5,7 +5,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 20% higher than the memory_usage check value
-  memory_allotment: 516 MiB
+  memory_allotment: 527 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -33,7 +33,7 @@ checks:
     bounds:
       series: total_pss_bytes
       # When updating this, update the memory_allotment in the target section to 20% higher
-      upper_bound: 430 MiB
+      upper_bound: 439 MiB
 
   - name: cpu_usage
     description: "CPU usage quality gate. This puts a bound on the total average collector millicore usage."

--- a/test/regression/cases/quality_gate_private_action_runner/experiment.yaml
+++ b/test/regression/cases/quality_gate_private_action_runner/experiment.yaml
@@ -13,7 +13,7 @@ target:
   command: /bin/entrypoint.sh
   cpu_allotment: 4
   # Set to 20% higher than the memory_usage check value.
-  memory_allotment: 90 MiB
+  memory_allotment: 92 MiB
 
   environment:
     ENTRYPOINT: privateactionrunner
@@ -32,7 +32,7 @@ checks:
       series: total_pss_bytes
       # When updating this, update
       # memory_allotment in the target section to 20% higher.
-      upper_bound: "75 MiB"
+      upper_bound: "76 MiB"
 
 report_links:
   - text: "bounds checks dashboard"

--- a/test/regression/cases/quality_gate_security_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_security_idle/experiment.yaml
@@ -5,7 +5,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 20% higher than the memory_usage check value
-  memory_allotment: 390 MiB
+  memory_allotment: 402 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -48,7 +48,7 @@ checks:
     bounds:
       series: total_pss_bytes
       # When updating this, update the memory_allotment in the target section to 20% higher.
-      upper_bound: "330 MiB"
+      upper_bound: "335 MiB"
 
   - name: cpu_usage
     description: "CPU usage quality gate. This puts a bound on the total average collector millicore usage."

--- a/test/regression/cases/quality_gate_security_mean_fs_load/experiment.yaml
+++ b/test/regression/cases/quality_gate_security_mean_fs_load/experiment.yaml
@@ -5,7 +5,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 20% higher than the memory_usage check value
-  memory_allotment: 370 MiB
+  memory_allotment: 377 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -48,7 +48,7 @@ checks:
     bounds:
       series: total_pss_bytes
       # When updating this, update the memory_allotment in the target section to 20% higher.
-      upper_bound: "310 MiB"
+      upper_bound: "314 MiB"
 
   - name: cpu_usage
     description: "CPU usage quality gate. This puts a bound on the total average collector millicore usage."

--- a/test/regression/cases/quality_gate_security_no_fs_load/experiment.yaml
+++ b/test/regression/cases/quality_gate_security_no_fs_load/experiment.yaml
@@ -5,7 +5,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 20% higher than the memory_usage check value
-  memory_allotment: 380 MiB
+  memory_allotment: 412 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -48,7 +48,7 @@ checks:
     bounds:
       series: total_pss_bytes
       # When updating this, update the memory_allotment in the target section to 20% higher.
-      upper_bound: "320 MiB"
+      upper_bound: "343 MiB"
 
   - name: cpu_usage
     description: "CPU usage quality gate. This puts a bound on the total average collector millicore usage."


### PR DESCRIPTION
ADP pre-flight mode (#54175) adds 23 MiB to peak PSS on every workload that exercises a default Agent configuration. Pre-flight is enabled by default and runs ADP for 90 seconds at startup in anticipation of turning it on by default.

This PR re-baselines all Quality Gate memory thresholds.

| Gate | Old (MiB) | Observed (MiB) | New (MiB) |
|---|---|---|---|
| `quality_gate_idle` | 154 | 174.89 | 178 |
| `quality_gate_logs` | 195 | 216.59 | 229 |
| `quality_gate_metrics_logs` | 430 | 417.52 | 439 |
| `quality_gate_idle_all_features` | 512 | 524.74 | 538 |
| `quality_gate_security_idle` | 330 | 330.55 | 335 |
| `quality_gate_security_no_fs_load` | 320 | 319.31 | 343 |
| `quality_gate_security_mean_fs_load` | 310 | 309.05 | 314 |
| `quality_gate_private_action_runner` | 75 | 74.04 | 76 |

Observed values come from `total_pss_bytes` on the comparison variant of last night's Quality Gate run.

Bounds are sized to 1% over observed + 1 MiB, with the exception of `logs`, `metrics_logs`, and `security_no_fs_load`. Those three are sized against their three-week peak to account for variability that is not currently captured every night.