### PR TITLE
feat(forwarder): add additive metrics dual-ship to Observability Pipelines Worker

### DIFF
--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -159,6 +159,41 @@ func getObsPipelineURLForPrefix(log log.Component, datatype string, prefix strin
 	return "", nil
 }
 
+// getObsPipelineDualShipURL returns the dual-ship URL for the given datatype if dual_ship is enabled.
+// Unlike getObsPipelineURL (which routes data exclusively to OPW), dual_ship keeps the primary
+// endpoint active and adds OPW as an additional destination.
+func getObsPipelineDualShipURL(log log.Component, datatype string, config pkgconfigmodel.Reader) (string, error) {
+	if config.GetBool(fmt.Sprintf("observability_pipelines_worker.%s.dual_ship", datatype)) {
+		return getObsPipelineDualShipURLForPrefix(log, datatype, "observability_pipelines_worker", config)
+	} else if config.GetBool(fmt.Sprintf("vector.%s.dual_ship", datatype)) {
+		return getObsPipelineDualShipURLForPrefix(log, datatype, "vector", config)
+	}
+	return "", nil
+}
+
+func getObsPipelineDualShipURLForPrefix(log log.Component, datatype string, prefix string, config pkgconfigmodel.Reader) (string, error) {
+	if config.GetBool(fmt.Sprintf("%s.%s.dual_ship", prefix, datatype)) {
+		pipelineURL := config.GetString(fmt.Sprintf("%s.%s.dual_ship_url", prefix, datatype))
+		if pipelineURL == "" {
+			log.Errorf("%s.%s.dual_ship is set to true, but %s.%s.dual_ship_url is empty", prefix, datatype, prefix, datatype)
+			return "", nil
+		}
+		_, err := url.Parse(pipelineURL)
+		if err != nil {
+			return "", fmt.Errorf("could not parse %s %s dual_ship endpoint: %s", prefix, datatype, err)
+		}
+		return pipelineURL, nil
+	}
+	return "", nil
+}
+
+// isMetricsEndpoint reports whether the given endpoint carries time-series or sketch metrics.
+func isMetricsEndpoint(e transaction.Endpoint) bool {
+	return e == endpoints.V1SeriesEndpoint ||
+		e == endpoints.SeriesEndpoint ||
+		e == endpoints.SketchSeriesEndpoint
+}
+
 // NewOptions creates a configuration for the forwarder with OPW enabled.
 //
 // Deprecated, use NewOptionsWithOPW instead.
@@ -190,6 +225,21 @@ func NewOptionsWithOPW(config config.Component, log log.Component, eds utils.End
 			return nil, err
 		}
 		resolvers[utils.GetInfraEndpoint(config)] = resolver
+	}
+
+	dualShipMetricsURL, err := getObsPipelineDualShipURL(log, pkgconfigsetup.Metrics, config)
+	if err != nil {
+		log.Error("Misconfiguration of agent observability_pipelines_worker dual_ship endpoint for metrics: ", err)
+	}
+	if dualShipMetricsURL != "" {
+		log.Debugf("Configuring forwarder to dual-ship metrics to observability_pipelines_worker: %s", dualShipMetricsURL)
+		primaryResolver := resolvers[utils.GetInfraEndpoint(config)]
+		apiKeys, _ := primaryResolver.GetAPIKeysInfo()
+		dualResolver, err := pkgresolver.NewDomainResolverMetricsDualShip(dualShipMetricsURL, apiKeys)
+		if err != nil {
+			return nil, err
+		}
+		resolvers[dualShipMetricsURL] = dualResolver
 	}
 
 	return NewOptionsWithResolvers(config, log, resolvers), nil
@@ -539,6 +589,10 @@ func (f *DefaultForwarder) createAdvancedHTTPTransactions(endpoint transaction.E
 			}
 			// Autoscaling failover endpoint can only receive series payloads.
 			if dr.IsLocal() && endpoint != endpoints.SeriesEndpoint {
+				continue
+			}
+			// Dual-ship resolvers only forward metrics endpoints; skip everything else.
+			if dr.IsMetricsOnly() && !isMetricsEndpoint(endpoint) {
 				continue
 			}
 

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
@@ -62,7 +62,8 @@ type domainResolver struct {
 	overrides           map[string]destination
 	alternateDomainList []string
 
-	isMRF bool
+	isMRF       bool
+	metricsOnly bool
 }
 
 // OnUpdateConfig adds a hook into the config which will listen for updates to the API keys
@@ -379,6 +380,18 @@ func NewDomainResolverWithMetricToVector(mainEndpoint string, apiKeys []utils.AP
 	return r, nil
 }
 
