### PR TITLE
feat: Detect macOS applications in ~/Library/Application Support

### DIFF
--- a/pkg/inventory/software/collector_darwin_apps.go
+++ b/pkg/inventory/software/collector_darwin_apps.go
@@ -92,7 +92,7 @@ func populatePkgInfoFromIndex(items []appPkgLookup) {
 
 // Collect scans the /Applications directory recursively for installed applications.
 // This includes apps in subdirectories like /Applications/SentinelOne/SentinelOne Extensions.app
-// It also scans ~/Applications for all local users on the system.
+// It also scans ~/Applications and ~/Library/Application Support for all local users on the system.
 func (c *applicationsCollector) Collect() ([]*Entry, []*Warning, error) {
 
 	var entries []*Entry
@@ -114,6 +114,7 @@ func (c *applicationsCollector) Collect() ([]*Entry, []*Warning, error) {
 	for _, userHome := range localUsers {
 		username := filepath.Base(userHome)
 		userAppsPath := filepath.Join(userHome, "Applications")
+		userLibAppSupportPath := filepath.Join(userHome, "Library", "Application Support")
 
 		// Check if the user's Applications directory exists and is accessible
 		if info, err := os.Stat(userAppsPath); err == nil && info.IsDir() {
@@ -121,6 +122,11 @@ func (c *applicationsCollector) Collect() ([]*Entry, []*Warning, error) {
 		}
 		// If directory doesn't exist or can't be accessed, silently skip
 		// (most users won't have ~/Applications)
+
+		// Check if the user's Library/Application Support directory exists and is accessible
+		if info, err := os.Stat(userLibAppSupportPath); err == nil && info.IsDir() {
+			appDirs = append(appDirs, userAppDir{path: userLibAppSupportPath, username: username})
+		}
 	}
 
 	for _, appDir := range appDirs {


### PR DESCRIPTION
Some applications are stored in sub-directories of ~/Library/Application Support, for example:

Those applications are detected by osquery, and the Software Inventory in the DD agent should also detect them.

<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

It detects macOS applications in subdirectories of ~/Library/Application Support.

Some examples:

```
 /Users/myuser/Library/Application Support/JetBrains/Daemon/bundles/current/jetbrainsd.app/Contents/Helpers/JetBrains.app
 /Users/myuser/Library/Application Support/Steam/steamapps/common/AoE2DE/Age Of Empires II.app
```

### Motivation

To get a better inventory (and who wants Steam games on work computers, right?). osquery also detects those applications. 

### Describe how you validated your changes

Sadly, a build with Omnibus didn't work, I get an unrelated issue:

```
bundler: failed to load command: omnibus (/opt/homebrew/lib/ruby/gems/4.0.0/bin/omnibus)
/opt/homebrew/lib/ruby/gems/4.0.0/gems/thor-0.20.3/lib/thor/error.rb:109:in '<class:Thor>': uninitialized constant DidYouMean::SPELL_CHECKERS (NameError)

    DidYouMean::SPELL_CHECKERS.merge!(
              ^^^^^^^^^^^^^^^^
Did you mean?  DidYouMean::SpellChecker
```
