### PR TITLE
Load the authored-script package.yaml manifest

### DIFF
--- a/pkg/privateactionrunner/bundle-support/authoredscripts/BUILD.bazel
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+
+go_library(
+    name = "authoredscripts",
+    srcs = ["manifest.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundle-support/authoredscripts",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
+        "@in_yaml_go_yaml_v3//:yaml",
+    ],
+)
+
+dd_agent_go_test(
+    name = "authoredscripts_test",
+    srcs = ["manifest_test.go"],
+    embed = [":authoredscripts"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/BUILD.bazel
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/BUILD.bazel
@@ -6,10 +6,7 @@ go_library(
     srcs = ["manifest.go"],
     importpath = "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundle-support/authoredscripts",
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
-        "@in_yaml_go_yaml_v3//:yaml",
-    ],
+    deps = ["@in_yaml_go_yaml_v3//:yaml"],
 )
 
 dd_agent_go_test(

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/manifest.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/manifest.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 
-	securejoin "github.com/cyphar/filepath-securejoin"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -140,10 +139,6 @@ func validateManifestEnvironmentVariables(scope string, variables []EnvironmentV
 	return nil
 }
 
-// openPackageFile resolves path against root, opens it, and verifies it is a regular file.
-// The regular-file check happens on the open descriptor rather than the path so that
-// whatever is checked is exactly what gets read, with no window for the file at path to be
-// swapped for a symlink, FIFO, or device in between.
 func openPackageFile(root, path string) (*os.File, error) {
 	if path == "" {
 		return nil, errors.New("path is empty")
@@ -152,11 +147,13 @@ func openPackageFile(root, path string) (*os.File, error) {
 		return nil, fmt.Errorf("path %q is not relative to the package", path)
 	}
 
-	resolvedPath, err := securejoin.SecureJoin(root, path)
+	rootHandle, err := os.OpenRoot(root)
 	if err != nil {
-		return nil, fmt.Errorf("could not resolve path %q: %w", path, err)
+		return nil, fmt.Errorf("could not open package root: %w", err)
 	}
-	file, err := os.Open(resolvedPath)
+	defer rootHandle.Close()
+
+	file, err := rootHandle.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("could not access file %q: %w", path, err)
 	}

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/manifest.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/manifest.go
@@ -1,0 +1,173 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package authoredscripts
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
+	"go.yaml.in/yaml/v3"
+)
+
+const (
+	manifestSchemaVersion    = "v1"
+	scriptDirectory          = "script"
+	manifestFile             = "package.yaml"
+	maxManifestSize          = 1 << 20
+	environmentKindValue     = "value"
+	environmentKindFile      = "file"
+	environmentKindDirectory = "directory"
+)
+
+// Manifest describes how an authored-script package is executed.
+type Manifest struct {
+	SchemaVersion string       `yaml:"schema-version"`
+	Package       string       `yaml:"dd-package"`
+	Version       string       `yaml:"version"`
+	Title         string       `yaml:"title"`
+	Description   string       `yaml:"description"`
+	FQN           string       `yaml:"fqn"`
+	URL           string       `yaml:"url"`
+	Config        ScriptConfig `yaml:"config"`
+	Dependencies  []Dependency `yaml:"dependencies"`
+}
+
+// ScriptConfig describes the command, inputs, and environment available to a script.
+type ScriptConfig struct {
+	Command           []string               `yaml:"command"`
+	ParameterSchema   map[string]interface{} `yaml:"parameterSchema"`
+	AllowedEnvVars    []string               `yaml:"allowedEnvVars"`
+	SetGlobalEnvVars  []EnvironmentVariable  `yaml:"setGlobalEnvVars"`
+	SetSessionEnvVars []EnvironmentVariable  `yaml:"setSessionEnvVars"`
+}
+
+// EnvironmentVariable describes an environment value created for a script. File and
+// directory values are paths relative to their global or session state directory.
+type EnvironmentVariable struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
+	Kind  string `yaml:"kind"`
+}
+
+// Dependency identifies a tool bundled with an authored-script package.
+type Dependency struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+}
+
+// LoadManifest reads and validates the package.yaml manifest for an authored-script
+// package that has already been downloaded and extracted to artifactDirectory.
+func LoadManifest(artifactDirectory string) (*Manifest, error) {
+	file, err := openPackageFile(artifactDirectory, filepath.Join(scriptDirectory, manifestFile))
+	if err != nil {
+		return nil, fmt.Errorf("could not open authored-script manifest: %w", err)
+	}
+	defer file.Close()
+
+	contents, err := io.ReadAll(io.LimitReader(file, maxManifestSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("could not read authored-script manifest: %w", err)
+	}
+	if len(contents) > maxManifestSize {
+		return nil, fmt.Errorf("authored-script manifest exceeds the %d byte limit", maxManifestSize)
+	}
+
+	manifest := &Manifest{}
+	decoder := yaml.NewDecoder(bytes.NewReader(contents))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(manifest); err != nil {
+		return nil, fmt.Errorf("could not decode authored-script manifest: %w", err)
+	}
+	if err := decoder.Decode(new(yaml.Node)); !errors.Is(err, io.EOF) {
+		return nil, errors.New("authored-script manifest must contain exactly one YAML document")
+	}
+	if err := validateManifest(manifest); err != nil {
+		return nil, err
+	}
+
+	return manifest, nil
+}
+
+func validateManifest(manifest *Manifest) error {
+	if manifest.SchemaVersion != manifestSchemaVersion {
+		return fmt.Errorf("unsupported authored-script manifest schema version %q", manifest.SchemaVersion)
+	}
+	if manifest.Package == "" {
+		return errors.New("authored-script manifest package is required")
+	}
+	if manifest.Version == "" {
+		return errors.New("authored-script manifest version is required")
+	}
+	if manifest.FQN == "" {
+		return errors.New("authored-script manifest FQN is required")
+	}
+	if len(manifest.Config.Command) == 0 || manifest.Config.Command[0] == "" {
+		return errors.New("authored-script manifest command is required")
+	}
+	if err := validateManifestEnvironmentVariables("global", manifest.Config.SetGlobalEnvVars); err != nil {
+		return err
+	}
+	if err := validateManifestEnvironmentVariables("session", manifest.Config.SetSessionEnvVars); err != nil {
+		return err
+	}
+	for _, dependency := range manifest.Dependencies {
+		if dependency.Name == "" || dependency.Version == "" {
+			return errors.New("authored-script manifest dependencies require a name and version")
+		}
+	}
+	return nil
+}
+
+func validateManifestEnvironmentVariables(scope string, variables []EnvironmentVariable) error {
+	for _, environmentVariable := range variables {
+		if environmentVariable.Name == "" || environmentVariable.Value == "" || environmentVariable.Kind == "" {
+			return fmt.Errorf("authored-script manifest %s environment variables require a name, value, and kind", scope)
+		}
+		switch environmentVariable.Kind {
+		case environmentKindValue, environmentKindFile, environmentKindDirectory:
+		default:
+			return fmt.Errorf("authored-script manifest %s environment variable %q has unsupported kind %q", scope, environmentVariable.Name, environmentVariable.Kind)
+		}
+	}
+	return nil
+}
+
+// openPackageFile resolves path against root, opens it, and verifies it is a regular file.
+// The regular-file check happens on the open descriptor rather than the path so that
+// whatever is checked is exactly what gets read, with no window for the file at path to be
+// swapped for a symlink, FIFO, or device in between.
+func openPackageFile(root, path string) (*os.File, error) {
+	if path == "" {
+		return nil, errors.New("path is empty")
+	}
+	if !filepath.IsLocal(path) {
+		return nil, fmt.Errorf("path %q is not relative to the package", path)
+	}
+
+	resolvedPath, err := securejoin.SecureJoin(root, path)
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve path %q: %w", path, err)
+	}
+	file, err := os.Open(resolvedPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not access file %q: %w", path, err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, fmt.Errorf("could not access file %q: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		file.Close()
+		return nil, fmt.Errorf("path %q is not a regular file", path)
+	}
+	return file, nil
+}

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/manifest_test.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/manifest_test.go
@@ -1,0 +1,287 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package authoredscripts
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validManifest = `
+schema-version: v1
+dd-package: dd-par-scripts-echo
+version: 0.0.1
+title: Echo
+description: Prints a message to stdout.
+fqn: com.datadoghq.authoredscripts.echo
+config:
+  command: ["run.sh"]
+  allowedEnvVars: ["HOME"]
+`
+
+func writeManifest(t *testing.T, contents string) string {
+	t.Helper()
+	artifactDirectory := t.TempDir()
+	scriptDir := filepath.Join(artifactDirectory, scriptDirectory)
+	require.NoError(t, os.MkdirAll(scriptDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(scriptDir, manifestFile), []byte(contents), 0o644))
+	return artifactDirectory
+}
+
+func TestLoadManifest_Valid(t *testing.T) {
+	artifactDirectory := writeManifest(t, validManifest)
+
+	manifest, err := LoadManifest(artifactDirectory)
+
+	require.NoError(t, err)
+	assert.Equal(t, "v1", manifest.SchemaVersion)
+	assert.Equal(t, "dd-par-scripts-echo", manifest.Package)
+	assert.Equal(t, []string{"run.sh"}, manifest.Config.Command)
+	assert.Equal(t, []string{"HOME"}, manifest.Config.AllowedEnvVars)
+}
+
+func TestLoadManifest_WithGlobalAndSessionEnvVars(t *testing.T) {
+	artifactDirectory := writeManifest(t, validManifest+`
+  setGlobalEnvVars:
+    - name: EXAMPLE_FILE
+      value: path/to/file
+      kind: file
+  setSessionEnvVars:
+    - name: SESSION_EXAMPLE_VALUE
+      value: example-session-value
+      kind: value
+`)
+
+	manifest, err := LoadManifest(artifactDirectory)
+
+	require.NoError(t, err)
+	require.Len(t, manifest.Config.SetGlobalEnvVars, 1)
+	assert.Equal(t, environmentKindFile, manifest.Config.SetGlobalEnvVars[0].Kind)
+	require.Len(t, manifest.Config.SetSessionEnvVars, 1)
+	assert.Equal(t, environmentKindValue, manifest.Config.SetSessionEnvVars[0].Kind)
+}
+
+func TestLoadManifest_MissingManifestFile(t *testing.T) {
+	artifactDirectory := t.TempDir()
+
+	_, err := LoadManifest(artifactDirectory)
+
+	require.Error(t, err)
+}
+
+func TestLoadManifest_RejectsUnknownField(t *testing.T) {
+	artifactDirectory := writeManifest(t, validManifest+"\nunexpectedField: true\n")
+
+	_, err := LoadManifest(artifactDirectory)
+
+	require.Error(t, err)
+}
+
+func TestLoadManifest_RejectsMultipleDocuments(t *testing.T) {
+	artifactDirectory := writeManifest(t, validManifest+"\n---\nschema-version: v1\n")
+
+	_, err := LoadManifest(artifactDirectory)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one YAML document")
+}
+
+func TestLoadManifest_RejectsOversizedManifest(t *testing.T) {
+	padding := strings.Repeat("a", maxManifestSize+1)
+	artifactDirectory := writeManifest(t, validManifest+"\n# "+padding+"\n")
+
+	_, err := LoadManifest(artifactDirectory)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "byte limit")
+}
+
+func TestLoadManifest_RejectsDirectoryInPlaceOfManifest(t *testing.T) {
+	artifactDirectory := t.TempDir()
+	scriptDir := filepath.Join(artifactDirectory, scriptDirectory)
+	require.NoError(t, os.MkdirAll(filepath.Join(scriptDir, manifestFile), 0o755))
+
+	_, err := LoadManifest(artifactDirectory)
+
+	require.Error(t, err)
+}
+
+func TestValidateManifest(t *testing.T) {
+	validCommand := []string{"run.sh"}
+
+	tests := []struct {
+		name        string
+		manifest    *Manifest
+		expectError string
+	}{
+		{
+			name: "unsupported schema version",
+			manifest: &Manifest{
+				SchemaVersion: "v2",
+				Package:       "dd-par-scripts-echo",
+				Version:       "0.0.1",
+				FQN:           "com.datadoghq.authoredscripts.echo",
+				Config:        ScriptConfig{Command: validCommand},
+			},
+			expectError: "unsupported authored-script manifest schema version",
+		},
+		{
+			name: "missing package",
+			manifest: &Manifest{
+				SchemaVersion: manifestSchemaVersion,
+				Version:       "0.0.1",
+				FQN:           "com.datadoghq.authoredscripts.echo",
+				Config:        ScriptConfig{Command: validCommand},
+			},
+			expectError: "package is required",
+		},
+		{
+			name: "missing version",
+			manifest: &Manifest{
+				SchemaVersion: manifestSchemaVersion,
+				Package:       "dd-par-scripts-echo",
+				FQN:           "com.datadoghq.authoredscripts.echo",
+				Config:        ScriptConfig{Command: validCommand},
+			},
+			expectError: "version is required",
+		},
+		{
+			name: "missing fqn",
+			manifest: &Manifest{
+				SchemaVersion: manifestSchemaVersion,
+				Package:       "dd-par-scripts-echo",
+				Version:       "0.0.1",
+				Config:        ScriptConfig{Command: validCommand},
+			},
+			expectError: "FQN is required",
+		},
+		{
+			name: "missing command",
+			manifest: &Manifest{
+				SchemaVersion: manifestSchemaVersion,
+				Package:       "dd-par-scripts-echo",
+				Version:       "0.0.1",
+				FQN:           "com.datadoghq.authoredscripts.echo",
+			},
+			expectError: "command is required",
+		},
+		{
+			name: "empty first command argument",
+			manifest: &Manifest{
+				SchemaVersion: manifestSchemaVersion,
+				Package:       "dd-par-scripts-echo",
+				Version:       "0.0.1",
+				FQN:           "com.datadoghq.authoredscripts.echo",
+				Config:        ScriptConfig{Command: []string{""}},
+			},
+			expectError: "command is required",
+		},
+		{
+			name: "unsupported global env var kind",
+			manifest: &Manifest{
+				SchemaVersion: manifestSchemaVersion,
+				Package:       "dd-par-scripts-echo",
+				Version:       "0.0.1",
+				FQN:           "com.datadoghq.authoredscripts.echo",
+				Config: ScriptConfig{
+					Command:          validCommand,
+					SetGlobalEnvVars: []EnvironmentVariable{{Name: "X", Value: "y", Kind: "socket"}},
+				},
+			},
+			expectError: "global environment variable",
+		},
+		{
+			name: "incomplete session env var",
+			manifest: &Manifest{
+				SchemaVersion: manifestSchemaVersion,
+				Package:       "dd-par-scripts-echo",
+				Version:       "0.0.1",
+				FQN:           "com.datadoghq.authoredscripts.echo",
+				Config: ScriptConfig{
+					Command:           validCommand,
+					SetSessionEnvVars: []EnvironmentVariable{{Name: "X", Kind: environmentKindValue}},
+				},
+			},
+			expectError: "session environment variables require",
+		},
+		{
+			name: "dependency missing version",
+			manifest: &Manifest{
+				SchemaVersion: manifestSchemaVersion,
+				Package:       "dd-par-scripts-echo",
+				Version:       "0.0.1",
+				FQN:           "com.datadoghq.authoredscripts.echo",
+				Config:        ScriptConfig{Command: validCommand},
+				Dependencies:  []Dependency{{Name: "jq"}},
+			},
+			expectError: "dependencies require a name and version",
+		},
+		{
+			name: "valid manifest",
+			manifest: &Manifest{
+				SchemaVersion: manifestSchemaVersion,
+				Package:       "dd-par-scripts-echo",
+				Version:       "0.0.1",
+				FQN:           "com.datadoghq.authoredscripts.echo",
+				Config:        ScriptConfig{Command: validCommand},
+				Dependencies:  []Dependency{{Name: "jq", Version: "1.7.1"}},
+			},
+			expectError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateManifest(tt.manifest)
+			if tt.expectError == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+		})
+	}
+}
+
+func TestOpenPackageFile(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "file.txt"), []byte("data"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "subdir"), 0o755))
+
+	t.Run("regular file opens", func(t *testing.T) {
+		file, err := openPackageFile(root, "file.txt")
+		require.NoError(t, err)
+		defer file.Close()
+		assert.Equal(t, filepath.Join(root, "file.txt"), file.Name())
+	})
+
+	t.Run("empty path rejected", func(t *testing.T) {
+		_, err := openPackageFile(root, "")
+		require.Error(t, err)
+	})
+
+	t.Run("parent traversal rejected", func(t *testing.T) {
+		_, err := openPackageFile(root, "../file.txt")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not relative to the package")
+	})
+
+	t.Run("missing file rejected", func(t *testing.T) {
+		_, err := openPackageFile(root, "missing.txt")
+		require.Error(t, err)
+	})
+
+	t.Run("directory rejected", func(t *testing.T) {
+		_, err := openPackageFile(root, "subdir")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a regular file")
+	})
+}

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/manifest_test.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/manifest_test.go
@@ -104,16 +104,6 @@ func TestLoadManifest_RejectsOversizedManifest(t *testing.T) {
 	assert.Contains(t, err.Error(), "byte limit")
 }
 
