### PR TITLE
dyninst/rc_tester: always start the tracer

### DIFF
--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -20,14 +20,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 951 EventRootType Probe[main.HandleHTTP]
-              InjectionPoints: [{PC: "0xd5acd3", Frameless: false}]
+              InjectionPoints: [{PC: "0xd5ac93", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 952 EventRootType Probe[main.HandleHTTP]Return
               InjectionPoints:
-                - PC: "0xd5af14"
+                - PC: "0xd5aed4"
                   Frameless: false
-                - PC: "0xd5af2b"
+                - PC: "0xd5aeeb"
                   Frameless: false
               Condition: null
     - id: look_at_the_request
@@ -43,34 +43,34 @@ Probes:
           events:
             - Kind: Entry
               Type: 953 EventRootType Probe[main.LookAtTheRequest]
-              InjectionPoints: [{PC: "0xd5b02e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd5afee", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 954 EventRootType Probe[main.LookAtTheRequest]Return
-              InjectionPoints: [{PC: "0xd5b0bd", Frameless: false}]
+              InjectionPoints: [{PC: "0xd5b07d", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.HandleHTTP
-      OutOfLinePCRanges: [0xd5acc0..0xd5af5c]
+      OutOfLinePCRanges: [0xd5ac80..0xd5af1c]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 105 GoInterfaceType net/http.ResponseWriter
           Locations:
-            - Range: 0xd5acc0..0xd5ad2c
+            - Range: 0xd5ac80..0xd5acec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd5ad2c..0xd5ad2f
+            - Range: 0xd5acec..0xd5acef
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd5ad2f..0xd5af5c
+            - Range: 0xd5acef..0xd5af1c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -82,9 +82,9 @@ Subprograms:
         - Name: r
           Type: 106 PointerType *net/http.Request
           Locations:
-            - Range: 0xd5acc0..0xd5ad36
+            - Range: 0xd5ac80..0xd5acf6
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd5ad36..0xd5af5c
+            - Range: 0xd5acf6..0xd5af1c
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -92,7 +92,7 @@ Subprograms:
         - Name: span
           Type: 108 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
-            - Range: 0xd5ad48..0xd5ad81
+            - Range: 0xd5ad08..0xd5ad41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -100,9 +100,9 @@ Subprograms:
         - Name: '&buf'
           Type: 110 PointerType *bytes.Buffer
           Locations:
-            - Range: 0xd5ae58..0xd5ae7a
+            - Range: 0xd5ae18..0xd5ae3a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd5ae7a..0xd5af5c
+            - Range: 0xd5ae3a..0xd5af1c
               Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
           Role: Local
           DictIndex: -1
@@ -110,13 +110,13 @@ Subprograms:
       DictRegister: null
     - ID: 2
       Name: main.LookAtTheRequest
-      OutOfLinePCRanges: [0xd5b020..0xd5b0e5]
+      OutOfLinePCRanges: [0xd5afe0..0xd5b0a5]
       InlinePCRanges: []
       Variables:
         - Name: path
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd5b020..0xd5b045
+            - Range: 0xd5afe0..0xd5b005
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -20,14 +20,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1012 EventRootType Probe[main.HandleHTTP]
-              InjectionPoints: [{PC: "0xd32a93", Frameless: false}]
+              InjectionPoints: [{PC: "0xd32a53", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1013 EventRootType Probe[main.HandleHTTP]Return
               InjectionPoints:
-                - PC: "0xd32ccf"
+                - PC: "0xd32c8f"
                   Frameless: false
-                - PC: "0xd32ce5"
+                - PC: "0xd32ca5"
                   Frameless: false
               Condition: null
     - id: look_at_the_request
@@ -43,34 +43,34 @@ Probes:
           events:
             - Kind: Entry
               Type: 1014 EventRootType Probe[main.LookAtTheRequest]
-              InjectionPoints: [{PC: "0xd32dee", Frameless: false}]
+              InjectionPoints: [{PC: "0xd32dae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1015 EventRootType Probe[main.LookAtTheRequest]Return
-              InjectionPoints: [{PC: "0xd32e7d", Frameless: false}]
+              InjectionPoints: [{PC: "0xd32e3d", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.HandleHTTP
-      OutOfLinePCRanges: [0xd32a80..0xd32d19]
+      OutOfLinePCRanges: [0xd32a40..0xd32cd9]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 110 GoInterfaceType net/http.ResponseWriter
           Locations:
-            - Range: 0xd32a80..0xd32aec
+            - Range: 0xd32a40..0xd32aac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd32aec..0xd32aef
+            - Range: 0xd32aac..0xd32aaf
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd32aef..0xd32d19
+            - Range: 0xd32aaf..0xd32cd9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -82,9 +82,9 @@ Subprograms:
         - Name: r
           Type: 111 PointerType *net/http.Request
           Locations:
-            - Range: 0xd32a80..0xd32af6
+            - Range: 0xd32a40..0xd32ab6
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd32af6..0xd32d19
+            - Range: 0xd32ab6..0xd32cd9
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -92,7 +92,7 @@ Subprograms:
         - Name: span
           Type: 113 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
-            - Range: 0xd32b08..0xd32b41
+            - Range: 0xd32ac8..0xd32b01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -100,9 +100,9 @@ Subprograms:
         - Name: '&buf'
           Type: 115 PointerType *bytes.Buffer
           Locations:
-            - Range: 0xd32c17..0xd32c32
+            - Range: 0xd32bd7..0xd32bf2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd32c32..0xd32d19
+            - Range: 0xd32bf2..0xd32cd9
               Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
           Role: Local
           DictIndex: -1
@@ -110,13 +110,13 @@ Subprograms:
       DictRegister: null
     - ID: 2
       Name: main.LookAtTheRequest
-      OutOfLinePCRanges: [0xd32de0..0xd32ea5]
+      OutOfLinePCRanges: [0xd32da0..0xd32e65]
       InlinePCRanges: []
       Variables:
         - Name: path
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd32de0..0xd32e05
+            - Range: 0xd32da0..0xd32dc5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -20,14 +20,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1032 EventRootType Probe[main.HandleHTTP]
-              InjectionPoints: [{PC: "0xd37873", Frameless: false}]
+              InjectionPoints: [{PC: "0xd37853", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1033 EventRootType Probe[main.HandleHTTP]Return
               InjectionPoints:
-                - PC: "0xd37aaf"
+                - PC: "0xd37a8f"
                   Frameless: false
-                - PC: "0xd37ac5"
+                - PC: "0xd37aa5"
                   Frameless: false
               Condition: null
     - id: look_at_the_request
@@ -43,34 +43,34 @@ Probes:
           events:
             - Kind: Entry
               Type: 1034 EventRootType Probe[main.LookAtTheRequest]
-              InjectionPoints: [{PC: "0xd37bce", Frameless: false}]
+              InjectionPoints: [{PC: "0xd37bae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1035 EventRootType Probe[main.LookAtTheRequest]Return
-              InjectionPoints: [{PC: "0xd37c5d", Frameless: false}]
+              InjectionPoints: [{PC: "0xd37c3d", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.HandleHTTP
-      OutOfLinePCRanges: [0xd37860..0xd37af9]
+      OutOfLinePCRanges: [0xd37840..0xd37ad9]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 112 GoInterfaceType net/http.ResponseWriter
           Locations:
-            - Range: 0xd37860..0xd378cc
+            - Range: 0xd37840..0xd378ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd378cc..0xd378cf
+            - Range: 0xd378ac..0xd378af
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd378cf..0xd37af9
+            - Range: 0xd378af..0xd37ad9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -82,9 +82,9 @@ Subprograms:
         - Name: r
           Type: 113 PointerType *net/http.Request
           Locations:
-            - Range: 0xd37860..0xd378d6
+            - Range: 0xd37840..0xd378b6
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd378d6..0xd37af9
+            - Range: 0xd378b6..0xd37ad9
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -92,7 +92,7 @@ Subprograms:
         - Name: span
           Type: 115 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
-            - Range: 0xd378e8..0xd37921
+            - Range: 0xd378c8..0xd37901
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -100,9 +100,9 @@ Subprograms:
         - Name: '&buf'
           Type: 117 PointerType *bytes.Buffer
           Locations:
-            - Range: 0xd379f7..0xd37a12
+            - Range: 0xd379d7..0xd379f2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd37a12..0xd37af9
+            - Range: 0xd379f2..0xd37ad9
               Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
           Role: Local
           DictIndex: -1
@@ -110,13 +110,13 @@ Subprograms:
       DictRegister: null
     - ID: 2
       Name: main.LookAtTheRequest
-      OutOfLinePCRanges: [0xd37bc0..0xd37c85]
+      OutOfLinePCRanges: [0xd37ba0..0xd37c65]
       InlinePCRanges: []
       Variables:
         - Name: path
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd37bc0..0xd37be5
+            - Range: 0xd37ba0..0xd37bc5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.26rc1.yaml
@@ -20,14 +20,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1042 EventRootType Probe[main.HandleHTTP]
-              InjectionPoints: [{PC: "0xd42e93", Frameless: false}]
+              InjectionPoints: [{PC: "0xd42e53", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1043 EventRootType Probe[main.HandleHTTP]Return
               InjectionPoints:
-                - PC: "0xd430c2"
+                - PC: "0xd43082"
                   Frameless: false
-                - PC: "0xd430d6"
+                - PC: "0xd43096"
                   Frameless: false
               Condition: null
     - id: look_at_the_request
@@ -43,34 +43,34 @@ Probes:
           events:
             - Kind: Entry
               Type: 1044 EventRootType Probe[main.LookAtTheRequest]
-              InjectionPoints: [{PC: "0xd431ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xd4318e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1045 EventRootType Probe[main.LookAtTheRequest]Return
-              InjectionPoints: [{PC: "0xd4324b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd4320b", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.HandleHTTP
-      OutOfLinePCRanges: [0xd42e80..0xd43107]
+      OutOfLinePCRanges: [0xd42e40..0xd430c7]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 118 GoInterfaceType net/http.ResponseWriter
           Locations:
-            - Range: 0xd42e80..0xd42eec
+            - Range: 0xd42e40..0xd42eac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd42eec..0xd42eef
+            - Range: 0xd42eac..0xd42eaf
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd42eef..0xd43107
+            - Range: 0xd42eaf..0xd430c7
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -82,9 +82,9 @@ Subprograms:
         - Name: r
           Type: 119 PointerType *net/http.Request
           Locations:
-            - Range: 0xd42e80..0xd42ef6
+            - Range: 0xd42e40..0xd42eb6
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd42ef6..0xd43107
+            - Range: 0xd42eb6..0xd430c7
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -92,7 +92,7 @@ Subprograms:
         - Name: span
           Type: 121 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
-            - Range: 0xd42f08..0xd42f41
+            - Range: 0xd42ec8..0xd42f01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -100,9 +100,9 @@ Subprograms:
         - Name: '&buf'
           Type: 123 PointerType *bytes.Buffer
           Locations:
-            - Range: 0xd43009..0xd43024
+            - Range: 0xd42fc9..0xd42fe4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd43024..0xd43107
+            - Range: 0xd42fe4..0xd430c7
               Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
           Role: Local
           DictIndex: -1
@@ -110,13 +110,13 @@ Subprograms:
       DictRegister: null
     - ID: 2
       Name: main.LookAtTheRequest
-      OutOfLinePCRanges: [0xd431c0..0xd43274]
+      OutOfLinePCRanges: [0xd43180..0xd43234]
       InlinePCRanges: []
       Variables:
         - Name: path
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd431c0..0xd431e5
+            - Range: 0xd43180..0xd431a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -20,14 +20,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 951 EventRootType Probe[main.HandleHTTP]
-              InjectionPoints: [{PC: "0x8e1900", Frameless: false}]
+              InjectionPoints: [{PC: "0x8e18c0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 952 EventRootType Probe[main.HandleHTTP]Return
               InjectionPoints:
-                - PC: "0x8e1ad4"
+                - PC: "0x8e1a94"
                   Frameless: false
-                - PC: "0x8e1aec"
+                - PC: "0x8e1aac"
                   Frameless: false
               Condition: null
     - id: look_at_the_request
@@ -43,34 +43,34 @@ Probes:
           events:
             - Kind: Entry
               Type: 953 EventRootType Probe[main.LookAtTheRequest]
-              InjectionPoints: [{PC: "0x8e1c18", Frameless: false}]
+              InjectionPoints: [{PC: "0x8e1bd8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 954 EventRootType Probe[main.LookAtTheRequest]Return
-              InjectionPoints: [{PC: "0x8e1c8c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8e1c4c", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.HandleHTTP
-      OutOfLinePCRanges: [0x8e18e0..0x8e1b20]
+      OutOfLinePCRanges: [0x8e18a0..0x8e1ae0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 105 GoInterfaceType net/http.ResponseWriter
           Locations:
-            - Range: 0x8e18e0..0x8e1938
+            - Range: 0x8e18a0..0x8e18f8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8e1938..0x8e193c
+            - Range: 0x8e18f8..0x8e18fc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8e193c..0x8e1b20
+            - Range: 0x8e18fc..0x8e1ae0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -82,9 +82,9 @@ Subprograms:
         - Name: r
           Type: 106 PointerType *net/http.Request
           Locations:
-            - Range: 0x8e18e0..0x8e1944
+            - Range: 0x8e18a0..0x8e1904
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8e1944..0x8e1b20
+            - Range: 0x8e1904..0x8e1ae0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -92,7 +92,7 @@ Subprograms:
         - Name: span
           Type: 108 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
-            - Range: 0x8e1958..0x8e1988
+            - Range: 0x8e1918..0x8e1948
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -100,9 +100,9 @@ Subprograms:
         - Name: '&buf'
           Type: 110 PointerType *bytes.Buffer
           Locations:
-            - Range: 0x8e1a2c..0x8e1a48
+            - Range: 0x8e19ec..0x8e1a08
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8e1a48..0x8e1b20
+            - Range: 0x8e1a08..0x8e1ae0
               Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
           Role: Local
           DictIndex: -1
@@ -110,13 +110,13 @@ Subprograms:
       DictRegister: null
     - ID: 2
       Name: main.LookAtTheRequest
-      OutOfLinePCRanges: [0x8e1c00..0x8e1cc0]
+      OutOfLinePCRanges: [0x8e1bc0..0x8e1c80]
       InlinePCRanges: []
       Variables:
         - Name: path
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x8e1c00..0x8e1c24
+            - Range: 0x8e1bc0..0x8e1be4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -20,14 +20,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1012 EventRootType Probe[main.HandleHTTP]
-              InjectionPoints: [{PC: "0x8a2900", Frameless: false}]
+              InjectionPoints: [{PC: "0x8a28d0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1013 EventRootType Probe[main.HandleHTTP]Return
               InjectionPoints:
-                - PC: "0x8a2ad0"
+                - PC: "0x8a2aa0"
                   Frameless: false
-                - PC: "0x8a2ae8"
+                - PC: "0x8a2ab8"
                   Frameless: false
               Condition: null
     - id: look_at_the_request
@@ -43,34 +43,34 @@ Probes:
           events:
             - Kind: Entry
               Type: 1014 EventRootType Probe[main.LookAtTheRequest]
-              InjectionPoints: [{PC: "0x8a2bf8", Frameless: false}]
+              InjectionPoints: [{PC: "0x8a2bc8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1015 EventRootType Probe[main.LookAtTheRequest]Return
-              InjectionPoints: [{PC: "0x8a2c6c", Frameless: false}]
+              InjectionPoints: [{PC: "0x8a2c3c", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.HandleHTTP
-      OutOfLinePCRanges: [0x8a28e0..0x8a2b10]
+      OutOfLinePCRanges: [0x8a28b0..0x8a2ae0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 110 GoInterfaceType net/http.ResponseWriter
           Locations:
-            - Range: 0x8a28e0..0x8a2938
+            - Range: 0x8a28b0..0x8a2908
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8a2938..0x8a293c
+            - Range: 0x8a2908..0x8a290c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8a293c..0x8a2b10
+            - Range: 0x8a290c..0x8a2ae0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -82,9 +82,9 @@ Subprograms:
         - Name: r
           Type: 111 PointerType *net/http.Request
           Locations:
-            - Range: 0x8a28e0..0x8a2944
+            - Range: 0x8a28b0..0x8a2914
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8a2944..0x8a2b10
+            - Range: 0x8a2914..0x8a2ae0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -92,7 +92,7 @@ Subprograms:
         - Name: span
           Type: 113 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
-            - Range: 0x8a2958..0x8a2988
+            - Range: 0x8a2928..0x8a2958
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -100,9 +100,9 @@ Subprograms:
         - Name: '&buf'
           Type: 115 PointerType *bytes.Buffer
           Locations:
-            - Range: 0x8a2a2c..0x8a2a40
+            - Range: 0x8a29fc..0x8a2a10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8a2a40..0x8a2b10
+            - Range: 0x8a2a10..0x8a2ae0
               Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
           Role: Local
           DictIndex: -1
@@ -110,13 +110,13 @@ Subprograms:
       DictRegister: null
     - ID: 2
       Name: main.LookAtTheRequest
-      OutOfLinePCRanges: [0x8a2be0..0x8a2c90]
+      OutOfLinePCRanges: [0x8a2bb0..0x8a2c60]
       InlinePCRanges: []
       Variables:
         - Name: path
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8a2be0..0x8a2c04
+            - Range: 0x8a2bb0..0x8a2bd4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -20,14 +20,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1032 EventRootType Probe[main.HandleHTTP]
-              InjectionPoints: [{PC: "0x85b350", Frameless: false}]
+              InjectionPoints: [{PC: "0x85b320", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1033 EventRootType Probe[main.HandleHTTP]Return
               InjectionPoints:
-                - PC: "0x85b4f4"
+                - PC: "0x85b4c4"
                   Frameless: false
-                - PC: "0x85b50c"
+                - PC: "0x85b4dc"
                   Frameless: false
               Condition: null
     - id: look_at_the_request
@@ -43,34 +43,34 @@ Probes:
           events:
             - Kind: Entry
               Type: 1034 EventRootType Probe[main.LookAtTheRequest]
-              InjectionPoints: [{PC: "0x85b628", Frameless: false}]
+              InjectionPoints: [{PC: "0x85b5f8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1035 EventRootType Probe[main.LookAtTheRequest]Return
-              InjectionPoints: [{PC: "0x85b690", Frameless: false}]
+              InjectionPoints: [{PC: "0x85b660", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.HandleHTTP
-      OutOfLinePCRanges: [0x85b330..0x85b540]
+      OutOfLinePCRanges: [0x85b300..0x85b510]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 112 GoInterfaceType net/http.ResponseWriter
           Locations:
-            - Range: 0x85b330..0x85b384
+            - Range: 0x85b300..0x85b354
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x85b384..0x85b388
+            - Range: 0x85b354..0x85b358
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x85b388..0x85b540
+            - Range: 0x85b358..0x85b510
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -82,9 +82,9 @@ Subprograms:
         - Name: r
           Type: 113 PointerType *net/http.Request
           Locations:
-            - Range: 0x85b330..0x85b390
+            - Range: 0x85b300..0x85b360
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x85b390..0x85b540
+            - Range: 0x85b360..0x85b510
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -92,7 +92,7 @@ Subprograms:
         - Name: span
           Type: 115 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
-            - Range: 0x85b3a4..0x85b3d4
+            - Range: 0x85b374..0x85b3a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -100,9 +100,9 @@ Subprograms:
         - Name: '&buf'
           Type: 117 PointerType *bytes.Buffer
           Locations:
-            - Range: 0x85b460..0x85b478
+            - Range: 0x85b430..0x85b448
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x85b478..0x85b540
+            - Range: 0x85b448..0x85b510
               Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
           Role: Local
           DictIndex: -1
@@ -110,13 +110,13 @@ Subprograms:
       DictRegister: null
     - ID: 2
       Name: main.LookAtTheRequest
-      OutOfLinePCRanges: [0x85b610..0x85b6b0]
+      OutOfLinePCRanges: [0x85b5e0..0x85b680]
       InlinePCRanges: []
       Variables:
         - Name: path
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x85b610..0x85b634
+            - Range: 0x85b5e0..0x85b604
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.26rc1.yaml
@@ -20,14 +20,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1042 EventRootType Probe[main.HandleHTTP]
-              InjectionPoints: [{PC: "0x856060", Frameless: false}]
+              InjectionPoints: [{PC: "0x856020", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1043 EventRootType Probe[main.HandleHTTP]Return
               InjectionPoints:
-                - PC: "0x856200"
+                - PC: "0x8561c0"
                   Frameless: false
-                - PC: "0x856218"
+                - PC: "0x8561d8"
                   Frameless: false
               Condition: null
     - id: look_at_the_request
@@ -43,34 +43,34 @@ Probes:
           events:
             - Kind: Entry
               Type: 1044 EventRootType Probe[main.LookAtTheRequest]
-              InjectionPoints: [{PC: "0x856308", Frameless: false}]
+              InjectionPoints: [{PC: "0x8562c8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1045 EventRootType Probe[main.LookAtTheRequest]Return
-              InjectionPoints: [{PC: "0x856364", Frameless: false}]
+              InjectionPoints: [{PC: "0x856324", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.HandleHTTP
-      OutOfLinePCRanges: [0x856040..0x856240]
+      OutOfLinePCRanges: [0x856000..0x856200]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 118 GoInterfaceType net/http.ResponseWriter
           Locations:
-            - Range: 0x856040..0x856094
+            - Range: 0x856000..0x856054
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x856094..0x856098
+            - Range: 0x856054..0x856058
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x856098..0x856240
+            - Range: 0x856058..0x856200
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -82,9 +82,9 @@ Subprograms:
         - Name: r
           Type: 119 PointerType *net/http.Request
           Locations:
-            - Range: 0x856040..0x8560a0
+            - Range: 0x856000..0x856060
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8560a0..0x856240
+            - Range: 0x856060..0x856200
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -92,7 +92,7 @@ Subprograms:
         - Name: span
           Type: 121 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
-            - Range: 0x8560b4..0x8560e4
+            - Range: 0x856074..0x8560a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
           DictIndex: -1
@@ -100,9 +100,9 @@ Subprograms:
         - Name: '&buf'
           Type: 123 PointerType *bytes.Buffer
           Locations:
-            - Range: 0x85616c..0x856184
+            - Range: 0x85612c..0x856144
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x856184..0x856240
+            - Range: 0x856144..0x856200
               Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
           Role: Local
           DictIndex: -1
@@ -110,13 +110,13 @@ Subprograms:
       DictRegister: null
     - ID: 2
       Name: main.LookAtTheRequest
-      OutOfLinePCRanges: [0x8562f0..0x856390]
+      OutOfLinePCRanges: [0x8562b0..0x856350]
       InlinePCRanges: []
       Variables:
         - Name: path
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8562f0..0x856314
+            - Range: 0x8562b0..0x8562d4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -20,14 +20,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 936 EventRootType Probe[main.HandleHTTP]
-              InjectionPoints: [{PC: "0xd29ef3", Frameless: false}]
+              InjectionPoints: [{PC: "0xd29ed3", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 937 EventRootType Probe[main.HandleHTTP]Return
               InjectionPoints:
-                - PC: "0xd2a14b"
+                - PC: "0xd2a12b"
                   Frameless: false
-                - PC: "0xd2a15f"
+                - PC: "0xd2a13f"
                   Frameless: false
               Condition: null
     - id: look_at_the_request
@@ -43,34 +43,34 @@ Probes:
           events:
             - Kind: Entry
               Type: 938 EventRootType Probe[main.LookAtTheRequest]
-              InjectionPoints: [{PC: "0xd2a26e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd2a24e", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 939 EventRootType Probe[main.LookAtTheRequest]Return
-              InjectionPoints: [{PC: "0xd2a2fd", Frameless: false}]
+              InjectionPoints: [{PC: "0xd2a2dd", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.HandleHTTP
-      OutOfLinePCRanges: [0xd29ee0..0xd2a190]
+      OutOfLinePCRanges: [0xd29ec0..0xd2a170]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 105 GoInterfaceType net/http.ResponseWriter
           Locations:
-            - Range: 0xd29ee0..0xd29f4c
+            - Range: 0xd29ec0..0xd29f2c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd29f4c..0xd29f4f
+            - Range: 0xd29f2c..0xd29f2f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd29f4f..0xd2a190
+            - Range: 0xd29f2f..0xd2a170
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -82,9 +82,9 @@ Subprograms:
         - Name: r
           Type: 106 PointerType *net/http.Request
           Locations:
-            - Range: 0xd29ee0..0xd29f56
+            - Range: 0xd29ec0..0xd29f36
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd29f56..0xd2a190
+            - Range: 0xd29f36..0xd2a170
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -92,9 +92,9 @@ Subprograms:
         - Name: '&buf'
           Type: 108 PointerType *bytes.Buffer
           Locations:
-            - Range: 0xd2a08f..0xd2a0b1
+            - Range: 0xd2a06f..0xd2a091
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd2a0b1..0xd2a190
+            - Range: 0xd2a091..0xd2a170
               Pieces: [{Size: 8, Op: {CfaOffset: -136}}]
           Role: Local
           DictIndex: -1
@@ -102,19 +102,19 @@ Subprograms:
         - Name: span
           Type: 110 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
-            - Range: 0xd29f68..0xd29f68
+            - Range: 0xd29f48..0xd29f48
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0xd29f68..0xd29fa8
+            - Range: 0xd29f48..0xd29f88
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd29fa8..0xd29fac
+            - Range: 0xd29f88..0xd29f8c
               Pieces:
                 - Size: 8
                   Op: null
@@ -126,13 +126,13 @@ Subprograms:
       DictRegister: null
     - ID: 2
       Name: main.LookAtTheRequest
-      OutOfLinePCRanges: [0xd2a260..0xd2a325]
+      OutOfLinePCRanges: [0xd2a240..0xd2a305]
       InlinePCRanges: []
       Variables:
         - Name: path
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0xd2a260..0xd2a285
+            - Range: 0xd2a240..0xd2a265
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -20,14 +20,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 997 EventRootType Probe[main.HandleHTTP]
-              InjectionPoints: [{PC: "0xcfdd73", Frameless: false}]
+              InjectionPoints: [{PC: "0xcfdd53", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 998 EventRootType Probe[main.HandleHTTP]Return
               InjectionPoints:
-                - PC: "0xcfdfcb"
+                - PC: "0xcfdfab"
                   Frameless: false
-                - PC: "0xcfdfdf"
+                - PC: "0xcfdfbf"
                   Frameless: false
               Condition: null
     - id: look_at_the_request
@@ -43,34 +43,34 @@ Probes:
           events:
             - Kind: Entry
               Type: 999 EventRootType Probe[main.LookAtTheRequest]
-              InjectionPoints: [{PC: "0xcfe0ee", Frameless: false}]
+              InjectionPoints: [{PC: "0xcfe0ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1000 EventRootType Probe[main.LookAtTheRequest]Return
-              InjectionPoints: [{PC: "0xcfe17d", Frameless: false}]
+              InjectionPoints: [{PC: "0xcfe15d", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.HandleHTTP
-      OutOfLinePCRanges: [0xcfdd60..0xcfe010]
+      OutOfLinePCRanges: [0xcfdd40..0xcfdff0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 110 GoInterfaceType net/http.ResponseWriter
           Locations:
-            - Range: 0xcfdd60..0xcfddcc
+            - Range: 0xcfdd40..0xcfddac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcfddcc..0xcfddcf
+            - Range: 0xcfddac..0xcfddaf
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcfddcf..0xcfe010
+            - Range: 0xcfddaf..0xcfdff0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -82,9 +82,9 @@ Subprograms:
         - Name: r
           Type: 111 PointerType *net/http.Request
           Locations:
-            - Range: 0xcfdd60..0xcfddd6
+            - Range: 0xcfdd40..0xcfddb6
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcfddd6..0xcfe010
+            - Range: 0xcfddb6..0xcfdff0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -92,9 +92,9 @@ Subprograms:
         - Name: '&buf'
           Type: 113 PointerType *bytes.Buffer
           Locations:
-            - Range: 0xcfdf0e..0xcfdf29
+            - Range: 0xcfdeee..0xcfdf09
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcfdf29..0xcfe010
+            - Range: 0xcfdf09..0xcfdff0
               Pieces: [{Size: 8, Op: {CfaOffset: -136}}]
           Role: Local
           DictIndex: -1
@@ -102,19 +102,19 @@ Subprograms:
         - Name: span
           Type: 115 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
-            - Range: 0xcfdde8..0xcfdde8
+            - Range: 0xcfddc8..0xcfddc8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0xcfdde8..0xcfde28
+            - Range: 0xcfddc8..0xcfde08
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcfde28..0xcfde2c
+            - Range: 0xcfde08..0xcfde0c
               Pieces:
                 - Size: 8
                   Op: null
@@ -126,13 +126,13 @@ Subprograms:
       DictRegister: null
     - ID: 2
       Name: main.LookAtTheRequest
-      OutOfLinePCRanges: [0xcfe0e0..0xcfe1a5]
+      OutOfLinePCRanges: [0xcfe0c0..0xcfe185]
       InlinePCRanges: []
       Variables:
         - Name: path
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xcfe0e0..0xcfe105
+            - Range: 0xcfe0c0..0xcfe0e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -20,14 +20,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1019 EventRootType Probe[main.HandleHTTP]
-              InjectionPoints: [{PC: "0xd06393", Frameless: false}]
+              InjectionPoints: [{PC: "0xd06353", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1020 EventRootType Probe[main.HandleHTTP]Return
               InjectionPoints:
-                - PC: "0xd065eb"
+                - PC: "0xd065ab"
                   Frameless: false
-                - PC: "0xd065ff"
+                - PC: "0xd065bf"
                   Frameless: false
               Condition: null
     - id: look_at_the_request
@@ -43,34 +43,34 @@ Probes:
           events:
             - Kind: Entry
               Type: 1021 EventRootType Probe[main.LookAtTheRequest]
-              InjectionPoints: [{PC: "0xd0670e", Frameless: false}]
+              InjectionPoints: [{PC: "0xd066ce", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1022 EventRootType Probe[main.LookAtTheRequest]Return
-              InjectionPoints: [{PC: "0xd0679d", Frameless: false}]
+              InjectionPoints: [{PC: "0xd0675d", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.HandleHTTP
-      OutOfLinePCRanges: [0xd06380..0xd06630]
+      OutOfLinePCRanges: [0xd06340..0xd065f0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 112 GoInterfaceType net/http.ResponseWriter
           Locations:
-            - Range: 0xd06380..0xd063ec
+            - Range: 0xd06340..0xd063ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd063ec..0xd063ef
+            - Range: 0xd063ac..0xd063af
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd063ef..0xd06630
+            - Range: 0xd063af..0xd065f0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -82,9 +82,9 @@ Subprograms:
         - Name: r
           Type: 113 PointerType *net/http.Request
           Locations:
-            - Range: 0xd06380..0xd063f6
+            - Range: 0xd06340..0xd063b6
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd063f6..0xd06630
+            - Range: 0xd063b6..0xd065f0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -92,9 +92,9 @@ Subprograms:
         - Name: '&buf'
           Type: 115 PointerType *bytes.Buffer
           Locations:
-            - Range: 0xd0652e..0xd06549
+            - Range: 0xd064ee..0xd06509
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd06549..0xd06630
+            - Range: 0xd06509..0xd065f0
               Pieces: [{Size: 8, Op: {CfaOffset: -136}}]
           Role: Local
           DictIndex: -1
@@ -102,19 +102,19 @@ Subprograms:
         - Name: span
           Type: 117 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
-            - Range: 0xd06408..0xd06408
+            - Range: 0xd063c8..0xd063c8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0xd06408..0xd06448
+            - Range: 0xd063c8..0xd06408
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd06448..0xd0644c
+            - Range: 0xd06408..0xd0640c
               Pieces:
                 - Size: 8
                   Op: null
@@ -126,13 +126,13 @@ Subprograms:
       DictRegister: null
     - ID: 2
       Name: main.LookAtTheRequest
-      OutOfLinePCRanges: [0xd06700..0xd067c5]
+      OutOfLinePCRanges: [0xd066c0..0xd06785]
       InlinePCRanges: []
       Variables:
         - Name: path
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd06700..0xd06725
+            - Range: 0xd066c0..0xd066e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.26rc1.yaml
@@ -20,14 +20,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1029 EventRootType Probe[main.HandleHTTP]
-              InjectionPoints: [{PC: "0xd11493", Frameless: false}]
+              InjectionPoints: [{PC: "0xd11473", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1030 EventRootType Probe[main.HandleHTTP]Return
               InjectionPoints:
-                - PC: "0xd116d0"
+                - PC: "0xd116b0"
                   Frameless: false
-                - PC: "0xd116e5"
+                - PC: "0xd116c5"
                   Frameless: false
               Condition: null
     - id: look_at_the_request
@@ -43,34 +43,34 @@ Probes:
           events:
             - Kind: Entry
               Type: 1031 EventRootType Probe[main.LookAtTheRequest]
-              InjectionPoints: [{PC: "0xd117ce", Frameless: false}]
+              InjectionPoints: [{PC: "0xd117ae", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1032 EventRootType Probe[main.LookAtTheRequest]Return
-              InjectionPoints: [{PC: "0xd1184b", Frameless: false}]
+              InjectionPoints: [{PC: "0xd1182b", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.HandleHTTP
-      OutOfLinePCRanges: [0xd11480..0xd11719]
+      OutOfLinePCRanges: [0xd11460..0xd116f9]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 118 GoInterfaceType net/http.ResponseWriter
           Locations:
-            - Range: 0xd11480..0xd114ec
+            - Range: 0xd11460..0xd114cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd114ec..0xd114ef
+            - Range: 0xd114cc..0xd114cf
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd114ef..0xd11719
+            - Range: 0xd114cf..0xd116f9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -82,9 +82,9 @@ Subprograms:
         - Name: r
           Type: 119 PointerType *net/http.Request
           Locations:
-            - Range: 0xd11480..0xd114f6
+            - Range: 0xd11460..0xd114d6
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd114f6..0xd11719
+            - Range: 0xd114d6..0xd116f9
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
           DictIndex: -1
@@ -92,9 +92,9 @@ Subprograms:
         - Name: '&buf'
           Type: 121 PointerType *bytes.Buffer
           Locations:
-            - Range: 0xd11618..0xd11633
+            - Range: 0xd115f8..0xd11613
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd11633..0xd11719
+            - Range: 0xd11613..0xd116f9
               Pieces: [{Size: 8, Op: {CfaOffset: -136}}]
           Role: Local
           DictIndex: -1
@@ -102,19 +102,19 @@ Subprograms:
         - Name: span
           Type: 123 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
-            - Range: 0xd11508..0xd11508
+            - Range: 0xd114e8..0xd114e8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0xd11508..0xd11548
+            - Range: 0xd114e8..0xd11528
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd11548..0xd1154c
+            - Range: 0xd11528..0xd1152c
               Pieces:
                 - Size: 8
                   Op: null
@@ -126,13 +126,13 @@ Subprograms:
       DictRegister: null
     - ID: 2
       Name: main.LookAtTheRequest
-      OutOfLinePCRanges: [0xd117c0..0xd11874]
+      OutOfLinePCRanges: [0xd117a0..0xd11854]
       InlinePCRanges: []
       Variables:
         - Name: path
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd117c0..0xd117e5
+            - Range: 0xd117a0..0xd117c5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -20,14 +20,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 936 EventRootType Probe[main.HandleHTTP]
-              InjectionPoints: [{PC: "0x8af230", Frameless: false}]
+              InjectionPoints: [{PC: "0x8af1f0", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 937 EventRootType Probe[main.HandleHTTP]Return
               InjectionPoints:
-                - PC: "0x8af40c"
+                - PC: "0x8af3cc"
                   Frameless: false
-                - PC: "0x8af424"
+                - PC: "0x8af3e4"
                   Frameless: false
               Condition: null
     - id: look_at_the_request
@@ -43,34 +43,34 @@ Probes:
           events:
             - Kind: Entry
               Type: 938 EventRootType Probe[main.LookAtTheRequest]
-              InjectionPoints: [{PC: "0x8af558", Frameless: false}]
+              InjectionPoints: [{PC: "0x8af518", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 939 EventRootType Probe[main.LookAtTheRequest]Return
-              InjectionPoints: [{PC: "0x8af5cc", Frameless: false}]
+              InjectionPoints: [{PC: "0x8af58c", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.HandleHTTP
-      OutOfLinePCRanges: [0x8af210..0x8af460]
+      OutOfLinePCRanges: [0x8af1d0..0x8af420]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 105 GoInterfaceType net/http.ResponseWriter
           Locations:
-            - Range: 0x8af210..0x8af268
+            - Range: 0x8af1d0..0x8af228
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8af268..0x8af26c
+            - Range: 0x8af228..0x8af22c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8af26c..0x8af460
+            - Range: 0x8af22c..0x8af420
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -82,9 +82,9 @@ Subprograms:
         - Name: r
           Type: 106 PointerType *net/http.Request
           Locations:
-            - Range: 0x8af210..0x8af274
+            - Range: 0x8af1d0..0x8af234
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8af274..0x8af460
+            - Range: 0x8af234..0x8af420
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -92,9 +92,9 @@ Subprograms:
         - Name: '&buf'
           Type: 108 PointerType *bytes.Buffer
           Locations:
-            - Range: 0x8af364..0x8af380
+            - Range: 0x8af324..0x8af340
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8af380..0x8af460
+            - Range: 0x8af340..0x8af420
               Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
           Role: Local
           DictIndex: -1
@@ -102,19 +102,19 @@ Subprograms:
         - Name: span
           Type: 110 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
-            - Range: 0x8af288..0x8af288
+            - Range: 0x8af248..0x8af248
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x8af288..0x8af2c0
+            - Range: 0x8af248..0x8af280
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8af2c0..0x8af2c4
+            - Range: 0x8af280..0x8af284
               Pieces:
                 - Size: 8
                   Op: null
@@ -126,13 +126,13 @@ Subprograms:
       DictRegister: null
     - ID: 2
       Name: main.LookAtTheRequest
-      OutOfLinePCRanges: [0x8af540..0x8af600]
+      OutOfLinePCRanges: [0x8af500..0x8af5c0]
       InlinePCRanges: []
       Variables:
         - Name: path
           Type: 13 GoStringHeaderType string
           Locations:
-            - Range: 0x8af540..0x8af564
+            - Range: 0x8af500..0x8af524
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -20,14 +20,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 997 EventRootType Probe[main.HandleHTTP]
-              InjectionPoints: [{PC: "0x86dd70", Frameless: false}]
+              InjectionPoints: [{PC: "0x86dd40", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 998 EventRootType Probe[main.HandleHTTP]Return
               InjectionPoints:
-                - PC: "0x86df48"
+                - PC: "0x86df18"
                   Frameless: false
-                - PC: "0x86df60"
+                - PC: "0x86df30"
                   Frameless: false
               Condition: null
     - id: look_at_the_request
@@ -43,34 +43,34 @@ Probes:
           events:
             - Kind: Entry
               Type: 999 EventRootType Probe[main.LookAtTheRequest]
-              InjectionPoints: [{PC: "0x86e078", Frameless: false}]
+              InjectionPoints: [{PC: "0x86e048", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1000 EventRootType Probe[main.LookAtTheRequest]Return
-              InjectionPoints: [{PC: "0x86e0ec", Frameless: false}]
+              InjectionPoints: [{PC: "0x86e0bc", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.HandleHTTP
-      OutOfLinePCRanges: [0x86dd50..0x86df90]
+      OutOfLinePCRanges: [0x86dd20..0x86df60]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 110 GoInterfaceType net/http.ResponseWriter
           Locations:
-            - Range: 0x86dd50..0x86dda8
+            - Range: 0x86dd20..0x86dd78
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x86dda8..0x86ddac
+            - Range: 0x86dd78..0x86dd7c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x86ddac..0x86df90
+            - Range: 0x86dd7c..0x86df60
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -82,9 +82,9 @@ Subprograms:
         - Name: r
           Type: 111 PointerType *net/http.Request
           Locations:
-            - Range: 0x86dd50..0x86ddb4
+            - Range: 0x86dd20..0x86dd84
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x86ddb4..0x86df90
+            - Range: 0x86dd84..0x86df60
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -92,9 +92,9 @@ Subprograms:
         - Name: '&buf'
           Type: 113 PointerType *bytes.Buffer
           Locations:
-            - Range: 0x86dea4..0x86deb8
+            - Range: 0x86de74..0x86de88
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x86deb8..0x86df90
+            - Range: 0x86de88..0x86df60
               Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
           Role: Local
           DictIndex: -1
@@ -102,19 +102,19 @@ Subprograms:
         - Name: span
           Type: 115 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
-            - Range: 0x86ddc8..0x86ddc8
+            - Range: 0x86dd98..0x86dd98
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x86ddc8..0x86de00
+            - Range: 0x86dd98..0x86ddd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x86de00..0x86de04
+            - Range: 0x86ddd0..0x86ddd4
               Pieces:
                 - Size: 8
                   Op: null
@@ -126,13 +126,13 @@ Subprograms:
       DictRegister: null
     - ID: 2
       Name: main.LookAtTheRequest
-      OutOfLinePCRanges: [0x86e060..0x86e110]
+      OutOfLinePCRanges: [0x86e030..0x86e0e0]
       InlinePCRanges: []
       Variables:
         - Name: path
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x86e060..0x86e084
+            - Range: 0x86e030..0x86e054
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -20,14 +20,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1019 EventRootType Probe[main.HandleHTTP]
-              InjectionPoints: [{PC: "0x82cad0", Frameless: false}]
+              InjectionPoints: [{PC: "0x82ca90", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1020 EventRootType Probe[main.HandleHTTP]Return
               InjectionPoints:
-                - PC: "0x82cc98"
+                - PC: "0x82cc58"
                   Frameless: false
-                - PC: "0x82ccb0"
+                - PC: "0x82cc70"
                   Frameless: false
               Condition: null
     - id: look_at_the_request
@@ -43,34 +43,34 @@ Probes:
           events:
             - Kind: Entry
               Type: 1021 EventRootType Probe[main.LookAtTheRequest]
-              InjectionPoints: [{PC: "0x82cdc8", Frameless: false}]
+              InjectionPoints: [{PC: "0x82cd88", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1022 EventRootType Probe[main.LookAtTheRequest]Return
-              InjectionPoints: [{PC: "0x82ce30", Frameless: false}]
+              InjectionPoints: [{PC: "0x82cdf0", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.HandleHTTP
-      OutOfLinePCRanges: [0x82cab0..0x82cce0]
+      OutOfLinePCRanges: [0x82ca70..0x82cca0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 112 GoInterfaceType net/http.ResponseWriter
           Locations:
-            - Range: 0x82cab0..0x82cb04
+            - Range: 0x82ca70..0x82cac4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x82cb04..0x82cb08
+            - Range: 0x82cac4..0x82cac8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x82cb08..0x82cce0
+            - Range: 0x82cac8..0x82cca0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -82,9 +82,9 @@ Subprograms:
         - Name: r
           Type: 113 PointerType *net/http.Request
           Locations:
-            - Range: 0x82cab0..0x82cb10
+            - Range: 0x82ca70..0x82cad0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x82cb10..0x82cce0
+            - Range: 0x82cad0..0x82cca0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -92,9 +92,9 @@ Subprograms:
         - Name: '&buf'
           Type: 115 PointerType *bytes.Buffer
           Locations:
-            - Range: 0x82cbfc..0x82cc18
+            - Range: 0x82cbbc..0x82cbd8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x82cc18..0x82cce0
+            - Range: 0x82cbd8..0x82cca0
               Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
           Role: Local
           DictIndex: -1
@@ -102,13 +102,13 @@ Subprograms:
         - Name: span
           Type: 117 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
-            - Range: 0x82cb24..0x82cb24
+            - Range: 0x82cae4..0x82cae4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x82cb24..0x82cb64
+            - Range: 0x82cae4..0x82cb24
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -120,13 +120,13 @@ Subprograms:
       DictRegister: null
     - ID: 2
       Name: main.LookAtTheRequest
-      OutOfLinePCRanges: [0x82cdb0..0x82ce50]
+      OutOfLinePCRanges: [0x82cd70..0x82ce10]
       InlinePCRanges: []
       Variables:
         - Name: path
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x82cdb0..0x82cdd4
+            - Range: 0x82cd70..0x82cd94
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.26rc1.yaml
@@ -20,14 +20,14 @@ Probes:
           events:
             - Kind: Entry
               Type: 1029 EventRootType Probe[main.HandleHTTP]
-              InjectionPoints: [{PC: "0x827860", Frameless: false}]
+              InjectionPoints: [{PC: "0x827820", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1030 EventRootType Probe[main.HandleHTTP]Return
               InjectionPoints:
-                - PC: "0x827a24"
+                - PC: "0x8279e4"
                   Frameless: false
-                - PC: "0x827a3c"
+                - PC: "0x8279fc"
                   Frameless: false
               Condition: null
     - id: look_at_the_request
@@ -43,34 +43,34 @@ Probes:
           events:
             - Kind: Entry
               Type: 1031 EventRootType Probe[main.LookAtTheRequest]
-              InjectionPoints: [{PC: "0x827b38", Frameless: false}]
+              InjectionPoints: [{PC: "0x827af8", Frameless: false}]
               Condition: null
             - Kind: Return
               Type: 1032 EventRootType Probe[main.LookAtTheRequest]Return
-              InjectionPoints: [{PC: "0x827b94", Frameless: false}]
+              InjectionPoints: [{PC: "0x827b54", Frameless: false}]
               Condition: null
 Subprograms:
     - ID: 1
       Name: main.HandleHTTP
-      OutOfLinePCRanges: [0x827840..0x827a70]
+      OutOfLinePCRanges: [0x827800..0x827a30]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 118 GoInterfaceType net/http.ResponseWriter
           Locations:
-            - Range: 0x827840..0x827894
+            - Range: 0x827800..0x827854
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x827894..0x827898
+            - Range: 0x827854..0x827858
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x827898..0x827a70
+            - Range: 0x827858..0x827a30
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -82,9 +82,9 @@ Subprograms:
         - Name: r
           Type: 119 PointerType *net/http.Request
           Locations:
-            - Range: 0x827840..0x8278a0
+            - Range: 0x827800..0x827860
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8278a0..0x827a70
+            - Range: 0x827860..0x827a30
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
           DictIndex: -1
@@ -92,9 +92,9 @@ Subprograms:
         - Name: '&buf'
           Type: 121 PointerType *bytes.Buffer
           Locations:
-            - Range: 0x827988..0x8279a4
+            - Range: 0x827948..0x827964
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8279a4..0x827a70
+            - Range: 0x827964..0x827a30
               Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
           Role: Local
           DictIndex: -1
@@ -102,13 +102,13 @@ Subprograms:
         - Name: span
           Type: 123 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
-            - Range: 0x8278b4..0x8278b4
+            - Range: 0x827874..0x827874
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x8278b4..0x8278f4
+            - Range: 0x827874..0x8278b4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -120,13 +120,13 @@ Subprograms:
       DictRegister: null
     - ID: 2
       Name: main.LookAtTheRequest
-      OutOfLinePCRanges: [0x827b20..0x827bc0]
+      OutOfLinePCRanges: [0x827ae0..0x827b80]
       InlinePCRanges: []
       Variables:
         - Name: path
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x827b20..0x827b44
+            - Range: 0x827ae0..0x827b04
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,40 +1,40 @@
 === yield 1 [final=true] ===
 Package: main
-	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
-		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])
-		Arg: r: *net/http.Request (declared at line 82, available: [82-91])
-		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-85])
-		Var: &buf: *bytes.Buffer (declared at line 88, available: [82-91])
-		Var: .autotmp_14: context.backgroundCtx (declared at line 212, available: [82-91])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [80:89] injectible: [80-89]
+		Arg: w: net/http.ResponseWriter (declared at line 80, available: [80-89])
+		Arg: r: *net/http.Request (declared at line 80, available: [80-89])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 81, available: [82-83])
+		Var: &buf: *bytes.Buffer (declared at line 86, available: [80-89])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 212, available: [80-89])
 	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )
 		Var: format: string (declared at line 398, available: [398-398])
 		Var: v: []interface {} (declared at line 398, available: [398-398])
-	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [94:96] injectible: [94-96]
-		Arg: path: string (declared at line 94, available: [94-95])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [92:94] injectible: [92-94]
+		Arg: path: string (declared at line 92, available: [92-93])
 	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )
 		Var: format: string (declared at line 398, available: [398-398])
 		Var: v: []interface {} (declared at line 398, available: [398-398])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:80] injectible: [26-29], [33-35], [37-37], [39-41], [44-45], [49-50], [53-55], [57-57], [60-62], [64-64], [66-67], [69-73], [75-75], [77-80]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:78] injectible: [26-29], [33-33], [35-35], [37-39], [42-43], [47-48], [51-53], [55-55], [58-60], [62-62], [64-65], [67-71], [73-73], [75-78]
 		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
-		Var: tracerEnabled: bool (declared at line 33, available: [26-80])
-		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 69, available: [66-80])
-		Var: port: int (declared at line 66, available: [67-67])
-		Var: s: *net/http.Server (declared at line 71, available: [66-80])
-		Var: ctx: context.Context (declared at line 27, available: [26-80])
-		Var: ln: net.Listener (declared at line 60, available: [26-80])
-		Var: err: error (declared at line 60, available: [61-62])
-		Var: .autotmp_38: context.backgroundCtx (declared at line 212, available: [26-80])
+		Var: tracerEnabled: bool (declared at line 33, available: [35-35])
+		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 67, available: [64-78])
+		Var: port: int (declared at line 64, available: [65-65])
+		Var: s: *net/http.Server (declared at line 69, available: [64-78])
+		Var: ctx: context.Context (declared at line 27, available: [26-78])
+		Var: ln: net.Listener (declared at line 58, available: [26-78])
+		Var: err: error (declared at line 58, available: [59-60])
+		Var: .autotmp_38: context.backgroundCtx (declared at line 212, available: [26-78])
 		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
 		Var: ~r0.len: int (declared at line 236, available: )
-		Scope: 40-64
-			Var: ddAgentHost: string (declared at line 40, available: [41-64])
-			Var: ddAgentPort: string (declared at line 44, available: [41-53])
-			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
-			Var: err: error (declared at line 53, available: [54-55])
+		Scope: 38-62
+			Var: ddAgentHost: string (declared at line 38, available: [39-62])
+			Var: ddAgentPort: string (declared at line 42, available: [39-51])
+			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 46, available: [51-51])
+			Var: err: error (declared at line 51, available: [52-53])
 	Function: main.Printf.func4 (main.main.Printf.func4) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,40 +1,40 @@
 === yield 1 [final=true] ===
 Package: main
-	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
-		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])
-		Arg: r: *net/http.Request (declared at line 82, available: [82-91])
-		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-85])
-		Var: &buf: *bytes.Buffer (declared at line 88, available: [82-91])
-		Var: .autotmp_14: context.backgroundCtx (declared at line 216, available: [82-91])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [80:89] injectible: [80-89]
+		Arg: w: net/http.ResponseWriter (declared at line 80, available: [80-89])
+		Arg: r: *net/http.Request (declared at line 80, available: [80-89])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 81, available: [82-83])
+		Var: &buf: *bytes.Buffer (declared at line 86, available: [80-89])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 216, available: [80-89])
 	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )
 		Var: format: string (declared at line 398, available: [398-398])
 		Var: v: []interface {} (declared at line 398, available: [398-398])
-	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [94:96] injectible: [94-96]
-		Arg: path: string (declared at line 94, available: [94-95])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [92:94] injectible: [92-94]
+		Arg: path: string (declared at line 92, available: [92-93])
 	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )
 		Var: format: string (declared at line 398, available: [398-398])
 		Var: v: []interface {} (declared at line 398, available: [398-398])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:80] injectible: [26-29], [33-35], [37-37], [39-41], [44-45], [49-50], [53-55], [57-57], [60-62], [64-64], [66-67], [69-73], [75-75], [77-80]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:78] injectible: [26-29], [33-33], [35-35], [37-39], [42-43], [47-48], [51-53], [55-55], [58-60], [62-62], [64-65], [67-71], [73-73], [75-78]
 		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
-		Var: tracerEnabled: bool (declared at line 33, available: [26-80])
-		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 69, available: [66-80])
-		Var: port: int (declared at line 66, available: [67-67])
-		Var: s: *net/http.Server (declared at line 71, available: [66-80])
-		Var: ctx: context.Context (declared at line 27, available: [26-80])
-		Var: ln: net.Listener (declared at line 60, available: [26-80])
-		Var: err: error (declared at line 60, available: [61-62])
-		Var: .autotmp_38: context.backgroundCtx (declared at line 216, available: [26-80])
+		Var: tracerEnabled: bool (declared at line 33, available: [35-35])
+		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 67, available: [64-78])
+		Var: port: int (declared at line 64, available: [65-65])
+		Var: s: *net/http.Server (declared at line 69, available: [64-78])
+		Var: ctx: context.Context (declared at line 27, available: [26-78])
+		Var: ln: net.Listener (declared at line 58, available: [26-78])
+		Var: err: error (declared at line 58, available: [59-60])
+		Var: .autotmp_38: context.backgroundCtx (declared at line 216, available: [26-78])
 		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
 		Var: ~r0.len: int (declared at line 236, available: )
-		Scope: 40-64
-			Var: ddAgentHost: string (declared at line 40, available: [41-64])
-			Var: ddAgentPort: string (declared at line 44, available: [41-53])
-			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
-			Var: err: error (declared at line 53, available: [54-55])
+		Scope: 38-62
+			Var: ddAgentHost: string (declared at line 38, available: [39-62])
+			Var: ddAgentPort: string (declared at line 42, available: [39-51])
+			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 46, available: [51-51])
+			Var: err: error (declared at line 51, available: [52-53])
 	Function: main.Printf.func4 (main.main.Printf.func4) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,38 +1,38 @@
 === yield 1 [final=true] ===
 Package: main
-	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
-		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])
-		Arg: r: *net/http.Request (declared at line 82, available: [82-91])
-		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-85])
-		Var: &buf: *bytes.Buffer (declared at line 88, available: [82-91])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [80:89] injectible: [80-89]
+		Arg: w: net/http.ResponseWriter (declared at line 80, available: [80-89])
+		Arg: r: *net/http.Request (declared at line 80, available: [80-89])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 81, available: [82-83])
+		Var: &buf: *bytes.Buffer (declared at line 86, available: [80-89])
 	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )
 		Var: format: string (declared at line 409, available: [409-409])
 		Var: v: []interface {} (declared at line 409, available: [409-409])
-	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [94:96] injectible: [94-96]
-		Arg: path: string (declared at line 94, available: [94-95])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [92:94] injectible: [92-94]
+		Arg: path: string (declared at line 92, available: [92-93])
 	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )
 		Var: format: string (declared at line 409, available: [409-409])
 		Var: v: []interface {} (declared at line 409, available: [409-409])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:80] injectible: [26-29], [33-35], [37-37], [39-41], [44-45], [49-50], [53-55], [57-57], [60-62], [64-64], [66-67], [69-73], [75-75], [77-80]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:78] injectible: [26-29], [33-33], [35-35], [37-39], [42-43], [47-48], [51-53], [55-55], [58-60], [62-62], [64-65], [67-71], [73-73], [75-78]
 		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
-		Var: tracerEnabled: bool (declared at line 33, available: [26-80])
-		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 69, available: [66-80])
-		Var: port: int (declared at line 66, available: [67-67])
-		Var: s: *net/http.Server (declared at line 71, available: [66-80])
-		Var: ctx: context.Context (declared at line 27, available: [26-80])
-		Var: ln: net.Listener (declared at line 60, available: [26-80])
-		Var: err: error (declared at line 60, available: [61-62])
+		Var: tracerEnabled: bool (declared at line 33, available: [35-35])
+		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 67, available: [64-78])
+		Var: port: int (declared at line 64, available: [65-65])
+		Var: s: *net/http.Server (declared at line 69, available: [64-78])
+		Var: ctx: context.Context (declared at line 27, available: [26-78])
+		Var: ln: net.Listener (declared at line 58, available: [26-78])
+		Var: err: error (declared at line 58, available: [59-60])
 		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
 		Var: ~r0.len: int (declared at line 236, available: )
-		Scope: 40-64
-			Var: ddAgentHost: string (declared at line 40, available: [41-64])
-			Var: ddAgentPort: string (declared at line 44, available: [41-50])
-			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
-			Var: err: error (declared at line 53, available: [54-55])
+		Scope: 38-62
+			Var: ddAgentHost: string (declared at line 38, available: [39-62])
+			Var: ddAgentPort: string (declared at line 42, available: [39-48])
+			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 46, available: [51-51])
+			Var: err: error (declared at line 51, available: [52-53])
 	Function: main.Printf.func4 (main.main.Printf.func4) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1,38 +1,38 @@
 === yield 1 [final=true] ===
 Package: main
-	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
-		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])
-		Arg: r: *net/http.Request (declared at line 82, available: [82-91])
-		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-85])
-		Var: &buf: *bytes.Buffer (declared at line 88, available: [82-91])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [80:89] injectible: [80-89]
+		Arg: w: net/http.ResponseWriter (declared at line 80, available: [80-89])
+		Arg: r: *net/http.Request (declared at line 80, available: [80-89])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 81, available: [82-83])
+		Var: &buf: *bytes.Buffer (declared at line 86, available: [80-89])
 	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )
 		Var: format: string (declared at line 409, available: [409-409])
 		Var: v: []interface {} (declared at line 409, available: [409-409])
-	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [94:96] injectible: [94-96]
-		Arg: path: string (declared at line 94, available: [94-95])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [92:94] injectible: [92-94]
+		Arg: path: string (declared at line 92, available: [92-93])
 	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )
 		Var: format: string (declared at line 409, available: [409-409])
 		Var: v: []interface {} (declared at line 409, available: [409-409])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:80] injectible: [26-29], [33-35], [37-37], [39-41], [44-45], [48-50], [53-55], [57-57], [60-62], [64-64], [66-67], [69-73], [75-75], [77-80]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:78] injectible: [26-29], [33-33], [35-35], [37-39], [42-43], [46-48], [51-53], [55-55], [58-60], [62-62], [64-65], [67-71], [73-73], [75-78]
 		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
-		Var: tracerEnabled: bool (declared at line 33, available: [26-80])
-		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 69, available: [66-80])
-		Var: port: int (declared at line 66, available: [67-67])
-		Var: s: *net/http.Server (declared at line 71, available: [66-80])
-		Var: ctx: context.Context (declared at line 27, available: [26-80])
-		Var: ln: net.Listener (declared at line 60, available: [26-80])
-		Var: err: error (declared at line 60, available: [61-62])
+		Var: tracerEnabled: bool (declared at line 33, available: [35-35])
+		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 67, available: [64-78])
+		Var: port: int (declared at line 64, available: [65-65])
+		Var: s: *net/http.Server (declared at line 69, available: [64-78])
+		Var: ctx: context.Context (declared at line 27, available: [26-78])
+		Var: ln: net.Listener (declared at line 58, available: [26-78])
+		Var: err: error (declared at line 58, available: [59-60])
 		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
 		Var: ~r0.len: int (declared at line 236, available: )
-		Scope: 40-60
-			Var: ddAgentHost: string (declared at line 40, available: [41-60])
-			Var: ddAgentPort: string (declared at line 44, available: [41-49], [50-50])
-			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
-			Var: err: error (declared at line 53, available: [54-55])
+		Scope: 38-58
+			Var: ddAgentHost: string (declared at line 38, available: [39-58])
+			Var: ddAgentPort: string (declared at line 42, available: [39-47], [48-48])
+			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 46, available: [51-51])
+			Var: err: error (declared at line 51, available: [52-53])
 	Function: main.Printf.func4 (main.main.Printf.func4) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,40 +1,40 @@
 === yield 1 [final=true] ===
 Package: main
-	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
-		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])
-		Arg: r: *net/http.Request (declared at line 82, available: [82-91])
-		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-85])
-		Var: &buf: *bytes.Buffer (declared at line 88, available: [82-91])
-		Var: .autotmp_14: context.backgroundCtx (declared at line 212, available: [82-91])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [80:89] injectible: [80-89]
+		Arg: w: net/http.ResponseWriter (declared at line 80, available: [80-89])
+		Arg: r: *net/http.Request (declared at line 80, available: [80-89])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 81, available: [82-83])
+		Var: &buf: *bytes.Buffer (declared at line 86, available: [80-89])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 212, available: [80-89])
 	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )
 		Var: format: string (declared at line 398, available: [398-398])
 		Var: v: []interface {} (declared at line 398, available: [398-398])
-	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [94:96] injectible: [94-96]
-		Arg: path: string (declared at line 94, available: [94-95])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [92:94] injectible: [92-94]
+		Arg: path: string (declared at line 92, available: [92-93])
 	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )
 		Var: format: string (declared at line 398, available: [398-398])
 		Var: v: []interface {} (declared at line 398, available: [398-398])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:80] injectible: [26-29], [33-35], [37-37], [39-41], [44-45], [49-50], [53-55], [57-57], [60-62], [64-64], [66-67], [69-73], [75-75], [77-80]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:78] injectible: [26-29], [33-33], [35-35], [37-39], [42-43], [47-48], [51-53], [55-55], [58-60], [62-62], [64-65], [67-71], [73-73], [75-78]
 		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
-		Var: tracerEnabled: bool (declared at line 33, available: [26-80])
-		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 69, available: [66-80])
-		Var: port: int (declared at line 66, available: [67-67])
-		Var: s: *net/http.Server (declared at line 71, available: [66-80])
-		Var: ctx: context.Context (declared at line 27, available: [26-80])
-		Var: ln: net.Listener (declared at line 60, available: [26-80])
-		Var: err: error (declared at line 60, available: [61-62])
-		Var: .autotmp_38: context.backgroundCtx (declared at line 212, available: [26-80])
+		Var: tracerEnabled: bool (declared at line 33, available: [35-35])
+		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 67, available: [64-78])
+		Var: port: int (declared at line 64, available: [65-65])
+		Var: s: *net/http.Server (declared at line 69, available: [64-78])
+		Var: ctx: context.Context (declared at line 27, available: [26-78])
+		Var: ln: net.Listener (declared at line 58, available: [26-78])
+		Var: err: error (declared at line 58, available: [59-60])
+		Var: .autotmp_38: context.backgroundCtx (declared at line 212, available: [26-78])
 		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
 		Var: ~r0.len: int (declared at line 236, available: )
-		Scope: 40-64
-			Var: ddAgentHost: string (declared at line 40, available: [41-64])
-			Var: ddAgentPort: string (declared at line 44, available: [41-53])
-			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
-			Var: err: error (declared at line 53, available: [54-55])
+		Scope: 38-62
+			Var: ddAgentHost: string (declared at line 38, available: [39-62])
+			Var: ddAgentPort: string (declared at line 42, available: [39-51])
+			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 46, available: [51-51])
+			Var: err: error (declared at line 51, available: [52-53])
 	Function: main.Printf.func4 (main.main.Printf.func4) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,40 +1,40 @@
 === yield 1 [final=true] ===
 Package: main
-	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
-		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])
-		Arg: r: *net/http.Request (declared at line 82, available: [82-91])
-		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-85])
-		Var: &buf: *bytes.Buffer (declared at line 88, available: [82-91])
-		Var: .autotmp_14: context.backgroundCtx (declared at line 216, available: [82-91])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [80:89] injectible: [80-89]
+		Arg: w: net/http.ResponseWriter (declared at line 80, available: [80-89])
+		Arg: r: *net/http.Request (declared at line 80, available: [80-89])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 81, available: [82-83])
+		Var: &buf: *bytes.Buffer (declared at line 86, available: [80-89])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 216, available: [80-89])
 	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )
 		Var: format: string (declared at line 398, available: [398-398])
 		Var: v: []interface {} (declared at line 398, available: [398-398])
-	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [94:96] injectible: [94-96]
-		Arg: path: string (declared at line 94, available: [94-95])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [92:94] injectible: [92-94]
+		Arg: path: string (declared at line 92, available: [92-93])
 	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )
 		Var: format: string (declared at line 398, available: [398-398])
 		Var: v: []interface {} (declared at line 398, available: [398-398])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:80] injectible: [26-29], [33-35], [37-37], [39-41], [44-45], [49-50], [53-55], [57-57], [60-62], [64-64], [66-67], [69-73], [75-75], [77-80]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:78] injectible: [26-29], [33-33], [35-35], [37-39], [42-43], [47-48], [51-53], [55-55], [58-60], [62-62], [64-65], [67-71], [73-73], [75-78]
 		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
-		Var: tracerEnabled: bool (declared at line 33, available: [26-80])
-		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 69, available: [66-80])
-		Var: port: int (declared at line 66, available: [67-67])
-		Var: s: *net/http.Server (declared at line 71, available: [66-80])
-		Var: ctx: context.Context (declared at line 27, available: [26-80])
-		Var: ln: net.Listener (declared at line 60, available: [26-80])
-		Var: err: error (declared at line 60, available: [61-62])
-		Var: .autotmp_38: context.backgroundCtx (declared at line 216, available: [26-80])
+		Var: tracerEnabled: bool (declared at line 33, available: [35-35])
+		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 67, available: [64-78])
+		Var: port: int (declared at line 64, available: [65-65])
+		Var: s: *net/http.Server (declared at line 69, available: [64-78])
+		Var: ctx: context.Context (declared at line 27, available: [26-78])
+		Var: ln: net.Listener (declared at line 58, available: [26-78])
+		Var: err: error (declared at line 58, available: [59-60])
+		Var: .autotmp_38: context.backgroundCtx (declared at line 216, available: [26-78])
 		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
 		Var: ~r0.len: int (declared at line 236, available: )
-		Scope: 40-64
-			Var: ddAgentHost: string (declared at line 40, available: [41-64])
-			Var: ddAgentPort: string (declared at line 44, available: [41-53])
-			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
-			Var: err: error (declared at line 53, available: [54-55])
+		Scope: 38-62
+			Var: ddAgentHost: string (declared at line 38, available: [39-62])
+			Var: ddAgentPort: string (declared at line 42, available: [39-51])
+			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 46, available: [51-51])
+			Var: err: error (declared at line 51, available: [52-53])
 	Function: main.Printf.func4 (main.main.Printf.func4) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,38 +1,38 @@
 === yield 1 [final=true] ===
 Package: main
-	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
-		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])
-		Arg: r: *net/http.Request (declared at line 82, available: [82-91])
-		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-85])
-		Var: &buf: *bytes.Buffer (declared at line 88, available: [82-91])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [80:89] injectible: [80-89]
+		Arg: w: net/http.ResponseWriter (declared at line 80, available: [80-89])
+		Arg: r: *net/http.Request (declared at line 80, available: [80-89])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 81, available: [82-83])
+		Var: &buf: *bytes.Buffer (declared at line 86, available: [80-89])
 	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )
 		Var: format: string (declared at line 409, available: [409-409])
 		Var: v: []interface {} (declared at line 409, available: [409-409])
-	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [94:96] injectible: [94-96]
-		Arg: path: string (declared at line 94, available: [94-95])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [92:94] injectible: [92-94]
+		Arg: path: string (declared at line 92, available: [92-93])
 	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )
 		Var: format: string (declared at line 409, available: [409-409])
 		Var: v: []interface {} (declared at line 409, available: [409-409])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:80] injectible: [26-29], [33-35], [37-37], [39-41], [44-45], [49-50], [53-55], [57-57], [60-62], [64-64], [66-67], [69-73], [75-75], [77-80]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:78] injectible: [26-29], [33-33], [35-35], [37-39], [42-43], [47-48], [51-53], [55-55], [58-60], [62-62], [64-65], [67-71], [73-73], [75-78]
 		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
-		Var: tracerEnabled: bool (declared at line 33, available: [26-80])
-		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 69, available: [66-80])
-		Var: port: int (declared at line 66, available: [67-67])
-		Var: s: *net/http.Server (declared at line 71, available: [66-80])
-		Var: ctx: context.Context (declared at line 27, available: [26-80])
-		Var: ln: net.Listener (declared at line 60, available: [26-80])
-		Var: err: error (declared at line 60, available: [61-62])
+		Var: tracerEnabled: bool (declared at line 33, available: [35-35])
+		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 67, available: [64-78])
+		Var: port: int (declared at line 64, available: [65-65])
+		Var: s: *net/http.Server (declared at line 69, available: [64-78])
+		Var: ctx: context.Context (declared at line 27, available: [26-78])
+		Var: ln: net.Listener (declared at line 58, available: [26-78])
+		Var: err: error (declared at line 58, available: [59-60])
 		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
 		Var: ~r0.len: int (declared at line 236, available: )
-		Scope: 40-64
-			Var: ddAgentHost: string (declared at line 40, available: [41-64])
-			Var: ddAgentPort: string (declared at line 44, available: [41-53])
-			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 48, available: )
-			Var: err: error (declared at line 53, available: [54-55])
+		Scope: 38-62
+			Var: ddAgentHost: string (declared at line 38, available: [39-62])
+			Var: ddAgentPort: string (declared at line 42, available: [39-51])
+			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 46, available: )
+			Var: err: error (declared at line 51, available: [52-53])
 	Function: main.Printf.func4 (main.main.Printf.func4) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1,38 +1,38 @@
 === yield 1 [final=true] ===
 Package: main
-	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91] injectible: [82-91]
-		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])
-		Arg: r: *net/http.Request (declared at line 82, available: [82-91])
-		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-85])
-		Var: &buf: *bytes.Buffer (declared at line 88, available: [82-91])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [80:89] injectible: [80-89]
+		Arg: w: net/http.ResponseWriter (declared at line 80, available: [80-89])
+		Arg: r: *net/http.Request (declared at line 80, available: [80-89])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 81, available: [82-83])
+		Var: &buf: *bytes.Buffer (declared at line 86, available: [80-89])
 	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )
 		Var: format: string (declared at line 409, available: [409-409])
 		Var: v: []interface {} (declared at line 409, available: [409-409])
-	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [94:96] injectible: [94-96]
-		Arg: path: string (declared at line 94, available: [94-95])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [92:94] injectible: [92-94]
+		Arg: path: string (declared at line 92, available: [92-93])
 	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )
 		Var: format: string (declared at line 409, available: [409-409])
 		Var: v: []interface {} (declared at line 409, available: [409-409])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:80] injectible: [26-29], [33-35], [37-37], [39-41], [44-45], [48-50], [53-55], [57-57], [60-62], [64-64], [66-67], [69-73], [75-75], [77-80]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:78] injectible: [26-29], [33-33], [35-35], [37-39], [42-43], [46-48], [51-53], [55-55], [58-60], [62-62], [64-65], [67-71], [73-73], [75-78]
 		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
