### PR TITLE
ci: default GitLab jobs to shallow clones, keep full history where needed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -175,7 +175,8 @@ default:
     when: always
 
 # Full git history. Override the global GIT_DEPTH: 1 on jobs that run
-# merge-base, ancestor, git describe, git log ranges, or HEAD^ walks.
+# merge-base, ancestor, git describe, git log ranges, HEAD^ walks,
+# three-dot diffs, or checkout of another branch.
 .needs_full_git_history:
   variables:
     GIT_DEPTH: 0
@@ -383,8 +384,9 @@ variables:
 
   # Job cloning strategy
   # GIT_DEPTH: 1 is a shallow clone of HEAD only (enough for the working tree).
-  # Jobs that need git history (merge-base, ancestor, git describe, git log ranges)
-  # must set GIT_DEPTH: 0. See .needs_full_git_history.
+  # Jobs that need git history (merge-base, ancestor, git describe, git log
+  # ranges, HEAD^ walks, three-dot diffs, or checkout of another branch) must
+  # set GIT_DEPTH: 0. See .needs_full_git_history.
   GIT_STRATEGY: "fetch"
   GIT_DEPTH: 1
   DISABLE_GIT_CACHE: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -174,9 +174,7 @@ default:
     max: 1 # Retry everything once on failure
     when: always
 
-# Full git history. Override the global GIT_DEPTH: 1 on jobs that run
-# merge-base, ancestor, git describe, git log ranges, HEAD^ walks,
-# three-dot diffs, or checkout of another branch.
+# Full git history. Override the default shallow clone.
 .needs_full_git_history:
   variables:
     GIT_DEPTH: 0
@@ -382,11 +380,7 @@ variables:
   DD_PKG_GITLAB_URL: "https://artifact-gateway.us1.ddbuild.io/internal/artifact-gateway/api/v4"
   PIPELINE_KEY_ALIAS: "alias/ci_datadog-agent_pipeline-key"
 
-  # Job cloning strategy
-  # GIT_DEPTH: 1 is a shallow clone of HEAD only (enough for the working tree).
-  # Jobs that need git history (merge-base, ancestor, git describe, git log
-  # ranges, HEAD^ walks, three-dot diffs, or checkout of another branch) must
-  # set GIT_DEPTH: 0. See .needs_full_git_history.
+  # Shallow clone by default.
   GIT_STRATEGY: "fetch"
   GIT_DEPTH: 1
   DISABLE_GIT_CACHE: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -174,6 +174,12 @@ default:
     max: 1 # Retry everything once on failure
     when: always
 
+# Full git history. Override the global GIT_DEPTH: 1 on jobs that run
+# merge-base, ancestor, git describe, git log ranges, or HEAD^ walks.
+.needs_full_git_history:
+  variables:
+    GIT_DEPTH: 0
+
 stages:
   - .pre
   - setup
@@ -376,7 +382,11 @@ variables:
   PIPELINE_KEY_ALIAS: "alias/ci_datadog-agent_pipeline-key"
 
   # Job cloning strategy
+  # GIT_DEPTH: 1 is a shallow clone of HEAD only (enough for the working tree).
+  # Jobs that need git history (merge-base, ancestor, git describe, git log ranges)
+  # must set GIT_DEPTH: 0. See .needs_full_git_history.
   GIT_STRATEGY: "fetch"
+  GIT_DEPTH: 1
   DISABLE_GIT_CACHE: true
 
   # Job stage attempts (see https://docs.gitlab.com/ee/ci/runners/configure_runners.html#job-stages-attempts)

--- a/.gitlab/.pre/ci_configuration.yml
+++ b/.gitlab/.pre/ci_configuration.yml
@@ -15,6 +15,8 @@ test_gitlab_compare_to:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64"]
   extends: .dd_octo_sts
+  variables:
+    GIT_DEPTH: 0  # Full history: gitlab_configuration_is_modified uses merge-base and HEAD^
   rules:
     - !reference [.except_mergequeue]
     - !reference [.on_gitlab_changes]
@@ -30,6 +32,8 @@ compute_gitlab_ci_config:
   stage: .pre
   needs: []
   tags: ["arch:arm64"]
+  variables:
+    GIT_DEPTH: 0  # Full history: computes gitlab-ci config diff against merge-base
   before_script:
     # Get main history
     - git fetch origin main
@@ -57,5 +61,7 @@ lint_github_actions_shellcheck:
         compare_to: $COMPARE_TO_BRANCH
       when: on_success
   allow_failure: true
+  variables:
+    GIT_DEPTH: 0  # Full history: linter.github-actions-shellcheck uses git merge-base
   script:
     - dda inv -- -e linter.github-actions-shellcheck

