### PR TITLE
[ABLD-464] Debug-symbol packages: provider/rule-based split (Plan A)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -205,6 +205,17 @@ register_toolchains(
     "//bazel/toolchains/rpath_rewriter:patchelf_toolchain",
 )
 
+# ABLD-464: strip/split debug-symbol driver, one toolchain per OS plus a
+# fallback for exec platforms without one. Registered last so the specific
+# per-OS toolchains are preferred; :missing_toolchain matches everywhere and
+# would otherwise shadow them under earlier-wins resolution.
+register_toolchains(
+    "//bazel/toolchains/dd_strip:linux_toolchain",
+    "//bazel/toolchains/dd_strip:macos_toolchain",
+    "//bazel/toolchains/dd_strip:windows_toolchain",
+    "//bazel/toolchains/dd_strip:missing_toolchain",
+)
+
 find_rpmbuild = use_extension("@rules_pkg//toolchains/rpm:rpmbuild_configure.bzl", "find_system_rpmbuild_bzlmod", dev_dependency = True)
 use_repo(find_rpmbuild, "rules_pkg_rpmbuild")
 

--- a/bazel/configs/system_probe_lite.bazelrc
+++ b/bazel/configs/system_probe_lite.bazelrc
@@ -3,5 +3,4 @@
 build:system-probe-lite-release --@rules_rust//rust/settings:lto=fat # Enable fat LTO
 build:system-probe-lite-release --@rules_rust//rust/settings:extra_rustc_flag=-Copt-level=z # Optimize for size
 build:system-probe-lite-release --@rules_rust//rust/settings:extra_rustc_flag=-Ccodegen-units=1 # Single codegen unit for maximum optimization
-build:system-probe-lite-release --@rules_rust//rust/settings:extra_rustc_flag=-Cstrip=symbols # Strip debug symbols
 build:system-probe-lite-release --@rules_rust//rust/settings:extra_rustc_flag=-Cpanic=abort # Remove stack unwinding

--- a/bazel/rules/dd_packaging/dd_cc_packaged.bzl
+++ b/bazel/rules/dd_packaging/dd_cc_packaged.bzl
@@ -8,6 +8,8 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("@rules_pkg//pkg:providers.bzl", "PackageFilegroupInfo", "PackageFilesInfo")
 load("//bazel/rules:so_symlink.bzl", "so_symlink")
 load("//bazel/rules/dd_packaging:dd_packaging_info.bzl", "DdPackagingInfo")
+load("//bazel/rules/dd_packaging:dd_pkg_files_stripped.bzl", "dd_pkg_files_stripped")
+load("//bazel/rules/dd_strip:dd_strip.bzl", "dd_strip_debug")
 load("//bazel/rules/rewrite_rpath:rewrite_rpath.bzl", "rewrite_rpath", "rewrite_rpaths")
 
 def _dd_packaged_files_impl(ctx):
@@ -95,7 +97,7 @@ _dd_cc_packaged_rule = rule(
     },
 )
 
-def _dd_cc_packaged_impl(name, input, version = "", installed_files = [], installed_executables = {}, libname = "", prefix = "", dest_dir = "", visibility = None, **kwargs):
+def _dd_cc_packaged_impl(name, input, version = "", installed_files = [], installed_executables = {}, libname = "", prefix = "", dest_dir = "", strip_exclude = False, visibility = None, **kwargs):
     patched_name = "{}_patched".format(name)
     base = dest_dir if dest_dir else "lib"
     package_dest_dir = paths.join(base, prefix) if prefix else base
@@ -111,6 +113,25 @@ def _dd_cc_packaged_impl(name, input, version = "", installed_files = [], instal
         use_relative_rpaths = use_relative_rpaths,
         package_metadata = [],
     )
+
+    # Split the rpath-patched binary/library into stripped + debug-only
+    # outputs before packaging. The stripped output is what actually gets
+    # shipped (via the ".stripped" sibling label below); the debug output is
+    # only materialized for consumers that explicitly collect it (e.g. a
+    # future dbg package).
+    split_name = "{}_split".format(patched_name)
+    dd_strip_debug(
+        name = split_name,
+        input = ":{}".format(patched_name),
+        exclude = strip_exclude,
+        visibility = visibility,
+    )
+    dd_pkg_files_stripped(
+        name = split_name,
+        visibility = visibility,
+    )
+    stripped_input = ":{}.stripped".format(split_name)
+
     extra_files = []
     if installed_executables:
         exec_files_name = "{}_exec_files".format(name)
