### PR TITLE
#incident-59224: drop DWARF from Windows Go test binary links

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -662,6 +662,9 @@ def test(
     build_cpus_opt = f"-p {cpus}" if cpus else ""
     test_cpus_opt = f"-parallel {cpus}" if cpus else ""
     trimpath_opt = "-trimpath" if 'DELVE' not in os.environ else ""
+    if sys.platform == "win32" and "DELVE" not in os.environ:
+        # incident-59224: omit DWARF to deflate peak link memory, while preserving symbol table diagnostics
+        ldflags += "-w"
 
     nocache = '-count=1' if not cache else ''
 


### PR DESCRIPTION
### What does this PR do?
Pass `-w` to the Go linker for test binaries on Windows, so the external linker no longer loads Go's DWARF.

The guard that already skips `-trimpath` under `DELVE` skips `-w` too, so _local debugging keeps its debug info_.

### Motivation
`tests_windows-x64` started failing on OOM while linking, more and more frequently since mid-July 2026, leading to [#incident-59224](https://dd.enterprise.slack.com/archives/C0BQ6LTADFG) today.

The external linker happens to run out of memory on the largest test binaries:
```
ld.exe: final link failed: memory exhausted
runtime: VirtualAlloc of 8192 bytes failed with errno=1455
```
`errno` 1455 is `ERROR_COMMITMENT_LIMIT`, so an 8 KB allocation failing points at container commit exhaustion rather than a linker address space ceiling.

`gcc` already gets `-s`, but that strips the output only, long after `ld` has read the DWARF out of `go.o`.

### Describe how you validated your changes
On an isolated cgo program forced to `-linkmode=external`, `go.o` shrinks from 11.68 MB to 5.16 MB with `-w`.

**No diagnostic is lost**: test failure locations, uncaught panic stacks, timeout goroutine dumps, `runtime.Caller` and `pprof` all keep symbolizing through the `pclntab`.

No Windows test consumes DWARF either, the only `debug/dwarf` importers being ELF readers and `linux_bpf` gated files.

### Additional Notes
E2E test binaries already link with `-w` and `-s` in `tasks/new_e2e_tests.py`, introduced by #38083.
This change is narrower, keeping the symbol table.