### PR TITLE
Bump internal agent image to tmpl-v26 (check_intake_queue 1.5.1)

### DIFF
--- a/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
@@ -71,7 +71,7 @@ publish_internal_container_image-jmx:
         IMAGE_VERSION: tmpl-v24
       - COMPRESSION: ""
         RELEASE_TAG_COMPRESSION_SUFFIX: ""
-        IMAGE_VERSION: tmpl-v25
+        IMAGE_VERSION: tmpl-v26
   needs:
     - job: docker_build_agent7_jmx
       artifacts: false
@@ -92,7 +92,7 @@ publish_internal_container_image-fips:
         IMAGE_VERSION: tmpl-v24
       - COMPRESSION: ""
         RELEASE_TAG_COMPRESSION_SUFFIX: ""
-        IMAGE_VERSION: tmpl-v25
+        IMAGE_VERSION: tmpl-v26
   needs:
     - job: docker_build_fips_agent7_jmx
       artifacts: false


### PR DESCRIPTION
### What does this PR do?

Points the uncompressed `-jmx` and `-fips` internal `datadog-agent` image builds at `datadog-agent/tmpl-v26` (was `tmpl-v25`) in the images repo:

```diff
 publish_internal_container_image-jmx / -fips:
   - COMPRESSION: ""
-        IMAGE_VERSION: tmpl-v25
+        IMAGE_VERSION: tmpl-v26
```

### Motivation

`tmpl-v26` bumps `check_intake_queue` `1.3.2 -> 1.5.1` (cell-tagged zero for an empty intake queue; DataDog/integrations-internal#283). The template was added in DataDog/images#11094 rather than editing `tmpl-v25` in place (the in-place bump images#11084 was reverted in images#11093).