--- a/.gitlab/.pre/common/prebuild-workspace-image.yml
+++ b/.gitlab/.pre/common/prebuild-workspace-image.yml
@@ -9,5 +9,9 @@ prebuild-workspace-image-check:
         paths:
           - .devcontainer/datadog/default/**/*
         compare_to: $COMPARE_TO_BRANCH
+  variables:
+    GIT_DEPTH: 0  # Full history: three-dot diff is from merge-base to HEAD
   script:
+    - git fetch origin "$COMPARE_TO_BRANCH"
+    - export SOURCE_REF="origin/$COMPARE_TO_BRANCH"
     - bash tools/prebuild-devcontainer-check.sh

--- a/.gitlab/.pre/setup/setup.yml
+++ b/.gitlab/.pre/setup/setup.yml
@@ -23,3 +23,4 @@ setup_agent_version:
       dotenv: build.env
   variables:
     DISABLE_GIT_CACHE: true
+    GIT_DEPTH: 0  # git describe --tags needs reachable tags

--- a/.gitlab/build/binary_build/fakeintake.yml
+++ b/.gitlab/build/binary_build/fakeintake.yml
@@ -23,5 +23,7 @@ fakeintake_check_version_bump:
   needs: []
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
+  variables:
+    GIT_DEPTH: 0  # Full history: fakeintake.check-version-bump uses merge-base
   script:
     - dda inv -- fakeintake.check-version-bump

--- a/.gitlab/build/lint/technical_linters.yml
+++ b/.gitlab/build/lint/technical_linters.yml
@@ -89,6 +89,8 @@ validate_experiment_systemd_units:
 lint_releasenotes_rst:
   extends: .lint
   rules: !reference [.on_releasenotes_changes]
+  variables:
+    GIT_DEPTH: 0  # Full history: linter.rst-releasenotes --only-changed uses merge-base
   script:
     - dda inv -- -e linter.rst-releasenotes --only-changed
 

--- a/.gitlab/build/pkg_metrics/pkg_metrics.yml
+++ b/.gitlab/build/pkg_metrics/pkg_metrics.yml
@@ -102,5 +102,7 @@ check_pkg_size:
     - dogstatsd_deb-arm64
     - agent_rpm-arm64-a7
     - iot_agent_rpm-arm64
+  variables:
+    GIT_DEPTH: 0  # Full history: package.check-size uses git merge-base
   script:
     - dda inv -- package.check-size

--- a/.gitlab/build/source_test/ebpf.yml
+++ b/.gitlab/build/source_test/ebpf.yml
@@ -102,6 +102,7 @@ prepare_sysprobe_ebpf_functional_tests_x64:
     KUBERNETES_CPU_REQUEST: 4
     KUBERNETES_MEMORY_REQUEST: "12Gi"
     KUBERNETES_MEMORY_LIMIT: "12Gi"
+    GIT_DEPTH: 0  # Full history: kmt.prepare embeds git merge-base in the testsuite binary
   artifacts:
     when: always
     paths:

--- a/.gitlab/build/source_test/golang_deps_diff.yml
+++ b/.gitlab/build/source_test/golang_deps_diff.yml
@@ -12,6 +12,7 @@ golang_deps_diff:
   needs: ["go_deps"]
   variables:
     KUBERNETES_CPU_REQUEST: 8
+    GIT_DEPTH: 0  # Full history: go-deps.diff uses git merge-base
     GIT_STRATEGY: "clone" # needed because this job uses `git merge-base`
     KUBERNETES_MEMORY_REQUEST: "16Gi"
     KUBERNETES_MEMORY_LIMIT: "16Gi"

--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -197,6 +197,7 @@ new-e2e-unit-tests:
     KUBERNETES_MEMORY_REQUEST: 12Gi
     KUBERNETES_MEMORY_LIMIT: 16Gi
     KUBERNETES_CPU_REQUEST: 6
+    GIT_DEPTH: 1  # Overrides .linux_tests: this job does not use --only-impacted-packages or coverage cache
   timeout: 20m  # Not less than 20m because job startup can take time.
 
 tests_gpu:

--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -18,6 +18,7 @@
     - !reference [.fast_on_dev_branch_only]
   variables:
     FLAVORS: '--flavor base'
+    GIT_DEPTH: 0  # Full history: --only-impacted-packages and coverage cache use merge-base
     KUBERNETES_CPU_REQUEST: 16
     KUBERNETES_MEMORY_REQUEST: 32Gi
     KUBERNETES_MEMORY_LIMIT: 32Gi

