### PR TITLE
fix(logs): protect PublicJSON from racing with SetTailingMode

### DIFF
--- a/comp/metadata/inventorychecks/impl/inventorychecks.go
+++ b/comp/metadata/inventorychecks/impl/inventorychecks.go
@@ -222,7 +222,7 @@ func (ic *inventorychecksImpl) getPayload(withConfigs bool) marshaler.JSONMarsha
 					logsMetadata[logSource.Name] = []metadata{}
 				}
 
-				parsedJSON, err := logSource.Config.PublicJSON()
+				parsedJSON, err := logSource.PublicJSON()
 				if err != nil {
 					ic.log.Debugf("could not parse log configuration for source metadata %s: %v", logSource.Name, err)
 					continue

--- a/pkg/logs/sources/source.go
+++ b/pkg/logs/sources/source.go
@@ -121,6 +121,15 @@ func (s *LogSource) GetTailingMode() string {
 	return s.Config.TailingMode
 }
 
+// PublicJSON returns the public JSON representation of the source's logs config.
+// The lock is held because Config.TailingMode can be mutated at runtime by
+// SetTailingMode on another goroutine.
+func (s *LogSource) PublicJSON() ([]byte, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.Config.PublicJSON()
+}
+
 // SetTailingMode sets the tailing mode configured for this source. This is mutated after
 // creation when a tailing mode is inferred at launch time, so it must go through the lock.
 func (s *LogSource) SetTailingMode(mode string) {

--- a/pkg/logs/sources/source_test.go
+++ b/pkg/logs/sources/source_test.go
@@ -104,3 +104,45 @@ func TestConcurrentTailingModeAndStatusAccess(t *testing.T) {
 	close(stop)
 	wg.Wait()
 }
+
+// TestConcurrentPublicJSONAndSetTailingMode verifies that PublicJSON (which reads
+// Config.TailingMode) does not race with SetTailingMode (which writes it).
+// Before the fix, PublicJSON was called on Config directly without the LogSource
+// lock, racing with SetTailingMode on another goroutine.
+func TestConcurrentPublicJSONAndSetTailingMode(t *testing.T) {
+	t.Parallel()
+
+	source := NewLogSource("test", &config.LogsConfig{
+		Type:        "file",
+		Path:        "/var/log/test.log",
+		TailingMode: "end",
+	})
+
+	const iterations = 5000
+	var wg sync.WaitGroup
+	var start sync.WaitGroup
+	start.Add(1)
+
+	// writer: mimics (*Launcher).launchTailers mutating TailingMode concurrently.
+	wg.Go(func() {
+		start.Wait()
+		for i := range iterations {
+			if i%2 == 0 {
+				source.SetTailingMode("beginning")
+			} else {
+				source.SetTailingMode("end")
+			}
+		}
+	})
+
+	// reader: mimics inventorychecksImpl.getPayload calling PublicJSON concurrently.
+	wg.Go(func() {
+		start.Wait()
+		for range iterations {
+			_, _ = source.PublicJSON()
+		}
+	})
+
+	start.Done()
+	wg.Wait()
+}


### PR DESCRIPTION
### What does this PR do?
Fixes a data race on `LogsConfig.TailingMode`: `PublicJSON()` was called on `*LogsConfig` directly without the `LogSource` lock, racing with `SetTailingMode()` which writes `Config.TailingMode` under the lock. Adds a `PublicJSON()` method to `*LogSource` that takes the lock before delegating to `Config.PublicJSON()`, and updates the caller in `inventorychecks` to use it.

### Motivation
Fix a race, found via a race-detector-enabled build in staging (see #54333 for context).

### Describe how you validated your changes
Added `TestConcurrentPublicJSONAndSetTailingMode` which races `SetTailingMode` (writer) against `PublicJSON` (reader) on the same `LogSource`; fails under `-race` before the fix and passes after (`dda inv test --targets=./pkg/logs/sources/... --race`).