### PR TITLE
Add manual to software_test

### DIFF
--- a/pkg/inventory/software/BUILD.bazel
+++ b/pkg/inventory/software/BUILD.bazel
@@ -66,12 +66,13 @@ dd_agent_go_test(
     env = select({
         "@rules_go//go/platform:windows": {
             "INTEROP_DLL_PATH": "$(rlocationpath //tools/windows/DatadogInterop:libdatadog_interop)",
-            # Override .bazelrc's RunAsInvoker so admin users get an elevated token
-            # (needed for Get-AppxPackage -AllUsers / FindPackagesWithPackageTypes).
-            "__COMPAT_LAYER": "RunAsHighest",
         },
         "//conditions:default": {},
     }),
+    # Windows MS Store / Appx collection needs an elevated token. Opt in:
+    #   bazel test //pkg/inventory/software:software_test
+    # from an elevated prompt.
+    tags = ["manual"],
     deps = [
         "@com_github_stretchr_testify//assert",
     ] + select({


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

`software_test` requires elevated privileges so it cannot be treated as a unit test. It can still work locally given that a user is running bazel test command as Administrator.

