### PR TITLE
Deflake `TestKeepTryingLockingIfPermissionDenied` with `synctest`

### DIFF
--- a/pkg/util/filesystem/concurrent_write_test.go
+++ b/pkg/util/filesystem/concurrent_write_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"crypto/rand"
@@ -53,7 +54,6 @@ func newMockArtiFactory(t *testing.T) (string, *MockArtiFactory) {
 }
 
 func TestFetchArtifact(t *testing.T) {
-	t.Parallel()
 	location, mockFactory := newMockArtiFactory(t)
 
 	_, err := TryFetchArtifact(location, mockFactory)
@@ -72,10 +72,9 @@ func TestFetchArtifact(t *testing.T) {
 }
 
 func TestCreateNewArtifact(t *testing.T) {
-	t.Parallel()
 	location, mockFactory := newMockArtiFactory(t)
 
-	artifact, err := FetchOrCreateArtifact(context.Background(), location, mockFactory)
+	artifact, err := FetchOrCreateArtifact(t.Context(), location, mockFactory)
 	assert.NoError(t, err)
 	assert.Equal(t, mockFactory.data, artifact)
 
@@ -93,7 +92,10 @@ func TestCreateNewArtifact(t *testing.T) {
 }
 
 func TestContextCancellation(t *testing.T) {
-	t.Parallel()
+	synctest.Test(t, syncTestContextCancellation)
+}
+
+func syncTestContextCancellation(t *testing.T) {
 	location, mockFactory := newMockArtiFactory(t)
 
 	// Ensure the artifact file does not exist
@@ -107,7 +109,7 @@ func TestContextCancellation(t *testing.T) {
 	defer lockFile.Unlock()
 
 	// Create a context with a timeout to simulate cancellation
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
 
 	// Call FetchOrCreateArtifact with the context
@@ -119,7 +121,10 @@ func TestContextCancellation(t *testing.T) {
 }
 
 func TestHandleMultipleConcurrentWrites(t *testing.T) {
-	t.Parallel()
+	synctest.Test(t, syncTestHandleMultipleConcurrentWrites)
+}
+
+func syncTestHandleMultipleConcurrentWrites(t *testing.T) {
 	dir := t.TempDir()
 	location := path.Join(dir, "test_artifact")
 
@@ -145,7 +150,7 @@ func TestHandleMultipleConcurrentWrites(t *testing.T) {
 				id:            i,
 				dataGenerator: generator,
 			}
-			res, err := FetchOrCreateArtifact(context.Background(), location, instance)
+			res, err := FetchOrCreateArtifact(t.Context(), location, instance)
 			results <- res
 			return err
 		})
@@ -173,7 +178,10 @@ func TestHandleMultipleConcurrentWrites(t *testing.T) {
 }
 
 func TestKeepTryingLockingIfPermissionDenied(t *testing.T) {
-	t.Parallel()
+	synctest.Test(t, syncTestKeepTryingLockingIfPermissionDenied)
+}
+
+func syncTestKeepTryingLockingIfPermissionDenied(t *testing.T) {
 	location, mockFactory := newMockArtiFactory(t)
 	lockFilePath := location + lockSuffix
 
@@ -189,7 +197,7 @@ func TestKeepTryingLockingIfPermissionDenied(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a context with a timeout to simulate cancellation
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
 
 	// Calling FetchOrCreateArtifact in a goroutine to simulate a concurrent call
@@ -199,8 +207,8 @@ func TestKeepTryingLockingIfPermissionDenied(t *testing.T) {
 		return err
 	})
 
-	// Wait for a while to ensure FetchOrCreateArtifact tried at least once to acquire the lock
-	time.Sleep(1 * time.Second)
+	// Wait for FetchOrCreateArtifact to try at least once to acquire the lock
+	synctest.Wait()
 
 	// Make the lock file readable again and release it
 	err = os.Chmod(lockFilePath, 0o600)


### PR DESCRIPTION
### What does this PR do?
Wrap `TestKeepTryingLockingIfPermissionDenied`, `TestContextCancellation` and `TestHandleMultipleConcurrentWrites` in `synctest` "bubbles" by extracting their body into `sync<same name>` functions while dropping `t.Parallel()` (disallowed inside a bubble).

Drop remaining `t.Parallel()` from the file's other 2 tests too (Bazel schedules this whole test binary as one action regardless of it).

Also switch every `context.Background()` in the file to `t.Context()` for good measure (test-bound, canceled right before running Cleanup functions).

### Motivation
`TestKeepTryingLockingIfPermissionDenied` races a 500ms retry loop against its own 2s context timeout using real time, so a scheduling stall near either boundary can flip a would-be success into a failure.

It failed exactly that way in a local `bazel test` run on Linux:
```
--- FAIL: TestKeepTryingLockingIfPermissionDenied (3.00s)
    concurrent_write_test.go:212:
                Error Trace:    pkg/util/filesystem/concurrent_write_test.go:212
                Error:          Received unexpected error:
                                unable to read the artifact or acquire the lock in the given time
                                open /tmp/TestKeepTryingLockingIfPermissionDenied252193597/001/test_artifact.lock: permission denied
                Test:           TestKeepTryingLockingIfPermissionDenied
    concurrent_write_test.go:216:
                Error Trace:    pkg/util/filesystem/concurrent_write_test.go:216
                Error:          Expected error with "file does not exist" in chain but got nil.
                Test:           TestKeepTryingLockingIfPermissionDenied
                Messages:       lock file should not exist after successful creation and concurrent reads

```

The flakiness may manifest itself in a slightly different way, like for instance in [a CI job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1928209794#L476) on Windows where 2 `t.Parallel()` siblings in the same batch also ran multiple real seconds longer than their own logic requires, showing the whole binary stalled right when the retry loop needed to recheck the lock:
```
=== NAME  TestKeepTryingLockingIfPermissionDenied
    concurrent_write_test.go:212:
        	Error Trace:	pkg/util/filesystem/concurrent_write_test.go:212
        	Error:      	Received unexpected error:
        	            	unable to read the artifact or acquire the lock in the given time
        	Test:       	TestKeepTryingLockingIfPermissionDenied
    concurrent_write_test.go:216:
        	Error Trace:	pkg/util/filesystem/concurrent_write_test.go:216
        	Error:      	Expected error with "file does not exist" in chain but got nil.
        	Test:       	TestKeepTryingLockingIfPermissionDenied
        	Messages:   	lock file should not exist after successful creation and concurrent reads
--- FAIL: TestKeepTryingLockingIfPermissionDenied (2.11s)
```

`TestContextCancellation` and `TestHandleMultipleConcurrentWrites` don't share that specific failure mode, but they do pay their timers' full real duration on every run regardless of load.

### Describe how you validated your changes
Isolated timing before/after:
- `TestKeepTryingLockingIfPermissionDenied`: 1.05s to 0.02s,
- `TestContextCancellation`: 0.10s to 0.00s,
- `TestHandleMultipleConcurrentWrites`: 0.50s to 0.05s.

All tests pass 30/30 under `--config=gorace`, and the package passes 60/60 repeated runs under heavy artificial CPU oversubscription.

### Additional Notes
Dropping `t.Parallel()` doesn't cost anything net:
- ~1.65s before this change,
- ~0.07s after.

This is because virtualizing sleeps removes far more real time than serializing 5 tests loses.