### PR TITLE
Reland `go_shim`, replacing `go` runner by SDK's raw `go`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -992,6 +992,7 @@ workflow:
   - changes:
       paths:
         - .gitlab/test/e2e/e2e.yml
+        - internal/tools/**/* # Go tools: gotestsum, etc. (incident-59251/59255/59256/59257/59258)
         - test/e2e-framework/**/*
         - test/new-e2e/go.mod
         - flakes.yaml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -992,6 +992,7 @@ workflow:
   - changes:
       paths:
         - .gitlab/test/e2e/e2e.yml
+        - bazel/rules/go_shim/**/* # Runs bazelified Go tools
         - internal/tools/**/* # Go tools: gotestsum, etc. (incident-59251/59255/59256/59257/59258)
         - test/e2e-framework/**/*
         - test/new-e2e/go.mod

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,6 +12,7 @@ load("@dd_release_json//:release_json.bzl", "release_json")
 load("@gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_license//rules:license.bzl", "license")
+load("//bazel/rules/go_shim:defs.bzl", "go_shim")
 load("//compliance/rules:purl.bzl", "purl_for_generic")
 load("//tasks:build_tags.bzl", "GAZELLE_BUILD_TAGS")
 
@@ -123,9 +124,9 @@ alias(
 )
 
 # bazel run //:go_mod_tidy_all -- -x
