### PR TITLE
Publish datadog-fips-proxy to the pipeline testing repositories

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -101,6 +101,7 @@ deploy_rpm_testing*                  @DataDog/agent-delivery
 deploy_suse_rpm_testing*             @DataDog/agent-delivery
 deploy_windows_testing*              @DataDog/agent-delivery
 deploy_dmg_testing*                @DataDog/agent-delivery
+deploy_fips_proxy_testing*           @DataDog/agent-devx
 
 # Image build
 docker_build*                        @DataDog/agent-build

--- a/.gitlab/deploy/e2e_testing_deploy/e2e_deploy.yml
+++ b/.gitlab/deploy/e2e_testing_deploy/e2e_deploy.yml
@@ -56,15 +56,17 @@ deploy_deb_testing-a7_x64:
   extends:
     - .deploy_deb_testing-a7
   needs:
-    [
-      "installer_deb-amd64",
-      "agent_deb-x64-a7",
-      "agent_deb-x64-a7-fips",
-      "agent_heroku_deb-x64-a7",
-      "iot_agent_deb-x64",
-      "dogstatsd_deb-x64",
-      "ddot_deb-x64",
-    ]
+    - "installer_deb-amd64"
+    - "agent_deb-x64-a7"
+    - "agent_deb-x64-a7-fips"
+    - "agent_heroku_deb-x64-a7"
+    - "iot_agent_deb-x64"
+    - "dogstatsd_deb-x64"
+    - "ddot_deb-x64"
+    # deb-s3 rewrites the repository index, so uploads to it must not overlap. The job below only
+    # exists on pipelines that publish datadog-fips-proxy.
+    - job: deploy_fips_proxy_testing-a7_x64
+      optional: true
   script:
     # setup_signing_keys_package must be done *before* setup_signing
     # because setup_signing replaces gpg with gpg-vault
@@ -118,14 +120,16 @@ deploy_rpm_testing-a7_x64:
   extends:
     - .deploy_rpm_testing-a7
   needs:
-    [
-      "installer_rpm-amd64",
-      "agent_rpm-x64-a7",
-      "agent_rpm-x64-a7-fips",
-      "iot_agent_rpm-x64",
-      "dogstatsd_rpm-x64",
-      "ddot_rpm-x64",
-    ]
+    - "installer_rpm-amd64"
+    - "agent_rpm-x64-a7"
+    - "agent_rpm-x64-a7-fips"
+    - "iot_agent_rpm-x64"
+    - "dogstatsd_rpm-x64"
+    - "ddot_rpm-x64"
+    # rpm-s3 rewrites the repository metadata, so uploads to it must not overlap. The job below only
+    # exists on pipelines that publish datadog-fips-proxy.
+    - job: deploy_fips_proxy_testing-a7_x64
+      optional: true
   script:
     - *setup_signing
     - |
@@ -199,6 +203,44 @@ deploy_suse_rpm_testing_arm64-a7:
         tools/ci/signing/sign_rpm_package.sh "$package" $GPG_TEST_KEY_ID out/
       done
     - python2 /opt/rpm-s3/bin/rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "suse/testing/pipeline-$DD_PIPELINE_ID/7/aarch64/" -a "aarch64" --sign --metadata-signing-key $GPG_TEST_KEY_ID --repodata-store-public-key out/datadog-*-7.*aarch64.rpm
