### PR TITLE
refactor(gitlab): remove zstd-nydus variants from internal image deploy jobs

### DIFF
--- a/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
@@ -16,10 +16,8 @@
     - export IMAGES_GIT_REF="master"
     # Job specific variables
     - export BASE_RELEASE_TAG="${CI_COMMIT_REF_NAME//\//-}"
-    - export RELEASE_TAG="${BASE_RELEASE_TAG}${RELEASE_TAG_SUFFIX}${RELEASE_TAG_COMPRESSION_SUFFIX}"
+    - export RELEASE_TAG="${BASE_RELEASE_TAG}${RELEASE_TAG_SUFFIX}"
     - export TMPL_SRC_IMAGE="v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TMPL_SRC_IMAGE_SUFFIX}"
-    # Specify the compression
-    - export IMAGE_VERSION="${IMAGE_VERSION}${COMPRESSION}"
     # BUILD_TAG is always RELEASE_TAG
     - export BUILD_TAG="${RELEASE_TAG}"
     # Fetch Gitlab token
@@ -27,10 +25,10 @@
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
     - |
       if [ "$BUCKET_BRANCH" = "nightly" ]; then
-        RELEASE_TAG="${BASE_RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}${RELEASE_TAG_SUFFIX}${RELEASE_TAG_COMPRESSION_SUFFIX}"
+        RELEASE_TAG="${BASE_RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}${RELEASE_TAG_SUFFIX}"
         TMPL_SRC_REPO="${TMPL_SRC_REPO}-nightly"
       fi
-    - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${BASE_RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}${RELEASE_TAG_SUFFIX}${RELEASE_TAG_COMPRESSION_SUFFIX}"; fi
+    - if [ "$BUCKET_BRANCH" = "dev" ]; then RELEASE_TAG="dev-${BASE_RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}${RELEASE_TAG_SUFFIX}"; fi
     - |
       # TODO: Remove this workaround once JIT replication is reliable for these
       # images.
@@ -44,19 +42,23 @@
 
 # -- binary specific variables --
 .agent_variables: &agent_variables
+  IMAGE_VERSION: tmpl-v25
   IMAGE_NAME: datadog-agent
   TMPL_SRC_REPO: ci/datadog-agent/agent
 
 .cluster_agent_variables: &cluster_agent_variables
+  IMAGE_VERSION: tmpl-v13
   IMAGE_NAME: datadog-cluster-agent
   TMPL_SRC_REPO: ci/datadog-agent/cluster-agent
   RELEASE_PROD: "true"
 
 .ot_standalone_variables: &ot_standalone_variables
+  IMAGE_VERSION: tmpl-v8
   IMAGE_NAME: otel-agent
   TMPL_SRC_REPO: ci/datadog-agent/otel-agent
 
 .host_profiler_standalone_variables: &host_profiler_standalone_variables
+  IMAGE_VERSION: tmpl-v2
   IMAGE_NAME: ddot-ebpf
   TMPL_SRC_REPO: ci/datadog-agent/ddot-ebpf
   RELEASE_PROD_OVERRIDE: "true"
@@ -64,14 +66,6 @@
 # -- publish jobs --
 publish_internal_container_image-jmx:
   extends: .docker_trigger_base
-  parallel:
-    matrix:
-      - COMPRESSION: "-nydus"
-        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
-        IMAGE_VERSION: tmpl-v24
-      - COMPRESSION: ""
-        RELEASE_TAG_COMPRESSION_SUFFIX: ""
-        IMAGE_VERSION: tmpl-v25
   needs:
     - job: docker_build_agent7_jmx
       artifacts: false
@@ -85,14 +79,6 @@ publish_internal_container_image-jmx:
 
 publish_internal_container_image-fips:
   extends: .docker_trigger_base
-  parallel:
-    matrix:
-      - COMPRESSION: "-nydus"
-        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
-        IMAGE_VERSION: tmpl-v24
-      - COMPRESSION: ""
-        RELEASE_TAG_COMPRESSION_SUFFIX: ""
-        IMAGE_VERSION: tmpl-v25
   needs:
     - job: docker_build_fips_agent7_jmx
       artifacts: false
@@ -105,14 +91,6 @@ publish_internal_container_image-fips:
 
 publish_internal_container_image-ot_standalone:
   extends: .docker_trigger_base
-  parallel:
-    matrix:
-      - COMPRESSION: "-nydus"
-        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
-        IMAGE_VERSION: tmpl-v7
-      - COMPRESSION: ""
-        RELEASE_TAG_COMPRESSION_SUFFIX: ""
-        IMAGE_VERSION: tmpl-v8
   needs:
     - job: docker_build_ot_agent_standalone_amd64
       artifacts: false
@@ -124,14 +102,6 @@ publish_internal_container_image-ot_standalone:
 
 publish_internal_container_image-ot_standalone-fips:
   extends: .docker_trigger_base
-  parallel:
-    matrix:
-      - COMPRESSION: "-nydus"
-        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
-        IMAGE_VERSION: tmpl-v7
-      - COMPRESSION: ""
-        RELEASE_TAG_COMPRESSION_SUFFIX: ""
-        IMAGE_VERSION: tmpl-v8
   needs:
     - job: docker_build_ot_agent_standalone_fips_amd64
       artifacts: false
@@ -144,14 +114,6 @@ publish_internal_container_image-ot_standalone-fips:
 
 publish_internal_container_image-host_profiler_standalone:
   extends: .docker_trigger_base
