### PR TITLE
Skip full git clones on Windows package jobs

### DIFF
--- a/.gitlab/windows/build/package_build/windows.yml
+++ b/.gitlab/windows/build/package_build/windows.yml
@@ -3,10 +3,10 @@
   stage: package_build
   extends: [.windows_docker_default, .bazel:defs:cache:windows]  # the latter for `bazel run @openssl//:install`
   needs: ["go_deps"]
-  variables:
-    GIT_DEPTH: 0  # git describe --tags needs reachable tags
   script:
     - $ErrorActionPreference = 'Stop'
+    - Invoke-Expression "$S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache ."
+    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - !reference [.sanitize_goproxy_windows]
     - if (Test-Path omnibus\pkg) { remove-item -recurse -force omnibus\pkg }
     - mkdir omnibus\pkg
@@ -97,9 +97,10 @@ windows_msi_and_bosh_zip_x64-a7-fips:
   needs: ["go_deps"]
   variables:
     ARCH: "x64"
-    GIT_DEPTH: 0  # git describe --tags needs reachable tags
   script:
     - $ErrorActionPreference = "Stop"
+    - Invoke-Expression "$S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache ."
+    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - !reference [.sanitize_goproxy_windows]
     - if (Test-Path omnibus\pkg) { remove-item -recurse -force omnibus\pkg }
     - mkdir omnibus\pkg
@@ -172,9 +173,10 @@ windows_zip_ddot_x64:
   needs: ["go_deps"]
   variables:
     ARCH: "x64"
-    GIT_DEPTH: 0  # git describe --tags needs reachable tags
   script:
     - $ErrorActionPreference = "Stop"
+    - Invoke-Expression "$S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache ."
+    - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - !reference [.sanitize_goproxy_windows]
     - if (Test-Path omnibus\pkg) { remove-item -recurse -force omnibus\pkg }
     - mkdir omnibus\pkg

