### PR TITLE
[ACTP] Improve PAR error when an aciton is not allowed

### DIFF
--- a/pkg/privateactionrunner/runners/workflow_task_executor.go
+++ b/pkg/privateactionrunner/runners/workflow_task_executor.go
@@ -139,7 +139,7 @@ func (e *WorkflowTaskExecutor) RunTask(
 	}
 	if !e.config.IsActionAllowed(bundleName, actionName) {
 		return nil, util.DefaultActionError(fmt.Errorf(
-			"action %s is not allowlisted in the private action runner config. Update your agent config value at private_action_runner.actionsAllowlist or your environment variable DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST",
+			"action %s is not allowlisted in the private action runner config. Update the agent config `actionsAllowlist` or the environment variable `DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST`",
 			fqn,
 		))
 	}

--- a/pkg/privateactionrunner/runners/workflow_task_executor.go
+++ b/pkg/privateactionrunner/runners/workflow_task_executor.go
@@ -138,7 +138,10 @@ func (e *WorkflowTaskExecutor) RunTask(
 		)
 	}
 	if !e.config.IsActionAllowed(bundleName, actionName) {
-		return nil, util.DefaultActionError(fmt.Errorf("action %s is not in the allow list", fqn))
+		return nil, util.DefaultActionError(fmt.Errorf(
+			"action %s is not allowlisted in the private action runner config. Update your agent config value at private_action_runner.actionsAllowlist or your environment variable DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST",
+			fqn,
+		))
 	}
 
 	logger := log.FromContext(ctx)


### PR DESCRIPTION
## Description
When a Private Action Runner (PAR) rejects an action because it's not in the runner's allowlist, the error message is unhelpful: action <fqn> is not in the allow list. Users have no guidance on how to resolve it.