### PR TITLE
Bump internal agent image to tmpl-v26 (check_intake_queue 1.5.0)

### DIFF
--- a/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
@@ -71,7 +71,7 @@ publish_internal_container_image-jmx:
         IMAGE_VERSION: tmpl-v24
       - COMPRESSION: ""
         RELEASE_TAG_COMPRESSION_SUFFIX: ""
-        IMAGE_VERSION: tmpl-v25
+        IMAGE_VERSION: tmpl-v26
   needs:
     - job: docker_build_agent7_jmx
       artifacts: false
@@ -92,7 +92,7 @@ publish_internal_container_image-fips:
         IMAGE_VERSION: tmpl-v24
       - COMPRESSION: ""
         RELEASE_TAG_COMPRESSION_SUFFIX: ""
-        IMAGE_VERSION: tmpl-v25
+        IMAGE_VERSION: tmpl-v26
   needs:
     - job: docker_build_fips_agent7_jmx
       artifacts: false


### PR DESCRIPTION
## What does this PR do?

Recreates DataDog/datadog-agent#54851 from a branch inside DataDog/datadog-agent so internal GitHub Actions secrets are available.

Points the uncompressed `-jmx` and `-fips` internal datadog-agent image builds at `datadog-agent/tmpl-v26` in the images repo. `tmpl-v26` includes the `check_intake_queue` 1.5.0 bump.

## Motivation

The original PR came from `alyssamui2`'s fork, so the `ask-reviews` workflow ran without `SLACK_DATADOG_AGENT_BOT_TOKEN` and failed with Slack `not_authed`, blocking merge despite the code change being mergeable.

Related work:
- Original PR: DataDog/datadog-agent#54851
- New template: DataDog/images#11094
- Revert of in-place tmpl-v25 bump: DataDog/images#11093

## Change type

CI configuration only. No user-facing Agent code change.
