### PR TITLE
[ACTP] add bootstrap-par-control command

### DIFF
--- a/cmd/privateactionrunner/subcommands/BUILD.bazel
+++ b/cmd/privateactionrunner/subcommands/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/privateactionrunner/command",
+        "//cmd/privateactionrunner/subcommands/bootstrapparcontrol",
         "//cmd/privateactionrunner/subcommands/rotateidentity",
         "//cmd/privateactionrunner/subcommands/run",
         "//cmd/privateactionrunner/subcommands/runexecutor",

--- a/cmd/privateactionrunner/subcommands/bootstrapparcontrol/BUILD.bazel
+++ b/cmd/privateactionrunner/subcommands/bootstrapparcontrol/BUILD.bazel
@@ -1,0 +1,51 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+
+go_library(
+    name = "bootstrapparcontrol",
+    srcs = [
+        "command.go",
+        "enrollment.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/cmd/privateactionrunner/subcommands/bootstrapparcontrol",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/privateactionrunner/command",
+        "//comp/core",
+        "//comp/core/config",
+        "//comp/core/hostname",
+        "//comp/core/hostname/hostnameimpl",
+        "//comp/core/log/def",
+        "//comp/privateactionrunner/def",
+        "//pkg/api/security/cert",
+        "//pkg/config/model",
+        "//pkg/fips",
+        "//pkg/privateactionrunner/adapters/config",
+        "//pkg/privateactionrunner/adapters/constants",
+        "//pkg/privateactionrunner/adapters/modes",
+        "//pkg/privateactionrunner/autoconnections",
+        "//pkg/privateactionrunner/enrollment",
+        "//pkg/privateactionrunner/util",
+        "//pkg/util/fxutil",
+        "//pkg/util/http",
+        "@com_github_spf13_cobra//:cobra",
+        "@org_uber_go_fx//:fx",
+    ],
+)
+
+dd_agent_go_test(
+    name = "bootstrapparcontrol_test",
+    srcs = ["command_test.go"],
+    embed = [":bootstrapparcontrol"],
+    deps = [
+        "//cmd/privateactionrunner/command",
+        "//comp/core/config",
+        "//comp/core/hostname/hostnameinterface/mock",
+        "//pkg/privateactionrunner/adapters/constants",
+        "//pkg/privateactionrunner/enrollment",
+        "//pkg/privateactionrunner/util",
+        "//pkg/util/fxutil",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/cmd/privateactionrunner/subcommands/bootstrapparcontrol/command.go
+++ b/cmd/privateactionrunner/subcommands/bootstrapparcontrol/command.go
@@ -1,0 +1,232 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package bootstrapparcontrol implements the bootstrap-par-control subcommand.
+package bootstrapparcontrol
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/cmd/privateactionrunner/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	par "github.com/DataDog/datadog-agent/comp/privateactionrunner/def"
+	"github.com/DataDog/datadog-agent/pkg/api/security/cert"
+	"github.com/DataDog/datadog-agent/pkg/fips"
+	parconfig "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
+	app "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/constants"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/modes"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
+)
+
+// Identity is the runner identity par-control signs OPMS requests with.
+type Identity struct {
+	URN        string `json:"urn"`
+	PrivateKey string `json:"private_key"`
+	OrgID      int64  `json:"org_id"`
+	RunnerID   string `json:"runner_id"`
+}
+
+// TLS mirrors the Agent TLS settings par-control applies to OPMS connections.
+type TLS struct {
+	SkipSSLValidation bool   `json:"skip_ssl_validation"`
+	MinTLSVersion     string `json:"min_tls_version"`
+}
+
+// ControlPlaneConfig is the resolved configuration consumed by par-control.
+type ControlPlaneConfig struct {
+	SplitMode bool   `json:"split_mode"`
+	LogLevel  string `json:"log_level"`
+
+	Identity *Identity `json:"identity,omitempty"`
+
+	OPMSBaseURL      string            `json:"opms_base_url,omitempty"`
+	OPMSProxyURL     string            `json:"opms_proxy_url,omitempty"`
+	AgentVersion     string            `json:"agent_version,omitempty"`
+	Modes            []string          `json:"modes,omitempty"`
+	TaskConcurrency  int32             `json:"task_concurrency,omitempty"`
+	ExecutorSocket   string            `json:"executor_socket,omitempty"`
+	IPCCertFilePath  string            `json:"ipc_cert_file_path,omitempty"`
+	OPMSExtraHeaders map[string]string `json:"opms_extra_headers,omitempty"`
+
+	TLS *TLS `json:"tls,omitempty"`
+
+	LoopIntervalMilliseconds       int64 `json:"loop_interval_milliseconds,omitempty"`
+	HeartbeatIntervalMilliseconds  int64 `json:"heartbeat_interval_milliseconds,omitempty"`
+	HealthCheckIntervalMillisecond int64 `json:"health_check_interval_milliseconds,omitempty"`
+	OPMSRequestTimeoutMilliseconds int64 `json:"opms_request_timeout_milliseconds,omitempty"`
+	MinBackoffMilliseconds         int64 `json:"min_backoff_milliseconds,omitempty"`
+	MaxBackoffMilliseconds         int64 `json:"max_backoff_milliseconds,omitempty"`
+	WaitBeforeRetryMilliseconds    int64 `json:"wait_before_retry_milliseconds,omitempty"`
+	MaxAttempts                    int32 `json:"max_attempts,omitempty"`
+}
+
+// Commands returns the bootstrap-par-control subcommand.
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bootstrap-par-control",
+		Short: "Resolve the Private Action Runner split-mode control-plane configuration",
+		Long: `Loads the canonical Agent configuration, ensures that the runner has a valid
+identity, and writes the resolved par-control configuration to stdout.
+
+When split mode is disabled the command succeeds without enrolling and reports
+only the launch gate and log level.`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return fxutil.OneShot(run,
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath)),
+					LogParams:    log.ForOneShot(command.LoggerName, "off", false),
+				}),
+				core.Bundle(core.WithSecrets()),
+				hostnameimpl.Module(),
+			)
+		},
+	}
+	return []*cobra.Command{cmd}
+}
+
+func run(cfg config.Component, hostnameComp hostname.Component) error {
+	return bootstrap(context.Background(), cfg, hostnameComp, enrollAndPersist, os.Stdout)
+}
+
+func bootstrap(ctx context.Context, cfg config.Component, hostnameComp hostname.Component, enrollAndPersist enrollAndPersistFunc, out io.Writer) error {
+	resolved, err := resolveConfig(ctx, cfg, hostnameComp, enrollAndPersist)
+	if err != nil {
+		return err
+	}
+	return emitConfig(out, resolved)
+}
+
+func resolveConfig(ctx context.Context, cfg config.Component, hostnameComp hostname.Component, enrollAndPersist enrollAndPersistFunc) (*ControlPlaneConfig, error) {
+	logLevel := cfg.GetString("log_level")
+	splitMode := cfg.GetBool(par.PAREnabled) && cfg.GetBool(par.PARSplitEnabled)
+
+	if !splitMode {
+		return &ControlPlaneConfig{SplitMode: false, LogLevel: logLevel}, nil
+	}
+
+	if err := rejectFIPS(cfg); err != nil {
+		return nil, err
+	}
+
+	if err := ensureEnrollment(ctx, cfg, hostnameComp, enrollAndPersist); err != nil {
+		return nil, err
+	}
+
+	cert.PersistCertFilepath(cfg)
+
+	parCfg, err := parconfig.FromDDConfig(cfg, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive the Private Action Runner configuration: %w", err)
+	}
+	if parCfg.IdentityIsIncomplete() {
+		return nil, errors.New("the resolved Private Action Runner identity is incomplete")
+	}
+
+	opmsBaseURL := opmsEndpointURL(parCfg)
+	opmsProxyURL, err := resolveProxy(cfg, opmsBaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve the OPMS proxy: %w", err)
+	}
+
+	return &ControlPlaneConfig{
+		SplitMode: true,
+		LogLevel:  logLevel,
+		Identity: &Identity{
+			URN:        parCfg.Urn,
+			PrivateKey: cfg.GetString(par.PARPrivateKey),
+			OrgID:      parCfg.OrgId,
+			RunnerID:   parCfg.RunnerId,
+		},
+		OPMSBaseURL:      opmsBaseURL,
+		OPMSProxyURL:     opmsProxyURL,
+		AgentVersion:     parCfg.Version,
+		Modes:            modes.ToStrings(parCfg.Modes),
+		TaskConcurrency:  parCfg.RunnerPoolSize,
+		ExecutorSocket:   cfg.GetString(par.PARExecutorSocketPath),
+		IPCCertFilePath:  cfg.GetString("ipc_cert_file_path"),
+		OPMSExtraHeaders: parCfg.OpmsExtraHeaders,
+		TLS: &TLS{
+			SkipSSLValidation: cfg.GetBool("skip_ssl_validation"),
+			MinTLSVersion:     cfg.GetString("min_tls_version"),
+		},
+		LoopIntervalMilliseconds:       parCfg.LoopInterval.Milliseconds(),
+		HeartbeatIntervalMilliseconds:  parCfg.HeartbeatInterval.Milliseconds(),
+		HealthCheckIntervalMillisecond: int64(parCfg.HealthCheckInterval),
+		OPMSRequestTimeoutMilliseconds: int64(parCfg.OpmsRequestTimeout),
+		MinBackoffMilliseconds:         parCfg.MinBackoff.Milliseconds(),
+		MaxBackoffMilliseconds:         parCfg.MaxBackoff.Milliseconds(),
+		WaitBeforeRetryMilliseconds:    parCfg.WaitBeforeRetry.Milliseconds(),
+		MaxAttempts:                    parCfg.MaxAttempts,
+	}, nil
+}
+
+func rejectFIPS(cfg config.Component) error {
+	if cfg.GetBool("fips.enabled") {
+		return errors.New("private_action_runner.split_enabled is not supported with fips.enabled; disable split mode or FIPS mode")
+	}
+	if enabled, err := fips.Enabled(); err == nil && enabled {
+		return errors.New("private_action_runner.split_enabled is not supported by the FIPS Agent; use the monolithic runner")
+	}
+	return nil
+}
+
+func opmsEndpointURL(cfg *parconfig.Config) string {
+	scheme, host := "https", cfg.DDApiHost
+	if os.Getenv(app.InternalUseDDURLForOPMSEnvVar) == "true" {
+		host = cfg.DDHost
+		if strings.HasPrefix(host, "http://") {
+			scheme = "http"
+		}
+		host = strings.TrimPrefix(strings.TrimPrefix(host, "http://"), "https://")
+	}
+	return (&url.URL{Scheme: scheme, Host: host}).String()
+}
+
+func resolveProxy(cfg config.Component, target string) (string, error) {
+	proxies := cfg.GetProxies()
+	if proxies == nil {
+		return "", nil
+	}
+
+	request, err := http.NewRequest(http.MethodGet, target, nil)
+	if err != nil {
+		return "", errors.New("invalid OPMS URL")
+	}
+	proxyURL, err := httputils.GetProxyTransportFunc(proxies, cfg)(request)
+	if err != nil {
+		return "", errors.New("invalid Agent proxy configuration")
+	}
+	if proxyURL == nil {
+		return "", nil
+	}
+	return proxyURL.String(), nil
+}
+
+func emitConfig(out io.Writer, resolved *ControlPlaneConfig) error {
+	encoded, err := json.Marshal(resolved)
+	if err != nil {
+		return errors.New("failed to serialize the par-control configuration")
+	}
+	if _, err := out.Write(encoded); err != nil {
+		return errors.New("failed to write the par-control configuration")
+	}
+	return nil
+}