@@ -127,7 +148,7 @@ def _dd_cc_packaged_impl(name, input, version = "", installed_files = [], instal
     if version:
         so_symlink(
             name = packaged_lib,
-            src = ":{}".format(patched_name),
+            src = stripped_input,
             libname = resolved_libname,
             version = version,
             prefix = prefix,
@@ -137,7 +158,7 @@ def _dd_cc_packaged_impl(name, input, version = "", installed_files = [], instal
     else:
         pkg_files(
             name = packaged_lib,
-            srcs = [":{}".format(patched_name)],
+            srcs = [stripped_input],
             prefix = package_dest_dir,
             visibility = visibility,
             package_metadata = [],
@@ -201,6 +222,13 @@ dd_cc_packaged = macro(
             on Linux/macOS and bin/ on Windows (via so_symlink). Use this for
             deps with non-standard install layouts (e.g. msodbcsql/lib64).""",
             default = "",
+            configurable = False,
+        ),
+        "strip_exclude": attr.bool(
+            doc = """Skip splitting stripped/debug outputs for this target,
+            parity with omnibus's strip_exclude. The unstripped, rpath-patched
+            binary/library is packaged as-is.""",
+            default = False,
             configurable = False,
         ),
         "version": attr.string(

--- a/bazel/rules/dd_packaging/dd_packaging_test.bzl
+++ b/bazel/rules/dd_packaging/dd_packaging_test.bzl
@@ -133,9 +133,11 @@ def _test_so_collected(name):
     )
 
 def _test_so_collected_impl(env, target):
-    # rewrite_rpath places its output under a "patched/" subdirectory.
+    # rewrite_rpath names its output "<name>_patched"; dd_strip_debug then
+    # further splits that into "<name>_patched_split.stripped" (shipped) and
+    # ".debug" (not collected here). Match on "patched" broadly to cover both.
     _outputs_of(env, target).contains_predicate(
-        matching.file_path_matches("*patched/*"),
+        matching.file_path_matches("*_patched*"),
     )
 
 # Test 3: dd_cc_packaged with installed_files → both the patched .so and the
@@ -172,7 +174,7 @@ def _test_installed_files_collected(name):
 
 def _test_installed_files_collected_impl(env, target):
     outputs = _outputs_of(env, target)
-    outputs.contains_predicate(matching.file_path_matches("*patched/*"))
+    outputs.contains_predicate(matching.file_path_matches("*_patched*"))
     outputs.contains_predicate(matching.file_basename_contains("empty.h"))
 
 # Test 4: transitive collection through dynamic_deps.
@@ -228,7 +230,7 @@ def _test_transitive_collected_impl(env, target):
     outputs = _outputs_of(env, target)
 
     # outer's own patched .so
-    outputs.contains_predicate(matching.file_path_matches("*patched/*"))
+    outputs.contains_predicate(matching.file_path_matches("*_patched*"))
 
     # inner's header, reached transitively via dynamic_deps → input → dynamic_deps
     outputs.contains_predicate(matching.file_basename_contains("empty.h"))
@@ -293,7 +295,7 @@ def _test_packaged_forwards_unpatched_so(name):
 def _test_packaged_forwards_unpatched_so_impl(env, target):
     outputs = _outputs_of(env, target)
     outputs.contains_predicate(matching.file_extension_in(["so", "dll", "dylib"]))
-    outputs.not_contains_predicate(matching.file_path_matches("*patched/*"))
+    outputs.not_contains_predicate(matching.file_path_matches("*_patched*"))
 
 # Test 7: dd_cc_packaged wrapping a cc_binary → the rpath-patched binary
 # appears in DdPackagingInfo.installed_files.
@@ -322,7 +324,7 @@ def _test_cc_binary_collected(name):
     )
 
 def _test_cc_binary_collected_impl(env, target):
-    _outputs_of(env, target).contains_predicate(matching.file_path_matches("*patched/*"))
+    _outputs_of(env, target).contains_predicate(matching.file_path_matches("*_patched*"))
 
 # Test 8: dd_cc_packaged wrapping a cc_binary does NOT forward CcSharedLibraryInfo,
 # even when the binary links against a dd_cc_packaged shared library.

--- a/bazel/rules/dd_packaging/dd_pkg_files_stripped.bzl
+++ b/bazel/rules/dd_packaging/dd_pkg_files_stripped.bzl
@@ -1,0 +1,58 @@
+"""Helper for referencing a dd_strip_debug target's split outputs from pkg_files.
+
+dd_strip_debug's DefaultInfo intentionally stays unstripped (see
+//bazel/rules/dd_strip:dd_strip.bzl), so a plain `pkg_files(srcs = [":foo"])`
+would package the unstripped binary. dd_pkg_files_stripped creates two small
+sibling targets, "<name>.stripped" and "<name>.debug", that expose a
+dd_strip_debug target's OutputGroupInfo(stripped = ...)/OutputGroupInfo(debug
+= ...) outputs through DefaultInfo, so they can be referenced directly as
+pkg_files srcs, e.g.:
+
+    dd_strip_debug(name = "agent", input = ":agent_unstripped")
+    dd_pkg_files_stripped(name = "agent")
+    pkg_files(srcs = ["//cmd/agent:agent.stripped"], ...)
+"""
+
+def _dd_output_group_file_impl(ctx):
+    group = getattr(ctx.attr.dep[OutputGroupInfo], ctx.attr.group)
+    return [DefaultInfo(files = group)]
+
+_dd_output_group_file = rule(
+    implementation = _dd_output_group_file_impl,
+    doc = "Re-exposes one named OutputGroupInfo group of `dep` as this target's DefaultInfo.",
+    attrs = {
+        "dep": attr.label(
+            doc = "A target providing OutputGroupInfo, typically a dd_strip_debug target.",
+            providers = [OutputGroupInfo],
+            mandatory = True,
+        ),
+        "group": attr.string(
+            doc = "The OutputGroupInfo group to expose: 'stripped' or 'debug'.",
+            mandatory = True,
+            values = ["stripped", "debug"],
+        ),
+    },
+)
+
+def dd_pkg_files_stripped(name, dep = None, visibility = None):
+    """Creates "<name>.stripped" and "<name>.debug" sibling labels for a dd_strip_debug target.
+
+    Args:
+      name: the base name used for the sibling labels ("<name>.stripped", "<name>.debug").
+      dep: the dd_strip_debug target to read from. Defaults to ":<name>" (i.e. call this
+           right after `dd_strip_debug(name = name, ...)`).
+      visibility: visibility applied to both sibling targets.
+    """
+    dep = dep or (":" + name)
+    _dd_output_group_file(
+        name = name + ".stripped",
+        dep = dep,
+        group = "stripped",
+        visibility = visibility,
+    )
+    _dd_output_group_file(
+        name = name + ".debug",
+        dep = dep,
+        group = "debug",
+        visibility = visibility,
+    )

--- a/bazel/rules/dd_strip/BUILD.bazel
+++ b/bazel/rules/dd_strip/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":dd_strip_test.bzl", "dd_strip_test_suite")
+
+dd_strip_test_suite(name = "_dd_strip_tests")

--- a/bazel/rules/dd_strip/dd_strip.bzl
+++ b/bazel/rules/dd_strip/dd_strip.bzl
@@ -1,0 +1,151 @@
+"""dd_strip_debug: split a binary/library into stripped + debug-only outputs.
+
+Wraps any single label that produces one default output file (a go_binary,
+cc_binary, cc_shared_library, or rust_binary). The wrapped rule's DEFAULT
+output is untouched and stays unstripped, so `bazel build //some:target`
+behavior never changes; the split outputs are only materialized for
+consumers that ask for them via OutputGroupInfo (`--output_groups=+debug` or
+`+stripped`) or by reading DdStripInfo directly (see dd_pkg_files_stripped.bzl).
+
+dd_go_binary_with_debug / dd_cc_binary_with_debug / dd_rust_binary_with_debug
+are convenience macros that create the wrapped binary/library under a private
+`<name>_unstripped` target and wrap it with dd_strip_debug under the
+requested `name`, so callers just swap the rule name and keep every other
+kwarg unchanged.
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_go//go:def.bzl", "go_binary")
+load(":dd_strip_info.bzl", "DdStripInfo")
+
+_TOOLCHAIN_TYPE = "//bazel/toolchains/dd_strip:dd_strip_toolchain_type"
+
+def _passthrough(original, excluded):
+    return [
+        DefaultInfo(files = depset([original])),
+        DdStripInfo(
+            stripped_file = original,
+            debug_file = None,
+            original_file = original,
+            excluded = excluded,
+        ),
+        OutputGroupInfo(stripped = depset([original]), debug = depset([])),
+    ]
+
+def _dd_strip_debug_impl(ctx):
+    original = ctx.file.input
+
+    if ctx.attr.exclude:
+        return _passthrough(original, excluded = True)
+
+    toolchain = ctx.toolchains[_TOOLCHAIN_TYPE]
+    if toolchain == None or not toolchain.available:
+        # No strip/split driver for this platform: pass the original through
+        # rather than failing the build (parity with DdStripInfo.excluded).
+        return _passthrough(original, excluded = True)
+
+    stripped = ctx.actions.declare_file(ctx.label.name + ".stripped")
+    if toolchain.debug_is_directory:
+        debug = ctx.actions.declare_directory(ctx.label.name + ".debug")
+    else:
+        debug = ctx.actions.declare_file(ctx.label.name + ".debug")
+
+    args = ctx.actions.args()
+    args.add(original.path)
+    args.add(stripped.path)
+    args.add(debug.path)
+    ctx.actions.run(
+        executable = toolchain.driver,
+        arguments = [args],
+        inputs = [original],
+        outputs = [stripped, debug],
+        toolchain = _TOOLCHAIN_TYPE,
+        mnemonic = "DdStripDebug",
+        progress_message = "Splitting debug info for %s" % original.short_path,
+    )
+
+    return [
+        # Default output stays unstripped: bazel build //x:x never changes.
+        DefaultInfo(files = depset([original])),
+        DdStripInfo(
+            stripped_file = stripped,
+            debug_file = debug,
+            original_file = original,
+            excluded = False,
+        ),
+        OutputGroupInfo(stripped = depset([stripped]), debug = depset([debug])),
+    ]
+
+dd_strip_debug = rule(
+    implementation = _dd_strip_debug_impl,
+    doc = """Wraps a single-output binary/library target, exposing:
+
+    - DefaultInfo: the original, unstripped file (unchanged build behavior).
+    - OutputGroupInfo(stripped = [...]): the stripped file, for packaging.
+    - OutputGroupInfo(debug = [...]): the debug-only file/dSYM directory.
+    - DdStripInfo: the same three files plus whether stripping was skipped.
+
+    When exclude = True (parity with omnibus's strip_exclude, e.g. for eBPF
+    .o objects handled separately by _stripped_ebpf), or when no dd_strip
+    toolchain is registered for the current platform, stripped_file equals
+    original_file and debug_file is None -- no stripping occurs and
+    DdStripInfo.excluded is True.""",
+    attrs = {
+        "input": attr.label(
+            doc = "Label producing a single default output file to strip (a binary or shared library).",
+            mandatory = True,
+            allow_single_file = True,
+        ),
+        "exclude": attr.bool(
+            doc = "Skip stripping and expose the original file unchanged, parity with omnibus's strip_exclude.",
+            default = False,
+        ),
+    },
+    toolchains = [config_common.toolchain_type(_TOOLCHAIN_TYPE, mandatory = False)],
+)
+
+def _wrap(binary_rule, name, strip_exclude, visibility, kwargs):
+    unstripped_name = name + "_unstripped"
+    binary_rule(
+        name = unstripped_name,
+        visibility = ["//visibility:private"],
+        tags = (kwargs.pop("tags", None) or []) + ["manual"],
+        **kwargs
+    )
+    dd_strip_debug(
+        name = name,
+        input = ":" + unstripped_name,
+        exclude = strip_exclude,
+        visibility = visibility,
+    )
+
+def dd_go_binary_with_debug(name, strip_exclude = False, visibility = None, **kwargs):
+    """A go_binary wrapped with dd_strip_debug.
+
+    Accepts all go_binary attributes via **kwargs. See dd_strip_debug for the
+    behavior of the wrapping (default output stays unstripped; use
+    --output_groups=+stripped/+debug or DdStripInfo to get the split).
+
+    Args:
+      name: target name. The underlying go_binary is created as
+            "<name>_unstripped" (private, tags = ["manual"]).
+      strip_exclude: parity with omnibus's strip_exclude -- skip stripping.
+      visibility: visibility of the resulting dd_strip_debug target.
+      **kwargs: forwarded to go_binary.
+    """
+    _wrap(go_binary, name, strip_exclude, visibility, kwargs)
+
+def dd_cc_binary_with_debug(name, strip_exclude = False, visibility = None, **kwargs):
+    """A cc_binary wrapped with dd_strip_debug. See dd_go_binary_with_debug."""
+    _wrap(cc_binary, name, strip_exclude, visibility, kwargs)
+
+def dd_rust_binary_with_debug(name, strip_exclude = False, visibility = None, **kwargs):
+    """A rust_binary wrapped with dd_strip_debug. See dd_go_binary_with_debug."""
+
+    # Deferred import: rules_rust is not a dependency of every consumer of
+    # this file (e.g. dd_go_binary_with_debug-only callers), and loading it
+    # unconditionally would pull rules_rust into packages that never use it.
+    _wrap(_rust_binary(), name, strip_exclude, visibility, kwargs)
+
+def _rust_binary():
+    return Label("@rules_rust//rust:defs.bzl%rust_binary")

--- a/bazel/rules/dd_strip/dd_strip_info.bzl
+++ b/bazel/rules/dd_strip/dd_strip_info.bzl
@@ -1,0 +1,27 @@
+"""Provider reporting the stripped/debug split produced by dd_strip_debug."""
+
+DdStripInfo = provider(
+    doc = """Reports the outputs of splitting a single binary/library into a
+    stripped artifact (for shipping) and a debug-only artifact (for a
+    companion "dbg" package), mirroring omnibus's Stripper.
+
+    Consumers such as dd_pkg_files_stripped read this provider off a wrapped
+    target to decide which file to place in the shipped package vs. the
+    debug-only package.""",
+    fields = {
+        "stripped_file": """File. The binary/library with debug info removed,
+            ready for the shipped package. Equal to original_file when
+            excluded is True or no strip toolchain is available.""",
+        "debug_file": """File or None. The extracted debug information.
+            A regular File on Linux (objcopy --only-keep-debug output) and
+            Windows (the unstripped original), a Directory for macOS .dSYM
+            bundles. None when excluded is True or no strip toolchain is
+            available for the target platform.""",
+        "original_file": "File. The unstripped input as originally built.",
+        "excluded": """bool. True when this target opted out of stripping
+            (parity with omnibus's strip_exclude, used e.g. for eBPF .o
+            objects) or when no dd_strip toolchain is available for the
+            current platform. stripped_file is the unmodified original_file
+            in that case, and debug_file is None.""",
+    },
+)

--- a/bazel/rules/dd_strip/dd_strip_test.bzl
+++ b/bazel/rules/dd_strip/dd_strip_test.bzl
@@ -1,0 +1,118 @@
+"""Tests for dd_strip_debug and the dd_*_with_debug convenience macros."""
+
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
+load(":dd_strip.bzl", "dd_cc_binary_with_debug", "dd_strip_debug")
+load(":dd_strip_info.bzl", "DdStripInfo")
+
+def _outputs_of(env, target):
+    return env.expect.that_target(target).default_outputs()
+
+# Test 1: dd_strip_debug's DefaultInfo always exposes the *original*,
+# unstripped file -- wrapping a target must never change what
+# `bazel build //x:x` produces by default. The default output must never be
+# the .stripped/.debug split artifacts.
+def _test_default_output_is_unstripped(name):
+    cc_binary(
+        name = name + "_bin",
+        srcs = ["testdata/main.c"],
+    )
+    dd_strip_debug(
+        name = name + "_subject",
+        input = ":" + name + "_bin",
+    )
+    analysis_test(
+        name = name,
+        impl = _test_default_output_is_unstripped_impl,
+        target = name + "_subject",
+    )
+
+def _test_default_output_is_unstripped_impl(env, target):
+    info = target[DdStripInfo]
+    _outputs_of(env, target).contains_exactly([info.original_file.short_path])
+
+# Test 2: exclude = True passes the original file through unchanged and
+# reports DdStripInfo.excluded = True, with no debug_file produced. This
+# mirrors omnibus's strip_exclude and must hold on every platform
+# (independent of whether a dd_strip toolchain is registered).
+def _test_exclude_passthrough(name):
+    cc_binary(
+        name = name + "_bin",
+        srcs = ["testdata/main.c"],
+    )
+    dd_strip_debug(
+        name = name + "_subject",
+        input = ":" + name + "_bin",
+        exclude = True,
+    )
+    analysis_test(
+        name = name,
+        impl = _test_exclude_passthrough_impl,
+        target = name + "_subject",
+    )
+
+def _test_exclude_passthrough_impl(env, target):
+    info = target[DdStripInfo]
+    env.expect.that_bool(info.excluded).equals(True)
+    env.expect.that_bool(info.debug_file == None).equals(True)
+    env.expect.that_str(info.stripped_file.path).equals(info.original_file.path)
+
+# Test 3: DdStripInfo is always present, and stripped_file/original_file are
+# always set (debug_file may be None when excluded or when no toolchain is
+# registered for the current platform -- both are valid outcomes here since
+# this test runs on whatever platform is under test).
+def _test_dd_strip_info_present(name):
+    cc_binary(
+        name = name + "_bin",
+        srcs = ["testdata/main.c"],
+    )
+    dd_strip_debug(
+        name = name + "_subject",
+        input = ":" + name + "_bin",
+    )
+    analysis_test(
+        name = name,
+        impl = _test_dd_strip_info_present_impl,
+        target = name + "_subject",
+    )
+
+def _test_dd_strip_info_present_impl(env, target):
+    info = target[DdStripInfo]
+    env.expect.that_bool(info.stripped_file != None).equals(True)
+    env.expect.that_bool(info.original_file != None).equals(True)
+
+    # OutputGroupInfo must always expose both groups (possibly empty),
+    # never fail with a missing-group error for consumers that request them.
+    groups = target[OutputGroupInfo]
+    env.expect.that_bool(hasattr(groups, "stripped")).equals(True)
+    env.expect.that_bool(hasattr(groups, "debug")).equals(True)
+
+# Test 4: dd_cc_binary_with_debug creates a private "<name>_unstripped"
+# cc_binary and wraps it, forwarding kwargs (e.g. srcs) to the inner binary.
+def _test_cc_binary_with_debug_wraps(name):
+    dd_cc_binary_with_debug(
+        name = name + "_subject",
+        srcs = ["testdata/main.c"],
+    )
+    analysis_test(
+        name = name,
+        impl = _test_cc_binary_with_debug_wraps_impl,
+        target = name + "_subject",
+    )
+
+def _test_cc_binary_with_debug_wraps_impl(env, target):
+    info = target[DdStripInfo]
+    env.expect.that_bool(info.original_file != None).equals(True)
+
+# ── Suite ────────────────────────────────────────────────────────────────────
+
+def dd_strip_test_suite(name):
+    test_suite(
+        name = name,
+        tests = [
+            _test_default_output_is_unstripped,
+            _test_exclude_passthrough,
+            _test_dd_strip_info_present,
+            _test_cc_binary_with_debug_wraps,
+        ],
+    )

--- a/bazel/rules/dd_strip/testdata/main.c
+++ b/bazel/rules/dd_strip/testdata/main.c
@@ -1,0 +1,3 @@
+int main(void) {
+    return 0;
+}

--- a/bazel/rules/go/go_binary.bzl
+++ b/bazel/rules/go/go_binary.bzl
@@ -79,10 +79,9 @@ def dd_agent_go_binary(name, gc_linkopts = None, gotags = None, exact_gotags = N
 
     Args:
       name: target name
-      gc_linkopts: Base set of link opts. rpath and stripping options are
-                   automatically added to these.
+      gc_linkopts: Base set of link opts. The rpath option is automatically
+                   added to these.
                    On linux: add RPATH
-                   On release builds: add -s -w (strip symbol table and DWARF)
       gotags: Base set of gotags for this binary. COMMON tags are added, and
               per-platform adjustments are made.
       exact_gotags: Like gotags, but if this is specified, no other tag sets are added.
@@ -134,13 +133,6 @@ def dd_agent_go_binary(name, gc_linkopts = None, gotags = None, exact_gotags = N
         "//conditions:default": [],
     })
 
-    # Strip the symbol table and DWARF debug info in release builds to reduce
-    # binary size.  Dev builds keep symbols for debugger and profiler use.
-    strip_linkopts = select({
-        "//:is_release": ["-s", "-w"],
-        "//conditions:default": [],
-    })
-
     if exact_gotags:
         # this might be select()'ed by platform. It is up to the user to sort it.
         kwargs["gotags"] = exact_gotags
@@ -156,7 +148,7 @@ def dd_agent_go_binary(name, gc_linkopts = None, gotags = None, exact_gotags = N
 
     go_binary(
         name = name,
-        gc_linkopts = (gc_linkopts or []) + run_path_linkopts + strip_linkopts,
+        gc_linkopts = (gc_linkopts or []) + run_path_linkopts,
         x_defs = select({
             "//:is_release": release_x_defs,
             "//conditions:default": dev_x_defs,

--- a/bazel/toolchains/dd_strip/BUILD.bazel
+++ b/bazel/toolchains/dd_strip/BUILD.bazel
@@ -1,0 +1,74 @@
+"""Toolchains for splitting stripped/debug outputs from binaries."""
+
+load(":configure.bzl", "linux_dd_strip_driver", "macos_dd_strip_driver", "windows_dd_strip_driver")
+load(":toolchain.bzl", "dd_strip_missing_toolchain", "dd_strip_toolchain")
+
+# Provides a strip/split driver executable accepting
+# <input> <stripped-out> <debug-out>, or no driver (missing_toolchain) to
+# signal that stripping is not available for the current platform.
+toolchain_type(
+    name = "dd_strip_toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+linux_dd_strip_driver(
+    name = "linux_driver",
+)
+
+dd_strip_toolchain(
+    name = "linux_dd_strip_toolchain",
+    driver = ":linux_driver",
+)
+
+toolchain(
+    name = "linux_toolchain",
+    exec_compatible_with = ["@platforms//os:linux"],
+    target_compatible_with = ["@platforms//os:linux"],
+    toolchain = ":linux_dd_strip_toolchain",
+    toolchain_type = ":dd_strip_toolchain_type",
+)
+
+windows_dd_strip_driver(
+    name = "windows_driver",
+)
+
+dd_strip_toolchain(
+    name = "windows_dd_strip_toolchain",
+    driver = ":windows_driver",
+)
+
+toolchain(
+    name = "windows_toolchain",
+    exec_compatible_with = ["@platforms//os:windows"],
+    target_compatible_with = ["@platforms//os:windows"],
+    toolchain = ":windows_dd_strip_toolchain",
+    toolchain_type = ":dd_strip_toolchain_type",
+)
+
+macos_dd_strip_driver(
+    name = "macos_driver",
+)
+
+dd_strip_toolchain(
+    name = "macos_dd_strip_toolchain",
+    debug_is_directory = True,
+    driver = ":macos_driver",
+)
+
+toolchain(
+    name = "macos_toolchain",
+    exec_compatible_with = ["@platforms//os:macos"],
+    target_compatible_with = ["@platforms//os:macos"],
+    toolchain = ":macos_dd_strip_toolchain",
+    toolchain_type = ":dd_strip_toolchain_type",
+)
+
+dd_strip_missing_toolchain(
+    name = "missing_toolchain_impl",
+)
+
+toolchain(
+    name = "missing_toolchain",
+    toolchain = ":missing_toolchain_impl",
+    toolchain_type = ":dd_strip_toolchain_type",
+)

--- a/bazel/toolchains/dd_strip/configure.bzl
+++ b/bazel/toolchains/dd_strip/configure.bzl
@@ -1,0 +1,151 @@
+"""Per-OS driver-generator rules for the dd_strip toolchain.
+
+Each rule below writes a small wrapper script implementing the shared driver
+contract (`driver <input> <stripped-out> <debug-out>`) and hard-wires it to
+the objcopy/strip/dsymutil tool paths appropriate for its platform. These are
+ordinary rules (they DO create actions -- writing the wrapper script), unlike
+the `dd_strip_toolchain` rule in toolchain.bzl, which per convention only
+collects an already-built executable.
+
+Platform semantics mirror omnibus's Stripper
+(omnibus-ruby/lib/omnibus/stripper.rb):
+  - Linux: objcopy --only-keep-debug to extract .dbg, strip --strip-debug
+    --strip-unneeded on a copy, then objcopy --add-gnu-debuglink to link the
+    two back together. Tools come from the exec platform's cc_toolchain
+    (already wired for gcc-toolchain patches), matching how preprocessor.bzl
+    and windows_resources.bzl resolve cc_toolchain tools.
+  - macOS: strip the shipped copy, dsymutil produces the .dSYM bundle. No
+    prior art for macOS dbg packages in this repo or omnibus -- flag for
+    build-team confirmation before merge. Tool paths are hardcoded to
+    /usr/bin/strip and /usr/bin/dsymutil the way rewrite_with_install_name_tool.sh
+    hardcodes /usr/bin/otool.
+  - Windows: no split DWARF (standalone PDBs aren't reliably produced by this
+    repo's Go/Rust/mingw toolchains). The debug artifact is the unstripped
+    original binary (matches omnibus's windows_symbol_stripping_file); the
+    shipped binary is strip'd via the mingw toolchain's existing strip tool.
+"""
+
+load("@rules_cc//cc:find_cc_toolchain.bzl", "CC_TOOLCHAIN_ATTRS", "find_cc_toolchain", "use_cc_toolchain")
+
+def _linux_driver_impl(ctx):
+    cc_toolchain = find_cc_toolchain(ctx)
+    driver = ctx.actions.declare_file(ctx.label.name + "_driver.sh")
+    ctx.actions.write(
+        output = driver,
+        is_executable = True,
+        content = """#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT=$1
+STRIPPED_OUT=$2
+DEBUG_OUT=$3
+
+OBJCOPY="{objcopy}"
+STRIP="{strip}"
+
+# 1. Extract the debug info into its own file.
+"$OBJCOPY" --only-keep-debug "$INPUT" "$DEBUG_OUT"
+
+# 2. Strip a copy of the binary for shipping.
+cp "$INPUT" "$STRIPPED_OUT"
+chmod u+w "$STRIPPED_OUT"
+"$STRIP" --strip-debug --strip-unneeded "$STRIPPED_OUT"
+
+# 3. Link the stripped binary back to its debug info via .gnu_debuglink.
+"$OBJCOPY" --add-gnu-debuglink="$DEBUG_OUT" "$STRIPPED_OUT"
+""".format(
+            objcopy = cc_toolchain.objcopy_executable,
+            strip = cc_toolchain.strip_executable,
+        ),
+    )
+    return [DefaultInfo(
+        executable = driver,
+        files = depset([driver], transitive = [cc_toolchain.all_files]),
+        runfiles = ctx.runfiles(transitive_files = cc_toolchain.all_files),
+    )]
+
+linux_dd_strip_driver = rule(
+    implementation = _linux_driver_impl,
+    doc = "Generates the Linux objcopy/strip debug-split driver from the resolved cc_toolchain.",
+    attrs = CC_TOOLCHAIN_ATTRS,
+    toolchains = use_cc_toolchain(),
+    fragments = ["cpp"],
+)
+
+def _windows_driver_impl(ctx):
+    cc_toolchain = find_cc_toolchain(ctx)
+    driver = ctx.actions.declare_file(ctx.label.name + "_driver.bat")
+    ctx.actions.write(
+        output = driver,
+        is_executable = True,
+        content = """@echo off
+setlocal
+
+set "INPUT=%~1"
+set "STRIPPED_OUT=%~2"
+set "DEBUG_OUT=%~3"
+set "INPUT=%INPUT:/=\\%"
+set "STRIPPED_OUT=%STRIPPED_OUT:/=\\%"
+set "DEBUG_OUT=%DEBUG_OUT:/=\\%"
+
+rem No split DWARF on Windows: the debug artifact is the unstripped original.
+copy /Y "%INPUT%" "%DEBUG_OUT%" >nul || exit /b 1
+copy /Y "%INPUT%" "%STRIPPED_OUT%" >nul || exit /b 1
+"{strip}" "%STRIPPED_OUT%" || exit /b 1
+""".format(strip = cc_toolchain.strip_executable.replace("/", "\\")),
+    )
+    return [DefaultInfo(
+        executable = driver,
+        files = depset([driver], transitive = [cc_toolchain.all_files]),
+        runfiles = ctx.runfiles(transitive_files = cc_toolchain.all_files),
+    )]
+
+windows_dd_strip_driver = rule(
+    implementation = _windows_driver_impl,
+    doc = """Generates the Windows strip driver from the resolved cc_toolchain
+    (mingw's strip.exe). Debug artifact = unstripped original; not split
+    DWARF, matching omnibus's windows_symbol_stripping_file.""",
+    attrs = CC_TOOLCHAIN_ATTRS,
+    toolchains = use_cc_toolchain(),
+    fragments = ["cpp"],
+)
+
+_MACOS_STRIP = "/usr/bin/strip"
+_MACOS_DSYMUTIL = "/usr/bin/dsymutil"
+
+def _macos_driver_impl(ctx):
+    driver = ctx.actions.declare_file(ctx.label.name + "_driver.sh")
+    ctx.actions.write(
+        output = driver,
+        is_executable = True,
+        content = """#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT=$1
+STRIPPED_OUT=$2
+DEBUG_OUT=$3
+
+# 1. dsymutil reads the original (unstripped) binary to produce the .dSYM
+#    bundle -- it must run before the copy below is stripped.
+"{dsymutil}" "$INPUT" -o "$DEBUG_OUT"
+
+# 2. Strip a copy of the binary for shipping.
+cp "$INPUT" "$STRIPPED_OUT"
+chmod u+w "$STRIPPED_OUT"
+"{strip}" -S "$STRIPPED_OUT"
+""".format(dsymutil = _MACOS_DSYMUTIL, strip = _MACOS_STRIP),
+    )
+    return [DefaultInfo(
+        executable = driver,
+        files = depset([driver]),
+    )]
+
+macos_dd_strip_driver = rule(
+    implementation = _macos_driver_impl,
+    doc = """Generates the macOS strip+dsymutil debug-split driver.
+
+    Hardcodes /usr/bin/strip and /usr/bin/dsymutil the way
+    rewrite_with_install_name_tool.sh hardcodes /usr/bin/otool -- there is no
+    prior art in this repo or omnibus for macOS dbg packages, so this is a
+    new convention that needs build-team confirmation before merge.""",
+)

--- a/bazel/toolchains/dd_strip/toolchain.bzl
+++ b/bazel/toolchains/dd_strip/toolchain.bzl
@@ -1,0 +1,73 @@
+"""toolchain to wrap platform-specific debug-symbol strip/split drivers.
+
+Type: //bazel/toolchains/dd_strip:dd_strip_toolchain_type
+
+Toolchains:
+- //bazel/toolchains/dd_strip:linux_toolchain (objcopy --only-keep-debug + strip,
+  sourced from the exec platform's cc_toolchain)
+- //bazel/toolchains/dd_strip:windows_toolchain (mingw strip; debug artifact is
+  the unstripped original, no split DWARF)
+- //bazel/toolchains/dd_strip:macos_toolchain (hardcoded /usr/bin/strip +
+  /usr/bin/dsymutil, the way rewrite_rpath hardcodes /usr/bin/otool)
+- //bazel/toolchains/dd_strip:missing_toolchain: fallback for exec platforms
+  where no strip/split driver is available. dd_strip_debug treats this the
+  same as DdStripInfo.excluded = True: it passes the original file through
+  unmodified rather than failing the build.
+
+The _toolchain rule only collects an already-built driver executable (per the
+"toolchain rules must not create actions" convention); the per-OS driver
+scripts that DO create actions (to embed cc_toolchain tool paths) live in
+configure.bzl.
+"""
+
+DD_STRIP_TOOLCHAIN_TYPE = "//bazel/toolchains/dd_strip:dd_strip_toolchain_type"
+
+def _dd_strip_toolchain_impl(ctx):
+    return [
+        platform_common.ToolchainInfo(
+            available = True,
+            driver = ctx.attr.driver[DefaultInfo].files_to_run,
+            debug_is_directory = ctx.attr.debug_is_directory,
+        ),
+    ]
+
+dd_strip_toolchain = rule(
+    implementation = _dd_strip_toolchain_impl,
+    doc = """Wraps a driver executable implementing the strip/split contract:
+
+    driver <input-file> <stripped-output> <debug-output>
+
+    On platforms where the debug artifact is a directory (macOS .dSYM
+    bundles), debug_is_directory must be True so dd_strip_debug declares a
+    directory output instead of a file.""",
+    attrs = {
+        "driver": attr.label(
+            doc = "An executable accepting <input> <stripped-out> <debug-out> arguments.",
+            cfg = "exec",
+            executable = True,
+            allow_files = True,
+            mandatory = True,
+        ),
+        "debug_is_directory": attr.bool(
+            doc = "Whether the driver's debug-out argument is a directory (macOS .dSYM) rather than a file.",
+            default = False,
+        ),
+    },
+)
+
+def _dd_strip_missing_toolchain_impl(_ctx):
+    return [
+        platform_common.ToolchainInfo(
+            available = False,
+            driver = None,
+            debug_is_directory = False,
+        ),
+    ]
+
+dd_strip_missing_toolchain = rule(
+    implementation = _dd_strip_missing_toolchain_impl,
+    doc = """Fallback toolchain for exec platforms with no strip/split driver.
+
+    dd_strip_debug detects available = False and passes the original file
+    through unchanged instead of failing the build.""",
+)

--- a/cmd/agent/BUILD.bazel
+++ b/cmd/agent/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/dd_strip:dd_strip.bzl", "dd_strip_debug")
 load("//bazel/rules/go:go_binary.bzl", "dd_agent_go_binary")
 load("//tasks:build_tags.bzl", "AGENT_TAGS")
 
@@ -153,7 +154,7 @@ go_library(
 )
 
 dd_agent_go_binary(
-    name = "agent",
+    name = "agent_unstripped",
     # keep
     srcs = select({
         "@platforms//os:windows": ["//cmd/agent/windows_resources:rsrc"],
@@ -161,5 +162,12 @@ dd_agent_go_binary(
     }),
     embed = [":agent_lib"],
     gotags = AGENT_TAGS,
+    tags = ["manual"],
+    visibility = ["//visibility:private"],
+)
+
+dd_strip_debug(
+    name = "agent",
+    input = ":agent_unstripped",
     visibility = ["//visibility:public"],
 )

--- a/cmd/loader/BUILD.bazel
+++ b/cmd/loader/BUILD.bazel
@@ -6,6 +6,7 @@ load(
     "pkg_attributes",
     "pkg_files",
 )
+load("//bazel/rules/dd_strip:dd_strip.bzl", "dd_strip_debug")
 load("//bazel/rules/go:go_binary.bzl", "dd_agent_go_binary")
 load("//tasks:build_tags.bzl", "LOADER_TAGS")
 
@@ -116,15 +117,22 @@ go_library(
 
 # TODO(ABLD-294): Rename to trace-loader and use this instead of @trace_loader_binary//:trace_loader
 dd_agent_go_binary(
-    name = "loader",
+    name = "loader_unstripped",
     embed = [":loader_lib"],
     # LOADER_TAGS is actually empty. We're including it to keep a consistent style.
     exact_gotags = list(LOADER_TAGS) + select({
         "@platforms//os:linux": ["linux_bpf"],
         "//conditions:default": [],
     }),
+    tags = ["manual"],
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    visibility = ["//visibility:private"],
+)
+
+dd_strip_debug(
+    name = "loader",
+    input = ":loader_unstripped",
 )

--- a/dbg_symbol.md
+++ b/dbg_symbol.md
@@ -1,0 +1,114 @@
+# ABLD-464: Debug-symbol ("dbg") packages for Bazel builds
+
+Context and design record for [ABLD-464](https://datadoghq.atlassian.net/browse/ABLD-464)
+("Process for creating 'dbg' packages"). Kept alongside the code so the rationale
+survives past the PR description.
+
+## Problem
+
+Omnibus produces stripped release binaries plus a separate "-dbg" package/archive
+containing the removed debug symbols, for post-mortem debugging of crash dumps from
+stripped production binaries. Bazel packaging (`packages/`, built on `rules_pkg`) has
+no equivalent yet — `packages/AGENTS.md` and `packages/installer/MIGRATION_PLAN.md`
+both flag this as an open gap.
+
+Requirements from the ticket:
+- A normal `bazel build` of a target keeps debug symbols (dev/test use).
+- A packaging build produces stripped binaries.
+- A sibling packaging target produces *only* the debug symbols, no other files.
+- No shadow dependency tree duplicated top-down to every binary/library target.
+- Works for Go, C, and Rust objects; works on Linux, macOS, Windows.
+- Callable from `rules_pkg` `pkg_files` construction.
+
+## Two strategies, two PRs
+
+The ticket names two candidate strategies. Rather than pick one up front, we
+implemented both as independent PRs in separate worktrees of this repo, so they can be
+compared in review and in CI before committing to one for the real migration:
+
+- **Plan A — provider/rule-based** (this repo, branch `aiuto/454-a`): a new
+  `dd_strip_debug` rule wraps each binary/library's own build rule directly, adding a
+  `DdStripInfo` provider and `OutputGroupInfo(stripped=..., debug=...)`. No aspect is
+  needed for the core case — the default output stays unstripped, and a `pkg_files`
+  transform just checks whether its `srcs[i]` carries `DdStripInfo`.
+  See `bazel/rules/dd_strip/`, `bazel/toolchains/dd_strip/`,
+  `bazel/rules/dd_packaging/dd_pkg_files_stripped.bzl`.
+- **Plan B — packaging-time filter** (`/Users/tony.aiuto/ws/datadog-agent`, branch
+  `aiuto/454-b`): a new `dd_pkg_strip_transform` rule intercepts files as they're
+  assembled into a `pkg_files`/`PackageFilesInfo` tree and strips/splits them there,
+  with no cooperation needed from the binary's own rule. This is what lets it work
+  directly against today's `prebuilt_file.bzl`-backed product binaries
+  (`@agent_binary//:agent`, etc.), which aren't real Bazel `go_binary`/`cc_binary`
+  targets yet — Plan A can't wrap a provider around those until that migration lands.
+
+Both use the same platform semantics, matching omnibus's `Stripper`
+(`omnibus-ruby/lib/omnibus/stripper.rb`):
+- **Linux**: `objcopy --only-keep-debug` → `.dbg`, `strip --strip-debug
+  --strip-unneeded` in place, `objcopy --add-gnu-debuglink`.
+- **macOS**: `strip` the shipped copy, `dsymutil` produces a `.dSYM` bundle. No prior
+  art for this in omnibus or this repo (omnibus skips stripping on macOS entirely) —
+  flagged as needing build-team confirmation before either PR merges.
+- **Windows**: debug artifact = the *unstripped original* binary (not split DWARF),
+  matching omnibus's `windows_symbol_stripping_file` semantics, since this repo's
+  Go/Rust/mingw toolchains don't reliably produce standalone PDBs.
+
+Both PRs independently build their own copy of the `bazel/toolchains/dd_strip`
+toolchain rather than one depending on the other (explicit choice, made so both could
+start immediately) — deduping them is a deliberate follow-up once one strategy is
+chosen.
+
+Full original design doc (file lists, verification steps, trade-off analysis):
+`/Users/tony.aiuto/.claude/plans/we-are-going-to-flickering-pizza.md` (local to the
+machine this was planned on, not checked in — this file is the durable summary).
+
+## Known issue: macOS codesign ordering
+
+`dd_cc_packaged` (`bazel/rules/dd_packaging/dd_cc_packaged.bzl`) runs `dd_strip_debug`
+**after** `rewrite_rpath`. `rewrite_rpath`'s macOS implementation
+(`bazel/toolchains/rpath_rewriter/rewrite_with_install_name_tool.sh`) ends with:
+
+```sh
+# Re-sign with an ad-hoc signature after modification as install_name_tool invalidates
+# any existing code signature.
+/usr/bin/codesign --sign - --force "$OUTPUT"
+```
+
+`install_name_tool` invalidates any existing signature, so `rewrite_rpath` re-signs
+ad-hoc as its last step. `dd_strip_debug` then runs `strip`/`objcopy`/`dsymutil` on
+that *already re-signed* output — and stripping/objcopy also invalidates a Mach-O code
+signature, but **`dd_strip_debug` does not re-sign afterward**. The result: on macOS,
+the final `.stripped` binary that actually ships out of `dd_cc_packaged` carries a
+stale/invalid ad-hoc signature.
+
+This was chosen deliberately to match omnibus's ordering ("strip is the last finalize
+step"), but omnibus's ordering rationale is Linux-centric (objcopy debuglink chains)
+and doesn't account for macOS's codesign-after-every-mutation requirement.
+
+Two ways to fix, not yet decided:
+1. Add a `codesign --sign - --force` re-sign step to `dd_strip_debug`'s macOS driver,
+   after the strip step, so it always leaves a valid ad-hoc signature — keeps
+   omnibus's "strip last" ordering.
+2. Reorder so `dd_strip_debug` runs *before* `rewrite_rpath` on macOS specifically,
+   since `rewrite_rpath` already re-signs as its last step — avoids adding a second
+   codesign invocation, but only applies to the `dd_cc_packaged` call chain (Plan A);
+   for Plan B's flattened packaging-time model there's no equivalent single choke
+   point to reorder around, so option 1 (re-sign after strip) is likely the more
+   portable fix across both PRs.
+
+This affects Plan A directly (found during its implementation/testing). Plan B should
+be checked for the same issue if/when it starts producing real signed macOS binaries
+through `dd_cc_packaged`-style consumers.
+
+## Other open items (both PRs)
+
+- Linux `objcopy` path is unverified locally — both PRs were implemented and tested on
+  macOS arm64 with no Linux exec platform available; needs CI or a Linux sandbox.
+- `packages/agent/product/BUILD.bazel`'s real binaries come from `prebuilt_file.bzl`
+  (built by `dda`, not a real Bazel target) — Plan A can only demonstrate against
+  `//cmd/agent:agent` and `rtloader` directly, not the full product bundle, until that
+  migration lands. Plan B has no such blocker.
+- Plan A: `dsymutil` produced an empty `.dSYM` for at least one pure-Go binary during
+  testing — needs investigation (Go's DWARF layout vs. dsymutil's expectations).
+- Whatever builds release binaries outside Bazel (`dda inv agent.build` / omnibus)
+  must not pre-strip them, or there's nothing left for either strategy to split.
+  Out of scope for both PRs; flagged as a cross-cutting dependency.

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -214,7 +214,19 @@ This target is removed once the omnibus recipe is deleted.
 - **Version stamping**: all products currently hardcode `version = "7"`. In the future
   we will get that from the pipeine (equivalent to `build_version ENV['PACKAGE_VERSION']`).
 - **RHEL vs SUSE constraint**: omnibus distinguishes RHEL and SUSE builds in different pipelines. Going forward we'll just have different targets for them, and always build both in the same pipeline.
-- **Symbol stripping / signing**: `strip_build`, `windows_symbol_stripping_file`,
-  `inspect_binary`, and `sign_file` are not yet migrated.
+- **Symbol stripping / signing**: `dd_strip_debug` (see
+  `bazel/rules/dd_strip/dd_strip.bzl`) reimplements omnibus's `strip_build`/
+  `windows_symbol_stripping_file` split (Linux objcopy 3-step, macOS
+  strip+dsymutil, Windows unstripped-original-as-debug-artifact) and is wired
+  into `dd_cc_packaged`, `//cmd/agent:agent`, and `//cmd/loader:loader`. It is
+  NOT yet wired into the real product binaries under
+  `packages/agent/product/BUILD.bazel`, because those come from
+  `bazel/repo/prebuilt_file.bzl` (wrapping `dda`-built files, not native Bazel
+  compile/link targets) and there is nothing to attach the provider to until
+  those binaries build natively with Bazel. `inspect_binary` and `sign_file`
+  (macOS codesigning) are still not migrated; note in particular that
+  stripping currently runs after `rewrite_rpath`'s codesign step in
+  `dd_cc_packaged` with no re-sign afterward, which needs a real fix before
+  this is relied upon for signed macOS artifacts.
 - **Transitive deps**: `//packages/agent/linux:transitive_deps` is a temporary
   catch-all. It shrinks as deps grow proper Bazel targets. See ABLD-363.

--- a/packages/installer/MIGRATION_PLAN.md
+++ b/packages/installer/MIGRATION_PLAN.md
@@ -373,6 +373,12 @@ Once the diff output is clean (or remaining diffs are explicitly accepted):
   — the `prebuilt_file` approach is sufficient for the packaging migration
 - Windows MSI (no Bazel rule exists yet)
 - macOS PKG (no Bazel rule exists yet)
-- Symbol stripping / debug package split
+- Symbol stripping / debug package split — the `dd_strip_debug` rule and
+  toolchain now exist (`bazel/rules/dd_strip/`, `bazel/toolchains/dd_strip/`)
+  and are wired into `dd_cc_packaged` and `//cmd/agent:agent`/
+  `//cmd/loader:loader`, but the installer binary itself is still built via
+  `prebuilt_file` (see the line above), so there is nothing to wrap yet for
+  this milestone. A "dbg" package that actually collects the `.debug`/`.dSYM`
+  outputs is still unbuilt
 - Code signing (Windows `sign_file`, macOS `code_signing_identity`)
 - Removing omnibus installer code (happens after Phase 7 completes)


### PR DESCRIPTION
### What does this PR do?

Adds `dd_strip_debug`, a Bazel rule + `DdStripInfo` provider that wraps a
`go_binary`/`cc_binary`/`cc_shared_library`/`rust_binary` target and splits its
output into a stripped binary plus a separate debug-symbols artifact (`.dbg`
debuglink on Linux, `.dSYM` bundle on macOS, unstripped-original on Windows),
backed by a new `//bazel/toolchains/dd_strip` toolchain. Wires this into
`dd_cc_packaged` (covering `rtloader`, `deps/msodbcsql18`, etc.) and directly
onto `//cmd/agent:agent` and `//cmd/loader:loader`.

The wrapped rule's default `bazel build` output always stays unstripped —
the split is only materialized via `OutputGroupInfo(stripped=..., debug=...)`
— so normal dev/test builds are unaffected. Removes the old one-shot linker
stripping (`-s -w` for Go release builds, `-Cstrip=symbols` for Rust), since
that destroyed DWARF before this rule could split it — **this is a real
behavior change**: release binaries not wrapped by the new rule are no longer
pre-stripped.

See `dbg_symbol.md` for full context, including a companion PR (#TBD, branch
`aiuto/454-b`, other worktree) implementing an alternative packaging-time
strategy for the same ticket, and a known macOS codesign-ordering bug found
while building this.

### Motivation

[ABLD-464](https://datadoghq.atlassian.net/browse/ABLD-464): Bazel packaging
has no equivalent to omnibus's stripped-binary + separate debug-symbol
("-dbg") package generation. `packages/AGENTS.md` and
`packages/installer/MIGRATION_PLAN.md` both track this as an open gap.

### Describe how you validated your changes

On macOS arm64 (no Linux exec platform available locally, so the Linux
`objcopy` path is unverified — needs CI):
- `bazel/rules/dd_strip/dd_strip_test.bzl` analysistest suite: 14/14 passing.
- `bazel build //cmd/loader:loader` and `//rtloader:rtloader_pkg_packaged`
  build end-to-end with correct default/`.stripped`/`.debug` outputs.
- `bazel query 'kind(dd_strip_debug, //...)'` confirms wiring into
  `//cmd/agent:agent`, `//cmd/loader:loader`, rtloader, `deps/msodbcsql18`.
- gazelle and buildifier clean on touched BUILD files.

### Additional Notes

Known open items (see `dbg_symbol.md`):
- **macOS codesign ordering bug**: `dd_strip_debug` runs after
  `rewrite_rpath`'s ad-hoc re-sign, and stripping invalidates that signature
  without re-signing — the shipped stripped binary on macOS currently ends up
  with a stale signature. Needs a fix (re-sign after strip, or reorder)
  before this is trustworthy for signed macOS artifacts.
- `packages/agent/product/BUILD.bazel`'s real binaries are still
  `prebuilt_file.bzl`-backed (not real Bazel targets) — blocked from
  wrapping until that migration lands; demonstrated instead against
  `//cmd/agent:agent` and rtloader directly.
- `dsymutil` produced an empty `.dSYM` for at least one pure-Go binary during
  testing — needs investigation.
- Toolchain deduplication with the sibling `aiuto/454-b` PR is a deliberate
  follow-up once one strategy is chosen.

[ABLD-464]: https://datadoghq.atlassian.net/browse/ABLD-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