### PR TITLE
[OTAGENT-1285] Remove the debugexporter from the default Agent OTLP Ingest pipeline

### DIFF
--- a/comp/otelcol/otlp/collector.go
+++ b/comp/otelcol/otlp/collector.go
@@ -161,12 +161,15 @@ type PipelineConfig struct {
 	MetricsBatch map[string]interface{}
 }
 
-// shouldSetLoggingSection returns whether debug logging is enabled.
-// Debug logging is enabled when verbosity is set to a valid value except for "none", or left unset.
+// shouldSetLoggingSection reports whether the debug exporter should be attached
+// to the OTLP ingest pipelines. It is enabled only when the user explicitly sets
+// otlp_config.debug.verbosity to a valid value other than "none". When verbosity
+// is unset, the debug exporter is not attached, so no per-batch debug logs are
+// emitted by default.
 func (p *PipelineConfig) shouldSetLoggingSection() bool {
 	v, ok := p.Debug["verbosity"]
 	if !ok {
-		return true
+		return false
 	}
 	s, ok := v.(string)
 	if !ok {

--- a/comp/otelcol/otlp/collector.go
+++ b/comp/otelcol/otlp/collector.go
@@ -161,11 +161,12 @@ type PipelineConfig struct {
 	MetricsBatch map[string]interface{}
 }
 
-// shouldSetLoggingSection reports whether the debug exporter should be attached
-// to the OTLP ingest pipelines. It is enabled only when the user explicitly sets
-// otlp_config.debug.verbosity to a valid value other than "none". When verbosity
-// is unset, the debug exporter is not attached, so no per-batch debug logs are
-// emitted by default.
+// shouldSetLoggingSection reports whether the debug exporter should be attached to
+// the OTLP ingest pipelines. FromAgentConfig populates Debug["verbosity"] whenever the
+// user configures the otlp_config.debug section (defaulting it when the section is
+// declared without a verbosity), so a missing verbosity here means the section was not
+// configured and the exporter is not attached. An explicit "none" also leaves it
+// detached. As a result, no per-batch debug logs are emitted unless the user opts in.
 func (p *PipelineConfig) shouldSetLoggingSection() bool {
 	v, ok := p.Debug["verbosity"]
 	if !ok {

--- a/comp/otelcol/otlp/config.go
+++ b/comp/otelcol/otlp/config.go
@@ -109,6 +109,15 @@ func FromAgentConfig(cfg config.Reader) (PipelineConfig, error) {
 	}
 
 	debugConfig := configcheck.ReadConfigSection(cfg, coreconfig.OTLPDebug)
+	debugMap := debugConfig.ToStringMap()
+	// If the user explicitly declares the otlp_config.debug section but does not set a
+	// verbosity, attach the debug exporter using the default verbosity. When the section
+	// is absent entirely, verbosity is left unset so the debug exporter is not attached.
+	if _, ok := debugMap["verbosity"]; !ok {
+		if cfg.HasSection(coreconfig.OTLPDebug) || cfg.IsConfigured(coreconfig.OTLPDebug) {
+			debugMap["verbosity"] = cfg.GetString(coreconfig.OTLPDebug + ".verbosity")
+		}
+	}
 
 	return PipelineConfig{
 		OTLPReceiverConfig:           otlpReceiverConfigMap,
@@ -122,7 +131,7 @@ func FromAgentConfig(cfg config.Reader) (PipelineConfig, error) {
 		LogsTagsAsDDTags:             logsTagsAsDDTags,
 		MetricsBatch:                 metricsBatchConfig.ToStringMap(),
 		Logs:                         logsConfig.ToStringMap(),
-		Debug:                        debugConfig.ToStringMap(),
+		Debug:                        debugMap,
 	}, multierr.Combine(errs...)
 }
 

--- a/comp/otelcol/otlp/config_test.go
+++ b/comp/otelcol/otlp/config_test.go
@@ -729,9 +729,9 @@ func TestFromAgentConfigDebug(t *testing.T) {
 		err       string
 	}{
 		{
-			// A debug section with no verbosity does not enable the debug exporter:
-			// only an explicit non-"none" verbosity attaches it.
-			path:      "debug/empty_but_set_debug.yaml",
+			// A fully absent debug section leaves the exporter detached: verbosity is
+			// never populated, so no per-batch debug logs are emitted by default.
+			path:      "debug/absent_debug.yaml",
 			shouldSet: false,
 			cfg: PipelineConfig{
 				OTLPReceiverConfig:           map[string]interface{}{},
@@ -743,6 +743,31 @@ func TestFromAgentConfigDebug(t *testing.T) {
 				TracesContainerTagPromotion:  "off",
 				Logs:                         map[string]interface{}{},
 				Debug:                        map[string]interface{}{},
+				Metrics: map[string]interface{}{
+					"enabled":                                true,
+					"tag_cardinality":                        "low",
+					"apm_stats_receiver_addr":                "http://localhost:8126/v0.6/stats",
+					"instrumentation_scope_metadata_as_tags": true,
+				},
+				MetricsBatch: map[string]interface{}{},
+			},
+		},
+		{
+			// Explicitly declaring the debug section without a verbosity attaches the
+			// debug exporter using the default verbosity ("basic"). Only a fully absent
+			// debug section or an explicit "none" leaves the exporter detached.
+			path:      "debug/empty_but_set_debug.yaml",
+			shouldSet: true,
+			cfg: PipelineConfig{
+				OTLPReceiverConfig:           map[string]interface{}{},
+				TracePort:                    5003,
+				MetricsEnabled:               true,
+				TracesEnabled:                true,
+				LogsEnabled:                  false,
+				TracesInfraAttributesEnabled: true,
+				TracesContainerTagPromotion:  "off",
+				Logs:                         map[string]interface{}{},
+				Debug:                        map[string]interface{}{"verbosity": "basic"},
 				Metrics: map[string]interface{}{
 					"enabled":                                true,
 					"tag_cardinality":                        "low",

--- a/comp/otelcol/otlp/config_test.go
+++ b/comp/otelcol/otlp/config_test.go
@@ -729,8 +729,10 @@ func TestFromAgentConfigDebug(t *testing.T) {
 		err       string
 	}{
 		{
+			// A debug section with no verbosity does not enable the debug exporter:
+			// only an explicit non-"none" verbosity attaches it.
 			path:      "debug/empty_but_set_debug.yaml",
-			shouldSet: true,
+			shouldSet: false,
 			cfg: PipelineConfig{
 				OTLPReceiverConfig:           map[string]interface{}{},
 				TracePort:                    5003,

--- a/comp/otelcol/otlp/testdata/debug/absent_debug.yaml
+++ b/comp/otelcol/otlp/testdata/debug/absent_debug.yaml
@@ -1,0 +1,1 @@
+otlp_config:

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -5939,6 +5939,8 @@ properties:
             description: |-
               Verbosity of debug logs when Datadog Agent receives otlp traces/metrics.
               Valid values are basic, normal, detailed, none.
+              The debugexporter is off unless this is explicitly set; when unset,
+              no per-batch debug logs are emitted.
             comment: Debug settings (default from OTel debugexporter)
       grpc_port:
         node_type: setting

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -5928,6 +5928,9 @@ properties:
           This template lists the most commonly used settings; see the OpenTelemetry Collector documentation
           for a full list of available settings:
           https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter#getting-started
+          The debugexporter is off by default; it is attached only when this debug section
+          is configured. Declaring the section (even empty) enables it with the default
+          verbosity; set verbosity to none to leave it detached.
         tags:
         - template_section:CoreAgent
         properties:
@@ -5939,8 +5942,8 @@ properties:
             description: |-
               Verbosity of debug logs when Datadog Agent receives otlp traces/metrics.
               Valid values are basic, normal, detailed, none.
-              The debugexporter is off unless this is explicitly set; when unset,
-              no per-batch debug logs are emitted.
+              This default applies only once the debug section is configured; set it to
+              none to keep the debugexporter detached even when the section is present.
             comment: Debug settings (default from OTel debugexporter)
       grpc_port:
         node_type: setting

--- a/releasenotes/notes/otlp-ingest-debug-exporter-default-off-3f6c1a9b7e2d4c85.yaml
+++ b/releasenotes/notes/otlp-ingest-debug-exporter-default-off-3f6c1a9b7e2d4c85.yaml
@@ -1,0 +1,17 @@
+---
+enhancements:
+  - |
+    The Agent's OTLP ingestion pipeline no longer attaches the OpenTelemetry
+    ``debug`` exporter by default. Previously it was enabled whenever
+    ``otlp_config.debug.verbosity`` was left unset, emitting one INFO log line
+    per received batch. The ``debug`` exporter is now attached only when
+    ``otlp_config.debug.verbosity`` (or ``DD_OTLP_CONFIG_DEBUG_VERBOSITY``) is
+    explicitly set to ``basic``, ``normal``, or ``detailed``.
+upgrade:
+  - |
+    OTLP ingestion no longer logs the per-batch ``debug`` exporter summary
+    lines unless ``otlp_config.debug.verbosity`` is explicitly set to a value
+    other than ``none``. If you relied on these logs to confirm that telemetry
+    is flowing, set ``otlp_config.debug.verbosity`` (or
+    ``DD_OTLP_CONFIG_DEBUG_VERBOSITY``) to ``basic``, ``normal``, or
+    ``detailed`` to restore them.

--- a/releasenotes/notes/otlp-ingest-debug-exporter-default-off-3f6c1a9b7e2d4c85.yaml
+++ b/releasenotes/notes/otlp-ingest-debug-exporter-default-off-3f6c1a9b7e2d4c85.yaml
@@ -1,17 +1,7 @@
 ---
-enhancements:
+fixes:
   - |
-    The Agent's OTLP ingestion pipeline no longer attaches the OpenTelemetry
-    ``debug`` exporter by default. Previously it was enabled whenever
-    ``otlp_config.debug.verbosity`` was left unset, emitting one INFO log line
-    per received batch. The ``debug`` exporter is now attached only when
+    Agent OTLP Ingest no longer attaches the OpenTelemetry
+    ``debugexporter`` by default. The ``debugexporter`` is now attached only when
     ``otlp_config.debug.verbosity`` (or ``DD_OTLP_CONFIG_DEBUG_VERBOSITY``) is
     explicitly set to ``basic``, ``normal``, or ``detailed``.
-upgrade:
-  - |
-    OTLP ingestion no longer logs the per-batch ``debug`` exporter summary
-    lines unless ``otlp_config.debug.verbosity`` is explicitly set to a value
-    other than ``none``. If you relied on these logs to confirm that telemetry
-    is flowing, set ``otlp_config.debug.verbosity`` (or
-    ``DD_OTLP_CONFIG_DEBUG_VERBOSITY``) to ``basic``, ``normal``, or
-    ``detailed`` to restore them.

--- a/releasenotes/notes/otlp-ingest-debug-exporter-default-off-3f6c1a9b7e2d4c85.yaml
+++ b/releasenotes/notes/otlp-ingest-debug-exporter-default-off-3f6c1a9b7e2d4c85.yaml
@@ -3,5 +3,8 @@ fixes:
   - |
     Agent OTLP Ingest no longer attaches the OpenTelemetry
     ``debugexporter`` by default. The ``debugexporter`` is now attached only when
-    ``otlp_config.debug.verbosity`` (or ``DD_OTLP_CONFIG_DEBUG_VERBOSITY``) is
-    explicitly set to ``basic``, ``normal``, or ``detailed``.
+    the ``otlp_config.debug`` section is explicitly configured. Declaring the
+    section without a verbosity uses the default verbosity (``basic``), while
+    setting ``otlp_config.debug.verbosity`` (or ``DD_OTLP_CONFIG_DEBUG_VERBOSITY``)
+    to ``basic``, ``normal``, or ``detailed`` selects the verbosity. Setting it to
+    ``none`` leaves the exporter detached.


### PR DESCRIPTION
### What does this PR do?

Stops attaching the OpenTelemetry `debugexporter` to the Agent's OTLP ingest pipelines by default.

`PipelineConfig.shouldSetLoggingSection()` previously returned `true` when `otlp_config.debug.verbosity` was unset, so the `debug` exporter was always attached and emitted one summary log line per received batch out of the box. The exporter is now attached only when the user explicitly configures the `otlp_config.debug` section:

- **Absent** `debug` section → exporter not attached (no per-batch logs).
- **Declared but empty** `debug:` section → exporter attached with the default verbosity (`basic`).
- **`otlp_config.debug.verbosity`** (or `DD_OTLP_CONFIG_DEBUG_VERBOSITY`) set to `basic`/`normal`/`detailed` → exporter attached at that verbosity.
- **`verbosity: none`** → exporter not attached.

`FromAgentConfig` injects the default verbosity into `PipelineConfig.Debug` when the section is declared without one. It uses `HasSection`/`IsConfigured` (which skip schema defaults and report only user-provided sources) to distinguish an explicitly-declared empty section from an absent one, so schema defaults do not silently enable the exporter.

The config-schema documentation for `otlp_config.debug` is updated to state that the exporter is off by default and is attached only when the section is configured.

### Motivation

OTAGENT-1285. OTLP ingestion enabling the debug exporter by default produces noisy per-batch INFO logs in a standard Agent install, which is surprising and undesirable for users who did not opt into debug output. The `basic`/`normal`/`detailed` verbosity levels remain available for users who want those logs.

### Describe how you validated your changes

- `go test -tags 'otlp test' ./comp/otelcol/otlp/` passes, including `TestFromAgentConfigDebug` and `TestNewMap`.
- `TestFromAgentConfigDebug` covers all cases: absent section (`shouldSet: false`), declared-but-empty section (`shouldSet: true`, defaults to `basic`), and explicit `detailed`/`normal`/`none` verbosity.
- Confirmed the schema default (`basic`) is filtered out by `configcheck.convertToStringConfMap` (keeps only user-configured keys), so an unconfigured Agent has no `debug` section and the exporter is not attached.

### Additional Notes

A release note is included documenting the default change and how to restore the per-batch logs by configuring the `otlp_config.debug` section.
