### PR TITLE
fix(aix): discover Python checks via integrations-core AIX manifest tag

### DIFF
--- a/packaging/aix/stages/09-integrations.sh
+++ b/packaging/aix/stages/09-integrations.sh
@@ -78,7 +78,13 @@ fi
 
 # ─── Step 2: Install Python checks from integrations-core ─────────────────────
 #
-# Install each check from the pinned integrations-core checkout.
+# Discover every check in the pinned integrations-core checkout whose
+# manifest.json declares "Supported OS::AIX" in tile.classifier_tags, then
+# install each one. This mirrors how deps/agent_integrations/source_packages.bzl
+# selects checks for the other platforms (Supported OS::Linux/macOS/Windows),
+# so integrations-core is the single source of truth for AIX support instead
+# of a hardcoded list here.
+#
 # --constraint pins all transitive deps to the exact versions frozen by Stage 08,
 # matching the Linux omnibus approach and failing loudly if a dep is unavailable.
 # --find-links allows pip to locate native AIX wheels (pydantic-core, cryptography)
@@ -90,29 +96,48 @@ fi
 # ImportError at runtime if the missing native extension is not present on the
 # target system.
 
-PYTHON_CHECKS="lparstats openmetrics process ibm_mq ibm_ace ibm_db2 ibm_i ibm_was ibm_spectrum_lsf"
+PYTHON_CHECKS=$(python3.12 -c "
+import json
+import os
 
-log "Installing Python checks: $PYTHON_CHECKS"
+checks = []
+for name in sorted(os.listdir('$INTEGRATIONS_CORE')):
+    check_dir = os.path.join('$INTEGRATIONS_CORE', name)
+    if not os.path.isfile(os.path.join(check_dir, 'pyproject.toml')):
+        continue
+    manifest_path = os.path.join(check_dir, 'manifest.json')
+    if not os.path.isfile(manifest_path):
+        continue
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+    tags = manifest.get('tile', {}).get('classifier_tags', [])
+    if 'Supported OS::AIX' in tags:
+        checks.append(name)
+print(' '.join(checks))
+")
+
+if [ -z "$PYTHON_CHECKS" ]; then
+    log "ERROR: no integrations-core checks found with the Supported OS::AIX manifest tag"
+    exit 1
+fi
+
+log "Discovered Python checks tagged Supported OS::AIX: $PYTHON_CHECKS"
 
 for check in $PYTHON_CHECKS; do
     CHECK_DIR="$INTEGRATIONS_CORE/$check"
-    if [ -f "$CHECK_DIR/pyproject.toml" ]; then
-        log "Installing check: $check"
-        $PIP install \
-            --constraint "$STAGING/constraints.txt" \
-            --find-links "$WHEEL_CACHE" \
-            "$CHECK_DIR"
-        mkdir -p "$STAGING/etc/datadog-agent/conf.d/${check}.d"
-        EXAMPLE="$CHECK_DIR/datadog_checks/$check/data/conf.yaml.example"
-        if [ -f "$EXAMPLE" ]; then
-            cp "$EXAMPLE" "$STAGING/etc/datadog-agent/conf.d/${check}.d/"
-        else
-            log "WARNING: no conf.yaml.example found for $check at $EXAMPLE"
-        fi
-        log "Check $check installed successfully"
+    log "Installing check: $check"
+    $PIP install \
+        --constraint "$STAGING/constraints.txt" \
+        --find-links "$WHEEL_CACHE" \
+        "$CHECK_DIR"
+    mkdir -p "$STAGING/etc/datadog-agent/conf.d/${check}.d"
+    EXAMPLE="$CHECK_DIR/datadog_checks/$check/data/conf.yaml.example"
+    if [ -f "$EXAMPLE" ]; then
+        cp "$EXAMPLE" "$STAGING/etc/datadog-agent/conf.d/${check}.d/"
     else
-        log "WARNING: $check not found in integrations-core at $CHECK_DIR — skipping"
+        log "WARNING: no conf.yaml.example found for $check at $EXAMPLE"
     fi
+    log "Check $check installed successfully"
 done
 
 log "All Python checks processed"


### PR DESCRIPTION
### What does this PR do?

Replaces the hardcoded AIX Python check list with dynamic discovery of every integrations-core check tagged `Supported OS::AIX`.

### Motivation

Keep AIX in sync with integrations-core instead of drifting from a hand-maintained list.

### Describe how you validated your changes

Ran the updated stage on an AIX 7.3 build host: it installed all currently AIX-tagged checks with no errors.

### Additional Notes

`ibm_spectrum_lsf` is dropped — it was hardcoded before but never actually tagged for AIX upstream.