-func TestLoadManifest_RejectsDirectoryInPlaceOfManifest(t *testing.T) {
-	artifactDirectory := t.TempDir()
-	scriptDir := filepath.Join(artifactDirectory, scriptDirectory)
-	require.NoError(t, os.MkdirAll(filepath.Join(scriptDir, manifestFile), 0o755))
-
-	_, err := LoadManifest(artifactDirectory)
-
-	require.Error(t, err)
-}
-
 func TestValidateManifest(t *testing.T) {
 	validCommand := []string{"run.sh"}
 


### PR DESCRIPTION
## Summary
- Adds `LoadManifest` to read and validate the `package.yaml` manifest for an authored-script package that has already been downloaded and extracted to a local artifact directory.
- This PR only covers loading/validating the manifest. Downloading/acquiring the package artifact and wiring this into the bundle handler/routing will land in subsequent PRs.

**How will this be used:**
After the files are downloaded and available in local cache, we will load the Manifest object so that they can be used in other places like setting env vars, loading the script package which in turn will be used for executing the command


See the RFC for the broader intergration: [RFC Authored script download, storage and isolation](https://datadoghq.atlassian.net/wiki/spaces/ACT/pages/7060063493/RFC+Authored+script+download+storage+and+isolation)

## Test plan
- [x] `bazel test //pkg/privateactionrunner/bundle-support/authoredscripts:authoredscripts_test`