### PR TITLE
Tentatively fix `Service catalog metadata validation` failure

### DIFF
--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -94,6 +94,7 @@ extensions:
           branch: "7.81.x"
           schedule: "30 2 * * *"
           build_only: true
+          parent_environments: ["staging"]
           options:
             disable_bia: true
             disable_failure_notifications: true
@@ -101,6 +102,7 @@ extensions:
           branch: "main"
           schedule: "0 3 * * 6,0"
           build_only: true
+          parent_environments: ["staging"]
           options:
             disable_bia: true
             disable_failure_notifications: true


### PR DESCRIPTION
### What does this PR do?
Set `parent_environments` to `["staging"]` on the `stable-nightly-build` and `main-nightly-build` targets of the `datadog-agent-nightly` conductor.

This does not address why a check advertised as not mandatory fails the merge queue, which `#sre-core-observability` is investigating.

### Motivation
The `validate-service-metadata` job went red and [puzzled its readers](https://dd.slack.com/archives/C06PBHLD4DQ/p1786712886965919), while [blocking the merge](https://dd.slack.com/archives/C0701E5KYSX/p1786719308338409) of #54653.

Asked for advice, its owners confirmed the check is not mandatory, which seems to hold for the `Merge` button but not for the merge queue, and [recommended fixing the file meanwhile](https://dd.slack.com/archives/C03BZTDFUKY/p1786722568536699).

The failure code is [`conductor_no_parent_environments`](gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1952249035).

### Describe how you validated your changes
Relying on CI: the validator runs as an Atlas workflow, and its offline counterpart lives in `dd-source`.

### Additional Notes
Being unaware of what the nightly targets feed, I picked "staging" to mirror the sibling `build_only` target `beta-build-publish-image`, out of `prod`, `staging`, `gov` and `dr`, so **owners should confirm**.