### PR TITLE
[AAD-51] Evict seriesIDStats

### DIFF
--- a/comp/anomalydetection/observer/def/types.go
+++ b/comp/anomalydetection/observer/def/types.go
@@ -148,8 +148,9 @@ func (sd SeriesDescriptor) Key() string {
 }
 
 // SeriesRef is a compact numeric handle for a stored time series.
-// Storage assigns a SeriesRef when a series key is first created;
-// the ref remains stable for the lifetime of the storage instance.
+// Storage assigns a unique SeriesRef when a series key is first created. The
+// ref remains stable while the series is live and is never reused; after
+// eviction it is invalid for the remainder of the storage instance lifetime.
 type SeriesRef int
 
 // QueryHandle pairs a storage series ref with its aggregate, providing
@@ -615,11 +616,11 @@ type Detector interface {
 // segment buffers, ScanWelch posterior, the seriesDetectorAdapter visible
 // point count map, etc.) keyed by SeriesRef. Storage frees the series
 // payload itself when extractors evict their LRU contexts and the engine
-// calls RemoveSeriesByKeys, but without this hook the detector-side maps
+// calls its series-removal methods, but without this hook the detector-side maps
 // keep growing unbounded with the cumulative number of series ever
 // observed. The engine fans the freed refs out to every detector that
-// implements this interface immediately after RemoveSeriesByKeys returns
-// them, keeping detector state symmetric with storage state.
+// implements this interface immediately after storage returns them, keeping
+// detector state symmetric with storage state.
 //
 // Implementations should be cheap (a handful of map deletes) and tolerant
 // of refs they have never seen — adapters routinely receive refs for

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -558,8 +558,8 @@ type seriesDetectorAdapter struct {
 
 	// lastVisibleCount is keyed by the storage's compact SeriesRef so we
 	// avoid rebuilding a string key per series per Detect call. SeriesRefs
-	// are append-only (storage.go:305) so they remain stable for the lifetime
-	// of a series.
+	// are unique and never reused, so they remain stable for the lifetime of
+	// a series.
 	lastVisibleCount map[observerdef.SeriesRef]int
 }
 

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -1294,7 +1294,7 @@ func (s *timeSeriesStorage) CompactSeriesID(fullKey string) string {
 
 // StorageReader interface implementation
 
-// ListSeries returns metadata for all series matching the filter.
+// ListSeries returns metadata for all series matching the filter, ordered by ref.
 func (s *timeSeriesStorage) ListSeries(filter observer.SeriesFilter) []observer.SeriesMeta {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1319,11 +1319,12 @@ func (s *timeSeriesStorage) ListSeries(filter observer.SeriesFilter) []observer.
 			Tags:      stats.Tags,
 		})
 	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Ref < result[j].Ref })
 	return result
 }
 
 // ListSeriesRefsInto uses dst as scratch and returns refs for all series
-// matching the filter. Previous dst contents are discarded. It is the
+// matching the filter, ordered by ref. Previous dst contents are discarded. It is the
 // allocation-light detector hot path for callers that only need the stable
 // numeric SeriesRef handles.
 func (s *timeSeriesStorage) ListSeriesRefsInto(filter observer.SeriesFilter, dst []observer.SeriesRef) []observer.SeriesRef {
@@ -1344,6 +1345,7 @@ func (s *timeSeriesStorage) ListSeriesRefsInto(filter observer.SeriesFilter, dst
 		}
 		dst = append(dst, stats.ref)
 	}