--- a/.gitlab/build/source_test/macos.yml
+++ b/.gitlab/build/source_test/macos.yml
@@ -10,6 +10,7 @@
   variables:
     FLAKY_PATTERNS_CONFIG: $CI_PROJECT_DIR/flaky-patterns-runtime.yaml
     TEST_OUTPUT_FILE: test_output
+    GIT_DEPTH: 0  # Full history: --only-impacted-packages and coverage cache use merge-base
   script:
     - dda inv -- -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH
     - FAST_TESTS_FLAG=""

--- a/.gitlab/childs/smp-regression-child-pipeline.yml
+++ b/.gitlab/childs/smp-regression-child-pipeline.yml
@@ -16,6 +16,7 @@ stages:
 
 variables:
   SMP_ALLOW_FAILURE: "true"
+  GIT_DEPTH: 1
 
 .smp_config_only_job_submit:
   - |

--- a/.gitlab/deploy/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
+++ b/.gitlab/deploy/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
@@ -47,6 +47,8 @@ notify-slack:
   tags: ["arch:arm64", "specific:true"]
   needs: ["internal_kubernetes_deploy_experimental"]
   allow_failure: true
+  variables:
+    GIT_DEPTH: 0  # Full history: pipeline.changelog walks git log between commits
   script:
     - export SDM_JWT=$(vault read -field=token identity/oidc/token/sdm)
     - dda self dep sync -f legacy-tasks -f legacy-notifications

--- a/.gitlab/test/benchmarks/benchmarks.yml
+++ b/.gitlab/test/benchmarks/benchmarks.yml
@@ -7,10 +7,13 @@ benchmark:
   interruptible: true
   needs: ["setup_agent_version"]
   tags: ["team:apm-k8s-tweaked-metal-datadog-agent", "specific:true"]
+  variables:
+    GIT_DEPTH: 0  # Full history: run-benchmarks.sh / analyze-results.sh check out BASE_BRANCH
   script:
     - export ARTIFACTS_DIR="$(pwd)/artifacts" && mkdir -p $ARTIFACTS_DIR
     - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX#*-}"
     - export BASE_BRANCH="$(cat release.json | jq ".base_branch" | tr -d '"')"
+    - git fetch origin "$BASE_BRANCH"
     - export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
     - pip install "git+https://github.com/DataDog/datadog-agent-dev.git@${DDA_VERSION}"
     - dda self dep sync -f legacy-tasks

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -65,6 +65,7 @@
     - export WINDOWS_DDNPM_DRIVER=${WINDOWS_DDNPM_DRIVER:-$(dda inv release.get-release-json-value "dependencies::WINDOWS_DDNPM_DRIVER" --no-worktree)}
     - export WINDOWS_DDPROCMON_DRIVER=${WINDOWS_DDPROCMON_DRIVER:-$(dda inv release.get-release-json-value "dependencies::WINDOWS_DDPROCMON_DRIVER" --no-worktree)}
   variables:
+    GIT_DEPTH: 0  # Full history: --impacted tests use git merge-base
     GIT_STRATEGY: "clone" # Needed because we use git merge-base
     DYNAMIC_TESTS_FLAG: "--impacted"
     SHOULD_RUN_IN_FLAKES_FINDER: "true"

--- a/.gitlab/test/e2e_install_packages/common.yml
+++ b/.gitlab/test/e2e_install_packages/common.yml
@@ -37,6 +37,7 @@
     TEAM: agent-delivery
     EXTRA_PARAMS: --flavor $FLAVOR --osdescriptors $E2E_DESCRIPTORS --run TestUpgradeScript
     E2E_LOGS_PROCESSING_TEST_DEPTH: 2 # We use a single test suite and run all the platforms test as subtest
+    GIT_DEPTH: 1  # Overrides .new_e2e_template: this job does not pass --impacted
   parallel:
     matrix:
       - START_MAJOR_VERSION: [5, 6, 7]
@@ -52,6 +53,7 @@
     TEAM: agent-delivery
     EXTRA_PARAMS: --flavor $FLAVOR --osdescriptors $E2E_DESCRIPTORS --run TestPersistingIntegrations
     E2E_LOGS_PROCESSING_TEST_DEPTH: 2 # We use a single test suite and run all the platforms test as subtest
+    GIT_DEPTH: 1  # Overrides .new_e2e_template: this job does not pass --impacted
   script:
     - DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $INSTALL_SCRIPT_API_KEY_ORG2 token) || exit $?; export DATADOG_AGENT_API_KEY
     - dda inv -- -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_ID}.tgz" ${EXTRA_PARAMS} --src-agent-version 7 --test-washer
