### PR TITLE
[CONTP-2006] feat(ddi): Add resolved target to workloadmeta

### DIFF
--- a/comp/core/autodiscovery/integration/BUILD.bazel
+++ b/comp/core/autodiscovery/integration/BUILD.bazel
@@ -44,6 +44,7 @@ dd_agent_go_test(
     deps = [
         "//comp/core/autodiscovery/common/types",
         "//comp/core/workloadfilter/def",
+        "//pkg/proto/pbgo/core",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@in_yaml_go_yaml_v2//:yaml",

--- a/comp/core/autodiscovery/integration/matching_program_test.go
+++ b/comp/core/autodiscovery/integration/matching_program_test.go
@@ -120,9 +120,9 @@ func TestCreateMatchingPrograms_SingleType(t *testing.T) {
 	}
 }
 
-func TestCreateMatchingPrograms_ResolvedTarget(t *testing.T) {
+func TestCreateMatchingPrograms_MatchedOwner(t *testing.T) {
 	rules := workloadfilter.Rules{
-		Containers: []string{`container.pod.resolved_targets.exists(target, target.group == "apps.kruise.io" && target.kind == "CloneSet" && target.namespace == "default" && target.name == "nginx") && container.image.reference != ""`},
+		Containers: []string{`container.pod.matched_owners.exists(owner, owner.group == "apps.kruise.io" && owner.kind == "CloneSet" && owner.namespace == "default" && owner.name == "nginx") && container.image.reference != ""`},
 	}
 
 	programs, _, err := CreateMatchingPrograms(rules, true)
@@ -132,14 +132,14 @@ func TestCreateMatchingPrograms_ResolvedTarget(t *testing.T) {
 
 	container := workloadfilter.CreateContainer("container-id", "nginx", "nginx:latest", &workloadfilter.Pod{
 		FilterPod: &core.FilterPod{
-			ResolvedTargets: []*core.FilterResolvedTarget{
+			MatchedOwners: []*core.FilterMatchedOwner{
 				{Group: "apps.kruise.io", Kind: "CloneSet", Namespace: "default", Name: "nginx"},
 			},
 		},
 	})
 	assert.True(t, program.IsMatched(container))
 
-	container.FilterContainer.GetPod().ResolvedTargets[0].Name = "other"
+	container.FilterContainer.GetPod().MatchedOwners[0].Name = "other"
 	assert.False(t, program.IsMatched(container))
 }
 

--- a/comp/core/autodiscovery/integration/matching_program_test.go
+++ b/comp/core/autodiscovery/integration/matching_program_test.go
@@ -15,6 +15,7 @@ import (
 
 	adtypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 )
 
 func TestCreateMatchingPrograms_EmptyRules(t *testing.T) {
@@ -117,6 +118,29 @@ func TestCreateMatchingPrograms_SingleType(t *testing.T) {
 			assert.Equal(t, tt.expectedADID, celADIDs[0])
 		})
 	}
+}
+
+func TestCreateMatchingPrograms_ResolvedTarget(t *testing.T) {
+	rules := workloadfilter.Rules{
+		Containers: []string{`container.pod.resolved_targets.exists(target, target.group == "apps.kruise.io" && target.kind == "CloneSet" && target.namespace == "default" && target.name == "nginx") && container.image.reference != ""`},
+	}
+
+	programs, _, err := CreateMatchingPrograms(rules, true)
+	require.NoError(t, err)
+	program := programs[workloadfilter.ContainerType]
+	require.NotNil(t, program)
+
+	container := workloadfilter.CreateContainer("container-id", "nginx", "nginx:latest", &workloadfilter.Pod{
+		FilterPod: &core.FilterPod{
+			ResolvedTargets: []*core.FilterResolvedTarget{
+				{Group: "apps.kruise.io", Kind: "CloneSet", Namespace: "default", Name: "nginx"},
+			},
+		},
+	})
+	assert.True(t, program.IsMatched(container))
+
+	container.FilterContainer.GetPod().ResolvedTargets[0].Name = "other"
+	assert.False(t, program.IsMatched(container))
 }
 
 func TestCreateMatchingPrograms_MultipleTypes(t *testing.T) {

--- a/comp/core/workloadfilter/util/workloadmeta/create.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create.go
@@ -37,13 +37,26 @@ func CreatePod(pod *workloadmeta.KubernetesPod) *workloadfilter.Pod {
 		return nil
 	}
 
+	resolvedTargets := make([]*core.FilterResolvedTarget, 0, len(pod.ResolvedTargets))
+	for _, target := range pod.ResolvedTargets {
+		resolvedTargets = append(resolvedTargets, &core.FilterResolvedTarget{
+			Group:     target.Group,
+			Version:   target.Version,
+			Kind:      target.Kind,
+			Namespace: target.Namespace,
+			Name:      target.Name,
+			Uid:       target.ID,
+		})
+	}
+
 	return &workloadfilter.Pod{
 		FilterPod: &core.FilterPod{
-			Id:          pod.ID,
-			Name:        pod.Name,
-			Namespace:   pod.Namespace,
-			Annotations: pod.Annotations,
-			Rootowner:   resolveRootOwner(pod.Owners, pod.Labels),
+			Id:              pod.ID,
+			Name:            pod.Name,
+			Namespace:       pod.Namespace,
+			Annotations:     pod.Annotations,
+			Rootowner:       resolveRootOwner(pod.Owners, pod.Labels),
+			ResolvedTargets: resolvedTargets,
 		},
 	}
 }

--- a/comp/core/workloadfilter/util/workloadmeta/create.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create.go
@@ -37,25 +37,25 @@ func CreatePod(pod *workloadmeta.KubernetesPod) *workloadfilter.Pod {
 		return nil
 	}
 
-	resolvedTargets := make([]*core.FilterResolvedTarget, 0, len(pod.ResolvedTargets))
-	for _, target := range pod.ResolvedTargets {
-		resolvedTargets = append(resolvedTargets, &core.FilterResolvedTarget{
-			Group:     target.Group,
-			Version:   target.Version,
-			Kind:      target.Kind,
-			Namespace: target.Namespace,
-			Name:      target.Name,
+	matchedOwners := make([]*core.FilterMatchedOwner, 0, len(pod.MatchedOwners))
+	for _, owner := range pod.MatchedOwners {
+		matchedOwners = append(matchedOwners, &core.FilterMatchedOwner{
+			Group:     owner.Group,
+			Version:   owner.Version,
+			Kind:      owner.Kind,
+			Namespace: owner.Namespace,
+			Name:      owner.Name,
 		})
 	}
 
 	return &workloadfilter.Pod{
 		FilterPod: &core.FilterPod{
-			Id:              pod.ID,
-			Name:            pod.Name,
-			Namespace:       pod.Namespace,
-			Annotations:     pod.Annotations,
-			Rootowner:       resolveRootOwner(pod.Owners, pod.Labels),
-			ResolvedTargets: resolvedTargets,
+			Id:            pod.ID,
+			Name:          pod.Name,
+			Namespace:     pod.Namespace,
+			Annotations:   pod.Annotations,
+			Rootowner:     resolveRootOwner(pod.Owners, pod.Labels),
+			MatchedOwners: matchedOwners,
 		},
 	}
 }

--- a/comp/core/workloadfilter/util/workloadmeta/create.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create.go
@@ -45,7 +45,6 @@ func CreatePod(pod *workloadmeta.KubernetesPod) *workloadfilter.Pod {
 			Kind:      target.Kind,
 			Namespace: target.Namespace,
 			Name:      target.Name,
-			Uid:       target.ID,
 		})
 	}
 

--- a/comp/core/workloadfilter/util/workloadmeta/create_test.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create_test.go
@@ -102,35 +102,64 @@ func TestResolveRootOwner(t *testing.T) {
 	}
 }
 
-func TestCreatePodWithRootOwner(t *testing.T) {
-	pod := &workloadmeta.KubernetesPod{
-		EntityMeta: workloadmeta.EntityMeta{
-			Name:      "my-app-6d4f5b7c8-abc12",
-			Namespace: "default",
+func TestCreatePod(t *testing.T) {
+	tests := []struct {
+		name            string
+		pod             *workloadmeta.KubernetesPod
+		rootOwner       *core.FilterRootOwner
+		resolvedTargets []*core.FilterResolvedTarget
+	}{
+		{
+			name: "deployment root owner",
+			pod: &workloadmeta.KubernetesPod{
+				Owners: []workloadmeta.KubernetesPodOwner{
+					{Kind: "ReplicaSet", Name: "my-app-6d4f5b7c8", Controller: boolPtr(true)},
+				},
+			},
+			rootOwner: &core.FilterRootOwner{Kind: "Deployment", Name: "my-app"},
 		},
-		Owners: []workloadmeta.KubernetesPodOwner{
-			{Kind: "ReplicaSet", Name: "my-app-6d4f5b7c8", Controller: boolPtr(true)},
+		{
+			name: "rollout root owner",
+			pod: &workloadmeta.KubernetesPod{
+				EntityMeta: workloadmeta.EntityMeta{
+					Labels: map[string]string{kubernetes.ArgoRolloutLabelKey: "9b8dc4bd6"},
+				},
+				Owners: []workloadmeta.KubernetesPodOwner{
+					{Kind: "ReplicaSet", Name: "my-rollout-9b8dc4bd6", Controller: boolPtr(true)},
+				},
+			},
+			rootOwner: &core.FilterRootOwner{Kind: "Rollout", Name: "my-rollout"},
+		},
+		{
+			name: "resolved target",
+			pod: &workloadmeta.KubernetesPod{
+				ResolvedTargets: []workloadmeta.KubernetesResolvedTarget{
+					{
+						Group:     "apps.kruise.io",
+						Version:   "v1alpha1",
+						Kind:      "CloneSet",
+						Namespace: "default",
+						Name:      "nginx",
+					},
+				},
+			},
+			resolvedTargets: []*core.FilterResolvedTarget{
+				{
+					Group:     "apps.kruise.io",
+					Version:   "v1alpha1",
+					Kind:      "CloneSet",
+					Namespace: "default",
+					Name:      "nginx",
+				},
+			},
 		},
 	}
-	result := CreatePod(pod)
-	assert.NotNil(t, result.FilterPod.Rootowner)
-	assert.Equal(t, "Deployment", result.FilterPod.Rootowner.Kind)
-	assert.Equal(t, "my-app", result.FilterPod.Rootowner.Name)
-}
 
-func TestCreatePodWithRolloutRootOwner(t *testing.T) {
-	pod := &workloadmeta.KubernetesPod{
-		EntityMeta: workloadmeta.EntityMeta{
-			Name:      "my-rollout-9b8dc4bd6-abc12",
-			Namespace: "default",
-			Labels:    map[string]string{kubernetes.ArgoRolloutLabelKey: "9b8dc4bd6"},
-		},
-		Owners: []workloadmeta.KubernetesPodOwner{
-			{Kind: "ReplicaSet", Name: "my-rollout-9b8dc4bd6", Controller: boolPtr(true)},
-		},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CreatePod(tt.pod)
+			assert.Equal(t, tt.rootOwner, result.FilterPod.Rootowner)
+			assert.ElementsMatch(t, tt.resolvedTargets, result.FilterPod.ResolvedTargets)
+		})
 	}
-	result := CreatePod(pod)
-	assert.NotNil(t, result.FilterPod.Rootowner)
-	assert.Equal(t, "Rollout", result.FilterPod.Rootowner.Kind)
-	assert.Equal(t, "my-rollout", result.FilterPod.Rootowner.Name)
 }

--- a/comp/core/workloadfilter/util/workloadmeta/create_test.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create_test.go
@@ -104,10 +104,10 @@ func TestResolveRootOwner(t *testing.T) {
 
 func TestCreatePod(t *testing.T) {
 	tests := []struct {
-		name            string
-		pod             *workloadmeta.KubernetesPod
-		rootOwner       *core.FilterRootOwner
-		resolvedTargets []*core.FilterResolvedTarget
+		name          string
+		pod           *workloadmeta.KubernetesPod
+		rootOwner     *core.FilterRootOwner
+		matchedOwners []*core.FilterMatchedOwner
 	}{
 		{
 			name: "deployment root owner",
@@ -131,9 +131,9 @@ func TestCreatePod(t *testing.T) {
 			rootOwner: &core.FilterRootOwner{Kind: "Rollout", Name: "my-rollout"},
 		},
 		{
-			name: "resolved target",
+			name: "matched owner",
 			pod: &workloadmeta.KubernetesPod{
-				ResolvedTargets: []workloadmeta.KubernetesResolvedTarget{
+				MatchedOwners: []workloadmeta.KubernetesMatchedOwner{
 					{
 						Group:     "apps.kruise.io",
 						Version:   "v1alpha1",
@@ -143,7 +143,7 @@ func TestCreatePod(t *testing.T) {
 					},
 				},
 			},
-			resolvedTargets: []*core.FilterResolvedTarget{
+			matchedOwners: []*core.FilterMatchedOwner{
 				{
 					Group:     "apps.kruise.io",
 					Version:   "v1alpha1",
@@ -159,7 +159,7 @@ func TestCreatePod(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := CreatePod(tt.pod)
 			assert.Equal(t, tt.rootOwner, result.FilterPod.Rootowner)
-			assert.ElementsMatch(t, tt.resolvedTargets, result.FilterPod.ResolvedTargets)
+			assert.ElementsMatch(t, tt.matchedOwners, result.FilterPod.MatchedOwners)
 		})
 	}
 }

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/pod.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/pod.go
@@ -268,10 +268,12 @@ func (p minimalPodParser) Parse(obj interface{}) workloadmeta.Entity {
 	for _, o := range pod.OwnerReferences {
 		gv, _ := schema.ParseGroupVersion(o.APIVersion)
 		owners = append(owners, workloadmeta.KubernetesPodOwner{
-			Kind:  o.Kind,
-			Name:  o.Name,
-			ID:    string(o.UID),
-			Group: gv.Group,
+			APIVersion: o.APIVersion,
+			Kind:       o.Kind,
+			Name:       o.Name,
+			ID:         string(o.UID),
+			Group:      gv.Group,
+			Controller: o.Controller,
 		})
 	}
 

--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod.go
@@ -54,10 +54,12 @@ func (p podParser) Parse(obj interface{}) workloadmeta.Entity {
 	for _, o := range pod.OwnerReferences {
 		gv, _ := schema.ParseGroupVersion(o.APIVersion)
 		owners = append(owners, workloadmeta.KubernetesPodOwner{
-			Kind:  o.Kind,
-			Name:  o.Name,
-			ID:    string(o.UID),
-			Group: gv.Group,
+			APIVersion: o.APIVersion,
+			Kind:       o.Kind,
+			Name:       o.Name,
+			ID:         string(o.UID),
+			Group:      gv.Group,
+			Controller: o.Controller,
 		})
 	}
 

--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod_test.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod_test.go
@@ -22,6 +22,7 @@ import (
 
 func TestPodParser_Parse(t *testing.T) {
 	filterAnnotations := []string{"ignoreAnnotation"}
+	controller := true
 
 	parser, err := NewPodParser(filterAnnotations)
 	assert.NoError(t, err)
@@ -32,9 +33,11 @@ func TestPodParser_Parse(t *testing.T) {
 			UID:  "uniqueIdentifier",
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					Kind: "ReplicaSet",
-					Name: "deployment-hashrs",
-					UID:  "ownerUID",
+					APIVersion: "apps.kruise.io/v1alpha1",
+					Kind:       "CloneSet",
+					Name:       "nginx",
+					UID:        "ownerUID",
+					Controller: &controller,
 				},
 			},
 			Annotations: map[string]string{
@@ -113,9 +116,12 @@ func TestPodParser_Parse(t *testing.T) {
 		Phase: "Running",
 		Owners: []workloadmeta.KubernetesPodOwner{
 			{
-				Kind: "ReplicaSet",
-				Name: "deployment-hashrs",
-				ID:   "ownerUID",
+				APIVersion: "apps.kruise.io/v1alpha1",
+				Kind:       "CloneSet",
+				Name:       "nginx",
+				ID:         "ownerUID",
+				Group:      "apps.kruise.io",
+				Controller: &controller,
 			},
 		},
 		PersistentVolumeClaimNames: []string{"pvcName"},

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1034,18 +1034,12 @@ type KubernetesResolvedTarget struct {
 	Kind      string
 	Namespace string
 	Name      string
-	ID        string
 }
 
 // String returns a string representation of KubernetesResolvedTarget.
-func (t KubernetesResolvedTarget) String(verbose bool) string {
+func (t KubernetesResolvedTarget) String(_ bool) string {
 	var sb strings.Builder
 	_, _ = fmt.Fprintln(&sb, "Group:", t.Group, "Version:", t.Version, "Kind:", t.Kind, "Namespace:", t.Namespace, "Name:", t.Name)
-
-	if verbose {
-		_, _ = fmt.Fprintln(&sb, "ID:", t.ID)
-	}
-
 	return sb.String()
 }
 

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -831,6 +831,7 @@ type KubernetesPod struct {
 	GPUVendorList              []string `proto:"ignore"`
 	RuntimeClass               string
 	KubeServices               []string
+	ResolvedTargets            []KubernetesResolvedTarget `proto:"ignore"`
 	NamespaceLabels            map[string]string
 	NamespaceAnnotations       map[string]string   `proto:"ignore"`
 	FinishedAt                 time.Time           `proto:"ignore"`
@@ -998,6 +999,13 @@ func (p KubernetesPod) String(verbose bool) string {
 		_, _ = fmt.Fprintln(&sb, "FsGroup:", p.SecurityContext.FsGroup)
 	}
 
+	if len(p.ResolvedTargets) > 0 {
+		_, _ = fmt.Fprintln(&sb, "----------- Resolved Targets -----------")
+		for _, t := range p.ResolvedTargets {
+			_, _ = fmt.Fprint(&sb, t.String(verbose))
+		}
+	}
+
 	return sb.String()
 }
 
@@ -1010,11 +1018,35 @@ var _ Entity = &KubernetesPod{}
 
 // KubernetesPodOwner is extracted from a pod's owner references.
 type KubernetesPodOwner struct {
+	APIVersion string `proto:"ignore"`
 	Kind       string
 	Name       string
 	ID         string
 	Group      string
 	Controller *bool `proto:"ignore"`
+}
+
+// KubernetesResolvedTarget identifies a configured workload target found in a
+// Pod's Kubernetes owner-reference chain by the Cluster Agent.
+type KubernetesResolvedTarget struct {
+	Group     string
+	Version   string
+	Kind      string
+	Namespace string
+	Name      string
+	ID        string
+}
+
+// String returns a string representation of KubernetesResolvedTarget.
+func (t KubernetesResolvedTarget) String(verbose bool) string {
+	var sb strings.Builder
+	_, _ = fmt.Fprintln(&sb, "Group:", t.Group, "Version:", t.Version, "Kind:", t.Kind, "Namespace:", t.Namespace, "Name:", t.Name)
+
+	if verbose {
+		_, _ = fmt.Fprintln(&sb, "ID:", t.ID)
+	}
+
+	return sb.String()
 }
 
 // String returns a string representation of KubernetesPodOwner.

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -818,7 +818,14 @@ var GetRunningContainers EntityFilterFunc[*Container] = func(container *Containe
 type KubernetesPod struct {
 	EntityID
 	EntityMeta
-	Owners                     []KubernetesPodOwner
+
+	// Owners contains the direct ownerReferences declared on the Pod.
+	Owners []KubernetesPodOwner
+
+	// MatchedOwners contains configured owners matched while traversing the Pod's
+	// ownership chain. It may include direct or indirect owners and is not the
+	// complete ownership chain.
+	MatchedOwners              []KubernetesMatchedOwner `proto:"ignore"`
 	PersistentVolumeClaimNames []string
 	InitContainers             []OrchestratorContainer
 	Containers                 []OrchestratorContainer
@@ -831,7 +838,6 @@ type KubernetesPod struct {
 	GPUVendorList              []string `proto:"ignore"`
 	RuntimeClass               string
 	KubeServices               []string
-	ResolvedTargets            []KubernetesResolvedTarget `proto:"ignore"`
 	NamespaceLabels            map[string]string
 	NamespaceAnnotations       map[string]string   `proto:"ignore"`
 	FinishedAt                 time.Time           `proto:"ignore"`
@@ -999,10 +1005,10 @@ func (p KubernetesPod) String(verbose bool) string {
 		_, _ = fmt.Fprintln(&sb, "FsGroup:", p.SecurityContext.FsGroup)
 	}
 
-	if len(p.ResolvedTargets) > 0 {
-		_, _ = fmt.Fprintln(&sb, "----------- Resolved Targets -----------")
-		for _, t := range p.ResolvedTargets {
-			_, _ = fmt.Fprint(&sb, t.String(verbose))
+	if len(p.MatchedOwners) > 0 {
+		_, _ = fmt.Fprintln(&sb, "----------- Matched Owners -----------")
+		for _, o := range p.MatchedOwners {
+			_, _ = fmt.Fprint(&sb, o.String(verbose))
 		}
 	}
 
@@ -1026,9 +1032,9 @@ type KubernetesPodOwner struct {
 	Controller *bool `proto:"ignore"`
 }
 
-// KubernetesResolvedTarget identifies a configured workload target found in a
-// Pod's Kubernetes owner-reference chain by the Cluster Agent.
-type KubernetesResolvedTarget struct {
+// KubernetesMatchedOwner identifies a configured owner matched while traversing
+// a Pod's Kubernetes owner-reference chain.
+type KubernetesMatchedOwner struct {
 	Group     string
 	Version   string
 	Kind      string
@@ -1036,10 +1042,10 @@ type KubernetesResolvedTarget struct {
 	Name      string
 }
 
-// String returns a string representation of KubernetesResolvedTarget.
-func (t KubernetesResolvedTarget) String(_ bool) string {
+// String returns a string representation of KubernetesMatchedOwner.
+func (o KubernetesMatchedOwner) String(_ bool) string {
 	var sb strings.Builder
-	_, _ = fmt.Fprintln(&sb, "Group:", t.Group, "Version:", t.Version, "Kind:", t.Kind, "Namespace:", t.Namespace, "Name:", t.Name)
+	_, _ = fmt.Fprintln(&sb, "Group:", o.Group, "Version:", o.Version, "Kind:", o.Kind, "Namespace:", o.Namespace, "Name:", o.Name)
 	return sb.String()
 }
 

--- a/pkg/proto/datadog/workloadfilter/workloadfilter.proto
+++ b/pkg/proto/datadog/workloadfilter/workloadfilter.proto
@@ -56,7 +56,6 @@ message FilterResolvedTarget {
   string kind = 3;
   string namespace = 4;
   string name = 5;
-  string uid = 6;
 }
 
 message FilterProcess {

--- a/pkg/proto/datadog/workloadfilter/workloadfilter.proto
+++ b/pkg/proto/datadog/workloadfilter/workloadfilter.proto
@@ -42,11 +42,21 @@ message FilterPod {
   string namespace = 3;
   map<string, string> annotations = 4;
   FilterRootOwner rootowner = 5;
+  repeated FilterResolvedTarget resolved_targets = 6;
 }
 
 message FilterRootOwner {
   string kind = 1;
   string name = 2;
+}
+
+message FilterResolvedTarget {
+  string group = 1;
+  string version = 2;
+  string kind = 3;
+  string namespace = 4;
+  string name = 5;
+  string uid = 6;
 }
 
 message FilterProcess {

--- a/pkg/proto/datadog/workloadfilter/workloadfilter.proto
+++ b/pkg/proto/datadog/workloadfilter/workloadfilter.proto
@@ -42,7 +42,7 @@ message FilterPod {
   string namespace = 3;
   map<string, string> annotations = 4;
   FilterRootOwner rootowner = 5;
-  repeated FilterResolvedTarget resolved_targets = 6;
+  repeated FilterMatchedOwner matched_owners = 6;
 }
 
 message FilterRootOwner {
@@ -50,7 +50,7 @@ message FilterRootOwner {
   string name = 2;
 }
 
-message FilterResolvedTarget {
+message FilterMatchedOwner {
   string group = 1;
   string version = 2;
   string kind = 3;

--- a/pkg/proto/pbgo/core/workloadfilter.pb.go
+++ b/pkg/proto/pbgo/core/workloadfilter.pb.go
@@ -509,7 +509,6 @@ type FilterResolvedTarget struct {
 	Kind          string                 `protobuf:"bytes,3,opt,name=kind,proto3" json:"kind,omitempty"`
 	Namespace     string                 `protobuf:"bytes,4,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	Name          string                 `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"`
-	Uid           string                 `protobuf:"bytes,6,opt,name=uid,proto3" json:"uid,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -575,13 +574,6 @@ func (x *FilterResolvedTarget) GetNamespace() string {
 func (x *FilterResolvedTarget) GetName() string {
 	if x != nil {
 		return x.Name
-	}
-	return ""
-}
-
-func (x *FilterResolvedTarget) GetUid() string {
-	if x != nil {
-		return x.Uid
 	}
 	return ""
 }
@@ -907,14 +899,13 @@ const file_datadog_workloadfilter_workloadfilter_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"9\n" +
 	"\x0fFilterRootOwner\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\"\x9e\x01\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\"\x8c\x01\n" +
 	"\x14FilterResolvedTarget\x12\x14\n" +
 	"\x05group\x18\x01 \x01(\tR\x05group\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12\x12\n" +
 	"\x04kind\x18\x03 \x01(\tR\x04kind\x12\x1c\n" +
 	"\tnamespace\x18\x04 \x01(\tR\tnamespace\x12\x12\n" +
-	"\x04name\x18\x05 \x01(\tR\x04name\x12\x10\n" +
-	"\x03uid\x18\x06 \x01(\tR\x03uid\"l\n" +
+	"\x04name\x18\x05 \x01(\tR\x04name\"l\n" +
 	"\rFilterProcess\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\acmdline\x18\x02 \x01(\tR\acmdline\x12\x12\n" +

--- a/pkg/proto/pbgo/core/workloadfilter.pb.go
+++ b/pkg/proto/pbgo/core/workloadfilter.pb.go
@@ -367,14 +367,15 @@ func (*FilterContainer_Pod) isFilterContainer_Owner() {}
 func (*FilterContainer_EcsTask) isFilterContainer_Owner() {}
 
 type FilterPod struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	Namespace     string                 `protobuf:"bytes,3,opt,name=namespace,proto3" json:"namespace,omitempty"`
-	Annotations   map[string]string      `protobuf:"bytes,4,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Rootowner     *FilterRootOwner       `protobuf:"bytes,5,opt,name=rootowner,proto3" json:"rootowner,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state           protoimpl.MessageState  `protogen:"open.v1"`
+	Id              string                  `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name            string                  `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Namespace       string                  `protobuf:"bytes,3,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Annotations     map[string]string       `protobuf:"bytes,4,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Rootowner       *FilterRootOwner        `protobuf:"bytes,5,opt,name=rootowner,proto3" json:"rootowner,omitempty"`
+	ResolvedTargets []*FilterResolvedTarget `protobuf:"bytes,6,rep,name=resolved_targets,json=resolvedTargets,proto3" json:"resolved_targets,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *FilterPod) Reset() {
@@ -442,6 +443,13 @@ func (x *FilterPod) GetRootowner() *FilterRootOwner {
 	return nil
 }
 
+func (x *FilterPod) GetResolvedTargets() []*FilterResolvedTarget {
+	if x != nil {
+		return x.ResolvedTargets
+	}
+	return nil
+}
+
 type FilterRootOwner struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Kind          string                 `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"`
@@ -494,6 +502,90 @@ func (x *FilterRootOwner) GetName() string {
 	return ""
 }
 
+type FilterResolvedTarget struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Group         string                 `protobuf:"bytes,1,opt,name=group,proto3" json:"group,omitempty"`
+	Version       string                 `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
+	Kind          string                 `protobuf:"bytes,3,opt,name=kind,proto3" json:"kind,omitempty"`
+	Namespace     string                 `protobuf:"bytes,4,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Name          string                 `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"`
+	Uid           string                 `protobuf:"bytes,6,opt,name=uid,proto3" json:"uid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FilterResolvedTarget) Reset() {
+	*x = FilterResolvedTarget{}
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FilterResolvedTarget) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FilterResolvedTarget) ProtoMessage() {}
+
+func (x *FilterResolvedTarget) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FilterResolvedTarget.ProtoReflect.Descriptor instead.
+func (*FilterResolvedTarget) Descriptor() ([]byte, []int) {
+	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *FilterResolvedTarget) GetGroup() string {
+	if x != nil {
+		return x.Group
+	}
+	return ""
+}
+
+func (x *FilterResolvedTarget) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
+func (x *FilterResolvedTarget) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *FilterResolvedTarget) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *FilterResolvedTarget) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *FilterResolvedTarget) GetUid() string {
+	if x != nil {
+		return x.Uid
+	}
+	return ""
+}
+
 type FilterProcess struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
 	Name    string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -507,7 +599,7 @@ type FilterProcess struct {
 
 func (x *FilterProcess) Reset() {
 	*x = FilterProcess{}
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[5]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -519,7 +611,7 @@ func (x *FilterProcess) String() string {
 func (*FilterProcess) ProtoMessage() {}
 
 func (x *FilterProcess) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[5]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -532,7 +624,7 @@ func (x *FilterProcess) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterProcess.ProtoReflect.Descriptor instead.
 func (*FilterProcess) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{5}
+	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *FilterProcess) GetName() string {
@@ -573,7 +665,7 @@ type FilterECSTask struct {
 
 func (x *FilterECSTask) Reset() {
 	*x = FilterECSTask{}
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[6]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -585,7 +677,7 @@ func (x *FilterECSTask) String() string {
 func (*FilterECSTask) ProtoMessage() {}
 
 func (x *FilterECSTask) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[6]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -598,7 +690,7 @@ func (x *FilterECSTask) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterECSTask.ProtoReflect.Descriptor instead.
 func (*FilterECSTask) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{6}
+	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *FilterECSTask) GetId() string {
@@ -626,7 +718,7 @@ type FilterKubeService struct {
 
 func (x *FilterKubeService) Reset() {
 	*x = FilterKubeService{}
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[7]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -638,7 +730,7 @@ func (x *FilterKubeService) String() string {
 func (*FilterKubeService) ProtoMessage() {}
 
 func (x *FilterKubeService) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[7]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -651,7 +743,7 @@ func (x *FilterKubeService) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterKubeService.ProtoReflect.Descriptor instead.
 func (*FilterKubeService) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{7}
+	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *FilterKubeService) GetName() string {
@@ -686,7 +778,7 @@ type FilterKubeEndpoint struct {
 
 func (x *FilterKubeEndpoint) Reset() {
 	*x = FilterKubeEndpoint{}
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[8]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -698,7 +790,7 @@ func (x *FilterKubeEndpoint) String() string {
 func (*FilterKubeEndpoint) ProtoMessage() {}
 
 func (x *FilterKubeEndpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[8]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -711,7 +803,7 @@ func (x *FilterKubeEndpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterKubeEndpoint.ProtoReflect.Descriptor instead.
 func (*FilterKubeEndpoint) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{8}
+	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *FilterKubeEndpoint) GetName() string {
@@ -744,7 +836,7 @@ type FilterImage struct {
 
 func (x *FilterImage) Reset() {
 	*x = FilterImage{}
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[9]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -756,7 +848,7 @@ func (x *FilterImage) String() string {
 func (*FilterImage) ProtoMessage() {}
 
 func (x *FilterImage) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[9]
+	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -769,7 +861,7 @@ func (x *FilterImage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterImage.ProtoReflect.Descriptor instead.
 func (*FilterImage) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{9}
+	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *FilterImage) GetReference() string {
@@ -802,19 +894,27 @@ const file_datadog_workloadfilter_workloadfilter_proto_rawDesc = "" +
 	"\x05image\x18\x03 \x01(\v2#.datadog.workloadfilter.FilterImageR\x05image\x125\n" +
 	"\x03pod\x18\x04 \x01(\v2!.datadog.workloadfilter.FilterPodH\x00R\x03pod\x12B\n" +
 	"\becs_task\x18\x05 \x01(\v2%.datadog.workloadfilter.FilterECSTaskH\x00R\aecsTaskB\a\n" +
-	"\x05owner\"\xaa\x02\n" +
+	"\x05owner\"\x83\x03\n" +
 	"\tFilterPod\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1c\n" +
 	"\tnamespace\x18\x03 \x01(\tR\tnamespace\x12T\n" +
 	"\vannotations\x18\x04 \x03(\v22.datadog.workloadfilter.FilterPod.AnnotationsEntryR\vannotations\x12E\n" +
-	"\trootowner\x18\x05 \x01(\v2'.datadog.workloadfilter.FilterRootOwnerR\trootowner\x1a>\n" +
+	"\trootowner\x18\x05 \x01(\v2'.datadog.workloadfilter.FilterRootOwnerR\trootowner\x12W\n" +
+	"\x10resolved_targets\x18\x06 \x03(\v2,.datadog.workloadfilter.FilterResolvedTargetR\x0fresolvedTargets\x1a>\n" +
 	"\x10AnnotationsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"9\n" +
 	"\x0fFilterRootOwner\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\"l\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\"\x9e\x01\n" +
+	"\x14FilterResolvedTarget\x12\x14\n" +
+	"\x05group\x18\x01 \x01(\tR\x05group\x12\x18\n" +
+	"\aversion\x18\x02 \x01(\tR\aversion\x12\x12\n" +
+	"\x04kind\x18\x03 \x01(\tR\x04kind\x12\x1c\n" +
+	"\tnamespace\x18\x04 \x01(\tR\tnamespace\x12\x12\n" +
+	"\x04name\x18\x05 \x01(\tR\x04name\x12\x10\n" +
+	"\x03uid\x18\x06 \x01(\tR\x03uid\"l\n" +
 	"\rFilterProcess\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\acmdline\x18\x02 \x01(\tR\acmdline\x12\x12\n" +
@@ -857,7 +957,7 @@ func file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP() []byte {
 }
 
 var file_datadog_workloadfilter_workloadfilter_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_datadog_workloadfilter_workloadfilter_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_datadog_workloadfilter_workloadfilter_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_datadog_workloadfilter_workloadfilter_proto_goTypes = []any{
 	(WorkloadFilterResult)(0),              // 0: datadog.workloadfilter.WorkloadFilterResult
 	(*WorkloadFilterEvaluateRequest)(nil),  // 1: datadog.workloadfilter.WorkloadFilterEvaluateRequest
@@ -865,34 +965,36 @@ var file_datadog_workloadfilter_workloadfilter_proto_goTypes = []any{
 	(*FilterContainer)(nil),                // 3: datadog.workloadfilter.FilterContainer
 	(*FilterPod)(nil),                      // 4: datadog.workloadfilter.FilterPod
 	(*FilterRootOwner)(nil),                // 5: datadog.workloadfilter.FilterRootOwner
-	(*FilterProcess)(nil),                  // 6: datadog.workloadfilter.FilterProcess
-	(*FilterECSTask)(nil),                  // 7: datadog.workloadfilter.FilterECSTask
-	(*FilterKubeService)(nil),              // 8: datadog.workloadfilter.FilterKubeService
-	(*FilterKubeEndpoint)(nil),             // 9: datadog.workloadfilter.FilterKubeEndpoint
-	(*FilterImage)(nil),                    // 10: datadog.workloadfilter.FilterImage
-	nil,                                    // 11: datadog.workloadfilter.FilterPod.AnnotationsEntry
-	nil,                                    // 12: datadog.workloadfilter.FilterKubeService.AnnotationsEntry
-	nil,                                    // 13: datadog.workloadfilter.FilterKubeEndpoint.AnnotationsEntry
+	(*FilterResolvedTarget)(nil),           // 6: datadog.workloadfilter.FilterResolvedTarget
+	(*FilterProcess)(nil),                  // 7: datadog.workloadfilter.FilterProcess
+	(*FilterECSTask)(nil),                  // 8: datadog.workloadfilter.FilterECSTask
+	(*FilterKubeService)(nil),              // 9: datadog.workloadfilter.FilterKubeService
+	(*FilterKubeEndpoint)(nil),             // 10: datadog.workloadfilter.FilterKubeEndpoint
+	(*FilterImage)(nil),                    // 11: datadog.workloadfilter.FilterImage
+	nil,                                    // 12: datadog.workloadfilter.FilterPod.AnnotationsEntry
+	nil,                                    // 13: datadog.workloadfilter.FilterKubeService.AnnotationsEntry
+	nil,                                    // 14: datadog.workloadfilter.FilterKubeEndpoint.AnnotationsEntry
 }
 var file_datadog_workloadfilter_workloadfilter_proto_depIdxs = []int32{
 	3,  // 0: datadog.workloadfilter.WorkloadFilterEvaluateRequest.container:type_name -> datadog.workloadfilter.FilterContainer
 	4,  // 1: datadog.workloadfilter.WorkloadFilterEvaluateRequest.pod:type_name -> datadog.workloadfilter.FilterPod
-	6,  // 2: datadog.workloadfilter.WorkloadFilterEvaluateRequest.process:type_name -> datadog.workloadfilter.FilterProcess
-	8,  // 3: datadog.workloadfilter.WorkloadFilterEvaluateRequest.kube_service:type_name -> datadog.workloadfilter.FilterKubeService
-	9,  // 4: datadog.workloadfilter.WorkloadFilterEvaluateRequest.kube_endpoint:type_name -> datadog.workloadfilter.FilterKubeEndpoint
+	7,  // 2: datadog.workloadfilter.WorkloadFilterEvaluateRequest.process:type_name -> datadog.workloadfilter.FilterProcess
+	9,  // 3: datadog.workloadfilter.WorkloadFilterEvaluateRequest.kube_service:type_name -> datadog.workloadfilter.FilterKubeService
+	10, // 4: datadog.workloadfilter.WorkloadFilterEvaluateRequest.kube_endpoint:type_name -> datadog.workloadfilter.FilterKubeEndpoint
 	0,  // 5: datadog.workloadfilter.WorkloadFilterEvaluateResponse.result:type_name -> datadog.workloadfilter.WorkloadFilterResult
-	10, // 6: datadog.workloadfilter.FilterContainer.image:type_name -> datadog.workloadfilter.FilterImage
+	11, // 6: datadog.workloadfilter.FilterContainer.image:type_name -> datadog.workloadfilter.FilterImage
 	4,  // 7: datadog.workloadfilter.FilterContainer.pod:type_name -> datadog.workloadfilter.FilterPod
-	7,  // 8: datadog.workloadfilter.FilterContainer.ecs_task:type_name -> datadog.workloadfilter.FilterECSTask
-	11, // 9: datadog.workloadfilter.FilterPod.annotations:type_name -> datadog.workloadfilter.FilterPod.AnnotationsEntry
+	8,  // 8: datadog.workloadfilter.FilterContainer.ecs_task:type_name -> datadog.workloadfilter.FilterECSTask
+	12, // 9: datadog.workloadfilter.FilterPod.annotations:type_name -> datadog.workloadfilter.FilterPod.AnnotationsEntry
 	5,  // 10: datadog.workloadfilter.FilterPod.rootowner:type_name -> datadog.workloadfilter.FilterRootOwner
-	12, // 11: datadog.workloadfilter.FilterKubeService.annotations:type_name -> datadog.workloadfilter.FilterKubeService.AnnotationsEntry
-	13, // 12: datadog.workloadfilter.FilterKubeEndpoint.annotations:type_name -> datadog.workloadfilter.FilterKubeEndpoint.AnnotationsEntry
-	13, // [13:13] is the sub-list for method output_type
-	13, // [13:13] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	6,  // 11: datadog.workloadfilter.FilterPod.resolved_targets:type_name -> datadog.workloadfilter.FilterResolvedTarget
+	13, // 12: datadog.workloadfilter.FilterKubeService.annotations:type_name -> datadog.workloadfilter.FilterKubeService.AnnotationsEntry
+	14, // 13: datadog.workloadfilter.FilterKubeEndpoint.annotations:type_name -> datadog.workloadfilter.FilterKubeEndpoint.AnnotationsEntry
+	14, // [14:14] is the sub-list for method output_type
+	14, // [14:14] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_datadog_workloadfilter_workloadfilter_proto_init() }
@@ -917,7 +1019,7 @@ func file_datadog_workloadfilter_workloadfilter_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_datadog_workloadfilter_workloadfilter_proto_rawDesc), len(file_datadog_workloadfilter_workloadfilter_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   13,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/proto/pbgo/core/workloadfilter.pb.go
+++ b/pkg/proto/pbgo/core/workloadfilter.pb.go
@@ -367,15 +367,15 @@ func (*FilterContainer_Pod) isFilterContainer_Owner() {}
 func (*FilterContainer_EcsTask) isFilterContainer_Owner() {}
 
 type FilterPod struct {
-	state           protoimpl.MessageState  `protogen:"open.v1"`
-	Id              string                  `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Name            string                  `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	Namespace       string                  `protobuf:"bytes,3,opt,name=namespace,proto3" json:"namespace,omitempty"`
-	Annotations     map[string]string       `protobuf:"bytes,4,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Rootowner       *FilterRootOwner        `protobuf:"bytes,5,opt,name=rootowner,proto3" json:"rootowner,omitempty"`
-	ResolvedTargets []*FilterResolvedTarget `protobuf:"bytes,6,rep,name=resolved_targets,json=resolvedTargets,proto3" json:"resolved_targets,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Namespace     string                 `protobuf:"bytes,3,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Annotations   map[string]string      `protobuf:"bytes,4,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Rootowner     *FilterRootOwner       `protobuf:"bytes,5,opt,name=rootowner,proto3" json:"rootowner,omitempty"`
+	MatchedOwners []*FilterMatchedOwner  `protobuf:"bytes,6,rep,name=matched_owners,json=matchedOwners,proto3" json:"matched_owners,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *FilterPod) Reset() {
@@ -443,9 +443,9 @@ func (x *FilterPod) GetRootowner() *FilterRootOwner {
 	return nil
 }
 
-func (x *FilterPod) GetResolvedTargets() []*FilterResolvedTarget {
+func (x *FilterPod) GetMatchedOwners() []*FilterMatchedOwner {
 	if x != nil {
-		return x.ResolvedTargets
+		return x.MatchedOwners
 	}
 	return nil
 }
@@ -502,7 +502,7 @@ func (x *FilterRootOwner) GetName() string {
 	return ""
 }
 
-type FilterResolvedTarget struct {
+type FilterMatchedOwner struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Group         string                 `protobuf:"bytes,1,opt,name=group,proto3" json:"group,omitempty"`
 	Version       string                 `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
@@ -513,20 +513,20 @@ type FilterResolvedTarget struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *FilterResolvedTarget) Reset() {
-	*x = FilterResolvedTarget{}
+func (x *FilterMatchedOwner) Reset() {
+	*x = FilterMatchedOwner{}
 	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *FilterResolvedTarget) String() string {
+func (x *FilterMatchedOwner) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*FilterResolvedTarget) ProtoMessage() {}
+func (*FilterMatchedOwner) ProtoMessage() {}
 
-func (x *FilterResolvedTarget) ProtoReflect() protoreflect.Message {
+func (x *FilterMatchedOwner) ProtoReflect() protoreflect.Message {
 	mi := &file_datadog_workloadfilter_workloadfilter_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -538,40 +538,40 @@ func (x *FilterResolvedTarget) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use FilterResolvedTarget.ProtoReflect.Descriptor instead.
-func (*FilterResolvedTarget) Descriptor() ([]byte, []int) {
+// Deprecated: Use FilterMatchedOwner.ProtoReflect.Descriptor instead.
+func (*FilterMatchedOwner) Descriptor() ([]byte, []int) {
 	return file_datadog_workloadfilter_workloadfilter_proto_rawDescGZIP(), []int{5}
 }
 
-func (x *FilterResolvedTarget) GetGroup() string {
+func (x *FilterMatchedOwner) GetGroup() string {
 	if x != nil {
 		return x.Group
 	}
 	return ""
 }
 
-func (x *FilterResolvedTarget) GetVersion() string {
+func (x *FilterMatchedOwner) GetVersion() string {
 	if x != nil {
 		return x.Version
 	}
 	return ""
 }
 
-func (x *FilterResolvedTarget) GetKind() string {
+func (x *FilterMatchedOwner) GetKind() string {
 	if x != nil {
 		return x.Kind
 	}
 	return ""
 }
 
-func (x *FilterResolvedTarget) GetNamespace() string {
+func (x *FilterMatchedOwner) GetNamespace() string {
 	if x != nil {
 		return x.Namespace
 	}
 	return ""
 }
 
-func (x *FilterResolvedTarget) GetName() string {
+func (x *FilterMatchedOwner) GetName() string {
 	if x != nil {
 		return x.Name
 	}
@@ -886,21 +886,21 @@ const file_datadog_workloadfilter_workloadfilter_proto_rawDesc = "" +
 	"\x05image\x18\x03 \x01(\v2#.datadog.workloadfilter.FilterImageR\x05image\x125\n" +
 	"\x03pod\x18\x04 \x01(\v2!.datadog.workloadfilter.FilterPodH\x00R\x03pod\x12B\n" +
 	"\becs_task\x18\x05 \x01(\v2%.datadog.workloadfilter.FilterECSTaskH\x00R\aecsTaskB\a\n" +
-	"\x05owner\"\x83\x03\n" +
+	"\x05owner\"\xfd\x02\n" +
 	"\tFilterPod\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1c\n" +
 	"\tnamespace\x18\x03 \x01(\tR\tnamespace\x12T\n" +
 	"\vannotations\x18\x04 \x03(\v22.datadog.workloadfilter.FilterPod.AnnotationsEntryR\vannotations\x12E\n" +
-	"\trootowner\x18\x05 \x01(\v2'.datadog.workloadfilter.FilterRootOwnerR\trootowner\x12W\n" +
-	"\x10resolved_targets\x18\x06 \x03(\v2,.datadog.workloadfilter.FilterResolvedTargetR\x0fresolvedTargets\x1a>\n" +
+	"\trootowner\x18\x05 \x01(\v2'.datadog.workloadfilter.FilterRootOwnerR\trootowner\x12Q\n" +
+	"\x0ematched_owners\x18\x06 \x03(\v2*.datadog.workloadfilter.FilterMatchedOwnerR\rmatchedOwners\x1a>\n" +
 	"\x10AnnotationsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"9\n" +
 	"\x0fFilterRootOwner\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\"\x8c\x01\n" +
-	"\x14FilterResolvedTarget\x12\x14\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\"\x8a\x01\n" +
+	"\x12FilterMatchedOwner\x12\x14\n" +
 	"\x05group\x18\x01 \x01(\tR\x05group\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12\x12\n" +
 	"\x04kind\x18\x03 \x01(\tR\x04kind\x12\x1c\n" +
@@ -956,7 +956,7 @@ var file_datadog_workloadfilter_workloadfilter_proto_goTypes = []any{
 	(*FilterContainer)(nil),                // 3: datadog.workloadfilter.FilterContainer
 	(*FilterPod)(nil),                      // 4: datadog.workloadfilter.FilterPod
 	(*FilterRootOwner)(nil),                // 5: datadog.workloadfilter.FilterRootOwner
-	(*FilterResolvedTarget)(nil),           // 6: datadog.workloadfilter.FilterResolvedTarget
+	(*FilterMatchedOwner)(nil),             // 6: datadog.workloadfilter.FilterMatchedOwner
 	(*FilterProcess)(nil),                  // 7: datadog.workloadfilter.FilterProcess
 	(*FilterECSTask)(nil),                  // 8: datadog.workloadfilter.FilterECSTask
 	(*FilterKubeService)(nil),              // 9: datadog.workloadfilter.FilterKubeService
@@ -978,7 +978,7 @@ var file_datadog_workloadfilter_workloadfilter_proto_depIdxs = []int32{
 	8,  // 8: datadog.workloadfilter.FilterContainer.ecs_task:type_name -> datadog.workloadfilter.FilterECSTask
 	12, // 9: datadog.workloadfilter.FilterPod.annotations:type_name -> datadog.workloadfilter.FilterPod.AnnotationsEntry
 	5,  // 10: datadog.workloadfilter.FilterPod.rootowner:type_name -> datadog.workloadfilter.FilterRootOwner
-	6,  // 11: datadog.workloadfilter.FilterPod.resolved_targets:type_name -> datadog.workloadfilter.FilterResolvedTarget
+	6,  // 11: datadog.workloadfilter.FilterPod.matched_owners:type_name -> datadog.workloadfilter.FilterMatchedOwner
 	13, // 12: datadog.workloadfilter.FilterKubeService.annotations:type_name -> datadog.workloadfilter.FilterKubeService.AnnotationsEntry
 	14, // 13: datadog.workloadfilter.FilterKubeEndpoint.annotations:type_name -> datadog.workloadfilter.FilterKubeEndpoint.AnnotationsEntry
 	14, // [14:14] is the sub-list for method output_type


### PR DESCRIPTION
### What does this PR do?

Adds group- and version-aware resolved workload targets to Kubernetes Pod workload metadata and the workload-filter CEL model.

- Preserves `apiVersion` and `controller` from Kubernetes owner references in both Pod parsers.
- Adds `KubernetesPod.ResolvedTargets` with group, version, kind, namespace, name, and UID identity.
- Exposes resolved targets to CEL as `container.pod.resolved_targets`.

This is an additive data-model change and does not alter current DatadogInstrumentation matching behavior.

### Motivation

[CONTP-2006](https://datadoghq.atlassian.net/browse/CONTP-2006)

DatadogInstrumentation currently matches workload Pods through `rootowner`, which only carries kind and name and relies on built-in ownership conventions. Supporting arbitrary workload CRs requires a structured, API-group-aware identity that can distinguish identical kinds from different API groups and carry targets resolved by the Cluster Agent to CEL evaluation.

### Describe how you validated your changes

### Additional Notes

[CONTP-2006]: https://datadoghq.atlassian.net/browse/CONTP-2006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