### PR TITLE
Platform-independent output on md5sums generation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,8 +14,6 @@ devenv/answer_files/**/*.xml -text
 pkg/collector/corechecks/containers/kubelet/testdata/summary.json -text
 releasenotes/notes/*.yaml -text
 tasks/unit_tests/testdata/secret.tar.gz/*.xml -text
-# The test that uses this file needs adjustment to not rely on autocrlf
-bazel/tools/tar_checksums/testdata/expected_checksums.txt -eol
 
 # Set batch file line endings to CRLF so that they can be executed on Windows
 *.bat text eol=crlf

--- a/bazel/tools/tar_checksums/generate_md5sum.py
+++ b/bazel/tools/tar_checksums/generate_md5sum.py
@@ -39,7 +39,8 @@ def _open_tar(path):
 
 
 def generate_md5sums(tar_path, output_path):
-    with open(output_path, 'w') as out:
+    # newline = '\n' prevents automatic translation to '\r\n' on Windows
+    with open(output_path, 'w', newline='\n') as out:
         with _open_tar(tar_path) as tf:
             for member in tf:
                 if not member.isfile():


### PR DESCRIPTION
### What does this PR do?

Makes `tar_checksums` output use the same line breaks regardless of platform (`\n`).

### Motivation

We want to use `LF` line endings by default in the repo regardless of platform (https://github.com/DataDog/datadog-agent/pull/54776). That would break these tests because Python files' `write` method adds platform-dependent newlines on the default `open`, and for the tests to pass on Windows, the golden files need to be checkout with `\r\n` to match.

### Describe how you validated your changes

CI.

### Additional Notes