-		Var: tracerEnabled: bool (declared at line 33, available: [26-80])
-		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 69, available: [66-80])
-		Var: port: int (declared at line 66, available: [67-67])
-		Var: s: *net/http.Server (declared at line 71, available: [66-80])
-		Var: ctx: context.Context (declared at line 27, available: [26-80])
-		Var: ln: net.Listener (declared at line 60, available: [26-80])
-		Var: err: error (declared at line 60, available: [61-62])
+		Var: tracerEnabled: bool (declared at line 33, available: [35-35])
+		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 67, available: [64-78])
+		Var: port: int (declared at line 64, available: [65-65])
+		Var: s: *net/http.Server (declared at line 69, available: [64-78])
+		Var: ctx: context.Context (declared at line 27, available: [26-78])
+		Var: ln: net.Listener (declared at line 58, available: [26-78])
+		Var: err: error (declared at line 58, available: [59-60])
 		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
 		Var: ~r0.len: int (declared at line 236, available: )
-		Scope: 40-60
-			Var: ddAgentHost: string (declared at line 40, available: [41-60])
-			Var: ddAgentPort: string (declared at line 44, available: [41-53])
-			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 48, available: )
-			Var: err: error (declared at line 53, available: [54-55])
+		Scope: 38-58
+			Var: ddAgentHost: string (declared at line 38, available: [39-58])
+			Var: ddAgentPort: string (declared at line 42, available: [39-51])
+			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 46, available: )
+			Var: err: error (declared at line 51, available: [52-53])
 	Function: main.Printf.func4 (main.main.Printf.func4) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,39 +1,39 @@
 === yield 1 [final=true] ===
 Package: main
