### PR TITLE
[AAD-37] Optimize total series count

### DIFF
--- a/comp/anomalydetection/observer/impl/baseline_test.go
+++ b/comp/anomalydetection/observer/impl/baseline_test.go
@@ -282,7 +282,7 @@ func TestBaseline_FastCompletionRemovesSeriesFromSlowerDetector(t *testing.T) {
 	e.Advance(100) // both detectors are analysing and nominate cpu for muting
 	e.Advance(200) // fast completes, immediately reclaiming cpu everywhere
 
-	assert.Zero(t, storage.TotalSeriesCount(""))
+	assert.Zero(t, storage.TotalSeriesCount())
 	assert.Equal(t, []observerdef.SeriesRef{ref}, fast.removed)
 	assert.Equal(t, []observerdef.SeriesRef{ref}, slow.removed)
 	assert.True(t, e.baseline.detectors["fast"].completed)
@@ -452,14 +452,14 @@ func TestBaseline_VirtualMetricDroppedAfterFreeze(t *testing.T) {
 	e.Advance(100)
 
 	// During the window: subsequent ingests must still reach storage.
-	countBefore := storage.TotalSeriesCount("")
+	countBefore := storage.TotalSeriesCount()
 	e.IngestLog("src", &logObs{timestampMs: 200_000})
-	assert.Equal(t, countBefore, storage.TotalSeriesCount(""))
+	assert.Equal(t, countBefore, storage.TotalSeriesCount())
 
 	e.Advance(700) // freeze: series removed from storage
-	assert.Equal(t, 0, storage.TotalSeriesCount(""))
+	assert.Equal(t, 0, storage.TotalSeriesCount())
 
 	// After freeze: virtual metric is dropped at ingest and not re-created.
 	e.IngestLog("src", &logObs{timestampMs: 800_000})
-	assert.Equal(t, 0, storage.TotalSeriesCount(""))
+	assert.Equal(t, 0, storage.TotalSeriesCount())
 }

--- a/comp/anomalydetection/observer/impl/debug.go
+++ b/comp/anomalydetection/observer/impl/debug.go
@@ -92,8 +92,8 @@ type StateView interface {
 	LatestDataTime() int64
 	MaxTimestamp() int64
 
-	// Storage stats (excluding a given namespace, typically TelemetryNamespace)
-	TotalSeriesCount(excludeNamespace string) int
+	// Storage stats
+	TotalSeriesCount() int
 	TotalSampleCount(excludeNamespace string) int64
 
 	// GetSeriesAll returns all points for a series.

--- a/comp/anomalydetection/observer/impl/engine.go
+++ b/comp/anomalydetection/observer/impl/engine.go
@@ -855,7 +855,7 @@ func (e *engine) completeBaseline(detectorName string, upToSec int64) {
 		e.baseline.recordMutedNames(displayNames)
 	}
 
-	totalSeries := e.storage.TotalSeriesCount("")
+	totalSeries := e.storage.TotalSeriesCount()
 
 	// Emit before removal so testbench sinks can read metadata. The controller
 	// uses copy-on-write snapshots, so this immutable union can be published to

--- a/comp/anomalydetection/observer/impl/log_count_bucketizer_test.go
+++ b/comp/anomalydetection/observer/impl/log_count_bucketizer_test.go
@@ -199,7 +199,7 @@ func TestEngineCapacityEvictionDropsIdleBucketizerState(t *testing.T) {
 	assert.Nil(t, storage.GetSeries(
 		"fixed_log_count", "log.fixed.count", logTags, observerdef.AggregateAverage,
 	))
-	assert.Equal(t, 1, storage.TotalSeriesCount(""))
+	assert.Equal(t, 1, storage.TotalSeriesCount())
 }
 
 func TestLogCountBucketConfigFromAgent(t *testing.T) {

--- a/comp/anomalydetection/observer/impl/log_pattern_extractor_test.go
+++ b/comp/anomalydetection/observer/impl/log_pattern_extractor_test.go
@@ -437,7 +437,7 @@ func TestEngine_LogPatternLRUEvictionFreesStorage(t *testing.T) {
 	// seen leaves a series behind). With it, the LRU eviction during the 3rd
 	// ingest removes cluster #1 from storage before cluster #3's series is
 	// added, so count is 2.
-	require.Equal(t, 2, storage.TotalSeriesCount(""),
+	require.Equal(t, 2, storage.TotalSeriesCount(),
 		"LRU eviction must shrink storage; before the fix storage grew unboundedly")
 
 	// Surviving series must have context stored on them.
@@ -526,7 +526,7 @@ func TestEngine_LogPatternLRUEvictionFreesDetectorState(t *testing.T) {
 	// Storage shrunk to two series (LRU cap), so detector maps must now
 	// have at most two entries per agg too. Without the fan-out, they
 	// would still hold three entries (one per series ever observed).
-	require.Equal(t, 2, storage.TotalSeriesCount(""), "LRU should keep storage bounded")
+	require.Equal(t, 2, storage.TotalSeriesCount(), "LRU should keep storage bounded")
 
 	// Each detector defaults to 2 aggregations (Average, Count). Before the
 	// fan-out fix, the maps held 3 series × 2 aggs = 6 entries even though

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -507,11 +507,20 @@ func (o *observerImpl) run() {
 		for _, req := range requests {
 			_ = o.engine.advanceWithReason(req.upToSec, req.reason)
 		}
-		if o.telemetry != nil {
-			o.telemetry.setSeriesCount(o.engine.Storage().TotalSeriesCount(observerdef.TelemetryNamespace))
+		if len(requests) > 0 {
+			o.publishSeriesCount()
 		}
 		o.replayMu.Unlock()
 	}
+}
+
+// publishSeriesCount updates the series-count gauge after an analysis advance,
+// when any storage capacity eviction triggered by that advance has completed.
+func (o *observerImpl) publishSeriesCount() {
+	if o.telemetry == nil {
+		return
+	}
+	o.telemetry.setSeriesCount(o.engine.Storage().TotalSeriesCount())
 }
 
 // defaultDetectorWindowSec is the default window (in seconds) that limits how
@@ -814,6 +823,7 @@ func (o *observerImpl) Reset(settings ComponentSettings, storageCfg StorageConfi
 	o.replayMu.Lock()
 	o.metricFilter.muted.Store(nil)
 	o.engine.ResetForReplay(detectors, correlators, scorer, extractors, storageCfg, settings.Baseline)
+	o.publishSeriesCount()
 	o.replayMu.Unlock()
 }
 
@@ -935,6 +945,7 @@ func (o *observerImpl) ReplayStoredData() {
 	o.replayMu.Lock()
 	o.engine.resetAnalysisState()
 	o.engine.ReplayStoredData()
+	o.publishSeriesCount()
 	o.replayMu.Unlock()
 }
 
@@ -958,7 +969,6 @@ func (o *observerImpl) IngestLogForReplay(source string, msg observerdef.LogView
 	o.engine.storage.RecordObservationTime(lo.timestampMs / 1000)
 	if o.telemetry != nil {
 		o.telemetry.recordLogIngested(classifyLogSource(source, lo.tags), len(lo.content))
-		o.telemetry.setSeriesCount(o.engine.Storage().TotalSeriesCount(observerdef.TelemetryNamespace))
 	}
 	o.replayMu.Unlock()
 }
@@ -976,7 +986,9 @@ func (o *observerImpl) IngestLogAndAdvance(source string, msg observerdef.LogVie
 	o.engine.replayAnomalies.Store(int64(o.engine.TotalAnomalyCount()))
 	if o.telemetry != nil {
 		o.telemetry.recordLogIngested(classifyLogSource(source, lo.tags), len(lo.content))
-		o.telemetry.setSeriesCount(o.engine.Storage().TotalSeriesCount(observerdef.TelemetryNamespace))
+	}
+	if len(requests) > 0 {
+		o.publishSeriesCount()
 	}
 	o.replayMu.Unlock()
 }
@@ -986,6 +998,7 @@ func (o *observerImpl) IngestLogAndAdvance(source string, msg observerdef.LogVie
 func (o *observerImpl) FinishReplayStream() {
 	o.replayMu.Lock()
 	o.engine.FinishReplayStream()
+	o.publishSeriesCount()
 	o.replayMu.Unlock()
 }
 
@@ -1054,8 +1067,8 @@ func (o *observerImpl) IngestMetricSync(source string, sample observerdef.Metric
 		o.engine.replayAdvances.Add(1)
 	}
 	o.engine.replayAnomalies.Store(int64(o.engine.TotalAnomalyCount()))
-	if o.telemetry != nil {
-		o.telemetry.setSeriesCount(o.engine.Storage().TotalSeriesCount(observerdef.TelemetryNamespace))
+	if len(requests) > 0 {
+		o.publishSeriesCount()
 	}
 	o.replayMu.Unlock()
 }

--- a/comp/anomalydetection/observer/impl/observer_test.go
+++ b/comp/anomalydetection/observer/impl/observer_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/anomalydetection/observer/def"
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
+	telemetryimpl "github.com/DataDog/datadog-agent/comp/core/telemetry/impl"
+	"github.com/stretchr/testify/require"
 )
 
 func TestObserverResetActivatesScorerCorrelationWatcher(t *testing.T) {
@@ -98,6 +101,74 @@ func TestSeriesDetectorAdapter_ResetClearsVisibleCountCache(t *testing.T) {
 	if len(afterReset.Anomalies) != 1 {
 		t.Fatalf("expected 1 anomaly after reset, got %d", len(afterReset.Anomalies))
 	}
+}
+
+func TestObserverPublishesSeriesCountOnAdvanceAndReplayBoundaries(t *testing.T) {
+	telComp := telemetryimpl.GetCompatComponent()
+	telComp.Reset()
+	t.Cleanup(telComp.Reset)
+
+	filter, err := newDefaultMetricsFilterRules()
+	require.NoError(t, err)
+	obs := &observerImpl{
+		engine:       newEngine(engineConfig{storage: newTimeSeriesStorage()}),
+		catalog:      defaultCatalog(),
+		obsCh:        make(chan observation, 4),
+		telemetry:    newObserverTelemetry(telComp),
+		metricFilter: filter,
+	}
+	done := make(chan struct{})
+	go func() {
+		obs.run()
+		close(done)
+	}()
+	t.Cleanup(func() {
+		close(obs.obsCh)
+		<-done
+	})
+
+	// The first observation creates a series but does not advance analysis.
+	obs.obsCh <- observation{source: "ns", metric: &metricObs{name: "requests", value: 1, timestamp: 0}}
+	obs.Flush()
+	requireSeriesCountTelemetry(t, telComp, 0)
+
+	// A later observation advances analysis and publishes the current count.
+	obs.obsCh <- observation{source: "ns", metric: &metricObs{name: "requests", value: 1, timestamp: 2}}
+	obs.Flush()
+	requireSeriesCountTelemetry(t, telComp, 1)
+
+	// Replacing storage during reset clears the gauge immediately.
+	obs.Reset(ComponentSettings{}, DefaultStorageConfig())
+	requireSeriesCountTelemetry(t, telComp, 0)
+
+	// Replay publishes once at its completion, not when data is preloaded.
+	obs.engine.storage.Add("ns", "replayed", 1, 10, nil)
+	requireSeriesCountTelemetry(t, telComp, 0)
+	obs.ReplayStoredData()
+	requireSeriesCountTelemetry(t, telComp, 1)
+
+	// The final stream flush publishes even when no advance is needed.
+	obs.engine.storage.RemoveSeriesByMetricName("ns", "replayed")
+	obs.FinishReplayStream()
+	requireSeriesCountTelemetry(t, telComp, 0)
+}
+
+func requireSeriesCountTelemetry(t *testing.T, telemetryComp telemetry.Component, want float64) {
+	t.Helper()
+	metricFamilies, err := telemetryComp.Gather(false)
+	require.NoError(t, err)
+	for _, family := range metricFamilies {
+		if family.GetName() != "observer__"+telemetrySeriesCount {
+			continue
+		}
+		require.Len(t, family.GetMetric(), 1)
+		require.Equal(t, want, family.GetMetric()[0].GetGauge().GetValue())
+		return
+	}
+	if want == 0 {
+		return
+	}
+	t.Fatalf("series-count telemetry gauge was not registered")
 }
 
 func TestBaselineCompletedCallbackSink_AccumulatesGroupsUntilAllBaselinesComplete(t *testing.T) {

--- a/comp/anomalydetection/observer/impl/stateview.go
+++ b/comp/anomalydetection/observer/impl/stateview.go
@@ -194,9 +194,9 @@ func (sv *stateView) LatestDataTime() int64 {
 	return sv.engine.latestDataTime
 }
 
-// TotalSeriesCount returns the number of unique metric series, excluding the given namespace.
-func (sv *stateView) TotalSeriesCount(excludeNamespace string) int {
-	return sv.engine.storage.TotalSeriesCount(excludeNamespace)
+// TotalSeriesCount returns the number of unique non-telemetry metric series.
+func (sv *stateView) TotalSeriesCount() int {
+	return sv.engine.storage.TotalSeriesCount()
 }
 
 // TotalSampleCount returns the total number of stored data points, excluding the given namespace.

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -86,6 +86,10 @@ type timeSeriesStorage struct {
 	// seriesIDStats[ref] is the live *seriesStats (nil when the slot is retired).
 	seriesIDStats []*seriesStats // numeric ID → *seriesStats (index = ID)
 
+	// liveSeriesCount is the number of non-telemetry series in the catalog.
+	// It is updated under mu whenever a non-telemetry series is added or removed.
+	liveSeriesCount int
+
 	// Global generation for the series catalog; increments only when a new
 	// series key is created, not on every write to an existing series.
 	seriesGen uint64
@@ -342,6 +346,9 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 			s.series[h] = stats
 		}
 		s.seriesIDStats = append(s.seriesIDStats, stats)
+		if namespace != observer.TelemetryNamespace {
+			s.liveSeriesCount++
+		}
 		s.seriesGen++
 	}
 	res := AddResult{IsNew: !exists, Ref: stats.ref}
@@ -1059,16 +1066,32 @@ func (s *timeSeriesStorage) RemoveSeriesByRefs(refs []observer.SeriesRef) []obse
 		if stats == nil {
 			continue
 		}
-		s.releaseTagIntern(stats.tagsHash)
-		h := seriesKeyHash(stats.Namespace, stats.Name, stats.Tags)
-		delete(s.series, h)
-		s.seriesIDStats[ref] = nil
-		removed = append(removed, ref)
+		if s.removeSeries(stats) {
+			removed = append(removed, ref)
+		}
 	}
 	if len(removed) > 0 {
 		s.seriesGen++
 	}
 	return removed
+}
+
+// removeSeries removes a live series from every catalog index and cardinality
+// counter. The caller must hold s.mu for writing.
+func (s *timeSeriesStorage) removeSeries(stats *seriesStats) bool {
+	if stats == nil || stats.ref < 0 || int(stats.ref) >= len(s.seriesIDStats) || s.seriesIDStats[stats.ref] != stats {
+		return false
+	}
+	s.releaseTagIntern(stats.tagsHash)
+	h := seriesKeyHash(stats.Namespace, stats.Name, stats.Tags)
+	if s.series[h] == stats {
+		delete(s.series, h)
+	}
+	s.seriesIDStats[stats.ref] = nil
+	if stats.Namespace != observer.TelemetryNamespace {
+		s.liveSeriesCount--
+	}
+	return true
 }
 
 // SetContext stores a MetricContext on the series identified by ref.
@@ -1157,11 +1180,9 @@ func (s *timeSeriesStorage) RemoveSeriesByMetricName(namespace, name string) []o
 		if stats == nil || stats.Namespace != namespace || stats.Name != name {
 			continue
 		}
-		s.releaseTagIntern(stats.tagsHash)
-		h := seriesKeyHash(stats.Namespace, stats.Name, stats.Tags)
-		delete(s.series, h)
-		s.seriesIDStats[stats.ref] = nil
-		removed = append(removed, stats.ref)
+		if s.removeSeries(stats) {
+			removed = append(removed, stats.ref)
+		}
 	}
 	if len(removed) > 0 {
 		s.seriesGen++
@@ -1180,13 +1201,8 @@ func (s *timeSeriesStorage) EvictToCapacity(seriesLimit, target int) []observer.
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Count first — common case is under the limit, skip allocation entirely.
-	count := 0
-	for _, st := range s.seriesIDStats {
-		if st != nil {
-			count++
-		}
-	}
+	// Common case is under the limit, skip allocation entirely.
+	count := s.liveSeriesCount
 	if count <= seriesLimit {
 		return nil
 	}
@@ -1218,13 +1234,9 @@ func (s *timeSeriesStorage) EvictToCapacity(seriesLimit, target int) []observer.
 		if st == nil {
 			continue
 		}
-		h := seriesKeyHash(st.Namespace, st.Name, st.Tags)
-		s.releaseTagIntern(st.tagsHash)
-		if s.series[h] == st {
-			delete(s.series, h)
+		if s.removeSeries(st) {
+			freed = append(freed, candidates[i].ref)
 		}
-		s.seriesIDStats[candidates[i].ref] = nil
-		freed = append(freed, candidates[i].ref)
 	}
 	if len(freed) > 0 {
 		s.seriesGen++
@@ -1361,22 +1373,12 @@ func (s *timeSeriesStorage) TotalSampleCount(excludeNamespace string) int64 {
 	return total
 }
 
-// TotalSeriesCount returns the number of unique series (name + tag combinations),
-// excluding series in excludeNamespace (pass "" to include all namespaces).
-func (s *timeSeriesStorage) TotalSeriesCount(excludeNamespace string) int {
+// TotalSeriesCount returns the number of unique non-telemetry series (name +
+// tag combinations).
+func (s *timeSeriesStorage) TotalSeriesCount() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	total := 0
-	for _, stats := range s.seriesIDStats {
-		if stats == nil {
-			continue
-		}
-		if excludeNamespace != "" && stats.Namespace == excludeNamespace {
-			continue
-		}
-		total++
-	}
-	return total
+	return s.liveSeriesCount
 }
 
 // PointCountUpTo returns the number of raw data points with timestamp <= endTime.

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -620,7 +620,7 @@ func TestTimeSeriesStorage_RemoveSeriesByRefs(t *testing.T) {
 	resA := s.Add("ns", "a", 1.0, 1000, []string{"k:1"})
 	resB := s.Add("ns", "b", 2.0, 1000, []string{"k:2"})
 	resC := s.Add("ns", "c", 3.0, 1000, []string{"k:3"})
-	require.Equal(t, 3, s.TotalSeriesCount(""))
+	require.Equal(t, 3, s.TotalSeriesCount())
 	genBefore := s.SeriesGeneration()
 
 	refA, refB, refC := resA.Ref, resB.Ref, resC.Ref
@@ -629,7 +629,7 @@ func TestTimeSeriesStorage_RemoveSeriesByRefs(t *testing.T) {
 	removed := s.RemoveSeriesByRefs([]observer.SeriesRef{refB, refC, -1})
 	require.Len(t, removed, 2, "out-of-range refs are silently ignored")
 	require.ElementsMatch(t, []observer.SeriesRef{refB, refC}, removed, "freed refs are returned for fan-out to detectors")
-	require.Equal(t, 1, s.TotalSeriesCount(""), "only series 'a' should remain")
+	require.Equal(t, 1, s.TotalSeriesCount(), "only series 'a' should remain")
 	require.Greater(t, s.SeriesGeneration(), genBefore, "seriesGen bumps on removal")
 
 	require.Nil(t, s.GetSeriesMeta(refB), "removed ref resolves to nil")
@@ -638,9 +638,50 @@ func TestTimeSeriesStorage_RemoveSeriesByRefs(t *testing.T) {
 
 	// A subsequent Add for the same series creates a fresh series with a new ref.
 	res2B := s.Add("ns", "b", 99.0, 1100, []string{"k:2"})
-	require.Equal(t, 2, s.TotalSeriesCount(""), "re-add re-creates the series")
+	require.Equal(t, 2, s.TotalSeriesCount(), "re-add re-creates the series")
 	require.NotEqual(t, refB, res2B.Ref, "new ref minted; old ref is retired")
 	require.Nil(t, s.GetSeriesMeta(refB), "old ref still resolves to nil after re-add")
+}
+
+func TestTimeSeriesStorage_TotalSeriesCountTracksCatalogMutations(t *testing.T) {
+	s := newTimeSeriesStorage()
+
+	first := s.Add("workload", "requests", 1, 1, nil)
+	s.Add("workload", "requests", 2, 2, nil) // existing series must not change counts
+	s.Add("workload", "errors", 1, 1, nil)
+	s.Add(observer.TelemetryNamespace, "internal", 1, 1, nil)
+	require.Equal(t, 2, s.TotalSeriesCount())
+	require.Equal(t, 2, s.TotalSeriesCount())
+
+	// Rejected values do not create a series.
+	s.Add("workload", "invalid", math.NaN(), 1, nil)
+	require.Equal(t, 2, s.TotalSeriesCount())
+
+	require.Equal(t, []observer.SeriesRef{first.Ref}, s.RemoveSeriesByRefs([]observer.SeriesRef{first.Ref}))
+	require.Equal(t, 1, s.TotalSeriesCount())
+	require.Equal(t, 1, s.TotalSeriesCount())
+
+	removed := s.RemoveSeriesByMetricName("workload", "errors")
+	require.Len(t, removed, 1)
+	require.Zero(t, s.TotalSeriesCount())
+	require.Zero(t, s.TotalSeriesCount())
+
+	// Re-adding a removed key creates a fresh live series and restores its count.
+	s.Add("workload", "requests", 3, 3, nil)
+	require.Equal(t, 1, s.TotalSeriesCount())
+	require.Equal(t, 1, s.TotalSeriesCount())
+}
+
+func TestTimeSeriesStorage_TotalSeriesCountTracksCapacityEviction(t *testing.T) {
+	s := newTimeSeriesStorage()
+	s.Add("workload", "old", 1, 1, nil)
+	s.Add("workload", "middle", 1, 2, nil)
+	s.Add("workload", "new", 1, 3, nil)
+
+	freed := s.EvictToCapacity(2, 1)
+	require.Len(t, freed, 2)
+	require.Equal(t, 1, s.TotalSeriesCount())
+	require.Equal(t, 1, s.TotalSeriesCount())
 }
 
 func TestTimeSeriesStorage_FindRefsByHashes(t *testing.T) {

--- a/internal/qbranch/anomalydetection-testbench/bench/bench.go
+++ b/internal/qbranch/anomalydetection-testbench/bench/bench.go
@@ -774,7 +774,7 @@ func (tb *Bench) GetStatus() StatusResponse {
 	return StatusResponse{
 		Ready:                 tb.ready,
 		Scenario:              tb.loadedScenario,
-		SeriesCount:           sv.TotalSeriesCount(observerdef.TelemetryNamespace),
+		SeriesCount:           sv.TotalSeriesCount(),
 		AnomalyCount:          sv.TotalAnomalyCount(),
 		LogAnomalyCount:       len(tb.logAnomalies),
 		ComponentCount:        componentCount,


### PR DESCRIPTION
### What does this PR do?

`TotalSeriesCount` was taking a lot of CPU time (and mostly for telemetry), removed overhead by O(1) CPU / memory.

This removes 36.8% of CPU on the staging cluster I tested, quick win!

### Motivation

### Describe how you validated your changes

[Profile](https://ddstaging.datadoghq.com/profiling/comparison?query=service%3Adatadog-agent%20kube_cluster_name%3Astingchameleon&compare_end_A=1786621749000&compare_end_B=1786626605000&compare_start_A=1786620495000&compare_start_B=1786625998000&compareValuesMode=absolute&my_code=enabled&profiling-flame-graph__filter=focus_on%28package%3Agithub.com%2FDataDog%2Fdatadog-agent%2Fcomp%2Fanomalydetection%29&viz=flame_graph&from_ts=1786623005144&to_ts=1786626605144&live=false)

<img width="2375" height="497" alt="Screenshot 2026-08-13 at 15 21 37" src="https://github.com/user-attachments/assets/126c3a5c-543e-4e92-8f02-4682e20e45e4" />

### Additional Notes
