### PR TITLE
Revert "#incident-59224: drop DWARF from Windows Go test binary links"

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -662,9 +662,6 @@ def test(
     build_cpus_opt = f"-p {cpus}" if cpus else ""
     test_cpus_opt = f"-parallel {cpus}" if cpus else ""
     trimpath_opt = "-trimpath" if 'DELVE' not in os.environ else ""
-    if sys.platform == "win32" and "DELVE" not in os.environ:
-        # incident-59224: omit DWARF to deflate peak link memory, while preserving symbol table diagnostics
-        ldflags += "-w"
 
     nocache = '-count=1' if not cache else ''
 


### PR DESCRIPTION
Reverts DataDog/datadog-agent#54903

Speculative to see if this fixes the currently broken USM tests.

https://app.datadoghq.com/incidents/59255
https://app.datadoghq.com/incidents/59256