### PR TITLE
Emit per-interval GPU XID error counts

### DIFF
--- a/pkg/collector/corechecks/gpu/integrationtests/check_test.go
+++ b/pkg/collector/corechecks/gpu/integrationtests/check_test.go
@@ -102,7 +102,7 @@ func (suite *CheckTestSuite) SetupTest() {
 	err = checkInstance.Run()
 	require.NoError(t, err, "Check.Run() should not return an error")
 
-	// Inject XID events for each device to ensure the errors.xid.total metric is emitted.
+	// Inject XID events for each device to ensure the errors.xid.total and errors.xid metrics are emitted.
 	for _, device := range devices {
 		deviceUUID := device.GetDeviceInfo().UUID
 		require.NoError(t, checkInternal.InjectXIDEventsForTest(deviceUUID, []safenvml.DeviceEventData{{

--- a/pkg/collector/corechecks/gpu/nvidia/device_events.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events.go
@@ -32,6 +32,8 @@ const (
 	xidOriginDriver               = "driver"
 	xidOriginHardware             = "hardware"
 	xidOriginUnknown              = "unknown"
+	xidErrorsTotalMetricName      = "errors.xid.total"
+	xidErrorsCountMetricName      = "errors.xid"
 )
 
 var eventSetWaitTimeout = defaultEventSetWaitTimeout
@@ -48,7 +50,7 @@ type deviceEventsCollector struct {
 	registrationAttempts int
 	device               ddnvml.Device
 	eventsCache          deviceEventsCollectorCache
-	metricsByXidCode     map[uint64]*Metric
+	accumulatedCounts    map[uint64]int
 }
 
 func newDeviceEventsCollector(device ddnvml.Device, deps *CollectorDependencies) (c Collector, err error) {
@@ -68,9 +70,9 @@ func newDeviceEventsCollectorWithCache(device ddnvml.Device, cache deviceEventsC
 	}
 
 	return &deviceEventsCollector{
-		device:           device,
-		eventsCache:      cache,
-		metricsByXidCode: map[uint64]*Metric{},
+		device:            device,
+		eventsCache:       cache,
+		accumulatedCounts: map[uint64]int{},
 	}, nil
 }
 
@@ -92,36 +94,49 @@ func (c *deviceEventsCollector) Collect() ([]*Metric, error) {
 		return nil, fmt.Errorf("failed collecting device events: %w", err)
 	}
 
+	intervalCounts := make(map[uint64]int)
 	for _, evt := range events {
 		if evt.EventType != nvml.EventTypeXidCriticalError {
 			// currently considering only xid events
 			continue
 		}
 
-		if _, ok := c.metricsByXidCode[evt.EventData]; !ok {
-			xidOrigin, ok := xidCodeToOrigin[evt.EventData]
-			if !ok {
-				xidOrigin = xidOriginUnknown
-			}
-			c.metricsByXidCode[evt.EventData] = &Metric{
-				Name:     "errors.xid.total",
-				Type:     metrics.GaugeType,
-				Priority: Medium,
-				Tags: []string{
-					"type:" + strconv.Itoa(int(evt.EventData)),
-					"origin:" + xidOrigin,
-				},
-			}
+		intervalCounts[evt.EventData]++
+		c.accumulatedCounts[evt.EventData]++
+	}
+
+	var metricsOut []*Metric
+	// iterate through accumulated counts so that we always emit metrics for XID codes we have seen previously, even
+	// if they were not seen in the current interval
+	for xidCode, accumulatedCount := range c.accumulatedCounts {
+		xidOrigin, ok := xidCodeToOrigin[xidCode]
+		if !ok {
+			xidOrigin = xidOriginUnknown
 		}
 
-		c.metricsByXidCode[evt.EventData].Value++
+		tags := []string{
+			"type:" + strconv.Itoa(int(xidCode)),
+			"origin:" + xidOrigin,
+		}
+
+		metricsOut = append(metricsOut, &Metric{
+			Name:     xidErrorsCountMetricName,
+			Value:    float64(intervalCounts[xidCode]),
+			Type:     metrics.CountType,
+			Priority: Medium,
+			Tags:     tags,
+		})
+
+		metricsOut = append(metricsOut, &Metric{
+			Name:     xidErrorsTotalMetricName,
+			Value:    float64(accumulatedCount),
+			Type:     metrics.GaugeType,
+			Priority: Medium,
+			Tags:     tags,
+		})
 	}
 
-	var metrics []*Metric
-	for _, m := range c.metricsByXidCode {
-		metrics = append(metrics, m)
-	}
-	return metrics, nil
+	return metricsOut, nil
 }
 
 // note: watching device events seems to require specific permission/status with the NVIDIA driver,

--- a/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
@@ -193,9 +193,23 @@ func TestDeviceEventsCollector(t *testing.T) {
 	require.Empty(t, mm)
 
 	// add event to cache and check that metrics are properly computed.
-	// since we don't change events between subsequent calls, we check
-	// that the counter is increased
-	xidErrorsMetricName := "errors.xid.total"
+	// GetEvents is idempotent until Refresh, so subsequent Collect calls with
+	// the same cached events increase the lifetime gauge and re-emit the
+	// interval count as the number of events in that Collect call.
+	xid31Tags := []string{"type:31", "origin:hardware"}
+	xid12Tags := []string{"type:12", "origin:driver"}
+	xid31Total := func(value float64) *Metric {
+		return &Metric{Name: xidErrorsTotalMetricName, Value: value, Type: metrics.GaugeType, Priority: Medium, Tags: xid31Tags}
+	}
+	xid31Count := func(value float64) *Metric {
+		return &Metric{Name: xidErrorsCountMetricName, Value: value, Type: metrics.CountType, Priority: Medium, Tags: xid31Tags}
+	}
+	xid12Total := func(value float64) *Metric {
+		return &Metric{Name: xidErrorsTotalMetricName, Value: value, Type: metrics.GaugeType, Priority: Medium, Tags: xid12Tags}
+	}
+	xid12Count := func(value float64) *Metric {
+		return &Metric{Name: xidErrorsCountMetricName, Value: value, Type: metrics.CountType, Priority: Medium, Tags: xid12Tags}
+	}
 	cache.events = []safenvml.DeviceEventData{
 		{
 			DeviceUUID: uuid,
@@ -205,19 +219,11 @@ func TestDeviceEventsCollector(t *testing.T) {
 	}
 	mm, err = collector.Collect()
 	require.NoError(t, err)
-	require.Len(t, mm, 1)
-	assert.Equal(t, &Metric{
-		Name:     xidErrorsMetricName,
-		Value:    1,
-		Type:     metrics.GaugeType,
-		Priority: Medium,
-		Tags:     []string{"type:31", "origin:hardware"},
-	}, mm[0])
+	assert.ElementsMatch(t, []*Metric{xid31Total(1), xid31Count(1)}, mm)
 
 	mm, err = collector.Collect()
 	require.NoError(t, err)
-	require.Len(t, mm, 1)
-	assert.Equal(t, float64(2), mm[0].Value)
+	assert.ElementsMatch(t, []*Metric{xid31Total(2), xid31Count(1)}, mm)
 
 	// make sure different xid errors produce distinct metric contexts
 	cache.events = []safenvml.DeviceEventData{
@@ -229,27 +235,43 @@ func TestDeviceEventsCollector(t *testing.T) {
 	}
 	mm2, err := collector.Collect()
 	require.NoError(t, err)
-	require.Len(t, mm2, 2)
 	assert.ElementsMatch(t, []*Metric{
-		{
-			Name:     xidErrorsMetricName,
-			Value:    1,
-			Type:     metrics.GaugeType,
-			Priority: Medium,
-			Tags:     []string{"type:12", "origin:driver"},
-		},
-		{
-			Name:     xidErrorsMetricName,
-			Value:    2,
-			Type:     metrics.GaugeType,
-			Priority: Medium,
-			Tags:     []string{"type:31", "origin:hardware"},
-		},
+		xid12Total(1),
+		xid12Count(1),
+		xid31Total(2),
+		xid31Count(0),
 	}, mm2)
 
-	// make sure there's no update in case we have no cached events
+	// no new events: lifetime gauges stay, interval counts are emitted as zero
 	cache.events = nil
 	mm3, err := collector.Collect()
 	require.NoError(t, err)
-	require.ElementsMatch(t, mm2, mm3)
+	assert.ElementsMatch(t, []*Metric{
+		xid12Total(1),
+		xid12Count(0),
+		xid31Total(2),
+		xid31Count(0),
+	}, mm3)
+
+	// multiple events of the same xid in one interval increase the count by that amount
+	cache.events = []safenvml.DeviceEventData{
+		{
+			DeviceUUID: uuid,
+			EventType:  nvml.EventTypeXidCriticalError,
+			EventData:  31,
+		},
+		{
+			DeviceUUID: uuid,
+			EventType:  nvml.EventTypeXidCriticalError,
+			EventData:  31,
+		},
+	}
+	mm4, err := collector.Collect()
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []*Metric{
+		xid31Total(4),
+		xid31Count(2),
+		xid12Total(1),
+		xid12Count(0),
+	}, mm4)
 }

--- a/pkg/collector/corechecks/gpu/spec/aggregations.yaml
+++ b/pkg/collector/corechecks/gpu/spec/aggregations.yaml
@@ -14,6 +14,11 @@ aggregations:
     time_aggregator: "max/last"
     group_aggregator: "sum"
     granularity_aggregator: "max"
+  interval_count:
+    description: "Number of events counted in each collection interval"
+    time_aggregator: "sum"
+    group_aggregator: "sum"
+    granularity_aggregator: "sum"
   sensor_data:
     description: "GPU sensor readings"
     time_aggregator: "avg"

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -575,6 +575,26 @@ metrics:
         mig: false
         physical: true
         vgpu: false
+  errors.xid:
+    metadata:
+      metric_type: counter
+      description: >-
+        XID errors received during the last collection interval. XID errors are
+        NVIDIA driver error codes that indicate GPU hardware or software issues
+        like thermal throttling to hardware defects. Investigate these errors
+        immediately as they often precede total GPU failures.
+      aggregation: interval_count
+    tagsets:
+      - device
+    custom_tags:
+      - origin
+      - type
+    support:
+      unsupported_architectures: []
+      device_modes:
+        mig: false
+        physical: true
+        vgpu: false
   errors.xid.total:
     metadata:
       metric_type: gauge

--- a/releasenotes/notes/gpu-xid-interval-count-dd98c89d28c6ccc4.yaml
+++ b/releasenotes/notes/gpu-xid-interval-count-dd98c89d28c6ccc4.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    GPU: emit ``gpu.errors.xid``, a count of NVIDIA XID errors in each collection interval.
+    ``gpu.errors.xid.total`` remains the lifetime total since the Agent started collecting events.


### PR DESCRIPTION
### What does this PR do?
Emit `gpu.errors.xid`, a count of NVIDIA XID errors in each collection interval. `gpu.errors.xid.total` remains the lifetime gauge.

### Motivation

Make it easier to see the amount of errors that happened in a given interval.

### Describe how you validated your changes

Unit tests. Local Datadog check with injected XID events.

### Additional Notes