+// NewDomainResolverMetricsDualShip creates a resolver that sends metrics (series v1/v2
+// and sketches) to an additional Vector/OPW endpoint without replacing the primary resolver.
+// The forwarder skips non-metrics endpoints for resolvers where IsMetricsOnly() is true.
+func NewDomainResolverMetricsDualShip(opwURL string, apiKeys []utils.APIKeys) (DomainResolver, error) {
+	r, err := NewMultiDomainResolver(opwURL, apiKeys)
+	if err != nil {
+		return nil, err
+	}
+	r.metricsOnly = true
+	return r, nil
+}
+
 // NewLocalDomainResolver creates a LocalDomainResolver with domain in local cluster and authToken for internal communication
 // For example, the internal cluster-agent endpoint
 func NewLocalDomainResolver(domain string, authToken string) DomainResolver {
@@ -403,6 +416,12 @@ func (r *domainResolver) IsLocal() bool {
 // IsMRF returns true when the domain is used as the target for multi region failover.
 func (r *domainResolver) IsMRF() bool {
 	return r.isMRF
+}
+
+// IsMetricsOnly returns true when the resolver should only handle metrics endpoints
+// (series v1/v2 and sketches) and skip all other endpoint types.
+func (r *domainResolver) IsMetricsOnly() bool {
+	return r.metricsOnly
 }
 
 type authHeader struct {

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1971,6 +1971,15 @@ func bindVectorOptions(config pkgconfigmodel.Setup, datatype string) {
 
 	config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.enabled", datatype), false)
 	config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.url", datatype), "")
+
+	// dual_ship sends data to OPW in addition to (not instead of) the primary endpoint.
+	// Only registered for metrics; logs use logs_config.additional_endpoints for this purpose.
+	if datatype == Metrics {
+		config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.dual_ship", datatype), false)
+		config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.dual_ship_url", datatype), "")
+		config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.dual_ship", datatype), false)
+		config.BindEnvAndSetDefault(fmt.Sprintf("vector.%s.dual_ship_url", datatype), "")
+	}
 }
 
 func cloudfoundry(config pkgconfigmodel.Setup) {


### PR DESCRIPTION
## Summary

- Add `observability_pipelines_worker.metrics.dual_ship` + `dual_ship_url` config keys so the agent can send metrics to **both** the primary Datadog intake and an OPW instance simultaneously
- Mirrors the `observability_pipelines_worker.logs.dual_ship` feature that already exists for logs
- Introduces `NewDomainResolverMetricsDualShip` — a metrics-only resolver that is added alongside the primary resolver so non-metrics payloads (APM, process, orchestrator) are never sent to OPW

## Context / motivation

Two existing mechanisms for routing metrics to OPW fall short of the desired use case:

| Option | Additive? | Metrics-only? |
|--------|-----------|---------------|
| `observability_pipelines_worker.metrics.enabled` | ❌ replaces primary | ✅ |
| `additional_endpoints` | ✅ | ❌ sends all forwarder data |

This PR closes the gap with a third option that is both additive and metrics-scoped, equivalent to what `logs_config.additional_endpoints` / `observability_pipelines_worker.logs.dual_ship` provides for logs.

See gap analysis: https://datadoghq.atlassian.net/wiki/spaces/CD1/pages/6994592682

## Changes

- **`pkg/config/setup/common_settings.go`** — register `dual_ship` and `dual_ship_url` inside `bindVectorOptions` (metrics only; logs already have their own path via `LogsConfigKeys`)
- **`comp/forwarder/defaultforwarder/resolver/domain_resolver.go`** — add `metricsOnly bool` field, `IsMetricsOnly()`, and `NewDomainResolverMetricsDualShip` constructor
- **`comp/forwarder/defaultforwarder/default_forwarder.go`** — add `getObsPipelineDualShipURL`, `isMetricsEndpoint` helper, guard in `createAdvancedHTTPTransactions` to skip non-metrics endpoints for metrics-only resolvers, and wire-up in `NewOptionsWithOPW`

## Configuration example

```yaml
observability_pipelines_worker:
  metrics:
    dual_ship: true
    dual_ship_url: http://your-opw-host:8080
```

Env vars: `DD_OBSERVABILITY_PIPELINES_WORKER_METRICS_DUAL_SHIP` and `DD_OBSERVABILITY_PIPELINES_WORKER_METRICS_DUAL_SHIP_URL`.

## Test plan

- [ ] Unit test: `NewDomainResolverMetricsDualShip` returns a resolver with `IsMetricsOnly() == true`
- [ ] Unit test: `createAdvancedHTTPTransactions` produces two transactions for a series payload (one to primary, one to OPW) and only one for metadata payloads when `dual_ship` is configured
- [ ] Unit test: `getObsPipelineDualShipURL` reads config correctly and validates the URL
- [ ] Build: `dda inv agent.build --build-exclude=systemd`
- [ ] Manual: run agent with `dual_ship: true` pointing at a local HTTP listener; confirm metrics arrive at both the primary intake and the OPW URL

> ⚠️ **Draft** — build not yet verified locally (dependency sync was interrupted). Opening for early review of the approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)