### PR TITLE
[EBPF] gpu: serialize NVML field value queries

### DIFF
--- a/pkg/gpu/safenvml/device_impl.go
+++ b/pkg/gpu/safenvml/device_impl.go
@@ -106,12 +106,13 @@ func (d *safeDeviceImpl) GetFanSpeed_v2(fanIndex int) (uint32, error) {
 }
 
 func (d *safeDeviceImpl) GetFieldValues(values []nvml.FieldValue) error {
-	d.lib.fieldValuesLock()
-	defer d.lib.fieldValuesUnlock()
-
 	if err := d.lib.lookup(toNativeName("GetFieldValues")); err != nil {
 		return err
 	}
+
+	d.lib.fieldValuesLock()
+	defer d.lib.fieldValuesUnlock()
+
 	ret := d.nvmlDevice.GetFieldValues(values)
 	return NewNvmlAPIErrorOrNil("GetFieldValues", ret)
 }

--- a/pkg/gpu/safenvml/device_impl.go
+++ b/pkg/gpu/safenvml/device_impl.go
@@ -106,6 +106,9 @@ func (d *safeDeviceImpl) GetFanSpeed_v2(fanIndex int) (uint32, error) {
 }
 
 func (d *safeDeviceImpl) GetFieldValues(values []nvml.FieldValue) error {
+	d.lib.fieldValuesLock()
+	defer d.lib.fieldValuesUnlock()
+
 	if err := d.lib.lookup(toNativeName("GetFieldValues")); err != nil {
 		return err
 	}

--- a/pkg/gpu/safenvml/lib.go
+++ b/pkg/gpu/safenvml/lib.go
@@ -119,6 +119,13 @@ type nvmlSafety interface {
 	// gpmUnlock unlocks the GPM mutex. Despite NVIDIA documentation, the GPM API is not thread safe.
 	// We need to unlock the mutex to allow other threads to access the GPM API.
 	gpmUnlock()
+
+	// fieldValuesLock locks the field values mutex. Similarly to GPM, the field values API is not thread safe
+	// despite docs saying that NVML is thread safe.
+	fieldValuesLock()
+	// fieldValuesUnlock unlocks the field values mutex. Similarly to GPM, the field values API is not thread safe
+	// despite docs saying that NVML is thread safe.
+	fieldValuesUnlock()
 }
 
 // SafeNVML represents a safe wrapper around NVML library operations.
@@ -149,10 +156,11 @@ type SafeNVML interface {
 }
 
 type safeNvml struct {
-	lib          nvml.Interface
-	mu           sync.Mutex
-	gpmMutex     sync.Mutex
-	capabilities map[string]struct{}
+	lib              nvml.Interface
+	mu               sync.Mutex
+	gpmMutex         sync.Mutex
+	fieldValuesMutex sync.Mutex
+	capabilities     map[string]struct{}
 }
 
 func toNativeName(symbol string) string {
@@ -173,6 +181,14 @@ func (s *safeNvml) gpmLock() {
 
 func (s *safeNvml) gpmUnlock() {
 	s.gpmMutex.Unlock()
+}
+
+func (s *safeNvml) fieldValuesLock() {
+	s.fieldValuesMutex.Lock()
+}
+
+func (s *safeNvml) fieldValuesUnlock() {
+	s.fieldValuesMutex.Unlock()
 }
 
 // SystemGetDriverVersion returns the Nvidia driver version

--- a/releasenotes/notes/gpu-serialize-field-values-3ada93da5080b0fa.yaml
+++ b/releasenotes/notes/gpu-serialize-field-values-3ada93da5080b0fa.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    gpu: fix concurrent calls to NVML GetFieldValues API, that could cause missing NVLink metrics.


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Ensures that calls to `GetFieldValues` are serialized as that is not a thread safe  API.

### Motivation

#incident-59170 - `nvlink_fields` collector might mark some ports as unsupported. This is an extra safety on top of #54817, in case parallel collection is enabled. 

### Describe how you validated your changes

Tested in an A100 instance.

### Additional Notes
