### PR TITLE
[SVLS-9526] Prototype: serverless-init inventory payload + 9-platform POC deploy scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.idea
+.vscode
+__pycache__
+*.pyc
+bin

--- a/cmd/serverless-init/diagnostic/BUILD.bazel
+++ b/cmd/serverless-init/diagnostic/BUILD.bazel
@@ -1,0 +1,201 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+
+go_library(
+    name = "diagnostic",
+    srcs = ["diagnostic.go"],
+    importpath = "github.com/DataDog/datadog-agent/cmd/serverless-init/diagnostic",
+    visibility = ["//visibility:public"],
+    deps = select({
+        "@rules_go//go/platform:aix": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//pkg/config/setup",
+            "//pkg/serverless/tags",
+            "//pkg/util/uuid",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:android": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//pkg/config/setup",
+            "//pkg/serverless/tags",
+            "//pkg/util/uuid",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//pkg/config/setup",
+            "//pkg/serverless/tags",
+            "//pkg/util/uuid",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:dragonfly": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//pkg/config/setup",
+            "//pkg/serverless/tags",
+            "//pkg/util/uuid",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:freebsd": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//pkg/config/setup",
+            "//pkg/serverless/tags",
+            "//pkg/util/uuid",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:illumos": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//pkg/config/setup",
+            "//pkg/serverless/tags",
+            "//pkg/util/uuid",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:ios": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//pkg/config/setup",
+            "//pkg/serverless/tags",
+            "//pkg/util/uuid",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:js": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//pkg/config/setup",
+            "//pkg/serverless/tags",
+            "//pkg/util/uuid",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//pkg/config/setup",
+            "//pkg/serverless/tags",
+            "//pkg/util/uuid",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:netbsd": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//pkg/config/setup",
+            "//pkg/serverless/tags",
+            "//pkg/util/uuid",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:openbsd": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//pkg/config/setup",
+            "//pkg/serverless/tags",
+            "//pkg/util/uuid",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:osx": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//pkg/config/setup",
+            "//pkg/serverless/tags",
+            "//pkg/util/uuid",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:plan9": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//pkg/config/setup",
+            "//pkg/serverless/tags",
+            "//pkg/util/uuid",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:qnx": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//pkg/config/setup",
+            "//pkg/serverless/tags",
+            "//pkg/util/uuid",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:solaris": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//pkg/config/setup",
+            "//pkg/serverless/tags",
+            "//pkg/util/uuid",
+            "//pkg/version",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+dd_agent_go_test(
+    name = "diagnostic_test",
+    srcs = ["diagnostic_test.go"],
+    embed = [":diagnostic"],
+    deps = select({
+        "@rules_go//go/platform:aix": [
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:android": [
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:dragonfly": [
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:freebsd": [
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:illumos": [
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:ios": [
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:js": [
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:netbsd": [
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:openbsd": [
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:osx": [
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:plan9": [
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:qnx": [
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:solaris": [
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/cmd/serverless-init/diagnostic/diagnostic.go
+++ b/cmd/serverless-init/diagnostic/diagnostic.go
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+// Package diagnostic provides optional startup-time diagnostic logging for
+// serverless-init. Enable by setting DD_SERVERLESS_DIAGNOSTIC_INFO=true.
+//
+// When enabled, logs all environment variables (with secrets masked), key
+// agent configuration values, and mode/origin detection results on startup.
+//
+// WARNING: Output may contain sensitive values. Do not enable in production.
+package diagnostic
+
+import (
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/mode"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const diagnosticEnvVar = "DD_SERVERLESS_DIAGNOSTIC_INFO"
+
+// secretKeywords are substrings whose presence in an env var name triggers masking.
+var secretKeywords = []string{"API_KEY", "SECRET", "PASSWORD", "TOKEN"}
+
+// LogIfEnabled logs diagnostic startup information when DD_SERVERLESS_DIAGNOSTIC_INFO=true.
+// Call once after DetectMode and GetCloudServiceType, before fxutil.OneShot.
+func LogIfEnabled(modeConf mode.Conf, cs cloudservice.CloudService) {
+	if strings.ToLower(os.Getenv(diagnosticEnvVar)) != "true" {
+		return
+	}
+
+	log.Infof("[SERVERLESS_DIAGNOSTIC] mode=%s sidecar=%v origin=%s",
+		modeConf.LoggerName, modeConf.SidecarMode, cs.GetOrigin())
+
+	envVars := os.Environ()
+	sort.Strings(envVars)
+	log.Infof("[SERVERLESS_DIAGNOSTIC] env_var_count=%d", len(envVars))
+	for _, e := range envVars {
+		log.Infof("[SERVERLESS_DIAGNOSTIC] env: %s", maskSecret(e))
+	}
+
+	cfg := pkgconfigsetup.Datadog()
+	log.Infof("[SERVERLESS_DIAGNOSTIC] config: dd_site=%s logs_enabled=%v apm_enabled=%v rc_enabled=%v api_key_present=%v",
+		cfg.GetString("dd_site"),
+		cfg.GetBool("logs_enabled"),
+		cfg.GetBool("apm_config.enabled"),
+		cfg.GetBool("remote_configuration.enabled"),
+		cfg.GetString("api_key") != "",
+	)
+}
+
+// maskSecret replaces the value portion of a KEY=value pair with *** when the
+// key contains a known secret keyword. Non-secret vars are returned unchanged.
+func maskSecret(kv string) string {
+	parts := strings.SplitN(kv, "=", 2)
+	if len(parts) != 2 {
+		return kv
+	}
+	upper := strings.ToUpper(parts[0])
+	for _, keyword := range secretKeywords {
+		if strings.Contains(upper, keyword) {
+			return parts[0] + "=***"
+		}
+	}
+	return kv
+}

--- a/cmd/serverless-init/diagnostic/diagnostic.go
+++ b/cmd/serverless-init/diagnostic/diagnostic.go
@@ -15,20 +15,66 @@
 package diagnostic
 
 import (
+	"fmt"
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/mode"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	servertags "github.com/DataDog/datadog-agent/pkg/serverless/tags"
+	pkgversion "github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/DataDog/datadog-agent/pkg/util/uuid"
 )
 
 const diagnosticEnvVar = "DD_SERVERLESS_DIAGNOSTIC_INFO"
 
 // secretKeywords are substrings whose presence in an env var name triggers masking.
 var secretKeywords = []string{"API_KEY", "SECRET", "PASSWORD", "TOKEN"}
+
+// envDescriptions maps known environment variable names to a short human-readable
+// description shown alongside the value in diagnostic output.
+var envDescriptions = map[string]string{
+	// Datadog configuration
+	"DD_API_KEY":                          "Datadog API key (masked)",
+	"DD_SITE":                             "Datadog intake site (e.g. datadoghq.com, datadoghq.eu)",
+	"DD_SERVICE":                          "Service name used for tagging all telemetry",
+	"DD_ENV":                              "Deployment environment tag (dev/staging/prod)",
+	"DD_VERSION":                          "App version tag for deployments",
+	"DD_LOGS_ENABLED":                     "Enable log collection and forwarding to Datadog",
+	"DD_APM_ENABLED":                      "Enable APM trace collection",
+	"DD_TRACE_ENABLED":                    "Enable distributed tracing via ddtrace",
+	"DD_HOSTNAME":                         "Override the hostname reported to Datadog",
+	"DD_REMOTE_CONFIGURATION_ENABLED":     "Enable Remote Configuration (live config updates from Datadog UI)",
+	"DD_SERVERLESS_DIAGNOSTIC_INFO":       "Enable this diagnostic output on startup",
+	"DD_INSTRUMENTATION_TELEMETRY_ENABLED": "Send ddtrace instrumentation telemetry to Datadog",
+	// Cloud Run platform
+	"K_SERVICE":                 "Cloud Run service name",
+	"K_REVISION":                "Current Cloud Run revision (e.g. myservice-00005-abc)",
+	"K_CONFIGURATION":           "Cloud Run configuration name",
+	"PORT":                      "Port the container must listen on",
+	"CLOUD_RUN_TIMEOUT_SECONDS": "Maximum request handling time before Cloud Run terminates the instance",
+	// Python base image
+	"PYTHON_VERSION": "Python runtime version injected by the python base image",
+	"PYTHON_SHA256":  "SHA256 checksum of the Python release tarball",
+	"GPG_KEY":        "GPG key used to verify the Python release",
+	// Node base image
+	"NODE_VERSION": "Node.js runtime version injected by the node base image",
+	// Standard
+	"PATH": "Executable search path",
+	"HOME": "Home directory of the running user",
+	"PWD":  "Current working directory",
+	"LANG": "System locale",
+}
+
+// diag writes a single SERVERLESS_DIAGNOSTIC line to stdout. Using fmt.Fprintf
+// (not log.Infof) ensures output is visible in Cloud Logging even when called
+// before the Fx logger is initialized.
+func diag(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stdout, "[SERVERLESS_DIAGNOSTIC] "+format+"\n", args...)
+}
 
 // LogIfEnabled logs diagnostic startup information when DD_SERVERLESS_DIAGNOSTIC_INFO=true.
 // Call once after DetectMode and GetCloudServiceType, before fxutil.OneShot.
@@ -37,24 +83,129 @@ func LogIfEnabled(modeConf mode.Conf, cs cloudservice.CloudService) {
 		return
 	}
 
-	log.Infof("[SERVERLESS_DIAGNOSTIC] mode=%s sidecar=%v origin=%s",
-		modeConf.LoggerName, modeConf.SidecarMode, cs.GetOrigin())
+	agentVersion := "(unknown)"
+	if v, err := pkgversion.Agent(); err == nil {
+		agentVersion = v.String()
+	}
+	commit := pkgversion.Commit
+	if commit == "" {
+		commit = "(unknown)"
+	}
+	// Agent version = underlying agent release (e.g. 7.83.0-dev for branch builds, 7.81.2 for releases).
+	// The official serverless-init image tag (e.g. 1.10.2) maps 1:1 to an agent release; Datadog's CI
+	// sets both. To correlate: gcr.io/datadoghq/serverless-init:1.10.2 was built from agent 7.81.2.
+	diag("agent version:           %s  # Datadog Agent release this binary is built from; official serverless-init tag (e.g. 1.10.2) maps 1:1 to this", agentVersion)
+	diag("commit:                  %s  # git SHA of the source — for branch builds this identifies the exact code running", commit)
+	diag("serverless_init_version: %s  # Docker image tag (e.g. 1.10.0); injected at build time via -ldflags (pkg/serverless/tags.currentExtensionVersion)", servertags.GetExtensionVersion())
+	diag("started:      %s", time.Now().UTC().Format(time.RFC3339))
+	diag("mode:         %s", modeConf.LoggerName)
+	diag("sidecar:      %v", modeConf.SidecarMode)
+	if modeConf.SidecarMode {
+		diag("deployment_model: sidecar        # serverless-init runs as a sidecar; the app is a separate container")
+		diag("wrapped_command:  (none — sidecar mode)")
+	} else {
+		wrappedCmd := strings.Join(os.Args[1:], " ")
+		if wrappedCmd == "" {
+			wrappedCmd = "(none)"
+		}
+		diag("deployment_model: init-container  # serverless-init wraps the app command")
+		diag("wrapped_command:  %s", wrappedCmd)
+	}
+	diag("origin:       %s  # cloud platform detected at runtime (cloudrun, cloudrunfunctions, azure, etc.)", cs.GetOrigin())
+	diag("build_tags:   serverless,otlp  # compile-time flags: 'serverless'=serverless code paths + no zlib/zstd, 'otlp'=OTLP trace/metric endpoint")
+	diag("runtime:      %s  # language runtime inferred from base image env vars", detectRuntime())
+	diag("revision:     %s  # current deployment revision", firstEnv("K_REVISION", "WEBSITE_SITE_NAME", "CONTAINER_APP_NAME"))
+	diag("ddtrace:      %s  # ddtrace library version (set DD_TRACE_VERSION env var to surface this)", firstEnv("DD_TRACE_VERSION", "DD_TRACER_VERSION"))
 
 	envVars := os.Environ()
 	sort.Strings(envVars)
-	log.Infof("[SERVERLESS_DIAGNOSTIC] env_var_count=%d", len(envVars))
+	diag("--- env vars (%d total) ---", len(envVars))
 	for _, e := range envVars {
-		log.Infof("[SERVERLESS_DIAGNOSTIC] env: %s", maskSecret(e))
+		masked := maskSecret(e)
+		key := strings.SplitN(e, "=", 2)[0]
+		if desc, ok := envDescriptions[key]; ok {
+			diag("env: %-45s  # %s", masked, desc)
+		} else {
+			diag("env: %s", masked)
+		}
 	}
 
 	cfg := pkgconfigsetup.Datadog()
-	log.Infof("[SERVERLESS_DIAGNOSTIC] config: dd_site=%s logs_enabled=%v apm_enabled=%v rc_enabled=%v api_key_present=%v",
-		cfg.GetString("dd_site"),
-		cfg.GetBool("logs_enabled"),
-		cfg.GetBool("apm_config.enabled"),
-		cfg.GetBool("remote_configuration.enabled"),
-		cfg.GetString("api_key") != "",
-	)
+	diag("--- agent config ---")
+	diag("config: dd_site=%s                       # Datadog intake site", cfg.GetString("site"))
+	diag("config: logs_enabled=%v                  # log collection active", cfg.GetBool("logs_enabled"))
+	diag("config: apm_enabled=%v                  # APM trace collection active", cfg.GetBool("apm_config.enabled"))
+	diag("config: serializer_compressor_kind=%s   # metric payload compression; forced 'none' because zstd/zlib not compiled in (serverless build tag)", cfg.GetString("serializer_compressor_kind"))
+	diag("config: logs_use_compression=%v         # log payload compression; forced false for same reason", cfg.GetBool("logs_config.use_compression"))
+	diag("config: api_key_present=%v              # Datadog API key is configured", cfg.GetString("api_key") != "")
+
+	// --- Inventory pipeline identity ---
+	// uuid.GetUUID() returns the gopsutil DMI product_uuid (or random UUID fallback).
+	// hostname is always "" in the serverless build (pkg/util/hostname/providers_serverless.go
+	// returns "" unconditionally). Subotka accepts UUID-only payloads per PR #22542.
+	// Look for this UUID in REDAPL: SELECT * FROM datadog_agent WHERE uuid = '<value below>'
+	diag("--- inventory pipeline (Subotka → agentmetadata track → datadog_agent table) ---")
+	diag("uuid (agent):        %s  # gopsutil UUID — this is what inventoryagent sends to Subotka; query REDAPL by this value", uuid.GetUUID())
+	diag("hostname (payload):  (empty string)  # pkg/util/hostname/providers_serverless.go always returns \"\"; Subotka uses UUID as PK instead")
+	diag("ccrid (from tags):   %s  # cloud resource ID for REDAPL join — links datadog_agent row to cloud resource tables", cloudCCRID(cs))
+	diag("REDAPL query hint:   SELECT * FROM datadog_agent WHERE agent_version LIKE '7.83.0%%' LIMIT 20")
+
+	enabled := cfg.GetBool("enable_metadata_collection")
+	firstDelay := cfg.GetDuration("inventories_first_run_delay")
+	minInterval := cfg.GetInt("inventories_min_interval")
+	maxInterval := cfg.GetInt("inventories_max_interval")
+	diag("enable_metadata_collection: %v  # if false, metadata runner does not start and NO payload is ever sent", enabled)
+	diag("inventories_first_run_delay: %v  # payload is suppressed until this time has elapsed since agent start (default: 0)", firstDelay)
+	diag("inventories_min_interval:   %ds  # runner polls every N seconds (default: 60)", minInterval)
+	diag("inventories_max_interval:   %ds  # payload forced even without change every N seconds (default: 600)", maxInterval)
+	if !enabled {
+		diag("WARNING: enable_metadata_collection=false — inventoryagent will NOT send anything to Subotka")
+	}
+}
+
+// cloudCCRID returns the Canonical Cloud Resource ID from the tags already computed by
+// cloudservice.GetTags(). These are the same tags used to set uuid.GetUUID in main.go,
+// so they match what Subotka will receive.
+func cloudCCRID(cs cloudservice.CloudService) string {
+	tags := cs.GetTags()
+	for _, key := range []string{"gcr.resource_name", "gcrfx.resource_name", "gcrj.resource_name", "resource_id"} {
+		if v := tags[key]; v != "" {
+			return v
+		}
+	}
+	return fmt.Sprintf("(not found in tags — origin=%s)", cs.GetOrigin())
+}
+
+// firstEnv returns the value of the first env var in the list that is set and
+// non-empty, or "(unknown)" if none match.
+func firstEnv(keys ...string) string {
+	for _, k := range keys {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+	}
+	return "(unknown)"
+}
+
+// detectRuntime infers the language runtime from well-known env vars injected
+// by base images (PYTHON_VERSION, NODE_VERSION, etc.).
+func detectRuntime() string {
+	if v := os.Getenv("PYTHON_VERSION"); v != "" {
+		return "python" + v
+	}
+	if v := os.Getenv("NODE_VERSION"); v != "" {
+		return "node" + v
+	}
+	if v := os.Getenv("JAVA_VERSION"); v != "" {
+		return "java" + v
+	}
+	if v := os.Getenv("DOTNET_VERSION"); v != "" {
+		return "dotnet" + v
+	}
+	if v := os.Getenv("RUBY_VERSION"); v != "" {
+		return "ruby" + v
+	}
+	return "(unknown)"
 }
 
 // maskSecret replaces the value portion of a KEY=value pair with *** when the

--- a/cmd/serverless-init/diagnostic/diagnostic.go
+++ b/cmd/serverless-init/diagnostic/diagnostic.go
@@ -108,7 +108,7 @@ func LogIfEnabled(modeConf mode.Conf, cs cloudservice.CloudService) {
 		if wrappedCmd == "" {
 			wrappedCmd = "(none)"
 		}
-		diag("deployment_model: init-container  # serverless-init wraps the app command")
+		diag("deployment_model: in-container   # serverless-init wraps the app command")
 		diag("wrapped_command:  %s", wrappedCmd)
 	}
 	diag("origin:       %s  # cloud platform detected at runtime (cloudrun, cloudrunfunctions, azure, etc.)", cs.GetOrigin())

--- a/cmd/serverless-init/diagnostic/diagnostic.go
+++ b/cmd/serverless-init/diagnostic/diagnostic.go
@@ -25,8 +25,8 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/mode"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	servertags "github.com/DataDog/datadog-agent/pkg/serverless/tags"
-	pkgversion "github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-agent/pkg/util/uuid"
+	pkgversion "github.com/DataDog/datadog-agent/pkg/version"
 )
 
 const diagnosticEnvVar = "DD_SERVERLESS_DIAGNOSTIC_INFO"

--- a/cmd/serverless-init/diagnostic/diagnostic.go
+++ b/cmd/serverless-init/diagnostic/diagnostic.go
@@ -38,17 +38,17 @@ var secretKeywords = []string{"API_KEY", "SECRET", "PASSWORD", "TOKEN"}
 // description shown alongside the value in diagnostic output.
 var envDescriptions = map[string]string{
 	// Datadog configuration
-	"DD_API_KEY":                          "Datadog API key (masked)",
-	"DD_SITE":                             "Datadog intake site (e.g. datadoghq.com, datadoghq.eu)",
-	"DD_SERVICE":                          "Service name used for tagging all telemetry",
-	"DD_ENV":                              "Deployment environment tag (dev/staging/prod)",
-	"DD_VERSION":                          "App version tag for deployments",
-	"DD_LOGS_ENABLED":                     "Enable log collection and forwarding to Datadog",
-	"DD_APM_ENABLED":                      "Enable APM trace collection",
-	"DD_TRACE_ENABLED":                    "Enable distributed tracing via ddtrace",
-	"DD_HOSTNAME":                         "Override the hostname reported to Datadog",
-	"DD_REMOTE_CONFIGURATION_ENABLED":     "Enable Remote Configuration (live config updates from Datadog UI)",
-	"DD_SERVERLESS_DIAGNOSTIC_INFO":       "Enable this diagnostic output on startup",
+	"DD_API_KEY":                           "Datadog API key (masked)",
+	"DD_SITE":                              "Datadog intake site (e.g. datadoghq.com, datadoghq.eu)",
+	"DD_SERVICE":                           "Service name used for tagging all telemetry",
+	"DD_ENV":                               "Deployment environment tag (dev/staging/prod)",
+	"DD_VERSION":                           "App version tag for deployments",
+	"DD_LOGS_ENABLED":                      "Enable log collection and forwarding to Datadog",
+	"DD_APM_ENABLED":                       "Enable APM trace collection",
+	"DD_TRACE_ENABLED":                     "Enable distributed tracing via ddtrace",
+	"DD_HOSTNAME":                          "Override the hostname reported to Datadog",
+	"DD_REMOTE_CONFIGURATION_ENABLED":      "Enable Remote Configuration (live config updates from Datadog UI)",
+	"DD_SERVERLESS_DIAGNOSTIC_INFO":        "Enable this diagnostic output on startup",
 	"DD_INSTRUMENTATION_TELEMETRY_ENABLED": "Send ddtrace instrumentation telemetry to Datadog",
 	// Cloud Run platform
 	"K_SERVICE":                 "Cloud Run service name",

--- a/cmd/serverless-init/diagnostic/diagnostic_test.go
+++ b/cmd/serverless-init/diagnostic/diagnostic_test.go
@@ -1,0 +1,111 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package diagnostic
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/mode"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaskSecret(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "masks DD_API_KEY",
+			input: "DD_API_KEY=abc123",
+			want:  "DD_API_KEY=***",
+		},
+		{
+			name:  "masks TOKEN",
+			input: "MY_TOKEN=secret-value",
+			want:  "MY_TOKEN=***",
+		},
+		{
+			name:  "masks SECRET",
+			input: "DB_SECRET=pass",
+			want:  "DB_SECRET=***",
+		},
+		{
+			name:  "masks PASSWORD",
+			input: "ROOT_PASSWORD=hunter2",
+			want:  "ROOT_PASSWORD=***",
+		},
+		{
+			name:  "passes DD_SITE",
+			input: "DD_SITE=datadoghq.com",
+			want:  "DD_SITE=datadoghq.com",
+		},
+		{
+			name:  "passes K_SERVICE",
+			input: "K_SERVICE=my-cloud-run-service",
+			want:  "K_SERVICE=my-cloud-run-service",
+		},
+		{
+			name:  "passes K_REVISION",
+			input: "K_REVISION=my-cloud-run-service-00001-abc",
+			want:  "K_REVISION=my-cloud-run-service-00001-abc",
+		},
+		{
+			name:  "passes CONTAINER_APP_NAME",
+			input: "CONTAINER_APP_NAME=my-app",
+			want:  "CONTAINER_APP_NAME=my-app",
+		},
+		{
+			name:  "passes WEBSITE_SITE_NAME",
+			input: "WEBSITE_SITE_NAME=my-web-app",
+			want:  "WEBSITE_SITE_NAME=my-web-app",
+		},
+		{
+			name:  "handles no equals sign",
+			input: "MALFORMED",
+			want:  "MALFORMED",
+		},
+		{
+			name:  "case-insensitive key matching",
+			input: "my_api_key=value",
+			want:  "my_api_key=***",
+		},
+		{
+			name:  "preserves value with embedded equals sign",
+			input: "DD_SITE=us1.datadoghq.com",
+			want:  "DD_SITE=us1.datadoghq.com",
+		},
+		{
+			name:  "preserves empty value",
+			input: "K_SERVICE=",
+			want:  "K_SERVICE=",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, maskSecret(tt.input))
+		})
+	}
+}
+
+// TestLogIfEnabled_NoopWhenDisabled verifies that LogIfEnabled is a no-op
+// when DD_SERVERLESS_DIAGNOSTIC_INFO is not "true". We pass nil for cloudService
+// to ensure the function exits before dereferencing it — a nil deref here
+// would mean the guard is broken.
+func TestLogIfEnabled_NoopWhenDisabled(t *testing.T) {
+	for _, val := range []string{"", "false", "FALSE", "0", "yes"} {
+		t.Run("env="+val, func(t *testing.T) {
+			t.Setenv(diagnosticEnvVar, val)
+			// Must not panic — cs.GetOrigin() is never reached when disabled.
+			assert.NotPanics(t, func() {
+				LogIfEnabled(mode.Conf{}, nil)
+			})
+		})
+	}
+}

--- a/cmd/serverless-init/inventory/BUILD.bazel
+++ b/cmd/serverless-init/inventory/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
             "//cmd/serverless-init/mode",
             "//comp/metadata/inventoryagent/def",
             "//pkg/config/setup",
+            "//pkg/serverless/tags",
             "//pkg/version",
         ],
         "@rules_go//go/platform:android": [
@@ -19,6 +20,7 @@ go_library(
             "//cmd/serverless-init/mode",
             "//comp/metadata/inventoryagent/def",
             "//pkg/config/setup",
+            "//pkg/serverless/tags",
             "//pkg/version",
         ],
         "@rules_go//go/platform:darwin": [
@@ -26,6 +28,7 @@ go_library(
             "//cmd/serverless-init/mode",
             "//comp/metadata/inventoryagent/def",
             "//pkg/config/setup",
+            "//pkg/serverless/tags",
             "//pkg/version",
         ],
         "@rules_go//go/platform:dragonfly": [
@@ -33,6 +36,7 @@ go_library(
             "//cmd/serverless-init/mode",
             "//comp/metadata/inventoryagent/def",
             "//pkg/config/setup",
+            "//pkg/serverless/tags",
             "//pkg/version",
         ],
         "@rules_go//go/platform:freebsd": [
@@ -40,6 +44,7 @@ go_library(
             "//cmd/serverless-init/mode",
             "//comp/metadata/inventoryagent/def",
             "//pkg/config/setup",
+            "//pkg/serverless/tags",
             "//pkg/version",
         ],
         "@rules_go//go/platform:illumos": [
@@ -47,6 +52,7 @@ go_library(
             "//cmd/serverless-init/mode",
             "//comp/metadata/inventoryagent/def",
             "//pkg/config/setup",
+            "//pkg/serverless/tags",
             "//pkg/version",
         ],
         "@rules_go//go/platform:ios": [
@@ -54,6 +60,7 @@ go_library(
             "//cmd/serverless-init/mode",
             "//comp/metadata/inventoryagent/def",
             "//pkg/config/setup",
+            "//pkg/serverless/tags",
             "//pkg/version",
         ],
         "@rules_go//go/platform:js": [
@@ -61,6 +68,7 @@ go_library(
             "//cmd/serverless-init/mode",
             "//comp/metadata/inventoryagent/def",
             "//pkg/config/setup",
+            "//pkg/serverless/tags",
             "//pkg/version",
         ],
         "@rules_go//go/platform:linux": [
@@ -68,6 +76,7 @@ go_library(
             "//cmd/serverless-init/mode",
             "//comp/metadata/inventoryagent/def",
             "//pkg/config/setup",
+            "//pkg/serverless/tags",
             "//pkg/version",
         ],
         "@rules_go//go/platform:netbsd": [
@@ -75,6 +84,7 @@ go_library(
             "//cmd/serverless-init/mode",
             "//comp/metadata/inventoryagent/def",
             "//pkg/config/setup",
+            "//pkg/serverless/tags",
             "//pkg/version",
         ],
         "@rules_go//go/platform:openbsd": [
@@ -82,6 +92,7 @@ go_library(
             "//cmd/serverless-init/mode",
             "//comp/metadata/inventoryagent/def",
             "//pkg/config/setup",
+            "//pkg/serverless/tags",
             "//pkg/version",
         ],
         "@rules_go//go/platform:osx": [
@@ -89,6 +100,7 @@ go_library(
             "//cmd/serverless-init/mode",
             "//comp/metadata/inventoryagent/def",
             "//pkg/config/setup",
+            "//pkg/serverless/tags",
             "//pkg/version",
         ],
         "@rules_go//go/platform:plan9": [
@@ -96,6 +108,7 @@ go_library(
             "//cmd/serverless-init/mode",
             "//comp/metadata/inventoryagent/def",
             "//pkg/config/setup",
+            "//pkg/serverless/tags",
             "//pkg/version",
         ],
         "@rules_go//go/platform:qnx": [
@@ -103,6 +116,7 @@ go_library(
             "//cmd/serverless-init/mode",
             "//comp/metadata/inventoryagent/def",
             "//pkg/config/setup",
+            "//pkg/serverless/tags",
             "//pkg/version",
         ],
         "@rules_go//go/platform:solaris": [
@@ -110,6 +124,7 @@ go_library(
             "//cmd/serverless-init/mode",
             "//comp/metadata/inventoryagent/def",
             "//pkg/config/setup",
+            "//pkg/serverless/tags",
             "//pkg/version",
         ],
         "//conditions:default": [],

--- a/cmd/serverless-init/inventory/BUILD.bazel
+++ b/cmd/serverless-init/inventory/BUILD.bazel
@@ -1,0 +1,201 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+
+go_library(
+    name = "inventory",
+    srcs = ["inventory.go"],
+    importpath = "github.com/DataDog/datadog-agent/cmd/serverless-init/inventory",
+    visibility = ["//visibility:public"],
+    deps = select({
+        "@rules_go//go/platform:aix": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//comp/metadata/inventoryagent/def",
+            "//pkg/config/setup",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:android": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//comp/metadata/inventoryagent/def",
+            "//pkg/config/setup",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//comp/metadata/inventoryagent/def",
+            "//pkg/config/setup",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:dragonfly": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//comp/metadata/inventoryagent/def",
+            "//pkg/config/setup",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:freebsd": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//comp/metadata/inventoryagent/def",
+            "//pkg/config/setup",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:illumos": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//comp/metadata/inventoryagent/def",
+            "//pkg/config/setup",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:ios": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//comp/metadata/inventoryagent/def",
+            "//pkg/config/setup",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:js": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//comp/metadata/inventoryagent/def",
+            "//pkg/config/setup",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//comp/metadata/inventoryagent/def",
+            "//pkg/config/setup",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:netbsd": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//comp/metadata/inventoryagent/def",
+            "//pkg/config/setup",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:openbsd": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//comp/metadata/inventoryagent/def",
+            "//pkg/config/setup",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:osx": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//comp/metadata/inventoryagent/def",
+            "//pkg/config/setup",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:plan9": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//comp/metadata/inventoryagent/def",
+            "//pkg/config/setup",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:qnx": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//comp/metadata/inventoryagent/def",
+            "//pkg/config/setup",
+            "//pkg/version",
+        ],
+        "@rules_go//go/platform:solaris": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "//comp/metadata/inventoryagent/def",
+            "//pkg/config/setup",
+            "//pkg/version",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+dd_agent_go_test(
+    name = "inventory_test",
+    srcs = ["inventory_test.go"],
+    embed = [":inventory"],
+    deps = select({
+        "@rules_go//go/platform:aix": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:android": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:dragonfly": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:freebsd": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:illumos": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:ios": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:js": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:netbsd": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:openbsd": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:osx": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:plan9": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:qnx": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "@rules_go//go/platform:solaris": [
+            "//cmd/serverless-init/cloudservice",
+            "//cmd/serverless-init/mode",
+            "@com_github_stretchr_testify//assert",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/cmd/serverless-init/inventory/inventory.go
+++ b/cmd/serverless-init/inventory/inventory.go
@@ -1,0 +1,159 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+// Package inventory populates serverless-init-specific fields in the
+// inventoryagent payload. The agentmetadata EPRW decoder (SVLS-9607) reads
+// these fields to write a serverless_init_agent REDAPL record in addition to
+// (or instead of) the standard datadog_agent record.
+//
+// All fields are prefixed "serverless_" so the decoder can identify them and
+// route them to the correct table. Fields that are empty or unknown are
+// omitted via the Component.Set no-op path.
+package inventory
+
+import (
+	"os"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/mode"
+	inventoryagent "github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/def"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	pkgversion "github.com/DataDog/datadog-agent/pkg/version"
+)
+
+// SetInventoryFields populates serverless-init-specific metadata in the
+// inventoryagent component. Call once in run() before ForceCollect() so all
+// fields are present in the first payload sent per container lifecycle.
+//
+// Fields map to the serverless_init_agent REDAPL table defined in SVLS-9604.
+// The EPRW agentmetadata decoder (SVLS-9607) extracts fields prefixed with
+// "serverless_" and writes them to that table.
+func SetInventoryFields(ia inventoryagent.Component, cs cloudservice.CloudService, mc mode.Conf) {
+	origin := cs.GetOrigin()
+
+	ia.Set("serverless_cloud_provider", cloudProviderFromOrigin(origin))
+	ia.Set("serverless_workload_type", workloadTypeFromOrigin(origin))
+	ia.Set("serverless_origin", origin)
+	ia.Set("serverless_deployment_model", deploymentModelFromConf(mc))
+	ia.Set("serverless_agent_commit", pkgversion.Commit)
+	ia.Set("serverless_runtime", detectRuntime())
+
+	if name := resourceNameFromOrigin(origin); name != "" {
+		ia.Set("serverless_resource_name", name)
+	}
+	if !mc.SidecarMode {
+		ia.Set("serverless_wrapped_command", strings.Join(os.Args[1:], " "))
+	}
+
+	cfg := pkgconfigsetup.Datadog()
+	ia.Set("serverless_dd_site", cfg.GetString("site"))
+	ia.Set("serverless_logs_enabled", cfg.GetBool("logs_enabled"))
+	ia.Set("serverless_apm_enabled", cfg.GetBool("apm_config.enabled"))
+
+	// Category B — user-set; omit if absent so REDAPL stores NULL not empty string
+	if v := os.Getenv("DD_ENV"); v != "" {
+		ia.Set("serverless_dd_env", v)
+	}
+	if v := os.Getenv("DD_SERVICE"); v != "" {
+		ia.Set("serverless_dd_service", v)
+	}
+	if v := os.Getenv("DD_VERSION"); v != "" {
+		ia.Set("serverless_dd_version", v)
+	}
+	if v := firstEnv("DD_TRACE_VERSION", "DD_TRACER_VERSION"); v != "" {
+		ia.Set("serverless_tracer_version", v)
+	}
+
+	// Azure-only identity fields
+	if v := os.Getenv(cloudservice.AzureSubscriptionIdEnvVar); v != "" {
+		ia.Set("serverless_subscription_id", v)
+	}
+	if v := os.Getenv(cloudservice.AzureResourceGroupEnvVar); v != "" {
+		ia.Set("serverless_resource_group", v)
+	}
+}
+
+// cloudProviderFromOrigin maps the cloudservice origin string to a canonical
+// cloud provider name used in the serverless_init_agent table.
+func cloudProviderFromOrigin(origin string) string {
+	switch origin {
+	case cloudservice.CloudRunOrigin, cloudservice.CloudRunJobsOrigin:
+		return "gcp"
+	case cloudservice.ContainerAppOrigin, cloudservice.AppServiceOrigin:
+		return "azure"
+	default:
+		return origin
+	}
+}
+
+// workloadTypeFromOrigin maps the cloudservice origin to a workload type enum
+// value matching the serverless_init_agent table schema (SVLS-9604).
+func workloadTypeFromOrigin(origin string) string {
+	switch origin {
+	case cloudservice.CloudRunOrigin:
+		// Cloud Run Functions gen2 run on Cloud Run but expose FUNCTION_TARGET.
+		if os.Getenv("FUNCTION_TARGET") != "" {
+			return "cloud_run_function"
+		}
+		return "cloud_run_service"
+	case cloudservice.CloudRunJobsOrigin:
+		return "cloud_run_job"
+	case cloudservice.ContainerAppOrigin:
+		return "container_app"
+	case cloudservice.AppServiceOrigin:
+		return "app_service"
+	default:
+		return origin
+	}
+}
+
+// resourceNameFromOrigin returns the human-readable resource name for Fleet
+// display by reading the platform-injected env var for the detected origin.
+func resourceNameFromOrigin(origin string) string {
+	switch origin {
+	case cloudservice.CloudRunOrigin, cloudservice.CloudRunJobsOrigin:
+		return os.Getenv(cloudservice.ServiceNameEnvVar) // K_SERVICE
+	case cloudservice.ContainerAppOrigin:
+		return os.Getenv(cloudservice.ContainerAppNameEnvVar) // CONTAINER_APP_NAME
+	case cloudservice.AppServiceOrigin:
+		return os.Getenv(cloudservice.WebsiteName) // WEBSITE_SITE_NAME
+	}
+	return ""
+}
+
+func deploymentModelFromConf(mc mode.Conf) string {
+	if mc.SidecarMode {
+		return "sidecar"
+	}
+	return "init-container"
+}
+
+// detectRuntime infers the language runtime from well-known base-image env vars.
+func detectRuntime() string {
+	for prefix, env := range map[string]string{
+		"python": "PYTHON_VERSION",
+		"node":   "NODE_VERSION",
+		"java":   "JAVA_VERSION",
+		"dotnet": "DOTNET_VERSION",
+		"ruby":   "RUBY_VERSION",
+	} {
+		if v := os.Getenv(env); v != "" {
+			return prefix + v
+		}
+	}
+	return ""
+}
+
+func firstEnv(keys ...string) string {
+	for _, k := range keys {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/cmd/serverless-init/inventory/inventory.go
+++ b/cmd/serverless-init/inventory/inventory.go
@@ -136,7 +136,7 @@ func workloadTypeFromOrigin(origin string, tags map[string]string) string {
 		// (available in init-container) or build_function_target tag (available
 		// in sidecar, set by the Cloud Run collector).
 		if os.Getenv("FUNCTION_TARGET") != "" || tags["build_function_target"] != "" {
-			return "cloud_function_gen2"
+			return "cloud_run_function"
 		}
 		return "cloud_run_service"
 	case cloudservice.CloudRunJobsOrigin:

--- a/cmd/serverless-init/inventory/inventory.go
+++ b/cmd/serverless-init/inventory/inventory.go
@@ -231,7 +231,7 @@ func parentResourceIDFromTags(origin string, tags map[string]string) string {
 // report. resource_id is the canonical revision CCRID for revision-capable
 // workloads; deployment_id keeps the provider's short revision name available
 // for display and diagnostics.
-func deploymentIDFromOriginAndTags(origin string, tags map[string]string) string {
+func deploymentIDFromOriginAndTags(origin string, _ map[string]string) string {
 	switch origin {
 	case cloudservice.CloudRunOrigin:
 		return firstEnv("K_REVISION")

--- a/cmd/serverless-init/inventory/inventory.go
+++ b/cmd/serverless-init/inventory/inventory.go
@@ -27,7 +27,9 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/mode"
 	inventoryagent "github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	servertags "github.com/DataDog/datadog-agent/pkg/serverless/tags"
 	pkgversion "github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/DataDog/datadog-agent/pkg/util/uuid"
 )
 
 // SetInventoryFields populates serverless-init-specific metadata in the
@@ -45,25 +47,24 @@ func SetInventoryFields(ia inventoryagent.Component, cs cloudservice.CloudServic
 	tags := cs.GetTags()
 
 	// --- Required identity (RFC primary key: resource_id + uuid) ---
-	// uuid is the Agent host UUID already present in the inventory payload; the
-	// decoder reads it from amd["uuid"]. resource_id is the full cloud resource
-	// identifier derived from cloudservice tags so it joins to crawler resources.
+	// uuid must be in agent_metadata (ia.data) so the EPRW decoder can read it
+	// from amd["uuid"] inside createServerlessAgentResource. The top-level
+	// Payload.UUID is a separate field and is NOT present in agent_metadata.
+	ia.Set("uuid", uuid.GetUUID())
 	if rid := resourceIDFromTags(origin, tags); rid != "" {
 		ia.Set("resource_id", rid)
 	}
 	if name := resourceNameFromOrigin(origin, tags); name != "" {
 		ia.Set("resource_name", name)
 	}
-	if wt := workloadTypeFromOrigin(origin); wt != "" {
+	if wt := workloadTypeFromOrigin(origin, tags); wt != "" {
 		ia.Set("workload_type", wt)
 	}
 
 	// --- Nullable serverless-init fields (canonical names) ---
-	// agent_version_base and serverless_init_version are both the serverless-init
-	// image version, which is the Agent version it ships with.
 	ia.Set("agent_version_base", pkgversion.AgentVersion)
 	ia.Set("agent_commit", pkgversion.Commit)
-	ia.Set("serverless_init_version", pkgversion.AgentVersion)
+	ia.Set("serverless_init_version", servertags.GetExtensionVersion())
 	ia.Set("deployment_model", deploymentModelFromConf(mc))
 	ia.Set("runtime", detectRuntime())
 	if !mc.SidecarMode {
@@ -124,11 +125,13 @@ func cloudProviderFromOrigin(origin string) string {
 // value matching the RFC canonical vocabulary. Values MUST match the
 // validServerlessWorkloadTypes allowlist in the EPRW agentmetadata decoder
 // (dd-go agentmetadata_decoder.go); unrecognised values are rejected there.
-func workloadTypeFromOrigin(origin string) string {
+func workloadTypeFromOrigin(origin string, tags map[string]string) string {
 	switch origin {
 	case cloudservice.CloudRunOrigin:
-		// Cloud Functions Gen2 run on Cloud Run but expose FUNCTION_TARGET.
-		if os.Getenv("FUNCTION_TARGET") != "" {
+		// Cloud Functions Gen2 run on Cloud Run. Detect via FUNCTION_TARGET env
+		// (available in init-container) or build_function_target tag (available
+		// in sidecar, set by the Cloud Run collector).
+		if os.Getenv("FUNCTION_TARGET") != "" || tags["build_function_target"] != "" {
 			return "cloud_function_gen2"
 		}
 		return "cloud_run_service"
@@ -143,23 +146,35 @@ func workloadTypeFromOrigin(origin string) string {
 	}
 }
 
-// resourceNameFromOrigin returns the human-readable resource name for Fleet
-// display, read from the cloudservice tags (which already collect it).
+// resourceNameFromOrigin returns the short human-readable resource name for
+// Fleet display (e.g. "nina-cloudrun-init", not the full GCP path).
 func resourceNameFromOrigin(origin string, tags map[string]string) string {
 	switch origin {
 	case cloudservice.CloudRunOrigin:
-		if os.Getenv("FUNCTION_TARGET") != "" {
-			return tags["gcrfx.resource_name"]
+		if os.Getenv("FUNCTION_TARGET") != "" || tags["build_function_target"] != "" {
+			return lastPathSegment(tags["gcrfx.resource_name"])
 		}
-		return tags["gcr.resource_name"]
+		return lastPathSegment(tags["gcr.resource_name"])
 	case cloudservice.CloudRunJobsOrigin:
-		return tags["gcrj.resource_name"]
+		return lastPathSegment(tags["gcrj.resource_name"])
 	case cloudservice.ContainerAppOrigin:
 		return os.Getenv(cloudservice.ContainerAppNameEnvVar)
 	case cloudservice.AppServiceOrigin:
 		return os.Getenv(cloudservice.WebsiteName)
 	}
 	return ""
+}
+
+// lastPathSegment returns the final slash-delimited component of a GCP resource
+// path, e.g. "projects/.../services/my-svc" → "my-svc".
+func lastPathSegment(path string) string {
+	if path == "" {
+		return ""
+	}
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		return path[i+1:]
+	}
+	return path
 }
 
 // resourceIDFromTags returns the full cloud resource identifier (CCRID) for

--- a/cmd/serverless-init/inventory/inventory.go
+++ b/cmd/serverless-init/inventory/inventory.go
@@ -184,6 +184,19 @@ func lastPathSegment(path string) string {
 	return path
 }
 
+// cloudRunServicePath returns the backing Cloud Run service path. Gen2
+// function sidecars expose gcrfx.resource_name but do not always expose the
+// equivalent gcr.resource_name, so trim the function suffix when needed.
+func cloudRunServicePath(tags map[string]string) string {
+	if path := tags["gcr.resource_name"]; path != "" {
+		return path
+	}
+	if before, _, found := strings.Cut(tags["gcrfx.resource_name"], "/functions/"); found {
+		return before
+	}
+	return ""
+}
+
 // resourceIDFromTags returns the full cloud resource identifier (CCRID) for
 // the workload, derived from cloudservice tags. This joins to the crawler's
 // canonical_resource_id for the matching resource type. The format MUST match
@@ -194,7 +207,7 @@ func resourceIDFromTags(origin string, tags map[string]string) string {
 		// Cloud Run revisions are independently active and can receive traffic at
 		// the same time. Key their reports to the crawler's revision CCRID, while
 		// parent_resource_id retains the stable service identity.
-		return canonicalGCPRunRevisionID(tags["gcr.resource_name"], os.Getenv("K_REVISION"))
+		return canonicalGCPRunRevisionID(cloudRunServicePath(tags), os.Getenv("K_REVISION"))
 	case cloudservice.CloudRunJobsOrigin:
 		// tags["gcrj.resource_name"] = "projects/<p>/locations/<l>/jobs/<j>"
 		return canonicalGCPRunID(tags["gcrj.resource_name"])
@@ -219,7 +232,7 @@ func resourceIDFromTags(origin string, tags map[string]string) string {
 func parentResourceIDFromTags(origin string, tags map[string]string) string {
 	switch origin {
 	case cloudservice.CloudRunOrigin:
-		return canonicalGCPRunID(tags["gcr.resource_name"])
+		return canonicalGCPRunID(cloudRunServicePath(tags))
 	case cloudservice.ContainerAppOrigin:
 		return canonicalAzureID(tags["resource_id"])
 	default:

--- a/cmd/serverless-init/inventory/inventory.go
+++ b/cmd/serverless-init/inventory/inventory.go
@@ -52,6 +52,9 @@ func SetInventoryFields(ia inventoryagent.Component, cs cloudservice.CloudServic
 	if rid := resourceIDFromTags(origin, tags); rid != "" {
 		ia.Set("resource_id", rid)
 	}
+	if parentID := parentResourceIDFromTags(origin, tags); parentID != "" {
+		ia.Set("parent_resource_id", parentID)
+	}
 	if name := resourceNameFromOrigin(origin, tags); name != "" {
 		ia.Set("resource_name", name)
 	}
@@ -188,16 +191,15 @@ func lastPathSegment(path string) string {
 func resourceIDFromTags(origin string, tags map[string]string) string {
 	switch origin {
 	case cloudservice.CloudRunOrigin:
-		// tags["gcr.resource_name"] = "projects/<p>/locations/<l>/services/<s>"
-		// Gen2 function entrypoints are not separate Cloud Run resources, so do
-		// not append /functions/<target> to the stable resource identity.
-		return canonicalGCPRunID(tags["gcr.resource_name"])
+		// Cloud Run revisions are independently active and can receive traffic at
+		// the same time. Key their reports to the crawler's revision CCRID, while
+		// parent_resource_id retains the stable service identity.
+		return canonicalGCPRunRevisionID(tags["gcr.resource_name"], os.Getenv("K_REVISION"))
 	case cloudservice.CloudRunJobsOrigin:
 		// tags["gcrj.resource_name"] = "projects/<p>/locations/<l>/jobs/<j>"
 		return canonicalGCPRunID(tags["gcrj.resource_name"])
 	case cloudservice.ContainerAppOrigin:
-		// tags["resource_id"] = "/subscriptions/<s>/resourcegroups/<r>/providers/microsoft.app/containerapps/<a>"
-		return canonicalAzureID(tags["resource_id"])
+		return canonicalAzureRevisionID(tags["resource_id"], os.Getenv("CONTAINER_APP_REVISION"))
 	case cloudservice.AppServiceOrigin:
 		// AppService tags do not include a resource_id; construct from env.
 		sub := os.Getenv(cloudservice.AzureSubscriptionIdEnvVar)
@@ -206,14 +208,29 @@ func resourceIDFromTags(origin string, tags map[string]string) string {
 		if sub == "" || rg == "" || name == "" {
 			return ""
 		}
-		return fmt.Sprintf("//microsoft.azure/appServices/%s/%s/%s", sub, rg, strings.ToLower(name))
+		return canonicalAzureID(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Web/sites/%s", sub, rg, name))
 	}
 	return ""
 }
 
+// parentResourceIDFromTags returns the stable parent resource for workloads
+// whose REDAPL row identity is revision-scoped. It is omitted for workloads
+// without a separately crawlable revision resource.
+func parentResourceIDFromTags(origin string, tags map[string]string) string {
+	switch origin {
+	case cloudservice.CloudRunOrigin:
+		return canonicalGCPRunID(tags["gcr.resource_name"])
+	case cloudservice.ContainerAppOrigin:
+		return canonicalAzureID(tags["resource_id"])
+	default:
+		return ""
+	}
+}
+
 // deploymentIDFromOriginAndTags returns revision/deployment context for a
-// report. It is useful for explaining which revision produced a report, but it
-// is deliberately not part of REDAPL row identity.
+// report. resource_id is the canonical revision CCRID for revision-capable
+// workloads; deployment_id keeps the provider's short revision name available
+// for display and diagnostics.
 func deploymentIDFromOriginAndTags(origin string, tags map[string]string) string {
 	switch origin {
 	case cloudservice.CloudRunOrigin:
@@ -233,32 +250,31 @@ func canonicalGCPRunID(path string) string {
 	return "//run.googleapis.com/" + path
 }
 
-// canonicalAzureID normalizes an Azure ARM resource ID to the lowercase
-// //microsoft.azure/... CCRID scheme used by the crawler.
+func canonicalGCPRunRevisionID(servicePath, revision string) string {
+	if servicePath == "" || revision == "" {
+		return ""
+	}
+	parts := strings.Split(strings.TrimPrefix(servicePath, "/"), "/")
+	if len(parts) < 4 || parts[0] != "projects" || parts[2] != "locations" {
+		return ""
+	}
+	return fmt.Sprintf("//run.googleapis.com/projects/%s/locations/%s/revisions/%s", parts[1], parts[3], revision)
+}
+
+// canonicalAzureID normalizes an Azure ARM resource ID to the lowercase ARM
+// canonical_resource_id emitted by the Azure crawler.
 func canonicalAzureID(armID string) string {
 	if armID == "" {
 		return ""
 	}
-	// ARM IDs look like "/subscriptions/<s>/resourcegroups/<r>/providers/microsoft.app/containerapps/<a>"
-	// Normalize to //microsoft.azure/containerApps/<s>/<r>/<a>
-	parts := strings.Split(strings.TrimPrefix(armID, "/"), "/")
-	// find subscriptions, resourcegroups, containerapps segments
-	var sub, rg, name string
-	for i := 0; i < len(parts)-1; i++ {
-		switch strings.ToLower(parts[i]) {
-		case "subscriptions":
-			sub = parts[i+1]
-		case "resourcegroups":
-			rg = parts[i+1]
-		case "containerapps":
-			name = parts[i+1]
-		}
+	return "/" + strings.ToLower(strings.TrimPrefix(armID, "/"))
+}
+
+func canonicalAzureRevisionID(appARMID, revision string) string {
+	if appARMID == "" || revision == "" {
+		return ""
 	}
-	if sub == "" || rg == "" || name == "" {
-		// fall back to the raw ARM ID lowercased if we can't parse it
-		return "//microsoft.azure/" + strings.ToLower(armID)
-	}
-	return fmt.Sprintf("//microsoft.azure/containerApps/%s/%s/%s", sub, rg, strings.ToLower(name))
+	return canonicalAzureID(strings.TrimSuffix(appARMID, "/") + "/revisions/" + revision)
 }
 
 // gcpProjectIDFromTags extracts the GCP project id from cloudservice tags.

--- a/cmd/serverless-init/inventory/inventory.go
+++ b/cmd/serverless-init/inventory/inventory.go
@@ -8,14 +8,18 @@
 // Package inventory populates serverless-init-specific fields in the
 // inventoryagent payload. The agentmetadata EPRW decoder (SVLS-9607) reads
 // these fields to write a serverless_init_agent REDAPL record in addition to
-// (or instead of) the standard datadog_agent record.
+// the standard datadog_agent record.
 //
-// All fields are prefixed "serverless_" so the decoder can identify them and
-// route them to the correct table. Fields that are empty or unknown are
-// omitted via the Component.Set no-op path.
+// Routing: the decoder matches the inventory "flavor" field against the literal
+// "serverless-init". main.go calls flavor.SetFlavor("serverless-init") so the
+// per-flavor write branch fires. Field keys are UNPREFIXED and match the
+// decoder's stringFields allowlist exactly. Fields that are empty or unknown
+// are omitted via the Component.Set no-op path so REDAPL stores NULL, not a
+// sentinel.
 package inventory
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -31,55 +35,75 @@ import (
 // fields are present in the first payload sent per container lifecycle.
 //
 // Fields map to the serverless_init_agent REDAPL table defined in SVLS-9604.
-// The EPRW agentmetadata decoder (SVLS-9607) extracts fields prefixed with
-// "serverless_" and writes them to that table.
+// The EPRW agentmetadata decoder (SVLS-9607) reads the unprefixed keys below
+// from the agent_metadata map and writes them to that table. Required identity
+// fields (resource_id, uuid, resource_name, workload_type) MUST be present or
+// the decoder rejects the per-flavor write; the standard datadog_agent write
+// still proceeds.
 func SetInventoryFields(ia inventoryagent.Component, cs cloudservice.CloudService, mc mode.Conf) {
 	origin := cs.GetOrigin()
+	tags := cs.GetTags()
 
-	ia.Set("serverless_cloud_provider", cloudProviderFromOrigin(origin))
-	ia.Set("serverless_workload_type", workloadTypeFromOrigin(origin))
-	ia.Set("serverless_origin", origin)
-	ia.Set("serverless_deployment_model", deploymentModelFromConf(mc))
-	ia.Set("serverless_agent_commit", pkgversion.Commit)
-	ia.Set("serverless_runtime", detectRuntime())
-
-	if name := resourceNameFromOrigin(origin); name != "" {
-		ia.Set("serverless_resource_name", name)
+	// --- Required identity (RFC primary key: resource_id + uuid) ---
+	// uuid is the Agent host UUID already present in the inventory payload; the
+	// decoder reads it from amd["uuid"]. resource_id is the full cloud resource
+	// identifier derived from cloudservice tags so it joins to crawler resources.
+	if rid := resourceIDFromTags(origin, tags); rid != "" {
+		ia.Set("resource_id", rid)
 	}
+	if name := resourceNameFromOrigin(origin, tags); name != "" {
+		ia.Set("resource_name", name)
+	}
+	if wt := workloadTypeFromOrigin(origin); wt != "" {
+		ia.Set("workload_type", wt)
+	}
+
+	// --- Nullable serverless-init fields (canonical names) ---
+	// agent_version_base and serverless_init_version are both the serverless-init
+	// image version, which is the Agent version it ships with.
+	ia.Set("agent_version_base", pkgversion.AgentVersion)
+	ia.Set("agent_commit", pkgversion.Commit)
+	ia.Set("serverless_init_version", pkgversion.AgentVersion)
+	ia.Set("deployment_model", deploymentModelFromConf(mc))
+	ia.Set("runtime", detectRuntime())
 	if !mc.SidecarMode {
-		ia.Set("serverless_wrapped_command", strings.Join(os.Args[1:], " "))
+		ia.Set("wrapped_command", strings.Join(os.Args[1:], " "))
 	}
 
 	cfg := pkgconfigsetup.Datadog()
-	ia.Set("serverless_dd_site", cfg.GetString("site"))
-	ia.Set("serverless_logs_enabled", cfg.GetBool("logs_enabled"))
-	ia.Set("serverless_apm_enabled", cfg.GetBool("apm_config.enabled"))
+	ia.Set("dd_site", cfg.GetString("site"))
 
 	// Category B — user-set; omit if absent so REDAPL stores NULL not empty string
 	if v := os.Getenv("DD_ENV"); v != "" {
-		ia.Set("serverless_dd_env", v)
+		ia.Set("dd_env", v)
 	}
 	if v := os.Getenv("DD_SERVICE"); v != "" {
-		ia.Set("serverless_dd_service", v)
+		ia.Set("dd_service", v)
 	}
 	if v := os.Getenv("DD_VERSION"); v != "" {
-		ia.Set("serverless_dd_version", v)
-	}
-	if v := firstEnv("DD_TRACE_VERSION", "DD_TRACER_VERSION"); v != "" {
-		ia.Set("serverless_tracer_version", v)
+		ia.Set("dd_version", v)
 	}
 
-	// Azure-only identity fields
-	if v := os.Getenv(cloudservice.AzureSubscriptionIdEnvVar); v != "" {
-		ia.Set("serverless_subscription_id", v)
-	}
-	if v := os.Getenv(cloudservice.AzureResourceGroupEnvVar); v != "" {
-		ia.Set("serverless_resource_group", v)
+	// Cloud-provider-specific nullable identity fields (derived, not stored as
+	// cloud_provider per RFC — provider is implied by resource_id's scheme).
+	switch cloudProviderFromOrigin(origin) {
+	case "gcp":
+		if v := gcpProjectIDFromTags(tags); v != "" {
+			ia.Set("gcp_project_id", v)
+		}
+	case "azure":
+		if v := os.Getenv(cloudservice.AzureSubscriptionIdEnvVar); v != "" {
+			ia.Set("azure_subscription_id", v)
+		}
+		if v := os.Getenv(cloudservice.AzureResourceGroupEnvVar); v != "" {
+			ia.Set("azure_resource_group", v)
+		}
 	}
 }
 
 // cloudProviderFromOrigin maps the cloudservice origin string to a canonical
-// cloud provider name used in the serverless_init_agent table.
+// cloud provider name. Used only to gate provider-specific fields; it is NOT
+// emitted as a field (RFC: provider is derived from resource_id's scheme).
 func cloudProviderFromOrigin(origin string) string {
 	switch origin {
 	case cloudservice.CloudRunOrigin, cloudservice.CloudRunJobsOrigin:
@@ -92,11 +116,11 @@ func cloudProviderFromOrigin(origin string) string {
 }
 
 // workloadTypeFromOrigin maps the cloudservice origin to a workload type enum
-// value matching the serverless_init_agent table schema (SVLS-9604).
+// value matching the RFC canonical vocabulary.
 func workloadTypeFromOrigin(origin string) string {
 	switch origin {
 	case cloudservice.CloudRunOrigin:
-		// Cloud Run Functions gen2 run on Cloud Run but expose FUNCTION_TARGET.
+		// Cloud Functions Gen2 run on Cloud Run but expose FUNCTION_TARGET.
 		if os.Getenv("FUNCTION_TARGET") != "" {
 			return "cloud_run_function"
 		}
@@ -113,15 +137,97 @@ func workloadTypeFromOrigin(origin string) string {
 }
 
 // resourceNameFromOrigin returns the human-readable resource name for Fleet
-// display by reading the platform-injected env var for the detected origin.
-func resourceNameFromOrigin(origin string) string {
+// display, read from the cloudservice tags (which already collect it).
+func resourceNameFromOrigin(origin string, tags map[string]string) string {
 	switch origin {
-	case cloudservice.CloudRunOrigin, cloudservice.CloudRunJobsOrigin:
-		return os.Getenv(cloudservice.ServiceNameEnvVar) // K_SERVICE
+	case cloudservice.CloudRunOrigin:
+		if os.Getenv("FUNCTION_TARGET") != "" {
+			return tags["gcrfx.resource_name"]
+		}
+		return tags["gcr.resource_name"]
+	case cloudservice.CloudRunJobsOrigin:
+		return tags["gcrj.resource_name"]
 	case cloudservice.ContainerAppOrigin:
-		return os.Getenv(cloudservice.ContainerAppNameEnvVar) // CONTAINER_APP_NAME
+		return os.Getenv(cloudservice.ContainerAppNameEnvVar)
 	case cloudservice.AppServiceOrigin:
-		return os.Getenv(cloudservice.WebsiteName) // WEBSITE_SITE_NAME
+		return os.Getenv(cloudservice.WebsiteName)
+	}
+	return ""
+}
+
+// resourceIDFromTags returns the full cloud resource identifier (CCRID) for
+// the workload, derived from cloudservice tags. This joins to the crawler's
+// canonical_resource_id for the matching resource type. The format MUST match
+// the crawler's canonical scheme or the UDM relationship will not resolve.
+func resourceIDFromTags(origin string, tags map[string]string) string {
+	switch origin {
+	case cloudservice.CloudRunOrigin:
+		// tags["gcr.resource_name"] = "projects/<p>/locations/<l>/services/<s>"
+		// tags["gcrfx.resource_name"] = "projects/<p>/locations/<l>/services/<s>/functions/<f>"
+		if os.Getenv("FUNCTION_TARGET") != "" {
+			return canonicalGCPRunID(tags["gcrfx.resource_name"])
+		}
+		return canonicalGCPRunID(tags["gcr.resource_name"])
+	case cloudservice.CloudRunJobsOrigin:
+		// tags["gcrj.resource_name"] = "projects/<p>/locations/<l>/jobs/<j>"
+		return canonicalGCPRunID(tags["gcrj.resource_name"])
+	case cloudservice.ContainerAppOrigin:
+		// tags["resource_id"] = "/subscriptions/<s>/resourcegroups/<r>/providers/microsoft.app/containerapps/<a>"
+		return canonicalAzureID(tags["resource_id"])
+	case cloudservice.AppServiceOrigin:
+		// AppService tags do not include a resource_id; construct from env.
+		sub := os.Getenv(cloudservice.AzureSubscriptionIdEnvVar)
+		rg := os.Getenv(cloudservice.AzureResourceGroupEnvVar)
+		name := os.Getenv(cloudservice.WebsiteName)
+		if sub == "" || rg == "" || name == "" {
+			return ""
+		}
+		return fmt.Sprintf("//microsoft.azure/appServices/%s/%s/%s", sub, rg, strings.ToLower(name))
+	}
+	return ""
+}
+
+// canonicalGCPRunID wraps a Cloud Run "projects/.../services/..." path in the
+// run.googleapis.com CCRID scheme used by the crawler.
+func canonicalGCPRunID(path string) string {
+	if path == "" {
+		return ""
+	}
+	return "//run.googleapis.com/" + path
+}
+
+// canonicalAzureID normalizes an Azure ARM resource ID to the lowercase
+// //microsoft.azure/... CCRID scheme used by the crawler.
+func canonicalAzureID(armID string) string {
+	if armID == "" {
+		return ""
+	}
+	// ARM IDs look like "/subscriptions/<s>/resourcegroups/<r>/providers/microsoft.app/containerapps/<a>"
+	// Normalize to //microsoft.azure/containerApps/<s>/<r>/<a>
+	parts := strings.Split(strings.TrimPrefix(armID, "/"), "/")
+	// find subscriptions, resourcegroups, containerapps segments
+	var sub, rg, name string
+	for i := 0; i < len(parts)-1; i++ {
+		switch strings.ToLower(parts[i]) {
+		case "subscriptions":
+			sub = parts[i+1]
+		case "resourcegroups":
+			rg = parts[i+1]
+		case "containerapps":
+			name = parts[i+1]
+		}
+	}
+	if sub == "" || rg == "" || name == "" {
+		// fall back to the raw ARM ID lowercased if we can't parse it
+		return "//microsoft.azure/" + strings.ToLower(armID)
+	}
+	return fmt.Sprintf("//microsoft.azure/containerApps/%s/%s/%s", sub, rg, strings.ToLower(name))
+}
+
+// gcpProjectIDFromTags extracts the GCP project id from cloudservice tags.
+func gcpProjectIDFromTags(tags map[string]string) string {
+	if v := tags["project_id"]; v != "" && v != "unknown" {
+		return v
 	}
 	return ""
 }
@@ -130,7 +236,7 @@ func deploymentModelFromConf(mc mode.Conf) string {
 	if mc.SidecarMode {
 		return "sidecar"
 	}
-	return "init-container"
+	return "in-container"
 }
 
 // detectRuntime infers the language runtime from well-known base-image env vars.

--- a/cmd/serverless-init/inventory/inventory.go
+++ b/cmd/serverless-init/inventory/inventory.go
@@ -29,7 +29,6 @@ import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	servertags "github.com/DataDog/datadog-agent/pkg/serverless/tags"
 	pkgversion "github.com/DataDog/datadog-agent/pkg/version"
-	"github.com/DataDog/datadog-agent/pkg/util/uuid"
 )
 
 // SetInventoryFields populates serverless-init-specific metadata in the
@@ -39,18 +38,17 @@ import (
 // Fields map to the serverless_init_agent REDAPL table defined in SVLS-9604.
 // The EPRW agentmetadata decoder (SVLS-9607) reads the unprefixed keys below
 // from the agent_metadata map and writes them to that table. Required identity
-// fields (resource_id, uuid, resource_name, workload_type) MUST be present or
+// fields (resource_id, resource_name, workload_type) MUST be present or
 // the decoder rejects the per-flavor write; the standard datadog_agent write
 // still proceeds.
 func SetInventoryFields(ia inventoryagent.Component, cs cloudservice.CloudService, mc mode.Conf) {
 	origin := cs.GetOrigin()
 	tags := cs.GetTags()
 
-	// --- Required identity (RFC primary key: resource_id + uuid) ---
-	// uuid must be in agent_metadata (ia.data) so the EPRW decoder can read it
-	// from amd["uuid"] inside createServerlessAgentResource. The top-level
-	// Payload.UUID is a separate field and is NOT present in agent_metadata.
-	ia.Set("uuid", uuid.GetUUID())
+	// --- Required identity (RFC primary key: resource_id) ---
+	// The top-level inventory UUID identifies the reporting process. It must not
+	// be copied into agent_metadata or used as REDAPL row identity: a new UUID is
+	// generated for each instance and would turn cold starts into new rows.
 	if rid := resourceIDFromTags(origin, tags); rid != "" {
 		ia.Set("resource_id", rid)
 	}
@@ -66,6 +64,9 @@ func SetInventoryFields(ia inventoryagent.Component, cs cloudservice.CloudServic
 	ia.Set("agent_commit", pkgversion.Commit)
 	ia.Set("serverless_init_version", servertags.GetExtensionVersion())
 	ia.Set("deployment_model", deploymentModelFromConf(mc))
+	if deploymentID := deploymentIDFromOriginAndTags(origin, tags); deploymentID != "" {
+		ia.Set("deployment_id", deploymentID)
+	}
 	ia.Set("runtime", detectRuntime())
 	if !mc.SidecarMode {
 		ia.Set("wrapped_command", strings.Join(os.Args[1:], " "))
@@ -151,8 +152,11 @@ func workloadTypeFromOrigin(origin string, tags map[string]string) string {
 func resourceNameFromOrigin(origin string, tags map[string]string) string {
 	switch origin {
 	case cloudservice.CloudRunOrigin:
-		if os.Getenv("FUNCTION_TARGET") != "" || tags["build_function_target"] != "" {
-			return lastPathSegment(tags["gcrfx.resource_name"])
+		// A Gen2 function's gcrfx.resource_name ends in the function entrypoint
+		// (often "main"), not the deployed Cloud Run service name. Inventory is
+		// keyed to the backing Cloud Run resource, so use K_SERVICE/gcr here.
+		if service := os.Getenv(cloudservice.ServiceNameEnvVar); service != "" {
+			return service
 		}
 		return lastPathSegment(tags["gcr.resource_name"])
 	case cloudservice.CloudRunJobsOrigin:
@@ -185,10 +189,8 @@ func resourceIDFromTags(origin string, tags map[string]string) string {
 	switch origin {
 	case cloudservice.CloudRunOrigin:
 		// tags["gcr.resource_name"] = "projects/<p>/locations/<l>/services/<s>"
-		// tags["gcrfx.resource_name"] = "projects/<p>/locations/<l>/services/<s>/functions/<f>"
-		if os.Getenv("FUNCTION_TARGET") != "" {
-			return canonicalGCPRunID(tags["gcrfx.resource_name"])
-		}
+		// Gen2 function entrypoints are not separate Cloud Run resources, so do
+		// not append /functions/<target> to the stable resource identity.
 		return canonicalGCPRunID(tags["gcr.resource_name"])
 	case cloudservice.CloudRunJobsOrigin:
 		// tags["gcrj.resource_name"] = "projects/<p>/locations/<l>/jobs/<j>"
@@ -205,6 +207,19 @@ func resourceIDFromTags(origin string, tags map[string]string) string {
 			return ""
 		}
 		return fmt.Sprintf("//microsoft.azure/appServices/%s/%s/%s", sub, rg, strings.ToLower(name))
+	}
+	return ""
+}
+
+// deploymentIDFromOriginAndTags returns revision/deployment context for a
+// report. It is useful for explaining which revision produced a report, but it
+// is deliberately not part of REDAPL row identity.
+func deploymentIDFromOriginAndTags(origin string, tags map[string]string) string {
+	switch origin {
+	case cloudservice.CloudRunOrigin:
+		return firstEnv("K_REVISION")
+	case cloudservice.ContainerAppOrigin:
+		return firstEnv("CONTAINER_APP_REVISION")
 	}
 	return ""
 }

--- a/cmd/serverless-init/inventory/inventory.go
+++ b/cmd/serverless-init/inventory/inventory.go
@@ -84,6 +84,11 @@ func SetInventoryFields(ia inventoryagent.Component, cs cloudservice.CloudServic
 		ia.Set("dd_version", v)
 	}
 
+	// region: present in cloudservice tags under different keys per platform.
+	if r := regionFromOriginAndTags(origin, tags); r != "" && r != "unknown" {
+		ia.Set("region", r)
+	}
+
 	// Cloud-provider-specific nullable identity fields (derived, not stored as
 	// cloud_provider per RFC — provider is implied by resource_id's scheme).
 	switch cloudProviderFromOrigin(origin) {
@@ -116,21 +121,23 @@ func cloudProviderFromOrigin(origin string) string {
 }
 
 // workloadTypeFromOrigin maps the cloudservice origin to a workload type enum
-// value matching the RFC canonical vocabulary.
+// value matching the RFC canonical vocabulary. Values MUST match the
+// validServerlessWorkloadTypes allowlist in the EPRW agentmetadata decoder
+// (dd-go agentmetadata_decoder.go); unrecognised values are rejected there.
 func workloadTypeFromOrigin(origin string) string {
 	switch origin {
 	case cloudservice.CloudRunOrigin:
 		// Cloud Functions Gen2 run on Cloud Run but expose FUNCTION_TARGET.
 		if os.Getenv("FUNCTION_TARGET") != "" {
-			return "cloud_run_function"
+			return "cloud_function_gen2"
 		}
 		return "cloud_run_service"
 	case cloudservice.CloudRunJobsOrigin:
 		return "cloud_run_job"
 	case cloudservice.ContainerAppOrigin:
-		return "container_app"
+		return "azure_container_app"
 	case cloudservice.AppServiceOrigin:
-		return "app_service"
+		return "azure_app_service"
 	default:
 		return origin
 	}
@@ -225,6 +232,19 @@ func canonicalAzureID(armID string) string {
 }
 
 // gcpProjectIDFromTags extracts the GCP project id from cloudservice tags.
+// regionFromOriginAndTags returns the deployment region for the workload.
+// GCP cloudservice stores it under "location"; Azure under "region".
+// Returns "" if the value is absent so the caller can omit it (NULL in REDAPL).
+func regionFromOriginAndTags(origin string, tags map[string]string) string {
+	switch origin {
+	case cloudservice.CloudRunOrigin, cloudservice.CloudRunJobsOrigin:
+		return tags["location"]
+	case cloudservice.ContainerAppOrigin, cloudservice.AppServiceOrigin:
+		return tags["region"]
+	}
+	return ""
+}
+
 func gcpProjectIDFromTags(tags map[string]string) string {
 	if v := tags["project_id"]; v != "" && v != "unknown" {
 		return v

--- a/cmd/serverless-init/inventory/inventory_test.go
+++ b/cmd/serverless-init/inventory/inventory_test.go
@@ -1,0 +1,98 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package inventory
+
+import (
+	"os"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/mode"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloudProviderFromOrigin(t *testing.T) {
+	tests := []struct {
+		origin string
+		want   string
+	}{
+		{cloudservice.CloudRunOrigin, "gcp"},
+		{cloudservice.CloudRunJobsOrigin, "gcp"},
+		{cloudservice.ContainerAppOrigin, "azure"},
+		{cloudservice.AppServiceOrigin, "azure"},
+		{"unknown", "unknown"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, cloudProviderFromOrigin(tt.origin), "origin=%s", tt.origin)
+	}
+}
+
+func TestWorkloadTypeFromOrigin(t *testing.T) {
+	t.Run("cloud_run_service", func(t *testing.T) {
+		assert.Equal(t, "cloud_run_service", workloadTypeFromOrigin(cloudservice.CloudRunOrigin))
+	})
+	t.Run("cloud_run_function", func(t *testing.T) {
+		t.Setenv("FUNCTION_TARGET", "myHandler")
+		assert.Equal(t, "cloud_run_function", workloadTypeFromOrigin(cloudservice.CloudRunOrigin))
+	})
+	t.Run("cloud_run_job", func(t *testing.T) {
+		assert.Equal(t, "cloud_run_job", workloadTypeFromOrigin(cloudservice.CloudRunJobsOrigin))
+	})
+	t.Run("container_app", func(t *testing.T) {
+		assert.Equal(t, "container_app", workloadTypeFromOrigin(cloudservice.ContainerAppOrigin))
+	})
+	t.Run("app_service", func(t *testing.T) {
+		assert.Equal(t, "app_service", workloadTypeFromOrigin(cloudservice.AppServiceOrigin))
+	})
+}
+
+func TestResourceNameFromOrigin(t *testing.T) {
+	t.Run("cloud_run", func(t *testing.T) {
+		t.Setenv(cloudservice.ServiceNameEnvVar, "my-service")
+		assert.Equal(t, "my-service", resourceNameFromOrigin(cloudservice.CloudRunOrigin))
+	})
+	t.Run("container_app", func(t *testing.T) {
+		t.Setenv(cloudservice.ContainerAppNameEnvVar, "my-app")
+		assert.Equal(t, "my-app", resourceNameFromOrigin(cloudservice.ContainerAppOrigin))
+	})
+	t.Run("app_service", func(t *testing.T) {
+		t.Setenv(cloudservice.WebsiteName, "my-webapp")
+		assert.Equal(t, "my-webapp", resourceNameFromOrigin(cloudservice.AppServiceOrigin))
+	})
+}
+
+func TestDeploymentModelFromConf(t *testing.T) {
+	assert.Equal(t, "sidecar", deploymentModelFromConf(mode.Conf{SidecarMode: true}))
+	assert.Equal(t, "init-container", deploymentModelFromConf(mode.Conf{SidecarMode: false}))
+}
+
+func TestDetectRuntime(t *testing.T) {
+	t.Run("python", func(t *testing.T) {
+		t.Setenv("PYTHON_VERSION", "3.11.9")
+		assert.Equal(t, "python3.11.9", detectRuntime())
+	})
+	t.Run("node", func(t *testing.T) {
+		t.Setenv("NODE_VERSION", "20.11.0")
+		assert.Equal(t, "node20.11.0", detectRuntime())
+	})
+	t.Run("unknown", func(t *testing.T) {
+		os.Unsetenv("PYTHON_VERSION")
+		os.Unsetenv("NODE_VERSION")
+		os.Unsetenv("JAVA_VERSION")
+		os.Unsetenv("DOTNET_VERSION")
+		os.Unsetenv("RUBY_VERSION")
+		assert.Equal(t, "", detectRuntime())
+	})
+}
+
+func TestFirstEnv(t *testing.T) {
+	t.Setenv("KEY_A", "val_a")
+	assert.Equal(t, "val_a", firstEnv("KEY_A", "KEY_B"))
+	assert.Equal(t, "val_a", firstEnv("KEY_MISSING", "KEY_A"))
+	assert.Equal(t, "", firstEnv("KEY_MISSING1", "KEY_MISSING2"))
+}

--- a/cmd/serverless-init/inventory/inventory_test.go
+++ b/cmd/serverless-init/inventory/inventory_test.go
@@ -36,18 +36,40 @@ func TestWorkloadTypeFromOrigin(t *testing.T) {
 	t.Run("cloud_run_service", func(t *testing.T) {
 		assert.Equal(t, "cloud_run_service", workloadTypeFromOrigin(cloudservice.CloudRunOrigin))
 	})
-	t.Run("cloud_run_function", func(t *testing.T) {
+	t.Run("cloud_function_gen2", func(t *testing.T) {
 		t.Setenv("FUNCTION_TARGET", "myHandler")
-		assert.Equal(t, "cloud_run_function", workloadTypeFromOrigin(cloudservice.CloudRunOrigin))
+		assert.Equal(t, "cloud_function_gen2", workloadTypeFromOrigin(cloudservice.CloudRunOrigin))
 	})
 	t.Run("cloud_run_job", func(t *testing.T) {
 		assert.Equal(t, "cloud_run_job", workloadTypeFromOrigin(cloudservice.CloudRunJobsOrigin))
 	})
+	t.Run("azure_container_app", func(t *testing.T) {
+		assert.Equal(t, "azure_container_app", workloadTypeFromOrigin(cloudservice.ContainerAppOrigin))
+	})
+	t.Run("azure_app_service", func(t *testing.T) {
+		assert.Equal(t, "azure_app_service", workloadTypeFromOrigin(cloudservice.AppServiceOrigin))
+	})
+}
+
+func TestRegionFromOriginAndTags(t *testing.T) {
+	t.Run("cloud_run", func(t *testing.T) {
+		tags := map[string]string{"location": "us-central1"}
+		assert.Equal(t, "us-central1", regionFromOriginAndTags(cloudservice.CloudRunOrigin, tags))
+	})
+	t.Run("cloud_run_job", func(t *testing.T) {
+		tags := map[string]string{"location": "europe-west1"}
+		assert.Equal(t, "europe-west1", regionFromOriginAndTags(cloudservice.CloudRunJobsOrigin, tags))
+	})
 	t.Run("container_app", func(t *testing.T) {
-		assert.Equal(t, "container_app", workloadTypeFromOrigin(cloudservice.ContainerAppOrigin))
+		tags := map[string]string{"region": "eastus"}
+		assert.Equal(t, "eastus", regionFromOriginAndTags(cloudservice.ContainerAppOrigin, tags))
 	})
 	t.Run("app_service", func(t *testing.T) {
-		assert.Equal(t, "app_service", workloadTypeFromOrigin(cloudservice.AppServiceOrigin))
+		tags := map[string]string{"region": "westeurope"}
+		assert.Equal(t, "westeurope", regionFromOriginAndTags(cloudservice.AppServiceOrigin, tags))
+	})
+	t.Run("missing", func(t *testing.T) {
+		assert.Equal(t, "", regionFromOriginAndTags(cloudservice.CloudRunOrigin, map[string]string{}))
 	})
 }
 

--- a/cmd/serverless-init/inventory/inventory_test.go
+++ b/cmd/serverless-init/inventory/inventory_test.go
@@ -83,8 +83,12 @@ func TestResourceNameFromOrigin(t *testing.T) {
 	})
 	t.Run("cloud_run_function_via_env", func(t *testing.T) {
 		t.Setenv("FUNCTION_TARGET", "myHandler")
-		tags := map[string]string{"gcrfx.resource_name": "projects/p/locations/l/services/s/functions/myHandler"}
-		assert.Equal(t, "myHandler", resourceNameFromOrigin(cloudservice.CloudRunOrigin, tags))
+		t.Setenv(cloudservice.ServiceNameEnvVar, "my-fn-svc")
+		tags := map[string]string{
+			"gcr.resource_name":   "projects/p/locations/l/services/my-fn-svc",
+			"gcrfx.resource_name": "projects/p/locations/l/services/my-fn-svc/functions/myHandler",
+		}
+		assert.Equal(t, "my-fn-svc", resourceNameFromOrigin(cloudservice.CloudRunOrigin, tags))
 	})
 	t.Run("cloud_run_function_via_tag", func(t *testing.T) {
 		tags := map[string]string{
@@ -92,7 +96,7 @@ func TestResourceNameFromOrigin(t *testing.T) {
 			"gcrfx.resource_name":   "projects/p/locations/l/services/my-fn-svc/functions/myHandler",
 			"build_function_target": "myHandler",
 		}
-		assert.Equal(t, "myHandler", resourceNameFromOrigin(cloudservice.CloudRunOrigin, tags))
+		assert.Equal(t, "my-fn-svc", resourceNameFromOrigin(cloudservice.CloudRunOrigin, tags))
 	})
 	t.Run("container_app", func(t *testing.T) {
 		t.Setenv(cloudservice.ContainerAppNameEnvVar, "my-app")
@@ -111,8 +115,11 @@ func TestResourceIDFromTags(t *testing.T) {
 	})
 	t.Run("cloud_run_function", func(t *testing.T) {
 		t.Setenv("FUNCTION_TARGET", "myHandler")
-		tags := map[string]string{"gcrfx.resource_name": "projects/p/locations/l/services/s/functions/myHandler"}
-		assert.Equal(t, "//run.googleapis.com/projects/p/locations/l/services/s/functions/myHandler", resourceIDFromTags(cloudservice.CloudRunOrigin, tags))
+		tags := map[string]string{
+			"gcr.resource_name":   "projects/p/locations/l/services/s",
+			"gcrfx.resource_name": "projects/p/locations/l/services/s/functions/myHandler",
+		}
+		assert.Equal(t, "//run.googleapis.com/projects/p/locations/l/services/s", resourceIDFromTags(cloudservice.CloudRunOrigin, tags))
 	})
 	t.Run("cloud_run_job", func(t *testing.T) {
 		tags := map[string]string{"gcrj.resource_name": "projects/p/locations/l/jobs/my-job"}
@@ -136,6 +143,17 @@ func TestResourceIDFromTags(t *testing.T) {
 	})
 	t.Run("empty_path", func(t *testing.T) {
 		assert.Equal(t, "", resourceIDFromTags(cloudservice.CloudRunOrigin, map[string]string{}))
+	})
+}
+
+func TestDeploymentIDFromOriginAndTags(t *testing.T) {
+	t.Run("cloud_run_revision", func(t *testing.T) {
+		t.Setenv("K_REVISION", "my-service-00003-abc")
+		assert.Equal(t, "my-service-00003-abc", deploymentIDFromOriginAndTags(cloudservice.CloudRunOrigin, nil))
+	})
+	t.Run("instance_identity_is_not_deployment_identity", func(t *testing.T) {
+		t.Setenv("WEBSITE_INSTANCE_ID", "instance-123")
+		assert.Empty(t, deploymentIDFromOriginAndTags(cloudservice.AppServiceOrigin, nil))
 	})
 }
 

--- a/cmd/serverless-init/inventory/inventory_test.go
+++ b/cmd/serverless-init/inventory/inventory_test.go
@@ -123,6 +123,14 @@ func TestResourceIDFromTags(t *testing.T) {
 		}
 		assert.Equal(t, "//run.googleapis.com/projects/p/locations/l/revisions/s-00004-def", resourceIDFromTags(cloudservice.CloudRunOrigin, tags))
 	})
+	t.Run("cloud_run_function_with_only_function_resource_tag", func(t *testing.T) {
+		t.Setenv("FUNCTION_TARGET", "myHandler")
+		t.Setenv("K_REVISION", "s-00004-def")
+		tags := map[string]string{
+			"gcrfx.resource_name": "projects/p/locations/l/services/s/functions/myHandler",
+		}
+		assert.Equal(t, "//run.googleapis.com/projects/p/locations/l/revisions/s-00004-def", resourceIDFromTags(cloudservice.CloudRunOrigin, tags))
+	})
 	t.Run("cloud_run_job", func(t *testing.T) {
 		tags := map[string]string{"gcrj.resource_name": "projects/p/locations/l/jobs/my-job"}
 		assert.Equal(t, "//run.googleapis.com/projects/p/locations/l/jobs/my-job", resourceIDFromTags(cloudservice.CloudRunJobsOrigin, tags))
@@ -153,6 +161,10 @@ func TestParentResourceIDFromTags(t *testing.T) {
 	t.Run("cloud_run", func(t *testing.T) {
 		tags := map[string]string{"gcr.resource_name": "projects/p/locations/l/services/my-service"}
 		assert.Equal(t, "//run.googleapis.com/projects/p/locations/l/services/my-service", parentResourceIDFromTags(cloudservice.CloudRunOrigin, tags))
+	})
+	t.Run("cloud_run_function_with_only_function_resource_tag", func(t *testing.T) {
+		tags := map[string]string{"gcrfx.resource_name": "projects/p/locations/l/services/my-function/functions/main"}
+		assert.Equal(t, "//run.googleapis.com/projects/p/locations/l/services/my-function", parentResourceIDFromTags(cloudservice.CloudRunOrigin, tags))
 	})
 	t.Run("container_app", func(t *testing.T) {
 		tags := map[string]string{"resource_id": "/subscriptions/sub-1/resourceGroups/RG-1/providers/Microsoft.App/containerApps/My-App"}

--- a/cmd/serverless-init/inventory/inventory_test.go
+++ b/cmd/serverless-init/inventory/inventory_test.go
@@ -34,20 +34,23 @@ func TestCloudProviderFromOrigin(t *testing.T) {
 
 func TestWorkloadTypeFromOrigin(t *testing.T) {
 	t.Run("cloud_run_service", func(t *testing.T) {
-		assert.Equal(t, "cloud_run_service", workloadTypeFromOrigin(cloudservice.CloudRunOrigin))
+		assert.Equal(t, "cloud_run_service", workloadTypeFromOrigin(cloudservice.CloudRunOrigin, map[string]string{}))
 	})
-	t.Run("cloud_function_gen2", func(t *testing.T) {
+	t.Run("cloud_function_gen2_via_env", func(t *testing.T) {
 		t.Setenv("FUNCTION_TARGET", "myHandler")
-		assert.Equal(t, "cloud_function_gen2", workloadTypeFromOrigin(cloudservice.CloudRunOrigin))
+		assert.Equal(t, "cloud_function_gen2", workloadTypeFromOrigin(cloudservice.CloudRunOrigin, map[string]string{}))
+	})
+	t.Run("cloud_function_gen2_via_tag", func(t *testing.T) {
+		assert.Equal(t, "cloud_function_gen2", workloadTypeFromOrigin(cloudservice.CloudRunOrigin, map[string]string{"build_function_target": "myHandler"}))
 	})
 	t.Run("cloud_run_job", func(t *testing.T) {
-		assert.Equal(t, "cloud_run_job", workloadTypeFromOrigin(cloudservice.CloudRunJobsOrigin))
+		assert.Equal(t, "cloud_run_job", workloadTypeFromOrigin(cloudservice.CloudRunJobsOrigin, map[string]string{}))
 	})
 	t.Run("azure_container_app", func(t *testing.T) {
-		assert.Equal(t, "azure_container_app", workloadTypeFromOrigin(cloudservice.ContainerAppOrigin))
+		assert.Equal(t, "azure_container_app", workloadTypeFromOrigin(cloudservice.ContainerAppOrigin, map[string]string{}))
 	})
 	t.Run("azure_app_service", func(t *testing.T) {
-		assert.Equal(t, "azure_app_service", workloadTypeFromOrigin(cloudservice.AppServiceOrigin))
+		assert.Equal(t, "azure_app_service", workloadTypeFromOrigin(cloudservice.AppServiceOrigin, map[string]string{}))
 	})
 }
 
@@ -75,14 +78,21 @@ func TestRegionFromOriginAndTags(t *testing.T) {
 
 func TestResourceNameFromOrigin(t *testing.T) {
 	t.Run("cloud_run_service", func(t *testing.T) {
-		t.Setenv(cloudservice.ServiceNameEnvVar, "my-service")
 		tags := map[string]string{"gcr.resource_name": "projects/p/locations/l/services/my-service"}
-		assert.Equal(t, "projects/p/locations/l/services/my-service", resourceNameFromOrigin(cloudservice.CloudRunOrigin, tags))
+		assert.Equal(t, "my-service", resourceNameFromOrigin(cloudservice.CloudRunOrigin, tags))
 	})
-	t.Run("cloud_run_function", func(t *testing.T) {
+	t.Run("cloud_run_function_via_env", func(t *testing.T) {
 		t.Setenv("FUNCTION_TARGET", "myHandler")
 		tags := map[string]string{"gcrfx.resource_name": "projects/p/locations/l/services/s/functions/myHandler"}
-		assert.Equal(t, "projects/p/locations/l/services/s/functions/myHandler", resourceNameFromOrigin(cloudservice.CloudRunOrigin, tags))
+		assert.Equal(t, "myHandler", resourceNameFromOrigin(cloudservice.CloudRunOrigin, tags))
+	})
+	t.Run("cloud_run_function_via_tag", func(t *testing.T) {
+		tags := map[string]string{
+			"gcr.resource_name":     "projects/p/locations/l/services/my-fn-svc",
+			"gcrfx.resource_name":   "projects/p/locations/l/services/my-fn-svc/functions/myHandler",
+			"build_function_target": "myHandler",
+		}
+		assert.Equal(t, "myHandler", resourceNameFromOrigin(cloudservice.CloudRunOrigin, tags))
 	})
 	t.Run("container_app", func(t *testing.T) {
 		t.Setenv(cloudservice.ContainerAppNameEnvVar, "my-app")

--- a/cmd/serverless-init/inventory/inventory_test.go
+++ b/cmd/serverless-init/inventory/inventory_test.go
@@ -52,23 +52,64 @@ func TestWorkloadTypeFromOrigin(t *testing.T) {
 }
 
 func TestResourceNameFromOrigin(t *testing.T) {
-	t.Run("cloud_run", func(t *testing.T) {
+	t.Run("cloud_run_service", func(t *testing.T) {
 		t.Setenv(cloudservice.ServiceNameEnvVar, "my-service")
-		assert.Equal(t, "my-service", resourceNameFromOrigin(cloudservice.CloudRunOrigin))
+		tags := map[string]string{"gcr.resource_name": "projects/p/locations/l/services/my-service"}
+		assert.Equal(t, "projects/p/locations/l/services/my-service", resourceNameFromOrigin(cloudservice.CloudRunOrigin, tags))
+	})
+	t.Run("cloud_run_function", func(t *testing.T) {
+		t.Setenv("FUNCTION_TARGET", "myHandler")
+		tags := map[string]string{"gcrfx.resource_name": "projects/p/locations/l/services/s/functions/myHandler"}
+		assert.Equal(t, "projects/p/locations/l/services/s/functions/myHandler", resourceNameFromOrigin(cloudservice.CloudRunOrigin, tags))
 	})
 	t.Run("container_app", func(t *testing.T) {
 		t.Setenv(cloudservice.ContainerAppNameEnvVar, "my-app")
-		assert.Equal(t, "my-app", resourceNameFromOrigin(cloudservice.ContainerAppOrigin))
+		assert.Equal(t, "my-app", resourceNameFromOrigin(cloudservice.ContainerAppOrigin, nil))
 	})
 	t.Run("app_service", func(t *testing.T) {
 		t.Setenv(cloudservice.WebsiteName, "my-webapp")
-		assert.Equal(t, "my-webapp", resourceNameFromOrigin(cloudservice.AppServiceOrigin))
+		assert.Equal(t, "my-webapp", resourceNameFromOrigin(cloudservice.AppServiceOrigin, nil))
+	})
+}
+
+func TestResourceIDFromTags(t *testing.T) {
+	t.Run("cloud_run_service", func(t *testing.T) {
+		tags := map[string]string{"gcr.resource_name": "projects/p/locations/l/services/my-service"}
+		assert.Equal(t, "//run.googleapis.com/projects/p/locations/l/services/my-service", resourceIDFromTags(cloudservice.CloudRunOrigin, tags))
+	})
+	t.Run("cloud_run_function", func(t *testing.T) {
+		t.Setenv("FUNCTION_TARGET", "myHandler")
+		tags := map[string]string{"gcrfx.resource_name": "projects/p/locations/l/services/s/functions/myHandler"}
+		assert.Equal(t, "//run.googleapis.com/projects/p/locations/l/services/s/functions/myHandler", resourceIDFromTags(cloudservice.CloudRunOrigin, tags))
+	})
+	t.Run("cloud_run_job", func(t *testing.T) {
+		tags := map[string]string{"gcrj.resource_name": "projects/p/locations/l/jobs/my-job"}
+		assert.Equal(t, "//run.googleapis.com/projects/p/locations/l/jobs/my-job", resourceIDFromTags(cloudservice.CloudRunJobsOrigin, tags))
+	})
+	t.Run("container_app", func(t *testing.T) {
+		tags := map[string]string{"resource_id": "/subscriptions/sub-1/resourcegroups/rg-1/providers/microsoft.app/containerapps/My-App"}
+		assert.Equal(t, "//microsoft.azure/containerApps/sub-1/rg-1/my-app", resourceIDFromTags(cloudservice.ContainerAppOrigin, tags))
+	})
+	t.Run("app_service_full", func(t *testing.T) {
+		t.Setenv(cloudservice.AzureSubscriptionIdEnvVar, "sub-1")
+		t.Setenv(cloudservice.AzureResourceGroupEnvVar, "rg-1")
+		t.Setenv(cloudservice.WebsiteName, "My-Webapp")
+		assert.Equal(t, "//microsoft.azure/appServices/sub-1/rg-1/my-webapp", resourceIDFromTags(cloudservice.AppServiceOrigin, nil))
+	})
+	t.Run("app_service_missing", func(t *testing.T) {
+		os.Unsetenv(cloudservice.AzureSubscriptionIdEnvVar)
+		os.Unsetenv(cloudservice.AzureResourceGroupEnvVar)
+		os.Unsetenv(cloudservice.WebsiteName)
+		assert.Equal(t, "", resourceIDFromTags(cloudservice.AppServiceOrigin, nil))
+	})
+	t.Run("empty_path", func(t *testing.T) {
+		assert.Equal(t, "", resourceIDFromTags(cloudservice.CloudRunOrigin, map[string]string{}))
 	})
 }
 
 func TestDeploymentModelFromConf(t *testing.T) {
 	assert.Equal(t, "sidecar", deploymentModelFromConf(mode.Conf{SidecarMode: true}))
-	assert.Equal(t, "init-container", deploymentModelFromConf(mode.Conf{SidecarMode: false}))
+	assert.Equal(t, "in-container", deploymentModelFromConf(mode.Conf{SidecarMode: false}))
 }
 
 func TestDetectRuntime(t *testing.T) {

--- a/cmd/serverless-init/inventory/inventory_test.go
+++ b/cmd/serverless-init/inventory/inventory_test.go
@@ -110,30 +110,33 @@ func TestResourceNameFromOrigin(t *testing.T) {
 
 func TestResourceIDFromTags(t *testing.T) {
 	t.Run("cloud_run_service", func(t *testing.T) {
+		t.Setenv("K_REVISION", "my-service-00003-abc")
 		tags := map[string]string{"gcr.resource_name": "projects/p/locations/l/services/my-service"}
-		assert.Equal(t, "//run.googleapis.com/projects/p/locations/l/services/my-service", resourceIDFromTags(cloudservice.CloudRunOrigin, tags))
+		assert.Equal(t, "//run.googleapis.com/projects/p/locations/l/revisions/my-service-00003-abc", resourceIDFromTags(cloudservice.CloudRunOrigin, tags))
 	})
 	t.Run("cloud_run_function", func(t *testing.T) {
 		t.Setenv("FUNCTION_TARGET", "myHandler")
+		t.Setenv("K_REVISION", "s-00004-def")
 		tags := map[string]string{
 			"gcr.resource_name":   "projects/p/locations/l/services/s",
 			"gcrfx.resource_name": "projects/p/locations/l/services/s/functions/myHandler",
 		}
-		assert.Equal(t, "//run.googleapis.com/projects/p/locations/l/services/s", resourceIDFromTags(cloudservice.CloudRunOrigin, tags))
+		assert.Equal(t, "//run.googleapis.com/projects/p/locations/l/revisions/s-00004-def", resourceIDFromTags(cloudservice.CloudRunOrigin, tags))
 	})
 	t.Run("cloud_run_job", func(t *testing.T) {
 		tags := map[string]string{"gcrj.resource_name": "projects/p/locations/l/jobs/my-job"}
 		assert.Equal(t, "//run.googleapis.com/projects/p/locations/l/jobs/my-job", resourceIDFromTags(cloudservice.CloudRunJobsOrigin, tags))
 	})
 	t.Run("container_app", func(t *testing.T) {
+		t.Setenv("CONTAINER_APP_REVISION", "my-app--r2")
 		tags := map[string]string{"resource_id": "/subscriptions/sub-1/resourcegroups/rg-1/providers/microsoft.app/containerapps/My-App"}
-		assert.Equal(t, "//microsoft.azure/containerApps/sub-1/rg-1/my-app", resourceIDFromTags(cloudservice.ContainerAppOrigin, tags))
+		assert.Equal(t, "/subscriptions/sub-1/resourcegroups/rg-1/providers/microsoft.app/containerapps/my-app/revisions/my-app--r2", resourceIDFromTags(cloudservice.ContainerAppOrigin, tags))
 	})
 	t.Run("app_service_full", func(t *testing.T) {
 		t.Setenv(cloudservice.AzureSubscriptionIdEnvVar, "sub-1")
 		t.Setenv(cloudservice.AzureResourceGroupEnvVar, "rg-1")
 		t.Setenv(cloudservice.WebsiteName, "My-Webapp")
-		assert.Equal(t, "//microsoft.azure/appServices/sub-1/rg-1/my-webapp", resourceIDFromTags(cloudservice.AppServiceOrigin, nil))
+		assert.Equal(t, "/subscriptions/sub-1/resourcegroups/rg-1/providers/microsoft.web/sites/my-webapp", resourceIDFromTags(cloudservice.AppServiceOrigin, nil))
 	})
 	t.Run("app_service_missing", func(t *testing.T) {
 		os.Unsetenv(cloudservice.AzureSubscriptionIdEnvVar)
@@ -143,6 +146,20 @@ func TestResourceIDFromTags(t *testing.T) {
 	})
 	t.Run("empty_path", func(t *testing.T) {
 		assert.Equal(t, "", resourceIDFromTags(cloudservice.CloudRunOrigin, map[string]string{}))
+	})
+}
+
+func TestParentResourceIDFromTags(t *testing.T) {
+	t.Run("cloud_run", func(t *testing.T) {
+		tags := map[string]string{"gcr.resource_name": "projects/p/locations/l/services/my-service"}
+		assert.Equal(t, "//run.googleapis.com/projects/p/locations/l/services/my-service", parentResourceIDFromTags(cloudservice.CloudRunOrigin, tags))
+	})
+	t.Run("container_app", func(t *testing.T) {
+		tags := map[string]string{"resource_id": "/subscriptions/sub-1/resourceGroups/RG-1/providers/Microsoft.App/containerApps/My-App"}
+		assert.Equal(t, "/subscriptions/sub-1/resourcegroups/rg-1/providers/microsoft.app/containerapps/my-app", parentResourceIDFromTags(cloudservice.ContainerAppOrigin, tags))
+	})
+	t.Run("non_revision_workload", func(t *testing.T) {
+		assert.Empty(t, parentResourceIDFromTags(cloudservice.CloudRunJobsOrigin, nil))
 	})
 }
 

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -57,6 +57,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/diagnostic"
 	enhancedmetrics "github.com/DataDog/datadog-agent/cmd/serverless-init/enhanced-metrics"
 	serverlessInitTag "github.com/DataDog/datadog-agent/cmd/serverless-init/tag"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent/def"
@@ -258,6 +259,7 @@ func main() {
 
 	cloudService := cloudservice.GetCloudServiceType()
 	log.Debugf("Detected cloud service: %s", cloudService.GetOrigin())
+	diagnostic.LogIfEnabled(modeConf, cloudService)
 
 	// Compute tags after the early LoadDatadog so that yaml-configured
 	// `tags` and `extra_tags` (read by configUtils.GetConfiguredTags inside

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -56,6 +56,14 @@ import (
 
 	"go.uber.org/fx"
 
+	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
+	sysprobeconfig "github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/def"
+	inventoryagent "github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/def"
+	inventoryagentfx "github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/fx"
+	runner "github.com/DataDog/datadog-agent/comp/metadata/runner/def"
+	metadatarunnerfx "github.com/DataDog/datadog-agent/comp/metadata/runner/fx"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/diagnostic"
 	enhancedmetrics "github.com/DataDog/datadog-agent/cmd/serverless-init/enhanced-metrics"
@@ -71,6 +79,7 @@ import (
 	tracelog "github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/uuid"
 )
 
 const datadogConfigPath = "datadog.yaml"
@@ -186,6 +195,14 @@ func preloadEarly() {
 	// compile in. Adopting a compressor here is tracked in SVLS-9451.
 	setOverride("serializer_compressor_kind", "none")
 
+	// Disable logs-pipeline compression. The default is use_compression=true with
+	// compression_kind="zstd", but the serverless build tags exclude zstd
+	// (!zstd build constraint active), so NewCompressor("zstd", ...) hits the
+	// selector's default case and logs "invalid compression set" twice (once per
+	// pipeline construction). Disabling compression here silences those errors and
+	// matches the uncompressed-by-default intent of serializer_compressor_kind above.
+	setOverride("logs_config.use_compression", false)
+
 	// Disable UDS listener for the APM receiver — traces are sent via HTTP to
 	// localhost in serverless. Avoids noisy error logs.
 	setOverride("apm_config.receiver_socket", "")
@@ -206,6 +223,7 @@ func preloadEarly() {
 	// hardcodes forceFlushAll=false on ticks, so bucket-aligned flushes during
 	// the run are preserved.
 	setOverride("dogstatsd_flush_incomplete_buckets", true)
+
 }
 
 // setOverride sets key to val with SourceAgentRuntime priority, logging a
@@ -259,6 +277,14 @@ func main() {
 
 	cloudService := cloudservice.GetCloudServiceType()
 	log.Debugf("Detected cloud service: %s", cloudService.GetOrigin())
+
+	// Use the real gopsutil UUID (DMI product_uuid or random fallback). The
+	// cloud resource_name (a GCP/Azure path string) is not a valid UUID format
+	// and may be rejected by Subotka. The gopsutil UUID is a proper UUID v4
+	// that Subotka accepts. cloudCCRID is still logged in SERVERLESS_DIAGNOSTIC
+	// and sent as a tag for cloud resource linking.
+	log.Debugf("Agent UUID for inventoryagent payload: %s", uuid.GetUUID())
+
 	diagnostic.LogIfEnabled(modeConf, cloudService)
 
 	// Compute tags after the early LoadDatadog so that yaml-configured
@@ -337,10 +363,18 @@ func main() {
 		)),
 		dogstatsd.Bundle(dogstatsdServer.Params{Serverless: true}),
 		secretsfx.Module(),
-		fx.Supply(logdef.ForOneShot(modeConf.LoggerName, "error", true)),
+		fx.Supply(logdef.ForOneShot(modeConf.LoggerName, "trace", true)),
 		logfx.Module(),
 		nooptelemetry.Module(),
 		hostnameimpl.Module(),
+		// Inject shared serializer for inventoryagent (not yet a standalone component)
+		fx.Provide(func(d demultiplexer.Component) serializer.MetricSerializer {
+			return d.Serializer()
+		}),
+		ipcfx.ModuleReadWrite(),
+		sysprobeconfig.NoneModule(),
+		metadatarunnerfx.Module(),
+		inventoryagentfx.Module(),
 	)
 
 	if err != nil {
@@ -367,14 +401,26 @@ func run(
 	// (and fires its OnStop flush hook on shutdown); the body no longer calls
 	// into it directly now that flush-on-stop is internal to the component.
 	_ dogstatsdServer.Component,
+	_ runner.Component,
 	cloudService cloudservice.CloudService,
 	tagConfig tagConfiguration,
 	metricTags metrics.Tags,
+	inventoryAgentComp inventoryagent.Component,
 ) error {
 	cloudService, logConfig, tracingCtx, metricAgent, logsAgent, enhancedMetricsCollector, enhancedMetricsEnabled := setup(
 		secretComp, delegatedAuthComp, modeConf, tagger, logsCompression, hostname,
 		cloudService, tagConfig, metricTags, demux,
 	)
+
+	// Force one inventory payload into the forwarder queue before the wrapped
+	// process starts. This guarantees the payload is queued even on containers
+	// that scale to zero immediately after the workload completes. The forwarder
+	// shutdown drain (forwarder_stop_timeout) then delivers it. Without this
+	// call, the first periodic inventory fires only after firstRunDelay +
+	// MinInterval (~60 s), which is longer than most scale-to-zero windows.
+	if err := inventoryAgentComp.ForceCollect(); err != nil {
+		log.Warnf("serverless-init: initial inventory collection failed: %v", err)
+	}
 
 	err := modeConf.Runner(logConfig)
 

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -69,7 +69,6 @@ import (
 	enhancedmetrics "github.com/DataDog/datadog-agent/cmd/serverless-init/enhanced-metrics"
 	slinventory "github.com/DataDog/datadog-agent/cmd/serverless-init/inventory"
 	serverlessInitTag "github.com/DataDog/datadog-agent/cmd/serverless-init/tag"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -417,8 +416,6 @@ func run(
 	// Populate serverless-specific fields (cloud provider, workload type, etc.)
 	// before forcing the initial collection so all fields are present in the
 	// first payload sent per container lifecycle.
-	flavor.SetFlavor("serverless-init")
-
 	slinventory.SetInventoryFields(inventoryAgentComp, cloudService, modeConf)
 
 	// Force one inventory payload into the forwarder queue before the wrapped

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -67,6 +67,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/diagnostic"
 	enhancedmetrics "github.com/DataDog/datadog-agent/cmd/serverless-init/enhanced-metrics"
+	slinventory "github.com/DataDog/datadog-agent/cmd/serverless-init/inventory"
 	serverlessInitTag "github.com/DataDog/datadog-agent/cmd/serverless-init/tag"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -363,7 +364,7 @@ func main() {
 		)),
 		dogstatsd.Bundle(dogstatsdServer.Params{Serverless: true}),
 		secretsfx.Module(),
-		fx.Supply(logdef.ForOneShot(modeConf.LoggerName, "trace", true)),
+		fx.Supply(logdef.ForOneShot(modeConf.LoggerName, "error", true)),
 		logfx.Module(),
 		nooptelemetry.Module(),
 		hostnameimpl.Module(),
@@ -411,6 +412,11 @@ func run(
 		secretComp, delegatedAuthComp, modeConf, tagger, logsCompression, hostname,
 		cloudService, tagConfig, metricTags, demux,
 	)
+
+	// Populate serverless-specific fields (cloud provider, workload type, etc.)
+	// before forcing the initial collection so all fields are present in the
+	// first payload sent per container lifecycle.
+	slinventory.SetInventoryFields(inventoryAgentComp, cloudService, modeConf)
 
 	// Force one inventory payload into the forwarder queue before the wrapped
 	// process starts. This guarantees the payload is queued even on containers

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -434,12 +434,6 @@ func run(
 	// MinInterval (~60 s), which is longer than most scale-to-zero windows.
 	if err := inventoryAgentComp.ForceCollect(); err != nil {
 		log.Warnf("serverless-init: initial inventory collection failed: %v", err)
-	} else {
-		metadata := inventoryAgentComp.Get()
-		log.Infof(
-			"serverless-init: inventory report queued reason=startup process_id=%s resource_id=%v workload_type=%v deployment_id=%v",
-			uuid.GetUUID(), metadata["resource_id"], metadata["workload_type"], metadata["deployment_id"],
-		)
 	}
 
 	err := modeConf.Runner(logConfig)

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -78,6 +78,7 @@ import (
 	serverlessTag "github.com/DataDog/datadog-agent/pkg/serverless/tags"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace"
 	tracelog "github.com/DataDog/datadog-agent/pkg/trace/log"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/uuid"
@@ -257,6 +258,13 @@ func main() {
 	preloadEarly()
 
 	modeConf = mode.DetectMode()
+
+	// Set the agent flavor to "serverless-init" so the inventoryagent payload
+	// includes flavor="serverless-init". The EPRW agentmetadata decoder routes
+	// on this value to write a serverless_init_agent REDAPL record in addition
+	// to the standard datadog_agent record. Must be set before ForceCollect().
+	flavor.SetFlavor("serverless-init")
+
 	setEnvWithoutOverride(modeConf.EnvDefaults)
 
 	// Load the config file early so that yaml-configured values (e.g.
@@ -426,6 +434,12 @@ func run(
 	// MinInterval (~60 s), which is longer than most scale-to-zero windows.
 	if err := inventoryAgentComp.ForceCollect(); err != nil {
 		log.Warnf("serverless-init: initial inventory collection failed: %v", err)
+	} else {
+		metadata := inventoryAgentComp.Get()
+		log.Infof(
+			"serverless-init: inventory report queued reason=startup process_id=%s resource_id=%v workload_type=%v deployment_id=%v",
+			uuid.GetUUID(), metadata["resource_id"], metadata["workload_type"], metadata["deployment_id"],
+		)
 	}
 
 	err := modeConf.Runner(logConfig)

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -69,6 +69,7 @@ import (
 	enhancedmetrics "github.com/DataDog/datadog-agent/cmd/serverless-init/enhanced-metrics"
 	slinventory "github.com/DataDog/datadog-agent/cmd/serverless-init/inventory"
 	serverlessInitTag "github.com/DataDog/datadog-agent/cmd/serverless-init/tag"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -416,6 +417,8 @@ func run(
 	// Populate serverless-specific fields (cloud provider, workload type, etc.)
 	// before forcing the initial collection so all fields are present in the
 	// first payload sent per container lifecycle.
+	flavor.SetFlavor("serverless-init")
+
 	slinventory.SetInventoryFields(inventoryAgentComp, cloudService, modeConf)
 
 	// Force one inventory payload into the forwarder queue before the wrapped

--- a/cmd/serverless-init/mode/mode.go
+++ b/cmd/serverless-init/mode/mode.go
@@ -35,9 +35,12 @@ func DetectMode() Conf {
 	envToSet := map[string]string{
 		"DD_INSTRUMENTATION_TELEMETRY_ENABLED": "false",
 		"DD_REMOTE_CONFIGURATION_ENABLED":      "false",
-		"DD_HOSTNAME":                          "none",
-		"DD_APM_ENABLED":                       "true",
-		"DD_TRACE_ENABLED":                     "true",
+		// DD_HOSTNAME is intentionally NOT set here. Serverless agents have no host;
+		// the inventoryagent payload uses the cloud resource_name as UUID (PR #22542
+		// pattern). Setting hostname="none" would cause Subotka to key the row on the
+		// literal string "none" instead of the UUID, breaking Fleet lookups.
+		"DD_APM_ENABLED":   "true",
+		"DD_TRACE_ENABLED": "true",
 	}
 
 	if len(os.Args) == 1 {

--- a/comp/connectivitychecker/impl/connectivitychecker_test.go
+++ b/comp/connectivitychecker/impl/connectivitychecker_test.go
@@ -30,6 +30,7 @@ func (m *mockInventoryAgent) Set(name string, value interface{}) {
 func (m *mockInventoryAgent) Get() map[string]interface{} {
 	return m.data
 }
+func (m *mockInventoryAgent) ForceCollect() error { return nil }
 
 // Mock simple pour le lifecycle
 type mockLifecycle struct {

--- a/comp/metadata/internal/util/inventory_payload.go
+++ b/comp/metadata/internal/util/inventory_payload.go
@@ -246,6 +246,33 @@ func (i *InventoryPayload) RefreshTriggered() bool {
 	return i.forceRefresh.Load()
 }
 
+// ForceCollect immediately collects and sends one inventory payload, bypassing
+// the firstRunDelay and MinInterval/MaxInterval gates. It is intended for use
+// by serverless-init, which calls it once synchronously at container startup so
+// that the payload is queued in the forwarder before the wrapped process begins.
+// Combined with the forwarder's shutdown drain (forwarder_stop_timeout), this
+// guarantees that at least one inventory payload lands even when the container
+// lifetime is shorter than the normal firstRunDelay + MinInterval window.
+//
+// ForceCollect is safe to call concurrently with the runner's periodic collect
+// loop; it holds the same mutex. It does NOT update LastCollect or forceRefresh,
+// so the periodic loop continues on its normal schedule after this call.
+func (i *InventoryPayload) ForceCollect() error {
+	if !i.Enabled {
+		return nil
+	}
+	i.m.Lock()
+	defer i.m.Unlock()
+	if i.serializer == nil {
+		return nil
+	}
+	p := i.getPayload()
+	if p == nil {
+		return nil
+	}
+	return i.serializer.SendMetadata(p)
+}
+
 // GetAsJSON returns the payload as a JSON string. Useful to be displayed in the CLI or added to a flare.
 func (i *InventoryPayload) GetAsJSON() ([]byte, error) {
 	if !i.Enabled {

--- a/comp/metadata/internal/util/inventory_payload.go
+++ b/comp/metadata/internal/util/inventory_payload.go
@@ -81,6 +81,24 @@ var (
 // PayloadGetter is the callback to generate a new payload exposed by each inventory payload to InventoryPayload utils
 type PayloadGetter func() marshaler.JSONMarshaler
 
+// CollectionReason identifies why an inventory payload was submitted.
+type CollectionReason string
+
+const (
+	// CollectionReasonStartup is the synchronous collection performed when a
+	// serverless process starts.
+	CollectionReasonStartup CollectionReason = "startup"
+	// CollectionReasonPeriodic is the unchanged refresh performed after
+	// MaxInterval has elapsed.
+	CollectionReasonPeriodic CollectionReason = "periodic"
+	// CollectionReasonRefresh is a collection requested after metadata changes.
+	CollectionReasonRefresh CollectionReason = "refresh"
+)
+
+// CollectionObserver is called after an inventory submission attempt. It is
+// used by serverless-init to emit one producer log for every submission path.
+type CollectionObserver func(reason CollectionReason, err error)
+
 // InventoryPayload offers helpers for all inventory payloads providing all the common part to create a new payload.
 // InventoryPayload will handle the common configuration as well as refresh rates and flare. This type is meant to be
 // embedded.
@@ -111,6 +129,8 @@ type InventoryPayload struct {
 	MinInterval   time.Duration
 	MaxInterval   time.Duration
 	forceRefresh  atomic.Bool
+	collectReason CollectionReason
+	observer      CollectionObserver
 	FlareFileName string
 }
 
@@ -207,14 +227,19 @@ func (i *InventoryPayload) collect(_ context.Context) time.Duration {
 
 	// Collect will be called every MinInterval second. We send a new payload if a refresh was trigger or if it's
 	// been at least MaxInterval seconds since the last payload.
-	if !i.forceRefresh.Load() && i.MaxInterval-timeSince(i.LastCollect) > 0 {
+	refreshTriggered := i.forceRefresh.Load()
+	if !refreshTriggered && i.MaxInterval-timeSince(i.LastCollect) > 0 {
 		return i.MinInterval
 	}
 
 	i.forceRefresh.Store(false)
 	i.LastCollect = time.Now()
+	reason := CollectionReasonPeriodic
+	if refreshTriggered {
+		reason = CollectionReasonRefresh
+	}
 
-	p := i.getPayload()
+	p := i.payloadForReason(reason)
 	// If the payload is nil, we don't want to send it to the backend.
 	if p == nil {
 		i.log.Debugf("inventory payload is nil, skipping submission")
@@ -222,6 +247,9 @@ func (i *InventoryPayload) collect(_ context.Context) time.Duration {
 	}
 	if err := i.serializer.SendMetadata(p); err != nil {
 		i.log.Errorf("unable to submit inventories payload, %s", err)
+		i.observeCollection(reason, err)
+	} else {
+		i.observeCollection(reason, nil)
 	}
 	return i.MinInterval
 }
@@ -255,8 +283,9 @@ func (i *InventoryPayload) RefreshTriggered() bool {
 // lifetime is shorter than the normal firstRunDelay + MinInterval window.
 //
 // ForceCollect is safe to call concurrently with the runner's periodic collect
-// loop; it holds the same mutex. It does NOT update LastCollect or forceRefresh,
-// so the periodic loop continues on its normal schedule after this call.
+// loop; it holds the same mutex. It records the startup as the latest collection
+// and clears refreshes queued while startup metadata was populated. This avoids
+// an immediate duplicate from the periodic runner after firstRunDelay.
 func (i *InventoryPayload) ForceCollect() error {
 	if !i.Enabled {
 		return nil
@@ -266,11 +295,37 @@ func (i *InventoryPayload) ForceCollect() error {
 	if i.serializer == nil {
 		return nil
 	}
-	p := i.getPayload()
+	i.forceRefresh.Store(false)
+	i.LastCollect = time.Now()
+	p := i.payloadForReason(CollectionReasonStartup)
 	if p == nil {
 		return nil
 	}
-	return i.serializer.SendMetadata(p)
+	err := i.serializer.SendMetadata(p)
+	i.observeCollection(CollectionReasonStartup, err)
+	return err
+}
+
+// CollectionReason returns the reason assigned to the payload currently being
+// built. Payload implementations can include it as low-cardinality metadata.
+func (i *InventoryPayload) CollectionReason() CollectionReason {
+	return i.collectReason
+}
+
+// SetCollectionObserver registers a callback for completed submission attempts.
+func (i *InventoryPayload) SetCollectionObserver(observer CollectionObserver) {
+	i.observer = observer
+}
+
+func (i *InventoryPayload) payloadForReason(reason CollectionReason) marshaler.JSONMarshaler {
+	i.collectReason = reason
+	return i.getPayload()
+}
+
+func (i *InventoryPayload) observeCollection(reason CollectionReason, err error) {
+	if i.observer != nil {
+		i.observer(reason, err)
+	}
 }
 
 // GetAsJSON returns the payload as a JSON string. Useful to be displayed in the CLI or added to a flare.

--- a/comp/metadata/internal/util/inventory_payload_test.go
+++ b/comp/metadata/internal/util/inventory_payload_test.go
@@ -227,6 +227,54 @@ func TestCollect(t *testing.T) {
 	assert.False(t, i.forceRefresh.Load())
 }
 
+func TestCollectionReasons(t *testing.T) {
+	i := getTestInventoryPayload(t, map[string]any{
+		"inventories_first_run_delay": 0,
+	})
+	serializerMock := i.serializer.(*serializermock.MetricSerializer)
+	serializerMock.On("SendMetadata", mock.Anything).Return(nil).Times(3)
+
+	var reasons []CollectionReason
+	i.SetCollectionObserver(func(reason CollectionReason, err error) {
+		assert.NoError(t, err)
+		reasons = append(reasons, reason)
+	})
+
+	i.Refresh()
+	assert.NoError(t, i.ForceCollect())
+	assert.False(t, i.forceRefresh.Load(), "startup should consume queued metadata refreshes")
+	assert.Equal(t, CollectionReasonStartup, i.CollectionReason())
+
+	i.Refresh()
+	i.collect(context.Background())
+	assert.Equal(t, CollectionReasonRefresh, i.CollectionReason())
+
+	i.LastCollect = time.Now().Add(-i.MaxInterval - time.Second)
+	i.collect(context.Background())
+	assert.Equal(t, CollectionReasonPeriodic, i.CollectionReason())
+	assert.Equal(t, []CollectionReason{
+		CollectionReasonStartup,
+		CollectionReasonRefresh,
+		CollectionReasonPeriodic,
+	}, reasons)
+	serializerMock.AssertExpectations(t)
+}
+
+func TestForceCollectResetsPeriodicSchedule(t *testing.T) {
+	i := getTestInventoryPayload(t, map[string]any{
+		"inventories_first_run_delay": 0,
+	})
+	serializerMock := i.serializer.(*serializermock.MetricSerializer)
+	serializerMock.On("SendMetadata", mock.Anything).Return(nil).Once()
+
+	assert.NoError(t, i.ForceCollect())
+	lastCollect := i.LastCollect
+	i.collect(context.Background())
+
+	assert.Equal(t, lastCollect, i.LastCollect)
+	serializerMock.AssertExpectations(t)
+}
+
 func TestCollectEmptyPayload(t *testing.T) {
 	i := getEmptyInventoryPayload(t, nil)
 

--- a/comp/metadata/inventoryagent/def/component.go
+++ b/comp/metadata/inventoryagent/def/component.go
@@ -15,4 +15,10 @@ type Component interface {
 	Set(name string, value interface{})
 	// Get returns a copy of the agent metadata. Useful to be incorporated in the status page.
 	Get() map[string]interface{}
+	// ForceCollect immediately collects and sends one inventory payload, bypassing
+	// the normal firstRunDelay and MinInterval gates. It is intended for serverless-init,
+	// which calls it once at container startup to guarantee the payload reaches the
+	// forwarder queue before the wrapped process begins. Returns nil if inventory is
+	// disabled or the serializer is not available.
+	ForceCollect() error
 }

--- a/comp/metadata/inventoryagent/impl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/impl/inventoryagent.go
@@ -121,6 +121,7 @@ func NewComponent(deps Requires) Provides {
 		client:       deps.IPCClient,
 	}
 	ia.InventoryPayload = util.CreateInventoryPayload(deps.Config, deps.Log, deps.Serializer, ia.getPayload, "agent.json")
+	ia.SetCollectionObserver(ia.observeCollection)
 
 	if ia.Enabled {
 		ia.initData()
@@ -534,6 +535,9 @@ func (ia *inventoryagent) getPayload() marshaler.JSONMarshaler {
 	// Create a static copy of agentMetadata for the payload
 	data := make(agentMetadata)
 	maps.Copy(data, ia.data)
+	if flavor.GetFlavor() == "serverless-init" && ia.CollectionReason() != "" {
+		data["report_reason"] = string(ia.CollectionReason())
+	}
 
 	ia.getConfigs(data)
 
@@ -543,6 +547,24 @@ func (ia *inventoryagent) getPayload() marshaler.JSONMarshaler {
 		Metadata:  data,
 		UUID:      uuid.GetUUID(),
 	}
+}
+
+func (ia *inventoryagent) observeCollection(reason util.CollectionReason, err error) {
+	if flavor.GetFlavor() != "serverless-init" {
+		return
+	}
+	metadata := ia.Get()
+	if err != nil {
+		ia.log.Warnf(
+			"serverless-init: inventory report failed reason=%s process_id=%s resource_id=%v workload_type=%v deployment_id=%v error=%v",
+			reason, uuid.GetUUID(), metadata["resource_id"], metadata["workload_type"], metadata["deployment_id"], err,
+		)
+		return
+	}
+	ia.log.Infof(
+		"serverless-init: inventory report queued reason=%s process_id=%s resource_id=%v workload_type=%v deployment_id=%v",
+		reason, uuid.GetUUID(), metadata["resource_id"], metadata["workload_type"], metadata["deployment_id"],
+	)
 }
 
 // Get returns a copy of the agent metadata. Useful to be incorporated in the status page.

--- a/comp/metadata/inventoryagent/mock/mock.go
+++ b/comp/metadata/inventoryagent/mock/mock.go
@@ -42,6 +42,9 @@ func (m *inventoryagentMock) Get() map[string]interface{} {
 	return nil
 }
 
+// ForceCollect is a mocked function
+func (m *inventoryagentMock) ForceCollect() error { return nil }
+
 // Refresh is a mocked function
 func (m *inventoryagentMock) Refresh() {}
 

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1628,6 +1628,15 @@ func serverless(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("serverless.trace_enabled", true, "DD_TRACE_ENABLED")
 	config.BindEnvAndSetDefault("serverless.trace_managed_services", true, "DD_TRACE_MANAGED_SERVICES")
 	config.BindEnvAndSetDefault("serverless.service_mapping", "", "DD_SERVICE_MAPPING")
+
+	// inventoryagent is wired into serverless-init (Fleet/Subotka pipeline). Register
+	// these keys here so InventoryEnabled() works in the serverless config path, which
+	// only runs initCommonConfigComponents (not initCoreAgentFull where these live
+	// for the full agent). Defaults mirror initCoreAgentFull.
+	config.BindEnvAndSetDefault("inventories_enabled", true)
+	config.BindEnvAndSetDefault("inventories_first_run_delay", 60)
+	config.BindEnvAndSetDefault("inventories_min_interval", 0)
+	config.BindEnvAndSetDefault("inventories_max_interval", 0)
 }
 
 func forwarder(config pkgconfigmodel.Setup) {

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -1639,7 +1639,9 @@ func TestServerlessConfigInit(t *testing.T) {
 
 	// ensure some non-serverless configs are not declared
 	assert.False(t, conf.IsKnown("sbom.enabled"))
-	assert.False(t, conf.IsKnown("inventories_enabled"))
+	// inventories_enabled is registered in the serverless path because inventoryagent
+	// is wired into serverless-init for the Fleet/Subotka pipeline.
+	assert.True(t, conf.IsKnown("inventories_enabled"))
 
 	// comp/trace/config reads these unconditionally; serverless builds only run
 	// initCommonConfigComponents, so the defaults must be reachable from here.

--- a/scripts/serverless-deploy/.env.example
+++ b/scripts/serverless-deploy/.env.example
@@ -1,0 +1,17 @@
+# Copy to .env and fill in DD_API_KEY before running deploy.sh
+# Source with: set -a && source .env && set +a
+
+# GCP project (detected: datadog-serverless-gcp-demo)
+GCP_PROJECT=datadog-serverless-gcp-demo
+GCP_REGION=us-central1
+
+# Azure subscription (detected: serverless-dev)
+AZURE_SUBSCRIPTION_ID=1dd25961-a5c7-45bf-a5ba-c1475d365cc7
+AZURE_REGION=eastus
+
+# Datadog
+DD_SITE=datadoghq.com
+
+# Set this from vault before running:
+# vault kv get secret/dd-api-key
+DD_API_KEY=<set-from-vault>

--- a/scripts/serverless-deploy/Dockerfile.serverless-init
+++ b/scripts/serverless-deploy/Dockerfile.serverless-init
@@ -1,14 +1,25 @@
-FROM golang:1.23-alpine AS builder
+FROM golang:1.26-alpine AS builder
+
+ARG GIT_COMMIT=unknown
+ARG AGENT_VERSION=dev
+
+RUN apk add --no-cache gcc musl-dev
 
 WORKDIR /app
 
-COPY go.mod go.sum ./
-RUN go mod download
-
 COPY . .
-
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+# Disable Go workspace: go.work references test/* modules excluded from the build
+# context. GONOSUMCHECK skips checksum verification for local-replace modules.
+ENV GOWORK=off
+ENV GONOSUMCHECK=*
+# Skip go mod download (it resolves ALL replace directives including local ones
+# that aren't in the build context). go build only fetches actually-imported modules.
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+  -mod=mod \
   -tags "serverless otlp" \
+  -ldflags="-linkmode external -extldflags '-static' \
+    -X github.com/DataDog/datadog-agent/pkg/version.Commit=${GIT_COMMIT} \
+    -X github.com/DataDog/datadog-agent/pkg/version.AgentVersion=${AGENT_VERSION}" \
   -o /serverless-init \
   ./cmd/serverless-init/
 

--- a/scripts/serverless-deploy/Dockerfile.serverless-init
+++ b/scripts/serverless-deploy/Dockerfile.serverless-init
@@ -1,0 +1,19 @@
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+  -tags "serverless otlp" \
+  -o /serverless-init \
+  ./cmd/serverless-init/
+
+FROM gcr.io/distroless/static-debian12
+
+COPY --from=builder /serverless-init /serverless-init
+
+ENTRYPOINT ["/serverless-init"]

--- a/scripts/serverless-deploy/Dockerfile.serverless-init
+++ b/scripts/serverless-deploy/Dockerfile.serverless-init
@@ -2,6 +2,7 @@ FROM golang:1.26-alpine AS builder
 
 ARG GIT_COMMIT=unknown
 ARG AGENT_VERSION=dev
+ARG SERVERLESS_INIT_VERSION=dev
 
 RUN apk add --no-cache gcc musl-dev
 
@@ -19,7 +20,8 @@ RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
   -tags "serverless otlp" \
   -ldflags="-linkmode external -extldflags '-static' \
     -X github.com/DataDog/datadog-agent/pkg/version.Commit=${GIT_COMMIT} \
-    -X github.com/DataDog/datadog-agent/pkg/version.AgentVersion=${AGENT_VERSION}" \
+    -X github.com/DataDog/datadog-agent/pkg/version.AgentVersion=${AGENT_VERSION} \
+    -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=${SERVERLESS_INIT_VERSION}" \
   -o /serverless-init \
   ./cmd/serverless-init/
 

--- a/scripts/serverless-deploy/README.md
+++ b/scripts/serverless-deploy/README.md
@@ -1,0 +1,103 @@
+# SVLS-9526 Serverless Diagnostic Deployment
+
+Deploys 5 test services across GCP and Azure to capture what env vars and metadata
+are visible to `serverless-init` on each platform, using a custom image built from
+this branch (with `DD_SERVERLESS_DIAGNOSTIC_INFO=true` logging enabled).
+
+## Services deployed
+
+| Platform | Name | Notes |
+|---|---|---|
+| GCP Cloud Run Service | `dd-test-cloudrun-service` | HTTP, auto-scales |
+| GCP Cloud Run Job | `dd-test-cloudrun-job` | Runs once, no HTTP |
+| GCP Cloud Run Function v2 | `dd-test-cloudrun-function` | HTTP trigger |
+| Azure Container App | `dd-test-container-app` | HTTP, external ingress |
+| Azure Web App (Linux) | `dd-test-web-app` | HTTP, Python 3.11 |
+
+## Prerequisites
+
+Install the following CLIs:
+- `gcloud` (Google Cloud SDK)
+- `az` (Azure CLI)
+- `docker` (with buildx for `--platform linux/amd64`)
+
+Set the following environment variables:
+
+```bash
+export GCP_PROJECT=<your-gcp-project-id>
+export AZURE_SUBSCRIPTION_ID=<your-azure-subscription-id>
+
+# Fetch the API key from vault — do NOT hardcode it
+export DD_API_KEY=$(vault kv get -field=api_key secret/dd/serverless-test)
+```
+
+Optional overrides (defaults shown):
+
+```bash
+export DD_SITE=datadoghq.com
+export GCP_REGION=us-central1
+export AZURE_REGION=eastus
+export IMAGE_TAG=latest
+```
+
+## Step 1 — Build and push images
+
+Builds the custom `serverless-init` binary from the current branch source and the
+test Flask app, then pushes both to GCR Artifact Registry.
+
+```bash
+./build-image.sh
+```
+
+This creates (if needed) an Artifact Registry repo named `serverless-test` in your
+GCP project and pushes:
+- `<registry>/serverless-init:<IMAGE_TAG>`
+- `<registry>/test-app:<IMAGE_TAG>`
+
+## Step 2 — Deploy all 5 services
+
+```bash
+./deploy.sh
+```
+
+Deploys in sequence: Cloud Run Service, Cloud Run Job, Cloud Run Function v2,
+Azure Container App, Azure Web App. Prints URLs on completion.
+
+## Step 3 — Trigger each service
+
+Send a request to each HTTP service to generate diagnostic output:
+
+```bash
+curl "${CLOUDRUN_SERVICE_URL}"
+curl "${CLOUDRUN_FUNCTION_URL}"
+curl "${CONTAINER_APP_URL}"
+curl "${WEB_APP_URL}"
+# Cloud Run Job runs automatically during deploy (no HTTP endpoint)
+```
+
+## Step 4 — Check diagnostic logs
+
+```bash
+./check-logs.sh
+```
+
+Queries GCP Cloud Logging and Azure log streams for lines containing
+`SERVERLESS_DIAGNOSTIC` — the structured output emitted by `serverless-init`
+when `DD_SERVERLESS_DIAGNOSTIC_INFO=true` is set.
+
+## Directory structure
+
+```
+scripts/serverless-deploy/
+  deploy.sh                    # Main deploy script (all 5 platforms)
+  build-image.sh               # Build + push serverless-init and test-app images
+  check-logs.sh                # Fetch SERVERLESS_DIAGNOSTIC output from all platforms
+  Dockerfile.serverless-init   # Builds serverless-init from branch source
+  app/
+    app.py                     # Flask hello-world app (DogStatsD + structured logs)
+    requirements.txt
+    Dockerfile                 # Test app container image
+    function/
+      main.py                  # Cloud Run Function v2 handler
+      requirements.txt
+```

--- a/scripts/serverless-deploy/README.md
+++ b/scripts/serverless-deploy/README.md
@@ -1,103 +1,130 @@
-# SVLS-9526 Serverless Diagnostic Deployment
+# SVLS-9526 — Serverless Init Inventory POC
 
-Deploys 5 test services across GCP and Azure to capture what env vars and metadata
-are visible to `serverless-init` on each platform, using a custom image built from
-this branch (with `DD_SERVERLESS_DIAGNOSTIC_INFO=true` logging enabled).
+End-to-end proof of concept for [SVLS-9526]: serverless-init agents appear in
+the `datadog_agent` REDAPL table when `ForceCollect()` fires on cold start.
 
-## Services deployed
+Related PRs:
+- **#54537** — `ForceCollect()`: send inventory payload on every cold start
+- **#54538** — `inventories_first_run_delay` config key
+- **#54543** — `cmd/serverless-init/inventory`: `serverless_*` fields in payload
 
-| Platform | Name | Notes |
-|---|---|---|
-| GCP Cloud Run Service | `dd-test-cloudrun-service` | HTTP, auto-scales |
-| GCP Cloud Run Job | `dd-test-cloudrun-job` | Runs once, no HTTP |
-| GCP Cloud Run Function v2 | `dd-test-cloudrun-function` | HTTP trigger |
-| Azure Container App | `dd-test-container-app` | HTTP, external ingress |
-| Azure Web App (Linux) | `dd-test-web-app` | HTTP, Python 3.11 |
+## Services under test (9 total)
+
+| # | Platform | Name | Mode |
+|---|---|---|---|
+| 1 | GCP Cloud Run Service | `nina-cloudrun-init` | init-container |
+| 2 | GCP Cloud Run Service | `nina-cloudrun-sidecar` | sidecar |
+| 3 | GCP Cloud Run Job | `nina-cloudrun-job` | init-container |
+| 4 | GCP Cloud Run Function gen2 | `nina-cloudrun-function-sidecar` | sidecar |
+| 5 | Azure Container App | `nina-containerapp-init` | init-container |
+| 6 | Azure Container App | `nina-containerapp-sidecar` | sidecar |
+| 7 | Azure Web App (Linux Containers) | `nina-webapp-container` | init-container |
+| 8 | Azure Web App (SITECONTAINERS) | `nina-webapp-sidecar` | sidecar |
+| 9 | Azure Web App (Linux Code) | `nina-webapp-linux-code` | sidecar |
 
 ## Prerequisites
 
-Install the following CLIs:
-- `gcloud` (Google Cloud SDK)
-- `az` (Azure CLI)
-- `docker` (with buildx for `--platform linux/amd64`)
+Install:
+- `gcloud` (Google Cloud SDK) — `gcloud auth login` before running
+- `az` (Azure CLI) — `az login` before running
+- `docker` with buildx for `--platform linux/amd64`
+- `python3`, `envsubst` (from `gettext`)
 
-Set the following environment variables:
+## Quick start — one command
 
 ```bash
-export GCP_PROJECT=<your-gcp-project-id>
-export AZURE_SUBSCRIPTION_ID=<your-azure-subscription-id>
+export GCP_PROJECT=datadog-serverless-gcp-demo
+export AZURE_SUBSCRIPTION_ID=<your-subscription-id>
+export DD_API_KEY=$(vault kv get -field=api_key kv/dd/api_keys/dddev)
+export IMAGE_TAG=1.10.2-poc-$(date +%Y%m%d)   # or any tag
 
-# Fetch the API key from vault — do NOT hardcode it
-export DD_API_KEY=$(vault kv get -field=api_key secret/dd/serverless-test)
+cd scripts/serverless-deploy
+./demo.sh
 ```
 
-Optional overrides (defaults shown):
+`demo.sh` runs all three steps in sequence:
+1. **Build** — compiles serverless-init from the current branch and pushes to GCR + ACR
+2. **Deploy** — creates/updates all 9 services across GCP and Azure
+3. **Trigger** — forces a cold start on each service, waits 75s, then collects
+   `SERVERLESS_DIAGNOSTIC` logs and prints the REDAPL SQL query
+
+## Step-by-step (if you need to run stages individually)
+
+### Step 1 — Build and push images
 
 ```bash
-export DD_SITE=datadoghq.com
-export GCP_REGION=us-central1
-export AZURE_REGION=eastus
-export IMAGE_TAG=latest
-```
-
-## Step 1 — Build and push images
-
-Builds the custom `serverless-init` binary from the current branch source and the
-test Flask app, then pushes both to GCR Artifact Registry.
-
-```bash
+GCP_PROJECT=datadog-serverless-gcp-demo \
+AZURE_SUBSCRIPTION_ID=<sub-id> \
+IMAGE_TAG=1.10.2-poc \
 ./build-image.sh
 ```
 
-This creates (if needed) an Artifact Registry repo named `serverless-test` in your
-GCP project and pushes:
-- `<registry>/serverless-init:<IMAGE_TAG>`
-- `<registry>/test-app:<IMAGE_TAG>`
+Pushes three images to GCR Artifact Registry (and ACR if `AZURE_SUBSCRIPTION_ID` is set):
+- `serverless-init:<tag>` — built from current branch source
+- `test-app:<tag>` — Flask app with serverless-init as entrypoint (init-container mode)
+- `plain-app:<tag>` — Flask app only, no serverless-init (sidecar mode)
 
-## Step 2 — Deploy all 5 services
+### Step 2 — Deploy all 9 services
 
 ```bash
+GCP_PROJECT=datadog-serverless-gcp-demo \
+DD_API_KEY=<key> \
+AZURE_SUBSCRIPTION_ID=<sub-id> \
+IMAGE_TAG=1.10.2-poc \
 ./deploy.sh
 ```
 
-Deploys in sequence: Cloud Run Service, Cloud Run Job, Cloud Run Function v2,
-Azure Container App, Azure Web App. Prints URLs on completion.
-
-## Step 3 — Trigger each service
-
-Send a request to each HTTP service to generate diagnostic output:
+### Step 3 — Trigger cold starts + collect logs
 
 ```bash
-curl "${CLOUDRUN_SERVICE_URL}"
-curl "${CLOUDRUN_FUNCTION_URL}"
-curl "${CONTAINER_APP_URL}"
-curl "${WEB_APP_URL}"
-# Cloud Run Job runs automatically during deploy (no HTTP endpoint)
+GCP_PROJECT=datadog-serverless-gcp-demo \
+AZURE_SUBSCRIPTION_ID=<sub-id> \
+./deploy.sh trigger_all
 ```
 
-## Step 4 — Check diagnostic logs
+Triggers a cold start on each service, waits 75s for the inventory runner to
+fire, then calls `check-logs.sh` which:
+- Pulls `SERVERLESS_DIAGNOSTIC` lines from GCP Cloud Logging and Azure log streams
+- Extracts `uuid (agent):` values from each service
+- Prints a REDAPL SQL query to validate the payloads in `datadog_agent`
+
+### Step 4 — Validate in REDAPL
+
+Paste the generated query into **go/redapl → Queries → SQL**.
+
+Expected results:
+
+| Platform | UUID behaviour | Rows in `datadog_agent` |
+|---|---|---|
+| GCP Cloud Run | New UUID per cold start | 1 new row per trigger |
+| Azure Container App | Stable UUID per replica | Upserts same row |
+| Azure Web App | DMI UUID from underlying VM | 1 row per App Service Plan VM |
+
+The Azure App Service finding (two apps on the same Plan share a UUID) is the
+primary motivation for `serverless_init_agent` — a separate table keyed by
+CCRID (`resource_id`) instead of Agent UUID.
+
+## Skip flags
 
 ```bash
-./check-logs.sh
+SKIP_BUILD=true ./demo.sh    # use an already-pushed image
+SKIP_DEPLOY=true ./demo.sh   # only trigger + collect logs (services already deployed)
 ```
-
-Queries GCP Cloud Logging and Azure log streams for lines containing
-`SERVERLESS_DIAGNOSTIC` — the structured output emitted by `serverless-init`
-when `DD_SERVERLESS_DIAGNOSTIC_INFO=true` is set.
 
 ## Directory structure
 
 ```
 scripts/serverless-deploy/
-  deploy.sh                    # Main deploy script (all 5 platforms)
-  build-image.sh               # Build + push serverless-init and test-app images
-  check-logs.sh                # Fetch SERVERLESS_DIAGNOSTIC output from all platforms
+  demo.sh                      # One-command end-to-end runner (build → deploy → trigger)
+  deploy.sh                    # Deploy all 9 services; trigger_all subcommand
+  build-image.sh               # Build + push serverless-init, test-app, plain-app images
+  check-logs.sh                # Collect SERVERLESS_DIAGNOSTIC logs + generate REDAPL SQL
   Dockerfile.serverless-init   # Builds serverless-init from branch source
   app/
-    app.py                     # Flask hello-world app (DogStatsD + structured logs)
+    app.py                     # Flask hello-world (DogStatsD + structured logs)
     requirements.txt
-    Dockerfile                 # Test app container image
-    function/
-      main.py                  # Cloud Run Function v2 handler
-      requirements.txt
+    Dockerfile                 # test-app: serverless-init wraps Flask app
+    Dockerfile.plain           # plain-app: Flask app only (for sidecar deployments)
+    cloudrun-sidecar.yaml      # Knative multi-container spec (#2)
+    cloudrun-function-sidecar.yaml  # Knative multi-container spec (#4)
 ```

--- a/scripts/serverless-deploy/app/Dockerfile
+++ b/scripts/serverless-deploy/app/Dockerfile
@@ -1,12 +1,22 @@
+ARG REGISTRY
+ARG IMAGE_TAG=latest
+FROM ${REGISTRY}/serverless-init:${IMAGE_TAG} AS serverless-init
+
 FROM python:3.11-slim
+
+COPY --from=serverless-init /serverless-init /serverless-init
 
 WORKDIR /app
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app.py .
+COPY app.py job.py ./
 
 EXPOSE 8080
 
-ENTRYPOINT ["ddtrace-run", "python", "app.py"]
+# serverless-init wraps the app: starts the embedded DD agent, then exec's CMD.
+# For services: CMD is overridden at deploy time with "python app.py".
+# For jobs:     CMD is overridden at deploy time with "python job.py".
+ENTRYPOINT ["/serverless-init"]
+CMD ["python", "app.py"]

--- a/scripts/serverless-deploy/app/Dockerfile
+++ b/scripts/serverless-deploy/app/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py .
+
+EXPOSE 8080
+
+ENTRYPOINT ["ddtrace-run", "python", "app.py"]

--- a/scripts/serverless-deploy/app/Dockerfile.plain
+++ b/scripts/serverless-deploy/app/Dockerfile.plain
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py .
+
+EXPOSE 8080
+
+CMD ["python", "app.py"]

--- a/scripts/serverless-deploy/app/app.py
+++ b/scripts/serverless-deploy/app/app.py
@@ -1,19 +1,12 @@
 import json
-import logging
 import os
 
-from datadog import initialize, statsd
 from flask import Flask
-
-# Initialize DogStatsD
-initialize()
 
 app = Flask(__name__)
 
-logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-
-def _platform_name():
+def _platform():
     return (
         os.environ.get("K_SERVICE")
         or os.environ.get("CONTAINER_APP_NAME")
@@ -24,19 +17,12 @@ def _platform_name():
 
 @app.route("/")
 def hello():
-    platform = _platform_name()
-
-    # Emit DogStatsD metric
-    statsd.increment("serverless.test.request_count", tags=[f"platform:{platform}"])
-
-    # Structured log line
-    logging.info(
-        json.dumps({"message": "request received", "service": platform, "status": 200})
+    return (
+        json.dumps({"status": "ok", "platform": _platform()}),
+        200,
+        {"Content-Type": "application/json"},
     )
-
-    return json.dumps({"status": "ok", "platform": platform}), 200, {"Content-Type": "application/json"}
 
 
 if __name__ == "__main__":
-    port = int(os.environ.get("PORT", 8080))
-    app.run(host="0.0.0.0", port=port)
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))

--- a/scripts/serverless-deploy/app/app.py
+++ b/scripts/serverless-deploy/app/app.py
@@ -1,0 +1,42 @@
+import json
+import logging
+import os
+
+from datadog import initialize, statsd
+from flask import Flask
+
+# Initialize DogStatsD
+initialize()
+
+app = Flask(__name__)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+def _platform_name():
+    return (
+        os.environ.get("K_SERVICE")
+        or os.environ.get("CONTAINER_APP_NAME")
+        or os.environ.get("WEBSITE_SITE_NAME")
+        or "unknown"
+    )
+
+
+@app.route("/")
+def hello():
+    platform = _platform_name()
+
+    # Emit DogStatsD metric
+    statsd.increment("serverless.test.request_count", tags=[f"platform:{platform}"])
+
+    # Structured log line
+    logging.info(
+        json.dumps({"message": "request received", "service": platform, "status": 200})
+    )
+
+    return json.dumps({"status": "ok", "platform": platform}), 200, {"Content-Type": "application/json"}
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 8080))
+    app.run(host="0.0.0.0", port=port)

--- a/scripts/serverless-deploy/app/cloudrun-function-sidecar.yaml
+++ b/scripts/serverless-deploy/app/cloudrun-function-sidecar.yaml
@@ -1,0 +1,51 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: nina-cloudrun-function-sidecar
+  namespace: ${GCP_PROJECT}
+  annotations:
+    run.googleapis.com/launch-stage: BETA
+spec:
+  template:
+    metadata:
+      annotations:
+        # dd-agent must start before the app container begins serving traffic
+        run.googleapis.com/container-dependencies: '{"app":["dd-agent"]}'
+    spec:
+      containers:
+        # ── Ingress container (plain-app on port 8080) ────────────────────
+        - name: app
+          image: ${GCP_REGISTRY}/plain-app:${IMAGE_TAG}
+          ports:
+            - name: http1
+              containerPort: 8080
+
+        # ── dd-agent sidecar (no args → sidecar mode in serverless-init) ──
+        # Deployed as a Cloud Run Service using gen2 function infrastructure.
+        # gcloud run services replace is used (gcloud functions deploy does not
+        # support multi-container).
+        - name: dd-agent
+          image: ${GCP_REGISTRY}/serverless-init:${IMAGE_TAG}
+          startupProbe:
+            tcpSocket:
+              port: 5555
+            initialDelaySeconds: 1
+            periodSeconds: 3
+            failureThreshold: 20
+          env:
+            - name: DD_HEALTH_PORT
+              value: "5555"
+            - name: DD_SITE
+              value: "${DD_SITE}"
+            - name: DD_SERVICE
+              value: "nina-cloudrun-function-sidecar"
+            - name: DD_ENV
+              value: "nina"
+            - name: DD_APM_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_SERVERLESS_DIAGNOSTIC_INFO
+              value: "true"
+            - name: DD_API_KEY
+              value: "${DD_API_KEY}"

--- a/scripts/serverless-deploy/app/cloudrun-sidecar.yaml
+++ b/scripts/serverless-deploy/app/cloudrun-sidecar.yaml
@@ -1,0 +1,48 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: nina-cloudrun-sidecar
+  namespace: ${GCP_PROJECT}
+  annotations:
+    run.googleapis.com/launch-stage: BETA
+spec:
+  template:
+    metadata:
+      annotations:
+        # dd-agent must start before the app container begins serving traffic
+        run.googleapis.com/container-dependencies: '{"app":["dd-agent"]}'
+    spec:
+      containers:
+        # ── Ingress container ──────────────────────────────────────────────
+        - name: app
+          image: ${GCP_REGISTRY}/plain-app:${IMAGE_TAG}
+          ports:
+            - name: http1
+              containerPort: 8080
+
+        # ── dd-agent sidecar (no args → sidecar mode in serverless-init) ──
+        - name: dd-agent
+          image: ${GCP_REGISTRY}/serverless-init:${IMAGE_TAG}
+          startupProbe:
+            tcpSocket:
+              port: 5555
+            initialDelaySeconds: 1
+            periodSeconds: 3
+            failureThreshold: 20
+          env:
+            - name: DD_HEALTH_PORT
+              value: "5555"
+            - name: DD_SITE
+              value: "${DD_SITE}"
+            - name: DD_SERVICE
+              value: "nina-cloudrun-sidecar"
+            - name: DD_ENV
+              value: "nina"
+            - name: DD_APM_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+              value: "true"
+            - name: DD_SERVERLESS_DIAGNOSTIC_INFO
+              value: "true"
+            - name: DD_API_KEY
+              value: "${DD_API_KEY}"

--- a/scripts/serverless-deploy/app/containerapp-sidecar.yaml
+++ b/scripts/serverless-deploy/app/containerapp-sidecar.yaml
@@ -1,0 +1,70 @@
+# Reference YAML for the Azure Container App sidecar deployment.
+# Not used directly by deploy.sh (which builds the JSON body inline via Python
+# and calls az rest PUT). Kept as readable documentation of the minimum viable
+# configuration.
+#
+# Substituted variables: AZURE_SUBSCRIPTION_ID, AZURE_RESOURCE_GROUP,
+#   AZURE_CONTAINER_ENV, ACR_REGISTRY, ACR_USER, ACR_PASS, DD_SITE,
+#   DD_API_KEY, IMAGE_TAG
+
+location: eastus
+name: nina-containerapp-sidecar
+properties:
+  environmentId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP}/providers/Microsoft.App/managedEnvironments/${AZURE_CONTAINER_ENV}
+  configuration:
+    ingress:
+      external: true
+      targetPort: 8080
+      traffic:
+        - latestRevision: true
+          weight: 100
+    registries:
+      - server: ${ACR_REGISTRY}
+        username: ${ACR_USER}
+        passwordSecretRef: acr-password
+    secrets:
+      - name: acr-password
+        value: ${ACR_PASS}
+      - name: dd-api-key
+        value: ${DD_API_KEY}
+  template:
+    containers:
+      # ── Ingress container ────────────────────────────────────────────────
+      - name: app
+        image: ${ACR_REGISTRY}/plain-app:${IMAGE_TAG}
+        resources:
+          cpu: 0.5
+          memory: 1Gi
+        env:
+          - name: DD_SERVICE
+            value: nina-containerapp-sidecar
+          - name: DD_ENV
+            value: nina
+
+      # ── dd-agent sidecar (no args → sidecar mode in serverless-init) ────
+      - name: dd-agent
+        image: ${ACR_REGISTRY}/serverless-init:${IMAGE_TAG}
+        resources:
+          cpu: 0.5
+          memory: 1Gi
+        env:
+          - name: DD_SITE
+            value: ${DD_SITE}
+          - name: DD_SERVICE
+            value: nina-containerapp-sidecar
+          - name: DD_ENV
+            value: nina
+          - name: DD_APM_NON_LOCAL_TRAFFIC
+            value: "true"
+          - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
+            value: "true"
+          - name: DD_SERVERLESS_DIAGNOSTIC_INFO
+            value: "true"
+          - name: DD_HEALTH_PORT
+            value: "5555"
+          - name: DD_AZURE_SUBSCRIPTION_ID
+            value: ${AZURE_SUBSCRIPTION_ID}
+          - name: DD_AZURE_RESOURCE_GROUP
+            value: ${AZURE_RESOURCE_GROUP}
+          - name: DD_API_KEY
+            secretRef: dd-api-key

--- a/scripts/serverless-deploy/app/function/main.py
+++ b/scripts/serverless-deploy/app/function/main.py
@@ -1,0 +1,14 @@
+import functions_framework
+import json
+import logging
+import os
+
+
+@functions_framework.http
+def hello(request):
+    logging.info(
+        json.dumps({"message": "request received", "service": "dd-test-cloudrun-function"})
+    )
+    return json.dumps({"status": "ok", "platform": "cloud_run_function"}), 200, {
+        "Content-Type": "application/json"
+    }

--- a/scripts/serverless-deploy/app/function/main.py
+++ b/scripts/serverless-deploy/app/function/main.py
@@ -1,7 +1,7 @@
-import functions_framework
 import json
 import logging
-import os
+
+import functions_framework
 
 
 @functions_framework.http

--- a/scripts/serverless-deploy/app/function/main.py
+++ b/scripts/serverless-deploy/app/function/main.py
@@ -6,9 +6,5 @@ import os
 
 @functions_framework.http
 def hello(request):
-    logging.info(
-        json.dumps({"message": "request received", "service": "dd-test-cloudrun-function"})
-    )
-    return json.dumps({"status": "ok", "platform": "cloud_run_function"}), 200, {
-        "Content-Type": "application/json"
-    }
+    logging.info(json.dumps({"message": "request received", "service": "dd-test-cloudrun-function"}))
+    return json.dumps({"status": "ok", "platform": "cloud_run_function"}), 200, {"Content-Type": "application/json"}

--- a/scripts/serverless-deploy/app/function/requirements.txt
+++ b/scripts/serverless-deploy/app/function/requirements.txt
@@ -1,0 +1,2 @@
+functions-framework==3.*
+ddtrace==2.12.2

--- a/scripts/serverless-deploy/app/job.py
+++ b/scripts/serverless-deploy/app/job.py
@@ -1,0 +1,21 @@
+"""
+Minimal Cloud Run Job workload.
+Prints a JSON status line and exits so serverless-init can flush telemetry cleanly.
+"""
+import json
+import os
+import sys
+import time
+
+result = {
+    "status": "ok",
+    "service": os.environ.get("DD_SERVICE", "unknown"),
+    "env": os.environ.get("DD_ENV", "unknown"),
+}
+print(json.dumps(result), flush=True)
+
+# Give serverless-init a moment to flush its telemetry queue before the
+# process exits.  The ForceCollect() at startup already queued the inventory
+# payload; this small sleep lets the forwarder HTTP POST complete.
+time.sleep(3)
+sys.exit(0)

--- a/scripts/serverless-deploy/app/job.py
+++ b/scripts/serverless-deploy/app/job.py
@@ -2,6 +2,7 @@
 Minimal Cloud Run Job workload.
 Prints a JSON status line and exits so serverless-init can flush telemetry cleanly.
 """
+
 import json
 import os
 import sys

--- a/scripts/serverless-deploy/app/requirements.txt
+++ b/scripts/serverless-deploy/app/requirements.txt
@@ -1,3 +1,2 @@
 flask==3.0.3
-ddtrace==2.12.2
-datadog==0.49.1
+gunicorn==22.0.0

--- a/scripts/serverless-deploy/app/requirements.txt
+++ b/scripts/serverless-deploy/app/requirements.txt
@@ -1,0 +1,3 @@
+flask==3.0.3
+ddtrace==2.12.2
+datadog==0.49.1

--- a/scripts/serverless-deploy/build-image.sh
+++ b/scripts/serverless-deploy/build-image.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Builds the custom serverless-init image (from the current branch) and the
+# test-app image, then pushes both to GCR Artifact Registry.
+# ---------------------------------------------------------------------------
+
+: "${GCP_PROJECT:?GCP_PROJECT must be set}"
+
+GCP_REGION="${GCP_REGION:-us-central1}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+
+REGISTRY="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/serverless-test"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Repo root is two levels above scripts/serverless-deploy/
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+log() {
+  echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"
+}
+
+# ---------------------------------------------------------------------------
+# Configure Docker to push to GCR Artifact Registry
+# ---------------------------------------------------------------------------
+gcloud auth configure-docker "${GCP_REGION}-docker.pkg.dev" --quiet
+
+# ---------------------------------------------------------------------------
+# Create Artifact Registry repository (idempotent)
+# ---------------------------------------------------------------------------
+log "Ensuring Artifact Registry repository exists..."
+gcloud artifacts repositories create serverless-test \
+  --repository-format=docker \
+  --location="${GCP_REGION}" \
+  --project="${GCP_PROJECT}" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Build serverless-init from current branch source
+# ---------------------------------------------------------------------------
+log "Building serverless-init image from branch source..."
+docker build \
+  --platform linux/amd64 \
+  -f "${SCRIPT_DIR}/Dockerfile.serverless-init" \
+  -t "${REGISTRY}/serverless-init:${IMAGE_TAG}" \
+  "${REPO_ROOT}"
+
+# ---------------------------------------------------------------------------
+# Build the test app image
+# ---------------------------------------------------------------------------
+log "Building test-app image..."
+docker build \
+  --platform linux/amd64 \
+  -f "${SCRIPT_DIR}/app/Dockerfile" \
+  -t "${REGISTRY}/test-app:${IMAGE_TAG}" \
+  "${SCRIPT_DIR}/app"
+
+# ---------------------------------------------------------------------------
+# Push both images
+# ---------------------------------------------------------------------------
+log "Pushing serverless-init image..."
+docker push "${REGISTRY}/serverless-init:${IMAGE_TAG}"
+
+log "Pushing test-app image..."
+docker push "${REGISTRY}/test-app:${IMAGE_TAG}"
+
+log "Done. Images pushed:"
+log "  ${REGISTRY}/serverless-init:${IMAGE_TAG}"
+log "  ${REGISTRY}/test-app:${IMAGE_TAG}"

--- a/scripts/serverless-deploy/build-image.sh
+++ b/scripts/serverless-deploy/build-image.sh
@@ -10,6 +10,10 @@ set -euo pipefail
 
 GCP_REGION="${GCP_REGION:-us-central1}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
+AZURE_REGION="${AZURE_REGION:-eastus}"
+AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID:-}"
+AZURE_RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:-dd-serverless-test-aca}"
+ACR_NAME="${ACR_NAME:-ddsvlstestaca}"
 
 REGISTRY="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/serverless-test"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -38,21 +42,37 @@ gcloud artifacts repositories create serverless-test \
 # ---------------------------------------------------------------------------
 # Build serverless-init from current branch source
 # ---------------------------------------------------------------------------
-log "Building serverless-init image from branch source..."
+GIT_COMMIT="$(git -C "${REPO_ROOT}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+AGENT_VERSION="$(python3 -c "import json; d=json.load(open('${REPO_ROOT}/release.json')); print(d['current_milestone'])" 2>/dev/null || echo dev)-dev"
+log "Building serverless-init image from branch source (commit=${GIT_COMMIT}, agent=${AGENT_VERSION})..."
 docker build \
   --platform linux/amd64 \
+  --build-arg GIT_COMMIT="${GIT_COMMIT}" \
+  --build-arg AGENT_VERSION="${AGENT_VERSION}" \
   -f "${SCRIPT_DIR}/Dockerfile.serverless-init" \
   -t "${REGISTRY}/serverless-init:${IMAGE_TAG}" \
   "${REPO_ROOT}"
 
 # ---------------------------------------------------------------------------
-# Build the test app image
+# Build the test app image (wrapper: serverless-init as entrypoint)
 # ---------------------------------------------------------------------------
-log "Building test-app image..."
+log "Building test-app image (embedding serverless-init from branch)..."
 docker build \
   --platform linux/amd64 \
+  --build-arg REGISTRY="${REGISTRY}" \
+  --build-arg IMAGE_TAG="${IMAGE_TAG}" \
   -f "${SCRIPT_DIR}/app/Dockerfile" \
   -t "${REGISTRY}/test-app:${IMAGE_TAG}" \
+  "${SCRIPT_DIR}/app"
+
+# ---------------------------------------------------------------------------
+# Build the plain app image (sidecar: no serverless-init, just the Python app)
+# ---------------------------------------------------------------------------
+log "Building plain-app image (for sidecar deployments)..."
+docker build \
+  --platform linux/amd64 \
+  -f "${SCRIPT_DIR}/app/Dockerfile.plain" \
+  -t "${REGISTRY}/plain-app:${IMAGE_TAG}" \
   "${SCRIPT_DIR}/app"
 
 # ---------------------------------------------------------------------------
@@ -64,6 +84,48 @@ docker push "${REGISTRY}/serverless-init:${IMAGE_TAG}"
 log "Pushing test-app image..."
 docker push "${REGISTRY}/test-app:${IMAGE_TAG}"
 
-log "Done. Images pushed:"
+log "Pushing plain-app image..."
+docker push "${REGISTRY}/plain-app:${IMAGE_TAG}"
+
+log "Done. GAR images pushed:"
 log "  ${REGISTRY}/serverless-init:${IMAGE_TAG}"
 log "  ${REGISTRY}/test-app:${IMAGE_TAG}"
+log "  ${REGISTRY}/plain-app:${IMAGE_TAG}"
+
+# ---------------------------------------------------------------------------
+# Optional: also push to Azure Container Registry
+# ---------------------------------------------------------------------------
+if [[ -n "${AZURE_SUBSCRIPTION_ID}" ]]; then
+  ACR_REGISTRY="${ACR_NAME}.azurecr.io"
+  log "Pushing to Azure Container Registry (${ACR_REGISTRY})..."
+
+  # Create resource group and ACR (both idempotent)
+  az group create \
+    --name "${AZURE_RESOURCE_GROUP}" \
+    --location "${AZURE_REGION}" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
+
+  az acr create \
+    --name "${ACR_NAME}" \
+    --resource-group "${AZURE_RESOURCE_GROUP}" \
+    --sku Basic \
+    --location "${AZURE_REGION}" \
+    --admin-enabled true \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" 2>/dev/null || true
+
+  az acr login --name "${ACR_NAME}" --subscription "${AZURE_SUBSCRIPTION_ID}"
+
+  docker tag "${REGISTRY}/serverless-init:${IMAGE_TAG}" "${ACR_REGISTRY}/serverless-init:${IMAGE_TAG}"
+  docker push "${ACR_REGISTRY}/serverless-init:${IMAGE_TAG}"
+
+  docker tag "${REGISTRY}/test-app:${IMAGE_TAG}" "${ACR_REGISTRY}/test-app:${IMAGE_TAG}"
+  docker push "${ACR_REGISTRY}/test-app:${IMAGE_TAG}"
+
+  docker tag "${REGISTRY}/plain-app:${IMAGE_TAG}" "${ACR_REGISTRY}/plain-app:${IMAGE_TAG}"
+  docker push "${ACR_REGISTRY}/plain-app:${IMAGE_TAG}"
+
+  log "ACR images pushed:"
+  log "  ${ACR_REGISTRY}/serverless-init:${IMAGE_TAG}"
+  log "  ${ACR_REGISTRY}/test-app:${IMAGE_TAG}"
+  log "  ${ACR_REGISTRY}/plain-app:${IMAGE_TAG}"
+fi

--- a/scripts/serverless-deploy/build-image.sh
+++ b/scripts/serverless-deploy/build-image.sh
@@ -44,11 +44,13 @@ gcloud artifacts repositories create serverless-test \
 # ---------------------------------------------------------------------------
 GIT_COMMIT="$(git -C "${REPO_ROOT}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
 AGENT_VERSION="$(python3 -c "import json; d=json.load(open('${REPO_ROOT}/release.json')); print(d['current_milestone'])" 2>/dev/null || echo dev)-dev"
+SERVERLESS_INIT_VERSION="${SERVERLESS_INIT_VERSION:-${AGENT_VERSION}}"
 log "Building serverless-init image from branch source (commit=${GIT_COMMIT}, agent=${AGENT_VERSION})..."
 docker build \
   --platform linux/amd64 \
   --build-arg GIT_COMMIT="${GIT_COMMIT}" \
   --build-arg AGENT_VERSION="${AGENT_VERSION}" \
+  --build-arg SERVERLESS_INIT_VERSION="${SERVERLESS_INIT_VERSION}" \
   -f "${SCRIPT_DIR}/Dockerfile.serverless-init" \
   -t "${REGISTRY}/serverless-init:${IMAGE_TAG}" \
   "${REPO_ROOT}"

--- a/scripts/serverless-deploy/check-logs.sh
+++ b/scripts/serverless-deploy/check-logs.sh
@@ -2,52 +2,190 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# Checks all 5 deployed services for SERVERLESS_DIAGNOSTIC log output.
-# Run after deploy.sh and after triggering at least one request to each service.
+# Collects SERVERLESS_DIAGNOSTIC logs from all 8 deployed services and writes
+# the full output to a dated txt file. Generates a REDAPL SQL query at the end
+# using the agent UUIDs extracted from the diagnostic blocks.
+#
+# Usage: GCP_PROJECT=... AZURE_SUBSCRIPTION_ID=... ./check-logs.sh
+# Output file: diagnostic-results-YYYYMMDD-HHMMSS.txt (or set OUTPUT_FILE)
 # ---------------------------------------------------------------------------
 
 : "${GCP_PROJECT:?GCP_PROJECT must be set}"
-: "${AZURE_SUBSCRIPTION_ID:?AZURE_SUBSCRIPTION_ID must be set}"
+AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID:-}"
+AZURE_RG_ACA="${AZURE_RG_ACA:-dd-serverless-test-aca}"
+AZURE_RG_AAS="${AZURE_RG_AAS:-dd-serverless-test-aas}"
 
-echo "=== GCP Cloud Run Service ==="
-gcloud logging read \
-  "resource.type=cloud_run_revision AND resource.labels.service_name=dd-test-cloudrun-service AND textPayload:SERVERLESS_DIAGNOSTIC" \
-  --project="${GCP_PROJECT}" \
-  --limit=50 \
-  --format="value(textPayload)"
+OUTPUT_FILE="${OUTPUT_FILE:-${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/diagnostic-results-$(date -u +%Y%m%d-%H%M%S).txt}"
+
+log() { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"; }
+
+# ---------------------------------------------------------------------------
+# Log fetchers
+# ---------------------------------------------------------------------------
+
+_gcp_logs() {
+  local label="$1" resource_type="$2" filter_key="$3" filter_val="$4"
+  echo ""
+  echo "================================================================"
+  echo "# ${label}"
+  echo "================================================================"
+  gcloud logging read \
+    "resource.type=${resource_type} AND resource.labels.${filter_key}=${filter_val} AND textPayload:SERVERLESS_DIAGNOSTIC" \
+    --project="${GCP_PROJECT}" \
+    --limit=100 \
+    --format="value(textPayload)" \
+  || echo "(no diagnostic logs yet — trigger a request and retry)"
+}
+
+_azure_containerapp_logs() {
+  local label="$1" app_name="$2" container="${3:-}"
+  [[ -z "${AZURE_SUBSCRIPTION_ID}" ]] && return
+  echo ""
+  echo "================================================================"
+  echo "# ${label}"
+  echo "================================================================"
+  local args=(--name "${app_name}" --resource-group "${AZURE_RG_ACA}" \
+               --subscription "${AZURE_SUBSCRIPTION_ID}" --tail 300)
+  [[ -n "${container}" ]] && args+=(--container "${container}")
+  az containerapp logs show "${args[@]}" 2>/dev/null \
+  | grep "SERVERLESS_DIAGNOSTIC" \
+  || echo "(no diagnostic logs yet — trigger a request and retry)"
+}
+
+_azure_webapp_logs() {
+  local label="$1" app_name="$2" rg="${3:-${AZURE_RG_AAS}}"
+  [[ -z "${AZURE_SUBSCRIPTION_ID}" ]] && return
+  echo ""
+  echo "================================================================"
+  echo "# ${label}"
+  echo "================================================================"
+  # az webapp log tail only shows live streaming (misses already-warm containers).
+  # Use log download + grep instead — this captures archived logs from the
+  # containerStream and default_docker files written since last startup.
+  local tmp_zip
+  tmp_zip=$(mktemp /tmp/webapp-logs-XXXXXX.zip)
+  az webapp log download \
+    --name "${app_name}" \
+    --resource-group "${rg}" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" \
+    --log-file "${tmp_zip}" 2>/dev/null \
+  && unzip -p "${tmp_zip}" 2>/dev/null \
+     | grep -a "SERVERLESS_DIAGNOSTIC" \
+     | sort -u \
+  || echo "(no diagnostic logs yet — trigger a request and retry)"
+  rm -f "${tmp_zip}"
+}
+
+# ---------------------------------------------------------------------------
+# Run all checks
+# ---------------------------------------------------------------------------
+run_checks() {
+  echo "================================================================"
+  echo "SVLS-9526 — Serverless Init Diagnostic Results"
+  echo "Date: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+  echo "================================================================"
+
+  # GCP
+  _gcp_logs "#1 GCP Cloud Run Service (init-container)" \
+    cloud_run_revision service_name nina-cloudrun-init
+
+  _gcp_logs "#2 GCP Cloud Run Service (sidecar)" \
+    cloud_run_revision service_name nina-cloudrun-sidecar
+
+  _gcp_logs "#3 GCP Cloud Run Job (init-container)" \
+    cloud_run_job job_name nina-cloudrun-job
+
+  _gcp_logs "#4 GCP Cloud Run Function gen2 (sidecar)" \
+    cloud_run_revision service_name nina-cloudrun-function-sidecar
+
+  # Azure Container Apps
+  _azure_containerapp_logs "#5 Azure Container App (init-container)" \
+    nina-containerapp-init
+
+  _azure_containerapp_logs "#6 Azure Container App (sidecar, dd-agent)" \
+    nina-containerapp-sidecar dd-agent
+
+  # Azure Web Apps
+  _azure_webapp_logs "#7 Azure Web App Linux Containers (init-container)" \
+    nina-webapp-container
+
+  _azure_webapp_logs "#8 Azure Web App SITECONTAINERS (sidecar, dd-agent)" \
+    nina-webapp-sidecar
+
+  _azure_webapp_logs "#9 Azure Web App Linux Code + sidecar (dd-agent)" \
+    nina-webapp-linux-code
+}
+
+# ---------------------------------------------------------------------------
+# Extract agent UUIDs from the collected output and generate the REDAPL query
+# ---------------------------------------------------------------------------
+generate_sql() {
+  local output_file="$1"
+
+  # Extract UUIDs from lines like: [SERVERLESS_DIAGNOSTIC] uuid (agent): <uuid>
+  # Use python3 for portable regex (BSD grep lacks -P, GNU grep has it but not on macOS).
+  local uuids
+  uuids=$(python3 -c "
+import re, sys
+text = open('${output_file}').read()
+uuids = re.findall(r'uuid \(agent\):\s+([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})', text)
+print('\n'.join(sorted(set(uuids))))
+" 2>/dev/null || true)
+
+  echo ""
+  echo "================================================================"
+  echo "# REDAPL SQL Query — datadog_agent table"
+  echo "# Run in: go/redapl → Queries → SQL"
+  echo "================================================================"
+  echo ""
+
+  if [[ -n "${uuids}" ]]; then
+    echo "-- Query by agent UUID (extracted from diagnostic logs above):"
+    echo "SELECT"
+    echo "    _key             AS uuid,"
+    echo "    agent_version,"
+    echo "    first_seen_at,"
+    echo "    api_key_uuid"
+    echo "FROM datadog_agent"
+    echo "WHERE _key IN ("
+    while IFS= read -r uuid; do
+      echo "    '${uuid}',"
+    done <<< "${uuids}"
+    echo ")"
+    echo "ORDER BY first_seen_at DESC;"
+    echo ""
+    echo "-- Alternative: query by agent version + time window (catches any UUID):"
+  else
+    echo "-- No UUIDs extracted yet (run after services have started)."
+    echo "-- Fallback query by agent version + time window:"
+  fi
+
+  echo "SELECT"
+  echo "    _key             AS uuid,"
+  echo "    agent_version,"
+  echo "    first_seen_at,"
+  echo "    api_key_uuid"
+  echo "FROM datadog_agent"
+  echo "WHERE first_seen_at > NOW() - INTERVAL 2 HOUR"
+  echo "  AND agent_version LIKE '7.%'"
+  echo "ORDER BY first_seen_at DESC"
+  echo "LIMIT 20;"
+}
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+log "Collecting diagnostic logs → ${OUTPUT_FILE}"
+
+run_checks | tee "${OUTPUT_FILE}"
+generate_sql "${OUTPUT_FILE}" | tee -a "${OUTPUT_FILE}"
 
 echo ""
-echo "=== GCP Cloud Run Job ==="
-gcloud logging read \
-  "resource.type=cloud_run_job AND resource.labels.job_name=dd-test-cloudrun-job AND textPayload:SERVERLESS_DIAGNOSTIC" \
-  --project="${GCP_PROJECT}" \
-  --limit=50 \
-  --format="value(textPayload)"
-
-echo ""
-echo "=== GCP Cloud Run Function ==="
-gcloud logging read \
-  "resource.type=cloud_run_revision AND resource.labels.function_name=dd-test-cloudrun-function AND textPayload:SERVERLESS_DIAGNOSTIC" \
-  --project="${GCP_PROJECT}" \
-  --limit=50 \
-  --format="value(textPayload)"
-
-echo ""
-echo "=== Azure Container App ==="
-az containerapp logs show \
-  --name dd-test-container-app \
-  --resource-group dd-serverless-test-aca \
-  --subscription "${AZURE_SUBSCRIPTION_ID}" \
-  --tail 100 2>/dev/null | grep SERVERLESS_DIAGNOSTIC || echo "(no diagnostic logs yet)"
-
-echo ""
-echo "=== Azure Web App ==="
-# Stream logs briefly (background job) then kill
-az webapp log tail \
-  --name dd-test-web-app \
-  --resource-group dd-serverless-test-aas \
-  --subscription "${AZURE_SUBSCRIPTION_ID}" 2>/dev/null &
-TAIL_PID=$!
-sleep 5
-kill "${TAIL_PID}" 2>/dev/null || true
-wait "${TAIL_PID}" 2>/dev/null || true
+log "Done. Full output written to: ${OUTPUT_FILE}"
+log "Agent UUIDs in output:"
+python3 -c "
+import re
+text = open('${OUTPUT_FILE}').read()
+uuids = sorted(set(re.findall(r'uuid \(agent\):\s+([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})', text)))
+print('\n'.join('  ' + u for u in uuids))
+" 2>/dev/null || true

--- a/scripts/serverless-deploy/check-logs.sh
+++ b/scripts/serverless-deploy/check-logs.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Checks all 5 deployed services for SERVERLESS_DIAGNOSTIC log output.
+# Run after deploy.sh and after triggering at least one request to each service.
+# ---------------------------------------------------------------------------
+
+: "${GCP_PROJECT:?GCP_PROJECT must be set}"
+: "${AZURE_SUBSCRIPTION_ID:?AZURE_SUBSCRIPTION_ID must be set}"
+
+echo "=== GCP Cloud Run Service ==="
+gcloud logging read \
+  "resource.type=cloud_run_revision AND resource.labels.service_name=dd-test-cloudrun-service AND textPayload:SERVERLESS_DIAGNOSTIC" \
+  --project="${GCP_PROJECT}" \
+  --limit=50 \
+  --format="value(textPayload)"
+
+echo ""
+echo "=== GCP Cloud Run Job ==="
+gcloud logging read \
+  "resource.type=cloud_run_job AND resource.labels.job_name=dd-test-cloudrun-job AND textPayload:SERVERLESS_DIAGNOSTIC" \
+  --project="${GCP_PROJECT}" \
+  --limit=50 \
+  --format="value(textPayload)"
+
+echo ""
+echo "=== GCP Cloud Run Function ==="
+gcloud logging read \
+  "resource.type=cloud_run_revision AND resource.labels.function_name=dd-test-cloudrun-function AND textPayload:SERVERLESS_DIAGNOSTIC" \
+  --project="${GCP_PROJECT}" \
+  --limit=50 \
+  --format="value(textPayload)"
+
+echo ""
+echo "=== Azure Container App ==="
+az containerapp logs show \
+  --name dd-test-container-app \
+  --resource-group dd-serverless-test-aca \
+  --subscription "${AZURE_SUBSCRIPTION_ID}" \
+  --tail 100 2>/dev/null | grep SERVERLESS_DIAGNOSTIC || echo "(no diagnostic logs yet)"
+
+echo ""
+echo "=== Azure Web App ==="
+# Stream logs briefly (background job) then kill
+az webapp log tail \
+  --name dd-test-web-app \
+  --resource-group dd-serverless-test-aas \
+  --subscription "${AZURE_SUBSCRIPTION_ID}" 2>/dev/null &
+TAIL_PID=$!
+sleep 5
+kill "${TAIL_PID}" 2>/dev/null || true
+wait "${TAIL_PID}" 2>/dev/null || true

--- a/scripts/serverless-deploy/demo.sh
+++ b/scripts/serverless-deploy/demo.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# demo.sh — SVLS-9526 end-to-end POC
+#
+# Builds serverless-init from the current branch, deploys all 9 test services
+# across GCP and Azure, triggers cold starts, waits for the inventory runner
+# to fire, then prints the REDAPL SQL query to validate that agents appear in
+# the datadog_agent table.
+#
+# Related PRs:
+#   #54537 — ForceCollect(): send inventory payload on every cold start
+#   #54538 — inventories_first_run_delay config key
+#   #54543 — cmd/serverless-init/inventory: serverless_* fields in payload
+#
+# Usage:
+#   export GCP_PROJECT=datadog-serverless-gcp-demo
+#   export AZURE_SUBSCRIPTION_ID=<your-sub-id>
+#   export DD_API_KEY=$(vault kv get -field=api_key kv/dd/api_keys/dddev)
+#   export IMAGE_TAG=1.10.2-poc-$(date +%Y%m%d)   # optional, defaults to 'poc'
+#   ./demo.sh
+#
+# To skip the build (use an already-pushed image):
+#   SKIP_BUILD=true ./demo.sh
+#
+# To skip deployment (only trigger + collect logs):
+#   SKIP_DEPLOY=true ./demo.sh
+# ---------------------------------------------------------------------------
+
+: "${GCP_PROJECT:?GCP_PROJECT must be set (e.g. datadog-serverless-gcp-demo)}"
+: "${DD_API_KEY:?DD_API_KEY must be set — vault kv get -field=api_key kv/dd/api_keys/dddev}"
+: "${AZURE_SUBSCRIPTION_ID:?AZURE_SUBSCRIPTION_ID must be set}"
+
+IMAGE_TAG="${IMAGE_TAG:-poc}"
+SKIP_BUILD="${SKIP_BUILD:-false}"
+SKIP_DEPLOY="${SKIP_DEPLOY:-false}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+log() { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"; }
+header() {
+  echo ""
+  echo "=================================================="
+  echo "  $*"
+  echo "=================================================="
+}
+
+# ---------------------------------------------------------------------------
+# Step 1 — Build and push images
+# ---------------------------------------------------------------------------
+if [[ "${SKIP_BUILD}" != "true" ]]; then
+  header "Step 1/3 — Build + push images (IMAGE_TAG=${IMAGE_TAG})"
+  GCP_PROJECT="${GCP_PROJECT}" \
+  AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}" \
+  IMAGE_TAG="${IMAGE_TAG}" \
+    "${SCRIPT_DIR}/build-image.sh"
+else
+  log "Skipping build (SKIP_BUILD=true)"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2 — Deploy all 9 services
+# ---------------------------------------------------------------------------
+if [[ "${SKIP_DEPLOY}" != "true" ]]; then
+  header "Step 2/3 — Deploy all 9 services"
+  GCP_PROJECT="${GCP_PROJECT}" \
+  DD_API_KEY="${DD_API_KEY}" \
+  AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}" \
+  IMAGE_TAG="${IMAGE_TAG}" \
+    "${SCRIPT_DIR}/deploy.sh"
+else
+  log "Skipping deploy (SKIP_DEPLOY=true)"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3 — Trigger cold starts + collect diagnostic logs + print REDAPL query
+# ---------------------------------------------------------------------------
+header "Step 3/3 — Trigger cold starts + collect logs"
+log "Forcing a cold start on each service to exercise the ForceCollect() path..."
+log "Waiting ~75s after triggers for the inventory runner to fire and send the payload."
+log ""
+
+GCP_PROJECT="${GCP_PROJECT}" \
+AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}" \
+IMAGE_TAG="${IMAGE_TAG}" \
+  "${SCRIPT_DIR}/deploy.sh" trigger_all
+
+# ---------------------------------------------------------------------------
+# Done — print REDAPL validation instructions
+# ---------------------------------------------------------------------------
+echo ""
+echo "=================================================="
+echo "  POC complete — validate in REDAPL"
+echo "=================================================="
+echo ""
+echo "The REDAPL SQL query above was extracted from diagnostic logs."
+echo "To run it:"
+echo ""
+echo "  1. Go to go/redapl → Queries → SQL"
+echo "  2. Paste the query printed above and run it"
+echo "  3. You should see one row per service (GCP) or per App Service Plan"
+echo "     VM instance (Azure) that successfully sent an inventory payload."
+echo ""
+echo "What to look for:"
+echo "  - GCP Cloud Run:  new UUID per cold start (ForceCollect fires before scale-to-zero)"
+echo "  - Azure ACA:      stable UUID (same container runtime across restarts)"
+echo "  - Azure AAS:      stable DMI UUID per underlying VM; apps on the same"
+echo "                    App Service Plan share a UUID (CCRID needed for uniqueness)"
+echo ""
+echo "These results demonstrate the gap that motivates serverless_init_agent"
+echo "(a separate REDAPL table keyed by CCRID instead of UUID)."
+echo ""
+echo "Related PRs:"
+echo "  #54537  ForceCollect() — send inventory payload on every cold start"
+echo "  #54538  inventories_first_run_delay config key"
+echo "  #54543  cmd/serverless-init/inventory: serverless_* fields in payload"

--- a/scripts/serverless-deploy/deploy.sh
+++ b/scripts/serverless-deploy/deploy.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 # DD_API_KEY should come from vault: vault kv get secret/dd-api-key
 # ---------------------------------------------------------------------------
 : "${GCP_PROJECT:?GCP_PROJECT must be set}"
-: "${AZURE_SUBSCRIPTION_ID:?AZURE_SUBSCRIPTION_ID must be set}"
 : "${DD_API_KEY:?DD_API_KEY must be set (use vault: vault kv get ...)}"
+: "${AZURE_SUBSCRIPTION_ID:?AZURE_SUBSCRIPTION_ID must be set}"
 
 # ---------------------------------------------------------------------------
 # Defaults (override as needed)
@@ -16,254 +16,736 @@ DD_SITE="${DD_SITE:-datadoghq.com}"
 GCP_REGION="${GCP_REGION:-us-central1}"
 AZURE_REGION="${AZURE_REGION:-eastus}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
+ACR_NAME="${ACR_NAME:-ddsvlstestaca}"
+AZURE_RESOURCE_GROUP_ACA="${AZURE_RESOURCE_GROUP_ACA:-dd-serverless-test-aca}"
+AZURE_RESOURCE_GROUP_AAS="${AZURE_RESOURCE_GROUP_AAS:-dd-serverless-test-aas}"
+AZURE_CONTAINER_ENV="${AZURE_CONTAINER_ENV:-dd-serverless-env}"
 
 REGISTRY="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/serverless-test"
+GCP_REGISTRY="${REGISTRY}"
 APP_IMAGE="${REGISTRY}/test-app:${IMAGE_TAG}"
+ACR_REGISTRY="${ACR_NAME}.azurecr.io"
+AZURE_APP_IMAGE="${ACR_REGISTRY}/test-app:${IMAGE_TAG}"
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+log() { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"; }
 
 # ---------------------------------------------------------------------------
-# Helpers
+# ACR credential helper (called by Azure functions that need registry auth)
 # ---------------------------------------------------------------------------
-log() {
-  echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"
+_acr_creds() {
+  az acr update --name "${ACR_NAME}" --admin-enabled true \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
+  ACR_USER=$(az acr credential show --name "${ACR_NAME}" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" --query "username" -o tsv)
+  ACR_PASS=$(az acr credential show --name "${ACR_NAME}" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" --query "passwords[0].value" -o tsv)
 }
 
 # ---------------------------------------------------------------------------
-# GCP: Cloud Run Service
+# #1 — GCP Cloud Run Service (init-container)
 # ---------------------------------------------------------------------------
 deploy_cloudrun_service() {
-  log "=== Deploying Cloud Run Service ==="
+  log "=== #1 GCP Cloud Run Service (init-container) ==="
 
-  gcloud run deploy dd-test-cloudrun-service \
+  gcloud run deploy nina-cloudrun-init \
     --project="${GCP_PROJECT}" \
     --region="${GCP_REGION}" \
     --image="${APP_IMAGE}" \
     --platform=managed \
     --allow-unauthenticated \
-    --set-env-vars="DD_SITE=${DD_SITE},DD_ENV=dev,DD_SERVICE=dd-test-cloudrun-service,DD_VERSION=0.1.0,DD_SERVERLESS_DIAGNOSTIC_INFO=true,DD_LOGS_ENABLED=true,DD_API_KEY=${DD_API_KEY}" \
+    --set-env-vars="DD_SITE=${DD_SITE},DD_SERVICE=nina-cloudrun-init,DD_ENV=nina,DD_SERVERLESS_DIAGNOSTIC_INFO=true,DD_API_KEY=${DD_API_KEY}" \
     --port=8080
 
-  CLOUDRUN_SERVICE_URL=$(gcloud run services describe dd-test-cloudrun-service \
-    --project="${GCP_PROJECT}" \
-    --region="${GCP_REGION}" \
+  CLOUDRUN_SERVICE_URL=$(gcloud run services describe nina-cloudrun-init \
+    --project="${GCP_PROJECT}" --region="${GCP_REGION}" \
     --format="value(status.url)")
-
-  log "Cloud Run Service URL: ${CLOUDRUN_SERVICE_URL}"
+  log "#1 URL: ${CLOUDRUN_SERVICE_URL}"
   export CLOUDRUN_SERVICE_URL
 }
 
 # ---------------------------------------------------------------------------
-# GCP: Cloud Run Job
+# #2 — GCP Cloud Run Service (sidecar, multi-container via knative YAML)
+# ---------------------------------------------------------------------------
+deploy_cloudrun_sidecar() {
+  log "=== #2 GCP Cloud Run Service (sidecar) ==="
+
+  local tmp_yaml="/tmp/cloudrun-sidecar.yaml"
+  GCP_PROJECT="${GCP_PROJECT}" GCP_REGISTRY="${GCP_REGISTRY}" \
+  IMAGE_TAG="${IMAGE_TAG}" DD_SITE="${DD_SITE}" DD_API_KEY="${DD_API_KEY}" \
+    envsubst < "${SCRIPT_DIR}/app/cloudrun-sidecar.yaml" > "${tmp_yaml}"
+
+  gcloud run services replace "${tmp_yaml}" \
+    --project="${GCP_PROJECT}" --region="${GCP_REGION}"
+
+  CLOUDRUN_SIDECAR_URL=$(gcloud run services describe nina-cloudrun-sidecar \
+    --project="${GCP_PROJECT}" --region="${GCP_REGION}" \
+    --format="value(status.url)")
+  log "#2 URL: ${CLOUDRUN_SIDECAR_URL}"
+  export CLOUDRUN_SIDECAR_URL
+}
+
+# ---------------------------------------------------------------------------
+# #3 — GCP Cloud Run Job (init-container, runs job.py which exits cleanly)
 # ---------------------------------------------------------------------------
 deploy_cloudrun_job() {
-  log "=== Deploying Cloud Run Job ==="
+  log "=== #3 GCP Cloud Run Job (init-container) ==="
 
-  # Create or update the job
-  if gcloud run jobs describe dd-test-cloudrun-job \
-      --project="${GCP_PROJECT}" \
-      --region="${GCP_REGION}" &>/dev/null; then
-    gcloud run jobs update dd-test-cloudrun-job \
-      --project="${GCP_PROJECT}" \
-      --region="${GCP_REGION}" \
-      --image="${APP_IMAGE}" \
-      --set-env-vars="DD_SITE=${DD_SITE},DD_ENV=dev,DD_SERVICE=dd-test-cloudrun-job,DD_VERSION=0.1.0,DD_SERVERLESS_DIAGNOSTIC_INFO=true,DD_API_KEY=${DD_API_KEY}"
+  local common_flags=(
+    --project="${GCP_PROJECT}"
+    --region="${GCP_REGION}"
+    --image="${APP_IMAGE}"
+    --args="python,/app/job.py"
+    --set-env-vars="DD_SITE=${DD_SITE},DD_SERVICE=nina-cloudrun-job,DD_ENV=nina,DD_SERVERLESS_DIAGNOSTIC_INFO=true,DD_API_KEY=${DD_API_KEY}"
+  )
+
+  if gcloud run jobs describe nina-cloudrun-job \
+      --project="${GCP_PROJECT}" --region="${GCP_REGION}" &>/dev/null; then
+    gcloud run jobs update nina-cloudrun-job "${common_flags[@]}"
   else
-    gcloud run jobs create dd-test-cloudrun-job \
-      --project="${GCP_PROJECT}" \
-      --region="${GCP_REGION}" \
-      --image="${APP_IMAGE}" \
-      --set-env-vars="DD_SITE=${DD_SITE},DD_ENV=dev,DD_SERVICE=dd-test-cloudrun-job,DD_VERSION=0.1.0,DD_SERVERLESS_DIAGNOSTIC_INFO=true,DD_API_KEY=${DD_API_KEY}"
+    gcloud run jobs create nina-cloudrun-job "${common_flags[@]}"
   fi
 
-  # Execute once to capture diagnostics (Cloud Run Jobs don't serve HTTP)
-  gcloud run jobs execute dd-test-cloudrun-job \
-    --project="${GCP_PROJECT}" \
-    --region="${GCP_REGION}" \
-    --wait
+  gcloud run jobs execute nina-cloudrun-job \
+    --project="${GCP_PROJECT}" --region="${GCP_REGION}" --wait || true
 
-  log "Cloud Run Job executed successfully."
+  log "#3 Cloud Run Job executed."
 }
 
 # ---------------------------------------------------------------------------
-# GCP: Cloud Run Function v2 (gen2)
+# #4 — GCP Cloud Run Function gen2 (sidecar, deployed as Cloud Run Service)
 # ---------------------------------------------------------------------------
-deploy_cloudrun_function() {
-  log "=== Deploying Cloud Run Function v2 ==="
+deploy_cloudrun_function_sidecar() {
+  log "=== #4 GCP Cloud Run Function gen2 (sidecar) ==="
 
-  gcloud functions deploy dd-test-cloudrun-function \
-    --gen2 \
-    --project="${GCP_PROJECT}" \
-    --region="${GCP_REGION}" \
-    --runtime=python311 \
-    --source="${SCRIPT_DIR}/app/function" \
-    --entry-point=hello \
-    --trigger-http \
-    --allow-unauthenticated \
-    --set-env-vars="DD_SITE=${DD_SITE},DD_ENV=dev,DD_SERVICE=dd-test-cloudrun-function,DD_VERSION=0.1.0,DD_SERVERLESS_DIAGNOSTIC_INFO=true,DD_API_KEY=${DD_API_KEY}"
+  local tmp_yaml="/tmp/cloudrun-function-sidecar.yaml"
+  GCP_PROJECT="${GCP_PROJECT}" GCP_REGISTRY="${GCP_REGISTRY}" \
+  IMAGE_TAG="${IMAGE_TAG}" DD_SITE="${DD_SITE}" DD_API_KEY="${DD_API_KEY}" \
+    envsubst < "${SCRIPT_DIR}/app/cloudrun-function-sidecar.yaml" > "${tmp_yaml}"
 
-  CLOUDRUN_FUNCTION_URL=$(gcloud functions describe dd-test-cloudrun-function \
-    --gen2 \
-    --project="${GCP_PROJECT}" \
-    --region="${GCP_REGION}" \
-    --format="value(serviceConfig.uri)")
+  gcloud run services replace "${tmp_yaml}" \
+    --project="${GCP_PROJECT}" --region="${GCP_REGION}"
 
-  log "Cloud Run Function URL: ${CLOUDRUN_FUNCTION_URL}"
-  export CLOUDRUN_FUNCTION_URL
+  CLOUDRUN_FUNCTION_SIDECAR_URL=$(gcloud run services describe nina-cloudrun-function-sidecar \
+    --project="${GCP_PROJECT}" --region="${GCP_REGION}" \
+    --format="value(status.url)")
+  log "#4 URL: ${CLOUDRUN_FUNCTION_SIDECAR_URL}"
+  export CLOUDRUN_FUNCTION_SIDECAR_URL
 }
 
 # ---------------------------------------------------------------------------
-# Azure: Container App
+# #5 — Azure Container App (init-container)
 # ---------------------------------------------------------------------------
 deploy_container_app() {
-  log "=== Deploying Azure Container App ==="
+  log "=== #5 Azure Container App (init-container) ==="
 
-  # Create resource group (idempotent)
+  _acr_creds
+
   az group create \
-    --name dd-serverless-test-aca \
+    --name "${AZURE_RESOURCE_GROUP_ACA}" \
     --location "${AZURE_REGION}" \
-    --subscription "${AZURE_SUBSCRIPTION_ID}" || true
+    --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
 
-  # Create Container App environment (idempotent)
   az containerapp env create \
-    --name dd-serverless-env \
-    --resource-group dd-serverless-test-aca \
+    --name "${AZURE_CONTAINER_ENV}" \
+    --resource-group "${AZURE_RESOURCE_GROUP_ACA}" \
     --location "${AZURE_REGION}" \
-    --subscription "${AZURE_SUBSCRIPTION_ID}" || true
+    --subscription "${AZURE_SUBSCRIPTION_ID}" 2>/dev/null || true
 
-  # Deploy or update the Container App
+  local dd_env_vars=(
+    "DD_SITE=${DD_SITE}"
+    "DD_SERVICE=nina-containerapp-init"
+    "DD_ENV=nina"
+    "DD_SERVERLESS_DIAGNOSTIC_INFO=true"
+    "DD_LOG_LEVEL=warn"
+    "DD_AZURE_SUBSCRIPTION_ID=${AZURE_SUBSCRIPTION_ID}"
+    "DD_AZURE_RESOURCE_GROUP=${AZURE_RESOURCE_GROUP_ACA}"
+    "DD_API_KEY=${DD_API_KEY}"
+  )
+
   if az containerapp show \
-      --name dd-test-container-app \
-      --resource-group dd-serverless-test-aca \
+      --name "nina-containerapp-init" \
+      --resource-group "${AZURE_RESOURCE_GROUP_ACA}" \
       --subscription "${AZURE_SUBSCRIPTION_ID}" &>/dev/null; then
+    az containerapp registry set \
+      --name "nina-containerapp-init" \
+      --resource-group "${AZURE_RESOURCE_GROUP_ACA}" \
+      --server "${ACR_REGISTRY}" \
+      --username "${ACR_USER}" \
+      --password "${ACR_PASS}" \
+      --subscription "${AZURE_SUBSCRIPTION_ID}"
     az containerapp update \
-      --name dd-test-container-app \
-      --resource-group dd-serverless-test-aca \
-      --image "${APP_IMAGE}" \
-      --set-env-vars "DD_SITE=${DD_SITE}" "DD_ENV=dev" "DD_SERVICE=dd-test-container-app" "DD_VERSION=0.1.0" "DD_SERVERLESS_DIAGNOSTIC_INFO=true" "DD_LOGS_ENABLED=true" "DD_API_KEY=${DD_API_KEY}" \
+      --name "nina-containerapp-init" \
+      --resource-group "${AZURE_RESOURCE_GROUP_ACA}" \
+      --image "${AZURE_APP_IMAGE}" \
+      --set-env-vars "${dd_env_vars[@]}" \
       --subscription "${AZURE_SUBSCRIPTION_ID}"
   else
     az containerapp create \
-      --name dd-test-container-app \
-      --resource-group dd-serverless-test-aca \
-      --environment dd-serverless-env \
-      --image "${APP_IMAGE}" \
+      --name "nina-containerapp-init" \
+      --resource-group "${AZURE_RESOURCE_GROUP_ACA}" \
+      --environment "${AZURE_CONTAINER_ENV}" \
+      --image "${AZURE_APP_IMAGE}" \
       --target-port 8080 \
       --ingress external \
-      --env-vars "DD_SITE=${DD_SITE}" "DD_ENV=dev" "DD_SERVICE=dd-test-container-app" "DD_VERSION=0.1.0" "DD_SERVERLESS_DIAGNOSTIC_INFO=true" "DD_LOGS_ENABLED=true" "DD_API_KEY=${DD_API_KEY}" \
+      --registry-server "${ACR_REGISTRY}" \
+      --registry-username "${ACR_USER}" \
+      --registry-password "${ACR_PASS}" \
+      --env-vars "${dd_env_vars[@]}" \
       --subscription "${AZURE_SUBSCRIPTION_ID}"
   fi
 
+  az containerapp ingress enable \
+    --name "nina-containerapp-init" \
+    --resource-group "${AZURE_RESOURCE_GROUP_ACA}" \
+    --type external \
+    --target-port 8080 \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" 2>/dev/null || true
+
   CONTAINER_APP_URL=$(az containerapp show \
-    --name dd-test-container-app \
-    --resource-group dd-serverless-test-aca \
+    --name "nina-containerapp-init" \
+    --resource-group "${AZURE_RESOURCE_GROUP_ACA}" \
     --subscription "${AZURE_SUBSCRIPTION_ID}" \
     --query "properties.configuration.ingress.fqdn" \
     --output tsv)
-
-  log "Azure Container App URL: https://${CONTAINER_APP_URL}"
+  log "#5 URL: https://${CONTAINER_APP_URL}"
   export CONTAINER_APP_URL="https://${CONTAINER_APP_URL}"
 }
 
 # ---------------------------------------------------------------------------
-# Azure: Web App (Linux, Python 3.11)
+# #6 — Azure Container App (sidecar, multi-container via az rest PUT)
+# az containerapp create/update --yaml has a known Bool serialisation bug.
 # ---------------------------------------------------------------------------
-deploy_web_app() {
-  log "=== Deploying Azure Web App ==="
+deploy_container_app_sidecar() {
+  log "=== #6 Azure Container App (sidecar) ==="
 
-  # Create resource group (idempotent)
+  _acr_creds
+
+  local app_name="nina-containerapp-sidecar"
+  local env_id="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP_ACA}/providers/Microsoft.App/managedEnvironments/${AZURE_CONTAINER_ENV}"
+  local tmp_json="/tmp/containerapp-sidecar.json"
+
+  python3 - <<PYEOF
+import json
+body = {
+  "location": "eastus",
+  "properties": {
+    "managedEnvironmentId": "${env_id}",
+    "configuration": {
+      "ingress": {"external": True, "targetPort": 8080, "traffic": [{"latestRevision": True, "weight": 100}]},
+      "registries": [{"server": "${ACR_REGISTRY}", "username": "${ACR_USER}", "passwordSecretRef": "acr-password"}],
+      "secrets": [{"name": "acr-password", "value": "${ACR_PASS}"}, {"name": "dd-api-key", "value": "${DD_API_KEY}"}]
+    },
+    "template": {
+      "containers": [
+        {
+          "name": "app",
+          "image": "${ACR_REGISTRY}/plain-app:${IMAGE_TAG}",
+          "resources": {"cpu": 0.5, "memory": "1Gi"},
+          "env": [
+            {"name": "DD_SERVICE", "value": "nina-containerapp-sidecar"},
+            {"name": "DD_ENV",     "value": "nina"}
+          ]
+        },
+        {
+          "name": "dd-agent",
+          "image": "${ACR_REGISTRY}/serverless-init:${IMAGE_TAG}",
+          "resources": {"cpu": 0.5, "memory": "1Gi"},
+          "env": [
+            {"name": "DD_SITE",                       "value": "${DD_SITE}"},
+            {"name": "DD_SERVICE",                    "value": "nina-containerapp-sidecar"},
+            {"name": "DD_ENV",                        "value": "nina"},
+            {"name": "DD_APM_NON_LOCAL_TRAFFIC",      "value": "true"},
+            {"name": "DD_DOGSTATSD_NON_LOCAL_TRAFFIC","value": "true"},
+            {"name": "DD_SERVERLESS_DIAGNOSTIC_INFO", "value": "true"},
+            {"name": "DD_LOG_LEVEL",                  "value": "warn"},
+            {"name": "DD_HEALTH_PORT",                "value": "5555"},
+            {"name": "DD_AZURE_SUBSCRIPTION_ID",      "value": "${AZURE_SUBSCRIPTION_ID}"},
+            {"name": "DD_AZURE_RESOURCE_GROUP",       "value": "${AZURE_RESOURCE_GROUP_ACA}"},
+            {"name": "DD_API_KEY",                    "secretRef": "dd-api-key"}
+          ]
+        }
+      ]
+    }
+  }
+}
+with open("${tmp_json}", "w") as f:
+    json.dump(body, f)
+PYEOF
+
+  az rest \
+    --method PUT \
+    --url "https://management.azure.com/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP_ACA}/providers/Microsoft.App/containerApps/${app_name}?api-version=2024-03-01" \
+    --body "@${tmp_json}" \
+    --headers "Content-Type=application/json"
+
+  CONTAINER_APP_SIDECAR_URL=$(az containerapp show \
+    --name "${app_name}" \
+    --resource-group "${AZURE_RESOURCE_GROUP_ACA}" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" \
+    --query "properties.configuration.ingress.fqdn" \
+    --output tsv)
+  log "#6 URL: https://${CONTAINER_APP_SIDECAR_URL}"
+  export CONTAINER_APP_SIDECAR_URL="https://${CONTAINER_APP_SIDECAR_URL}"
+}
+
+# ---------------------------------------------------------------------------
+# ARM helper — registers a sitecontainer (main or sidecar) via REST API.
+# Ref: https://learn.microsoft.com/en-us/rest/api/appservice/web-apps/create-or-update-site-container
+# ---------------------------------------------------------------------------
+_webapp_sitecontainer_put() {
+  local rg="$1" site="$2" name="$3" body="$4"
+  az rest --method PUT \
+    --url "https://management.azure.com/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${rg}/providers/Microsoft.Web/sites/${site}/sitecontainers/${name}?api-version=2024-11-01" \
+    --body "${body}" >/dev/null
+}
+
+# Patches linuxFxVersion to "SITECONTAINERS" so the sidecontainers serve traffic.
+# Ref: terraform-azurerm-web-app-datadog/modules/linux/main.tf (azapi_update_resource.enable_sidecar)
+_webapp_enable_sitecontainers() {
+  local rg="$1" site="$2"
+  az rest --method PATCH \
+    --url "https://management.azure.com/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${rg}/providers/Microsoft.Web/sites/${site}?api-version=2022-03-01" \
+    --body '{"properties":{"siteConfig":{"linuxFxVersion":"SITECONTAINERS"}}}' >/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# #7 — Azure Web App Linux Containers (init-container)
+# Single-container; test-app image has serverless-init as ENTRYPOINT wrapping app.
+# ---------------------------------------------------------------------------
+deploy_web_app_container() {
+  log "=== #7 Azure Web App (Linux Containers, init-container) ==="
+
+  _acr_creds
+  local rg="${AZURE_RESOURCE_GROUP_AAS}"
+
   az group create \
-    --name dd-serverless-test-aas \
+    --name "${rg}" \
     --location "${AZURE_REGION}" \
-    --subscription "${AZURE_SUBSCRIPTION_ID}" || true
+    --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null || true
 
-  # Create App Service plan (idempotent)
   az appservice plan create \
-    --name dd-test-plan \
-    --resource-group dd-serverless-test-aas \
-    --sku B1 \
+    --name dd-test-plan-container \
+    --resource-group "${rg}" \
+    --sku B2 \
     --is-linux \
-    --subscription "${AZURE_SUBSCRIPTION_ID}" || true
+    --subscription "${AZURE_SUBSCRIPTION_ID}" 2>/dev/null || true
 
-  # Create Web App
-  az webapp create \
-    --name dd-test-web-app \
-    --resource-group dd-serverless-test-aas \
-    --plan dd-test-plan \
-    --runtime "PYTHON:3.11" \
-    --subscription "${AZURE_SUBSCRIPTION_ID}"
+  if az webapp show \
+      --name nina-webapp-container \
+      --resource-group "${rg}" \
+      --subscription "${AZURE_SUBSCRIPTION_ID}" &>/dev/null; then
+    az webapp config container set \
+      --name nina-webapp-container \
+      --resource-group "${rg}" \
+      --docker-custom-image-name "${AZURE_APP_IMAGE}" \
+      --docker-registry-server-url "https://${ACR_REGISTRY}" \
+      --docker-registry-server-user "${ACR_USER}" \
+      --docker-registry-server-password "${ACR_PASS}" \
+      --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
+  else
+    az webapp create \
+      --name nina-webapp-container \
+      --resource-group "${rg}" \
+      --plan dd-test-plan-container \
+      --deployment-container-image-name "${AZURE_APP_IMAGE}" \
+      --https-only true \
+      --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
+    az webapp config container set \
+      --name nina-webapp-container \
+      --resource-group "${rg}" \
+      --docker-registry-server-url "https://${ACR_REGISTRY}" \
+      --docker-registry-server-user "${ACR_USER}" \
+      --docker-registry-server-password "${ACR_PASS}" \
+      --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
+  fi
 
-  # Configure app settings (DD_API_KEY passed via env, not hardcoded)
   az webapp config appsettings set \
-    --name dd-test-web-app \
-    --resource-group dd-serverless-test-aas \
+    --name nina-webapp-container \
+    --resource-group "${rg}" \
     --settings \
       DD_SITE="${DD_SITE}" \
-      DD_ENV=dev \
-      DD_SERVICE=dd-test-web-app \
-      DD_VERSION=0.1.0 \
+      DD_SERVICE=nina-webapp-container \
+      DD_ENV=nina \
       DD_SERVERLESS_DIAGNOSTIC_INFO=true \
-      DD_LOGS_ENABLED=true \
+      DD_AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}" \
+      DD_AZURE_RESOURCE_GROUP="${rg}" \
       DD_API_KEY="${DD_API_KEY}" \
-    --subscription "${AZURE_SUBSCRIPTION_ID}"
+    --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
 
-  # Set startup command to use ddtrace-run
-  az webapp config set \
-    --name dd-test-web-app \
-    --resource-group dd-serverless-test-aas \
-    --startup-file "DD_SERVERLESS_DIAGNOSTIC_INFO=true ddtrace-run python app.py" \
-    --subscription "${AZURE_SUBSCRIPTION_ID}"
-
-  # Zip and deploy app code (exclude the Cloud Function subdirectory)
-  local zip_path="/tmp/dd-test-app.zip"
-  (cd "${SCRIPT_DIR}/app" && zip -r "${zip_path}" . -x "function/*")
-
-  az webapp deploy \
-    --name dd-test-web-app \
-    --resource-group dd-serverless-test-aas \
-    --src-path "${zip_path}" \
-    --type zip \
-    --subscription "${AZURE_SUBSCRIPTION_ID}"
-
-  WEB_APP_URL=$(az webapp show \
-    --name dd-test-web-app \
-    --resource-group dd-serverless-test-aas \
+  WEB_APP_CONTAINER_URL=$(az webapp show \
+    --name nina-webapp-container \
+    --resource-group "${rg}" \
     --subscription "${AZURE_SUBSCRIPTION_ID}" \
     --query "defaultHostName" \
     --output tsv)
+  log "#7 URL: https://${WEB_APP_CONTAINER_URL}"
+  export WEB_APP_CONTAINER_URL="https://${WEB_APP_CONTAINER_URL}"
+}
 
-  log "Azure Web App URL: https://${WEB_APP_URL}"
-  export WEB_APP_URL="https://${WEB_APP_URL}"
+# ---------------------------------------------------------------------------
+# #8 — Azure Web App Linux Containers (SITECONTAINERS sidecar)
+# main container: plain-app (port 8080) as isMain=true sitecontainer
+# dd-agent sidecar: serverless-init with no args → sidecar mode
+#
+# Env vars go in App Settings (az webapp config appsettings set); the dd-agent
+# sidecontainer inherits them automatically. Do NOT put env vars in the
+# sitecontainer body — they do not survive webapp restarts.
+# ---------------------------------------------------------------------------
+deploy_web_app_sidecar() {
+  log "=== #8 Azure Web App (SITECONTAINERS, sidecar) ==="
+
+  _acr_creds
+  local rg="${AZURE_RESOURCE_GROUP_AAS}"
+
+  az group create \
+    --name "${rg}" \
+    --location "${AZURE_REGION}" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null || true
+
+  az appservice plan create \
+    --name dd-test-plan-sidecar \
+    --resource-group "${rg}" \
+    --sku B2 \
+    --is-linux \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" 2>/dev/null || true
+
+  if az webapp show \
+      --name nina-webapp-sidecar \
+      --resource-group "${rg}" \
+      --subscription "${AZURE_SUBSCRIPTION_ID}" &>/dev/null; then
+    # Update main container image on existing webapp
+    az webapp config container set \
+      --name nina-webapp-sidecar \
+      --resource-group "${rg}" \
+      --docker-custom-image-name "${ACR_REGISTRY}/plain-app:${IMAGE_TAG}" \
+      --docker-registry-server-url "https://${ACR_REGISTRY}" \
+      --docker-registry-server-user "${ACR_USER}" \
+      --docker-registry-server-password "${ACR_PASS}" \
+      --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
+  else
+    az webapp create \
+      --name nina-webapp-sidecar \
+      --resource-group "${rg}" \
+      --plan dd-test-plan-sidecar \
+      --deployment-container-image-name "${ACR_REGISTRY}/plain-app:${IMAGE_TAG}" \
+      --https-only true \
+      --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
+    az webapp config container set \
+      --name nina-webapp-sidecar \
+      --resource-group "${rg}" \
+      --docker-registry-server-url "https://${ACR_REGISTRY}" \
+      --docker-registry-server-user "${ACR_USER}" \
+      --docker-registry-server-password "${ACR_PASS}" \
+      --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
+  fi
+
+  # All env vars in App Settings — sidecontainer inherits them automatically
+  az webapp config appsettings set \
+    --name nina-webapp-sidecar \
+    --resource-group "${rg}" \
+    --settings \
+      DD_SITE="${DD_SITE}" \
+      DD_SERVICE=nina-webapp-sidecar \
+      DD_ENV=nina \
+      DD_APM_NON_LOCAL_TRAFFIC=true \
+      DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true \
+      DD_SERVERLESS_DIAGNOSTIC_INFO=true \
+      DD_AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}" \
+      DD_AZURE_RESOURCE_GROUP="${rg}" \
+      DD_LOG_LEVEL=warn \
+      DD_API_KEY="${DD_API_KEY}" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
+
+  _webapp_enable_sitecontainers "${rg}" nina-webapp-sidecar
+
+  # Main app container (isMain=true, targetPort=8080) — no env vars in body
+  _webapp_sitecontainer_put "${rg}" nina-webapp-sidecar main "$(python3 -c "
+import json
+print(json.dumps({'properties': {
+  'image':          '${ACR_REGISTRY}/plain-app:${IMAGE_TAG}',
+  'isMain':         True,
+  'authType':       'UserCredentials',
+  'userName':       '${ACR_USER}',
+  'passwordSecret': '${ACR_PASS}',
+  'targetPort':     '8080',
+}}))
+")"
+
+  # dd-agent sidecar (isMain=false, no args → sidecar mode)
+  # startUpCommand must be empty so the distroless image's ENTRYPOINT is used.
+  # No environmentVariables here — inherited from App Settings above.
+  _webapp_sitecontainer_put "${rg}" nina-webapp-sidecar dd-agent "$(python3 -c "
+import json
+print(json.dumps({'properties': {
+  'image':          '${ACR_REGISTRY}/serverless-init:${IMAGE_TAG}',
+  'isMain':         False,
+  'authType':       'UserCredentials',
+  'userName':       '${ACR_USER}',
+  'passwordSecret': '${ACR_PASS}',
+  'startUpCommand': '',
+}}))
+")"
+
+  az webapp restart \
+    --name nina-webapp-sidecar \
+    --resource-group "${rg}" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
+
+  WEB_APP_SIDECAR_URL=$(az webapp show \
+    --name nina-webapp-sidecar \
+    --resource-group "${rg}" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" \
+    --query "defaultHostName" \
+    --output tsv)
+  log "#8 URL: https://${WEB_APP_SIDECAR_URL}"
+  export WEB_APP_SIDECAR_URL="https://${WEB_APP_SIDECAR_URL}"
+}
+
+# ---------------------------------------------------------------------------
+# #9 — Azure Web App Linux Code + sidecar
+# main app: Azure-managed Python 3.11 runtime (no custom Docker image)
+# dd-agent sidecar: serverless-init with no args → sidecar mode
+#
+# Env vars go in App Settings — sidecontainer inherits them.
+# WEBSITES_ENABLE_APP_SERVICE_STORAGE=true required for code apps with sidecars.
+# ---------------------------------------------------------------------------
+deploy_web_app_linux_code_sidecar() {
+  log "=== #9 Azure Web App (Linux Code + sidecar) ==="
+
+  _acr_creds
+  local rg="${AZURE_RESOURCE_GROUP_AAS}"
+
+  az group create \
+    --name "${rg}" \
+    --location "${AZURE_REGION}" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null || true
+
+  # #9 intentionally uses its OWN plan (dd-test-plan-linux-code) so that it
+  # gets a different underlying VM than #8 (dd-test-plan-sidecar). Both plans
+  # use the same region and SKU. Without this separation both apps report the
+  # same gopsutil/DMI UUID and collapse to a single row in REDAPL.
+  az appservice plan create \
+    --name dd-test-plan-linux-code \
+    --resource-group "${rg}" \
+    --sku B2 \
+    --is-linux \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" 2>/dev/null || true
+
+  # If the webapp already exists on the old shared plan, move it to the new one.
+  if az webapp show \
+      --name nina-webapp-linux-code \
+      --resource-group "${rg}" \
+      --subscription "${AZURE_SUBSCRIPTION_ID}" &>/dev/null; then
+    current_plan=$(az webapp show \
+      --name nina-webapp-linux-code \
+      --resource-group "${rg}" \
+      --subscription "${AZURE_SUBSCRIPTION_ID}" \
+      --query appServicePlanId -o tsv 2>/dev/null | sed 's|.*/||')
+    if [[ "${current_plan}" != "dd-test-plan-linux-code" ]]; then
+      log "#9 migrating nina-webapp-linux-code from plan '${current_plan}' → dd-test-plan-linux-code for distinct UUID"
+      az webapp update \
+        --name nina-webapp-linux-code \
+        --resource-group "${rg}" \
+        --plan dd-test-plan-linux-code \
+        --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
+    fi
+  else
+    az webapp create \
+      --name nina-webapp-linux-code \
+      --resource-group "${rg}" \
+      --plan dd-test-plan-linux-code \
+      --runtime "PYTHON:3.11" \
+      --https-only true \
+      --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
+    # Use a simple built-in HTTP server as the main app for testing
+    az webapp config set \
+      --name nina-webapp-linux-code \
+      --resource-group "${rg}" \
+      --startup-file "python3 -m http.server 8080" \
+      --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
+  fi
+
+  # All env vars in App Settings — sidecontainer inherits them automatically
+  az webapp config appsettings set \
+    --name nina-webapp-linux-code \
+    --resource-group "${rg}" \
+    --settings \
+      DD_SITE="${DD_SITE}" \
+      DD_SERVICE=nina-webapp-linux-code \
+      DD_ENV=nina \
+      DD_APM_NON_LOCAL_TRAFFIC=true \
+      DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true \
+      DD_SERVERLESS_DIAGNOSTIC_INFO=true \
+      DD_AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}" \
+      DD_AZURE_RESOURCE_GROUP="${rg}" \
+      DD_LOG_LEVEL=warn \
+      DD_API_KEY="${DD_API_KEY}" \
+      WEBSITES_ENABLE_APP_SERVICE_STORAGE=true \
+      WEBSITES_PORT=8080 \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
+
+  # dd-agent sidecar only (isMain=false) — Python runtime stays as the main app
+  # No environmentVariables in body — inherited from App Settings above.
+  _webapp_sitecontainer_put "${rg}" nina-webapp-linux-code dd-agent "$(python3 -c "
+import json
+print(json.dumps({'properties': {
+  'image':          '${ACR_REGISTRY}/serverless-init:${IMAGE_TAG}',
+  'isMain':         False,
+  'authType':       'UserCredentials',
+  'userName':       '${ACR_USER}',
+  'passwordSecret': '${ACR_PASS}',
+  'startUpCommand': '',
+}}))
+")"
+
+  az webapp restart \
+    --name nina-webapp-linux-code \
+    --resource-group "${rg}" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
+
+  WEB_APP_LINUX_CODE_URL=$(az webapp show \
+    --name nina-webapp-linux-code \
+    --resource-group "${rg}" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" \
+    --query "defaultHostName" \
+    --output tsv)
+  log "#9 URL: https://${WEB_APP_LINUX_CODE_URL}"
+  export WEB_APP_LINUX_CODE_URL="https://${WEB_APP_LINUX_CODE_URL}"
 }
 
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 main() {
-  log "Starting deployment to all 5 platforms..."
-  log "GCP_PROJECT=${GCP_PROJECT}, GCP_REGION=${GCP_REGION}"
-  log "AZURE_REGION=${AZURE_REGION}"
-  log "APP_IMAGE=${APP_IMAGE}"
+  log "Starting deployment (DD_ENV=nina, IMAGE_TAG=${IMAGE_TAG})"
+  log "GCP: ${APP_IMAGE}"
+  log "ACR: ${AZURE_APP_IMAGE}"
 
-  deploy_cloudrun_service
-  deploy_cloudrun_job
-  deploy_cloudrun_function
-  deploy_container_app
-  deploy_web_app
+  deploy_cloudrun_service              # #1 GCP Cloud Run Service (init-container)
+  deploy_cloudrun_sidecar              # #2 GCP Cloud Run Service (sidecar)
+  deploy_cloudrun_job                  # #3 GCP Cloud Run Job (init-container)
+  deploy_cloudrun_function_sidecar     # #4 GCP Cloud Run Function gen2 (sidecar)
+  deploy_container_app                 # #5 Azure Container App (init-container)
+  deploy_container_app_sidecar         # #6 Azure Container App (sidecar)
+  deploy_web_app_container             # #7 Azure Web App Linux Containers (init-container)
+  deploy_web_app_sidecar               # #8 Azure Web App SITECONTAINERS (sidecar)
+  deploy_web_app_linux_code_sidecar    # #9 Azure Web App Linux Code + sidecar
 
   echo ""
   echo "=========================================="
   echo "Deployment complete. Service URLs:"
-  echo "  Cloud Run Service : ${CLOUDRUN_SERVICE_URL:-N/A}"
-  echo "  Cloud Run Job     : (no HTTP — ran once for diagnostics)"
-  echo "  Cloud Run Function: ${CLOUDRUN_FUNCTION_URL:-N/A}"
-  echo "  Container App     : ${CONTAINER_APP_URL:-N/A}"
-  echo "  Web App           : ${WEB_APP_URL:-N/A}"
+  echo "  #1 GCP Cloud Run (init)            : ${CLOUDRUN_SERVICE_URL:-N/A}"
+  echo "  #2 GCP Cloud Run (sidecar)         : ${CLOUDRUN_SIDECAR_URL:-N/A}"
+  echo "  #3 GCP Cloud Run Job               : (no HTTP URL — job only)"
+  echo "  #4 GCP Cloud Run Fn gen2 (sidecar) : ${CLOUDRUN_FUNCTION_SIDECAR_URL:-N/A}"
+  echo "  #5 Azure Container App (init)      : ${CONTAINER_APP_URL:-N/A}"
+  echo "  #6 Azure Container App (sidecar)   : ${CONTAINER_APP_SIDECAR_URL:-N/A}"
+  echo "  #7 Azure Web App (containers)      : ${WEB_APP_CONTAINER_URL:-N/A}"
+  echo "  #8 Azure Web App (sidecar)         : ${WEB_APP_SIDECAR_URL:-N/A}"
+  echo "  #9 Azure Web App (Linux Code+sidecar): ${WEB_APP_LINUX_CODE_URL:-N/A}"
   echo "=========================================="
   echo ""
-  echo "Next steps:"
-  echo "  1. Trigger each service with a GET request (e.g. curl \${CLOUDRUN_SERVICE_URL})"
-  echo "  2. Run ./check-logs.sh to inspect SERVERLESS_DIAGNOSTIC output"
+  echo "Next: curl each URL, then run ./check-logs.sh to inspect SERVERLESS_DIAGNOSTIC output."
 }
 
-main "$@"
+# ---------------------------------------------------------------------------
+# trigger_all — force a cold start on every service and wait for inventory
+# ---------------------------------------------------------------------------
+# Usage: source ./deploy.sh && trigger_all
+#        Or with env vars set: ./deploy.sh trigger_all
+#
+# What it does:
+#   1. GCP Cloud Run: deploys a no-op revision bump (forces new instance UUID)
+#   2. Azure Web Apps: restarts the app (existing DMI UUID, but kicks the
+#      inventory runner on the next startup — good enough to confirm payload delivery)
+#   3. Azure Container Apps: restarts the replica
+#   4. Waits DD_INVENTORIES_MIN_INTERVAL (default 65s) then tails check-logs.sh
+#
+# For REDAPL validation:
+#   - Set DD_API_KEY to the dddev API key (from Vault: 'vault kv get kv/dd/api_keys/dddev')
+#   - After trigger_all completes, run: check-logs.sh then query REDAPL:
+#       SELECT _key AS uuid, agent_version, first_seen_at FROM datadog_agent
+#       WHERE first_seen_at > '<timestamp from this run>' ORDER BY first_seen_at DESC LIMIT 20;
+# ---------------------------------------------------------------------------
+trigger_all() {
+  : "${GCP_PROJECT:?GCP_PROJECT must be set}"
+  : "${AZURE_SUBSCRIPTION_ID:?AZURE_SUBSCRIPTION_ID must be set}"
+  local rg_aca="${AZURE_RG_ACA:-dd-serverless-test-aca}"
+  local rg_aas="${AZURE_RG_AAS:-dd-serverless-test-aas}"
+  local wait_secs="${DD_INVENTORIES_MIN_INTERVAL:-65}"
+
+  log "=== trigger_all: forcing cold starts on all 9 services ==="
+  log "Will wait ${wait_secs}s after triggers for inventory runner to fire"
+  log "Start time: $(date -u '+%Y-%m-%dT%H:%M:%SZ') — use this in your REDAPL WHERE clause"
+
+  # --- GCP Cloud Run: update env var to force a new revision (new container = new UUID) ---
+  local stamp="trigger-$(date -u +%Y%m%d%H%M%S)"
+  for svc in nina-cloudrun-init nina-cloudrun-sidecar nina-cloudrun-function-sidecar; do
+    log "GCP: redeploying ${svc} (new revision → new UUID)"
+    gcloud run services update "${svc}" \
+      --project="${GCP_PROJECT}" \
+      --region=us-central1 \
+      --update-env-vars "TRIGGER_STAMP=${stamp}" \
+      --quiet 2>/dev/null || log "  (warning: ${svc} update failed — may not exist)"
+    # Trigger an HTTP request to force the new revision to start
+    local url
+    url=$(gcloud run services describe "${svc}" --project="${GCP_PROJECT}" \
+      --region=us-central1 --format='value(status.url)' 2>/dev/null || true)
+    [[ -n "${url}" ]] && curl -sf --max-time 10 "${url}" >/dev/null 2>&1 \
+      && log "  triggered: ${url}" \
+      || log "  (no URL or request failed — instance may still start)"
+  done
+
+  # Cloud Run Job: execute one run
+  log "GCP: executing nina-cloudrun-job (new execution = new UUID)"
+  gcloud run jobs execute nina-cloudrun-job \
+    --project="${GCP_PROJECT}" \
+    --region=us-central1 \
+    --quiet 2>/dev/null || log "  (warning: job execute failed — may not exist)"
+
+  # --- Azure Container Apps: restart replicas ---
+  for app in nina-containerapp-init nina-containerapp-sidecar; do
+    log "Azure CA: restarting ${app}"
+    az containerapp revision restart \
+      --name "${app}" \
+      --resource-group "${rg_aca}" \
+      --subscription "${AZURE_SUBSCRIPTION_ID}" \
+      --revision "$(az containerapp show --name "${app}" --resource-group "${rg_aca}" \
+        --subscription "${AZURE_SUBSCRIPTION_ID}" \
+        --query 'properties.latestRevisionName' -o tsv 2>/dev/null)" \
+      2>/dev/null || log "  (warning: restart failed — trying webapp restart instead)"
+  done
+
+  # --- Azure Web Apps: restart (existing DMI UUID, but starts fresh Fx app) ---
+  for app in nina-webapp-container nina-webapp-sidecar nina-webapp-linux-code; do
+    log "Azure AAS: restarting ${app}"
+    az webapp restart \
+      --name "${app}" \
+      --resource-group "${rg_aas}" \
+      --subscription "${AZURE_SUBSCRIPTION_ID}" \
+      2>/dev/null || log "  (warning: restart failed for ${app})"
+  done
+
+  log "All triggers sent. Waiting ${wait_secs}s for inventory runner to fire..."
+  sleep "${wait_secs}"
+
+  log "=== Collecting logs ==="
+  local script_dir
+  script_dir="$(dirname "${BASH_SOURCE[0]:-$0}")"
+  GCP_PROJECT="${GCP_PROJECT}" \
+  AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}" \
+    "${script_dir}/check-logs.sh"
+}
+
+# Allow sourcing the file to call individual functions without running main.
+# Usage: source ./deploy.sh && deploy_web_app_sidecar
+#        source ./deploy.sh && trigger_all
+if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
+  if [[ "${1:-}" == "trigger_all" ]]; then
+    trigger_all
+  else
+    main "$@"
+  fi
+fi

--- a/scripts/serverless-deploy/deploy.sh
+++ b/scripts/serverless-deploy/deploy.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Required env vars — must be set before running this script.
+# DD_API_KEY should come from vault: vault kv get secret/dd-api-key
+# ---------------------------------------------------------------------------
+: "${GCP_PROJECT:?GCP_PROJECT must be set}"
+: "${AZURE_SUBSCRIPTION_ID:?AZURE_SUBSCRIPTION_ID must be set}"
+: "${DD_API_KEY:?DD_API_KEY must be set (use vault: vault kv get ...)}"
+
+# ---------------------------------------------------------------------------
+# Defaults (override as needed)
+# ---------------------------------------------------------------------------
+DD_SITE="${DD_SITE:-datadoghq.com}"
+GCP_REGION="${GCP_REGION:-us-central1}"
+AZURE_REGION="${AZURE_REGION:-eastus}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+
+REGISTRY="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/serverless-test"
+APP_IMAGE="${REGISTRY}/test-app:${IMAGE_TAG}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+log() {
+  echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"
+}
+
+# ---------------------------------------------------------------------------
+# GCP: Cloud Run Service
+# ---------------------------------------------------------------------------
+deploy_cloudrun_service() {
+  log "=== Deploying Cloud Run Service ==="
+
+  gcloud run deploy dd-test-cloudrun-service \
+    --project="${GCP_PROJECT}" \
+    --region="${GCP_REGION}" \
+    --image="${APP_IMAGE}" \
+    --platform=managed \
+    --allow-unauthenticated \
+    --set-env-vars="DD_SITE=${DD_SITE},DD_ENV=dev,DD_SERVICE=dd-test-cloudrun-service,DD_VERSION=0.1.0,DD_SERVERLESS_DIAGNOSTIC_INFO=true,DD_LOGS_ENABLED=true,DD_API_KEY=${DD_API_KEY}" \
+    --port=8080
+
+  CLOUDRUN_SERVICE_URL=$(gcloud run services describe dd-test-cloudrun-service \
+    --project="${GCP_PROJECT}" \
+    --region="${GCP_REGION}" \
+    --format="value(status.url)")
+
+  log "Cloud Run Service URL: ${CLOUDRUN_SERVICE_URL}"
+  export CLOUDRUN_SERVICE_URL
+}
+
+# ---------------------------------------------------------------------------
+# GCP: Cloud Run Job
+# ---------------------------------------------------------------------------
+deploy_cloudrun_job() {
+  log "=== Deploying Cloud Run Job ==="
+
+  # Create or update the job
+  if gcloud run jobs describe dd-test-cloudrun-job \
+      --project="${GCP_PROJECT}" \
+      --region="${GCP_REGION}" &>/dev/null; then
+    gcloud run jobs update dd-test-cloudrun-job \
+      --project="${GCP_PROJECT}" \
+      --region="${GCP_REGION}" \
+      --image="${APP_IMAGE}" \
+      --set-env-vars="DD_SITE=${DD_SITE},DD_ENV=dev,DD_SERVICE=dd-test-cloudrun-job,DD_VERSION=0.1.0,DD_SERVERLESS_DIAGNOSTIC_INFO=true,DD_API_KEY=${DD_API_KEY}"
+  else
+    gcloud run jobs create dd-test-cloudrun-job \
+      --project="${GCP_PROJECT}" \
+      --region="${GCP_REGION}" \
+      --image="${APP_IMAGE}" \
+      --set-env-vars="DD_SITE=${DD_SITE},DD_ENV=dev,DD_SERVICE=dd-test-cloudrun-job,DD_VERSION=0.1.0,DD_SERVERLESS_DIAGNOSTIC_INFO=true,DD_API_KEY=${DD_API_KEY}"
+  fi
+
+  # Execute once to capture diagnostics (Cloud Run Jobs don't serve HTTP)
+  gcloud run jobs execute dd-test-cloudrun-job \
+    --project="${GCP_PROJECT}" \
+    --region="${GCP_REGION}" \
+    --wait
+
+  log "Cloud Run Job executed successfully."
+}
+
+# ---------------------------------------------------------------------------
+# GCP: Cloud Run Function v2 (gen2)
+# ---------------------------------------------------------------------------
+deploy_cloudrun_function() {
+  log "=== Deploying Cloud Run Function v2 ==="
+
+  gcloud functions deploy dd-test-cloudrun-function \
+    --gen2 \
+    --project="${GCP_PROJECT}" \
+    --region="${GCP_REGION}" \
+    --runtime=python311 \
+    --source="${SCRIPT_DIR}/app/function" \
+    --entry-point=hello \
+    --trigger-http \
+    --allow-unauthenticated \
+    --set-env-vars="DD_SITE=${DD_SITE},DD_ENV=dev,DD_SERVICE=dd-test-cloudrun-function,DD_VERSION=0.1.0,DD_SERVERLESS_DIAGNOSTIC_INFO=true,DD_API_KEY=${DD_API_KEY}"
+
+  CLOUDRUN_FUNCTION_URL=$(gcloud functions describe dd-test-cloudrun-function \
+    --gen2 \
+    --project="${GCP_PROJECT}" \
+    --region="${GCP_REGION}" \
+    --format="value(serviceConfig.uri)")
+
+  log "Cloud Run Function URL: ${CLOUDRUN_FUNCTION_URL}"
+  export CLOUDRUN_FUNCTION_URL
+}
+
+# ---------------------------------------------------------------------------
+# Azure: Container App
+# ---------------------------------------------------------------------------
+deploy_container_app() {
+  log "=== Deploying Azure Container App ==="
+
+  # Create resource group (idempotent)
+  az group create \
+    --name dd-serverless-test-aca \
+    --location "${AZURE_REGION}" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" || true
+
+  # Create Container App environment (idempotent)
+  az containerapp env create \
+    --name dd-serverless-env \
+    --resource-group dd-serverless-test-aca \
+    --location "${AZURE_REGION}" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" || true
+
+  # Deploy or update the Container App
+  if az containerapp show \
+      --name dd-test-container-app \
+      --resource-group dd-serverless-test-aca \
+      --subscription "${AZURE_SUBSCRIPTION_ID}" &>/dev/null; then
+    az containerapp update \
+      --name dd-test-container-app \
+      --resource-group dd-serverless-test-aca \
+      --image "${APP_IMAGE}" \
+      --set-env-vars "DD_SITE=${DD_SITE}" "DD_ENV=dev" "DD_SERVICE=dd-test-container-app" "DD_VERSION=0.1.0" "DD_SERVERLESS_DIAGNOSTIC_INFO=true" "DD_LOGS_ENABLED=true" "DD_API_KEY=${DD_API_KEY}" \
+      --subscription "${AZURE_SUBSCRIPTION_ID}"
+  else
+    az containerapp create \
+      --name dd-test-container-app \
+      --resource-group dd-serverless-test-aca \
+      --environment dd-serverless-env \
+      --image "${APP_IMAGE}" \
+      --target-port 8080 \
+      --ingress external \
+      --env-vars "DD_SITE=${DD_SITE}" "DD_ENV=dev" "DD_SERVICE=dd-test-container-app" "DD_VERSION=0.1.0" "DD_SERVERLESS_DIAGNOSTIC_INFO=true" "DD_LOGS_ENABLED=true" "DD_API_KEY=${DD_API_KEY}" \
+      --subscription "${AZURE_SUBSCRIPTION_ID}"
+  fi
+
+  CONTAINER_APP_URL=$(az containerapp show \
+    --name dd-test-container-app \
+    --resource-group dd-serverless-test-aca \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" \
+    --query "properties.configuration.ingress.fqdn" \
+    --output tsv)
+
+  log "Azure Container App URL: https://${CONTAINER_APP_URL}"
+  export CONTAINER_APP_URL="https://${CONTAINER_APP_URL}"
+}
+
+# ---------------------------------------------------------------------------
+# Azure: Web App (Linux, Python 3.11)
+# ---------------------------------------------------------------------------
+deploy_web_app() {
+  log "=== Deploying Azure Web App ==="
+
+  # Create resource group (idempotent)
+  az group create \
+    --name dd-serverless-test-aas \
+    --location "${AZURE_REGION}" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" || true
+
+  # Create App Service plan (idempotent)
+  az appservice plan create \
+    --name dd-test-plan \
+    --resource-group dd-serverless-test-aas \
+    --sku B1 \
+    --is-linux \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" || true
+
+  # Create Web App
+  az webapp create \
+    --name dd-test-web-app \
+    --resource-group dd-serverless-test-aas \
+    --plan dd-test-plan \
+    --runtime "PYTHON:3.11" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}"
+
+  # Configure app settings (DD_API_KEY passed via env, not hardcoded)
+  az webapp config appsettings set \
+    --name dd-test-web-app \
+    --resource-group dd-serverless-test-aas \
+    --settings \
+      DD_SITE="${DD_SITE}" \
+      DD_ENV=dev \
+      DD_SERVICE=dd-test-web-app \
+      DD_VERSION=0.1.0 \
+      DD_SERVERLESS_DIAGNOSTIC_INFO=true \
+      DD_LOGS_ENABLED=true \
+      DD_API_KEY="${DD_API_KEY}" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}"
+
+  # Set startup command to use ddtrace-run
+  az webapp config set \
+    --name dd-test-web-app \
+    --resource-group dd-serverless-test-aas \
+    --startup-file "DD_SERVERLESS_DIAGNOSTIC_INFO=true ddtrace-run python app.py" \
+    --subscription "${AZURE_SUBSCRIPTION_ID}"
+
+  # Zip and deploy app code (exclude the Cloud Function subdirectory)
+  local zip_path="/tmp/dd-test-app.zip"
+  (cd "${SCRIPT_DIR}/app" && zip -r "${zip_path}" . -x "function/*")
+
+  az webapp deploy \
+    --name dd-test-web-app \
+    --resource-group dd-serverless-test-aas \
+    --src-path "${zip_path}" \
+    --type zip \
+    --subscription "${AZURE_SUBSCRIPTION_ID}"
+
+  WEB_APP_URL=$(az webapp show \
+    --name dd-test-web-app \
+    --resource-group dd-serverless-test-aas \
+    --subscription "${AZURE_SUBSCRIPTION_ID}" \
+    --query "defaultHostName" \
+    --output tsv)
+
+  log "Azure Web App URL: https://${WEB_APP_URL}"
+  export WEB_APP_URL="https://${WEB_APP_URL}"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+  log "Starting deployment to all 5 platforms..."
+  log "GCP_PROJECT=${GCP_PROJECT}, GCP_REGION=${GCP_REGION}"
+  log "AZURE_REGION=${AZURE_REGION}"
+  log "APP_IMAGE=${APP_IMAGE}"
+
+  deploy_cloudrun_service
+  deploy_cloudrun_job
+  deploy_cloudrun_function
+  deploy_container_app
+  deploy_web_app
+
+  echo ""
+  echo "=========================================="
+  echo "Deployment complete. Service URLs:"
+  echo "  Cloud Run Service : ${CLOUDRUN_SERVICE_URL:-N/A}"
+  echo "  Cloud Run Job     : (no HTTP — ran once for diagnostics)"
+  echo "  Cloud Run Function: ${CLOUDRUN_FUNCTION_URL:-N/A}"
+  echo "  Container App     : ${CONTAINER_APP_URL:-N/A}"
+  echo "  Web App           : ${WEB_APP_URL:-N/A}"
+  echo "=========================================="
+  echo ""
+  echo "Next steps:"
+  echo "  1. Trigger each service with a GET request (e.g. curl \${CLOUDRUN_SERVICE_URL})"
+  echo "  2. Run ./check-logs.sh to inspect SERVERLESS_DIAGNOSTIC output"
+}
+
+main "$@"

--- a/scripts/serverless-deploy/deploy.sh
+++ b/scripts/serverless-deploy/deploy.sh
@@ -545,11 +545,13 @@ deploy_web_app_linux_code_sidecar() {
       --query appServicePlanId -o tsv 2>/dev/null | sed 's|.*/||')
     if [[ "${current_plan}" != "dd-test-plan-linux-code" ]]; then
       log "#9 migrating nina-webapp-linux-code from plan '${current_plan}' → dd-test-plan-linux-code for distinct UUID"
+      # --plan flag removed in newer Azure CLI; use az appservice plan show + move-plan if needed
       az webapp update \
         --name nina-webapp-linux-code \
         --resource-group "${rg}" \
         --plan dd-test-plan-linux-code \
-        --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null
+        --subscription "${AZURE_SUBSCRIPTION_ID}" >/dev/null 2>&1 || \
+        log "#9 WARN: plan migration not supported by this az CLI version, skipping (webapp already exists on plan '${current_plan}')"
     fi
   else
     az webapp create \
@@ -627,11 +629,11 @@ main() {
   deploy_cloudrun_sidecar              # #2 GCP Cloud Run Service (sidecar)
   deploy_cloudrun_job                  # #3 GCP Cloud Run Job (init-container)
   deploy_cloudrun_function_sidecar     # #4 GCP Cloud Run Function gen2 (sidecar)
-  deploy_container_app                 # #5 Azure Container App (init-container)
-  deploy_container_app_sidecar         # #6 Azure Container App (sidecar)
-  deploy_web_app_container             # #7 Azure Web App Linux Containers (init-container)
-  deploy_web_app_sidecar               # #8 Azure Web App SITECONTAINERS (sidecar)
-  deploy_web_app_linux_code_sidecar    # #9 Azure Web App Linux Code + sidecar
+  deploy_container_app              || log "WARN: #5 Azure Container App (init) failed — skipping"
+  deploy_container_app_sidecar      || log "WARN: #6 Azure Container App (sidecar) failed — skipping"
+  deploy_web_app_container          || log "WARN: #7 Azure Web App (containers) failed — skipping"
+  deploy_web_app_sidecar            || log "WARN: #8 Azure Web App (sidecar) failed — skipping"
+  deploy_web_app_linux_code_sidecar || log "WARN: #9 Azure Web App (linux code) failed — skipping"
 
   echo ""
   echo "=========================================="


### PR DESCRIPTION
## What this is

A **prototype branch** containing the full stack of changes for SVLS-9526 in a single PR. Intended for review and discussion — these changes will be broken into the stacked PRs below before merge.

## Stacked PRs (final form)

| PR | Branch | Contents |
|---|---|---|
| #54537 | `svls-9526/force-collect` | `ForceCollect()` — send inventory payload on every cold start |
| #54538 | `svls-9526/diagnostic-v2` | `inventories_first_run_delay` config key + diagnostic enhancements |
| #54543 | `svls-9526/serverless-agent-table` | `cmd/serverless-init/inventory`: `serverless_*` fields in inventoryagent payload |

## What's in this PR

**Agent changes (will land via the stacked PRs above):**
- `ForceCollect()` added to `inventoryagent.Component` — fires before `modeConf.Runner()` so the inventory payload is sent before the container can scale to zero
- `inventories_first_run_delay` config key to control startup delay
- New `cmd/serverless-init/inventory` package: populates `serverless_*` fields (cloud provider, workload type, origin, resource name, deployment model, runtime, agent commit, DD config) into the inventoryagent payload
- Enhanced startup diagnostics (`DD_SERVERLESS_DIAGNOSTIC_INFO=true`) including UUID, CCRID, and inventory pipeline config

**POC deploy scripts (`scripts/serverless-deploy/`, not intended to merge to main):**
- Deploys 9 test services across GCP (Cloud Run Service/Job/Function) and Azure (Container App, Web App Containers, Web App SITECONTAINERS, Web App Linux Code)
- `demo.sh` — one-command end-to-end runner: build → deploy all 9 → trigger cold starts → collect logs → print REDAPL SQL query

## How to run the POC

```bash
export GCP_PROJECT=datadog-serverless-gcp-demo
export AZURE_SUBSCRIPTION_ID=<sub-id>
export DD_API_KEY=$(vault kv get -field=api_key kv/dd/api_keys/dddev)
export IMAGE_TAG=1.10.2-poc-$(date +%Y%m%d)

cd scripts/serverless-deploy
./demo.sh
```
###dd-auth command equivalent:

`export DD_API_KEY=$(dd-auth vault kv get -field=api_key kv/dd/api_keys/dddev)`

Or if it's wrapping the whole script:

`dd-auth ./demo.sh
`

Then paste the generated SQL into **go/redapl → Queries → SQL** to see the agents in `datadog_agent`.

## Key findings from 9-platform testing

| Platform | UUID behaviour | `datadog_agent` rows |
|---|---|---|
| GCP Cloud Run | New UUID per cold start | `ForceCollect()` required — container scales to zero before 60s delay |
| Azure Container App | Stable UUID per replica | Upserts same row reliably |
| Azure Web App | DMI UUID from underlying VM | Apps on same App Service Plan share UUID → need CCRID-based PK |

This motivates `serverless_init_agent` (SVLS-9604): a separate REDAPL table keyed by `resource_id` (CCRID) instead of Agent UUID.

## Not in scope for merge

- `scripts/serverless-deploy/` — test infrastructure only, not shipped in the agent
- `scripts/serverless-deploy/diagnostic-results-*.txt` — personal test output