### PR TITLE
[AGENTRUN-1446] Skip nss failover e2e test it if the fakeintakes are still in use

### DIFF
--- a/test/new-e2e/tests/agent-runtimes/BUILD.bazel
+++ b/test/new-e2e/tests/agent-runtimes/BUILD.bazel
@@ -92,6 +92,7 @@ dd_agent_go_test(
         "//test/fakeintake/client",
         "//test/new-e2e/tests/agent-platform/common",
         "//test/new-e2e/tests/agent-platform/common/svc-manager",
+        "@com_github_cenkalti_backoff_v7//:backoff",
         "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/test/new-e2e/tests/agent-runtimes/forwarder_nss_failover_test.go
+++ b/test/new-e2e/tests/agent-runtimes/forwarder_nss_failover_test.go
@@ -8,6 +8,7 @@ package agentruntimes
 import (
 	"bytes"
 	_ "embed"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -18,6 +19,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/cenkalti/backoff/v7"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -172,23 +174,39 @@ func (v *multiFakeIntakeSuite) BeforeTest(suiteName, testName string) {
 	v.BaseSuite.BeforeTest(suiteName, testName)
 
 	maxWaitTime := 10 * time.Minute
+	stillUsedErr := errors.New("fakeintake is still in use")
 
-	checkNotUsed := func(intake *fi.Client) {
-		require.EventuallyWithT(v.T(), func(t *assert.CollectT) {
-			intake.FlushServerAndResetAggregators()
+	skipTestIfUsed := func(intake *fi.Client) {
+		_, err := backoff.Retry(v.T().Context(), func() (any, error) {
+			if err := intake.FlushServerAndResetAggregators(); err != nil {
+				return nil, err
+			}
 
 			// give time to the agent to flush to the intake
 			time.Sleep(intakeUnusedWaitTime)
 
 			stats, err := intake.RouteStats()
-			require.NoError(t, err)
-			assert.Empty(t, stats)
+			if err != nil {
+				return nil, err
+			}
 
-		}, maxWaitTime, intakeTick)
+			if len(stats) == 0 {
+				return nil, nil
+			}
+
+			v.T().Logf("fakeintake %s is still in use: %+v", intake.URL(), stats)
+			return nil, stillUsedErr
+		}, backoff.WithMaxElapsedTime(maxWaitTime), backoff.WithBackOff(backoff.NewConstantBackOff(intakeTick)))
+
+		if errors.Is(err, stillUsedErr) {
+			v.T().Skipf("fakeintake %s is still in use", intake.URL())
+		}
+
+		require.NoError(v.T(), err)
 	}
 
-	checkNotUsed(v.Env().Fakeintake1.Client())
-	checkNotUsed(v.Env().Fakeintake2.Client())
+	skipTestIfUsed(v.Env().Fakeintake1.Client())
+	skipTestIfUsed(v.Env().Fakeintake2.Client())
 }
 
 // TestNSSFailover tests that the agent correctly picks-up an NSS change of the intake.


### PR DESCRIPTION


<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Due to a framework issue, the fakeintakes might still be in use (ie. an agent is still sending payloads to them) when the test starts, which makes the test flaky.
We added a detection logic to fail early in this case (to avoid confusion when debugging).
Update the logic to skip the test rather than fail it in this case.

### Motivation
Avoid receiving notifications for failed test for a framework issue.

### Describe how you validated your changes
CI

### Additional Notes
