### PR TITLE
[CWS] Disable sysctl snapshots when required sysfs files are missing

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2585,6 +2585,11 @@ func (p *EBPFProbe) startSysCtlSnapshotLoop() {
 		case <-ticker.C:
 			// create the sysctl snapshot
 			event, err := sysctl.NewSnapshotEvent(p.config.RuntimeSecurity.SysCtlSnapshotIgnoredBaseNames, p.config.RuntimeSecurity.SysCtlSnapshotKernelCompilationFlags)
+			if errors.Is(err, sysctl.ErrRequiredSysctlSnapshotFileNotFound) {
+				p.config.RuntimeSecurity.SysCtlSnapshotEnabled = false
+				seclog.Infof("disabling sysctl snapshots: %v", err)
+				return
+			}
 			if err != nil {
 				seclog.Warnf("sysctl snapshot failed: %v", err)
 				continue

--- a/pkg/security/probe/sysctl/snapshot.go
+++ b/pkg/security/probe/sysctl/snapshot.go
@@ -28,6 +28,11 @@ import (
 
 var (
 	redactedContent = "******"
+
+	// ErrRequiredSysctlSnapshotFileNotFound indicates that a sysfs file needed to
+	// build a sysctl snapshot is unavailable. Callers should disable snapshots
+	// rather than repeatedly retrying an unsupported host configuration.
+	ErrRequiredSysctlSnapshotFileNotFound = errors.New("required sysctl snapshot file not found")
 )
 
 // readFileContent reads a file and processes its content based on the given rules.
@@ -156,6 +161,9 @@ func (s *Snapshot) snapshotSys(ignoredBaseNames []string) error {
 		"/kernel/security/lsm",
 	} {
 		value, err := readFileContent(kernel.HostSys(systemControl), ignoredBaseNames)
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("%w: %w", ErrRequiredSysctlSnapshotFileNotFound, err)
+		}
 		if err != nil {
 			return err
 		}

--- a/pkg/security/probe/sysctl/snapshot.go
+++ b/pkg/security/probe/sysctl/snapshot.go
@@ -26,6 +26,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
+const sysctlSnapshotFallbackSysFSRoot = "/host/root/sys"
+
 var (
 	redactedContent = "******"
 
@@ -154,16 +156,32 @@ func (s *Snapshot) snapshotProcSys(ignoredBaseNames []string) error {
 	})
 }
 
+func readSnapshotSystemControl(primaryPath, fallbackPath string, ignoredBaseNames []string) ([]byte, error) {
+	value, err := readFileContent(primaryPath, ignoredBaseNames)
+	if err == nil {
+		return value, nil
+	}
+
+	fallbackValue, fallbackErr := readFileContent(fallbackPath, ignoredBaseNames)
+	if fallbackErr == nil {
+		return fallbackValue, nil
+	}
+
+	if errors.Is(err, fs.ErrNotExist) && errors.Is(fallbackErr, fs.ErrNotExist) {
+		return nil, fmt.Errorf("%w: %s and fallback %s: %w", ErrRequiredSysctlSnapshotFileNotFound, primaryPath, fallbackPath, fallbackErr)
+	}
+	return nil, fmt.Errorf("couldn't read %s or fallback %s: %w", primaryPath, fallbackPath, fallbackErr)
+}
+
 // snapshotSys reads security relevant files from the /sys filesystem
 func (s *Snapshot) snapshotSys(ignoredBaseNames []string) error {
 	for _, systemControl := range []string{
 		"/kernel/security/lockdown",
 		"/kernel/security/lsm",
 	} {
-		value, err := readFileContent(kernel.HostSys(systemControl), ignoredBaseNames)
-		if errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("%w: %w", ErrRequiredSysctlSnapshotFileNotFound, err)
-		}
+		primaryPath := kernel.HostSys(systemControl)
+		fallbackPath := filepath.Join(sysctlSnapshotFallbackSysFSRoot, strings.TrimPrefix(systemControl, "/"))
+		value, err := readSnapshotSystemControl(primaryPath, fallbackPath, ignoredBaseNames)
 		if err != nil {
 			return err
 		}

--- a/pkg/security/probe/sysctl/snapshot_test.go
+++ b/pkg/security/probe/sysctl/snapshot_test.go
@@ -8,8 +8,11 @@
 package sysctl
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 func TestSnapshotEvent_ToJSON(t *testing.T) {
@@ -88,6 +91,16 @@ func TestSnapshotEvent_ToJSON(t *testing.T) {
 			assert.JSONEqf(t, tt.want, string(got), "ToJSON() error")
 		})
 	}
+}
+
+func TestSnapshotSysMissingRequiredFile(t *testing.T) {
+	t.Cleanup(kernel.ResetProcSysRootCachesForTest)
+	t.Setenv("HOST_SYS", t.TempDir())
+	kernel.ResetProcSysRootCachesForTest()
+
+	snapshot := NewSnapshot()
+	err := snapshot.snapshotSys(nil)
+	assert.ErrorIs(t, err, ErrRequiredSysctlSnapshotFileNotFound)
 }
 
 func TestSnapshot_InsertSnapshotEntry(t *testing.T) {

--- a/pkg/security/probe/sysctl/snapshot_test.go
+++ b/pkg/security/probe/sysctl/snapshot_test.go
@@ -8,11 +8,11 @@
 package sysctl
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 func TestSnapshotEvent_ToJSON(t *testing.T) {
@@ -93,14 +93,24 @@ func TestSnapshotEvent_ToJSON(t *testing.T) {
 	}
 }
 
-func TestSnapshotSysMissingRequiredFile(t *testing.T) {
-	t.Cleanup(kernel.ResetProcSysRootCachesForTest)
-	t.Setenv("HOST_SYS", t.TempDir())
-	kernel.ResetProcSysRootCachesForTest()
+func TestReadSnapshotSystemControl(t *testing.T) {
+	t.Run("falls back when the primary path is unavailable", func(t *testing.T) {
+		root := t.TempDir()
+		primaryPath := filepath.Join(root, "sys", "kernel", "security", "lockdown")
+		fallbackPath := filepath.Join(root, "root", "sys", "kernel", "security", "lockdown")
+		assert.NoError(t, os.MkdirAll(filepath.Dir(fallbackPath), 0755))
+		assert.NoError(t, os.WriteFile(fallbackPath, []byte("integrity\n"), 0644))
 
-	snapshot := NewSnapshot()
-	err := snapshot.snapshotSys(nil)
-	assert.ErrorIs(t, err, ErrRequiredSysctlSnapshotFileNotFound)
+		value, err := readSnapshotSystemControl(primaryPath, fallbackPath, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "integrity\n", string(value))
+	})
+
+	t.Run("returns a sentinel error when both paths are unavailable", func(t *testing.T) {
+		root := t.TempDir()
+		_, err := readSnapshotSystemControl(filepath.Join(root, "sys", "lockdown"), filepath.Join(root, "root", "sys", "lockdown"), nil)
+		assert.ErrorIs(t, err, ErrRequiredSysctlSnapshotFileNotFound)
+	})
 }
 
 func TestSnapshot_InsertSnapshotEntry(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

- Adds a fallback from the configured host sysfs path to `/host/root/sys` when reading `kernel/security/lockdown` and `kernel/security/lsm` for sysctl snapshots.
- Disables sysctl snapshots after the first attempt when both paths are missing, preventing repeated warning logs and retries.

### Motivation

Some Helm or Operator deployments mount the host root filesystem under `/host/root`, while `/host/sys/kernel/security/lockdown` or `lsm` is unavailable. Sysctl snapshots should use the available host mount when possible and stop cleanly when these required files are unavailable from both locations.

Also, on some distributions (mainly CentOS7/RHEL7/AmazonLinux2) those paths are not present at all and should not produce a this warning log every hour:
`SYS-PROBE | WARN | (pkg/security/probe/probe_ebpf.go:2166 in startSysCtlSnapshotLoop) | sysctl snapshot failed: coudln't snapshot /sys: open /host/sys/kernel/security/lockdown: no such file or directory`

### Describe how you validated your changes

- `dda inv test --targets=./pkg/security/probe/sysctl`
- Added unit coverage for the fallback path and for the missing-primary-and-fallback sentinel error.

### Additional Notes

Other snapshot failures remain retryable and continue to be logged as warnings.