### PR TITLE
Remove bazel strptime_cgo_testlib override

### DIFF
--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -56,16 +56,6 @@ go_deps.gazelle_override(
     build_extra_args = ["-build_tags=trivy_no_javadb"],
     path = "github.com/aquasecurity/trivy",
 )
-go_deps.gazelle_override(
-    # strptime_cgo_testlib.go uses tm_gmtoff (GNU extension, absent in
-    # musl libc). Exclude the CGo test-helper files so Gazelle does not
-    # include them in the generated go_library BUILD rules.
-    build_extra_args = [
-        "-exclude=timeutils/strptime_cgo_testlib.go",
-        "-exclude=timeutils/strptime_cgo_test.go",
-    ],
-    path = "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal",
-)
 use_repo(
     go_deps,
     "cat_dario_mergo",


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Remove bazel strptime_cgo_testlib override.

### Motivation
Fixed by https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49516.

### Describe how you validated your changes
CI

### Additional Notes
