### PR TITLE
Fix: shim tools requiring `go` to use `rules_go`'s hermetic SDK

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,6 +12,7 @@ load("@dd_release_json//:release_json.bzl", "release_json")
 load("@gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_license//rules:license.bzl", "license")
+load("//bazel/rules/go_shim:defs.bzl", "go_shim")
 load("//compliance/rules:purl.bzl", "purl_for_generic")
 load("//tasks:build_tags.bzl", "GAZELLE_BUILD_TAGS")
 
@@ -123,9 +124,9 @@ alias(
 )
 
 # bazel run //:go_mod_tidy_all -- -x
-alias(
+go_shim(
     name = "go_mod_tidy_all",
-    actual = "//bazel/tools:go_mod_tidy_all",
+    tool = "//bazel/rules/go_mod_tidy_all",
 )
 
 run_binary(

--- a/bazel/rules/go_mod_tidy_all/BUILD.bazel
+++ b/bazel/rules/go_mod_tidy_all/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_python//python:py_binary.bzl", "py_binary")
+
+py_binary(
+    name = "go_mod_tidy_all",
+    srcs = ["go_mod_tidy_all.py"],
+    visibility = ["//:__pkg__"],
+)

--- a/bazel/rules/go_mod_tidy_all/go_mod_tidy_all.py
+++ b/bazel/rules/go_mod_tidy_all/go_mod_tidy_all.py
@@ -12,11 +12,9 @@ from datetime import timedelta
 from subprocess import PIPE, CalledProcessError
 from traceback import format_exception_only
 
-from python.runfiles import runfiles
 
-
-async def _exec(go, *args, **kwargs):
-    proc = await asyncio.create_subprocess_exec(go, *args, **kwargs)
+async def _exec(*args, **kwargs):
+    proc = await asyncio.create_subprocess_exec(*args, **kwargs)
     try:
         stdout, _ = await proc.communicate()
     except BaseException:  # reap the process on any CancelledError, KeyboardInterrupt, SystemExit, TimeoutError, etc.
@@ -30,26 +28,26 @@ async def _exec(go, *args, **kwargs):
         raise
     if proc.returncode == 0:
         return stdout
-    raise CalledProcessError(proc.returncode, " ".join((os.path.basename(go), *args)), output=stdout)
+    raise CalledProcessError(proc.returncode, " ".join(args), output=stdout)
 
 
-async def _tidy(max_workers, go, mod_path, args):
+async def _tidy(max_workers, mod_path, args):
     async with max_workers:
-        await _exec(go, "mod", "tidy", "-C", mod_path, *args)
+        await _exec("go", "mod", "tidy", "-C", mod_path, *args)
 
 
-async def main(go, args):
-    mod_paths = await _exec(go, "list", "-f", "{{.Dir}}", "-m", stdout=PIPE)
+async def main(args):
+    mod_paths = await _exec("go", "list", "-f", "{{.Dir}}", "-m", stdout=PIPE)
     max_workers = asyncio.Semaphore((os.cpu_count() or 1) + 4)  # TODO(regis): cpu_count -> Py 3.13's process_cpu_count
     # global timeout: on cold cache, per-task timeouts were unfairly hit because early tasks download most modules
     async with asyncio.timeout(timedelta(minutes=15).total_seconds()), asyncio.TaskGroup() as tg:
         for mod_path in mod_paths.decode().splitlines():
-            tg.create_task(_tidy(max_workers, go, mod_path, args))
+            tg.create_task(_tidy(max_workers, mod_path, args))
 
 
 if __name__ == "__main__":
     logging.getLogger("asyncio").setLevel(logging.ERROR)  # no `Unknown child process pid N, will report returncode 255`
     try:
-        asyncio.run(main(runfiles.Create().Rlocation(sys.argv[1]), sys.argv[2:]))
+        asyncio.run(main(sys.argv[1:]))
     except* BaseException as eg:
         sys.exit("\n".join(line.rstrip() for e in eg.exceptions for line in format_exception_only(e)))

--- a/bazel/rules/go_shim/BUILD.bazel
+++ b/bazel/rules/go_shim/BUILD.bazel
@@ -1,0 +1,7 @@
+exports_files(
+    [
+        "template.bat",
+        "template.sh",
+    ],
+    visibility = ["//visibility:private"],
+)

--- a/bazel/rules/go_shim/defs.bzl
+++ b/bazel/rules/go_shim/defs.bzl
@@ -1,0 +1,46 @@
+"""Shim to run a tool with @rules_go//go first in $PATH, from the current working directory like rules_go//go does.
+
+A (thin) wrapper is unavoidable because prepending to the inherited PATH cannot be expressed declaratively.
+
+References:
+- https://github.com/bazel-contrib/bazel-lib/blob/main/lib/private/bats.bzl (is_windows)
+- https://github.com/bazel-contrib/rules_go/blob/master/go/tools/go_bin_runner/main.go (BUILD_WORKING_DIRECTORY)
+- https://github.com/bazel-contrib/rules_multitool/blob/main/multitool/private/run_in.bzl (template)
+"""
+
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+def _go_shim_impl(ctx):
+    go_dir = paths.dirname(ctx.executable._go.short_path)
+    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
+    template = ctx.file._template_bat if is_windows else ctx.file._template_sh
+    tool = ctx.executable.tool.short_path
+    wrapper = ctx.actions.declare_file("{}.{}".format(ctx.label.name, template.extension))
+    ctx.actions.expand_template(
+        is_executable = True,
+        output = wrapper,
+        substitutions = {
+            "{{go_dir}}": go_dir.replace("/", "\\") if is_windows else go_dir,
+            "{{tool}}": tool.replace("/", "\\") if is_windows else tool,
+        },
+        template = template,
+    )
+    return [DefaultInfo(
+        executable = wrapper,
+        runfiles = ctx.runfiles([ctx.executable._go, ctx.executable.tool]).merge_all([
+            ctx.attr._go[DefaultInfo].default_runfiles,
+            ctx.attr.tool[DefaultInfo].default_runfiles,
+        ]),
+    )]
+
+go_shim = rule(
+    implementation = _go_shim_impl,
+    executable = True,
+    attrs = {
+        "_go": attr.label(cfg = "target", default = "@rules_go//go", executable = True),
+        "_template_bat": attr.label(allow_single_file = True, default = ":template.bat"),
+        "_template_sh": attr.label(allow_single_file = True, default = ":template.sh"),
+        "_windows_constraint": attr.label(default = "@platforms//os:windows"),
+        "tool": attr.label(cfg = "exec", executable = True, mandatory = True),
+    },
+)

--- a/bazel/rules/go_shim/template.bat
+++ b/bazel/rules/go_shim/template.bat
@@ -1,0 +1,8 @@
+@echo off
+
+set "PATH=%cd%\{{go_dir}};%PATH%"
+set "RUNFILES_DIR=%cd%\.."
+set "tool=%cd%\{{tool}}"
+
+cd /d "%BUILD_WORKING_DIRECTORY%" || exit /b
+"%tool%" %*

--- a/bazel/rules/go_shim/template.sh
+++ b/bazel/rules/go_shim/template.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$BUILD_WORKING_DIRECTORY"
+PATH="$OLDPWD/{{go_dir}}:$PATH" RUNFILES_DIR="$OLDPWD/.." exec "$OLDPWD/{{tool}}" "$@"

--- a/bazel/tools/BUILD.bazel
+++ b/bazel/tools/BUILD.bazel
@@ -2,15 +2,6 @@ load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_python//python:py_binary.bzl", "py_binary")
 
 py_binary(
-    name = "go_mod_tidy_all",
-    srcs = ["go_mod_tidy_all.py"],
-    args = ["$(rlocationpath @rules_go//go)"],
-    data = ["@rules_go//go"],
-    visibility = ["//:__pkg__"],
-    deps = ["@rules_python//python/runfiles"],
-)
-
-py_binary(
     name = "generate_module_bazel",
     srcs = ["generate_module_bazel.py"],
     visibility = ["//deps:__subpackages__"],

--- a/internal/tools/BUILD.bazel
+++ b/internal/tools/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
-load("@rules_multitool//multitool:cwd.bzl", "cwd")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
+load("//bazel/rules/go_shim:defs.bzl", "go_shim")
 
-cwd(
+go_shim(
     name = "gotestsum",
     tool = "@tools_gotest_gotestsum//:gotestsum",
 )


### PR DESCRIPTION
### What does this PR do?
Unbreak `dda inv test` on hosts whose ambient `go` differs from the one `go.work` requires.

Add `go_shim`, wrapping a tool so that `PATH` lookups of `go` reach Bazel's hermetic SDK, and so that it runs from the current working directory rather than the runfiles tree, superseding `rules_multitool`'s `cwd()`.

Wrap `gotestsum` and `go_mod_tidy_all`, the latter dropping the `$(rlocationpath @rules_go//go)` resolution it had grown for itself and moving to its own package, where the shim taking over `//:go_mod_tidy_all` leaves its `py_binary` the plain name.

### Motivation
Credits to @vitkyrka for [reporting](https://dd.slack.com/archives/C06PBHLD4DQ/p1786618886362859), as well as to @pgimalac and @hush-hush for following up.

#54107 routed `dda inv test` through `bazel run //internal/tools:gotestsum`, bringing `gotestsum` under `.bazelrc`'s `--run_env=GOTOOLCHAIN=local`.

That flag exists for `bazel run //:go`, where `PATH` already holds the hermetic SDK and pinning the toolchain is exactly right, but `gotestsum` instead execs the literal `go` resolved through `PATH`, so it inherited the pin while still reaching for whatever `go` the host had, and Go's own version auto-upgrade could no longer paper over the difference.

Every invocation then failed outright with `go.work requires go >= 1.26.5`, and exporting `GOTOOLCHAIN=auto` did not help, `--run_env` taking precedence over the caller's environment.

`go_mod_tidy_all` had already met the same need and solved it **alone**, being our own code and able to take a path.
`gotestsum` has no such flag, leaving `PATH` as the only lever, hence one rule for both and for whatever comes next.

### Describe how you validated your changes
On Linux, the reported reproducer, `dda inv test --targets=./pkg/discovery/tracermetadata/...`, passes while a stub announcing itself as go 1.24.0 shadows `go` in `PATH`, and `bazel run //:go_mod_tidy_all -- -diff` exits 0 across every module without ever reaching that stub.

On my Windows VM, where no `go` is installed at all, `where go` through the shim reports the hermetic `go.exe` and `go version` prints go1.26.5, against nothing found on merged `main`.

On both, a missing or unreachable `$BUILD_WORKING_DIRECTORY` aborts before the tool runs rather than running it somewhere unintended, and the tool's own exit code surfaces unchanged.

### Additional Notes
Prepending to `PATH` has no declarative spelling: `RunEnvironmentInfo` carries static strings only, and a key given in both `environment` and `inherited_environment` resolves to the inherited value, while replacing `PATH` outright would hide `sh`, `cc`, `git` and whatever else the toolchain reaches for.

Hence a (thin) wrapper reading the environment at runtime, inspired by:
- https://github.com/bazel-contrib/bazel-lib/blob/main/lib/private/bats.bzl
- https://github.com/bazel-contrib/rules_multitool/blob/main/multitool/private/run_in.bzl

`RUNFILES_DIR` is exported because `@rules_go//go` resolves its own runfiles through it and `bazel run` does not export it everywhere: without it the hermetic `go` exits with `runfiles: no runfiles found` on Windows.