### PR TITLE
fix(kubestatemetrics): serialize access to shared availableStores map

### DIFF
--- a/pkg/kubestatemetrics/builder/builder.go
+++ b/pkg/kubestatemetrics/builder/builder.go
@@ -69,6 +69,13 @@ type Builder struct {
 	eventMutex     sync.RWMutex
 }
 
+// ksmBuilderMu serializes access to the kube-state-metrics library's
+// package-level availableStores map, which is shared across all Builder
+// instances and mutated by WithCustomResourceStoreFactories / read by
+// BuildStores without internal synchronization. Without this lock, two
+// concurrent KSM check workers calling buildStores() race on that map.
+var ksmBuilderMu sync.Mutex
+
 // New returns new Builder instance
 func New() *Builder {
 	return &Builder{
@@ -174,6 +181,8 @@ func (b *Builder) WithGenerateCustomResourceStoresFunc(f ksmtypes.BuildCustomRes
 
 // WithCustomResourceStoreFactories configures a constom store factory
 func (b *Builder) WithCustomResourceStoreFactories(fs ...customresource.RegistryFactory) {
+	ksmBuilderMu.Lock()
+	defer ksmBuilderMu.Unlock()
 	b.ksmBuilder.WithCustomResourceStoreFactories(fs...)
 }
 
@@ -211,7 +220,9 @@ func (b *Builder) Build() metricsstore.MetricsWriterList {
 // BuildStores initializes and registers all enabled stores.
 // It returns metric cache stores.
 func (b *Builder) BuildStores() [][]cache.Store {
+	ksmBuilderMu.Lock()
 	stores := b.ksmBuilder.BuildStores()
+	ksmBuilderMu.Unlock()
 
 	if b.WorkloadmetaReflector != nil {
 		// Starting the workloadmeta reflector here allows us to start just one for all stores.

--- a/pkg/kubestatemetrics/builder/builder_race_test.go
+++ b/pkg/kubestatemetrics/builder/builder_race_test.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package builder
+
+import (
+	"sync"
+	"testing"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/kube-state-metrics/v2/pkg/customresource"
+	generator "k8s.io/kube-state-metrics/v2/pkg/metric_generator"
+)
+
+// fakeFactory is a minimal customresource.RegistryFactory implementation for
+// testing. It lets us call WithCustomResourceStoreFactories without pulling in
+// real Kubernetes clients.
+type fakeFactory struct {
+	name string
+}
+
+func (f *fakeFactory) Name() string { return f.name }
+func (f *fakeFactory) CreateClient(_ *rest.Config) (interface{}, error) {
+	return nil, nil
+}
+func (f *fakeFactory) MetricFamilyGenerators() []generator.FamilyGenerator { return nil }
+func (f *fakeFactory) ExpectedType() interface{}                           { return nil }
+func (f *fakeFactory) ListWatch(_ interface{}, _ string, _ string) cache.ListerWatcher {
+	return nil
+}
+
+var _ customresource.RegistryFactory = &fakeFactory{}
+
+// TestWithCustomResourceStoreFactoriesConcurrent verifies that concurrent
+// calls to WithCustomResourceStoreFactories on different Builder instances
+// don't race on the kube-state-metrics library's package-level availableStores
+// map. Without the ksmBuilderMu lock, this test fails under -race.
+func TestWithCustomResourceStoreFactoriesConcurrent(t *testing.T) {
+	t.Parallel()
+
+	const goroutines = 100
+	var wg sync.WaitGroup
+
+	for range goroutines {
+		wg.Go(func() {
+			b := New()
+			b.WithCustomResourceStoreFactories(&fakeFactory{name: "fake-resource"})
+		})
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
### What does this PR do?
Fixes a data race on the kube-state-metrics library's package-level `availableStores` map: `WithCustomResourceStoreFactories` and `BuildStores` mutate/read this shared map without synchronization, so two concurrent KSM check workers calling `buildStores()` race on it. Adds a package-level mutex (`ksmBuilderMu`) that serializes access to both methods.

### Motivation
Fix a race, found via a race-detector-enabled build in staging (see #54333 for context).

### Describe how you validated your changes
Added `TestWithCustomResourceStoreFactoriesConcurrent` which calls `WithCustomResourceStoreFactories` concurrently on 100 goroutines; it reproduces the race under `-race` before the fix and is clean after (`dda inv test --targets=./pkg/kubestatemetrics/builder/... --race`).