### PR TITLE
[ACTP] PAR secret resolution through agent secret management

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -664,7 +664,7 @@ func start(log log.Component,
 	}
 
 	if config.GetBool("private_action_runner.enabled") {
-		drain, err := startPrivateActionRunner(mainCtx, config, hostnameGetter, rcClient, le, log, taggerComp, tracerouteComp, eventPlatform, ipc, demultiplexer, helmactions, kubeActions)
+		drain, err := startPrivateActionRunner(mainCtx, config, hostnameGetter, rcClient, le, log, taggerComp, tracerouteComp, eventPlatform, ipc, demultiplexer, helmactions, kubeActions, secretResolver)
 		if err != nil {
 			log.Errorf("Cannot start private action runner: %v", err)
 		} else {
@@ -856,6 +856,7 @@ func startPrivateActionRunner(
 	demux demultiplexer.Component,
 	ha helmactions.Component,
 	ka kubeactionscomp.Component,
+	secretResolver secrets.Component,
 ) (func(), error) {
 	if rcClient == nil {
 		return nil, errors.New("Remote config is disabled or failed to initialize, remote config is a required dependency for private action runner")
@@ -873,7 +874,7 @@ func startPrivateActionRunner(
 		metricsClient = &ddgostatsd.NoOpClient{}
 	}
 
-	app, err := privateactionrunner.NewPrivateActionRunner(ctx, config, hostnameGetter, rcClient, log, tagger, tracerouteComp, eventPlatform, ipc, metricsClient, ha, ka)
+	app, err := privateactionrunner.NewPrivateActionRunner(ctx, config, hostnameGetter, rcClient, log, tagger, tracerouteComp, eventPlatform, ipc, secretResolver, metricsClient, ha, ka)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/privateactionrunner/impl/BUILD.bazel
+++ b/comp/privateactionrunner/impl/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//comp/core/hostname/hostnameinterface/def",
         "//comp/core/ipc/def",
         "//comp/core/log/def",
+        "//comp/core/secrets/def",
         "//comp/core/tagger/def",
         "//comp/def",
         "//comp/dogstatsd/statsd/def",

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	statsdcomp "github.com/DataDog/datadog-agent/comp/dogstatsd/statsd/def"
@@ -73,6 +74,7 @@ type Requires struct {
 	Traceroute    traceroute.Component
 	EventPlatform eventplatform.Component
 	IPC           ipc.Component
+	Secrets       secrets.Component
 	Statsd        statsdcomp.Component
 	HelmActions   helmactions.Component
 }
@@ -91,6 +93,7 @@ type PrivateActionRunner struct {
 	traceroute     traceroute.Component
 	eventPlatform  eventplatform.Component
 	ipc            ipc.Component
+	secretResolver secrets.Component
 	// metricsClient is the resolved metrics sink: a DogStatsD client built from
 	// config (standalone runner) or an in-process adapter (Cluster Agent).
 	metricsClient     statsdclient.ClientInterface
@@ -132,7 +135,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 	}
 	// The standalone/executor runner has no kubeactions provider (it is
 	// cluster-agent-only, wired via the cluster-agent start command), so pass nil.
-	runner, err := NewPrivateActionRunner(ctx, reqs.Config, reqs.Hostname, pkgrcclient.NewAdapter(reqs.RcClient), reqs.Log, reqs.Tagger, reqs.Traceroute, reqs.EventPlatform, reqs.IPC, metricsClient, reqs.HelmActions, nil)
+	runner, err := NewPrivateActionRunner(ctx, reqs.Config, reqs.Hostname, pkgrcclient.NewAdapter(reqs.RcClient), reqs.Log, reqs.Tagger, reqs.Traceroute, reqs.EventPlatform, reqs.IPC, reqs.Secrets, metricsClient, reqs.HelmActions, nil)
 	if err != nil {
 		return Provides{}, err
 	}
@@ -160,7 +163,7 @@ func NewExecutorComponent(reqs Requires) (Provides, error) {
 	}
 	// The standalone/executor runner has no kubeactions provider (it is
 	// cluster-agent-only, wired via the cluster-agent start command), so pass nil.
-	runner, err := NewPrivateActionRunner(ctx, reqs.Config, reqs.Hostname, pkgrcclient.NewAdapter(reqs.RcClient), reqs.Log, reqs.Tagger, reqs.Traceroute, reqs.EventPlatform, reqs.IPC, metricsClient, reqs.HelmActions, nil)
+	runner, err := NewPrivateActionRunner(ctx, reqs.Config, reqs.Hostname, pkgrcclient.NewAdapter(reqs.RcClient), reqs.Log, reqs.Tagger, reqs.Traceroute, reqs.EventPlatform, reqs.IPC, reqs.Secrets, metricsClient, reqs.HelmActions, nil)
 	if err != nil {
 		return Provides{}, err
 	}
@@ -184,6 +187,7 @@ func NewPrivateActionRunner(
 	tracerouteComp traceroute.Component,
 	eventPlatform eventplatform.Component,
 	ipcComp ipc.Component,
+	secretResolver secrets.Component,
 	metricsClient statsdclient.ClientInterface,
 	ha helmactions.Component,
 	ka kubeactions.Component,
@@ -197,6 +201,7 @@ func NewPrivateActionRunner(
 		traceroute:     tracerouteComp,
 		eventPlatform:  eventPlatform,
 		ipc:            ipcComp,
+		secretResolver: secretResolver,
 		metricsClient:  metricsClient,
 		startChan:      make(chan struct{}),
 		ha:             ha,
@@ -301,7 +306,7 @@ func (p *PrivateActionRunner) startExecutor(ctx context.Context) error {
 	keysManager := p.getKeysManager()
 	taskVerifier := taskverifier.NewTaskVerifier(keysManager, cfg)
 	p.encryptionStore = encryptioncontext.NewStore()
-	taskExecutor := runners.NewWorkflowTaskExecutor(cfg, taskVerifier, p.traceroute, p.eventPlatform, p.ipc.GetClient(), p.encryptionStore, p.ha, p.ka)
+	taskExecutor := runners.NewWorkflowTaskExecutor(cfg, taskVerifier, p.traceroute, p.eventPlatform, p.ipc.GetClient(), p.encryptionStore, p.ha, p.ka, p.secretResolver)
 
 	p.executorServer = executor.NewServer(taskExecutor, parversion.RunnerVersion)
 
@@ -439,7 +444,7 @@ func (p *PrivateActionRunner) start(ctx context.Context) error {
 	taskVerifier := taskverifier.NewTaskVerifier(keysManager, cfg)
 	opmsClient := opms.NewClient(p.coreConfig, cfg)
 
-	p.workflowRunner, err = runners.NewWorkflowRunner(cfg, keysManager, taskVerifier, opmsClient, p.traceroute, p.eventPlatform, p.ipc.GetClient(), p.ha, p.ka)
+	p.workflowRunner, err = runners.NewWorkflowRunner(cfg, keysManager, taskVerifier, opmsClient, p.traceroute, p.eventPlatform, p.ipc.GetClient(), p.ha, p.ka, p.secretResolver)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/example/datadog-agent_aix.yaml.example
+++ b/pkg/config/example/datadog-agent_aix.yaml.example
@@ -4601,6 +4601,14 @@ api_key:
 #
 #   default_actions_enabled: true
 
+#   # @param agent_secret_management_enabled - boolean - optional - default: true
+#   # @env DD_PRIVATE_ACTION_RUNNER_AGENT_SECRET_MANAGEMENT_ENABLED - boolean - optional - default: true
+#   # Enables resolving connection credentials with the Datadog Agent secret
+#   # management backend. Set to false to disable Agent secret resolution for
+#   # Private Action Runner connections.
+#
+#   agent_secret_management_enabled: true
+
 #   # @param http_timeout_seconds - integer - optional - default: 30
 #   # @env DD_PRIVATE_ACTION_RUNNER_HTTP_TIMEOUT_SECONDS - integer - optional - default: 30
 #   # Maximum time in seconds for HTTP actions before timing out. Must be > 1.

--- a/pkg/config/example/datadog-agent_darwin.yaml.example
+++ b/pkg/config/example/datadog-agent_darwin.yaml.example
@@ -4601,6 +4601,14 @@ api_key:
 #
 #   default_actions_enabled: true
 
+#   # @param agent_secret_management_enabled - boolean - optional - default: true
+#   # @env DD_PRIVATE_ACTION_RUNNER_AGENT_SECRET_MANAGEMENT_ENABLED - boolean - optional - default: true
+#   # Enables resolving connection credentials with the Datadog Agent secret
+#   # management backend. Set to false to disable Agent secret resolution for
+#   # Private Action Runner connections.
+#
+#   agent_secret_management_enabled: true
+
 #   # @param http_timeout_seconds - integer - optional - default: 30
 #   # @env DD_PRIVATE_ACTION_RUNNER_HTTP_TIMEOUT_SECONDS - integer - optional - default: 30
 #   # Maximum time in seconds for HTTP actions before timing out. Must be > 1.

--- a/pkg/config/example/datadog-agent_linux.yaml.example
+++ b/pkg/config/example/datadog-agent_linux.yaml.example
@@ -4737,6 +4737,14 @@ api_key:
 #
 #   default_actions_enabled: true
 
+#   # @param agent_secret_management_enabled - boolean - optional - default: true
+#   # @env DD_PRIVATE_ACTION_RUNNER_AGENT_SECRET_MANAGEMENT_ENABLED - boolean - optional - default: true
+#   # Enables resolving connection credentials with the Datadog Agent secret
+#   # management backend. Set to false to disable Agent secret resolution for
+#   # Private Action Runner connections.
+#
+#   agent_secret_management_enabled: true
+
 #   # @param http_timeout_seconds - integer - optional - default: 30
 #   # @env DD_PRIVATE_ACTION_RUNNER_HTTP_TIMEOUT_SECONDS - integer - optional - default: 30
 #   # Maximum time in seconds for HTTP actions before timing out. Must be > 1.

--- a/pkg/config/example/datadog-agent_windows.yaml.example
+++ b/pkg/config/example/datadog-agent_windows.yaml.example
@@ -4753,6 +4753,14 @@ api_key:
 #
 #   default_actions_enabled: true
 
+#   # @param agent_secret_management_enabled - boolean - optional - default: true
+#   # @env DD_PRIVATE_ACTION_RUNNER_AGENT_SECRET_MANAGEMENT_ENABLED - boolean - optional - default: true
+#   # Enables resolving connection credentials with the Datadog Agent secret
+#   # management backend. Set to false to disable Agent secret resolution for
+#   # Private Action Runner connections.
+#
+#   agent_secret_management_enabled: true
+
 #   # @param http_timeout_seconds - integer - optional - default: 30
 #   # @env DD_PRIVATE_ACTION_RUNNER_HTTP_TIMEOUT_SECONDS - integer - optional - default: 30
 #   # Maximum time in seconds for HTTP actions before timing out. Must be > 1.

--- a/pkg/config/example/dca_aix.yaml.example
+++ b/pkg/config/example/dca_aix.yaml.example
@@ -1632,6 +1632,14 @@ api_key:
 #
 #   default_actions_enabled: true
 
+#   # @param agent_secret_management_enabled - boolean - optional - default: true
+#   # @env DD_PRIVATE_ACTION_RUNNER_AGENT_SECRET_MANAGEMENT_ENABLED - boolean - optional - default: true
+#   # Enables resolving connection credentials with the Datadog Agent secret
+#   # management backend. Set to false to disable Agent secret resolution for
+#   # Private Action Runner connections.
+#
+#   agent_secret_management_enabled: true
+
 #   # @param http_timeout_seconds - integer - optional - default: 30
 #   # @env DD_PRIVATE_ACTION_RUNNER_HTTP_TIMEOUT_SECONDS - integer - optional - default: 30
 #   # Maximum time in seconds for HTTP actions before timing out. Must be > 1.

--- a/pkg/config/example/dca_darwin.yaml.example
+++ b/pkg/config/example/dca_darwin.yaml.example
@@ -1632,6 +1632,14 @@ api_key:
 #
 #   default_actions_enabled: true
 
+#   # @param agent_secret_management_enabled - boolean - optional - default: true
+#   # @env DD_PRIVATE_ACTION_RUNNER_AGENT_SECRET_MANAGEMENT_ENABLED - boolean - optional - default: true
+#   # Enables resolving connection credentials with the Datadog Agent secret
+#   # management backend. Set to false to disable Agent secret resolution for
+#   # Private Action Runner connections.
+#
+#   agent_secret_management_enabled: true
+
 #   # @param http_timeout_seconds - integer - optional - default: 30
 #   # @env DD_PRIVATE_ACTION_RUNNER_HTTP_TIMEOUT_SECONDS - integer - optional - default: 30
 #   # Maximum time in seconds for HTTP actions before timing out. Must be > 1.

--- a/pkg/config/example/dca_linux.yaml.example
+++ b/pkg/config/example/dca_linux.yaml.example
@@ -1632,6 +1632,14 @@ api_key:
 #
 #   default_actions_enabled: true
 
+#   # @param agent_secret_management_enabled - boolean - optional - default: true
+#   # @env DD_PRIVATE_ACTION_RUNNER_AGENT_SECRET_MANAGEMENT_ENABLED - boolean - optional - default: true
+#   # Enables resolving connection credentials with the Datadog Agent secret
+#   # management backend. Set to false to disable Agent secret resolution for
+#   # Private Action Runner connections.
+#
+#   agent_secret_management_enabled: true
+
 #   # @param http_timeout_seconds - integer - optional - default: 30
 #   # @env DD_PRIVATE_ACTION_RUNNER_HTTP_TIMEOUT_SECONDS - integer - optional - default: 30
 #   # Maximum time in seconds for HTTP actions before timing out. Must be > 1.

--- a/pkg/config/example/dca_windows.yaml.example
+++ b/pkg/config/example/dca_windows.yaml.example
@@ -1632,6 +1632,14 @@ api_key:
 #
 #   default_actions_enabled: true
 
+#   # @param agent_secret_management_enabled - boolean - optional - default: true
+#   # @env DD_PRIVATE_ACTION_RUNNER_AGENT_SECRET_MANAGEMENT_ENABLED - boolean - optional - default: true
+#   # Enables resolving connection credentials with the Datadog Agent secret
+#   # management backend. Set to false to disable Agent secret resolution for
+#   # Private Action Runner connections.
+#
+#   agent_secret_management_enabled: true
+
 #   # @param http_timeout_seconds - integer - optional - default: 30
 #   # @env DD_PRIVATE_ACTION_RUNNER_HTTP_TIMEOUT_SECONDS - integer - optional - default: 30
 #   # Maximum time in seconds for HTTP actions before timing out. Must be > 1.

--- a/pkg/config/schema/yaml/private_action_runner.yaml
+++ b/pkg/config/schema/yaml/private_action_runner.yaml
@@ -67,6 +67,15 @@ properties:
       When true, a set of default actions are automatically
       allowed without needing to be listed in actions_allowlist.
       Set to false to disable these default actions.
+  agent_secret_management_enabled:
+    node_type: setting
+    type: boolean
+    default: true
+    visibility: public
+    description: |-
+      Enables resolving connection credentials with the Datadog Agent secret
+      management backend. Set to false to disable Agent secret resolution for
+      Private Action Runner connections.
   http_timeout_seconds:
     node_type: setting
     type: integer

--- a/pkg/config/setup/privateactionrunner.go
+++ b/pkg/config/setup/privateactionrunner.go
@@ -20,11 +20,12 @@ const (
 	PARSkipConnectionCreation = "private_action_runner.skip_connection_creation"
 
 	// General config
-	PARTaskConcurrency       = "private_action_runner.task_concurrency"
-	PARTaskTimeoutSeconds    = "private_action_runner.task_timeout_seconds"
-	PARIdleTimeoutSeconds    = "private_action_runner.idle_timeout_seconds"
-	PARActionsAllowlist      = "private_action_runner.actions_allowlist"
-	PARDefaultActionsEnabled = "private_action_runner.default_actions_enabled"
+	PARTaskConcurrency              = "private_action_runner.task_concurrency"
+	PARTaskTimeoutSeconds           = "private_action_runner.task_timeout_seconds"
+	PARIdleTimeoutSeconds           = "private_action_runner.idle_timeout_seconds"
+	PARActionsAllowlist             = "private_action_runner.actions_allowlist"
+	PARDefaultActionsEnabled        = "private_action_runner.default_actions_enabled"
+	PARAgentSecretManagementEnabled = "private_action_runner.agent_secret_management_enabled"
 
 	// HTTP Action related
 	PARHttpTimeoutSeconds    = "private_action_runner.http_timeout_seconds"

--- a/pkg/config/setup/privateactionrunner_test.go
+++ b/pkg/config/setup/privateactionrunner_test.go
@@ -17,6 +17,20 @@ func TestPrivateActionRunnerApiKeyOnlyEnrollmentDefaultTrue(t *testing.T) {
 	assert.True(t, cfg.GetBool(PARApiKeyOnlyEnrollment))
 }
 
+func TestPrivateActionRunnerAgentSecretManagementEnabledDefaultTrue(t *testing.T) {
+	cfg := newTestConf(t)
+
+	assert.True(t, cfg.GetBool(PARAgentSecretManagementEnabled))
+}
+
+func TestPrivateActionRunnerAgentSecretManagementEnabledFromEnv(t *testing.T) {
+	t.Setenv("DD_PRIVATE_ACTION_RUNNER_AGENT_SECRET_MANAGEMENT_ENABLED", "false")
+
+	cfg := newTestConf(t)
+
+	assert.False(t, cfg.GetBool(PARAgentSecretManagementEnabled))
+}
+
 func TestPrivateActionRunnerApiKeyOnlyEnrollmentFromEnv(t *testing.T) {
 	t.Setenv("DD_PRIVATE_ACTION_RUNNER_API_KEY_ONLY_ENROLLMENT", "false")
 

--- a/pkg/privateactionrunner/adapters/config/config_adapter.go
+++ b/pkg/privateactionrunner/adapters/config/config_adapter.go
@@ -27,6 +27,7 @@ type Config struct {
 	RShellAllowedCommands          []string
 	RShellAllowedSystemServices    map[string][]string
 	RShellDisableDetailedTelemetry bool
+	AgentSecretManagementEnabled   bool
 	DDHost                         string
 	DDApiHost                      string
 	Modes                          []modes.Mode

--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -99,6 +99,7 @@ func FromDDConfig(config config.Component, metricsClient statsd.ClientInterface)
 		RShellAllowedCommands:          rshellAllowedCommands(config),
 		RShellAllowedSystemServices:    rshellAllowedSystemServices(config),
 		RShellDisableDetailedTelemetry: config.GetBool(setup.PARRestrictedShellDisableDetailedTelemetry),
+		AgentSecretManagementEnabled:   config.GetBool(setup.PARAgentSecretManagementEnabled),
 		OpmsExtraHeaders:               config.GetStringMapString(setup.PAROpmsExtraHeaders),
 		DDHost:                         ddHost,
 		DDApiHost:                      "api." + ddSite,

--- a/pkg/privateactionrunner/adapters/config/transform_test.go
+++ b/pkg/privateactionrunner/adapters/config/transform_test.go
@@ -640,6 +640,18 @@ private_action_runner:
 	assert.Equal(t, []string{"rshell:*"}, cfg.RShellAllowedCommands)
 	assert.Nil(t, cfg.RShellAllowedSystemServices)
 	assert.False(t, cfg.RShellDisableDetailedTelemetry)
+	assert.True(t, cfg.AgentSecretManagementEnabled)
+}
+
+func TestFromDDConfigPARAgentSecretManagementDisabled(t *testing.T) {
+	mockConfig := configmock.New(t)
+	mockConfig.SetInTest(setup.PARPrivateKey, "")
+	mockConfig.SetInTest(setup.PARUrn, "")
+	mockConfig.SetInTest(setup.PARAgentSecretManagementEnabled, false)
+
+	cfg, err := FromDDConfig(mockConfig, nil)
+	require.NoError(t, err)
+	assert.False(t, cfg.AgentSecretManagementEnabled)
 }
 
 func TestFromDDConfigPARRestrictedShellDisableDetailedTelemetryUnset(t *testing.T) {

--- a/pkg/privateactionrunner/credentials/resolver/BUILD.bazel
+++ b/pkg/privateactionrunner/credentials/resolver/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "resolver",
@@ -11,5 +12,18 @@ go_library(
         "//pkg/privateactionrunner/libs/privateconnection",
         "//pkg/proto/pbgo/privateactionrunner/privateactions",
         "@com_github_google_uuid//:uuid",
+    ],
+)
+
+dd_agent_go_test(
+    name = "resolver_test",
+    srcs = ["credentials_resolver_test.go"],
+    embed = [":resolver"],
+    deps = [
+        "//pkg/privateactionrunner/adapters/constants",
+        "//pkg/privateactionrunner/libs/privateconnection",
+        "//pkg/proto/pbgo/privateactionrunner/privateactions",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/privateactionrunner/credentials/resolver/BUILD.bazel
+++ b/pkg/privateactionrunner/credentials/resolver/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/privateactionrunner/libs/privateconnection",
         "//pkg/proto/pbgo/privateactionrunner/privateactions",
         "@com_github_google_uuid//:uuid",
+        "@in_yaml_go_yaml_v2//:yaml",
     ],
 )
 
@@ -25,5 +26,6 @@ dd_agent_go_test(
         "//pkg/proto/pbgo/privateactionrunner/privateactions",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@in_yaml_go_yaml_v2//:yaml",
     ],
 )

--- a/pkg/privateactionrunner/credentials/resolver/credentials_resolver.go
+++ b/pkg/privateactionrunner/credentials/resolver/credentials_resolver.go
@@ -73,8 +73,53 @@ func (p *privateCredentialResolver) ResolveConnectionInfoToCredential(ctx contex
 			Type:        privateconnection.BasicAuthType,
 			HttpDetails: details,
 		}, nil
+	case privateactionspb.CredentialsType_CONNECTION_TOKENS_V2:
+		resolvedTokens, err := resolveConnectionTokensV2(connInfo.GetTokensV2())
+		if err != nil {
+			return nil, err
+		}
+		tokens, details = privateconnection.ExtractConnectionDetails(&privateactionspb.ConnectionInfo{Tokens: resolvedTokens})
+		credentialTokens, err := resolveTokenAuthTokens(ctx, tokens)
+		if err != nil {
+			return nil, err
+		}
+		return &privateconnection.PrivateCredentials{
+			Tokens:      credentialTokens,
+			Type:        privateconnection.TokenAuthType,
+			HttpDetails: details,
+		}, nil
 	}
 	return nil, fmt.Errorf("unsupported credential type: %s", connInfo.CredentialsType)
+}
+
+func resolveConnectionTokensV2(tokens []*privateactionspb.ConnectionTokenV2) ([]*privateactionspb.ConnectionToken, error) {
+	resolved := make([]*privateactionspb.ConnectionToken, 0, len(tokens))
+	for _, token := range tokens {
+		if token == nil {
+			return nil, errors.New("connection token must not be nil")
+		}
+		if len(token.GetNameSegments()) == 0 {
+			return nil, errors.New("connection token name must not be empty")
+		}
+
+		tokenName := connlib.GetName(token)
+		switch source := token.GetSource().(type) {
+		case *privateactionspb.ConnectionTokenV2_PlainText_:
+			resolved = append(resolved, privateconnection.NewPlainTextToken(token.GetNameSegments(), source.PlainText.GetValue()))
+		case *privateactionspb.ConnectionTokenV2_EnvironmentVariable_:
+			name := source.EnvironmentVariable.GetName()
+			value, ok := os.LookupEnv(name)
+			if !ok {
+				return nil, fmt.Errorf("environment variable %q for connection token %q is not set", name, tokenName)
+			}
+			resolved = append(resolved, privateconnection.NewPlainTextToken(token.GetNameSegments(), value))
+		case *privateactionspb.ConnectionTokenV2_DatadogAgentSecret_:
+			return nil, fmt.Errorf("Datadog Agent secret references are not supported by the private action runner for connection token %q", tokenName)
+		default:
+			return nil, fmt.Errorf("unsupported source for connection token %q: %T", tokenName, token.GetSource())
+		}
+	}
+	return resolved, nil
 }
 
 func resolveTokenAuthTokens(ctx context.Context, tokens []*privateactionspb.ConnectionToken) ([]privateconnection.PrivateCredentialsToken, error) {

--- a/pkg/privateactionrunner/credentials/resolver/credentials_resolver.go
+++ b/pkg/privateactionrunner/credentials/resolver/credentials_resolver.go
@@ -14,6 +14,7 @@ import (
 	"os"
 
 	"github.com/google/uuid"
+	"go.yaml.in/yaml/v2"
 
 	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
 	connlib "github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/connection"
@@ -28,7 +29,14 @@ const (
 type PrivateCredentialResolver interface {
 	ResolveConnectionInfoToCredential(ctx context.Context, conn *privateactionspb.ConnectionInfo, userUUID *uuid.UUID) (*privateconnection.PrivateCredentials, error)
 }
+
+// SecretResolver resolves Datadog Agent secret-backend handles.
+type SecretResolver interface {
+	Resolve(data []byte, origin string, imageName string, kubeNamespace string, notify bool) ([]byte, error)
+}
+
 type privateCredentialResolver struct {
+	secretResolver SecretResolver
 }
 
 type PrivateConnectionConfig struct {
@@ -43,8 +51,8 @@ type Credential struct {
 	Password   string `json:"password,omitempty"`
 }
 
-func NewPrivateCredentialResolver() PrivateCredentialResolver {
-	return &privateCredentialResolver{}
+func NewPrivateCredentialResolver(secretResolver SecretResolver) PrivateCredentialResolver {
+	return &privateCredentialResolver{secretResolver: secretResolver}
 }
 
 func (p *privateCredentialResolver) ResolveConnectionInfoToCredential(ctx context.Context, connInfo *privateactionspb.ConnectionInfo, userUUID *uuid.UUID) (*privateconnection.PrivateCredentials, error) {
@@ -74,7 +82,7 @@ func (p *privateCredentialResolver) ResolveConnectionInfoToCredential(ctx contex
 			HttpDetails: details,
 		}, nil
 	case privateactionspb.CredentialsType_CONNECTION_TOKENS_V2:
-		resolvedTokens, err := resolveConnectionTokensV2(connInfo.GetTokensV2())
+		resolvedTokens, err := p.resolveConnectionTokensV2(connInfo.GetTokensV2(), connInfo.GetConnectionId())
 		if err != nil {
 			return nil, err
 		}
@@ -92,9 +100,11 @@ func (p *privateCredentialResolver) ResolveConnectionInfoToCredential(ctx contex
 	return nil, fmt.Errorf("unsupported credential type: %s", connInfo.CredentialsType)
 }
 
-func resolveConnectionTokensV2(tokens []*privateactionspb.ConnectionTokenV2) ([]*privateactionspb.ConnectionToken, error) {
-	resolved := make([]*privateactionspb.ConnectionToken, 0, len(tokens))
-	for _, token := range tokens {
+func (p *privateCredentialResolver) resolveConnectionTokensV2(tokens []*privateactionspb.ConnectionTokenV2, connectionID string) ([]*privateactionspb.ConnectionToken, error) {
+	resolvedValues := make([]string, len(tokens))
+	secretHandles := make([]string, 0)
+	secretTokenIndexes := make([]int, 0)
+	for i, token := range tokens {
 		if token == nil {
 			return nil, errors.New("connection token must not be nil")
 		}
@@ -105,21 +115,74 @@ func resolveConnectionTokensV2(tokens []*privateactionspb.ConnectionTokenV2) ([]
 		tokenName := connlib.GetName(token)
 		switch source := token.GetSource().(type) {
 		case *privateactionspb.ConnectionTokenV2_PlainText_:
-			resolved = append(resolved, privateconnection.NewPlainTextToken(token.GetNameSegments(), source.PlainText.GetValue()))
+			resolvedValues[i] = source.PlainText.GetValue()
 		case *privateactionspb.ConnectionTokenV2_EnvironmentVariable_:
 			name := source.EnvironmentVariable.GetName()
 			value, ok := os.LookupEnv(name)
 			if !ok {
 				return nil, fmt.Errorf("environment variable %q for connection token %q is not set", name, tokenName)
 			}
-			resolved = append(resolved, privateconnection.NewPlainTextToken(token.GetNameSegments(), value))
+			resolvedValues[i] = value
 		case *privateactionspb.ConnectionTokenV2_DatadogAgentSecret_:
-			return nil, fmt.Errorf("Datadog Agent secret references are not supported by the private action runner for connection token %q", tokenName)
+			handle := source.DatadogAgentSecret.GetHandle()
+			if handle == "" {
+				return nil, fmt.Errorf("Datadog Agent secret handle for connection token %q must not be empty", tokenName)
+			}
+			secretHandles = append(secretHandles, handle)
+			secretTokenIndexes = append(secretTokenIndexes, i)
 		default:
 			return nil, fmt.Errorf("unsupported source for connection token %q: %T", tokenName, token.GetSource())
 		}
 	}
+
+	if len(secretHandles) > 0 {
+		secretValues, err := p.resolveAgentSecrets(secretHandles, connectionID)
+		if err != nil {
+			return nil, fmt.Errorf("could not resolve Datadog Agent secrets: %w", err)
+		}
+		for i, tokenIndex := range secretTokenIndexes {
+			resolvedValues[tokenIndex] = secretValues[i]
+		}
+	}
+
+	resolved := make([]*privateactionspb.ConnectionToken, 0, len(tokens))
+	for i, token := range tokens {
+		resolved = append(resolved, privateconnection.NewPlainTextToken(token.GetNameSegments(), resolvedValues[i]))
+	}
 	return resolved, nil
+}
+
+func (p *privateCredentialResolver) resolveAgentSecrets(handles []string, connectionID string) ([]string, error) {
+	if p.secretResolver == nil {
+		return nil, errors.New("Datadog Agent secret resolver is unavailable")
+	}
+
+	data, err := yaml.Marshal(handles)
+	if err != nil {
+		return nil, fmt.Errorf("could not encode secret handles: %w", err)
+	}
+	origin := "private-action-runner"
+	if connectionID != "" {
+		origin += "/connection/" + connectionID
+	}
+	resolvedData, err := p.secretResolver.Resolve(data, origin, "", "", false)
+	if err != nil {
+		return nil, err
+	}
+
+	var resolvedValues []string
+	if err := yaml.Unmarshal(resolvedData, &resolvedValues); err != nil {
+		return nil, fmt.Errorf("could not decode resolved secrets: %w", err)
+	}
+	if len(resolvedValues) != len(handles) {
+		return nil, fmt.Errorf("secret resolver returned %d values for %d handles", len(resolvedValues), len(handles))
+	}
+	for i, resolvedValue := range resolvedValues {
+		if resolvedValue == handles[i] {
+			return nil, fmt.Errorf("secret handle %q was not resolved", handles[i])
+		}
+	}
+	return resolvedValues, nil
 }
 
 func resolveTokenAuthTokens(ctx context.Context, tokens []*privateactionspb.ConnectionToken) ([]privateconnection.PrivateCredentialsToken, error) {

--- a/pkg/privateactionrunner/credentials/resolver/credentials_resolver.go
+++ b/pkg/privateactionrunner/credentials/resolver/credentials_resolver.go
@@ -36,7 +36,8 @@ type SecretResolver interface {
 }
 
 type privateCredentialResolver struct {
-	secretResolver SecretResolver
+	secretResolver          SecretResolver
+	secretManagementEnabled bool
 }
 
 type PrivateConnectionConfig struct {
@@ -51,8 +52,11 @@ type Credential struct {
 	Password   string `json:"password,omitempty"`
 }
 
-func NewPrivateCredentialResolver(secretResolver SecretResolver) PrivateCredentialResolver {
-	return &privateCredentialResolver{secretResolver: secretResolver}
+func NewPrivateCredentialResolver(secretResolver SecretResolver, secretManagementEnabled bool) PrivateCredentialResolver {
+	return &privateCredentialResolver{
+		secretResolver:          secretResolver,
+		secretManagementEnabled: secretManagementEnabled,
+	}
 }
 
 func (p *privateCredentialResolver) ResolveConnectionInfoToCredential(ctx context.Context, connInfo *privateactionspb.ConnectionInfo, userUUID *uuid.UUID) (*privateconnection.PrivateCredentials, error) {
@@ -116,13 +120,6 @@ func (p *privateCredentialResolver) resolveConnectionTokensV2(tokens []*privatea
 		switch source := token.GetSource().(type) {
 		case *privateactionspb.ConnectionTokenV2_PlainText_:
 			resolvedValues[i] = source.PlainText.GetValue()
-		case *privateactionspb.ConnectionTokenV2_EnvironmentVariable_:
-			name := source.EnvironmentVariable.GetName()
-			value, ok := os.LookupEnv(name)
-			if !ok {
-				return nil, fmt.Errorf("environment variable %q for connection token %q is not set", name, tokenName)
-			}
-			resolvedValues[i] = value
 		case *privateactionspb.ConnectionTokenV2_DatadogAgentSecret_:
 			handle := source.DatadogAgentSecret.GetHandle()
 			if handle == "" {
@@ -153,6 +150,9 @@ func (p *privateCredentialResolver) resolveConnectionTokensV2(tokens []*privatea
 }
 
 func (p *privateCredentialResolver) resolveAgentSecrets(handles []string, connectionID string) ([]string, error) {
+	if !p.secretManagementEnabled {
+		return nil, errors.New("Datadog Agent secret management is disabled")
+	}
 	if p.secretResolver == nil {
 		return nil, errors.New("Datadog Agent secret resolver is unavailable")
 	}

--- a/pkg/privateactionrunner/credentials/resolver/credentials_resolver_test.go
+++ b/pkg/privateactionrunner/credentials/resolver/credentials_resolver_test.go
@@ -7,7 +7,6 @@ package resolver
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,21 +45,19 @@ func (r *fakeSecretResolver) Resolve(data []byte, origin string, _ string, _ str
 }
 
 func TestResolveConnectionInfoToCredentialConnectionTokensV2(t *testing.T) {
-	t.Setenv("PAR_DATABASE_PASSWORD", "resolved-password")
-	t.Setenv("PAR_DATABASE_URL", "https://database.example.com")
 	connInfo := &privateactionspb.ConnectionInfo{
 		CredentialsType: privateactionspb.CredentialsType_CONNECTION_TOKENS_V2,
 		TokensV2: []*privateactionspb.ConnectionTokenV2{
 			newV2PlainTextToken([]string{privateconnection.RootTokenGroupName, "username"}, "database-user"),
-			newV2EnvironmentVariableToken([]string{privateconnection.RootTokenGroupName, "password"}, "PAR_DATABASE_PASSWORD"),
-			newV2EnvironmentVariableToken([]string{http.BaseUrlTokenName}, "PAR_DATABASE_URL"),
+			newV2PlainTextToken([]string{privateconnection.RootTokenGroupName, "password"}, "database-password"),
+			newV2PlainTextToken([]string{http.BaseUrlTokenName}, "https://database.example.com"),
 		},
 	}
 	want := &privateconnection.PrivateCredentials{
 		Type: privateconnection.TokenAuthType,
 		Tokens: []privateconnection.PrivateCredentialsToken{
 			{Name: "username", Value: "database-user"},
-			{Name: "password", Value: "resolved-password"},
+			{Name: "password", Value: "database-password"},
 		},
 		HttpDetails: privateconnection.HttpDetails{
 			BaseURL:       "https://database.example.com",
@@ -69,24 +66,9 @@ func TestResolveConnectionInfoToCredentialConnectionTokensV2(t *testing.T) {
 		},
 	}
 
-	got, err := NewPrivateCredentialResolver(nil).ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
+	got, err := NewPrivateCredentialResolver(nil, true).ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
 	require.NoError(t, err)
 	assert.Equal(t, want, got)
-}
-
-func TestResolveConnectionInfoToCredentialConnectionTokensV2MissingEnvironmentVariable(t *testing.T) {
-	name := "PAR_ENVIRONMENT_VARIABLE_THAT_IS_NOT_SET"
-	require.NoError(t, os.Unsetenv(name))
-	connInfo := &privateactionspb.ConnectionInfo{
-		CredentialsType: privateactionspb.CredentialsType_CONNECTION_TOKENS_V2,
-		TokensV2: []*privateactionspb.ConnectionTokenV2{
-			newV2EnvironmentVariableToken([]string{privateconnection.RootTokenGroupName, "password"}, name),
-		},
-	}
-
-	got, err := NewPrivateCredentialResolver(nil).ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
-	assert.Nil(t, got)
-	assert.EqualError(t, err, "environment variable \"PAR_ENVIRONMENT_VARIABLE_THAT_IS_NOT_SET\" for connection token \"password\" is not set")
 }
 
 func TestResolveConnectionInfoToCredentialConnectionTokensV2DatadogAgentSecrets(t *testing.T) {
@@ -103,7 +85,7 @@ func TestResolveConnectionInfoToCredentialConnectionTokensV2DatadogAgentSecrets(
 		},
 	}
 
-	got, err := NewPrivateCredentialResolver(secretResolver).ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
+	got, err := NewPrivateCredentialResolver(secretResolver, true).ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"password": "resolved-password"}, got.AsTokenMap())
 	assert.Equal(t, []privateconnection.PrivateCredentialsToken{{Name: "X-API-Key", Value: "resolved-api-key"}}, got.HttpDetails.Headers)
@@ -122,9 +104,26 @@ func TestResolveConnectionInfoToCredentialConnectionTokensV2RejectsUnavailableSe
 		},
 	}
 
-	got, err := NewPrivateCredentialResolver(nil).ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
+	got, err := NewPrivateCredentialResolver(nil, true).ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
 	assert.Nil(t, got)
 	assert.EqualError(t, err, "could not resolve Datadog Agent secrets: Datadog Agent secret resolver is unavailable")
+}
+
+func TestResolveConnectionInfoToCredentialConnectionTokensV2RejectsDisabledSecretManagement(t *testing.T) {
+	secretResolver := &fakeSecretResolver{values: map[string]string{
+		"ENC[database_password]": "resolved-password",
+	}}
+	connInfo := &privateactionspb.ConnectionInfo{
+		CredentialsType: privateactionspb.CredentialsType_CONNECTION_TOKENS_V2,
+		TokensV2: []*privateactionspb.ConnectionTokenV2{
+			newV2DatadogAgentSecretToken([]string{privateconnection.RootTokenGroupName, "password"}, "ENC[database_password]"),
+		},
+	}
+
+	got, err := NewPrivateCredentialResolver(secretResolver, false).ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
+	assert.Nil(t, got)
+	assert.EqualError(t, err, "could not resolve Datadog Agent secrets: Datadog Agent secret management is disabled")
+	assert.Zero(t, secretResolver.calls)
 }
 
 func TestResolveConnectionInfoToCredentialConnectionTokensV2RejectsUnresolvedSecret(t *testing.T) {
@@ -135,7 +134,7 @@ func TestResolveConnectionInfoToCredentialConnectionTokensV2RejectsUnresolvedSec
 		},
 	}
 
-	got, err := NewPrivateCredentialResolver(&fakeSecretResolver{passthrough: true}).ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
+	got, err := NewPrivateCredentialResolver(&fakeSecretResolver{passthrough: true}, true).ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
 	assert.Nil(t, got)
 	assert.EqualError(t, err, "could not resolve Datadog Agent secrets: secret handle \"ENC[database_password]\" was not resolved")
 }
@@ -145,15 +144,6 @@ func newV2PlainTextToken(nameSegments []string, value string) *privateactionspb.
 		NameSegments: nameSegments,
 		Source: &privateactionspb.ConnectionTokenV2_PlainText_{
 			PlainText: &privateactionspb.ConnectionTokenV2_PlainText{Value: value},
-		},
-	}
-}
-
-func newV2EnvironmentVariableToken(nameSegments []string, name string) *privateactionspb.ConnectionTokenV2 {
-	return &privateactionspb.ConnectionTokenV2{
-		NameSegments: nameSegments,
-		Source: &privateactionspb.ConnectionTokenV2_EnvironmentVariable_{
-			EnvironmentVariable: &privateactionspb.ConnectionTokenV2_EnvironmentVariable{Name: name},
 		},
 	}
 }

--- a/pkg/privateactionrunner/credentials/resolver/credentials_resolver_test.go
+++ b/pkg/privateactionrunner/credentials/resolver/credentials_resolver_test.go
@@ -1,0 +1,103 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package resolver
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	http "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/constants"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
+	privateactionspb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/privateactions"
+)
+
+func TestResolveConnectionInfoToCredentialConnectionTokensV2(t *testing.T) {
+	t.Setenv("PAR_DATABASE_PASSWORD", "resolved-password")
+	t.Setenv("PAR_DATABASE_URL", "https://database.example.com")
+	connInfo := &privateactionspb.ConnectionInfo{
+		CredentialsType: privateactionspb.CredentialsType_CONNECTION_TOKENS_V2,
+		TokensV2: []*privateactionspb.ConnectionTokenV2{
+			newV2PlainTextToken([]string{privateconnection.RootTokenGroupName, "username"}, "database-user"),
+			newV2EnvironmentVariableToken([]string{privateconnection.RootTokenGroupName, "password"}, "PAR_DATABASE_PASSWORD"),
+			newV2EnvironmentVariableToken([]string{http.BaseUrlTokenName}, "PAR_DATABASE_URL"),
+		},
+	}
+	want := &privateconnection.PrivateCredentials{
+		Type: privateconnection.TokenAuthType,
+		Tokens: []privateconnection.PrivateCredentialsToken{
+			{Name: "username", Value: "database-user"},
+			{Name: "password", Value: "resolved-password"},
+		},
+		HttpDetails: privateconnection.HttpDetails{
+			BaseURL:       "https://database.example.com",
+			Headers:       []privateconnection.PrivateCredentialsToken{},
+			UrlParameters: []privateconnection.PrivateCredentialsToken{},
+		},
+	}
+
+	got, err := NewPrivateCredentialResolver().ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestResolveConnectionInfoToCredentialConnectionTokensV2MissingEnvironmentVariable(t *testing.T) {
+	name := "PAR_ENVIRONMENT_VARIABLE_THAT_IS_NOT_SET"
+	require.NoError(t, os.Unsetenv(name))
+	connInfo := &privateactionspb.ConnectionInfo{
+		CredentialsType: privateactionspb.CredentialsType_CONNECTION_TOKENS_V2,
+		TokensV2: []*privateactionspb.ConnectionTokenV2{
+			newV2EnvironmentVariableToken([]string{privateconnection.RootTokenGroupName, "password"}, name),
+		},
+	}
+
+	got, err := NewPrivateCredentialResolver().ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
+	assert.Nil(t, got)
+	assert.EqualError(t, err, "environment variable \"PAR_ENVIRONMENT_VARIABLE_THAT_IS_NOT_SET\" for connection token \"password\" is not set")
+}
+
+func TestResolveConnectionInfoToCredentialConnectionTokensV2RejectsDatadogAgentSecret(t *testing.T) {
+	connInfo := &privateactionspb.ConnectionInfo{
+		CredentialsType: privateactionspb.CredentialsType_CONNECTION_TOKENS_V2,
+		TokensV2: []*privateactionspb.ConnectionTokenV2{
+			newV2DatadogAgentSecretToken([]string{privateconnection.RootTokenGroupName, "password"}, "ENC[database_password]"),
+		},
+	}
+
+	got, err := NewPrivateCredentialResolver().ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
+	assert.Nil(t, got)
+	assert.EqualError(t, err, "Datadog Agent secret references are not supported by the private action runner for connection token \"password\"")
+}
+
+func newV2PlainTextToken(nameSegments []string, value string) *privateactionspb.ConnectionTokenV2 {
+	return &privateactionspb.ConnectionTokenV2{
+		NameSegments: nameSegments,
+		Source: &privateactionspb.ConnectionTokenV2_PlainText_{
+			PlainText: &privateactionspb.ConnectionTokenV2_PlainText{Value: value},
+		},
+	}
+}
+
+func newV2EnvironmentVariableToken(nameSegments []string, name string) *privateactionspb.ConnectionTokenV2 {
+	return &privateactionspb.ConnectionTokenV2{
+		NameSegments: nameSegments,
+		Source: &privateactionspb.ConnectionTokenV2_EnvironmentVariable_{
+			EnvironmentVariable: &privateactionspb.ConnectionTokenV2_EnvironmentVariable{Name: name},
+		},
+	}
+}
+
+func newV2DatadogAgentSecretToken(nameSegments []string, handle string) *privateactionspb.ConnectionTokenV2 {
+	return &privateactionspb.ConnectionTokenV2{
+		NameSegments: nameSegments,
+		Source: &privateactionspb.ConnectionTokenV2_DatadogAgentSecret_{
+			DatadogAgentSecret: &privateactionspb.ConnectionTokenV2_DatadogAgentSecret{Handle: handle},
+		},
+	}
+}

--- a/pkg/privateactionrunner/credentials/resolver/credentials_resolver_test.go
+++ b/pkg/privateactionrunner/credentials/resolver/credentials_resolver_test.go
@@ -12,11 +12,38 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v2"
 
 	http "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/constants"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
 	privateactionspb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/privateactions"
 )
+
+type fakeSecretResolver struct {
+	values      map[string]string
+	origin      string
+	encodedData []byte
+	passthrough bool
+	calls       int
+}
+
+func (r *fakeSecretResolver) Resolve(data []byte, origin string, _ string, _ string, _ bool) ([]byte, error) {
+	r.calls++
+	r.origin = origin
+	r.encodedData = data
+	if r.passthrough {
+		return data, nil
+	}
+	var handles []string
+	if err := yaml.Unmarshal(data, &handles); err != nil {
+		return nil, err
+	}
+	resolvedValues := make([]string, len(handles))
+	for i, handle := range handles {
+		resolvedValues[i] = r.values[handle]
+	}
+	return yaml.Marshal(resolvedValues)
+}
 
 func TestResolveConnectionInfoToCredentialConnectionTokensV2(t *testing.T) {
 	t.Setenv("PAR_DATABASE_PASSWORD", "resolved-password")
@@ -42,7 +69,7 @@ func TestResolveConnectionInfoToCredentialConnectionTokensV2(t *testing.T) {
 		},
 	}
 
-	got, err := NewPrivateCredentialResolver().ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
+	got, err := NewPrivateCredentialResolver(nil).ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
 	require.NoError(t, err)
 	assert.Equal(t, want, got)
 }
@@ -57,12 +84,37 @@ func TestResolveConnectionInfoToCredentialConnectionTokensV2MissingEnvironmentVa
 		},
 	}
 
-	got, err := NewPrivateCredentialResolver().ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
+	got, err := NewPrivateCredentialResolver(nil).ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
 	assert.Nil(t, got)
 	assert.EqualError(t, err, "environment variable \"PAR_ENVIRONMENT_VARIABLE_THAT_IS_NOT_SET\" for connection token \"password\" is not set")
 }
 
-func TestResolveConnectionInfoToCredentialConnectionTokensV2RejectsDatadogAgentSecret(t *testing.T) {
+func TestResolveConnectionInfoToCredentialConnectionTokensV2DatadogAgentSecrets(t *testing.T) {
+	secretResolver := &fakeSecretResolver{values: map[string]string{
+		"ENC[database_password]": "resolved-password",
+		"ENC[api_key]":           "resolved-api-key",
+	}}
+	connInfo := &privateactionspb.ConnectionInfo{
+		ConnectionId:    "connection-id",
+		CredentialsType: privateactionspb.CredentialsType_CONNECTION_TOKENS_V2,
+		TokensV2: []*privateactionspb.ConnectionTokenV2{
+			newV2DatadogAgentSecretToken([]string{privateconnection.RootTokenGroupName, "password"}, "ENC[database_password]"),
+			newV2DatadogAgentSecretToken([]string{"headers", "X-API-Key"}, "ENC[api_key]"),
+		},
+	}
+
+	got, err := NewPrivateCredentialResolver(secretResolver).ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"password": "resolved-password"}, got.AsTokenMap())
+	assert.Equal(t, []privateconnection.PrivateCredentialsToken{{Name: "X-API-Key", Value: "resolved-api-key"}}, got.HttpDetails.Headers)
+	assert.Equal(t, "private-action-runner/connection/connection-id", secretResolver.origin)
+	var encodedSecrets []string
+	require.NoError(t, yaml.Unmarshal(secretResolver.encodedData, &encodedSecrets))
+	assert.Equal(t, []string{"ENC[database_password]", "ENC[api_key]"}, encodedSecrets)
+	assert.Equal(t, 1, secretResolver.calls)
+}
+
+func TestResolveConnectionInfoToCredentialConnectionTokensV2RejectsUnavailableSecretResolver(t *testing.T) {
 	connInfo := &privateactionspb.ConnectionInfo{
 		CredentialsType: privateactionspb.CredentialsType_CONNECTION_TOKENS_V2,
 		TokensV2: []*privateactionspb.ConnectionTokenV2{
@@ -70,9 +122,22 @@ func TestResolveConnectionInfoToCredentialConnectionTokensV2RejectsDatadogAgentS
 		},
 	}
 
-	got, err := NewPrivateCredentialResolver().ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
+	got, err := NewPrivateCredentialResolver(nil).ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
 	assert.Nil(t, got)
-	assert.EqualError(t, err, "Datadog Agent secret references are not supported by the private action runner for connection token \"password\"")
+	assert.EqualError(t, err, "could not resolve Datadog Agent secrets: Datadog Agent secret resolver is unavailable")
+}
+
+func TestResolveConnectionInfoToCredentialConnectionTokensV2RejectsUnresolvedSecret(t *testing.T) {
+	connInfo := &privateactionspb.ConnectionInfo{
+		CredentialsType: privateactionspb.CredentialsType_CONNECTION_TOKENS_V2,
+		TokensV2: []*privateactionspb.ConnectionTokenV2{
+			newV2DatadogAgentSecretToken([]string{privateconnection.RootTokenGroupName, "password"}, "ENC[database_password]"),
+		},
+	}
+
+	got, err := NewPrivateCredentialResolver(&fakeSecretResolver{passthrough: true}).ResolveConnectionInfoToCredential(context.Background(), connInfo, nil)
+	assert.Nil(t, got)
+	assert.EqualError(t, err, "could not resolve Datadog Agent secrets: secret handle \"ENC[database_password]\" was not resolved")
 }
 
 func newV2PlainTextToken(nameSegments []string, value string) *privateactionspb.ConnectionTokenV2 {

--- a/pkg/privateactionrunner/runners/workflow_runner.go
+++ b/pkg/privateactionrunner/runners/workflow_runner.go
@@ -18,6 +18,7 @@ import (
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/credentials/resolver"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/encryptioncontext"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/observability"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/opms"
@@ -48,9 +49,10 @@ func NewWorkflowRunner(
 	ipcClient ipc.HTTPClient,
 	ha helmactions.Component,
 	ka kubeactions.Component,
+	secretResolver resolver.SecretResolver,
 ) (*WorkflowRunner, error) {
 	encryptionStore := encryptioncontext.NewStore()
-	taskExecutor := NewWorkflowTaskExecutor(configuration, verifier, traceroute, eventPlatform, ipcClient, encryptionStore, ha, ka)
+	taskExecutor := NewWorkflowTaskExecutor(configuration, verifier, traceroute, eventPlatform, ipcClient, encryptionStore, ha, ka, secretResolver)
 
 	return &WorkflowRunner{
 		config:          configuration,

--- a/pkg/privateactionrunner/runners/workflow_task_executor.go
+++ b/pkg/privateactionrunner/runners/workflow_task_executor.go
@@ -56,7 +56,7 @@ func NewWorkflowTaskExecutor(
 		registry:     privatebundles.NewRegistry(configuration, traceroute, eventPlatform, ipcClient, encryptionStore, ha, ka),
 		config:       configuration,
 		taskVerifier: taskVerifier,
-		resolver:     resolver.NewPrivateCredentialResolver(secretResolver),
+		resolver:     resolver.NewPrivateCredentialResolver(secretResolver, configuration.AgentSecretManagementEnabled),
 	}
 }
 

--- a/pkg/privateactionrunner/runners/workflow_task_executor.go
+++ b/pkg/privateactionrunner/runners/workflow_task_executor.go
@@ -50,12 +50,13 @@ func NewWorkflowTaskExecutor(
 	encryptionStore *encryptioncontext.Store,
 	ha helmactions.Component,
 	ka kubeactions.Component,
+	secretResolver resolver.SecretResolver,
 ) *WorkflowTaskExecutor {
 	return &WorkflowTaskExecutor{
 		registry:     privatebundles.NewRegistry(configuration, traceroute, eventPlatform, ipcClient, encryptionStore, ha, ka),
 		config:       configuration,
 		taskVerifier: taskVerifier,
-		resolver:     resolver.NewPrivateCredentialResolver(),
+		resolver:     resolver.NewPrivateCredentialResolver(secretResolver),
 	}
 }
 

--- a/pkg/proto/datadog/privateactionrunner/private_actions.proto
+++ b/pkg/proto/datadog/privateactionrunner/private_actions.proto
@@ -115,16 +115,11 @@ message ConnectionTokenV2 {
 
   oneof source {
     PlainText plain_text = 2;
-    EnvironmentVariable environment_variable = 3;
     DatadogAgentSecret datadog_agent_secret = 4;
   }
 
   message PlainText {
     string value = 1;
-  }
-
-  message EnvironmentVariable {
-    string name = 1;
   }
 
   message DatadogAgentSecret {

--- a/pkg/proto/datadog/privateactionrunner/private_actions.proto
+++ b/pkg/proto/datadog/privateactionrunner/private_actions.proto
@@ -73,9 +73,12 @@ message RemoteAction {
 
 message ConnectionInfo {
   string connection_id = 1;
+  // Legacy format with inline and file-backed values.
   repeated ConnectionToken tokens = 2;
   CredentialsType credentials_type = 3;
   string runner_id = 4;
+  // Connection tokens consumed by the private actions runner.
+  repeated ConnectionTokenV2 tokens_v2 = 5;
 }
 
 // The ConnectionToken is similar to connectionpb.ConnectionToken, but is specifically limited to data pertinent to private actions.
@@ -106,9 +109,34 @@ message ConnectionToken {
   }
 }
 
+// Connection tokens with inline values or runner-resolved secrets.
+message ConnectionTokenV2 {
+  repeated string name_segments = 1;
+
+  oneof source {
+    PlainText plain_text = 2;
+    EnvironmentVariable environment_variable = 3;
+    DatadogAgentSecret datadog_agent_secret = 4;
+  }
+
+  message PlainText {
+    string value = 1;
+  }
+
+  message EnvironmentVariable {
+    string name = 1;
+  }
+
+  message DatadogAgentSecret {
+    string handle = 1;
+  }
+}
+
 enum CredentialsType {
   UNSPECIFIED = 0;
   TOKEN_AUTH = 1;
   BASIC_AUTH = 2;
   OAUTH2 = 3;
+  // Credentials are encoded in tokens_v2.
+  CONNECTION_TOKENS_V2 = 5;
 }

--- a/pkg/proto/pbgo/privateactionrunner/privateactions/private_actions.pb.go
+++ b/pkg/proto/pbgo/privateactionrunner/privateactions/private_actions.pb.go
@@ -126,6 +126,8 @@ const (
 	CredentialsType_TOKEN_AUTH  CredentialsType = 1
 	CredentialsType_BASIC_AUTH  CredentialsType = 2
 	CredentialsType_OAUTH2      CredentialsType = 3
+	// Credentials are encoded in tokens_v2.
+	CredentialsType_CONNECTION_TOKENS_V2 CredentialsType = 5
 )
 
 // Enum value maps for CredentialsType.
@@ -135,12 +137,14 @@ var (
 		1: "TOKEN_AUTH",
 		2: "BASIC_AUTH",
 		3: "OAUTH2",
+		5: "CONNECTION_TOKENS_V2",
 	}
 	CredentialsType_value = map[string]int32{
-		"UNSPECIFIED": 0,
-		"TOKEN_AUTH":  1,
-		"BASIC_AUTH":  2,
-		"OAUTH2":      3,
+		"UNSPECIFIED":          0,
+		"TOKEN_AUTH":           1,
+		"BASIC_AUTH":           2,
+		"OAUTH2":               3,
+		"CONNECTION_TOKENS_V2": 5,
 	}
 )
 
@@ -548,13 +552,16 @@ func (x *RemoteAction) GetSystemServices() map[string]*structpb.ListValue {
 }
 
 type ConnectionInfo struct {
-	state           protoimpl.MessageState `protogen:"open.v1"`
-	ConnectionId    string                 `protobuf:"bytes,1,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty"`
-	Tokens          []*ConnectionToken     `protobuf:"bytes,2,rep,name=tokens,proto3" json:"tokens,omitempty"`
-	CredentialsType CredentialsType        `protobuf:"varint,3,opt,name=credentials_type,json=credentialsType,proto3,enum=datadog.privateactionrunner.privateactions.CredentialsType" json:"credentials_type,omitempty"`
-	RunnerId        string                 `protobuf:"bytes,4,opt,name=runner_id,json=runnerId,proto3" json:"runner_id,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	ConnectionId string                 `protobuf:"bytes,1,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty"`
+	// Legacy format with inline and file-backed values.
+	Tokens          []*ConnectionToken `protobuf:"bytes,2,rep,name=tokens,proto3" json:"tokens,omitempty"`
+	CredentialsType CredentialsType    `protobuf:"varint,3,opt,name=credentials_type,json=credentialsType,proto3,enum=datadog.privateactionrunner.privateactions.CredentialsType" json:"credentials_type,omitempty"`
+	RunnerId        string             `protobuf:"bytes,4,opt,name=runner_id,json=runnerId,proto3" json:"runner_id,omitempty"`
+	// Connection tokens consumed by the private actions runner.
+	TokensV2      []*ConnectionTokenV2 `protobuf:"bytes,5,rep,name=tokens_v2,json=tokensV2,proto3" json:"tokens_v2,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ConnectionInfo) Reset() {
@@ -613,6 +620,13 @@ func (x *ConnectionInfo) GetRunnerId() string {
 		return x.RunnerId
 	}
 	return ""
+}
+
+func (x *ConnectionInfo) GetTokensV2() []*ConnectionTokenV2 {
+	if x != nil {
+		return x.TokensV2
+	}
+	return nil
 }
 
 // The ConnectionToken is similar to connectionpb.ConnectionToken, but is specifically limited to data pertinent to private actions.
@@ -727,6 +741,113 @@ func (*ConnectionToken_FileSecret_) isConnectionToken_TokenValue() {}
 
 func (*ConnectionToken_YamlFile_) isConnectionToken_TokenValue() {}
 
+// Connection tokens with inline values or runner-resolved secrets.
+type ConnectionTokenV2 struct {
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	NameSegments []string               `protobuf:"bytes,1,rep,name=name_segments,json=nameSegments,proto3" json:"name_segments,omitempty"`
+	// Types that are valid to be assigned to Source:
+	//
+	//	*ConnectionTokenV2_PlainText_
+	//	*ConnectionTokenV2_EnvironmentVariable_
+	//	*ConnectionTokenV2_DatadogAgentSecret_
+	Source        isConnectionTokenV2_Source `protobuf_oneof:"source"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ConnectionTokenV2) Reset() {
+	*x = ConnectionTokenV2{}
+	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConnectionTokenV2) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConnectionTokenV2) ProtoMessage() {}
+
+func (x *ConnectionTokenV2) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConnectionTokenV2.ProtoReflect.Descriptor instead.
+func (*ConnectionTokenV2) Descriptor() ([]byte, []int) {
+	return file_datadog_privateactionrunner_private_actions_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *ConnectionTokenV2) GetNameSegments() []string {
+	if x != nil {
+		return x.NameSegments
+	}
+	return nil
+}
+
+func (x *ConnectionTokenV2) GetSource() isConnectionTokenV2_Source {
+	if x != nil {
+		return x.Source
+	}
+	return nil
+}
+
+func (x *ConnectionTokenV2) GetPlainText() *ConnectionTokenV2_PlainText {
+	if x != nil {
+		if x, ok := x.Source.(*ConnectionTokenV2_PlainText_); ok {
+			return x.PlainText
+		}
+	}
+	return nil
+}
+
+func (x *ConnectionTokenV2) GetEnvironmentVariable() *ConnectionTokenV2_EnvironmentVariable {
+	if x != nil {
+		if x, ok := x.Source.(*ConnectionTokenV2_EnvironmentVariable_); ok {
+			return x.EnvironmentVariable
+		}
+	}
+	return nil
+}
+
+func (x *ConnectionTokenV2) GetDatadogAgentSecret() *ConnectionTokenV2_DatadogAgentSecret {
+	if x != nil {
+		if x, ok := x.Source.(*ConnectionTokenV2_DatadogAgentSecret_); ok {
+			return x.DatadogAgentSecret
+		}
+	}
+	return nil
+}
+
+type isConnectionTokenV2_Source interface {
+	isConnectionTokenV2_Source()
+}
+
+type ConnectionTokenV2_PlainText_ struct {
+	PlainText *ConnectionTokenV2_PlainText `protobuf:"bytes,2,opt,name=plain_text,json=plainText,proto3,oneof"`
+}
+
+type ConnectionTokenV2_EnvironmentVariable_ struct {
+	EnvironmentVariable *ConnectionTokenV2_EnvironmentVariable `protobuf:"bytes,3,opt,name=environment_variable,json=environmentVariable,proto3,oneof"`
+}
+
+type ConnectionTokenV2_DatadogAgentSecret_ struct {
+	DatadogAgentSecret *ConnectionTokenV2_DatadogAgentSecret `protobuf:"bytes,4,opt,name=datadog_agent_secret,json=datadogAgentSecret,proto3,oneof"`
+}
+
+func (*ConnectionTokenV2_PlainText_) isConnectionTokenV2_Source() {}
+
+func (*ConnectionTokenV2_EnvironmentVariable_) isConnectionTokenV2_Source() {}
+
+func (*ConnectionTokenV2_DatadogAgentSecret_) isConnectionTokenV2_Source() {}
+
 type ConnectionToken_PlainText struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Value         string                 `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"`
@@ -736,7 +857,7 @@ type ConnectionToken_PlainText struct {
 
 func (x *ConnectionToken_PlainText) Reset() {
 	*x = ConnectionToken_PlainText{}
-	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[8]
+	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -748,7 +869,7 @@ func (x *ConnectionToken_PlainText) String() string {
 func (*ConnectionToken_PlainText) ProtoMessage() {}
 
 func (x *ConnectionToken_PlainText) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[8]
+	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -780,7 +901,7 @@ type ConnectionToken_FileSecret struct {
 
 func (x *ConnectionToken_FileSecret) Reset() {
 	*x = ConnectionToken_FileSecret{}
-	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[9]
+	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -792,7 +913,7 @@ func (x *ConnectionToken_FileSecret) String() string {
 func (*ConnectionToken_FileSecret) ProtoMessage() {}
 
 func (x *ConnectionToken_FileSecret) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[9]
+	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -824,7 +945,7 @@ type ConnectionToken_YamlFile struct {
 
 func (x *ConnectionToken_YamlFile) Reset() {
 	*x = ConnectionToken_YamlFile{}
-	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[10]
+	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -836,7 +957,7 @@ func (x *ConnectionToken_YamlFile) String() string {
 func (*ConnectionToken_YamlFile) ProtoMessage() {}
 
 func (x *ConnectionToken_YamlFile) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[10]
+	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -855,6 +976,138 @@ func (*ConnectionToken_YamlFile) Descriptor() ([]byte, []int) {
 func (x *ConnectionToken_YamlFile) GetPath() string {
 	if x != nil {
 		return x.Path
+	}
+	return ""
+}
+
+type ConnectionTokenV2_PlainText struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Value         string                 `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ConnectionTokenV2_PlainText) Reset() {
+	*x = ConnectionTokenV2_PlainText{}
+	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConnectionTokenV2_PlainText) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConnectionTokenV2_PlainText) ProtoMessage() {}
+
+func (x *ConnectionTokenV2_PlainText) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConnectionTokenV2_PlainText.ProtoReflect.Descriptor instead.
+func (*ConnectionTokenV2_PlainText) Descriptor() ([]byte, []int) {
+	return file_datadog_privateactionrunner_private_actions_proto_rawDescGZIP(), []int{7, 0}
+}
+
+func (x *ConnectionTokenV2_PlainText) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
+}
+
+type ConnectionTokenV2_EnvironmentVariable struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ConnectionTokenV2_EnvironmentVariable) Reset() {
+	*x = ConnectionTokenV2_EnvironmentVariable{}
+	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConnectionTokenV2_EnvironmentVariable) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConnectionTokenV2_EnvironmentVariable) ProtoMessage() {}
+
+func (x *ConnectionTokenV2_EnvironmentVariable) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConnectionTokenV2_EnvironmentVariable.ProtoReflect.Descriptor instead.
+func (*ConnectionTokenV2_EnvironmentVariable) Descriptor() ([]byte, []int) {
+	return file_datadog_privateactionrunner_private_actions_proto_rawDescGZIP(), []int{7, 1}
+}
+
+func (x *ConnectionTokenV2_EnvironmentVariable) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+type ConnectionTokenV2_DatadogAgentSecret struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Handle        string                 `protobuf:"bytes,1,opt,name=handle,proto3" json:"handle,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ConnectionTokenV2_DatadogAgentSecret) Reset() {
+	*x = ConnectionTokenV2_DatadogAgentSecret{}
+	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConnectionTokenV2_DatadogAgentSecret) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConnectionTokenV2_DatadogAgentSecret) ProtoMessage() {}
+
+func (x *ConnectionTokenV2_DatadogAgentSecret) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConnectionTokenV2_DatadogAgentSecret.ProtoReflect.Descriptor instead.
+func (*ConnectionTokenV2_DatadogAgentSecret) Descriptor() ([]byte, []int) {
+	return file_datadog_privateactionrunner_private_actions_proto_rawDescGZIP(), []int{7, 2}
+}
+
+func (x *ConnectionTokenV2_DatadogAgentSecret) GetHandle() string {
+	if x != nil {
+		return x.Handle
 	}
 	return ""
 }
@@ -898,12 +1151,13 @@ const file_datadog_privateactionrunner_private_actions_proto_rawDesc = "" +
 	"\x0fsystem_services\x18\x03 \x03(\v2L.datadog.privateactionrunner.privateactions.RemoteAction.SystemServicesEntryR\x0fsystem_services\x1a]\n" +
 	"\x13SystemServicesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
-	"\x05value\x18\x02 \x01(\v2\x1a.google.protobuf.ListValueR\x05value:\x028\x01\"\x8f\x02\n" +
+	"\x05value\x18\x02 \x01(\v2\x1a.google.protobuf.ListValueR\x05value:\x028\x01\"\xeb\x02\n" +
 	"\x0eConnectionInfo\x12#\n" +
 	"\rconnection_id\x18\x01 \x01(\tR\fconnectionId\x12S\n" +
 	"\x06tokens\x18\x02 \x03(\v2;.datadog.privateactionrunner.privateactions.ConnectionTokenR\x06tokens\x12f\n" +
 	"\x10credentials_type\x18\x03 \x01(\x0e2;.datadog.privateactionrunner.privateactions.CredentialsTypeR\x0fcredentialsType\x12\x1b\n" +
-	"\trunner_id\x18\x04 \x01(\tR\brunnerId\"\xe2\x03\n" +
+	"\trunner_id\x18\x04 \x01(\tR\brunnerId\x12Z\n" +
+	"\ttokens_v2\x18\x05 \x03(\v2=.datadog.privateactionrunner.privateactions.ConnectionTokenV2R\btokensV2\"\xe2\x03\n" +
 	"\x0fConnectionToken\x12#\n" +
 	"\rname_segments\x18\x01 \x03(\tR\fnameSegments\x12f\n" +
 	"\n" +
@@ -918,7 +1172,20 @@ const file_datadog_privateactionrunner_private_actions_proto_rawDesc = "" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x1a\x1e\n" +
 	"\bYamlFile\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04pathB\r\n" +
-	"\vtoken_value*:\n" +
+	"\vtoken_value\"\xb8\x04\n" +
+	"\x11ConnectionTokenV2\x12#\n" +
+	"\rname_segments\x18\x01 \x03(\tR\fnameSegments\x12h\n" +
+	"\n" +
+	"plain_text\x18\x02 \x01(\v2G.datadog.privateactionrunner.privateactions.ConnectionTokenV2.PlainTextH\x00R\tplainText\x12\x86\x01\n" +
+	"\x14environment_variable\x18\x03 \x01(\v2Q.datadog.privateactionrunner.privateactions.ConnectionTokenV2.EnvironmentVariableH\x00R\x13environmentVariable\x12\x84\x01\n" +
+	"\x14datadog_agent_secret\x18\x04 \x01(\v2P.datadog.privateactionrunner.privateactions.ConnectionTokenV2.DatadogAgentSecretH\x00R\x12datadogAgentSecret\x1a!\n" +
+	"\tPlainText\x12\x14\n" +
+	"\x05value\x18\x01 \x01(\tR\x05value\x1a)\n" +
+	"\x13EnvironmentVariable\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x1a,\n" +
+	"\x12DatadogAgentSecret\x12\x16\n" +
+	"\x06handle\x18\x01 \x01(\tR\x06handleB\b\n" +
+	"\x06source*:\n" +
 	"\aKeyType\x12\x14\n" +
 	"\x10KEY_TYPE_UNKNOWN\x10\x00\x12\f\n" +
 	"\bX509_RSA\x10\x01\x12\v\n" +
@@ -926,7 +1193,7 @@ const file_datadog_privateactionrunner_private_actions_proto_rawDesc = "" +
 	"\bHashType\x12\x15\n" +
 	"\x11HASH_TYPE_UNKNOWN\x10\x00\x12\n" +
 	"\n" +
-	"\x06SHA256\x10\x01*N\n" +
+	"\x06SHA256\x10\x01*h\n" +
 	"\x0fCredentialsType\x12\x0f\n" +
 	"\vUNSPECIFIED\x10\x00\x12\x0e\n" +
 	"\n" +
@@ -934,7 +1201,8 @@ const file_datadog_privateactionrunner_private_actions_proto_rawDesc = "" +
 	"\n" +
 	"BASIC_AUTH\x10\x02\x12\n" +
 	"\n" +
-	"\x06OAUTH2\x10\x03BTZRgithub.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/privateactionsb\x06proto3"
+	"\x06OAUTH2\x10\x03\x12\x18\n" +
+	"\x14CONNECTION_TOKENS_V2\x10\x05BTZRgithub.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/privateactionsb\x06proto3"
 
 var (
 	file_datadog_privateactionrunner_private_actions_proto_rawDescOnce sync.Once
@@ -949,50 +1217,58 @@ func file_datadog_privateactionrunner_private_actions_proto_rawDescGZIP() []byte
 }
 
 var file_datadog_privateactionrunner_private_actions_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_datadog_privateactionrunner_private_actions_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_datadog_privateactionrunner_private_actions_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_datadog_privateactionrunner_private_actions_proto_goTypes = []any{
-	(KeyType)(0),                          // 0: datadog.privateactionrunner.privateactions.KeyType
-	(HashType)(0),                         // 1: datadog.privateactionrunner.privateactions.HashType
-	(CredentialsType)(0),                  // 2: datadog.privateactionrunner.privateactions.CredentialsType
-	(*RemoteConfigSignatureEnvelope)(nil), // 3: datadog.privateactionrunner.privateactions.RemoteConfigSignatureEnvelope
-	(*Signature)(nil),                     // 4: datadog.privateactionrunner.privateactions.Signature
-	(*PrivateActionTask)(nil),             // 5: datadog.privateactionrunner.privateactions.PrivateActionTask
-	(*SystemInputs)(nil),                  // 6: datadog.privateactionrunner.privateactions.SystemInputs
-	(*RemoteAction)(nil),                  // 7: datadog.privateactionrunner.privateactions.RemoteAction
-	(*ConnectionInfo)(nil),                // 8: datadog.privateactionrunner.privateactions.ConnectionInfo
-	(*ConnectionToken)(nil),               // 9: datadog.privateactionrunner.privateactions.ConnectionToken
-	nil,                                   // 10: datadog.privateactionrunner.privateactions.RemoteAction.SystemServicesEntry
-	(*ConnectionToken_PlainText)(nil),     // 11: datadog.privateactionrunner.privateactions.ConnectionToken.PlainText
-	(*ConnectionToken_FileSecret)(nil),    // 12: datadog.privateactionrunner.privateactions.ConnectionToken.FileSecret
-	(*ConnectionToken_YamlFile)(nil),      // 13: datadog.privateactionrunner.privateactions.ConnectionToken.YamlFile
-	(*timestamppb.Timestamp)(nil),         // 14: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),               // 15: google.protobuf.Struct
-	(actionsclient.Client)(0),             // 16: datadog.privateactionrunner.actionsclient.Client
-	(*structpb.ListValue)(nil),            // 17: google.protobuf.ListValue
+	(KeyType)(0),                                  // 0: datadog.privateactionrunner.privateactions.KeyType
+	(HashType)(0),                                 // 1: datadog.privateactionrunner.privateactions.HashType
+	(CredentialsType)(0),                          // 2: datadog.privateactionrunner.privateactions.CredentialsType
+	(*RemoteConfigSignatureEnvelope)(nil),         // 3: datadog.privateactionrunner.privateactions.RemoteConfigSignatureEnvelope
+	(*Signature)(nil),                             // 4: datadog.privateactionrunner.privateactions.Signature
+	(*PrivateActionTask)(nil),                     // 5: datadog.privateactionrunner.privateactions.PrivateActionTask
+	(*SystemInputs)(nil),                          // 6: datadog.privateactionrunner.privateactions.SystemInputs
+	(*RemoteAction)(nil),                          // 7: datadog.privateactionrunner.privateactions.RemoteAction
+	(*ConnectionInfo)(nil),                        // 8: datadog.privateactionrunner.privateactions.ConnectionInfo
+	(*ConnectionToken)(nil),                       // 9: datadog.privateactionrunner.privateactions.ConnectionToken
+	(*ConnectionTokenV2)(nil),                     // 10: datadog.privateactionrunner.privateactions.ConnectionTokenV2
+	nil,                                           // 11: datadog.privateactionrunner.privateactions.RemoteAction.SystemServicesEntry
+	(*ConnectionToken_PlainText)(nil),             // 12: datadog.privateactionrunner.privateactions.ConnectionToken.PlainText
+	(*ConnectionToken_FileSecret)(nil),            // 13: datadog.privateactionrunner.privateactions.ConnectionToken.FileSecret
+	(*ConnectionToken_YamlFile)(nil),              // 14: datadog.privateactionrunner.privateactions.ConnectionToken.YamlFile
+	(*ConnectionTokenV2_PlainText)(nil),           // 15: datadog.privateactionrunner.privateactions.ConnectionTokenV2.PlainText
+	(*ConnectionTokenV2_EnvironmentVariable)(nil), // 16: datadog.privateactionrunner.privateactions.ConnectionTokenV2.EnvironmentVariable
+	(*ConnectionTokenV2_DatadogAgentSecret)(nil),  // 17: datadog.privateactionrunner.privateactions.ConnectionTokenV2.DatadogAgentSecret
+	(*timestamppb.Timestamp)(nil),                 // 18: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                       // 19: google.protobuf.Struct
+	(actionsclient.Client)(0),                     // 20: datadog.privateactionrunner.actionsclient.Client
+	(*structpb.ListValue)(nil),                    // 21: google.protobuf.ListValue
 }
 var file_datadog_privateactionrunner_private_actions_proto_depIdxs = []int32{
 	1,  // 0: datadog.privateactionrunner.privateactions.RemoteConfigSignatureEnvelope.hash_type:type_name -> datadog.privateactionrunner.privateactions.HashType
-	14, // 1: datadog.privateactionrunner.privateactions.RemoteConfigSignatureEnvelope.expiration_time:type_name -> google.protobuf.Timestamp
+	18, // 1: datadog.privateactionrunner.privateactions.RemoteConfigSignatureEnvelope.expiration_time:type_name -> google.protobuf.Timestamp
 	4,  // 2: datadog.privateactionrunner.privateactions.RemoteConfigSignatureEnvelope.signatures:type_name -> datadog.privateactionrunner.privateactions.Signature
 	0,  // 3: datadog.privateactionrunner.privateactions.Signature.key_type:type_name -> datadog.privateactionrunner.privateactions.KeyType
-	15, // 4: datadog.privateactionrunner.privateactions.PrivateActionTask.inputs:type_name -> google.protobuf.Struct
+	19, // 4: datadog.privateactionrunner.privateactions.PrivateActionTask.inputs:type_name -> google.protobuf.Struct
 	8,  // 5: datadog.privateactionrunner.privateactions.PrivateActionTask.connection_info:type_name -> datadog.privateactionrunner.privateactions.ConnectionInfo
-	14, // 6: datadog.privateactionrunner.privateactions.PrivateActionTask.expiration_time:type_name -> google.protobuf.Timestamp
-	16, // 7: datadog.privateactionrunner.privateactions.PrivateActionTask.client:type_name -> datadog.privateactionrunner.actionsclient.Client
+	18, // 6: datadog.privateactionrunner.privateactions.PrivateActionTask.expiration_time:type_name -> google.protobuf.Timestamp
+	20, // 7: datadog.privateactionrunner.privateactions.PrivateActionTask.client:type_name -> datadog.privateactionrunner.actionsclient.Client
 	6,  // 8: datadog.privateactionrunner.privateactions.PrivateActionTask.system_inputs:type_name -> datadog.privateactionrunner.privateactions.SystemInputs
 	7,  // 9: datadog.privateactionrunner.privateactions.SystemInputs.remote_action:type_name -> datadog.privateactionrunner.privateactions.RemoteAction
-	10, // 10: datadog.privateactionrunner.privateactions.RemoteAction.system_services:type_name -> datadog.privateactionrunner.privateactions.RemoteAction.SystemServicesEntry
+	11, // 10: datadog.privateactionrunner.privateactions.RemoteAction.system_services:type_name -> datadog.privateactionrunner.privateactions.RemoteAction.SystemServicesEntry
 	9,  // 11: datadog.privateactionrunner.privateactions.ConnectionInfo.tokens:type_name -> datadog.privateactionrunner.privateactions.ConnectionToken
 	2,  // 12: datadog.privateactionrunner.privateactions.ConnectionInfo.credentials_type:type_name -> datadog.privateactionrunner.privateactions.CredentialsType
-	11, // 13: datadog.privateactionrunner.privateactions.ConnectionToken.plain_text:type_name -> datadog.privateactionrunner.privateactions.ConnectionToken.PlainText
-	12, // 14: datadog.privateactionrunner.privateactions.ConnectionToken.file_secret:type_name -> datadog.privateactionrunner.privateactions.ConnectionToken.FileSecret
-	13, // 15: datadog.privateactionrunner.privateactions.ConnectionToken.yaml_file:type_name -> datadog.privateactionrunner.privateactions.ConnectionToken.YamlFile
-	17, // 16: datadog.privateactionrunner.privateactions.RemoteAction.SystemServicesEntry.value:type_name -> google.protobuf.ListValue
-	17, // [17:17] is the sub-list for method output_type
-	17, // [17:17] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	10, // 13: datadog.privateactionrunner.privateactions.ConnectionInfo.tokens_v2:type_name -> datadog.privateactionrunner.privateactions.ConnectionTokenV2
+	12, // 14: datadog.privateactionrunner.privateactions.ConnectionToken.plain_text:type_name -> datadog.privateactionrunner.privateactions.ConnectionToken.PlainText
+	13, // 15: datadog.privateactionrunner.privateactions.ConnectionToken.file_secret:type_name -> datadog.privateactionrunner.privateactions.ConnectionToken.FileSecret
+	14, // 16: datadog.privateactionrunner.privateactions.ConnectionToken.yaml_file:type_name -> datadog.privateactionrunner.privateactions.ConnectionToken.YamlFile
+	15, // 17: datadog.privateactionrunner.privateactions.ConnectionTokenV2.plain_text:type_name -> datadog.privateactionrunner.privateactions.ConnectionTokenV2.PlainText
+	16, // 18: datadog.privateactionrunner.privateactions.ConnectionTokenV2.environment_variable:type_name -> datadog.privateactionrunner.privateactions.ConnectionTokenV2.EnvironmentVariable
+	17, // 19: datadog.privateactionrunner.privateactions.ConnectionTokenV2.datadog_agent_secret:type_name -> datadog.privateactionrunner.privateactions.ConnectionTokenV2.DatadogAgentSecret
+	21, // 20: datadog.privateactionrunner.privateactions.RemoteAction.SystemServicesEntry.value:type_name -> google.protobuf.ListValue
+	21, // [21:21] is the sub-list for method output_type
+	21, // [21:21] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_datadog_privateactionrunner_private_actions_proto_init() }
@@ -1008,13 +1284,18 @@ func file_datadog_privateactionrunner_private_actions_proto_init() {
 		(*ConnectionToken_FileSecret_)(nil),
 		(*ConnectionToken_YamlFile_)(nil),
 	}
+	file_datadog_privateactionrunner_private_actions_proto_msgTypes[7].OneofWrappers = []any{
+		(*ConnectionTokenV2_PlainText_)(nil),
+		(*ConnectionTokenV2_EnvironmentVariable_)(nil),
+		(*ConnectionTokenV2_DatadogAgentSecret_)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_datadog_privateactionrunner_private_actions_proto_rawDesc), len(file_datadog_privateactionrunner_private_actions_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   11,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/proto/pbgo/privateactionrunner/privateactions/private_actions.pb.go
+++ b/pkg/proto/pbgo/privateactionrunner/privateactions/private_actions.pb.go
@@ -748,7 +748,6 @@ type ConnectionTokenV2 struct {
 	// Types that are valid to be assigned to Source:
 	//
 	//	*ConnectionTokenV2_PlainText_
-	//	*ConnectionTokenV2_EnvironmentVariable_
 	//	*ConnectionTokenV2_DatadogAgentSecret_
 	Source        isConnectionTokenV2_Source `protobuf_oneof:"source"`
 	unknownFields protoimpl.UnknownFields
@@ -808,15 +807,6 @@ func (x *ConnectionTokenV2) GetPlainText() *ConnectionTokenV2_PlainText {
 	return nil
 }
 
-func (x *ConnectionTokenV2) GetEnvironmentVariable() *ConnectionTokenV2_EnvironmentVariable {
-	if x != nil {
-		if x, ok := x.Source.(*ConnectionTokenV2_EnvironmentVariable_); ok {
-			return x.EnvironmentVariable
-		}
-	}
-	return nil
-}
-
 func (x *ConnectionTokenV2) GetDatadogAgentSecret() *ConnectionTokenV2_DatadogAgentSecret {
 	if x != nil {
 		if x, ok := x.Source.(*ConnectionTokenV2_DatadogAgentSecret_); ok {
@@ -834,17 +824,11 @@ type ConnectionTokenV2_PlainText_ struct {
 	PlainText *ConnectionTokenV2_PlainText `protobuf:"bytes,2,opt,name=plain_text,json=plainText,proto3,oneof"`
 }
 
-type ConnectionTokenV2_EnvironmentVariable_ struct {
-	EnvironmentVariable *ConnectionTokenV2_EnvironmentVariable `protobuf:"bytes,3,opt,name=environment_variable,json=environmentVariable,proto3,oneof"`
-}
-
 type ConnectionTokenV2_DatadogAgentSecret_ struct {
 	DatadogAgentSecret *ConnectionTokenV2_DatadogAgentSecret `protobuf:"bytes,4,opt,name=datadog_agent_secret,json=datadogAgentSecret,proto3,oneof"`
 }
 
 func (*ConnectionTokenV2_PlainText_) isConnectionTokenV2_Source() {}
-
-func (*ConnectionTokenV2_EnvironmentVariable_) isConnectionTokenV2_Source() {}
 
 func (*ConnectionTokenV2_DatadogAgentSecret_) isConnectionTokenV2_Source() {}
 
@@ -1024,50 +1008,6 @@ func (x *ConnectionTokenV2_PlainText) GetValue() string {
 	return ""
 }
 
-type ConnectionTokenV2_EnvironmentVariable struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *ConnectionTokenV2_EnvironmentVariable) Reset() {
-	*x = ConnectionTokenV2_EnvironmentVariable{}
-	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[13]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *ConnectionTokenV2_EnvironmentVariable) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*ConnectionTokenV2_EnvironmentVariable) ProtoMessage() {}
-
-func (x *ConnectionTokenV2_EnvironmentVariable) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[13]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use ConnectionTokenV2_EnvironmentVariable.ProtoReflect.Descriptor instead.
-func (*ConnectionTokenV2_EnvironmentVariable) Descriptor() ([]byte, []int) {
-	return file_datadog_privateactionrunner_private_actions_proto_rawDescGZIP(), []int{7, 1}
-}
-
-func (x *ConnectionTokenV2_EnvironmentVariable) GetName() string {
-	if x != nil {
-		return x.Name
-	}
-	return ""
-}
-
 type ConnectionTokenV2_DatadogAgentSecret struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Handle        string                 `protobuf:"bytes,1,opt,name=handle,proto3" json:"handle,omitempty"`
@@ -1077,7 +1017,7 @@ type ConnectionTokenV2_DatadogAgentSecret struct {
 
 func (x *ConnectionTokenV2_DatadogAgentSecret) Reset() {
 	*x = ConnectionTokenV2_DatadogAgentSecret{}
-	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[14]
+	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1089,7 +1029,7 @@ func (x *ConnectionTokenV2_DatadogAgentSecret) String() string {
 func (*ConnectionTokenV2_DatadogAgentSecret) ProtoMessage() {}
 
 func (x *ConnectionTokenV2_DatadogAgentSecret) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[14]
+	mi := &file_datadog_privateactionrunner_private_actions_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1102,7 +1042,7 @@ func (x *ConnectionTokenV2_DatadogAgentSecret) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use ConnectionTokenV2_DatadogAgentSecret.ProtoReflect.Descriptor instead.
 func (*ConnectionTokenV2_DatadogAgentSecret) Descriptor() ([]byte, []int) {
-	return file_datadog_privateactionrunner_private_actions_proto_rawDescGZIP(), []int{7, 2}
+	return file_datadog_privateactionrunner_private_actions_proto_rawDescGZIP(), []int{7, 1}
 }
 
 func (x *ConnectionTokenV2_DatadogAgentSecret) GetHandle() string {
@@ -1172,17 +1112,14 @@ const file_datadog_privateactionrunner_private_actions_proto_rawDesc = "" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x1a\x1e\n" +
 	"\bYamlFile\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04pathB\r\n" +
-	"\vtoken_value\"\xb8\x04\n" +
+	"\vtoken_value\"\x84\x03\n" +
 	"\x11ConnectionTokenV2\x12#\n" +
 	"\rname_segments\x18\x01 \x03(\tR\fnameSegments\x12h\n" +
 	"\n" +
-	"plain_text\x18\x02 \x01(\v2G.datadog.privateactionrunner.privateactions.ConnectionTokenV2.PlainTextH\x00R\tplainText\x12\x86\x01\n" +
-	"\x14environment_variable\x18\x03 \x01(\v2Q.datadog.privateactionrunner.privateactions.ConnectionTokenV2.EnvironmentVariableH\x00R\x13environmentVariable\x12\x84\x01\n" +
+	"plain_text\x18\x02 \x01(\v2G.datadog.privateactionrunner.privateactions.ConnectionTokenV2.PlainTextH\x00R\tplainText\x12\x84\x01\n" +
 	"\x14datadog_agent_secret\x18\x04 \x01(\v2P.datadog.privateactionrunner.privateactions.ConnectionTokenV2.DatadogAgentSecretH\x00R\x12datadogAgentSecret\x1a!\n" +
 	"\tPlainText\x12\x14\n" +
-	"\x05value\x18\x01 \x01(\tR\x05value\x1a)\n" +
-	"\x13EnvironmentVariable\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\x1a,\n" +
+	"\x05value\x18\x01 \x01(\tR\x05value\x1a,\n" +
 	"\x12DatadogAgentSecret\x12\x16\n" +
 	"\x06handle\x18\x01 \x01(\tR\x06handleB\b\n" +
 	"\x06source*:\n" +
@@ -1217,40 +1154,39 @@ func file_datadog_privateactionrunner_private_actions_proto_rawDescGZIP() []byte
 }
 
 var file_datadog_privateactionrunner_private_actions_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_datadog_privateactionrunner_private_actions_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_datadog_privateactionrunner_private_actions_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_datadog_privateactionrunner_private_actions_proto_goTypes = []any{
-	(KeyType)(0),                                  // 0: datadog.privateactionrunner.privateactions.KeyType
-	(HashType)(0),                                 // 1: datadog.privateactionrunner.privateactions.HashType
-	(CredentialsType)(0),                          // 2: datadog.privateactionrunner.privateactions.CredentialsType
-	(*RemoteConfigSignatureEnvelope)(nil),         // 3: datadog.privateactionrunner.privateactions.RemoteConfigSignatureEnvelope
-	(*Signature)(nil),                             // 4: datadog.privateactionrunner.privateactions.Signature
-	(*PrivateActionTask)(nil),                     // 5: datadog.privateactionrunner.privateactions.PrivateActionTask
-	(*SystemInputs)(nil),                          // 6: datadog.privateactionrunner.privateactions.SystemInputs
-	(*RemoteAction)(nil),                          // 7: datadog.privateactionrunner.privateactions.RemoteAction
-	(*ConnectionInfo)(nil),                        // 8: datadog.privateactionrunner.privateactions.ConnectionInfo
-	(*ConnectionToken)(nil),                       // 9: datadog.privateactionrunner.privateactions.ConnectionToken
-	(*ConnectionTokenV2)(nil),                     // 10: datadog.privateactionrunner.privateactions.ConnectionTokenV2
-	nil,                                           // 11: datadog.privateactionrunner.privateactions.RemoteAction.SystemServicesEntry
-	(*ConnectionToken_PlainText)(nil),             // 12: datadog.privateactionrunner.privateactions.ConnectionToken.PlainText
-	(*ConnectionToken_FileSecret)(nil),            // 13: datadog.privateactionrunner.privateactions.ConnectionToken.FileSecret
-	(*ConnectionToken_YamlFile)(nil),              // 14: datadog.privateactionrunner.privateactions.ConnectionToken.YamlFile
-	(*ConnectionTokenV2_PlainText)(nil),           // 15: datadog.privateactionrunner.privateactions.ConnectionTokenV2.PlainText
-	(*ConnectionTokenV2_EnvironmentVariable)(nil), // 16: datadog.privateactionrunner.privateactions.ConnectionTokenV2.EnvironmentVariable
-	(*ConnectionTokenV2_DatadogAgentSecret)(nil),  // 17: datadog.privateactionrunner.privateactions.ConnectionTokenV2.DatadogAgentSecret
-	(*timestamppb.Timestamp)(nil),                 // 18: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                       // 19: google.protobuf.Struct
-	(actionsclient.Client)(0),                     // 20: datadog.privateactionrunner.actionsclient.Client
-	(*structpb.ListValue)(nil),                    // 21: google.protobuf.ListValue
+	(KeyType)(0),                                 // 0: datadog.privateactionrunner.privateactions.KeyType
+	(HashType)(0),                                // 1: datadog.privateactionrunner.privateactions.HashType
+	(CredentialsType)(0),                         // 2: datadog.privateactionrunner.privateactions.CredentialsType
+	(*RemoteConfigSignatureEnvelope)(nil),        // 3: datadog.privateactionrunner.privateactions.RemoteConfigSignatureEnvelope
+	(*Signature)(nil),                            // 4: datadog.privateactionrunner.privateactions.Signature
+	(*PrivateActionTask)(nil),                    // 5: datadog.privateactionrunner.privateactions.PrivateActionTask
+	(*SystemInputs)(nil),                         // 6: datadog.privateactionrunner.privateactions.SystemInputs
+	(*RemoteAction)(nil),                         // 7: datadog.privateactionrunner.privateactions.RemoteAction
+	(*ConnectionInfo)(nil),                       // 8: datadog.privateactionrunner.privateactions.ConnectionInfo
+	(*ConnectionToken)(nil),                      // 9: datadog.privateactionrunner.privateactions.ConnectionToken
+	(*ConnectionTokenV2)(nil),                    // 10: datadog.privateactionrunner.privateactions.ConnectionTokenV2
+	nil,                                          // 11: datadog.privateactionrunner.privateactions.RemoteAction.SystemServicesEntry
+	(*ConnectionToken_PlainText)(nil),            // 12: datadog.privateactionrunner.privateactions.ConnectionToken.PlainText
+	(*ConnectionToken_FileSecret)(nil),           // 13: datadog.privateactionrunner.privateactions.ConnectionToken.FileSecret
+	(*ConnectionToken_YamlFile)(nil),             // 14: datadog.privateactionrunner.privateactions.ConnectionToken.YamlFile
+	(*ConnectionTokenV2_PlainText)(nil),          // 15: datadog.privateactionrunner.privateactions.ConnectionTokenV2.PlainText
+	(*ConnectionTokenV2_DatadogAgentSecret)(nil), // 16: datadog.privateactionrunner.privateactions.ConnectionTokenV2.DatadogAgentSecret
+	(*timestamppb.Timestamp)(nil),                // 17: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                      // 18: google.protobuf.Struct
+	(actionsclient.Client)(0),                    // 19: datadog.privateactionrunner.actionsclient.Client
+	(*structpb.ListValue)(nil),                   // 20: google.protobuf.ListValue
 }
 var file_datadog_privateactionrunner_private_actions_proto_depIdxs = []int32{
 	1,  // 0: datadog.privateactionrunner.privateactions.RemoteConfigSignatureEnvelope.hash_type:type_name -> datadog.privateactionrunner.privateactions.HashType
-	18, // 1: datadog.privateactionrunner.privateactions.RemoteConfigSignatureEnvelope.expiration_time:type_name -> google.protobuf.Timestamp
+	17, // 1: datadog.privateactionrunner.privateactions.RemoteConfigSignatureEnvelope.expiration_time:type_name -> google.protobuf.Timestamp
 	4,  // 2: datadog.privateactionrunner.privateactions.RemoteConfigSignatureEnvelope.signatures:type_name -> datadog.privateactionrunner.privateactions.Signature
 	0,  // 3: datadog.privateactionrunner.privateactions.Signature.key_type:type_name -> datadog.privateactionrunner.privateactions.KeyType
-	19, // 4: datadog.privateactionrunner.privateactions.PrivateActionTask.inputs:type_name -> google.protobuf.Struct
+	18, // 4: datadog.privateactionrunner.privateactions.PrivateActionTask.inputs:type_name -> google.protobuf.Struct
 	8,  // 5: datadog.privateactionrunner.privateactions.PrivateActionTask.connection_info:type_name -> datadog.privateactionrunner.privateactions.ConnectionInfo
-	18, // 6: datadog.privateactionrunner.privateactions.PrivateActionTask.expiration_time:type_name -> google.protobuf.Timestamp
-	20, // 7: datadog.privateactionrunner.privateactions.PrivateActionTask.client:type_name -> datadog.privateactionrunner.actionsclient.Client
+	17, // 6: datadog.privateactionrunner.privateactions.PrivateActionTask.expiration_time:type_name -> google.protobuf.Timestamp
+	19, // 7: datadog.privateactionrunner.privateactions.PrivateActionTask.client:type_name -> datadog.privateactionrunner.actionsclient.Client
 	6,  // 8: datadog.privateactionrunner.privateactions.PrivateActionTask.system_inputs:type_name -> datadog.privateactionrunner.privateactions.SystemInputs
 	7,  // 9: datadog.privateactionrunner.privateactions.SystemInputs.remote_action:type_name -> datadog.privateactionrunner.privateactions.RemoteAction
 	11, // 10: datadog.privateactionrunner.privateactions.RemoteAction.system_services:type_name -> datadog.privateactionrunner.privateactions.RemoteAction.SystemServicesEntry
@@ -1261,14 +1197,13 @@ var file_datadog_privateactionrunner_private_actions_proto_depIdxs = []int32{
 	13, // 15: datadog.privateactionrunner.privateactions.ConnectionToken.file_secret:type_name -> datadog.privateactionrunner.privateactions.ConnectionToken.FileSecret
 	14, // 16: datadog.privateactionrunner.privateactions.ConnectionToken.yaml_file:type_name -> datadog.privateactionrunner.privateactions.ConnectionToken.YamlFile
 	15, // 17: datadog.privateactionrunner.privateactions.ConnectionTokenV2.plain_text:type_name -> datadog.privateactionrunner.privateactions.ConnectionTokenV2.PlainText
-	16, // 18: datadog.privateactionrunner.privateactions.ConnectionTokenV2.environment_variable:type_name -> datadog.privateactionrunner.privateactions.ConnectionTokenV2.EnvironmentVariable
-	17, // 19: datadog.privateactionrunner.privateactions.ConnectionTokenV2.datadog_agent_secret:type_name -> datadog.privateactionrunner.privateactions.ConnectionTokenV2.DatadogAgentSecret
-	21, // 20: datadog.privateactionrunner.privateactions.RemoteAction.SystemServicesEntry.value:type_name -> google.protobuf.ListValue
-	21, // [21:21] is the sub-list for method output_type
-	21, // [21:21] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	16, // 18: datadog.privateactionrunner.privateactions.ConnectionTokenV2.datadog_agent_secret:type_name -> datadog.privateactionrunner.privateactions.ConnectionTokenV2.DatadogAgentSecret
+	20, // 19: datadog.privateactionrunner.privateactions.RemoteAction.SystemServicesEntry.value:type_name -> google.protobuf.ListValue
+	20, // [20:20] is the sub-list for method output_type
+	20, // [20:20] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_datadog_privateactionrunner_private_actions_proto_init() }
@@ -1286,7 +1221,6 @@ func file_datadog_privateactionrunner_private_actions_proto_init() {
 	}
 	file_datadog_privateactionrunner_private_actions_proto_msgTypes[7].OneofWrappers = []any{
 		(*ConnectionTokenV2_PlainText_)(nil),
-		(*ConnectionTokenV2_EnvironmentVariable_)(nil),
 		(*ConnectionTokenV2_DatadogAgentSecret_)(nil),
 	}
 	type x struct{}
@@ -1295,7 +1229,7 @@ func file_datadog_privateactionrunner_private_actions_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_datadog_privateactionrunner_private_actions_proto_rawDesc), len(file_datadog_privateactionrunner_private_actions_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   15,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/releasenotes/notes/par-connection-tokens-v2-dfe8d38a2f7ec20c.yaml
+++ b/releasenotes/notes/par-connection-tokens-v2-dfe8d38a2f7ec20c.yaml
@@ -1,4 +1,6 @@
 ---
 features:
   - |
-    Add support for resolving secrets through Agent Secrets Management for the private action runner
+    Add support for resolving secrets through Agent Secrets Management for the
+    Private Action Runner. Resolution is enabled by default and can be disabled
+    with ``private_action_runner.agent_secret_management_enabled``.

--- a/releasenotes/notes/par-connection-tokens-v2-dfe8d38a2f7ec20c.yaml
+++ b/releasenotes/notes/par-connection-tokens-v2-dfe8d38a2f7ec20c.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add support for resolving secrets through Agent Secrets Management for the private action runner


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

# What does this PR do?
Adds support for resolving Private Action connection tokens through [Agent Secrets Management](https://docs.datadoghq.com/agent/configuration/secrets-management/?tab=agentyamlfile)

# Motivation
Let customers store Private Action connection tokens as Datadog Agent secrets in addition to the previous file based sytem

# Describe how you validated your changes
Deployed a build on internal infrastructure and tested resolution with aws secret manager

# Additional Notes
Can be opted out with `private_action_runner.agent_secret_management_enabled: false`
