### PR TITLE
[go-update] Bump fakeintake version when updating Go

### DIFF
--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -164,6 +164,7 @@ def _get_pattern(pre_pattern: str, post_pattern: str, is_bugfix: bool) -> str:
 
 def _bump_fakeintake_version() -> None:
     from tasks.fakeintake import VERSION_FILE
+
     with open(VERSION_FILE) as f:
         current = int(f.read().strip()[1:])
     with open(VERSION_FILE, "w") as f:

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -90,6 +90,7 @@ def update_go(
                 raise
 
     _update_references(warn, version)
+    _bump_fakeintake_version()
     _update_go_mods(warn, version, include_otel_modules)
     bazel(ctx, "run", "//pkg/template:generate")
     tidy(ctx)
@@ -159,6 +160,14 @@ def _get_pattern(pre_pattern: str, post_pattern: str, is_bugfix: bool) -> str:
     version_pattern = PATTERN_MAJOR_MINOR_BUGFIX if is_bugfix else PATTERN_MAJOR_MINOR
     pattern = rf'({re.escape(pre_pattern)}){version_pattern}({re.escape(post_pattern)})'
     return pattern
+
+
+def _bump_fakeintake_version() -> None:
+    from tasks.fakeintake import VERSION_FILE
+    with open(VERSION_FILE) as f:
+        current = int(f.read().strip()[1:])
+    with open(VERSION_FILE, "w") as f:
+        f.write(f"v{current + 1}\n")
 
 
 def _update_references(warn: bool, version: str, dry_run: bool = False):


### PR DESCRIPTION
## What does this PR do?
Adds a `_bump_fakeintake_version()` call inside `inv update-go` (tasks/update_go.py) that increments `test/fakeintake/version/VERSION` whenever the Go version is updated.

## Motivation
`inv update-go` always modifies `test/fakeintake/Dockerfile` to use the new Go base image. That file is on the fakeintake image rebuild path, so the `fakeintake_check_version_bump` gate requires `VERSION` to be strictly greater than on the base branch — without the bump, every Go update PR fails this gate and requires a manual bump.

## Describe how you validated your changes
Verified the parse/write logic against multiple inputs (v1, v9, v10, v100) and confirmed it matches the format expected by `fakeintake._parse_version`.