-	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [54:88] injectible: [54-54], [79-88]
-		Arg: w: net/http.ResponseWriter (declared at line 79, available: [54-88])
-		Arg: r: *net/http.Request (declared at line 79, available: [54-88])
-		Var: &buf: *bytes.Buffer (declared at line 85, available: [54-88])
-		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 80, available: [81-82])
-		Var: .autotmp_14: context.backgroundCtx (declared at line 212, available: [54-88])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [54:86] injectible: [54-54], [77-86]
+		Arg: w: net/http.ResponseWriter (declared at line 77, available: [54-86])
+		Arg: r: *net/http.Request (declared at line 77, available: [54-86])
+		Var: &buf: *bytes.Buffer (declared at line 83, available: [54-86])
+		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 78, available: [79-80])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 212, available: [54-86])
 	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )
 		Var: format: string (declared at line 398, available: [398-398])
 		Var: v: []interface {} (declared at line 398, available: [398-398])
-	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [91:93] injectible: [91-93]
-		Arg: path: string (declared at line 91, available: [91-92])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [89:91] injectible: [89-91]
+		Arg: path: string (declared at line 89, available: [89-90])
 	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )
 		Var: format: string (declared at line 398, available: [398-398])
 		Var: v: []interface {} (declared at line 398, available: [398-398])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:77] injectible: [26-29], [33-35], [37-37], [39-41], [44-45], [49-50], [53-54], [57-59], [61-61], [63-64], [66-70], [72-72], [74-77]
