### PR TITLE
Fail fast for real on unusable `XDG_CACHE_HOME` on Windows

### DIFF
--- a/.gitlab/windows/build/lint/windows.yml
+++ b/.gitlab/windows/build/lint/windows.yml
@@ -1,7 +1,7 @@
 .lint_windows_base:
   stage: lint
   needs: ["go_deps", "go_tools_deps"]
-  extends: .windows_docker_default
+  extends: [.windows_docker_default, .bazel:defs:cache:windows]
   script:
     - $ErrorActionPreference = "Stop"
     - !reference [.sanitize_goproxy_windows]
@@ -11,11 +11,9 @@
     # Windows jobs are using either 8Gb or 16Gb of memory so we can limit memory to 16Gb on this job because even if we decided to limit to 10Gb for instance,
     # it would leave 6Gb free but we could not fit another job with these 6Gb remaining.
     - >
-      docker run --rm
+      .\tools\ci\docker-run-with-bazel-cache.ps1
       -m 24576M
-      --storage-opt "size=50GB"
       -v "$(Get-Location):c:\mnt"
-      -e CI
       -e GITLAB_CI
       -e DDA_FEATURE_FLAGS_CI_SSM_KEY_WINDOWS="${DDA_FEATURE_FLAGS_CI_SSM_KEY_WINDOWS}"
       -e AWS_NETWORKING=true

--- a/.gitlab/windows/build/package_build/windows.yml
+++ b/.gitlab/windows/build/package_build/windows.yml
@@ -1,7 +1,7 @@
 ---
 .windows_msi_base:
   stage: package_build
-  extends: [.windows_docker_default, .bazel:defs:cache:windows]  # the latter for `bazel run @openssl//:install`
+  extends: [.windows_docker_default, .bazel:defs:cache:windows]
   needs: ["go_deps"]
   variables:
     GIT_DEPTH: 0  # git describe --tags needs reachable tags
@@ -93,7 +93,7 @@ windows_msi_and_bosh_zip_x64-a7-fips:
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
-  extends: .windows_docker_default
+  extends: [.windows_docker_default, .bazel:defs:cache:windows]
   needs: ["go_deps"]
   variables:
     ARCH: "x64"
@@ -104,10 +104,9 @@ windows_msi_and_bosh_zip_x64-a7-fips:
     - if (Test-Path omnibus\pkg) { remove-item -recurse -force omnibus\pkg }
     - mkdir omnibus\pkg
     - >
-      docker run --rm
+      .\tools\ci\docker-run-with-bazel-cache.ps1
       -m 24576M
       -v "$(Get-Location):c:\mnt"
-      -e CI
       -e GITLAB_CI
       -e CI_COMMIT_BRANCH
       -e CI_PIPELINE_ID

--- a/.gitlab/windows/test/integration_test/windows.yml
+++ b/.gitlab/windows/test/integration_test/windows.yml
@@ -5,7 +5,7 @@
     - !reference [.except_mergequeue]
     - when: on_success
   needs: ["go_deps", "go_tools_deps"]
-  extends: .windows_docker_default
+  extends: [.windows_docker_default, .bazel:defs:cache:windows]
   before_script:
     - $tmpfile = [System.IO.Path]::GetTempFileName()
     - (& "$CI_PROJECT_DIR\tools\ci\fetch_secret.ps1" -parameterName "$Env:VCPKG_BLOB_SAS_URL" -parameterField url -tempFile "$tmpfile")
@@ -18,10 +18,9 @@
     # we pass in CI_JOB_URL and CI_JOB_NAME so that they can be added to additional tags
     # inside JUNIT_TAR and then later used by datadog-ci
     - >
-      docker run --rm
+      .\tools\ci\docker-run-with-bazel-cache.ps1
       -m 16384M
       -v "$(Get-Location):c:\mnt"