+	sort.Slice(dst, func(i, j int) bool { return dst[i] < dst[j] })
 	return dst
 }
 

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -82,9 +82,11 @@ type timeSeriesStorage struct {
 	// even if no metric series was written for that timestamp.
 	observationTimestamps map[int64]struct{}
 
-	// Compact numeric IDs for O(1) lookups and API responses.
-	// seriesIDStats[ref] is the live *seriesStats (nil when the slot is retired).
-	seriesIDStats []*seriesStats // numeric ID → *seriesStats (index = ID)
+	// Compact numeric IDs for O(1) lookups and API responses. Retired refs are
+	// removed from the map and never reused, keeping this index bounded by live
+	// series instead of cumulative series churn.
+	seriesIDStats map[observer.SeriesRef]*seriesStats
+	nextSeriesRef observer.SeriesRef
 
 	// liveSeriesCount is the number of non-telemetry series in the catalog.
 	// It is updated under mu whenever a non-telemetry series is added or removed.
@@ -268,6 +270,7 @@ func newTimeSeriesStorageWith(cfg StorageConfig) *timeSeriesStorage {
 	return &timeSeriesStorage{
 		cfg:                   cfg,
 		series:                make(map[uint64]*seriesStats),
+		seriesIDStats:         make(map[observer.SeriesRef]*seriesStats),
 		observationTimestamps: make(map[int64]struct{}),
 		tagIntern:             make(map[uint64]*tagInternEntry),
 		droppedByMetric:       make(map[string]int64),
@@ -332,7 +335,8 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 		// Only intern on new series creation so the ref count tracks exactly
 		// the number of live series holding the canonical slice.
 		canonical, th := s.internTags(tags)
-		id := observer.SeriesRef(len(s.seriesIDStats))
+		id := s.nextSeriesRef
+		s.nextSeriesRef++
 		stats = &seriesStats{
 			Namespace: namespace,
 			Name:      name,
@@ -345,7 +349,7 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 		if _, occupied := s.series[h]; !occupied {
 			s.series[h] = stats
 		}
-		s.seriesIDStats = append(s.seriesIDStats, stats)
+		s.seriesIDStats[id] = stats
 		if namespace != observer.TelemetryNamespace {
 			s.liveSeriesCount++
 		}
@@ -810,9 +814,9 @@ func seriesKeyHash(namespace, name string, tags []string) uint64 {
 }
 
 // resolveByID returns the seriesStats for a numeric series ID.
-// Returns nil for out-of-range IDs. Caller must hold s.mu (read or write).
+// Returns nil for unknown or retired IDs. Caller must hold s.mu (read or write).
 func (s *timeSeriesStorage) resolveByID(ref observer.SeriesRef) *seriesStats {
-	if ref < 0 || int(ref) >= len(s.seriesIDStats) {
+	if ref < 0 {
 		return nil
 	}
 	return s.seriesIDStats[ref]
@@ -1043,9 +1047,9 @@ func (s *timeSeriesStorage) SeriesGeneration() uint64 {
 }
 
 // RemoveSeriesByRefs deletes series by their compact numeric refs. Each removed
-// series has its seriesIDStats slot set to nil (ref is never reused) and its
-// hash slot deleted from s.series. Returns the refs actually freed; out-of-range
-// or already-nil refs are silently skipped. seriesGen is bumped iff at least
+// series is deleted from seriesIDStats (ref is never reused) and its hash slot
+// is deleted from s.series. Returns the refs actually freed; unknown or already
+// removed refs are silently skipped. seriesGen is bumped iff at least
 // one series was removed so cached ListSeries results are invalidated.
 //
 // Callers use the returned refs to fan out per-series teardown to detector
@@ -1059,10 +1063,7 @@ func (s *timeSeriesStorage) RemoveSeriesByRefs(refs []observer.SeriesRef) []obse
 	defer s.mu.Unlock()
 	var removed []observer.SeriesRef
 	for _, ref := range refs {
-		if ref < 0 || int(ref) >= len(s.seriesIDStats) {
-			continue
-		}
-		stats := s.seriesIDStats[ref]
+		stats := s.resolveByID(ref)
 		if stats == nil {
 			continue
 		}
@@ -1079,7 +1080,7 @@ func (s *timeSeriesStorage) RemoveSeriesByRefs(refs []observer.SeriesRef) []obse
 // removeSeries removes a live series from every catalog index and cardinality
 // counter. The caller must hold s.mu for writing.
 func (s *timeSeriesStorage) removeSeries(stats *seriesStats) bool {
-	if stats == nil || stats.ref < 0 || int(stats.ref) >= len(s.seriesIDStats) || s.seriesIDStats[stats.ref] != stats {
+	if stats == nil || stats.ref < 0 || s.seriesIDStats[stats.ref] != stats {
 		return false
 	}
 	s.releaseTagIntern(stats.tagsHash)
@@ -1087,7 +1088,7 @@ func (s *timeSeriesStorage) removeSeries(stats *seriesStats) bool {
 	if s.series[h] == stats {
 		delete(s.series, h)
 	}
-	s.seriesIDStats[stats.ref] = nil
+	delete(s.seriesIDStats, stats.ref)
 	if stats.Namespace != observer.TelemetryNamespace {
 		s.liveSeriesCount--
 	}

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -1294,7 +1294,7 @@ func (s *timeSeriesStorage) CompactSeriesID(fullKey string) string {
 
 // StorageReader interface implementation
 
-// ListSeries returns metadata for all series matching the filter, ordered by ref.
+// ListSeries returns metadata for all series matching the filter.
 func (s *timeSeriesStorage) ListSeries(filter observer.SeriesFilter) []observer.SeriesMeta {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1319,12 +1319,11 @@ func (s *timeSeriesStorage) ListSeries(filter observer.SeriesFilter) []observer.
 			Tags:      stats.Tags,
 		})
 	}
-	sort.Slice(result, func(i, j int) bool { return result[i].Ref < result[j].Ref })
 	return result
 }
 
 // ListSeriesRefsInto uses dst as scratch and returns refs for all series
-// matching the filter, ordered by ref. Previous dst contents are discarded. It is the
+// matching the filter. Previous dst contents are discarded. It is the
 // allocation-light detector hot path for callers that only need the stable
 // numeric SeriesRef handles.
 func (s *timeSeriesStorage) ListSeriesRefsInto(filter observer.SeriesFilter, dst []observer.SeriesRef) []observer.SeriesRef {
@@ -1345,7 +1344,6 @@ func (s *timeSeriesStorage) ListSeriesRefsInto(filter observer.SeriesFilter, dst
 		}
 		dst = append(dst, stats.ref)
 	}
-	sort.Slice(dst, func(i, j int) bool { return dst[i] < dst[j] })
 	return dst
 }
 

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -1226,7 +1226,10 @@ func (s *timeSeriesStorage) EvictToCapacity(seriesLimit, target int) []observer.
 	}
 
 	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].lastTs < candidates[j].lastTs
+		if candidates[i].lastTs != candidates[j].lastTs {
+			return candidates[i].lastTs < candidates[j].lastTs
+		}
+		return candidates[i].ref < candidates[j].ref
 	})
 
 	var freed []observer.SeriesRef

--- a/comp/anomalydetection/observer/impl/storage_instrumented.go
+++ b/comp/anomalydetection/observer/impl/storage_instrumented.go
@@ -122,8 +122,7 @@ func (s *instrumentedStorage) ListSeries(filter observerdef.SeriesFilter) []obse
 	result := s.inner.ListSeries(filter)
 
 	// Hash each series identity independently, then sort and combine.
-	// Hash independently so this remains valid for StorageReader implementations
-	// whose listing order is not deterministic.
+	// ListSeries iterates a Go map internally, so slice order is non-deterministic.
 	perSeries := make([]uint64, len(result))
 	for i, m := range result {
 		ih := newCallHasher()

--- a/comp/anomalydetection/observer/impl/storage_instrumented.go
+++ b/comp/anomalydetection/observer/impl/storage_instrumented.go
@@ -122,7 +122,8 @@ func (s *instrumentedStorage) ListSeries(filter observerdef.SeriesFilter) []obse
 	result := s.inner.ListSeries(filter)
 
 	// Hash each series identity independently, then sort and combine.
-	// ListSeries iterates a Go map internally, so slice order is non-deterministic.
+	// Hash independently so this remains valid for StorageReader implementations
+	// whose listing order is not deterministic.
 	perSeries := make([]uint64, len(result))
 	for i, m := range result {
 		ih := newCallHasher()

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -609,9 +609,27 @@ func TestTimeSeriesStorage_ListSeriesRefsInto_MatchesListSeriesFilters(t *testin
 			}
 
 			got := s.ListSeriesRefsInto(filter, []observer.SeriesRef{999})
-			require.ElementsMatch(t, want, got)
+			require.Equal(t, want, got)
 		})
 	}
+}
+
+func TestTimeSeriesStorage_ListSeriesOrdersByRef(t *testing.T) {
+	s := newTimeSeriesStorage()
+	first := s.Add("work", "first", 1, 1, nil).Ref
+	second := s.Add("work", "second", 1, 1, nil).Ref
+	third := s.Add("work", "third", 1, 1, nil).Ref
+	want := []observer.SeriesRef{first, second, third}
+
+	metas := s.ListSeries(observer.WorkloadSeriesFilter())
+	gotMetas := make([]observer.SeriesRef, 0, len(metas))
+	for _, meta := range metas {
+		gotMetas = append(gotMetas, meta.Ref)
+	}
+	require.Equal(t, want, gotMetas)
+
+	gotRefs := s.ListSeriesRefsInto(observer.WorkloadSeriesFilter(), nil)
+	require.Equal(t, want, gotRefs)
 }
 
 func TestTimeSeriesStorage_RemoveSeriesByRefs(t *testing.T) {

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -609,27 +609,9 @@ func TestTimeSeriesStorage_ListSeriesRefsInto_MatchesListSeriesFilters(t *testin
 			}
 
 			got := s.ListSeriesRefsInto(filter, []observer.SeriesRef{999})
-			require.Equal(t, want, got)
+			require.ElementsMatch(t, want, got)
 		})
 	}