@@ -63,6 +65,7 @@
     TEAM: agent-delivery
     EXTRA_PARAMS: --osdescriptors $E2E_DESCRIPTORS --run TestRpmScript
     E2E_LOGS_PROCESSING_TEST_DEPTH: 2 # We use a single test suite and run all the platforms test as subtest
+    GIT_DEPTH: 1  # Overrides .new_e2e_template: this job does not pass --impacted
   script:
     - DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $INSTALL_SCRIPT_API_KEY_ORG2 token) || exit $?; export DATADOG_AGENT_API_KEY
     - dda inv -- -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_ID}.tgz" ${EXTRA_PARAMS} --test-washer

--- a/.gitlab/test/functional_test/files_inventory_check.yml
+++ b/.gitlab/test/functional_test/files_inventory_check.yml
@@ -9,7 +9,7 @@ files_inventory_check:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   variables:
-    GIT_DEPTH: 0
+    GIT_DEPTH: 0  # Full history: files-inventory.check uses git merge-base
     GIT_STRATEGY: clone
   needs:
     - agent_deb-x64-a7

--- a/.gitlab/test/functional_test/regression_detector.yml
+++ b/.gitlab/test/functional_test/regression_detector.yml
@@ -20,7 +20,7 @@ single_machine_performance-regression_detector-merge_base_check:
     reports:
       dotenv: regression_detector.env  # Expose BASELINE_SHA as a CI variable for the trigger job
   variables:
-    GIT_DEPTH: 0  # Ensure we can fetch full history for merge-base calculation
+    GIT_DEPTH: 0  # Full history: merge-base, HEAD^, and ancestor walks
   script:
     # `datadog-ci` relies on `DATADOG_API_KEY` so we get that here.
     - DATADOG_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_API_KEY_ORG2" token)" || exit $?; export DATADOG_API_KEY

--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -83,7 +83,7 @@ static_quality_gates:
       - static_gate_report.json
     expire_in: 1 week
   variables:
-    GIT_DEPTH: 0
+    GIT_DEPTH: 0  # Full history: quality-gates.parse-and-trigger-gates uses git merge-base
     GIT_STRATEGY: "clone" # needed because this job uses git merge-base
     KUBERNETES_CPU_REQUEST: 8
 

--- a/.gitlab/test/kernel_matrix_testing/common.yml
+++ b/.gitlab/test/kernel_matrix_testing/common.yml
@@ -330,6 +330,8 @@
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   timeout: 15m
+  variables:
+    GIT_DEPTH: 0  # Full history: ebpf.generate-complexity-summary-for-pr uses merge-base
   needs:
     # We need to specify the jobs that generate complexity explicitly, else we hit the limit of "needs"
     # Important: the list of platforms should match the one in .define_if_collect_complexity

--- a/.gitlab/windows/build/source_test/windows.yml
+++ b/.gitlab/windows/build/source_test/windows.yml
@@ -58,6 +58,7 @@
     - If ($lastExitCode -ne "0") { exit "$lastExitCode" }
   variables:
     TEST_OUTPUT_FILE: "test_output"
+    GIT_DEPTH: 0  # Full history: --only-impacted-packages and coverage cache use merge-base
   artifacts:
     expire_in: 2 weeks
     when: always
@@ -111,6 +112,8 @@ tests_windows-x64:
   stage: source_test
   needs: ["go_deps", "go_tools_deps"]
   extends: [.windows_docker_default, .bazel:defs:cache:windows]
+  variables:
+    GIT_DEPTH: 0  # Full history: security-agent.e2e-prepare-win embeds git merge-base
   script:
     - $ErrorActionPreference = "Stop"
     - !reference [.sanitize_goproxy_windows]


### PR DESCRIPTION
## Summary
- Default GitLab jobs to `GIT_DEPTH: 1` so most checkouts are a shallow clone of HEAD only.
- Set `GIT_DEPTH: 0` on jobs that actually need git history (merge-base, ancestor walks, `git describe`, `git log` ranges).
- `GIT_STRATEGY: clone` is not a full clone; clone with depth 1 is still shallow. Full history requires `GIT_DEPTH: 0`.

## Test plan
- [ ] Confirm a typical build/lint job clones with depth 1 and still has the working tree.
- [ ] Confirm jobs that compute merge-base still succeed (`golang_deps_diff`, e2e `--impacted`, `static_quality_gates`, `files_inventory_check`, SMP merge-base check).
- [ ] Confirm `setup_agent_version` can still run `git describe --tags`.
- [ ] Confirm unit-test jobs with `FAST_TESTS=true` still detect impacted packages.


Made with [Cursor](https://cursor.com)