-		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 66, available: [63-77])
-		Var: port: int (declared at line 63, available: [64-64])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:75] injectible: [26-29], [33-33], [35-35], [37-39], [42-43], [47-48], [51-52], [55-57], [59-59], [61-62], [64-68], [70-70], [72-75]
+		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 64, available: [61-75])
+		Var: port: int (declared at line 61, available: [62-62])
 		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
-		Var: tracerEnabled: bool (declared at line 33, available: [26-77])
-		Var: s: *net/http.Server (declared at line 68, available: [63-77])
-		Var: ctx: context.Context (declared at line 27, available: [26-77])
-		Var: ln: net.Listener (declared at line 57, available: [26-77])
-		Var: err: error (declared at line 57, available: [58-59])
-		Var: .autotmp_35: context.backgroundCtx (declared at line 212, available: [26-77])
+		Var: tracerEnabled: bool (declared at line 33, available: [35-35])
+		Var: s: *net/http.Server (declared at line 66, available: [61-75])
+		Var: ctx: context.Context (declared at line 27, available: [26-75])
+		Var: ln: net.Listener (declared at line 55, available: [26-75])
+		Var: err: error (declared at line 55, available: [56-57])
+		Var: .autotmp_35: context.backgroundCtx (declared at line 212, available: [26-75])
 		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
 		Var: ~r0.len: int (declared at line 236, available: )
