### PR TITLE
APM: Raise the msgpack allocation limit for meta_struct to 10MiB

### DIFF
--- a/pkg/proto/datadog/trace/span.proto
+++ b/pkg/proto/datadog/trace/span.proto
@@ -136,7 +136,10 @@ message Span {
     // @gotags: json:"type" msg:"type"
     string type = 12;
     // meta_struct is a registry of structured "other" data used by, e.g., AppSec.
-    // @gotags: json:"meta_struct,omitempty" msg:"meta_struct,omitempty"
+    // Entries can legitimately be much larger than other span fields, so this
+    // field overrides the package-wide messagepack allocation limit with a 10MiB
+    // cap (see the //msgp:limit directives in pkg/proto/pbgo/trace).
+    // @gotags: json:"meta_struct,omitempty" msg:"meta_struct,omitempty,limit=10485760"
     map<string, bytes> meta_struct = 13;
     // span_links represents a collection of links, where each link defines a causal relationship between two spans.
     // @gotags: json:"span_links,omitempty" msg:"span_links,omitempty"

--- a/pkg/proto/pbgo/trace/limit_test.go
+++ b/pkg/proto/pbgo/trace/limit_test.go
@@ -162,6 +162,29 @@ func TestUnmarshalSpanLargeMetaMap(t *testing.T) {
 	}
 }
 
+// TestUnmarshalSpanLargeMetaStructValue verifies that a single meta_struct entry
+// larger than the package-wide allocation limit still decodes.  LLM Observability
+// writes payloads there that legitimately exceed what other span fields are
+// allowed, so the field carries its own higher cap (msg:"...,limit=10485760" in
+// span.proto).
+func TestUnmarshalSpanLargeMetaStructValue(t *testing.T) {
+	const size = 9 * 1024 * 1024
+	value := bytes.Repeat([]byte{0xAB}, size)
+
+	bts, err := (&Span{MetaStruct: map[string][]byte{"appsec": value}}).MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var s Span
+	if _, err := s.UnmarshalMsg(bts); err != nil {
+		t.Fatalf("unexpected error decoding a %d byte meta_struct entry: %v", size, err)
+	}
+	if !bytes.Equal(s.MetaStruct["appsec"], value) {
+		t.Fatalf("meta_struct entry not round-tripped: got %d bytes, want %d", len(s.MetaStruct["appsec"]), size)
+	}
+}
+
 // TestUnmarshalAgentPayloadLargeTagsMap verifies that AgentPayload.UnmarshalMsg
 // rejects a payload whose declared tags map count exceeds the configured limit.
 func TestUnmarshalAgentPayloadLargeTagsMap(t *testing.T) {

--- a/pkg/proto/pbgo/trace/span.pb.go
+++ b/pkg/proto/pbgo/trace/span.pb.go
@@ -555,8 +555,11 @@ type Span struct {
 	// @gotags: json:"type" msg:"type"
 	Type string `protobuf:"bytes,12,opt,name=type,proto3" json:"type" msg:"type"`
 	// meta_struct is a registry of structured "other" data used by, e.g., AppSec.
-	// @gotags: json:"meta_struct,omitempty" msg:"meta_struct,omitempty"
-	MetaStruct map[string][]byte `protobuf:"bytes,13,rep,name=meta_struct,json=metaStruct,proto3" json:"meta_struct,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value" msg:"meta_struct,omitempty"`
+	// Entries can legitimately be much larger than other span fields, so this
+	// field overrides the package-wide messagepack allocation limit with a 10MiB
+	// cap (see the //msgp:limit directives in pkg/proto/pbgo/trace).
+	// @gotags: json:"meta_struct,omitempty" msg:"meta_struct,omitempty,limit=10485760"
+	MetaStruct map[string][]byte `protobuf:"bytes,13,rep,name=meta_struct,json=metaStruct,proto3" json:"meta_struct,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value" msg:"meta_struct,omitempty,limit=10485760"`
 	// span_links represents a collection of links, where each link defines a causal relationship between two spans.
 	// @gotags: json:"span_links,omitempty" msg:"span_links,omitempty"
 	SpanLinks []*SpanLink `protobuf:"bytes,14,rep,name=spanLinks,proto3" json:"span_links,omitempty" msg:"span_links,omitempty"`

--- a/pkg/proto/pbgo/trace/span_gen.go
+++ b/pkg/proto/pbgo/trace/span_gen.go
@@ -805,7 +805,7 @@ func (z *Span) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "MetaStruct")
 				return
 			}
-			if zb0004 > zfb52131alimitMaps {
+			if zb0004 > 10485760 {
 				err = msgp.ErrLimitExceeded
 				return
 			}
@@ -829,7 +829,7 @@ func (z *Span) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "MetaStruct", za0005)
 					return
 				}
-				if zb0005 > zfb52131alimitArrays {
+				if zb0005 > 10485760 {
 					err = msgp.ErrLimitExceeded
 					return
 				}

--- a/releasenotes/notes/apm-meta-struct-limit-c18d822399e6da15.yaml
+++ b/releasenotes/notes/apm-meta-struct-limit-c18d822399e6da15.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    APM: Raise the messagepack decoder allocation limit for the span ``meta_struct``
+    field to 10MiB, so large ``meta_struct`` entries (as written by LLM Observability)
+    are no longer rejected by the package-wide 500,000 element limit. Other span
+    fields keep the lower limit.


### PR DESCRIPTION
### What does this PR do?
Gives the span `meta_struct` field its own 10MiB messagepack allocation limit, instead of the package-wide 500,000 limit that every other field uses.

### Motivation
#50818 capped messagepack map and array headers at 500,000 to stop a crafted payload from pre-allocating a huge map or slice. That cap is file-wide, and for a `map<string, bytes>` it applies to the byte length of each value as well as to the entry count — so it also rejects any single `meta_struct` entry larger than 500,000 bytes. LLM Observability legitimately writes entries above that size.

### Describe how you validated your changes
Added `TestUnmarshalSpanLargeMetaStructValue` to `pkg/proto/pbgo/trace/limit_test.go`: it round-trips a span with a single 9MiB `meta_struct` entry and asserts the bytes come back intact. Verified the test fails against the pre-change generated code (`msgp: configured reader limit exceeded`) and passes after.

`bazel test //pkg/proto/pbgo/trace/...` is green (22/22), including the `write_pb_go_*` targets that assert the generated files are committed in sync with the protos.

### Possible Drawbacks / Trade-offs
Technically makes increased payload allocations possible, but these are legitimately allowed so that's just how it is

### Additional Notes

### Backport
Labeled `backport/7.82.x` — this needs to ship in a 7.82 patch release. The cherry-pick onto `7.82.x` was verified locally as conflict-free (#50818 is already on that branch, so the generated code matches and no regeneration is needed there), and `bazel test //pkg/proto/pbgo/trace:trace_test` passes on that base.
