### PR TITLE
Sort nodes before generating synthetic cluster resourceVersion

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cluster.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cluster.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 
 	model "github.com/DataDog/agent-payload/v5/process"
@@ -210,6 +211,13 @@ func (p *ClusterProcessor) Process(ctx processors.ProcessorContext, list interfa
 }
 
 func fillClusterResourceVersion(c *model.Cluster) error {
+	// Nodes are collected from an informer-backed map whose iteration order is
+	// not stable. Canonicalize the slice before hashing it so an unchanged
+	// cluster always produces the same resource version and payload.
+	sort.Slice(c.NodesInfo, func(i, j int) bool {
+		return c.NodesInfo[i].GetName() < c.NodesInfo[j].GetName()
+	})
+
 	marshaller := jsoniter.ConfigCompatibleWithStandardLibrary
 	jsonClustermodel, err := marshaller.Marshal(c)
 	if err != nil {

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cluster_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cluster_test.go
@@ -31,9 +31,28 @@ import (
 )
 
 func TestClusterProcessor_fillClusterResourceVersion(t *testing.T) {
-	cluster := &model.Cluster{}
-	fillClusterResourceVersion(cluster)
+	cluster := &model.Cluster{NodesInfo: []*model.ClusterNodeInfo{
+		{Name: "node-b", KernelVersion: "6.1"},
+		{Name: "node-a", KernelVersion: "6.1"},
+	}}
+	reorderedCluster := &model.Cluster{NodesInfo: []*model.ClusterNodeInfo{
+		{Name: "node-a", KernelVersion: "6.1"},
+		{Name: "node-b", KernelVersion: "6.1"},
+	}}
+	changedCluster := &model.Cluster{NodesInfo: []*model.ClusterNodeInfo{
+		{Name: "node-a", KernelVersion: "6.2"},
+		{Name: "node-b", KernelVersion: "6.1"},
+	}}
+
+	require.NoError(t, fillClusterResourceVersion(cluster))
+	require.NoError(t, fillClusterResourceVersion(reorderedCluster))
+	require.NoError(t, fillClusterResourceVersion(changedCluster))
+
 	assert.NotEmpty(t, cluster.ResourceVersion)
+	assert.Equal(t, reorderedCluster.ResourceVersion, cluster.ResourceVersion)
+	assert.NotEqual(t, changedCluster.ResourceVersion, cluster.ResourceVersion)
+	assert.Equal(t, "node-a", cluster.NodesInfo[0].Name)
+	assert.Equal(t, "node-b", cluster.NodesInfo[1].Name)
 }
 
 func TestClusterProcessor_getKubeSystemCreationTimeStamp(t *testing.T) {

--- a/releasenotes/notes/fix-cluster-resource-version-churn-2534fffc08d8e48e.yaml
+++ b/releasenotes/notes/fix-cluster-resource-version-churn-2534fffc08d8e48e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Kubernetes orchestrator: Prevent unchanged clusters from being repeatedly
+    reported as updated when the node listing order changes.


### PR DESCRIPTION
### What does this PR do?

Sorts cluster node information by node name before generating the synthetic cluster resourceVersion.
This makes the generated resourceVersion and cluster payload deterministic when the cluster state has not changed.


### Motivation
Clusters are synthetic resources and do not have a Kubernetes-provided resourceVersion. The Agent generates one by hashing the serialized cluster payload.
Node information originates from an informer-backed map whose iteration order is not deterministic. Consequently, identical cluster states could serialize nodes in different orders and produce different synthetic resource versions. This caused unnecessary cache misses and payload churn.

### Describe how you validated your changes
Added a regression test verifying that:
* Identical nodes in different orders produce the same synthetic resourceVersion.
* An actual change to node information produces a different resourceVersion.
* Node information is emitted in canonical order.

Also confirmed the regression test fails without the fix and passes with it. The focused race suite passed all 335 tests.

### Additional Notes
This complements the backend cache-key changes by stabilizing the Agent-generated synthetic resourceVersion at its source.