### PR TITLE
perf: move #54639's `proto.Client` clone from `seen` to `activeClients`

### DIFF
--- a/pkg/config/remote/service/clients.go
+++ b/pkg/config/remote/service/clients.go
@@ -77,15 +77,9 @@ func (c *clients) seen(pbClient *pbgo.Client) {
 	defer c.m.Unlock()
 	now := c.clock.Now().UTC()
 	pbClient.LastSeen = uint64(now.UnixMilli())
-	// Store a copy: the caller may keep mutating pbClient after this returns.
-	pbCopy, ok := proto.Clone(pbClient).(*pbgo.Client)
-	if !ok {
-		// Unreachable: proto.Clone always returns the same concrete type.
-		pbCopy = pbClient
-	}
 	c.clients[pbClient.Id] = &client{
 		lastSeen: now,
-		pbClient: pbCopy,
+		pbClient: pbClient,
 	}
 }
 
@@ -110,7 +104,13 @@ func (c *clients) activeClients() []*pbgo.Client {
 			delete(c.clients, id)
 			continue
 		}
-		activeClients = append(activeClients, client.pbClient)
+		// Return a copy: seen() may keep mutating client.pbClient after this returns.
+		pbCopy, ok := proto.Clone(client.pbClient).(*pbgo.Client)
+		if !ok {
+			// Unreachable: proto.Clone always returns the same concrete type.
+			pbCopy = client.pbClient
+		}
+		activeClients = append(activeClients, pbCopy)
 	}
 	return activeClients
 }


### PR DESCRIPTION
### What does this PR do?
Move the `proto.Clone()` call that guards `pbgo.Client` aliasing from `clients.seen()` to `clients.activeClients()`.

### Motivation
Follow-up to #54639, discussed with its author beforehand.

`seen()` runs on every `ClientGetConfigs` poll from every client, up to twice per request via the bypass path, while `activeClients()` runs once per `refresh()` cycle regardless of client count.

Cloning in `seen()` therefore pays one allocation per poll instead of one per client per refresh cycle, and the gap widens with client count.

A micro-benchmark with 200 clients showed 29% fewer allocations at 2 polls per client per refresh cycle, and 50% fewer at 5 polls per client.

The only regime where the opposite holds is `activeClients()` being called more often than clients poll, which only `ConfigGetState` does, and that is a debug endpoint, not a hot path.

### Describe how you validated your changes
`TestClientsSeenActiveClientsRace` and the rest of the package's test suite pass unchanged under `-race`: the invariant it guards, that whatever escapes the lock is never mutated again, holds regardless of where the clone happens.