-alias(
+go_shim(
     name = "go_mod_tidy_all",
-    actual = "//bazel/tools:go_mod_tidy_all",
+    tool = "//bazel/rules/go_mod_tidy_all",
 )
 
 run_binary(

--- a/bazel/rules/go_mod_tidy_all/BUILD.bazel
+++ b/bazel/rules/go_mod_tidy_all/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_python//python:py_binary.bzl", "py_binary")
+
+py_binary(
+    name = "go_mod_tidy_all",
+    srcs = ["go_mod_tidy_all.py"],
+    visibility = ["//:__pkg__"],
+)

--- a/bazel/rules/go_mod_tidy_all/go_mod_tidy_all.py
+++ b/bazel/rules/go_mod_tidy_all/go_mod_tidy_all.py
@@ -12,11 +12,9 @@ from datetime import timedelta
 from subprocess import PIPE, CalledProcessError
 from traceback import format_exception_only
 
-from python.runfiles import runfiles
 
-
-async def _exec(go, *args, **kwargs):
-    proc = await asyncio.create_subprocess_exec(go, *args, **kwargs)
+async def _exec(*args, **kwargs):
+    proc = await asyncio.create_subprocess_exec(*args, **kwargs)
     try:
         stdout, _ = await proc.communicate()
     except BaseException:  # reap the process on any CancelledError, KeyboardInterrupt, SystemExit, TimeoutError, etc.
@@ -30,26 +28,26 @@ async def _exec(go, *args, **kwargs):
         raise
     if proc.returncode == 0:
         return stdout
-    raise CalledProcessError(proc.returncode, " ".join((os.path.basename(go), *args)), output=stdout)
+    raise CalledProcessError(proc.returncode, " ".join(args), output=stdout)
 
 
-async def _tidy(max_workers, go, mod_path, args):
+async def _tidy(max_workers, mod_path, args):
     async with max_workers:
-        await _exec(go, "mod", "tidy", "-C", mod_path, *args)
+        await _exec("go", "mod", "tidy", "-C", mod_path, *args)
 
 
-async def main(go, args):
-    mod_paths = await _exec(go, "list", "-f", "{{.Dir}}", "-m", stdout=PIPE)
+async def main(args):
+    mod_paths = await _exec("go", "list", "-f", "{{.Dir}}", "-m", stdout=PIPE)
     max_workers = asyncio.Semaphore((os.cpu_count() or 1) + 4)  # TODO(regis): cpu_count -> Py 3.13's process_cpu_count
     # global timeout: on cold cache, per-task timeouts were unfairly hit because early tasks download most modules
     async with asyncio.timeout(timedelta(minutes=15).total_seconds()), asyncio.TaskGroup() as tg:
         for mod_path in mod_paths.decode().splitlines():
-            tg.create_task(_tidy(max_workers, go, mod_path, args))
+            tg.create_task(_tidy(max_workers, mod_path, args))
 
 
 if __name__ == "__main__":
     logging.getLogger("asyncio").setLevel(logging.ERROR)  # no `Unknown child process pid N, will report returncode 255`
     try:
-        asyncio.run(main(runfiles.Create().Rlocation(sys.argv[1]), sys.argv[2:]))
+        asyncio.run(main(sys.argv[1:]))
     except* BaseException as eg:
         sys.exit("\n".join(line.rstrip() for e in eg.exceptions for line in format_exception_only(e)))

--- a/bazel/rules/go_shim/BUILD.bazel
+++ b/bazel/rules/go_shim/BUILD.bazel
@@ -1,0 +1,7 @@
+exports_files(
+    [
+        "template.bat",
+        "template.sh",
+    ],
+    visibility = ["//visibility:private"],
+)

--- a/bazel/rules/go_shim/defs.bzl
+++ b/bazel/rules/go_shim/defs.bzl
@@ -1,0 +1,51 @@
+"""Shim to run a tool with the hermetic Go SDK's `go` first in $PATH, from the current working directory.
+
+A (thin) wrapper is unavoidable because prepending to the inherited PATH cannot be expressed declaratively.
+The SDK's `go` is used over @rules_go//go, because the latter changes the current directory again, breaking subcommands.
+
+References:
+- https://github.com/bazel-contrib/bazel-lib/blob/main/lib/private/bats.bzl (is_windows)
+- https://github.com/bazel-contrib/rules_multitool/blob/main/multitool/private/run_in.bzl (template)
+"""
+
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+_GO_TOOLCHAIN = "@rules_go//go:toolchain"
+
+def _impl(ctx):
+    sdk = ctx.toolchains[_GO_TOOLCHAIN].sdk
+    go_dir = paths.dirname(sdk.go.short_path)
+    goroot = paths.dirname(sdk.root_file.short_path)
+    is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])
+    template = ctx.file._template_bat if is_windows else ctx.file._template_sh
+    tool = ctx.executable.tool.short_path
+    wrapper = ctx.actions.declare_file("{}.{}".format(ctx.label.name, template.extension))
+    ctx.actions.expand_template(
+        is_executable = True,
+        output = wrapper,
+        substitutions = {
+            "{{go_dir}}": go_dir.replace("/", "\\") if is_windows else go_dir,
+            "{{goroot}}": goroot.replace("/", "\\") if is_windows else goroot,
+            "{{tool}}": tool.replace("/", "\\") if is_windows else tool,
+        },
+        template = template,
+    )
+    return [DefaultInfo(
+        executable = wrapper,
+        runfiles = ctx.runfiles(
+            [sdk.go],
+            transitive_files = depset(transitive = [sdk.headers, sdk.libs, sdk.srcs, sdk.tools]),
+        ).merge(ctx.attr.tool[DefaultInfo].default_runfiles),
+    )]
+
+go_shim = rule(
+    implementation = _impl,
+    attrs = {
+        "_template_bat": attr.label(allow_single_file = True, default = ":template.bat"),
+        "_template_sh": attr.label(allow_single_file = True, default = ":template.sh"),
+        "_windows_constraint": attr.label(default = "@platforms//os:windows"),
+        "tool": attr.label(cfg = "exec", executable = True, mandatory = True),
+    },
+    executable = True,
+    toolchains = [_GO_TOOLCHAIN],
+)

--- a/bazel/rules/go_shim/template.bat
+++ b/bazel/rules/go_shim/template.bat
@@ -1,0 +1,9 @@
+@echo off
+
+set "GOROOT=%cd%\{{goroot}}"
+set "GOTOOLCHAIN=local"
+set "PATH=%cd%\{{go_dir}};%PATH%"
+set "tool=%cd%\{{tool}}"
+
+cd /d "%BUILD_WORKING_DIRECTORY%" || exit /b
+"%tool%" %*

--- a/bazel/rules/go_shim/template.sh
+++ b/bazel/rules/go_shim/template.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$BUILD_WORKING_DIRECTORY"
+GOROOT="$OLDPWD/{{goroot}}" GOTOOLCHAIN=local PATH="$OLDPWD/{{go_dir}}:$PATH" exec "$OLDPWD/{{tool}}" "$@"