--- a/tasks/libs/releasing/version.py
+++ b/tasks/libs/releasing/version.py
@@ -261,6 +261,36 @@ def _get_release_version_from_release_json(release_json, version_re, release_jso
     return release_component_version
 
 
+def _load_agent_version_cache(ctx, pipeline_id=None, project_name=None):
+    """Return parsed agent-version.cache contents, or None if unavailable.
+
+    A local cache file is used whenever it exists. S3 is only contacted when the
+    file is missing and CI coordinates are present. This matters for Omnibus:
+    its sanitized environment omits CI_PIPELINE_ID, so Windows package builds
+    cannot re-fetch the cache, but they do copy the file into the source tree.
+    """
+    if project_name is None:
+        project_name = os.getenv("CI_PROJECT_NAME")
+    try:
+        cache_exists = os.path.exists(AGENT_VERSION_CACHE_NAME)
+        if not cache_exists and pipeline_id and str(pipeline_id).isdigit() and project_name == REPO_NAME:
+            result = ctx.run(
+                f"aws s3 cp s3://dd-ci-artefacts-build-stable/datadog-agent/{pipeline_id}/{AGENT_VERSION_CACHE_NAME} .",
+                hide="stdout",
+            )
+            if "unable to locate credentials" in result.stderr.casefold():
+                raise Exit("Permanent error: unable to locate credentials, retry the job", 42)
+            cache_exists = True
+        if not cache_exists:
+            return None
+        with open(AGENT_VERSION_CACHE_NAME) as file:
+            return json.load(file)
+    except (OSError, json.JSONDecodeError) as e:
+        # If a cache file is found but corrupted we ignore it.
+        print(f"Error while recovering the version from {AGENT_VERSION_CACHE_NAME}: {e}", file=sys.stderr)
+        return None
+
+
 def get_version(
     ctx,
     url_safe=False,
@@ -280,28 +310,15 @@ def get_version(
 
     project_name = os.getenv("CI_PROJECT_NAME")
     try:
-        agent_version_cache_file_exist = os.path.exists(AGENT_VERSION_CACHE_NAME)
-        if not agent_version_cache_file_exist:
-            if pipeline_id and pipeline_id.isdigit() and project_name == REPO_NAME:
-                result = ctx.run(
-                    f"aws s3 cp s3://dd-ci-artefacts-build-stable/datadog-agent/{pipeline_id}/{AGENT_VERSION_CACHE_NAME} .",
-                    hide="stdout",
-                )
-                if "unable to locate credentials" in result.stderr.casefold():
-                    raise Exit("Permanent error: unable to locate credentials, retry the job", 42)
-                agent_version_cache_file_exist = True
-
-        if agent_version_cache_file_exist:
-            with open(AGENT_VERSION_CACHE_NAME) as file:
-                cache_data = json.load(file)
-
+        cache_data = _load_agent_version_cache(ctx, pipeline_id=pipeline_id, project_name=project_name)
+        if cache_data:
             version, pre, commits_since_version, git_sha, pipeline_id = cache_data[major_version]
             # Dev's versions behave the same as nightly
             is_nightly = cache_data["nightly"] or cache_data["dev"]
 
             if pre and include_pre:
                 version = f"{version}-{pre}"
-    except (OSError, json.JSONDecodeError, IndexError) as e:
+    except (IndexError, KeyError, TypeError, ValueError) as e:
         # If a cache file is found but corrupted we ignore it.
         print(f"Error while recovering the version from {AGENT_VERSION_CACHE_NAME}: {e}", file=sys.stderr)
         version = ""
@@ -344,24 +361,14 @@ def get_version_numeric_only(ctx, major_version='7'):
     version = ""
     pipeline_id = os.getenv("CI_PIPELINE_ID")
     project_name = os.getenv("CI_PROJECT_NAME")
-    if pipeline_id and pipeline_id.isdigit() and project_name == REPO_NAME:
-        try:
-            if not os.path.exists(AGENT_VERSION_CACHE_NAME):
-                result = ctx.run(
-                    f"aws s3 cp s3://dd-ci-artefacts-build-stable/datadog-agent/{pipeline_id}/{AGENT_VERSION_CACHE_NAME} .",
-                    hide="stdout",
-                )
-                if "unable to locate credentials" in result.stderr.casefold():
-                    raise Exit("Permanent error: unable to locate credentials, retry the job", 42)
-
-            with open(AGENT_VERSION_CACHE_NAME) as file:
-                cache_data = json.load(file)
-
+    try:
+        cache_data = _load_agent_version_cache(ctx, pipeline_id=pipeline_id, project_name=project_name)
+        if cache_data:
             version, *_ = cache_data[major_version]
-        except (OSError, json.JSONDecodeError, IndexError) as e:
-            # If a cache file is found but corrupted we ignore it.
-            print(f"Error while recovering the version from {AGENT_VERSION_CACHE_NAME}: {e}")
-            version = ""
+    except (IndexError, KeyError, TypeError, ValueError) as e:
+        # If a cache file is found but corrupted we ignore it.
+        print(f"Error while recovering the version from {AGENT_VERSION_CACHE_NAME}: {e}", file=sys.stderr)
+        version = ""
     if not version:
         version, *_ = query_version(ctx, major_version)
     return version

--- a/tasks/unit_tests/version_tests.py
+++ b/tasks/unit_tests/version_tests.py
@@ -524,7 +524,9 @@ class TestGetVersionNumericOnly(unittest.TestCase):
         self.assertEqual(get_version_numeric_only(ctx), "7.84.0")
         ctx.run.assert_not_called()
 
-    @patch.dict(os.environ, {"CI": "true", "CI_PIPELINE_ID": "131065751", "CI_PROJECT_NAME": "datadog-agent"}, clear=True)
+    @patch.dict(
+        os.environ, {"CI": "true", "CI_PIPELINE_ID": "131065751", "CI_PROJECT_NAME": "datadog-agent"}, clear=True
+    )
     @patch("tasks.libs.releasing.version.os.path.exists", return_value=False)
     def test_fetches_cache_from_s3_when_missing(self, _mock_exists):
         ctx = MagicMock()

--- a/tasks/unit_tests/version_tests.py
+++ b/tasks/unit_tests/version_tests.py
@@ -1,13 +1,15 @@
+import json
 import os
 import random
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 from invoke import MockContext, Result, UnexpectedExit
 
 from tasks.libs.releasing.version import (
     current_version_for_release_branch,
     get_matching_pattern,
+    get_version_numeric_only,
     next_rc_version,
     query_version,
 )
@@ -500,3 +502,34 @@ class TestNextVersionForReleaseBranch(unittest.TestCase):
         ctx.run.return_value.stdout = "7.63.0-installer"
         version = next_rc_version(ctx, '7.63.x')
         self.assertEqual(version, Version(7, 64, 0, rc=1))
+
+
+_CACHE_CONTENTS = {
+    "6": ["6.84.0", "devel", 10, "abc1234", "131065751"],
+    "7": ["7.84.0", "devel", 203, "db4c825", "131065751"],
+    "nightly": False,
+    "dev": True,
+}
+
+
+class TestGetVersionNumericOnly(unittest.TestCase):
+    @patch.dict(os.environ, {"CI": "true"}, clear=True)
+    @patch("tasks.libs.releasing.version.os.path.exists", return_value=True)
+    @patch("builtins.open", new_callable=mock_open, read_data=json.dumps(_CACHE_CONTENTS))
+    def test_uses_local_cache_without_pipeline_id(self, _mock_file, _mock_exists):
+        # Omnibus sanitizes CI_PIPELINE_ID out of the environment, but copies
+        # agent-version.cache into the source tree. The numeric version used
+        # for Windows resources must still come from that file.
+        ctx = MagicMock()
+        self.assertEqual(get_version_numeric_only(ctx), "7.84.0")
+        ctx.run.assert_not_called()
+
+    @patch.dict(os.environ, {"CI": "true", "CI_PIPELINE_ID": "131065751", "CI_PROJECT_NAME": "datadog-agent"}, clear=True)
+    @patch("tasks.libs.releasing.version.os.path.exists", return_value=False)
+    def test_fetches_cache_from_s3_when_missing(self, _mock_exists):
+        ctx = MagicMock()
+        ctx.run.return_value = Result(stderr="")
+        with patch("builtins.open", mock_open(read_data=json.dumps(_CACHE_CONTENTS))):
+            self.assertEqual(get_version_numeric_only(ctx), "7.84.0")
+        ctx.run.assert_called_once()
+        self.assertIn("aws s3 cp", ctx.run.call_args.args[0])


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Stop Windows MSI/zip package jobs from doing a full git clone (`GIT_DEPTH: 0`). They only needed history so `get_version()` could run `git describe --tags` inside the build container, which has no AWS credentials.

Instead, download `agent-version.cache` on the runner host (after `assume-role`) and fail the job if that copy fails. The file is mounted into the container and xcopied into the buildroot, so `get_version()` reads the cache and never calls `git describe`.

### Motivation

Full clones of this repo are expensive. These jobs can use the pipeline-default shallow clone once versioning comes from `setup_agent_version`'s S3 cache.

### Describe how you validated your changes

- Confirmed `go_deps` already `needs: setup_agent_version`, so the cache object exists before package jobs start.
- Confirmed the host `before_script` `assume-role` still runs (this change is in `script`, so it is not overwritten).
- S3 copy uses the same `Invoke-Expression` + `$lastExitCode` pattern as `.upload_sbom_artifacts_windows`, because PowerShell 5 does not fail the job on a native `aws.exe` error.

### Additional Notes

CI-only; no release note.

Made with [Cursor](https://cursor.com)