### PR TITLE
Drop stale macOS version allowance for `secret-generic-connector`

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -269,7 +269,6 @@ build do
             # https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
             allow_list = [
               "libddwaf\\.dylib",
-              "secret-generic-connector",
             ]
             command_on_repo_root "./omnibus/scripts/check_macos_version.sh",
                                  live_stream: Omnibus.logger.live_stream(:info),


### PR DESCRIPTION
### What does this PR do?
Remove `secret-generic-connector` from the `ALLOW_PATTERN` allow list in `check_macos_version.sh`, leaving `libddwaf.dylib` as the only remaining exception.

### Motivation
The allowance was added by #42507 when the floor was macOS 11.0, because Go 1.25 bumped the hardcoded `LC_BUILD_VERSION` min OS of internally linked darwin binaries to 12.0.

#47811 then raised both `MIN_ACCEPTABLE_VERSION` and `MACOSX_DEPLOYMENT_TARGET` to 12.0, which retired the exception without removing it.

A stale allowance is worse than a dead one: it would silently swallow a real regression, should Go bump that constant again or the cgo-linked FIPS variant drift away from the deployment target.

### Describe how you validated your changes
macOS package builds run the check.

### Additional Notes
The connector clears the bar exactly, not comfortably: non-FIPS builds set `CGO_ENABLED=0`, so Go links internally and stamps min OS to 12.0.0, which the check accepts on equality.