### PR TITLE
[CONTP-2006] feat(ddi): Add pod workload target resolution

### DIFF
--- a/pkg/clusteragent/instrumentation/targets/BUILD.bazel
+++ b/pkg/clusteragent/instrumentation/targets/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "targets",
+    srcs = [
+        "registry.go",
+        "resolver.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/clusteragent/instrumentation/targets",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/workloadmeta/def",
+        "//pkg/config/model",
+        "//pkg/config/structure",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/runtime/schema",
+        "@io_k8s_client_go//dynamic",
+    ],
+)

--- a/pkg/clusteragent/instrumentation/targets/registry.go
+++ b/pkg/clusteragent/instrumentation/targets/registry.go
@@ -1,0 +1,175 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software developed
+// at Datadog (https://www.datadoghq.com/). Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package targets contains the workload kinds supported by
+// DatadogInstrumentation and the owner-chain resolver used to associate Pods
+// with those workloads.
+package targets
+
+import (
+	"fmt"
+	"strings"
+
+	configmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/config/structure"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const customWorkloadTargetsConfigKey = "instrumentation_crd_controller.custom_workload_targets"
+
+// Resource identifies a namespaced Kubernetes workload resource.
+type Resource struct {
+	APIVersion string `mapstructure:"apiVersion" json:"apiVersion" yaml:"apiVersion"`
+	Kind       string `mapstructure:"kind" json:"kind" yaml:"kind"`
+	Resource   string `mapstructure:"resource" json:"resource" yaml:"resource"`
+}
+
+// Profile describes a supported DatadogInstrumentation target and the
+// intermediate owner kinds that may occur between a Pod and that target.
+type Profile struct {
+	Target Resource   `mapstructure:"target" json:"target" yaml:"target"`
+	Via    []Resource `mapstructure:"via" json:"via,omitempty" yaml:"via,omitempty"`
+}
+
+type resourceDescriptor struct {
+	resource    Resource
+	isTarget    bool
+	traversable bool
+}
+
+// Registry is the immutable set of built-in and customer-configured workload
+// profiles used by both DDI handlers and Pod owner resolution.
+type Registry struct {
+	resources map[string]resourceDescriptor
+	targets   map[string]Resource
+	hasCustom bool
+}
+
+// NewRegistry returns a registry containing native workload kinds plus custom
+// profiles configured by the cluster administrator.
+func NewRegistry(cfg configmodel.Reader) (*Registry, error) {
+	registry := &Registry{
+		resources: make(map[string]resourceDescriptor),
+		targets:   make(map[string]Resource),
+	}
+	for i, profile := range builtinProfiles() {
+		if err := registry.addProfile(profile); err != nil {
+			return registry, fmt.Errorf("built-in workload target profile %d: %w", i, err)
+		}
+	}
+
+	var custom []Profile
+	if err := structure.UnmarshalKey(cfg, customWorkloadTargetsConfigKey, &custom, structure.ErrorUnused); err != nil {
+		return registry, fmt.Errorf("parse %s: %w", customWorkloadTargetsConfigKey, err)
+	}
+	for i, profile := range custom {
+		if err := registry.addProfile(profile); err != nil {
+			return registry, fmt.Errorf("custom workload target profile %d: %w", i, err)
+		}
+	}
+	registry.hasCustom = len(custom) > 0
+	return registry, nil
+}
+
+// HasCustomTargets reports whether at least one customer workload profile was configured.
+func (r *Registry) HasCustomTargets() bool {
+	return r != nil && r.hasCustom
+}
+
+// Supports reports whether a DDI target reference identifies a registered
+// workload target. Empty API versions are accepted only for built-in kinds to
+// preserve compatibility with older DDI objects and tests.
+func (r *Registry) Supports(apiVersion, kind string) bool {
+	if r == nil {
+		return false
+	}
+	if apiVersion != "" {
+		_, found := r.targets[resourceKey(apiVersion, kind)]
+		return found
+	}
+	for _, target := range r.targets {
+		if target.Kind == kind && isBuiltinTarget(target) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Registry) descriptor(apiVersion, kind string) (resourceDescriptor, bool) {
+	descriptor, found := r.resources[resourceKey(apiVersion, kind)]
+	return descriptor, found
+}
+
+func (r *Registry) addProfile(profile Profile) error {
+	if err := validateResource(profile.Target); err != nil {
+		return fmt.Errorf("target: %w", err)
+	}
+	if err := r.addResource(profile.Target, true, false); err != nil {
+		return err
+	}
+	r.targets[resourceKey(profile.Target.APIVersion, profile.Target.Kind)] = profile.Target
+
+	for i, via := range profile.Via {
+		if err := validateResource(via); err != nil {
+			return fmt.Errorf("via[%d]: %w", i, err)
+		}
+		if err := r.addResource(via, false, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Registry) addResource(resource Resource, target, traversable bool) error {
+	key := resourceKey(resource.APIVersion, resource.Kind)
+	descriptor, found := r.resources[key]
+	if found && descriptor.resource.Resource != resource.Resource {
+		return fmt.Errorf("%s maps to both resources %q and %q", key, descriptor.resource.Resource, resource.Resource)
+	}
+	if !found {
+		descriptor.resource = resource
+	}
+	descriptor.isTarget = descriptor.isTarget || target
+	descriptor.traversable = descriptor.traversable || traversable
+	r.resources[key] = descriptor
+	return nil
+}
+
+func validateResource(resource Resource) error {
+	if strings.TrimSpace(resource.APIVersion) == "" || strings.TrimSpace(resource.Kind) == "" || strings.TrimSpace(resource.Resource) == "" {
+		return fmt.Errorf("apiVersion, kind, and resource are required")
+	}
+	if _, err := schema.ParseGroupVersion(resource.APIVersion); err != nil {
+		return fmt.Errorf("invalid apiVersion %q: %w", resource.APIVersion, err)
+	}
+	return nil
+}
+
+func resourceKey(apiVersion, kind string) string {
+	return apiVersion + "/" + kind
+}
+
+func isBuiltinTarget(resource Resource) bool {
+	for _, profile := range builtinProfiles() {
+		if profile.Target == resource {
+			return true
+		}
+	}
+	return false
+}
+
+func builtinProfiles() []Profile {
+	replicaSet := Resource{APIVersion: "apps/v1", Kind: "ReplicaSet", Resource: "replicasets"}
+	job := Resource{APIVersion: "batch/v1", Kind: "Job", Resource: "jobs"}
+	return []Profile{
+		{Target: Resource{APIVersion: "apps/v1", Kind: "Deployment", Resource: "deployments"}, Via: []Resource{replicaSet}},
+		{Target: Resource{APIVersion: "apps/v1", Kind: "DaemonSet", Resource: "daemonsets"}},
+		{Target: Resource{APIVersion: "apps/v1", Kind: "StatefulSet", Resource: "statefulsets"}},
+		{Target: Resource{APIVersion: "batch/v1", Kind: "CronJob", Resource: "cronjobs"}, Via: []Resource{job}},
+		{Target: job},
+		{Target: Resource{APIVersion: "argoproj.io/v1alpha1", Kind: "Rollout", Resource: "rollouts"}, Via: []Resource{replicaSet}},
+	}
+}

--- a/pkg/clusteragent/instrumentation/targets/resolver.go
+++ b/pkg/clusteragent/instrumentation/targets/resolver.go
@@ -1,0 +1,153 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software developed
+// at Datadog (https://www.datadoghq.com/). Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package targets
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+const maxOwnerChainDepth = 16
+
+type cachedOwner struct {
+	owners []metav1.OwnerReference
+}
+
+// Resolver follows configured Kubernetes owner-reference paths and returns the
+// registered workload targets found in a Pod's ownership chain.
+type Resolver struct {
+	registry *Registry
+	client   dynamic.Interface
+
+	cacheMutex sync.RWMutex
+	cache      map[string]cachedOwner
+}
+
+// NewResolver creates an owner-chain resolver.
+func NewResolver(registry *Registry, client dynamic.Interface) *Resolver {
+	return &Resolver{
+		registry: registry,
+		client:   client,
+		cache:    make(map[string]cachedOwner),
+	}
+}
+
+// Resolve returns all registered workload targets encountered from the Pod's
+// controller owner upward. Resolution stops at an unregistered owner kind or
+// an API read failure.
+func (r *Resolver) Resolve(ctx context.Context, pod *workloadmeta.KubernetesPod) ([]workloadmeta.KubernetesMatchedOwner, error) {
+	if r == nil || r.registry == nil || r.client == nil || pod == nil {
+		return nil, nil
+	}
+
+	owner, found := controllerOwner(pod.Owners)
+	if !found {
+		return nil, nil
+	}
+
+	resolved := make([]workloadmeta.KubernetesMatchedOwner, 0, 2)
+	for depth := 0; depth < maxOwnerChainDepth; depth++ {
+		descriptor, registered := r.registry.descriptor(owner.APIVersion, owner.Kind)
+		if !registered {
+			break
+		}
+
+		if descriptor.isTarget {
+			gv, _ := schema.ParseGroupVersion(owner.APIVersion)
+			resolved = append(resolved, workloadmeta.KubernetesMatchedOwner{
+				Group:     gv.Group,
+				Version:   gv.Version,
+				Kind:      owner.Kind,
+				Namespace: pod.Namespace,
+				Name:      owner.Name,
+			})
+		}
+
+		if !descriptor.traversable {
+			break
+		}
+		nextOwners, err := r.getOwners(ctx, descriptor.resource, pod.Namespace, owner.Name, owner.ID)
+		if err != nil {
+			return resolved, err
+		}
+		owner, found = metav1ControllerOwner(nextOwners)
+		if !found {
+			break
+		}
+	}
+	return resolved, nil
+}
+
+func (r *Resolver) getOwners(ctx context.Context, resource Resource, namespace, name, uid string) ([]metav1.OwnerReference, error) {
+	cacheKey := resourceKey(resource.APIVersion, resource.Kind) + "/" + namespace + "/" + name + "/" + uid
+	r.cacheMutex.RLock()
+	cached, found := r.cache[cacheKey]
+	r.cacheMutex.RUnlock()
+	if found {
+		return cached.owners, nil
+	}
+
+	gv, err := schema.ParseGroupVersion(resource.APIVersion)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := r.client.Resource(schema.GroupVersionResource{
+		Group:    gv.Group,
+		Version:  gv.Version,
+		Resource: resource.Resource,
+	}).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("resolve owner %s %s/%s: %w", resourceKey(resource.APIVersion, resource.Kind), namespace, name, err)
+	}
+	if uid != "" && string(obj.GetUID()) != uid {
+		return nil, fmt.Errorf("resolve owner %s %s/%s: UID changed from %s to %s", resourceKey(resource.APIVersion, resource.Kind), namespace, name, uid, obj.GetUID())
+	}
+
+	owners := obj.GetOwnerReferences()
+	r.cacheMutex.Lock()
+	r.cache[cacheKey] = cachedOwner{owners: owners}
+	r.cacheMutex.Unlock()
+	return owners, nil
+}
+
+func controllerOwner(owners []workloadmeta.KubernetesPodOwner) (workloadmeta.KubernetesPodOwner, bool) {
+	if len(owners) == 0 {
+		return workloadmeta.KubernetesPodOwner{}, false
+	}
+	for _, owner := range owners {
+		if owner.Controller != nil && *owner.Controller {
+			return owner, true
+		}
+	}
+	return owners[0], true
+}
+
+func metav1ControllerOwner(owners []metav1.OwnerReference) (workloadmeta.KubernetesPodOwner, bool) {
+	if len(owners) == 0 {
+		return workloadmeta.KubernetesPodOwner{}, false
+	}
+	selected := owners[0]
+	for _, owner := range owners {
+		if owner.Controller != nil && *owner.Controller {
+			selected = owner
+			break
+		}
+	}
+	return workloadmeta.KubernetesPodOwner{
+		APIVersion: selected.APIVersion,
+		Kind:       selected.Kind,
+		Name:       selected.Name,
+		ID:         string(selected.UID),
+		Controller: selected.Controller,
+	}, true
+}


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Adds a registry and owner-chain resolver for DatadogInstrumentation workload targets.

- Models built-in and customer-configured workload profiles using a `target` resource and optional `via` resources.
- Identifies every resource by `apiVersion`, kind, and plural resource name.
- Walks controller owner references with the dynamic Kubernetes client, validates owner UIDs, caches resolved owners, and limits traversal depth.

This PR only introduces the resolver package. It does not expose or activate custom workload target configuration.

### Motivation

[CONTP-2006](https://datadoghq.atlassian.net/browse/CONTP-2006)

Hard-coding every operator-managed workload does not scale and cannot represent indirect ownership such as Pod to Job to a custom workload. Explicit target and traversal profiles provide a general mechanism that distinguishes API groups and allows deployments to grant read access only to the intermediate resources required for resolution.

### Describe how you validated your changes

### Additional Notes


[CONTP-2006]: https://datadoghq.atlassian.net/browse/CONTP-2006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