### PR TITLE
Drop stale `.except_e2e_main_release_or_rc` rule

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -998,28 +998,6 @@ workflow:
         - release.json
       compare_to: $COMPARE_TO_BRANCH
 
-.except_e2e_main_release_or_rc: # This rule is to not trigger dynamic test evaluation when we force all e2e tests to run
-  - <<: *if_disable_e2e_tests
-    when: never
-  - !reference [.except_mergequeue]
-  - <<: *if_run_all_e2e_tests
-    when: never
-  - <<: *if_main_branch
-    when: never
-  - <<: *if_release_branch
-    when: never
-  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
-    when: never
-  - changes:
-      paths:
-        - .gitlab/test/e2e/e2e.yml
-        - test/e2e-framework/testing/**/*
-        - test/new-e2e/go.mod
-        - flakes.yaml
-        - release.json
-      compare_to: $COMPARE_TO_BRANCH
-    when: never
-
 .dynamic_tests:
   - changes:
       paths:


### PR DESCRIPTION
### What does this PR do?
Delete `.except_e2e_main_release_or_rc` from `.gitlab-ci.yml`.

### Motivation
#39364 introduced it on 2025-08-29 alongside dynamic test evaluation, and #41343 removed its only reference on 2025-09-29, leaving a stale rule.

It has also drifted from `.on_e2e_main_release_or_rc`, the rule it mirrors, listing `test/e2e-framework/testing/**/*` where that one lists `test/e2e-framework/**/*`, so reviving it as written would not invert the behavior it was written to invert.

### Describe how you validated your changes
No occurrence of the name remains anywhere in the repository, and every anchor it consumed keeps other consumers, so nothing else falls out of use in turn.

The configuration still parses, and the job set is unchanged, the rule having had no consumer to change.

### Additional Notes
`.dynamic_tests`, right below it, is the live rule the suites reference to skip tests from inside the job.