### PR TITLE
fix(data plane): run preflight mode for entire SMP experiment duration

### DIFF
--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -2979,8 +2979,9 @@ func TestDataPlanePreflightModeProfile(t *testing.T) {
 	require.NotNil(t, profile.Schedule)
 
 	// The first flush must land after the run finishes, or it would report an empty run. The
-	// window is preflightModeDuration in comp/dataplane/preflightmode/impl (90s, deliberately not
-	// configurable); this asserts the schedule keeps clear of it with margin. Raising that
+	// shortest possible window is minPreflightModeDuration in comp/dataplane/preflightmode/impl
+	// (90s; data_plane.preflight_mode_duration can only extend it, which the recurring schedule
+	// below covers). This asserts the schedule keeps clear of the floor with margin. Raising that
 	// constant past this bound should fail here.
 	const preflightModeWindowSeconds = 90
 	assert.Greater(t, int(profile.Schedule.StartAfter), preflightModeWindowSeconds,

--- a/comp/core/agenttelemetry/impl/defaultProfiles.yaml
+++ b/comp/core/agenttelemetry/impl/defaultProfiles.yaml
@@ -567,15 +567,15 @@ profiles:
           - finding
       - name: data_plane.preflight_mode_duration_seconds
   schedule:
-    # Preflight mode runs once at startup for preflightModeDuration (90s, see
+    # Preflight mode runs once at startup, for at least minPreflightModeDuration (90s, see
     # comp/dataplane/preflightmode/impl), so the first flush is delayed past that window;
     # otherwise it would report an empty run.
     #
-    # The schedule stays recurring (iterations: 0) so that raising that window cannot strand
-    # the outcome: a flush landing mid-run finds nothing, and with iterations: 1 there would be
-    # no later collection. Recurring costs nothing — the counters are delta-converted, so the
-    # increment ships on whichever flush first observes it and later flushes send zero, which
-    # zero_metric drops.
+    # The schedule stays recurring (iterations: 0) so that a window extended past this via
+    # data_plane.preflight_mode_duration cannot strand the outcome: a flush landing mid-run finds
+    # nothing, and with iterations: 1 there would be no later collection. Recurring costs
+    # nothing — the counters are delta-converted, so the increment ships on whichever flush first
+    # observes it and later flushes send zero, which zero_metric drops.
     start_after: 120 # 2 minutes
     iterations: 0
     period: 900

--- a/comp/dataplane/preflightmode/impl/config.go
+++ b/comp/dataplane/preflightmode/impl/config.go
@@ -21,9 +21,10 @@ import (
 const (
 	preflightConfigFileName = "datadog.yaml"
 
-	DataPlaneEnabled       = "data_plane.enabled"
-	DataPlanePreflightMode = "data_plane.preflight_mode"
-	DataPlaneStopTimeout   = "data_plane.stop_timeout"
+	DataPlaneEnabled               = "data_plane.enabled"
+	DataPlanePreflightMode         = "data_plane.preflight_mode"
+	DataPlanePreflightModeDuration = "data_plane.preflight_mode_duration"
+	DataPlaneStopTimeout           = "data_plane.stop_timeout"
 )
 
 // preflightModeDataPlaneOnlyOverrides holds settings ADP understands but the Core Agent does not, so they cannot be

--- a/comp/dataplane/preflightmode/impl/preflightmode.go
+++ b/comp/dataplane/preflightmode/impl/preflightmode.go
@@ -54,18 +54,20 @@ const (
 	maxShutdownGrace = 30 * time.Second
 )
 
-// preflightModeDuration is how long ADP is left running.
+// minPreflightModeDuration is the floor on how long ADP is left running, and the default
+// data_plane.preflight_mode_duration resolves to.
 //
-// Deliberately not a config setting. There is no operational reason to tune it: the off
-// switch operators actually need is data_plane.preflight_mode, and a documented duration would be
-// public API we have to support and later deprecate for a mechanism that only exists until ADP
-// goes GA. Fixing it also makes the agent telemetry schedule's start_after a provable
-// relationship rather than one that silently breaks when an operator raises the window past it.
+// It is a floor rather than a plain default because a window shorter than this does not measure
+// ADP, it measures the clock: 90s is what the pre-flight was sized for, and stopping ADP while
+// its startup is still in progress would report a healthy host as a finding. So a configured
+// value below this is raised to it rather than honoured. Only the upper end is open, which is
+// the direction the setting exists for — keeping ADP resident for the whole of a fixed-length
+// benchmark run.
 //
-// A var rather than a const only so tests can shorten it; nothing in production reassigns it.
-// If this is raised, check start_after on the data-plane-preflight-mode profile in
+// A var rather than a const only so tests can lower the floor; nothing in production reassigns
+// it. If this is raised, check start_after on the data-plane-preflight-mode profile in
 // comp/core/agenttelemetry/impl/defaultProfiles.yaml still lands after the window.
-var preflightModeDuration = 90 * time.Second
+var minPreflightModeDuration = 90 * time.Second
 
 // resolveDataPlanePath returns the ADP binary path. A variable so tests can substitute a
 // stand-in binary.
@@ -178,7 +180,7 @@ func NewComponent(reqs Requires) Provides {
 }
 
 // start kicks off the pre-flight in the background. It must not block: a preflight mode run
-// lasts a minute by default, and OnStart hooks run in sequence with every other
+// lasts at least minPreflightModeDuration, and OnStart hooks run in sequence with every other
 // component's.
 func (d *preflightModeComponent) start(context.Context) error {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -228,6 +230,15 @@ func (d *preflightModeComponent) stop(context.Context) error {
 func (d *preflightModeComponent) shutdownGrace() time.Duration {
 	grace := d.stopTimeout() + probeConnectTimeout + probeWriteTimeout + shutdownSlack
 	return min(grace, maxShutdownGrace)
+}
+
+// duration is how long ADP is left running, never less than minPreflightModeDuration.
+//
+// The clamp also absorbs the values GetDuration produces from input that is not a duration
+// string at all: a bare number is read as that many nanoseconds, and anything unparseable comes
+// back as zero. Both would otherwise stop ADP the instant it started.
+func (d *preflightModeComponent) duration() time.Duration {
+	return max(d.config.GetDuration(DataPlanePreflightModeDuration), minPreflightModeDuration)
 }
 
 // stopTimeout is how long ADP is given to exit after being asked to stop.
@@ -330,8 +341,12 @@ func (d *preflightModeComponent) run(ctx context.Context) {
 		return
 	}
 
+	// Read once, so the window the run is logged with, timed by and reported against is the same
+	// one even if the setting changes under it.
+	window := d.duration()
+
 	d.log.Infof("Starting Agent Data Plane in preflight mode for %s (binary %s, DogStatsD endpoint %s)",
-		preflightModeDuration, d.binPath, l.describe())
+		window, d.binPath, l.describe())
 	if err := cmd.Start(); err != nil {
 		d.log.Warnf("Agent Data Plane preflight mode could not start %s: %v", d.binPath, err)
 		o.add(findingSpawnFailed)
@@ -355,7 +370,7 @@ func (d *preflightModeComponent) run(ctx context.Context) {
 	probeResult := make(chan bool, 1)
 	go func() { probeResult <- d.probe(procCtx, l) }()
 
-	timer := time.NewTimer(preflightModeDuration)
+	timer := time.NewTimer(window)
 	defer timer.Stop()
 
 	var exitedEarly, interrupted bool
@@ -383,7 +398,7 @@ func (d *preflightModeComponent) run(ctx context.Context) {
 		// findings from what ADP actually logged are still added below.
 		o.add(findingInterrupted)
 	case exitedEarly:
-		d.log.Debugf("Agent Data Plane exited before the %s preflight mode window elapsed", preflightModeDuration)
+		d.log.Debugf("Agent Data Plane exited before the %s preflight mode window elapsed", window)
 		o.add(findingExitedEarly)
 	case probeFailed:
 		o.add(findingProbeFailed)

--- a/comp/dataplane/preflightmode/impl/preflightmode_test.go
+++ b/comp/dataplane/preflightmode/impl/preflightmode_test.go
@@ -264,13 +264,17 @@ func shortTempDir(t *testing.T) string {
 	return dir
 }
 
-// setPreflightModeDuration shortens (or lengthens) the run window for one test. preflightModeDuration
-// is read when the timer is armed, so this must be called before the lifecycle starts.
-func setPreflightModeDuration(t *testing.T, d time.Duration) {
+// setPreflightModeDuration shortens (or lengthens) the run window for one test. The window is
+// read when the timer is armed, so this must be called before the lifecycle starts.
+//
+// The floor moves with the setting because it is what a sub-90s window would otherwise be raised
+// to: leaving it in place would make every shortened test wait out the real window.
+func setPreflightModeDuration(t *testing.T, cfg pkgconfigmodel.Config, d time.Duration) {
 	t.Helper()
-	original := preflightModeDuration
-	preflightModeDuration = d
-	t.Cleanup(func() { preflightModeDuration = original })
+	original := minPreflightModeDuration
+	minPreflightModeDuration = d
+	t.Cleanup(func() { minPreflightModeDuration = original })
+	cfg.Set(DataPlanePreflightModeDuration, d.String(), pkgconfigmodel.SourceAgentRuntime)
 }
 
 // useFakeDataPlane points the component at this test binary and selects a behaviour.
@@ -297,10 +301,10 @@ type harness struct {
 func newHarness(t *testing.T, mode string, tweak func(pkgconfigmodel.Config)) *harness {
 	t.Helper()
 	useFakeDataPlane(t, mode)
-	// The real window is 90s; every lifecycle test would pay that in wall clock.
-	setPreflightModeDuration(t, 3*time.Second)
 
 	cfg := configmock.New(t)
+	// The real window is 90s; every lifecycle test would pay that in wall clock.
+	setPreflightModeDuration(t, cfg, 3*time.Second)
 	cfg.Set("run_path", shortTempDir(t), pkgconfigmodel.SourceAgentRuntime)
 	cfg.Set("api_key", "0123456789abcdef0123456789abcdef", pkgconfigmodel.SourceFile)
 	cfg.Set(DataPlaneStopTimeout, 2, pkgconfigmodel.SourceAgentRuntime)
@@ -522,7 +526,7 @@ func TestPreflightModeCleansUpWorkDir(t *testing.T) {
 // window: the pre-flight must unwind rather than leave an orphaned process behind.
 func TestPreflightModeStopDuringRun(t *testing.T) {
 	h := newHarness(t, modeNormal, nil)
-	setPreflightModeDuration(t, 120*time.Second)
+	setPreflightModeDuration(t, h.cfg, 120*time.Second)
 
 	h.lc.start(t)
 	// Wait until the process is actually up before pulling the rug out.
@@ -563,7 +567,7 @@ func TestPreflightModeStopDuringRun(t *testing.T) {
 // ended. Only the findings that are artefacts of us stopping it are suppressed.
 func TestPreflightModeInterruptedStillReportsRealErrors(t *testing.T) {
 	h := newHarness(t, modeErrors, nil)
-	setPreflightModeDuration(t, 120*time.Second)
+	setPreflightModeDuration(t, h.cfg, 120*time.Second)
 
 	h.lc.start(t)
 	require.Eventually(t, func() bool {
@@ -687,6 +691,35 @@ func TestPreflightModeInertWhenPreflightModeDisabled(t *testing.T) {
 	})
 	assert.Nil(t, h.comp.done)
 	assert.Empty(t, h.lc.hooks)
+}
+
+// TestPreflightModeDuration covers the clamp on data_plane.preflight_mode_duration. The floor is
+// the point of the setting's contract: the window may only be extended, because a shorter one
+// stops ADP mid-startup and reports a healthy host as a finding.
+func TestPreflightModeDuration(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value any
+		want  time.Duration
+	}{
+		{name: "unset", value: nil, want: minPreflightModeDuration},
+		{name: "longer is honoured", value: "15m", want: 15 * time.Minute},
+		{name: "shorter is raised to the floor", value: "30s", want: minPreflightModeDuration},
+		{name: "zero is raised to the floor", value: "0s", want: minPreflightModeDuration},
+		{name: "negative is raised to the floor", value: "-1m", want: minPreflightModeDuration},
+		// A bare number is read as nanoseconds, which is why the floor is not just a default.
+		{name: "unitless number is raised to the floor", value: 900, want: minPreflightModeDuration},
+		{name: "garbage is raised to the floor", value: "soon", want: minPreflightModeDuration},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := configmock.New(t)
+			if tc.value != nil {
+				cfg.Set(DataPlanePreflightModeDuration, tc.value, pkgconfigmodel.SourceFile)
+			}
+			d := &preflightModeComponent{config: cfg}
+			assert.Equal(t, tc.want, d.duration())
+		})
+	}
 }
 
 // TestPreflightModeInertWhenBinaryMissing covers the common case on builds that do not ship

--- a/docs/dev/agent-data-plane.md
+++ b/docs/dev/agent-data-plane.md
@@ -21,20 +21,29 @@ All of the following must hold:
 
 | Condition | Why |
 |---|---|
-| `data_plane.preflight_mode` is `true` (the default) | The off switch, and the only knob preflight mode exposes. |
+| `data_plane.preflight_mode` is `true` (the default) | The off switch, and the only knob operators need. |
 | `data_plane.enabled` has not been set **at all** | An explicit `true` means ADP is already running for real and two instances would contend for the API, secure API and telemetry ports plus the DogStatsD socket. An explicit `false` means the operator does not want ADP running. Either way the operator has an opinion and preflight mode stays out of the way. Note the platform gate in `sanitizeDataPlaneConfig` sets this to `false` on unsupported platforms, which also disables preflight mode. |
 | The Agent flavor is the default Agent | Heroku and IoT share the same `run` command with fewer build tags and neither ships ADP. |
 | No secrets are in play | The pre-flight writes the resolved configuration to a file, so a secret the resolver only ever held in memory would be materialized in plaintext on disk. Skipped when `secret_backend_command`, `secret_backend_type` or `multi_secret_backends` is set, or when anything at all is sitting in the config's `secret` source layer. See `secretsInUse`. |
 | The ADP binary is on disk | Absent on Heroku packages and slim container images. Silently skipped — not reported. |
 
-It runs **once** per Agent start, not on a schedule, for a fixed 90 seconds.
+It runs **once** per Agent start, not on a schedule, for 90 seconds.
 
-The window is deliberately **not** configurable (`preflightModeDuration` in
-`comp/dataplane/preflightmode/impl`). There is no operational reason to tune it — the switch
-operators need is `data_plane.preflight_mode` — and a documented duration setting would be public
-API to support and later deprecate for a mechanism that only exists until ADP goes GA. Fixing
-it also makes the agent telemetry `start_after` a provable relationship instead of one an
-operator could silently break.
+`data_plane.preflight_mode_duration` can extend that window but not shrink it: anything below
+`minPreflightModeDuration` (90s, in `comp/dataplane/preflightmode/impl`) is raised to it. The
+floor is the contract — a shorter window stops ADP while its startup is still in progress and
+turns a healthy host into a finding, and the clamp is also what absorbs a value that is not a
+duration at all, since `GetDuration` reads a bare `90` as 90 nanoseconds.
+
+Extending it is not something to do on a real host; the switch operators need is
+`data_plane.preflight_mode`. It exists for benchmarking harnesses that need ADP resident for the
+whole of a fixed-length run, where the pre-flight otherwise stops halfway through and the step
+down in RSS reads as an oscillation in the target's footprint. The SMP quality gates in
+`test/regression/cases/quality_gate_*` set it for exactly that reason.
+
+Extending the window past the agent telemetry `start_after` does not strand the outcome: the
+`data-plane-preflight-mode` schedule is recurring, so a flush landing mid-run finds nothing and a
+later one ships the result.
 
 ### What makes the run inert
 

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -6291,6 +6291,19 @@ properties:
           UDS or named pipe under run_path, and only runs when data_plane.enabled has not been set at all.
 
           See comp/dataplane/preflightmode for more details.
+      preflight_mode_duration:
+        node_type: setting
+        type: string
+        default: 90s
+        format: duration
+        comment: |-
+          How long the preflight process is left running. Clamped to a minimum of 90s, which is the window the
+          pre-flight was sized for: anything shorter stops ADP while startup is still in progress and turns a
+          healthy host into a finding.
+
+          The knob exists for benchmarking harnesses that need ADP resident for the whole of a fixed-length run
+          -- see test/regression/cases/quality_gate_* -- rather than for tuning on real hosts, where the only
+          knob that matters is data_plane.preflight_mode.
       remote_agent_enabled:
         node_type: setting
         type: boolean

--- a/releasenotes/notes/adp-preflight-mode-duration-7d1eadfedd499b6e.yaml
+++ b/releasenotes/notes/adp-preflight-mode-duration-7d1eadfedd499b6e.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    Adds ``data_plane.preflight_mode_duration``, which sets how long the Agent Data Plane (ADP)
+    pre-flight leaves ADP running. It defaults to ``90s`` and is clamped to that as a minimum, so
+    it can only extend the window: a shorter one stops ADP while its startup is still in progress
+    and reports a healthy host as a failure. It is intended for benchmarking harnesses that need
+    ADP resident for the whole of a fixed-length run; on a real host the setting to reach for
+    remains ``data_plane.preflight_mode``.

--- a/test/regression/cases/quality_gate_idle/datadog-agent/datadog.yaml
+++ b/test/regression/cases/quality_gate_idle/datadog-agent/datadog.yaml
@@ -10,3 +10,11 @@ cloud_provider_metadata: []
 
 telemetry.enabled: true
 telemetry.checks: '*'
+
+# Hold the Agent Data Plane pre-flight open for the whole run.
+#
+# The pre-flight starts ADP as a child of the Agent and stops it again after 90s. That step down
+# in total RSS lands in the middle of a replicate here, so the gate ends up measuring when the
+# timer fired as much as what the Agent costs. 30m is well past the ~10 minute experiment, so ADP
+# is resident for every sample instead.
+data_plane.preflight_mode_duration: 30m

--- a/test/regression/cases/quality_gate_idle_all_features/datadog-agent/datadog.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/datadog-agent/datadog.yaml
@@ -71,3 +71,11 @@ sbom:
 
 container_image:
   enabled: true
+
+# Hold the Agent Data Plane pre-flight open for the whole run.
+#
+# The pre-flight starts ADP as a child of the Agent and stops it again after 90s. That step down
+# in total RSS lands in the middle of a replicate here, so the gate ends up measuring when the
+# timer fired as much as what the Agent costs. 30m is well past the ~10 minute experiment, so ADP
+# is resident for every sample instead.
+data_plane.preflight_mode_duration: 30m

--- a/test/regression/cases/quality_gate_logs/datadog-agent/datadog.yaml
+++ b/test/regression/cases/quality_gate_logs/datadog-agent/datadog.yaml
@@ -17,3 +17,11 @@ process_config.process_dd_url: http://localhost:9093
 
 telemetry.enabled: true
 telemetry.checks: '*'
+
+# Hold the Agent Data Plane pre-flight open for the whole run.
+#
+# The pre-flight starts ADP as a child of the Agent and stops it again after 90s. That step down
+# in total RSS lands in the middle of a replicate here, so the gate ends up measuring when the
+# timer fired as much as what the Agent costs. 30m is well past the ~10 minute experiment, so ADP
+# is resident for every sample instead.
+data_plane.preflight_mode_duration: 30m

--- a/test/regression/cases/quality_gate_metrics_logs/datadog-agent/datadog.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/datadog-agent/datadog.yaml
@@ -19,3 +19,11 @@ telemetry.enabled: true
 telemetry.checks: '*'
 
 dogstatsd_socket: '/tmp/dsd.socket'
+
+# Hold the Agent Data Plane pre-flight open for the whole run.
+#
+# The pre-flight starts ADP as a child of the Agent and stops it again after 90s. That step down
+# in total RSS lands in the middle of a replicate here, so the gate ends up measuring when the
+# timer fired as much as what the Agent costs. 30m is well past the ~10 minute experiment, so ADP
+# is resident for every sample instead.
+data_plane.preflight_mode_duration: 30m

--- a/test/regression/cases/quality_gate_private_action_runner/datadog-agent/datadog.yaml
+++ b/test/regression/cases/quality_gate_private_action_runner/datadog-agent/datadog.yaml
@@ -19,3 +19,11 @@ private_action_runner:
   # before total_pss_bytes can be sampled. Never authenticates: egress is blackholed.
   urn: "urn:dd:apps:on-prem-runner:us1:1:smp-regression"
   private_key: "eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6IkhqMjZFRGtySVJiTXYyUlYta2hLM09JODZMVlUtS0E4dnJ6QkZWdmFYVUEiLCJ5Ijoic0RSREpPemxMZ2pEUnJKbS01YTMtdlFraTZiZExiT0IxY3FldEpxVXNnNCIsImQiOiJBbXhKaVJtMS1icTBLVS1FMng1eHlTclJKTVg3NmJHRlJFNlJLS3lqWDVRIiwiYWxnIjoiRVMyNTYiLCJ1c2UiOiJzaWcifQ"
+
+# Hold the Agent Data Plane pre-flight open for the whole run.
+#
+# The pre-flight starts ADP as a child of the Agent and stops it again after 90s. That step down
+# in total RSS lands in the middle of a replicate here, so the gate ends up measuring when the
+# timer fired as much as what the Agent costs. 30m is well past the ~10 minute experiment, so ADP
+# is resident for every sample instead.
+data_plane.preflight_mode_duration: 30m

--- a/test/regression/cases/quality_gate_security_idle/datadog-agent/datadog.yaml
+++ b/test/regression/cases/quality_gate_security_idle/datadog-agent/datadog.yaml
@@ -6,3 +6,11 @@ dd_url: http://127.0.0.1:9091
 # execution environment & network. This is particularly important if the target
 # has network access.
 cloud_provider_metadata: []
+
+# Hold the Agent Data Plane pre-flight open for the whole run.
+#
+# The pre-flight starts ADP as a child of the Agent and stops it again after 90s. That step down
+# in total RSS lands in the middle of a replicate here, so the gate ends up measuring when the
+# timer fired as much as what the Agent costs. 30m is well past the ~10 minute experiment, so ADP
+# is resident for every sample instead.
+data_plane.preflight_mode_duration: 30m

--- a/test/regression/cases/quality_gate_security_mean_fs_load/datadog-agent/datadog.yaml
+++ b/test/regression/cases/quality_gate_security_mean_fs_load/datadog-agent/datadog.yaml
@@ -6,3 +6,11 @@ dd_url: http://127.0.0.1:9091
 # execution environment & network. This is particularly important if the target
 # has network access.
 cloud_provider_metadata: []
+
+# Hold the Agent Data Plane pre-flight open for the whole run.
+#
+# The pre-flight starts ADP as a child of the Agent and stops it again after 90s. That step down
+# in total RSS lands in the middle of a replicate here, so the gate ends up measuring when the
+# timer fired as much as what the Agent costs. 30m is well past the ~10 minute experiment, so ADP
+# is resident for every sample instead.
+data_plane.preflight_mode_duration: 30m

--- a/test/regression/cases/quality_gate_security_no_fs_load/datadog-agent/datadog.yaml
+++ b/test/regression/cases/quality_gate_security_no_fs_load/datadog-agent/datadog.yaml
@@ -6,3 +6,11 @@ dd_url: http://127.0.0.1:9091
 # execution environment & network. This is particularly important if the target
 # has network access.
 cloud_provider_metadata: []
+
+# Hold the Agent Data Plane pre-flight open for the whole run.
+#
+# The pre-flight starts ADP as a child of the Agent and stops it again after 90s. That step down
+# in total RSS lands in the middle of a replicate here, so the gate ends up measuring when the
+# timer fired as much as what the Agent costs. 30m is well past the ~10 minute experiment, so ADP
+# is resident for every sample instead.
+data_plane.preflight_mode_duration: 30m


### PR DESCRIPTION
### What does this PR do?

This PR adds the ability to _increase_ the duration of preflight mode for ADP.

### Motivation

Since preflight mode now influences SMP experiments, we see the RSS for quality gate experiments increased even though ADP only runs for 90 seconds. While we need to adjust those QG limits no matter what, we also want to make ADP run for the _entire_ duration so that we avoid increasing the limits and then potentially letting other changes to the Agent effectively "hide" behind the temporary ADP usage.

### Describe how you validated your changes

- New and existing unit tests.

### Additional Notes
