### PR TITLE
fix(flare): mark TestWindowsFlareSuite/TestFlareDefaultFiles as flaky

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -45,9 +45,11 @@ on-log:
 
 # TODO: https://datadoghq.atlassian.net/browse/FLREM-153
 # TODO: https://datadoghq.atlassian.net/browse/FLREM-154
+# TODO: https://datadoghq.atlassian.net/browse/FLREM-146
 test/new-e2e/tests/agent-subcommands:
   - test: TestLinuxFlareSuite/TestFlareDefaultFiles
   - test: TestWindowsDiagnoseSuite/TestDiagnoseOtherCmdPort
+  - test: TestWindowsFlareSuite/TestFlareDefaultFiles
 
 # TODO: https://datadoghq.atlassian.net/browse/FLREM-148
 # TODO: https://datadoghq.atlassian.net/browse/FLREM-155


### PR DESCRIPTION
### What does this PR do?

Mutes `test/new-e2e/tests/agent-subcommands.TestWindowsFlareSuite/TestFlareDefaultFiles` in `flakes.yaml`.

### Motivation

This test has been reported failing intermittently in CI, tracked in [FLREM-146](https://datadoghq.atlassian.net/browse/FLREM-146).

`TestWindowsFlareSuite` is a testify suite with other subtests that were never reported as flaky, so the entry is scoped to the exact failing subtest (`TestFlareDefaultFiles`) rather than muting the whole suite — same approach as #54759 for the sibling Linux/Windows flare suites.

Muting it here unblocks other PRs from spurious CI failures while the underlying flakiness is investigated under that ticket.

### Describe how you validated your changes

Validated `flakes.yaml` parses correctly and follows the existing file's format/conventions.

### Additional Notes

[FLREM-146]: https://datadoghq.atlassian.net/browse/FLREM-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