--- a/bazel/tools/BUILD.bazel
+++ b/bazel/tools/BUILD.bazel
@@ -2,15 +2,6 @@ load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_python//python:py_binary.bzl", "py_binary")
 
 py_binary(
-    name = "go_mod_tidy_all",
-    srcs = ["go_mod_tidy_all.py"],
-    args = ["$(rlocationpath @rules_go//go)"],
-    data = ["@rules_go//go"],
-    visibility = ["//:__pkg__"],
-    deps = ["@rules_python//python/runfiles"],
-)
-
-py_binary(
     name = "generate_module_bazel",
     srcs = ["generate_module_bazel.py"],
     visibility = ["//deps:__subpackages__"],

--- a/internal/tools/BUILD.bazel
+++ b/internal/tools/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
-load("@rules_multitool//multitool:cwd.bzl", "cwd")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
+load("//bazel/rules/go_shim:defs.bzl", "go_shim")
 
-cwd(
+go_shim(
     name = "gotestsum",
     tool = "@tools_gotest_gotestsum//:gotestsum",
 )


### PR DESCRIPTION
### What does this PR do?
Reland #54887, which #54925 reverted after it broke E2E jobs on `main`.

To prevent that from happening again, changes to `bazel/rules/go_shim/**/*` and `internal/tools/**` now trigger E2E tests unconditionally.

Recalling that PR: `go_shim` wraps a tool so that `PATH` lookups of `go` reach Bazel's hermetic SDK, and so that the tool runs from the current working directory rather than the runfiles tree, superseding `rules_multitool`'s `cwd()`.
It wraps `gotestsum` and `go_mod_tidy_all`, the latter dropping the `$(rlocationpath @rules_go//go)` resolution it had grown for itself and moving to its own package, where the shim taking over `//:go_mod_tidy_all` leaves its `py_binary` the plain name.

Changed on top of it:
- `PATH` now holds the Go SDK's raw `go` (unwrapped), resolved through `@rules_go//go:toolchain`, in place of `@rules_go//go` (the runner),
- the wrapper exports `GOROOT` and sets `GOTOOLCHAIN=local` itself rather than leaning on `.bazelrc`, and `RUNFILES_DIR` goes away with the runner that needed it.

### Motivation
Unbreak `dda inv test` on hosts whose ambient `go` differs from the one `go.work` requires,
[reported](https://dd.slack.com/archives/C06PBHLD4DQ/p1786618886362859) by @vitkyrka and followed up by @pgimalac and @hush-hush. #54107 routed it through `bazel run //internal/tools:gotestsum`, bringing `gotestsum` under `.bazelrc`'s `--run_env=GOTOOLCHAIN=local` while it still resolved `go` through `PATH`, so every invocation failed with `go.work requires go >= 1.26.5` and exporting `GOTOOLCHAIN=auto` did not help.

That fix then broke `main`, because `@rules_go//go` is a runner rather than a `go`: it assigns `cmd.Dir` from `$BUILD_WORKING_DIRECTORY` on every exec, discarding the directory its caller chose. `gotest-custom` chooses one per test package, so each prebuilt E2E test binary ran at the repository root and no longer found its fixtures, failing on `compose/data`, `usmtest/test_tags.ps1`, `testdataprovision` and `checks/shared-library/files`.

The SDK's `go` honors its caller, which is the whole of the difference.

### Describe how you validated your changes
On Linux, a child `go` invoked from `test/new-e2e` under the shim reports that module's `go.mod`, where #54887 reported the repository root's.
Building a program importing `net/http` through the shim links, confirming the SDK's sources and tools are reachable.

The reported reproducer still holds: with a stub announcing itself as go 1.24.0 first in `PATH`, tools reach go1.26.5 and never the stub, and `bazel run //:go_mod_tidy_all -- -diff` exits 0 across every module.

### Additional Notes
Prepending to `PATH` has no declarative spelling: `RunEnvironmentInfo` carries static strings only, a key given in both `environment` and `inherited_environment` resolves to the inherited value, and replacing `PATH` outright would hide `sh`, `cc`, `git` and whatever else the toolchain reaches for.
Hence a (thin) wrapper reading the environment at runtime.

The runfiles mirror `go_bin_for_host`, rules_go's own definition of a runnable `go`: the SDK binary plus its headers, libs, sources and tools.

`install_gotestsum` and its per-platform variants keep extracting the raw binary, the shim being runfiles-bound and those tools driving pre-built test binaries through `--raw-command`, never resolving `go`.