-}
-
-func TestTimeSeriesStorage_ListSeriesOrdersByRef(t *testing.T) {
-	s := newTimeSeriesStorage()
-	first := s.Add("work", "first", 1, 1, nil).Ref
-	second := s.Add("work", "second", 1, 1, nil).Ref
-	third := s.Add("work", "third", 1, 1, nil).Ref
-	want := []observer.SeriesRef{first, second, third}
-
-	metas := s.ListSeries(observer.WorkloadSeriesFilter())
-	gotMetas := make([]observer.SeriesRef, 0, len(metas))
-	for _, meta := range metas {
-		gotMetas = append(gotMetas, meta.Ref)
-	}
-	require.Equal(t, want, gotMetas)
-
-	gotRefs := s.ListSeriesRefsInto(observer.WorkloadSeriesFilter(), nil)
-	require.Equal(t, want, gotRefs)
 }
 
 func TestTimeSeriesStorage_RemoveSeriesByRefs(t *testing.T) {

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -609,7 +609,7 @@ func TestTimeSeriesStorage_ListSeriesRefsInto_MatchesListSeriesFilters(t *testin
 			}
 
 			got := s.ListSeriesRefsInto(filter, []observer.SeriesRef{999})
-			require.Equal(t, want, got)
+			require.ElementsMatch(t, want, got)
 		})
 	}
 }