-		Scope: 40-61
-			Var: ddAgentHost: string (declared at line 40, available: [41-61])
-			Var: ddAgentPort: string (declared at line 44, available: [41-53])
-			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+		Scope: 38-59
+			Var: ddAgentHost: string (declared at line 38, available: [39-59])
+			Var: ddAgentPort: string (declared at line 42, available: [39-51])
+			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 46, available: [51-51])
 	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [405:406] injectible: [405-406]
 		Arg: b: []uint8 (declared at line 405, available: [405-406])
 		Arg: ~r0: []uint8 (declared at line 405, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,39 +1,39 @@
 === yield 1 [final=true] ===
 Package: main
-	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [54:88] injectible: [54-54], [79-88]
-		Arg: w: net/http.ResponseWriter (declared at line 79, available: [54-88])
-		Arg: r: *net/http.Request (declared at line 79, available: [54-88])
-		Var: &buf: *bytes.Buffer (declared at line 85, available: [54-88])
-		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 80, available: [81-82])
-		Var: .autotmp_14: context.backgroundCtx (declared at line 216, available: [54-88])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [54:86] injectible: [54-54], [77-86]
+		Arg: w: net/http.ResponseWriter (declared at line 77, available: [54-86])
+		Arg: r: *net/http.Request (declared at line 77, available: [54-86])
+		Var: &buf: *bytes.Buffer (declared at line 83, available: [54-86])
+		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 78, available: [79-80])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 216, available: [54-86])
 	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )
 		Var: format: string (declared at line 398, available: [398-398])
 		Var: v: []interface {} (declared at line 398, available: [398-398])