-  parallel:
-    matrix:
-      - COMPRESSION: "-nydus"
-        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
-        IMAGE_VERSION: tmpl-v1
-      - COMPRESSION: ""
-        RELEASE_TAG_COMPRESSION_SUFFIX: ""
-        IMAGE_VERSION: tmpl-v2
   needs:
     - job: docker_build_host_profiler_standalone_amd64
       artifacts: false
@@ -164,14 +126,6 @@ publish_internal_container_image-host_profiler_standalone:
 # DCA publish jobs
 publish_internal_dca_container_image:
   extends: .docker_trigger_base
-  parallel:
-    matrix:
-      - COMPRESSION: "-nydus"
-        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
-        IMAGE_VERSION: tmpl-v12
-      - COMPRESSION: ""
-        RELEASE_TAG_COMPRESSION_SUFFIX: ""
-        IMAGE_VERSION: tmpl-v13
   needs:
     - job: docker_build_cluster_agent_amd64
       artifacts: false
@@ -182,14 +136,6 @@ publish_internal_dca_container_image:
 
 publish_internal_dca_container_image-fips:
   extends: .docker_trigger_base
-  parallel:
-    matrix:
-      - COMPRESSION: "-nydus"
-        RELEASE_TAG_COMPRESSION_SUFFIX: "-zstd-nydus"
-        IMAGE_VERSION: tmpl-v12
-      - COMPRESSION: ""
-        RELEASE_TAG_COMPRESSION_SUFFIX: ""
-        IMAGE_VERSION: tmpl-v13
   needs:
     - job: docker_build_cluster_agent_fips_amd64
       artifacts: false


### PR DESCRIPTION
### What does this PR do?

Removes the `-zstd-nydus` (nydus-compressed) image variants from every job in [`.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml`](https://github.com/DataDog/datadog-agent/blob/main/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml).

Each `publish_internal_*` job used a `parallel:matrix` with two entries — one nydus, one uncompressed. With the nydus entry gone, the matrix held a single entry whose `COMPRESSION` and `RELEASE_TAG_COMPRESSION_SUFFIX` were both empty strings, so it was dropped entirely:

- `parallel:matrix` removed from all 7 jobs; `IMAGE_VERSION` hoisted into the per-image variable anchors (`agent_variables`, `cluster_agent_variables`, `ot_standalone_variables`, `host_profiler_standalone_variables`), since every consumer of a given anchor shared the same version.
- `COMPRESSION` and `RELEASE_TAG_COMPRESSION_SUFFIX` dropped from `.docker_trigger_base`, including `export IMAGE_VERSION="${IMAGE_VERSION}${COMPRESSION}"` and the suffix in all three `RELEASE_TAG` constructions (base, nightly, dev).

Resulting `IMAGE_VERSION` per job, each matching what the surviving (uncompressed) matrix entry produced before:

| Job | Anchor | `IMAGE_VERSION` |
|---|---|---|
| `publish_internal_container_image-jmx` | `agent_variables` | `tmpl-v25` |
| `publish_internal_container_image-fips` | `agent_variables` | `tmpl-v25` |
| `publish_internal_container_image-ot_standalone` | `ot_standalone_variables` | `tmpl-v8` |
| `publish_internal_container_image-ot_standalone-fips` | `ot_standalone_variables` | `tmpl-v8` |
| `publish_internal_container_image-host_profiler_standalone` | `host_profiler_standalone_variables` | `tmpl-v2` |
| `publish_internal_dca_container_image` | `cluster_agent_variables` | `tmpl-v13` |
| `publish_internal_dca_container_image-fips` | `cluster_agent_variables` | `tmpl-v13` |

### Motivation

The nydus-compressed variants are no longer needed. Publishing them doubles the number of triggered child pipelines in the [`DataDog/images`](https://github.com/DataDog/images) repo for no consumer.

### Describe how you validated your changes

CI-only change, no Agent code touched.

- Resolved the YAML (with merge keys enabled) and confirmed all 7 jobs end up on the same `IMAGE_VERSION` they had via the uncompressed matrix entry, and that none retain a `parallel` key.
- Confirmed release tags for the surviving variant are unchanged: `RELEASE_TAG_COMPRESSION_SUFFIX` was already `""` on that entry, so dropping it from `RELEASE_TAG` is a no-op.
- Grepped the repo for leftovers: no `COMPRESSION` or `RELEASE_TAG_COMPRESSION_SUFFIX` references remain (remaining `nydus` hits are unrelated SBOM/containerd snapshotter code under `pkg/util/trivy` and `pkg/sbom`).
- Checked downstream references still resolve: [`JOBOWNERS`](https://github.com/DataDog/datadog-agent/blob/main/.gitlab/JOBOWNERS) matches these jobs by glob, and the `needs` in [`internal_kubernetes_deploy.yml`](https://github.com/DataDog/datadog-agent/blob/main/.gitlab/deploy/internal_kubernetes_deploy/internal_kubernetes_deploy.yml) reference the base job names.

### Additional Notes

Dropping `parallel:matrix` changes the generated job names, e.g. `publish_internal_container_image-jmx: [, , tmpl-v25]` becomes `publish_internal_container_image-jmx`. Nothing in this repo depends on the suffixed form, but any external dashboard or job-name allowlist keyed on it would need updating.