+
+# The install script installs datadog-fips-proxy from the same repository as the Agent, but that legacy
+# package is released from another repository, so the install script FIPS tests can only exercise the
+# Agent packages built by this pipeline if a copy of it is published alongside them. It is a job of its
+# own rather than part of the Agent uploads so that only the pipelines running those tests pay for it.
+# x86_64 only, which is all those tests cover. Drop this job with datadog-fips-proxy itself.
+deploy_fips_proxy_testing-a7_x64:
+  rules:
+    # test_install_script, the only consumer, runs on deploy pipelines; the change rule keeps this job
+    # exercised when its own definition moves. Unlike its neighbors it must never be manual: the Agent
+    # package uploads need it, and a needs edge on an untriggered manual job skips them, optional or not.
+    - !reference [.on_deploy]
+    - !reference [.except_mergequeue]
+    - changes:
+        paths:
+          - .gitlab/deploy/e2e_testing_deploy/e2e_deploy.yml
+        compare_to: $COMPARE_TO_BRANCH
+  stage: e2e_deploy
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
+  tags: ["arch:amd64", "specific:true"]
+  # Nothing to wait for: the package comes from the public repositories.
+  needs: []
+  variables:
+    DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
+    # The install script installs this unversioned, but the package is frozen and pending deprecation,
+    # so pinning keeps a release of it from changing what Agent pipelines publish.
+    FIPS_PROXY_VERSION: 1.1.29-1
+  script:
+    - *setup_signing
+    - tools/ci/retry.sh curl -fsSLO "https://yum.datadoghq.com/stable/7/x86_64/datadog-fips-proxy-${FIPS_PROXY_VERSION}.x86_64.rpm"
+    # The deb sits under deb-s3's pool layout, pool/<first letter>/<first two letters>/.
+    - tools/ci/retry.sh curl -fsSLO "https://apt.datadoghq.com/pool/d/da/datadog-fips-proxy_${FIPS_PROXY_VERSION}_amd64.deb"
+    # yum verifies package signatures against the testing keys, which the released package is not signed with.
+    - tools/ci/signing/sign_rpm_package.sh "datadog-fips-proxy-${FIPS_PROXY_VERSION}.x86_64.rpm" $GPG_TEST_KEY_ID out/
+    - python2 /opt/rpm-s3/bin/rpm-s3 --verbose --visibility public-read -c "https://s3.amazonaws.com" -b $RPM_TESTING_S3_BUCKET -p "testing/pipeline-$DD_PIPELINE_ID/7/x86_64/" -a "x86_64" --sign --metadata-signing-key $GPG_TEST_KEY_ID "out/datadog-fips-proxy-${FIPS_PROXY_VERSION}.x86_64.rpm"
+    # apt only verifies the repository metadata, which deb-s3 signs with the testing key.
+    - deb-s3 upload -c "stable-x86_64" -m 7 -b $DEB_TESTING_S3_BUCKET -a amd64 --sign=$GPG_TEST_KEY_ID --gpg_options="--batch --digest-algo sha512" --preserve_versions --visibility public --prefix datadog-agent/pipeline-${DD_PIPELINE_ID} "datadog-fips-proxy_${FIPS_PROXY_VERSION}_amd64.deb"
+    - deb-s3 upload -c "stable-x86_64" -m 7 -b $DEB_TESTING_S3_BUCKET -a x86_64 --sign=$GPG_TEST_KEY_ID --gpg_options="--batch --digest-algo sha512" --preserve_versions --visibility public --prefix datadog-agent/pipeline-${DD_PIPELINE_ID} "datadog-fips-proxy_${FIPS_PROXY_VERSION}_amd64.deb"
 
 export_testing_public_key:
   rules:

--- a/.gitlab/test/install_script_testing/install_script_testing.yml
+++ b/.gitlab/test/install_script_testing/install_script_testing.yml
@@ -10,7 +10,7 @@ test_install_script:
     # test repositories are signed with the test keys
     - export TESTING_KEYS_URL=$TEST_KEYS_URL
     - export TEST_PIPELINE_ID=$CI_PIPELINE_ID
-    - "dda inv pipeline.trigger-child-pipeline --project-name DataDog/agent-linux-install-script --git-ref main --timeout 5400
+    - "dda inv pipeline.trigger-child-pipeline --project-name DataDog/agent-linux-install-script --git-ref revert-436-revert-430-kfairise/fix-install-args --timeout 5400
       --variable TESTING_APT_URL
       --variable TESTING_YUM_URL
       --variable TESTING_KEYS_URL
@@ -23,3 +23,6 @@ test_install_script:
     ]
   rules:
     - !reference [.on_deploy]
+    # TEMPORARY: makes the job exist on this PR pipeline. Nothing needs it, so leaving it untriggered
+    # skips nothing.
+    - !reference [.manual]