-	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [91:93] injectible: [91-93]
-		Arg: path: string (declared at line 91, available: [91-92])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [89:91] injectible: [89-91]
+		Arg: path: string (declared at line 89, available: [89-90])
 	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )
 		Var: format: string (declared at line 398, available: [398-398])
 		Var: v: []interface {} (declared at line 398, available: [398-398])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:77] injectible: [26-29], [33-35], [37-37], [39-41], [44-45], [49-50], [53-54], [57-59], [61-61], [63-64], [66-70], [72-72], [74-77]
-		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 66, available: [63-77])
-		Var: port: int (declared at line 63, available: [64-64])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:75] injectible: [26-29], [33-33], [35-35], [37-39], [42-43], [47-48], [51-52], [55-57], [59-59], [61-62], [64-68], [70-70], [72-75]
+		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 64, available: [61-75])
+		Var: port: int (declared at line 61, available: [62-62])
 		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
-		Var: tracerEnabled: bool (declared at line 33, available: [26-77])
-		Var: s: *net/http.Server (declared at line 68, available: [63-77])
-		Var: ctx: context.Context (declared at line 27, available: [26-77])
-		Var: ln: net.Listener (declared at line 57, available: [26-77])
-		Var: err: error (declared at line 57, available: [58-59])
-		Var: .autotmp_35: context.backgroundCtx (declared at line 216, available: [26-77])
+		Var: tracerEnabled: bool (declared at line 33, available: [35-35])
+		Var: s: *net/http.Server (declared at line 66, available: [61-75])
+		Var: ctx: context.Context (declared at line 27, available: [26-75])
+		Var: ln: net.Listener (declared at line 55, available: [26-75])
+		Var: err: error (declared at line 55, available: [56-57])
+		Var: .autotmp_35: context.backgroundCtx (declared at line 216, available: [26-75])
 		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
 		Var: ~r0.len: int (declared at line 236, available: )
