### PR TITLE
Add Kafka Actions opt-out

### DIFF
--- a/comp/core/autodiscovery/providers/datastreams/kafka_actions.go
+++ b/comp/core/autodiscovery/providers/datastreams/kafka_actions.go
@@ -161,7 +161,7 @@ func (c *actionsController) update(updates map[string]state.RawConfig, applyStat
 	for _, parsed := range remoteConfigs {
 		auth, base, err := extractKafkaAuthFromInstance(cfgs, parsed.bootstrapServers)
 		if err != nil {
-			log.Errorf("Failed to extract Kafka auth for config %s: %v", parsed.path, err)
+			log.Errorf("Failed to prepare Kafka action config %s: %v", parsed.path, err)
 			applyStateCallback(parsed.path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
 			continue
 		}
@@ -248,6 +248,8 @@ func parseActionsConfig(updates map[string]state.RawConfig, applyStateCallback f
 
 func extractKafkaAuthFromInstance(cfgs []integration.Config, bootstrapServers string) (map[string]any, *integration.Config, error) {
 	out := make(map[string]any)
+	var matchedAuth map[string]any
+	var matchedConfig *integration.Config
 
 	for cfgIdx := range cfgs {
 		cfg := cfgs[cfgIdx]
@@ -259,6 +261,9 @@ func extractKafkaAuthFromInstance(cfgs []integration.Config, bootstrapServers st
 		// It is a fallback in case matching by bootstrap_servers fails in some cases.
 		if bootstrapServers == "" {
 			if len(cfg.Instances) > 0 {
+				if !kafkaActionsAllowed(cfg.Instances[0]) {
+					return nil, &cfg, errors.New("kafka actions are disabled by the matching kafka_consumer instance")
+				}
 				auth := extractAuthFromInstanceData(cfg.Instances[0])
 				return auth, &cfg, nil
 			}
@@ -289,16 +294,33 @@ func extractKafkaAuthFromInstance(cfgs []integration.Config, bootstrapServers st
 			}
 
 			if connectStr != "" && normalizeBootstrapServers(connectStr) == bootstrapServers {
-				auth := extractAuthFromInstanceData(instanceData)
-				return auth, &cfg, nil
+				if !kafkaActionsAllowed(instanceData) {
+					return nil, &cfg, errors.New("kafka actions are disabled by the matching kafka_consumer instance")
+				}
+				if matchedConfig == nil {
+					matchedAuth = extractAuthFromInstanceData(instanceData)
+					matchedConfig = &cfg
+				}
 			}
 		}
 	}
 
+	if matchedConfig != nil {
+		return matchedAuth, matchedConfig, nil
+	}
 	if bootstrapServers == "" {
 		return out, nil, errors.New("kafka_consumer integration not found on this node")
 	}
 	return out, nil, fmt.Errorf("kafka_consumer integration with bootstrap_servers=%s not found", bootstrapServers)
+}
+
+func kafkaActionsAllowed(instanceData integration.Data) bool {
+	var instance map[string]any
+	if err := yaml.Unmarshal(instanceData, &instance); err != nil {
+		return true
+	}
+	allowed, configured := instance["allow_kafka_actions"].(bool)
+	return !configured || allowed
 }
 
 func extractAuthFromInstanceData(instanceData integration.Data) map[string]any {

--- a/comp/core/autodiscovery/providers/datastreams/kafka_actions_test.go
+++ b/comp/core/autodiscovery/providers/datastreams/kafka_actions_test.go
@@ -279,3 +279,46 @@ func TestActionsControllerNoMatchingKafkaConsumer(t *testing.T) {
 	assert.Equal(t, state.ApplyStateError, updateStatus["config_1"].State)
 	assert.Contains(t, updateStatus["config_1"].Error, "kafka_consumer integration")
 }
+
+func TestActionsControllerKafkaActionsDisabled(t *testing.T) {
+	allowedKafkaConsumerCfg := integration.Config{
+		Name: kafkaConsumerIntegrationName,
+		Instances: []integration.Data{integration.Data(`
+kafka_connect_str: localhost:9092
+`)},
+		InitConfig: integration.Data{},
+	}
+	kafkaConsumerCfg := integration.Config{
+		Name: kafkaConsumerIntegrationName,
+		Instances: []integration.Data{integration.Data(`
+kafka_connect_str: localhost:9092
+allow_kafka_actions: false
+`)},
+		InitConfig: integration.Data{},
+	}
+	c := &actionsController{
+		ac: getMockedAutodiscoveryActions(
+			t,
+			[]integration.Config{allowedKafkaConsumerCfg, kafkaConsumerCfg},
+		),
+		rcclient:      &mockedRcClient{},
+		configChanges: make(chan integration.ConfigChanges, 10),
+	}
+	actionsJSON, err := json.Marshal(map[string]any{"delete_topic": map[string]any{"topic": "test-topic"}})
+	require.NoError(t, err)
+	serializedConfig, err := json.Marshal(kafkaActionsConfig{
+		Actions:          actionsJSON,
+		BootstrapServers: "localhost:9092",
+	})
+	require.NoError(t, err)
+	updateStatus := make(map[string]state.ApplyStatus)
+
+	c.update(
+		map[string]state.RawConfig{"config_1": {Config: serializedConfig}},
+		func(path string, status state.ApplyStatus) { updateStatus[path] = status },
+	)
+
+	assert.Equal(t, state.ApplyStateError, updateStatus["config_1"].State)
+	assert.Contains(t, updateStatus["config_1"].Error, "kafka actions are disabled")
+	assert.Empty(t, c.configChanges)
+}

--- a/releasenotes/notes/kafka-actions-local-opt-out-0c8cf57ca3352178.yaml
+++ b/releasenotes/notes/kafka-actions-local-opt-out-0c8cf57ca3352178.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    DSM: Add an ``allow_kafka_actions`` option to the ``kafka_consumer`` integration. Set it to ``false`` to prevent
+    the Agent from executing one-time Kafka actions against the configured cluster without disabling other Remote
+    Configuration features.


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Prevents the DSM Kafka Actions provider from scheduling one-time actions when the matching `kafka_consumer` instance sets `allow_kafka_actions: false`. A deny on any instance matching the target bootstrap servers takes precedence.

### Motivation

Kafka Actions uses the dedicated `DSM_KAFKA_ACTIONS` Remote Configuration product, so `remote_configuration.agent_integrations.block_list` does not block it. Operators need a per-cluster opt-out that leaves Kafka monitoring and other Remote Configuration features enabled.

### Describe how you validated your changes

- `dda inv test --targets=./comp/core/autodiscovery/providers/datastreams`
- `dda inv linter.go --targets=./comp/core/autodiscovery/providers/datastreams`

### Additional Notes

DataDog/integrations-core#24858 adds and documents the `kafka_consumer` configuration option.