### PR TITLE
fix(ebpf): synchronize perfUsageCollector.Collect with Manager.Start

### DIFF
--- a/pkg/ebpf/BUILD.bazel
+++ b/pkg/ebpf/BUILD.bazel
@@ -200,6 +200,7 @@ go_library(
         "probes.go",
         "rc_btf.go",
         "status_codes.go",
+        "telemetry_mu_linux.go",
         "time.go",
         "types_linux.go",
     ],

--- a/pkg/ebpf/manager.go
+++ b/pkg/ebpf/manager.go
@@ -186,5 +186,10 @@ func (m *Manager) Start() error {
 		return err
 	}
 
+	// Hold the telemetry lock so concurrent Collect calls don't read
+	// PerfMap/RingBuffer fields while Start initializes them.
+	TelemetryMu.Lock()
+	defer TelemetryMu.Unlock()
+
 	return m.Manager.Start()
 }

--- a/pkg/ebpf/telemetry/perf_metrics.go
+++ b/pkg/ebpf/telemetry/perf_metrics.go
@@ -10,13 +10,13 @@ package telemetry
 import (
 	"slices"
 	"strconv"
-	"sync"
 
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf"
 	"github.com/prometheus/client_golang/prometheus"
 
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	ddeebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 )
 
 var (
@@ -25,7 +25,6 @@ var (
 
 type perfUsageCollector struct {
 	emitPerCPU bool
-	mtx        sync.Mutex
 	usage      *prometheus.GaugeVec
 	usagePct   *prometheus.GaugeVec
 	size       *prometheus.GaugeVec
@@ -106,8 +105,8 @@ func (p *perfUsageCollector) Describe(descs chan<- *prometheus.Desc) {
 
 // Collect implements prometheus.Collector.Collect
 func (p *perfUsageCollector) Collect(metrics chan<- prometheus.Metric) {
-	p.mtx.Lock()
-	defer p.mtx.Unlock()
+	ddeebpf.TelemetryMu.Lock()
+	defer ddeebpf.TelemetryMu.Unlock()
 
 	for _, pm := range p.perfMaps {
 		mapName, mapType := pm.Name, ebpf.PerfEventArray.String()
@@ -213,8 +212,8 @@ func (p *perfUsageCollector) registerPerfMap(pm *manager.PerfMap) {
 	if !pm.TelemetryEnabled {
 		return
 	}
-	p.mtx.Lock()
-	defer p.mtx.Unlock()
+	ddeebpf.TelemetryMu.Lock()
+	defer ddeebpf.TelemetryMu.Unlock()
 	p.perfMaps = append(p.perfMaps, pm)
 }
 
@@ -222,8 +221,8 @@ func (p *perfUsageCollector) registerPerfMapChannel(pm *manager.PerfMap, channel
 	if !pm.TelemetryEnabled {
 		return
 	}
-	p.mtx.Lock()
-	defer p.mtx.Unlock()
+	ddeebpf.TelemetryMu.Lock()
+	defer ddeebpf.TelemetryMu.Unlock()
 	p.perfChannelLenFuncs[pm] = channelLenFunc
 }
 
@@ -231,8 +230,8 @@ func (p *perfUsageCollector) registerRingBuffer(rb *manager.RingBuffer) {
 	if !rb.TelemetryEnabled {
 		return
 	}
-	p.mtx.Lock()
-	defer p.mtx.Unlock()
+	ddeebpf.TelemetryMu.Lock()
+	defer ddeebpf.TelemetryMu.Unlock()
 	p.ringBuffers = append(p.ringBuffers, rb)
 }
 
@@ -240,8 +239,8 @@ func (p *perfUsageCollector) registerRingBufferChannel(rb *manager.RingBuffer, c
 	if !rb.TelemetryEnabled {
 		return
 	}
-	p.mtx.Lock()
-	defer p.mtx.Unlock()
+	ddeebpf.TelemetryMu.Lock()
+	defer ddeebpf.TelemetryMu.Unlock()
 	p.ringChannelLenFuncs[rb] = channelLenFunc
 }
 
@@ -253,8 +252,8 @@ func UnregisterTelemetry(m *manager.Manager) {
 }
 
 func (p *perfUsageCollector) unregisterTelemetry(m *manager.Manager) {
-	p.mtx.Lock()
-	defer p.mtx.Unlock()
+	ddeebpf.TelemetryMu.Lock()
+	defer ddeebpf.TelemetryMu.Unlock()
 	p.perfMaps = slices.DeleteFunc(p.perfMaps, func(perfMap *manager.PerfMap) bool {
 		return slices.Contains(m.PerfMaps, perfMap)
 	})

--- a/pkg/ebpf/telemetry_mu_linux.go
+++ b/pkg/ebpf/telemetry_mu_linux.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package ebpf
+
+import "sync"
+
+// TelemetryMu synchronizes Manager.Start (which writes PerfMap/RingBuffer
+// telemetry fields) with perfUsageCollector.Collect (which reads them).
+// It lives here (in pkg/ebpf) rather than in pkg/ebpf/telemetry to avoid
+// a circular import: telemetry imports ebpf, so ebpf cannot import telemetry.
+var TelemetryMu sync.Mutex


### PR DESCRIPTION
### What does this PR do?
Fixes a data race between `perfUsageCollector.Collect` (reads PerfMap/RingBuffer telemetry fields during a Prometheus Gather tick) and `Manager.Start` (writes those fields during eBPF manager startup). Adds a shared `sync.Mutex` (`TelemetryMu`) in `pkg/ebpf` that both `Start` and `Collect` hold. It lives in `pkg/ebpf` to avoid a circular import (`pkg/ebpf/telemetry` already imports `pkg/ebpf`).

### Motivation
Fix a race, found via a race-detector-enabled build in staging (see #54333 for context).

### Describe how you validated your changes
No unit test added — the race requires eBPF support to trigger (`Manager.Start` writes to PerfMap/RingBuffer internal fields that can't be constructed in a unit test). The race is eliminated by construction: `Collect` and `Start` now share the same mutex, so they can never access the telemetry fields concurrently.