### PR TITLE
[Backport 7.82.x] [automated] Upgrade embedded Python patch version to 3.13.15

### DIFF
--- a/CHANGELOG-AIX.md
+++ b/CHANGELOG-AIX.md
@@ -9,6 +9,7 @@
 ## Unreleased
 
 <!-- Add entries here for changes not yet in a release. -->
+- Bump the embedded Python from 3.13.12 to 3.13.15, matching the version used by the Linux omnibus/bazel build
 - Build scripts: remove all hardcoded `/opt/datadog-agent` source-tree references — `AGENT_SRC` is now auto-resolved by walking up from the script directory to the nearest `.git` ancestor, so the agent source can live at any path on the build host
 - Remove the obsolete packaged integration constraints artifact from the AIX BFF package
 - Remove `sharedlibrarycheck` from the AIX agent build (the shared-library check loader was included but not validated on AIX)

--- a/deps/cpython/cpython.MODULE.bazel
+++ b/deps/cpython/cpython.MODULE.bazel
@@ -2,7 +2,7 @@ http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "ht
 
 constants_repo = use_repo_rule("//bazel/repo:constants_repo.bzl", "constants_repo")
 
-PYTHON_VERSION = "3.13.14"
+PYTHON_VERSION = "3.13.15"
 
 PYTHON_MAJOR_MINOR = ".".join(PYTHON_VERSION.split(".")[:2])
 
@@ -31,7 +31,7 @@ http_archive(
         "//deps/cpython:0003-propagate-pgo-test-exit-code.patch",
         "//deps/cpython:0004-Skip-bytecode-compilation-during-install.patch",
     ],
-    sha256 = "5ae535a36af0ebca6fca176ecb8197f5db9c1cb8c8f0cd12cdf1787046db1f41",
+    sha256 = "c28d9d213c09b5b5ab2c29812950e12f746999e099b82894231be954b26baed9",
     strip_prefix = "Python-{}".format(PYTHON_VERSION),
     url = "https://python.org/ftp/python/{0}/Python-{0}.tgz".format(PYTHON_VERSION),
 )

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -1,6 +1,6 @@
 name "python3"
 
-default_version "3.13.14"
+default_version "3.13.15"
 
 
 relative_path "Python-#{version}"

--- a/packaging/aix/lib/env.sh
+++ b/packaging/aix/lib/env.sh
@@ -11,7 +11,7 @@
 # any variable before sourcing this file.
 
 # ── Python version ────────────────────────────────────────────────────────────
-PYTHON_VERSION="3.13.12"
+PYTHON_VERSION="3.13.15"
 PYTHON_MAJ_MIN="${PYTHON_VERSION%.*}"   # e.g. 3.13
 export PYTHON_VERSION PYTHON_MAJ_MIN
 

--- a/releasenotes/notes/Bump-embedded-Python-to-3.13.15-3ce1819a2b93b6bd.yaml
+++ b/releasenotes/notes/Bump-embedded-Python-to-3.13.15-3ce1819a2b93b6bd.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+- |
+    The Agent's embedded Python has been upgraded from 3.13.14 to 3.13.15

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -228,7 +228,7 @@ const (
 	ExpectedPythonVersion2 = "2.7.18"
 	// ExpectedPythonVersion3 is the expected python 3 version
 	// Bump this version when the version in omnibus/config/software/python3.rb changes
-	ExpectedPythonVersion3 = "3.13.14"
+	ExpectedPythonVersion3 = "3.13.15"
 	// ExpectedUnloadedPython is the status value for uninitialized lazy loaded python runtime
 	ExpectedUnloadedPython = "unused"
 )


### PR DESCRIPTION
Backport of #54696 to `7.82.x`.

The automatic backport failed because `packaging/aix/lib/env.sh` is still on Python 3.13.12 in `7.82.x`, while the source change expected 3.13.14. This manually resolves the conflict by updating AIX directly from 3.13.12 to 3.13.15.

The automatic three-way merge also staged unrelated AIX changelog entries from 7.83. This backport preserves the branch-local changelog and adds only the Python 3.13.12 → 3.13.15 entry.

### Validation

- Commit/pre-push repository hooks passed, including release-note validation, shell checks, Go tests, Go lint, and module tidy checks.
- Full CI will run on this draft PR.