@@ -711,6 +711,37 @@ func TestTimeSeriesStorage_RemoveSeriesByRefsEmptyOrUnknown(t *testing.T) {
 	// Out-of-range refs (-1, 999) are silently skipped.
 	require.Empty(t, s.RemoveSeriesByRefs([]observer.SeriesRef{-1, 999}))
 	require.Equal(t, genBefore, s.SeriesGeneration(), "no removal → no gen bump")
+}
+
+func TestTimeSeriesStorage_SeriesRefIndexBoundedUnderChurn(t *testing.T) {
+	s := newTimeSeriesStorage()
+	lastRef := observer.SeriesRef(-1)
+
+	for i := 0; i < 1_000; i++ {
+		res := s.Add("workload", fmt.Sprintf("churn-%d", i), 1, int64(i), nil)
+		require.Greater(t, res.Ref, lastRef, "new refs must be monotonic and never reused")
+		lastRef = res.Ref
+
+		switch i % 3 {
+		case 0:
+			require.Equal(t, []observer.SeriesRef{res.Ref}, s.RemoveSeriesByRefs([]observer.SeriesRef{res.Ref}))
+		case 1:
+			require.Equal(t, []observer.SeriesRef{res.Ref}, s.RemoveSeriesByMetricName("workload", fmt.Sprintf("churn-%d", i)))
+		case 2:
+			second := s.Add("workload", fmt.Sprintf("churn-extra-%d", i), 1, int64(i), nil)
+			require.Greater(t, second.Ref, lastRef, "capacity eviction must not cause ref reuse")
+			lastRef = second.Ref
+			require.Len(t, s.EvictToCapacity(1, 0), 2)
+		}
+
+		require.Empty(t, s.seriesIDStats, "ref index must retain only live series")
+		require.Zero(t, s.TotalSeriesCount())
+	}
+
+	newRef := s.Add("workload", "final", 1, 1_000, nil).Ref
+	require.Greater(t, newRef, lastRef)
+	require.Len(t, s.seriesIDStats, 1)
+	require.Nil(t, s.GetSeriesMeta(lastRef), "retired refs must remain invalid")
 }
 
 func TestTimeSeriesStorage_AddReturnsRef(t *testing.T) {

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -684,6 +684,19 @@ func TestTimeSeriesStorage_TotalSeriesCountTracksCapacityEviction(t *testing.T) 
 	require.Equal(t, 1, s.TotalSeriesCount())
 }
 
+func TestTimeSeriesStorage_EvictToCapacityBreaksActivityTiesByRef(t *testing.T) {
+	s := newTimeSeriesStorage()
+	first := s.Add("workload", "first", 1, 100, nil).Ref
+	second := s.Add("workload", "second", 1, 100, nil).Ref
+	third := s.Add("workload", "third", 1, 100, nil).Ref
+
+	freed := s.EvictToCapacity(2, 2)
+	require.Equal(t, []observer.SeriesRef{first}, freed)
+	require.Nil(t, s.GetSeriesMeta(first))
+	require.NotNil(t, s.GetSeriesMeta(second))
+	require.NotNil(t, s.GetSeriesMeta(third))
+}
+
 func TestTimeSeriesStorage_FindRefsByHashes(t *testing.T) {
 	s := newTimeSeriesStorage()
 


### PR DESCRIPTION
### What does this PR do?

This evicts `seriesIDStats` that maps series ID to metadata.

It wasn't done and before it was a slice which is a possible source of collision (replaced by monotonic ID counter + map).

### Motivation

### Describe how you validated your changes

Ran the agent + triggered eviction and verified that the behavior is usual.

### Additional Notes