### PR TITLE
[AGENTRUN-1452][AGENTRUN-1453] fix(expvars): embed time/tzdata in tests to fix Windows CI flake

### DIFF
--- a/pkg/collector/runner/expvars/expvars_test.go
+++ b/pkg/collector/runner/expvars/expvars_test.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Embeds the IANA timezone database in the `expvars` test binary by importing `_ "time/tzdata"`.

### Motivation

`TestExpvarsRunningStats` and `TestTimestamp` flake on Windows CI because `time.LoadLocation("America/New_York")` fails when the system tz database is missing. Embedding `time/tzdata` fixes this on all platforms.

### Describe how you validated your changes

CI

### Additional Notes