-      -e CI
       -e GITLAB_CI
       -e DDA_FEATURE_FLAGS_CI_SSM_KEY_WINDOWS="${DDA_FEATURE_FLAGS_CI_SSM_KEY_WINDOWS}"
       -e CI_JOB_URL

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -11,10 +11,7 @@ exit /b 2
 :: Ensure `XDG_CACHE_HOME` denotes a directory
 if not defined DOTNET_RUNNING_IN_CONTAINER >nul 2>&1 sc query CExecSvc && set DOTNET_RUNNING_IN_CONTAINER=1
 if not exist "%XDG_CACHE_HOME%" (
-  if defined CI (
-    >&2 echo 🔴 XDG_CACHE_HOME ^(!XDG_CACHE_HOME!^) must denote a directory in CI!
-    exit /b 2
-  )
+  if defined CI goto :error_xdg_cache_home_must_exist
   if defined DOTNET_RUNNING_IN_CONTAINER (
     >&2 echo 💡 To persist caches across restarts, please set XDG_CACHE_HOME pointing to a mounted directory, e.g.:
     >&2 echo     docker.exe run --env=XDG_CACHE_HOME=C:\cache --volume="$HOME\.cache:C:\cache" ...
@@ -25,10 +22,7 @@ if not exist "%XDG_CACHE_HOME%" (
 set "extra_args="
 if defined XDG_CACHE_HOME (
   set "XDG_CACHE_HOME=!XDG_CACHE_HOME:/=\!"
-  if "!XDG_CACHE_HOME:~1,2!" neq ":\" if "!XDG_CACHE_HOME:~0,2!" neq "\\" (
-    >&2 echo 🔴 XDG_CACHE_HOME ^(!XDG_CACHE_HOME!^) must denote an absolute path!
-    exit /b 2
-  )
+  if "!XDG_CACHE_HOME:~1,2!" neq ":\" if "!XDG_CACHE_HOME:~0,2!" neq "\\" goto :error_xdg_cache_home_must_be_absolute
   set "GOCACHE=!XDG_CACHE_HOME!\go-build"
   set "GOMODCACHE=!XDG_CACHE_HOME!\go\mod"
   set "PIP_CACHE_DIR=!XDG_CACHE_HOME!\pip"
@@ -82,6 +76,14 @@ set "args=%*"
 if defined args if defined extra_args call :insert_extra_args
 "%BAZEL_REAL%" !startup_options! !args!
 exit /b !errorlevel!
+
+:error_xdg_cache_home_must_exist
+>&2 echo 🔴 XDG_CACHE_HOME ^(!XDG_CACHE_HOME!^) must denote a directory in CI
+exit /b 2
+
+:error_xdg_cache_home_must_be_absolute
+>&2 echo 🔴 XDG_CACHE_HOME ^(!XDG_CACHE_HOME!^) must denote an absolute path
+exit /b 2
 
 :: "--startup cmd ..." -> "--startup cmd --config=ci ..."
 :insert_extra_args


### PR DESCRIPTION
### Motivation
Accidentally found that a couple of jobs were printing fatal error messages without actually failing fast ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1956102344)) (i.e. continuing past the not-that-fatal error).

The problem is that `cmd.exe` happens to zero out the code of an `exit /b <code>` that does not end every enclosing parenthesized block, so `tools/bazel.bat` returned 0 and let subsequent steps to proceed.

### What does this PR do?
Reach both fatal diagnostics through `goto` labels placed after the main flow, where `exit /b 2` is now honored.

Route the affected jobs through `docker-run-with-bazel-cache.ps1`, as the fixed guards would otherwise fail them, on purpose.

### Describe how you validated your changes
On Windows Server 2022 with `bazelisk` 1.28.1, the wrapper returns 2 for an unset and for a relative `XDG_CACHE_HOME`, and still reaches `bazel` for a valid one.

`dda inv gitlab.print-ci` shows both jobs inheriting `XDG_CACHE_HOME=c:/bzl`, as `tests_windows-x64` and others already do.

### Additional Notes
The two remaining guards do end their blocks, so they already exit 2.

Yet another reason for rewriting both `tools/bazel*` hooks in Python.