--- a/.gitlab/test/install_script_testing/install_script_testing.yml
+++ b/.gitlab/test/install_script_testing/install_script_testing.yml
@@ -10,7 +10,7 @@ test_install_script:
     # test repositories are signed with the test keys
     - export TESTING_KEYS_URL=$TEST_KEYS_URL
     - export TEST_PIPELINE_ID=$CI_PIPELINE_ID
-    - "dda inv pipeline.trigger-child-pipeline --project-name DataDog/agent-linux-install-script --git-ref revert-436-revert-430-kfairise/fix-install-args --timeout 5400
+    - "dda inv pipeline.trigger-child-pipeline --project-name DataDog/agent-linux-install-script --git-ref main --timeout 5400
       --variable TESTING_APT_URL
       --variable TESTING_YUM_URL
       --variable TESTING_KEYS_URL
@@ -23,6 +23,3 @@ test_install_script:
     ]
   rules:
     - !reference [.on_deploy]
-    # TEMPORARY: makes the job exist on this PR pipeline. Nothing needs it, so leaving it untriggered
-    # skips nothing.
-    - !reference [.manual]


### PR DESCRIPTION
### What does this PR do?

Publishes the released `datadog-fips-proxy` package into the testing repositories of the pipelines whose install-script tests need it, so the install script resolves it from the same repository as the Agent packages built by that pipeline.

### Motivation

`test_install_script` triggers the `agent-linux-install-script` pipeline with `TESTING_APT_URL` and `TESTING_YUM_URL` so the install script installs the Agent built by the pipeline. Those variables land in the apt and yum configuration, so every Datadog package the script installs is resolved against the pipeline repository — including `datadog-fips-proxy`, which is released from another repository and is not published there. Nightly and RC pipelines failed with `Error: Unable to find a match: datadog-fips-proxy`.

The mitigation was to stop forwarding those variables for the FIPS test, which leaves it installing the latest stable Agent instead of the pipeline's packages.

### Describe how you validated your changes

`dda inv linter.full-gitlab-ci` passes locally.

The [pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/132516692) of test commit https://github.com/DataDog/datadog-agent/pull/54908/changes/89fb6f4c72f4f56a89ef8decd34b894923499b42 published `datadog-fips-proxy 1:1.1.29-1` into both testing repositories alongside the Agent it built. Its yum index still lists the package after the Agent upload rewrote that index, confirming `rpm-s3` merges rather than replaces.

The [job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1974262997) that triggers the install-script pipeline against it, on the [branch](https://github.com/DataDog/agent-linux-install-script/pull/446) that restores the testing-variable forwarding, ran the FIPS suite on all five of its platforms and passed. The Debian 11 [job](https://gitlab.ddbuild.io/DataDog/agent-linux-install-script/-/jobs/1974914627) installed every package from the pipeline repository:

```
Get:1 https://apttesting.***.com/datadog-agent/pipeline-132516692-a7 stable-x86_64/7 amd64 datadog-agent amd64 1:7.84.0~devel.git.171.89fb6f4.pipeline.132516692-1 [188 MB]
Get:2 https://apttesting.***.com/datadog-agent/pipeline-132516692-a7 stable-x86_64/7 amd64 datadog-fips-proxy amd64 1:1.1.29-1 [7590 kB]
Get:3 https://apttesting.***.com/datadog-agent/pipeline-132516692-a7 stable-x86_64/7 amd64 datadog-signing-keys all 1:1.4.0-1 [23.7 kB]
--- PASS: TestInstallFipsSuite/install-fips-datadog-agent-Debian_11-132584924/TestInstallFips
```

This is the configuration that previously failed with `Error: Unable to find a match: datadog-fips-proxy`.

### Additional Notes

- Merging is blocked by https://github.com/DataDog/agent-linux-install-script/pull/446.
- Publishing before the Agent uploads instead of after them fails safe. Were `rpm-s3` ever to replace repository metadata rather than merge into it, this order costs `datadog-fips-proxy` its index entry and the FIPS test behaves as it does today; the reverse order would drop the Agent packages and break every e2e test that consumes them. A failed download now blocks the two Agent testing uploads rather than only the install-script test. Making the job `allow_failure: true` would trade that for a silent index race.