### PR TITLE
[DSEC] Move dd-sds dependency to shared workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ rust-version = "1.91"
 [workspace.dependencies]
 anyhow = "1.0.98"
 cap-std = "4.0"
+# Keep only the `dd-sds` feature and disable default features so we pull in just
+# the necessary dependencies and avoid shipping the third-party checkers.
+dd_sds = { package = "dd-sensitive-data-scanner", version = "=0.1.0-20260803-1e4349aada52", default-features = false, features = ["dd-sds"] }
 caps = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }

--- a/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/Cargo.toml
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/Cargo.toml
@@ -17,9 +17,7 @@ engine-postgres = [
 [dependencies]
 anyhow.workspace = true
 shlib_core = { path = "../../core" }
-# Keep only the `dd-sds` feature and disable default features so we pull in just
-# the necessary dependencies and avoid shipping the third-party checkers.
-dd_sds = { package = "dd-sensitive-data-scanner", version = "=0.1.0-20260803-1e4349aada52", default-features = false, features = ["dd-sds"] }
+dd_sds.workspace = true
 libc.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
### What does this PR do?

Moves the `dd-sds` (`dd-sensitive-data-scanner`) dependency from the `datasecurity` check crate into the shared `[workspace.dependencies]` in the root `Cargo.toml`. The crate now references it via `dd_sds.workspace = true`.

### Motivation

Centralize the pinned version and feature set so future check crates share a single source of truth instead of duplicating the spec.

### Tests

Use docker image registry.ddbuild.io/ci/datadog-agent/agent:v130685756-40c89d95-7-amd64 generated in the CI and confirmed that data security check is correctly running.

```bash
dsec-perf-agent-dsec  | 2026-08-13 12:20:42 UTC | CORE | INFO | (pkg/collector/aggregator/aggregator.go:182 in LogMsg) | datasecurity: sub task succeeded (1 match(es))
dsec-perf-agent-dsec  | 2026-08-13 12:20:42 UTC | CORE | INFO | (pkg/collector/aggregator/aggregator.go:182 in LogMsg) | datasecurity: running sub task (sub_task_id=455ECD24-5C11-45AA-801B-5C2C43C8533C, platform=postgres)
dsec-perf-agent-dsec  | 2026-08-13 12:20:42 UTC | CORE | INFO | (comp/core/agenttelemetry/impl/agenttelemetry.go:665 in run) | Starting agent telemetry run
dsec-perf-agent-dsec  | 2026-08-13 12:20:42 UTC | CORE | INFO | (pkg/collector/aggregator/aggregator.go:182 in LogMsg) | datasecurity: sub task succeeded (1 match(es))
dsec-perf-agent-dsec  | 2026-08-13 12:20:42 UTC | CORE | INFO | (pkg/collector/aggregator/aggregator.go:182 in LogMsg) | datasecurity: check completed
dsec-perf-agent-dsec  | 2026-08-13 12:20:42 UTC | CORE | INFO | (pkg/collector/worker/check_logger.go:59 in CheckFinished) | check:datasecurity | Done running check
dsec-perf-agent-dsec  | 2026-08-13 12:20:42 UTC | CORE | INFO | (pkg/collector/worker/check_logger.go:65 in CheckFinished) | check:datasecurity | Check's one time execution has finished
``` 
