### PR TITLE
Fix interop DLL test load when Bazel materializes runfiles as a junction

### DIFF
--- a/pkg/inventory/software/main_windows_test.go
+++ b/pkg/inventory/software/main_windows_test.go
@@ -8,6 +8,7 @@
 package software
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,6 +27,29 @@ func TestMain(m *testing.M) {
 				p = filepath.Join(root, p)
 			}
 		}
+
+		// Bazel may materialize the runfiles entry as a directory junction pointing at
+		// the real DLL instead of as a file. Windows then reports the path as a
+		// directory and LoadLibrary refuses the image with ERROR_ACCESS_DENIED, which
+		// surfaces as an opaque "Access is denied" panic deep inside the collector.
+		// Resolve the reparse point first: os.Stat fails on such an entry and
+		// filepath.EvalSymlinks returns it unchanged, so os.Readlink is what works.
+		if fi, err := os.Lstat(p); err == nil && !fi.Mode().IsRegular() {
+			target, rerr := os.Readlink(p)
+			if rerr != nil {
+				fmt.Fprintf(os.Stderr, "interop DLL %q is not a regular file and could not be resolved: %v\n", p, rerr)
+				os.Exit(1)
+			}
+			if !filepath.IsAbs(target) {
+				target = filepath.Join(filepath.Dir(p), target)
+			}
+			p = target
+		}
+		if fi, err := os.Lstat(p); err != nil || !fi.Mode().IsRegular() {
+			fmt.Fprintf(os.Stderr, "interop DLL %q is not a regular file: %v\n", p, err)
+			os.Exit(1)
+		}
+
 		os.Setenv("PATH", filepath.Dir(p)+string(os.PathListSeparator)+os.Getenv("PATH"))
 	}
 	os.Exit(m.Run())


### PR DESCRIPTION
### What does this PR do?

Resolves the Bazel runfiles reparse point before adding its directory to `PATH` in
`pkg/inventory/software`'s `TestMain`. Test-only; no production code touched.

### Motivation

`//pkg/inventory/software:software_test` panics on `bazel:test:windows-amd64:go`:

```
panic: Failed to load libdatadog-interop.dll: Access is denied. [recovered, repanicked]
…datadoginterop.GetStore()  pkg/util/winutil/datadoginterop/msstoreapps.go:46
```

Bazel sometimes materializes the runfiles entry for the DLL as a **directory junction**
pointing at the real file. Windows reports it as a directory, so `LoadLibrary` refuses the
image with `ERROR_ACCESS_DENIED (5)` — which is why it's 5 and not
`ERROR_MOD_NOT_FOUND (126)`: the path is found, it just isn't a file. `TestMain` (added in
#54768) puts that directory on `PATH`, so this is the first time the runfiles path is used
to find the DLL.

Tested against the failing entry:

| Call | Behaviour |
|---|---|
| `filepath.EvalSymlinks` | returns the path **unchanged**, reports success |
| `os.Stat` | **fails**: `The directory name is invalid` |
| `IsDir()` / `&os.ModeSymlink` | both **false** — Go reports `ModeIrregular` |
| `os.Readlink` | **works** |

So detection is `!fi.Mode().IsRegular()` and resolution is `os.Readlink`. The added
"not a regular file" check fails loudly rather than putting a bogus directory on `PATH`.

### Describe how you validated your changes

Local Windows container on the agent build image, with `--nocache_test_results` (without it
Bazel serves a cached PASS and the failure looks intermittent).

Causal check — same binary, no rebuild, only the runfiles entry swapped:

| Runfiles entry | Result |
|---|---|
| directory junction | FAILED, `Access is denied` |
| real file | PASSED |

This change, with the junction **still present** during the passing run:

```
//pkg/inventory/software:software_test    PASSED in 22.1s
--- PASS: TestIntegrationCompareWithPowerShell/…Programs_provider (11.75s)
```

### Additional Notes

Out of scope here, worth separate fixes: `GetStore`/`FreeStore` panic instead of returning
an error (`LazyProc.Call` → `mustFind`), so the `error` return can never report a load
failure; and Bazel creating a directory junction for a file affects any Windows target with
a DLL in `data`.

https://datadoghq.atlassian.net/browse/WINA-3032