-		Scope: 40-61
-			Var: ddAgentHost: string (declared at line 40, available: [41-61])
-			Var: ddAgentPort: string (declared at line 44, available: [41-53])
-			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+		Scope: 38-59
+			Var: ddAgentHost: string (declared at line 38, available: [39-59])
+			Var: ddAgentPort: string (declared at line 42, available: [39-51])
+			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 46, available: [51-51])
 	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [405:406] injectible: [405-406]
 		Arg: b: []uint8 (declared at line 405, available: [405-406])
 		Arg: ~r0: []uint8 (declared at line 405, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,37 +1,37 @@
 === yield 1 [final=true] ===
 Package: main
-	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [60:88] injectible: [60-60], [79-88]
-		Arg: w: net/http.ResponseWriter (declared at line 79, available: [60-88])
-		Arg: r: *net/http.Request (declared at line 79, available: [60-88])
-		Var: &buf: *bytes.Buffer (declared at line 85, available: [60-88])
-		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 80, available: [81-82])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [60:86] injectible: [60-60], [77-86]
+		Arg: w: net/http.ResponseWriter (declared at line 77, available: [60-86])
+		Arg: r: *net/http.Request (declared at line 77, available: [60-86])
+		Var: &buf: *bytes.Buffer (declared at line 83, available: [60-86])
+		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 78, available: [79-80])
 	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )
 		Var: format: string (declared at line 409, available: [409-409])
 		Var: v: []interface {} (declared at line 409, available: [409-409])
-	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [91:93] injectible: [91-93]
-		Arg: path: string (declared at line 91, available: [91-92])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [89:91] injectible: [89-91]
+		Arg: path: string (declared at line 89, available: [89-90])
 	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )
 		Var: format: string (declared at line 409, available: [409-409])
 		Var: v: []interface {} (declared at line 409, available: [409-409])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:77] injectible: [26-29], [33-35], [37-37], [39-41], [44-45], [49-50], [53-54], [57-59], [61-61], [63-64], [66-70], [72-72], [74-77]
-		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 66, available: [63-77])
-		Var: port: int (declared at line 63, available: [64-64])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:75] injectible: [26-29], [33-33], [35-35], [37-39], [42-43], [47-48], [51-52], [55-57], [59-59], [61-62], [64-68], [70-70], [72-75]
+		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 64, available: [61-75])
+		Var: port: int (declared at line 61, available: [62-62])
 		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
-		Var: tracerEnabled: bool (declared at line 33, available: [26-77])
-		Var: s: *net/http.Server (declared at line 68, available: [63-77])
-		Var: ctx: context.Context (declared at line 27, available: [26-77])
-		Var: ln: net.Listener (declared at line 57, available: [26-77])
-		Var: err: error (declared at line 57, available: [58-59])
+		Var: tracerEnabled: bool (declared at line 33, available: [35-35])
+		Var: s: *net/http.Server (declared at line 66, available: [61-75])
+		Var: ctx: context.Context (declared at line 27, available: [26-75])
+		Var: ln: net.Listener (declared at line 55, available: [26-75])
+		Var: err: error (declared at line 55, available: [56-57])
 		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
 		Var: ~r0.len: int (declared at line 236, available: )
-		Scope: 40-61
-			Var: ddAgentHost: string (declared at line 40, available: [41-61])
-			Var: ddAgentPort: string (declared at line 44, available: [41-50])
-			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+		Scope: 38-59
+			Var: ddAgentHost: string (declared at line 38, available: [39-59])
+			Var: ddAgentPort: string (declared at line 42, available: [39-48])
+			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 46, available: [51-51])
 	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [416:417] injectible: [416-417]
 		Arg: b: []uint8 (declared at line 416, available: [416-417])
 		Arg: ~r0: []uint8 (declared at line 416, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1,37 +1,37 @@
 === yield 1 [final=true] ===
 Package: main
-	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88] injectible: [79-88]
-		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])
-		Arg: r: *net/http.Request (declared at line 79, available: [79-88])
-		Var: &buf: *bytes.Buffer (declared at line 85, available: [79-88])
-		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 80, available: [81-82])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [77:86] injectible: [77-86]
+		Arg: w: net/http.ResponseWriter (declared at line 77, available: [77-86])
+		Arg: r: *net/http.Request (declared at line 77, available: [77-86])
+		Var: &buf: *bytes.Buffer (declared at line 83, available: [77-86])
+		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 78, available: [79-80])
 	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )
 		Var: format: string (declared at line 409, available: [409-409])
 		Var: v: []interface {} (declared at line 409, available: [409-409])
-	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [91:93] injectible: [91-93]
-		Arg: path: string (declared at line 91, available: [91-92])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [89:91] injectible: [89-91]
+		Arg: path: string (declared at line 89, available: [89-90])
 	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )
 		Var: format: string (declared at line 409, available: [409-409])
 		Var: v: []interface {} (declared at line 409, available: [409-409])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:77] injectible: [26-29], [33-35], [37-37], [39-41], [44-45], [48-50], [53-54], [57-59], [61-61], [63-64], [66-70], [72-72], [74-77]
-		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 66, available: [63-77])
-		Var: port: int (declared at line 63, available: [64-64])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:75] injectible: [26-29], [33-33], [35-35], [37-39], [42-43], [46-48], [51-52], [55-57], [59-59], [61-62], [64-68], [70-70], [72-75]
+		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 64, available: [61-75])
+		Var: port: int (declared at line 61, available: [62-62])
 		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
-		Var: tracerEnabled: bool (declared at line 33, available: [26-77])
-		Var: s: *net/http.Server (declared at line 68, available: [63-77])
-		Var: ctx: context.Context (declared at line 27, available: [26-77])
-		Var: ln: net.Listener (declared at line 57, available: [26-77])
-		Var: err: error (declared at line 57, available: [58-59])
+		Var: tracerEnabled: bool (declared at line 33, available: [35-35])
+		Var: s: *net/http.Server (declared at line 66, available: [61-75])
+		Var: ctx: context.Context (declared at line 27, available: [26-75])
+		Var: ln: net.Listener (declared at line 55, available: [26-75])
+		Var: err: error (declared at line 55, available: [56-57])
 		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
 		Var: ~r0.len: int (declared at line 236, available: )
-		Scope: 40-57
-			Var: ddAgentHost: string (declared at line 40, available: [41-57])
-			Var: ddAgentPort: string (declared at line 44, available: [41-49], [50-50])
-			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+		Scope: 38-55
+			Var: ddAgentHost: string (declared at line 38, available: [39-55])
+			Var: ddAgentPort: string (declared at line 42, available: [39-47], [48-48])
+			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 46, available: [51-51])
 	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [416:417] injectible: [416-417]
 		Arg: b: []uint8 (declared at line 416, available: [416-417])
 		Arg: ~r0: []uint8 (declared at line 416, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,39 +1,39 @@
 === yield 1 [final=true] ===
 Package: main
-	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88] injectible: [79-88]
-		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])
-		Arg: r: *net/http.Request (declared at line 79, available: [79-88])
-		Var: &buf: *bytes.Buffer (declared at line 85, available: [79-88])
-		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 80, available: [81-82])
-		Var: .autotmp_14: context.backgroundCtx (declared at line 212, available: [79-88])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [77:86] injectible: [77-86]
+		Arg: w: net/http.ResponseWriter (declared at line 77, available: [77-86])
+		Arg: r: *net/http.Request (declared at line 77, available: [77-86])
+		Var: &buf: *bytes.Buffer (declared at line 83, available: [77-86])
+		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 78, available: [79-80])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 212, available: [77-86])
 	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )
 		Var: format: string (declared at line 398, available: [398-398])
 		Var: v: []interface {} (declared at line 398, available: [398-398])
-	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [91:93] injectible: [91-93]
-		Arg: path: string (declared at line 91, available: [91-92])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [89:91] injectible: [89-91]
+		Arg: path: string (declared at line 89, available: [89-90])
 	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )
 		Var: format: string (declared at line 398, available: [398-398])
 		Var: v: []interface {} (declared at line 398, available: [398-398])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:77] injectible: [26-29], [33-35], [37-37], [39-41], [44-45], [49-50], [53-54], [57-59], [61-61], [63-64], [66-70], [72-72], [74-77]
-		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 66, available: [63-77])
-		Var: port: int (declared at line 63, available: [64-64])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:75] injectible: [26-29], [33-33], [35-35], [37-39], [42-43], [47-48], [51-52], [55-57], [59-59], [61-62], [64-68], [70-70], [72-75]
+		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 64, available: [61-75])
+		Var: port: int (declared at line 61, available: [62-62])
 		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
