### PR TITLE
[flake] Prevent Windows flare archive collisions

### DIFF
--- a/comp/core/flare/helpers/builder.go
+++ b/comp/core/flare/helpers/builder.go
@@ -8,8 +8,6 @@ package helpers
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,6 +16,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/flare/types"
@@ -30,9 +29,10 @@ import (
 )
 
 const (
-	filePerm      = 0644
-	ciJobIDEnvVar = "CI_JOB_ID"
+	filePerm = 0644
 )
+
+var archiveNameCounter atomic.Uint64
 
 func newBuilder(root string, hostname string, localFlare bool, flareArgs types.FlareArgs) (*builder, error) {
 	fb := &builder{
@@ -146,16 +146,12 @@ type builder struct {
 	nonScrubbedFiles map[string]bool
 }
 
-func getArchiveName() (string, error) {
-	return getArchiveNameForTime(time.Now().UTC(), newArchiveNameID)
+func getArchiveName() string {
+	return getArchiveNameForTime(time.Now().UTC(), newArchiveNameID())
 }
 
-func getArchiveNameForTime(t time.Time, newID func() (string, error)) (string, error) {
+func getArchiveNameForTime(t time.Time, uniqueSuffix string) string {
 	timeString := strings.ReplaceAll(t.Format(time.RFC3339), ":", "-")
-	uniqueSuffix, err := newID()
-	if err != nil {
-		return "", fmt.Errorf("could not generate unique archive name suffix: %w", err)
-	}
 
 	logLevel, err := log.GetLogLevel()
 	logLevelString := ""
@@ -163,42 +159,11 @@ func getArchiveNameForTime(t time.Time, newID func() (string, error)) (string, e
 		logLevelString = "-" + logLevel.String()
 	}
 
-	return fmt.Sprintf("datadog-agent-%s-%s%s.zip", timeString, uniqueSuffix, logLevelString), nil
+	return fmt.Sprintf("datadog-agent-%s-%s%s.zip", timeString, uniqueSuffix, logLevelString)
 }
 
-func newArchiveNameID() (string, error) {
-	var randomBytes [8]byte
-	if _, err := rand.Read(randomBytes[:]); err != nil {
-		return "", err
-	}
-	return archiveNameID(os.Getenv(ciJobIDEnvVar), hex.EncodeToString(randomBytes[:])), nil
-}
-
-func archiveNameID(ciJobID string, randomID string) string {
-	ciJobID = sanitizeArchiveNamePart(ciJobID)
-	if ciJobID == "" {
-		return randomID
-	}
-	return fmt.Sprintf("job-%s-%s", ciJobID, randomID)
-}
-
-func sanitizeArchiveNamePart(value string) string {
-	var sanitized strings.Builder
-	for _, r := range value {
-		switch {
-		case r >= 'a' && r <= 'z':
-			sanitized.WriteRune(r)
-		case r >= 'A' && r <= 'Z':
-			sanitized.WriteRune(r)
-		case r >= '0' && r <= '9':
-			sanitized.WriteRune(r)
-		case r == '-' || r == '_':
-			sanitized.WriteRune(r)
-		default:
-			sanitized.WriteByte('-')
-		}
-	}
-	return strings.Trim(sanitized.String(), "-")
+func newArchiveNameID() string {
+	return fmt.Sprintf("%d-%d", os.Getpid(), archiveNameCounter.Add(1))
 }
 
 func (fb *builder) Save() (string, error) {
@@ -243,17 +208,14 @@ func (fb *builder) Save() (string, error) {
 	defer fb.Unlock()
 	fb.isClosed = true
 
-	archiveName, err := getArchiveName()
-	if err != nil {
-		return "", err
-	}
+	archiveName := getArchiveName()
 	archiveTmpPath := filepath.Join(fb.tmpDir, archiveName)
 	archiveFinalPath := filepath.Join(os.TempDir(), archiveName)
 
 	// We first create the archive in our fb.tmpDir directory which is only readable by the current user (and
 	// SYSTEM/ADMIN on Windows). Then we retrict the archive permissions before moving it to the system temporary
 	// directory. This prevents other users from being able to read local flares.
-	err = archive.Zip([]string{fb.flareDir}, archiveTmpPath)
+	err := archive.Zip([]string{fb.flareDir}, archiveTmpPath)
 	if err != nil {
 		return "", err
 	}

--- a/comp/core/flare/helpers/builder.go
+++ b/comp/core/flare/helpers/builder.go
@@ -8,6 +8,8 @@ package helpers
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,7 +18,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/flare/types"
@@ -31,8 +32,6 @@ import (
 const (
 	filePerm = 0644
 )
-
-var archiveNameCounter atomic.Uint64
 
 func newBuilder(root string, hostname string, localFlare bool, flareArgs types.FlareArgs) (*builder, error) {
 	fb := &builder{
@@ -146,13 +145,16 @@ type builder struct {
 	nonScrubbedFiles map[string]bool
 }
 
-func getArchiveName() string {
-	return getArchiveNameForTime(time.Now().UTC())
+func getArchiveName() (string, error) {
+	return getArchiveNameForTime(time.Now().UTC(), newArchiveNameID)
 }
 
-func getArchiveNameForTime(t time.Time) string {
+func getArchiveNameForTime(t time.Time, newID func() (string, error)) (string, error) {
 	timeString := strings.ReplaceAll(t.Format(time.RFC3339), ":", "-")
-	uniqueSuffix := fmt.Sprintf("%d-%d", os.Getpid(), archiveNameCounter.Add(1))
+	uniqueSuffix, err := newID()
+	if err != nil {
+		return "", fmt.Errorf("could not generate unique archive name suffix: %w", err)
+	}
 
 	logLevel, err := log.GetLogLevel()
 	logLevelString := ""
@@ -160,7 +162,15 @@ func getArchiveNameForTime(t time.Time) string {
 		logLevelString = "-" + logLevel.String()
 	}
 
-	return fmt.Sprintf("datadog-agent-%s-%s%s.zip", timeString, uniqueSuffix, logLevelString)
+	return fmt.Sprintf("datadog-agent-%s-%s%s.zip", timeString, uniqueSuffix, logLevelString), nil
+}
+
+func newArchiveNameID() (string, error) {
+	var randomBytes [8]byte
+	if _, err := rand.Read(randomBytes[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(randomBytes[:]), nil
 }
 
 func (fb *builder) Save() (string, error) {
@@ -205,14 +215,17 @@ func (fb *builder) Save() (string, error) {
 	defer fb.Unlock()
 	fb.isClosed = true
 
-	archiveName := getArchiveName()
+	archiveName, err := getArchiveName()
+	if err != nil {
+		return "", err
+	}
 	archiveTmpPath := filepath.Join(fb.tmpDir, archiveName)
 	archiveFinalPath := filepath.Join(os.TempDir(), archiveName)
 
 	// We first create the archive in our fb.tmpDir directory which is only readable by the current user (and
 	// SYSTEM/ADMIN on Windows). Then we retrict the archive permissions before moving it to the system temporary
 	// directory. This prevents other users from being able to read local flares.
-	err := archive.Zip([]string{fb.flareDir}, archiveTmpPath)
+	err = archive.Zip([]string{fb.flareDir}, archiveTmpPath)
 	if err != nil {
 		return "", err
 	}

--- a/comp/core/flare/helpers/builder.go
+++ b/comp/core/flare/helpers/builder.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/flare/types"
@@ -30,6 +31,8 @@ import (
 const (
 	filePerm = 0644
 )
+
+var archiveNameCounter atomic.Uint64
 
 func newBuilder(root string, hostname string, localFlare bool, flareArgs types.FlareArgs) (*builder, error) {
 	fb := &builder{
@@ -144,8 +147,12 @@ type builder struct {
 }
 
 func getArchiveName() string {
-	t := time.Now().UTC()
+	return getArchiveNameForTime(time.Now().UTC())
+}
+
+func getArchiveNameForTime(t time.Time) string {
 	timeString := strings.ReplaceAll(t.Format(time.RFC3339), ":", "-")
+	uniqueSuffix := fmt.Sprintf("%d-%d", os.Getpid(), archiveNameCounter.Add(1))
 
 	logLevel, err := log.GetLogLevel()
 	logLevelString := ""
@@ -153,7 +160,7 @@ func getArchiveName() string {
 		logLevelString = "-" + logLevel.String()
 	}
 
-	return fmt.Sprintf("datadog-agent-%s%s.zip", timeString, logLevelString)
+	return fmt.Sprintf("datadog-agent-%s-%s%s.zip", timeString, uniqueSuffix, logLevelString)
 }
 
 func (fb *builder) Save() (string, error) {

--- a/comp/core/flare/helpers/builder.go
+++ b/comp/core/flare/helpers/builder.go
@@ -30,7 +30,8 @@ import (
 )
 
 const (
-	filePerm = 0644
+	filePerm      = 0644
+	ciJobIDEnvVar = "CI_JOB_ID"
 )
 
 func newBuilder(root string, hostname string, localFlare bool, flareArgs types.FlareArgs) (*builder, error) {
@@ -170,7 +171,34 @@ func newArchiveNameID() (string, error) {
 	if _, err := rand.Read(randomBytes[:]); err != nil {
 		return "", err
 	}
-	return hex.EncodeToString(randomBytes[:]), nil
+	return archiveNameID(os.Getenv(ciJobIDEnvVar), hex.EncodeToString(randomBytes[:])), nil
+}
+
+func archiveNameID(ciJobID string, randomID string) string {
+	ciJobID = sanitizeArchiveNamePart(ciJobID)
+	if ciJobID == "" {
+		return randomID
+	}
+	return fmt.Sprintf("job-%s-%s", ciJobID, randomID)
+}
+
+func sanitizeArchiveNamePart(value string) string {
+	var sanitized strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			sanitized.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			sanitized.WriteRune(r)
+		case r >= '0' && r <= '9':
+			sanitized.WriteRune(r)
+		case r == '-' || r == '_':
+			sanitized.WriteRune(r)
+		default:
+			sanitized.WriteByte('-')
+		}
+	}
+	return strings.Trim(sanitized.String(), "-")
 }
 
 func (fb *builder) Save() (string, error) {

--- a/comp/core/flare/helpers/builder_test.go
+++ b/comp/core/flare/helpers/builder_test.go
@@ -8,6 +8,7 @@ package helpers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -127,7 +128,10 @@ func TestGetArchiveNameIsUniqueWithinSameSecond(t *testing.T) {
 	names := make(map[string]struct{})
 
 	for range 100 {
-		name := getArchiveNameForTime(timestamp)
+		name, err := getArchiveNameForTime(timestamp, func() (string, error) {
+			return fmt.Sprintf("unique-%d", len(names)), nil
+		})
+		require.NoError(t, err)
 		if _, found := names[name]; found {
 			t.Fatalf("archive name %q was generated more than once", name)
 		}

--- a/comp/core/flare/helpers/builder_test.go
+++ b/comp/core/flare/helpers/builder_test.go
@@ -122,6 +122,19 @@ func TestSave(t *testing.T) {
 	}
 }
 
+func TestGetArchiveNameIsUniqueWithinSameSecond(t *testing.T) {
+	timestamp := time.Date(2026, time.August, 14, 12, 0, 0, 0, time.UTC)
+	names := make(map[string]struct{})
+
+	for range 100 {
+		name := getArchiveNameForTime(timestamp)
+		if _, found := names[name]; found {
+			t.Fatalf("archive name %q was generated more than once", name)
+		}
+		names[name] = struct{}{}
+	}
+}
+
 func TestAddFileFromFunc(t *testing.T) {
 	fb := getNewBuilder(t)
 	defer fb.clean()

--- a/comp/core/flare/helpers/builder_test.go
+++ b/comp/core/flare/helpers/builder_test.go
@@ -8,7 +8,6 @@ package helpers
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -128,21 +127,12 @@ func TestGetArchiveNameIsUniqueWithinSameSecond(t *testing.T) {
 	names := make(map[string]struct{})
 
 	for range 100 {
-		name, err := getArchiveNameForTime(timestamp, func() (string, error) {
-			return fmt.Sprintf("unique-%d", len(names)), nil
-		})
-		require.NoError(t, err)
+		name := getArchiveNameForTime(timestamp, newArchiveNameID())
 		if _, found := names[name]; found {
 			t.Fatalf("archive name %q was generated more than once", name)
 		}
 		names[name] = struct{}{}
 	}
-}
-
-func TestArchiveNameIDIncludesCIJobIDWhenAvailable(t *testing.T) {
-	assert.Equal(t, "job-12345-abcdef", archiveNameID("12345", "abcdef"))
-	assert.Equal(t, "job-123-45-abcdef", archiveNameID("123/45", "abcdef"))
-	assert.Equal(t, "abcdef", archiveNameID("", "abcdef"))
 }
 
 func TestAddFileFromFunc(t *testing.T) {

--- a/comp/core/flare/helpers/builder_test.go
+++ b/comp/core/flare/helpers/builder_test.go
@@ -139,6 +139,12 @@ func TestGetArchiveNameIsUniqueWithinSameSecond(t *testing.T) {
 	}
 }
 
+func TestArchiveNameIDIncludesCIJobIDWhenAvailable(t *testing.T) {
+	assert.Equal(t, "job-12345-abcdef", archiveNameID("12345", "abcdef"))
+	assert.Equal(t, "job-123-45-abcdef", archiveNameID("123/45", "abcdef"))
+	assert.Equal(t, "abcdef", archiveNameID("", "abcdef"))
+}
+
 func TestAddFileFromFunc(t *testing.T) {
 	fb := getNewBuilder(t)
 	defer fb.clean()


### PR DESCRIPTION
<!-- dd-meta {"pullId":"e285912b-314c-4a9c-9246-8b3688311611","source":"chat","resourceId":"c5d0b2d1-7ec1-45c4-a402-380c09336a86","workflowId":"1ac88243-5f8a-42d5-9538-b344b38e3abf","codeChangeId":"1ac88243-5f8a-42d5-9538-b344b38e3abf","sourceType":"assistant"} -->
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

- Adds a process-local atomic counter suffix to flare archive filenames.
- Includes the process ID with the counter to keep the suffix readable and avoid same-second collisions with another local process.
- Keeps the existing timestamp and log-level filename context.
- Adds a deterministic regression test that verifies repeated archive names generated for the same timestamp do not collide.

### Motivation

Windows fails `os.Rename` when the destination archive already exists. `TestAgentTaskFlareSourceAndTags` creates several flare archives inside the same test process, with second-precision filenames. Once every ~2k runs, subtests created flares exactly at the same second in time, colliding on the file name. 

A process-local atomic counter directly addresses those rapid same-process creations.

Jira: FLREM-150

### Describe how you validated your changes

- Test passes on the CI
Will keep monitoring for further failures.

### Additional Notes

None.

---

PR with help of Bits - [View session in Datadog](https://app.datadoghq.com/code/c5d0b2d1-7ec1-45c4-a402-380c09336a86)