--- a/cmd/privateactionrunner/subcommands/bootstrapparcontrol/command_test.go
+++ b/cmd/privateactionrunner/subcommands/bootstrapparcontrol/command_test.go
@@ -1,0 +1,196 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package bootstrapparcontrol
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/privateactionrunner/command"
+	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
+	hostnamemock "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/mock"
+	app "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/constants"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/enrollment"
+	parutil "github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestBootstrapCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t, Commands(&command.GlobalParams{}), []string{"bootstrap-par-control"}, run, func() {})
+}
+
+func runBootstrap(t *testing.T, cfg coreconfig.Component, enroll enrollAndPersistFunc) (*ControlPlaneConfig, error) {
+	t.Helper()
+	hostnameComp, _ := hostnamemock.NewMock("test-host")
+	var out bytes.Buffer
+	if err := bootstrap(context.Background(), cfg, hostnameComp, enroll, &out); err != nil {
+		return nil, err
+	}
+	var resolved ControlPlaneConfig
+	require.NoError(t, json.Unmarshal(out.Bytes(), &resolved))
+	return &resolved, nil
+}
+
+func splitConfig(t *testing.T, overrides map[string]interface{}) coreconfig.Component {
+	values := map[string]interface{}{
+		"private_action_runner.enabled":            true,
+		"private_action_runner.split_enabled":      true,
+		"private_action_runner.identity_file_path": filepath.Join(t.TempDir(), "identity.json"),
+	}
+	for key, value := range overrides {
+		values[key] = value
+	}
+	return coreconfig.NewMockWithOverrides(t, values)
+}
+
+func TestBootstrapSplitModeDisabled(t *testing.T) {
+	cfg := coreconfig.NewMockWithOverrides(t, map[string]interface{}{
+		"private_action_runner.enabled":       true,
+		"private_action_runner.split_enabled": false,
+		"log_level":                           "debug",
+	})
+
+	resolved, err := runBootstrap(t, cfg, failIfEnrolled(t))
+
+	require.NoError(t, err)
+	assert.False(t, resolved.SplitMode)
+	assert.Equal(t, "debug", resolved.LogLevel)
+	assert.Nil(t, resolved.Identity)
+}
+
+func TestBootstrapPersistedIdentityWins(t *testing.T) {
+	cfg := splitConfig(t, map[string]interface{}{
+		"private_action_runner.urn":         parutil.MakeRunnerURN("us5", 999, "inline-runner"),
+		"private_action_runner.private_key": validPrivateKey(t),
+	})
+	writeIdentity(t, cfg, validURN(), validPrivateKey(t), "test-host")
+
+	resolved, err := runBootstrap(t, cfg, failIfEnrolled(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, validURN(), resolved.Identity.URN)
+	assert.Equal(t, int64(123), resolved.Identity.OrgID)
+}
+
+func TestBootstrapUsesInlineIdentity(t *testing.T) {
+	urn := parutil.MakeRunnerURN("us5", 999, "inline-runner")
+	key := validPrivateKey(t)
+	cfg := splitConfig(t, map[string]interface{}{
+		"private_action_runner.urn":         urn,
+		"private_action_runner.private_key": key,
+	})
+
+	resolved, err := runBootstrap(t, cfg, failIfEnrolled(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, urn, resolved.Identity.URN)
+	assert.Equal(t, key, resolved.Identity.PrivateKey)
+}
+
+func TestBootstrapSelfEnrolls(t *testing.T) {
+	cfg := splitConfig(t, map[string]interface{}{"private_action_runner.self_enroll": true})
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	resolved, err := runBootstrap(t, cfg, func(ctx context.Context, cfg coreconfig.Component, _ *enrollment.AgentIdentifier) (*enrollment.Result, error) {
+		result := &enrollment.Result{URN: validURN(), PrivateKey: privateKey, Hostname: "test-host"}
+		return result, enrollment.PersistIdentity(ctx, cfg, result)
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, validURN(), resolved.Identity.URN)
+	assert.NotEmpty(t, resolved.Identity.PrivateKey)
+}
+
+func TestBootstrapResolvesConfig(t *testing.T) {
+	cfg := splitConfig(t, map[string]interface{}{
+		"private_action_runner.urn":                  validURN(),
+		"private_action_runner.private_key":          validPrivateKey(t),
+		"private_action_runner.executor.socket_path": "/tmp/executor.sock",
+		"private_action_runner.task_concurrency":     7,
+		"proxy.https":                                "http://proxy.example:8443",
+		"skip_ssl_validation":                        true,
+		"min_tls_version":                            "tlsv1.3",
+	})
+
+	resolved, err := runBootstrap(t, cfg, failIfEnrolled(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, "http://proxy.example:8443", resolved.OPMSProxyURL)
+	assert.Equal(t, "/tmp/executor.sock", resolved.ExecutorSocket)
+	assert.Equal(t, int32(7), resolved.TaskConcurrency)
+	assert.True(t, resolved.TLS.SkipSSLValidation)
+	assert.Equal(t, "tlsv1.3", resolved.TLS.MinTLSVersion)
+	assert.NotZero(t, resolved.LoopIntervalMilliseconds)
+}
+
+func TestBootstrapRejectsFIPS(t *testing.T) {
+	cfg := splitConfig(t, map[string]interface{}{
+		"private_action_runner.urn":         validURN(),
+		"private_action_runner.private_key": validPrivateKey(t),
+		"fips.enabled":                      true,
+	})
+
+	_, err := runBootstrap(t, cfg, failIfEnrolled(t))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fips.enabled")
+}
+
+func TestBootstrapUsesDDURLForFakeintake(t *testing.T) {
+	t.Setenv(app.InternalUseDDURLForOPMSEnvVar, "true")
+	cfg := splitConfig(t, map[string]interface{}{
+		"private_action_runner.urn":         validURN(),
+		"private_action_runner.private_key": validPrivateKey(t),
+		"dd_url":                            "http://fakeintake.test:8080",
+	})
+
+	resolved, err := runBootstrap(t, cfg, failIfEnrolled(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, "http://fakeintake.test:8080", resolved.OPMSBaseURL)
+}
+
+func writeIdentity(t *testing.T, cfg coreconfig.Component, urn, key, hostname string) {
+	t.Helper()
+	result := &enrollment.Result{URN: urn, Hostname: hostname}
+	jwk, err := parutil.Base64ToJWK(key)
+	require.NoError(t, err)
+	result.PrivateKey = jwk.Key.(*ecdsa.PrivateKey)
+	require.NoError(t, enrollment.PersistIdentity(context.Background(), cfg, result))
+}
+
+func validURN() string {
+	return parutil.MakeRunnerURN("us1", 123, "test-runner")
+}
+
+func validPrivateKey(t *testing.T) string {
+	t.Helper()
+	privateJWK, _, err := parutil.GenerateKeys()
+	require.NoError(t, err)
+	encoded, err := privateJWK.MarshalJSON()
+	require.NoError(t, err)
+	return base64.RawURLEncoding.EncodeToString(encoded)
+}
+
+func failIfEnrolled(t *testing.T) enrollAndPersistFunc {
+	return func(context.Context, coreconfig.Component, *enrollment.AgentIdentifier) (*enrollment.Result, error) {
+		t.Fatal("unexpected enrollment")
+		return nil, nil
+	}
+}

--- a/cmd/privateactionrunner/subcommands/bootstrapparcontrol/enrollment.go
+++ b/cmd/privateactionrunner/subcommands/bootstrapparcontrol/enrollment.go
@@ -1,0 +1,85 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package bootstrapparcontrol
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
+	par "github.com/DataDog/datadog-agent/comp/privateactionrunner/def"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	parconfig "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/autoconnections"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/enrollment"
+	parutil "github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
+)
+
+type enrollAndPersistFunc func(context.Context, config.Component, *enrollment.AgentIdentifier) (*enrollment.Result, error)
+
+func ensureEnrollment(ctx context.Context, cfg config.Component, hostnameComp hostname.Component, enroll enrollAndPersistFunc) error {
+	agentID, err := enrollment.GetAgentIdentifier(ctx, hostnameComp)
+	if err != nil {
+		return err
+	}
+
+	identity, err := enrollment.GetIdentityFromPreviousEnrollment(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	if identity != nil && !enrollment.ShouldReenroll(agentID, identity) {
+		applyIdentity(cfg, identity)
+		return nil
+	}
+
+	if cfg.GetString(par.PARUrn) != "" && cfg.GetString(par.PARPrivateKey) != "" {
+		return nil
+	}
+	if !cfg.GetBool(par.PARSelfEnroll) {
+		return errors.New("no Private Action Runner identity is configured and self-enrollment is disabled")
+	}
+
+	if _, err := enroll(ctx, cfg, agentID); err != nil {
+		return err
+	}
+	identity, err = enrollment.GetIdentityFromPreviousEnrollment(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	applyIdentity(cfg, identity)
+	return nil
+}
+
+func applyIdentity(cfg config.Component, identity *enrollment.PersistedIdentity) {
+	if identity == nil {
+		return
+	}
+	cfg.Set(par.PARUrn, identity.URN, model.SourceAgentRuntime)
+	cfg.Set(par.PARPrivateKey, identity.PrivateKey, model.SourceAgentRuntime)
+}
+
+func enrollAndPersist(ctx context.Context, cfg config.Component, agentID *enrollment.AgentIdentifier) (*enrollment.Result, error) {
+	result, err := enrollment.Enroll(ctx, cfg, agentID)
+	if err != nil {
+		return nil, fmt.Errorf("enrollment failed: %w", err)
+	}
+	if err := enrollment.RotateIdentity(ctx, cfg, result); err != nil {
+		return nil, fmt.Errorf("failed to persist new identity: %w", err)
+	}
+
+	parCfg, err := parconfig.FromDDConfig(cfg, nil)
+	if err == nil {
+		if urn, err := parutil.ParseRunnerURN(result.URN); err == nil {
+			autoconnections.CreateConnectionsIfEnabled(
+				ctx, cfg, parCfg, cfg.GetString("api_key"), cfg.GetString("app_key"), urn.RunnerID,
+				result, autoconnections.NewBasicTagsProvider(),
+			)
+		}
+	}
+	return result, nil
+}

--- a/cmd/privateactionrunner/subcommands/subcommands.go
+++ b/cmd/privateactionrunner/subcommands/subcommands.go
@@ -8,6 +8,7 @@ package subcommands
 
 import (
 	"github.com/DataDog/datadog-agent/cmd/privateactionrunner/command"
+	"github.com/DataDog/datadog-agent/cmd/privateactionrunner/subcommands/bootstrapparcontrol"
 	"github.com/DataDog/datadog-agent/cmd/privateactionrunner/subcommands/rotateidentity"
 	"github.com/DataDog/datadog-agent/cmd/privateactionrunner/subcommands/run"
 	"github.com/DataDog/datadog-agent/cmd/privateactionrunner/subcommands/runexecutor"
@@ -17,6 +18,7 @@ import (
 // PrivateActionRunnerSubcommands returns all subcommands for the private-action-runner command
 func PrivateActionRunnerSubcommands() []command.SubcommandFactory {
 	return []command.SubcommandFactory{
+		bootstrapparcontrol.Commands,
 		run.Commands,
 		runexecutor.Commands,
 		version.Commands,

--- a/comp/privateactionrunner/def/component.go
+++ b/comp/privateactionrunner/def/component.go
@@ -32,4 +32,5 @@ const (
 	PARIdleTimeoutSeconds     = "private_action_runner.idle_timeout_seconds"
 
 	PARExecutorSocketPath = "private_action_runner.executor.socket_path"
+	PARSplitEnabled       = "private_action_runner.split_enabled"
 )


### PR DESCRIPTION
### What does this PR do?

Adds `privateactionrunner bootstrap-par-control`, making Go the configuration and identity authority for split mode.

The command loads Agent configuration, ensures enrollment, derives the PAR runtime configuration, and writes the resolved JSON to stdout.

### Motivation

Go already owns Agent configuration, secret resolution, enrollment, identity precedence, paths, and endpoint selection. Resolving those values in Go prevents the Rust control process from developing a second configuration implementation. We will however start to implement `saluku-config` soon to do this the right way in Rust.

### Describe how you validated your changes

- `dda env dev run -- bazel test //cmd/privateactionrunner/subcommands/bootstrapparcontrol:bootstrapparcontrol_test`
- Staging task execution