-		Var: tracerEnabled: bool (declared at line 33, available: [26-77])
-		Var: s: *net/http.Server (declared at line 68, available: [63-77])
-		Var: ctx: context.Context (declared at line 27, available: [26-77])
-		Var: ln: net.Listener (declared at line 57, available: [26-77])
-		Var: err: error (declared at line 57, available: [58-59])
-		Var: .autotmp_35: context.backgroundCtx (declared at line 212, available: [26-77])
+		Var: tracerEnabled: bool (declared at line 33, available: [35-35])
+		Var: s: *net/http.Server (declared at line 66, available: [61-75])
+		Var: ctx: context.Context (declared at line 27, available: [26-75])
+		Var: ln: net.Listener (declared at line 55, available: [26-75])
+		Var: err: error (declared at line 55, available: [56-57])
+		Var: .autotmp_35: context.backgroundCtx (declared at line 212, available: [26-75])
 		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
 		Var: ~r0.len: int (declared at line 236, available: )
-		Scope: 40-61
-			Var: ddAgentHost: string (declared at line 40, available: [41-61])
-			Var: ddAgentPort: string (declared at line 44, available: [41-53])
-			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+		Scope: 38-59
+			Var: ddAgentHost: string (declared at line 38, available: [39-59])
+			Var: ddAgentPort: string (declared at line 42, available: [39-51])
+			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 46, available: [51-51])
 	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [405:406] injectible: [405-406]
 		Arg: b: []uint8 (declared at line 405, available: [405-406])
 		Arg: ~r0: []uint8 (declared at line 405, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,39 +1,39 @@
 === yield 1 [final=true] ===
 Package: main
-	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88] injectible: [79-88]
-		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])
-		Arg: r: *net/http.Request (declared at line 79, available: [79-88])
-		Var: &buf: *bytes.Buffer (declared at line 85, available: [79-88])
-		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 80, available: [81-82])
-		Var: .autotmp_14: context.backgroundCtx (declared at line 216, available: [79-88])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [77:86] injectible: [77-86]
+		Arg: w: net/http.ResponseWriter (declared at line 77, available: [77-86])
+		Arg: r: *net/http.Request (declared at line 77, available: [77-86])
+		Var: &buf: *bytes.Buffer (declared at line 83, available: [77-86])
+		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 78, available: [79-80])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 216, available: [77-86])
 	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )
 		Var: format: string (declared at line 398, available: [398-398])
 		Var: v: []interface {} (declared at line 398, available: [398-398])
-	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [91:93] injectible: [91-93]
-		Arg: path: string (declared at line 91, available: [91-92])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [89:91] injectible: [89-91]
+		Arg: path: string (declared at line 89, available: [89-90])
 	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398] injectible: [397-398]
 		Arg: b: []uint8 (declared at line 397, available: [397-398])
 		Arg: ~r0: []uint8 (declared at line 397, available: )
 		Var: format: string (declared at line 398, available: [398-398])
 		Var: v: []interface {} (declared at line 398, available: [398-398])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:77] injectible: [26-29], [33-35], [37-37], [39-41], [44-45], [49-50], [53-54], [57-59], [61-61], [63-64], [66-70], [72-72], [74-77]
-		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 66, available: [63-77])
-		Var: port: int (declared at line 63, available: [64-64])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:75] injectible: [26-29], [33-33], [35-35], [37-39], [42-43], [47-48], [51-52], [55-57], [59-59], [61-62], [64-68], [70-70], [72-75]
+		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 64, available: [61-75])
+		Var: port: int (declared at line 61, available: [62-62])
 		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
-		Var: tracerEnabled: bool (declared at line 33, available: [26-77])
-		Var: s: *net/http.Server (declared at line 68, available: [63-77])
-		Var: ctx: context.Context (declared at line 27, available: [26-77])
-		Var: ln: net.Listener (declared at line 57, available: [26-77])
-		Var: err: error (declared at line 57, available: [58-59])
-		Var: .autotmp_35: context.backgroundCtx (declared at line 216, available: [26-77])
+		Var: tracerEnabled: bool (declared at line 33, available: [35-35])
+		Var: s: *net/http.Server (declared at line 66, available: [61-75])
+		Var: ctx: context.Context (declared at line 27, available: [26-75])
+		Var: ln: net.Listener (declared at line 55, available: [26-75])
+		Var: err: error (declared at line 55, available: [56-57])
+		Var: .autotmp_35: context.backgroundCtx (declared at line 216, available: [26-75])
 		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
 		Var: ~r0.len: int (declared at line 236, available: )
-		Scope: 40-61
-			Var: ddAgentHost: string (declared at line 40, available: [41-61])
-			Var: ddAgentPort: string (declared at line 44, available: [41-53])
-			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+		Scope: 38-59
+			Var: ddAgentHost: string (declared at line 38, available: [39-59])
+			Var: ddAgentPort: string (declared at line 42, available: [39-51])
+			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 46, available: [51-51])
 	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [405:406] injectible: [405-406]
 		Arg: b: []uint8 (declared at line 405, available: [405-406])
 		Arg: ~r0: []uint8 (declared at line 405, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,37 +1,37 @@
 === yield 1 [final=true] ===
 Package: main
-	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88] injectible: [79-88]
-		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])
-		Arg: r: *net/http.Request (declared at line 79, available: [79-88])
-		Var: &buf: *bytes.Buffer (declared at line 85, available: [79-88])
-		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 80, available: [81-82])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [77:86] injectible: [77-86]
+		Arg: w: net/http.ResponseWriter (declared at line 77, available: [77-86])
+		Arg: r: *net/http.Request (declared at line 77, available: [77-86])
+		Var: &buf: *bytes.Buffer (declared at line 83, available: [77-86])
+		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 78, available: [79-80])
 	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )
 		Var: format: string (declared at line 409, available: [409-409])
 		Var: v: []interface {} (declared at line 409, available: [409-409])
-	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [91:93] injectible: [91-93]
-		Arg: path: string (declared at line 91, available: [91-92])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [89:91] injectible: [89-91]
+		Arg: path: string (declared at line 89, available: [89-90])
 	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )
 		Var: format: string (declared at line 409, available: [409-409])
 		Var: v: []interface {} (declared at line 409, available: [409-409])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:77] injectible: [26-29], [33-35], [37-37], [39-41], [44-45], [49-50], [53-54], [57-59], [61-61], [63-64], [66-70], [72-72], [74-77]
-		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 66, available: [63-77])
-		Var: port: int (declared at line 63, available: [64-64])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:75] injectible: [26-29], [33-33], [35-35], [37-39], [42-43], [47-48], [51-52], [55-57], [59-59], [61-62], [64-68], [70-70], [72-75]
+		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 64, available: [61-75])
+		Var: port: int (declared at line 61, available: [62-62])
 		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
-		Var: tracerEnabled: bool (declared at line 33, available: [26-77])
-		Var: s: *net/http.Server (declared at line 68, available: [63-77])
-		Var: ctx: context.Context (declared at line 27, available: [26-77])
-		Var: ln: net.Listener (declared at line 57, available: [26-77])
-		Var: err: error (declared at line 57, available: [58-59])
+		Var: tracerEnabled: bool (declared at line 33, available: [35-35])
+		Var: s: *net/http.Server (declared at line 66, available: [61-75])
+		Var: ctx: context.Context (declared at line 27, available: [26-75])
+		Var: ln: net.Listener (declared at line 55, available: [26-75])
+		Var: err: error (declared at line 55, available: [56-57])
 		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
 		Var: ~r0.len: int (declared at line 236, available: )
-		Scope: 40-61
-			Var: ddAgentHost: string (declared at line 40, available: [41-61])
-			Var: ddAgentPort: string (declared at line 44, available: [41-53])
-			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 48, available: )
+		Scope: 38-59
+			Var: ddAgentHost: string (declared at line 38, available: [39-59])
+			Var: ddAgentPort: string (declared at line 42, available: [39-51])
+			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 46, available: )
 	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [416:417] injectible: [416-417]
 		Arg: b: []uint8 (declared at line 416, available: [416-417])
 		Arg: ~r0: []uint8 (declared at line 416, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1,37 +1,37 @@
 === yield 1 [final=true] ===
 Package: main
-	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88] injectible: [79-88]
-		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])
-		Arg: r: *net/http.Request (declared at line 79, available: [79-88])
-		Var: &buf: *bytes.Buffer (declared at line 85, available: [79-88])
-		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 80, available: [81-82])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [77:86] injectible: [77-86]
+		Arg: w: net/http.ResponseWriter (declared at line 77, available: [77-86])
+		Arg: r: *net/http.Request (declared at line 77, available: [77-86])
+		Var: &buf: *bytes.Buffer (declared at line 83, available: [77-86])
+		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 78, available: [79-80])
 	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )
 		Var: format: string (declared at line 409, available: [409-409])
 		Var: v: []interface {} (declared at line 409, available: [409-409])
-	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [91:93] injectible: [91-93]
-		Arg: path: string (declared at line 91, available: [91-92])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [89:91] injectible: [89-91]
+		Arg: path: string (declared at line 89, available: [89-90])
 	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [408:409] injectible: [408-409]
 		Arg: b: []uint8 (declared at line 408, available: [408-409])
 		Arg: ~r0: []uint8 (declared at line 408, available: )
 		Var: format: string (declared at line 409, available: [409-409])
 		Var: v: []interface {} (declared at line 409, available: [409-409])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:77] injectible: [26-29], [33-35], [37-37], [39-41], [44-45], [48-50], [53-54], [57-59], [61-61], [63-64], [66-70], [72-72], [74-77]
-		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 66, available: [63-77])
-		Var: port: int (declared at line 63, available: [64-64])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:75] injectible: [26-29], [33-33], [35-35], [37-39], [42-43], [46-48], [51-52], [55-57], [59-59], [61-62], [64-68], [70-70], [72-75]
+		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 64, available: [61-75])
+		Var: port: int (declared at line 61, available: [62-62])
 		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
-		Var: tracerEnabled: bool (declared at line 33, available: [26-77])
-		Var: s: *net/http.Server (declared at line 68, available: [63-77])
-		Var: ctx: context.Context (declared at line 27, available: [26-77])
-		Var: ln: net.Listener (declared at line 57, available: [26-77])
-		Var: err: error (declared at line 57, available: [58-59])
+		Var: tracerEnabled: bool (declared at line 33, available: [35-35])
+		Var: s: *net/http.Server (declared at line 66, available: [61-75])
+		Var: ctx: context.Context (declared at line 27, available: [26-75])
+		Var: ln: net.Listener (declared at line 55, available: [26-75])
+		Var: err: error (declared at line 55, available: [56-57])
 		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
 		Var: ~r0.len: int (declared at line 236, available: )
-		Scope: 40-57
-			Var: ddAgentHost: string (declared at line 40, available: [41-57])
-			Var: ddAgentPort: string (declared at line 44, available: [41-53])
-			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 48, available: )
+		Scope: 38-55
+			Var: ddAgentHost: string (declared at line 38, available: [39-55])
+			Var: ddAgentPort: string (declared at line 42, available: [39-51])
+			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 46, available: )
 	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [416:417] injectible: [416-417]
 		Arg: b: []uint8 (declared at line 416, available: [416-417])
 		Arg: ~r0: []uint8 (declared at line 416, available: )

--- a/pkg/dyninst/testprogs/progs/rc_tester/main.go
+++ b/pkg/dyninst/testprogs/progs/rc_tester/main.go
@@ -30,9 +30,7 @@ func main() {
 		log.Println("Stopping sample process")
 	}()
 
-	tracerEnabled := os.Getenv("DD_SERVICE") != "" &&
-		os.Getenv("DD_DYNAMIC_INSTRUMENTATION_ENABLED") != "" &&
-		os.Getenv("DD_DYNAMIC_INSTRUMENTATION_OFFLINE") == ""
+	tracerEnabled := os.Getenv("DD_SERVICE") != ""
 
 	log.Println("Starting sample process with tracerEnabled=", tracerEnabled)
 

--- a/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go
+++ b/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go
@@ -30,9 +30,7 @@ func main() {
 		log.Println("Stopping sample process")
 	}()
 
-	tracerEnabled := os.Getenv("DD_SERVICE") != "" &&
-		os.Getenv("DD_DYNAMIC_INSTRUMENTATION_ENABLED") != "" &&
-		os.Getenv("DD_DYNAMIC_INSTRUMENTATION_OFFLINE") == ""
+	tracerEnabled := os.Getenv("DD_SERVICE") != ""
 
 	log.Println("Starting sample process with tracerEnabled=", tracerEnabled)
 


### PR DESCRIPTION
This test program was only starting the tracer when DD_DYNAMIC_INSTRUMENTATION_ENABLED was set. I want to use this program for testing remote enablement, for example, so let's always start the tracer. I don't think there was a good reason for the old behavior.

