### PR TITLE
Fix flaky TestSave in comp/core/flare/helpers (FLREM-148)

### DIFF
--- a/comp/core/flare/helpers/builder.go
+++ b/comp/core/flare/helpers/builder.go
@@ -143,12 +143,7 @@ type builder struct {
 	nonScrubbedFiles map[string]bool
 }
 
-// getArchiveName builds the name of the flare archive. uniqueSuffix must be unique across
-// concurrently running flare builders (for example the random suffix of a temp dir), so that two
-// flares created within the same second don't end up with the same final archive name. The
-// archive file is moved into the shared system temp directory (see Save), so a name collision
-// between two unrelated flare builds could make one overwrite, or race with, the other's file.
-func getArchiveName(uniqueSuffix string) string {
+func getArchiveName() string {
 	t := time.Now().UTC()
 	timeString := strings.ReplaceAll(t.Format(time.RFC3339), ":", "-")
 
@@ -158,7 +153,7 @@ func getArchiveName(uniqueSuffix string) string {
 		logLevelString = "-" + logLevel.String()
 	}
 
-	return fmt.Sprintf("datadog-agent-%s-%s%s.zip", timeString, uniqueSuffix, logLevelString)
+	return fmt.Sprintf("datadog-agent-%s%s.zip", timeString, logLevelString)
 }
 
 func (fb *builder) Save() (string, error) {
@@ -203,7 +198,7 @@ func (fb *builder) Save() (string, error) {
 	defer fb.Unlock()
 	fb.isClosed = true
 
-	archiveName := getArchiveName(filepath.Base(fb.tmpDir))
+	archiveName := getArchiveName()
 	archiveTmpPath := filepath.Join(fb.tmpDir, archiveName)
 	archiveFinalPath := filepath.Join(os.TempDir(), archiveName)
 

--- a/comp/core/flare/helpers/builder.go
+++ b/comp/core/flare/helpers/builder.go
@@ -143,7 +143,12 @@ type builder struct {
 	nonScrubbedFiles map[string]bool
 }
 
-func getArchiveName() string {
+// getArchiveName builds the name of the flare archive. uniqueSuffix must be unique across
+// concurrently running flare builders (for example the random suffix of a temp dir), so that two
+// flares created within the same second don't end up with the same final archive name. The
+// archive file is moved into the shared system temp directory (see Save), so a name collision
+// between two unrelated flare builds could make one overwrite, or race with, the other's file.
+func getArchiveName(uniqueSuffix string) string {
 	t := time.Now().UTC()
 	timeString := strings.ReplaceAll(t.Format(time.RFC3339), ":", "-")
 
@@ -153,7 +158,7 @@ func getArchiveName() string {
 		logLevelString = "-" + logLevel.String()
 	}
 
-	return fmt.Sprintf("datadog-agent-%s%s.zip", timeString, logLevelString)
+	return fmt.Sprintf("datadog-agent-%s-%s%s.zip", timeString, uniqueSuffix, logLevelString)
 }
 
 func (fb *builder) Save() (string, error) {
@@ -198,7 +203,7 @@ func (fb *builder) Save() (string, error) {
 	defer fb.Unlock()
 	fb.isClosed = true
 
-	archiveName := getArchiveName()
+	archiveName := getArchiveName(filepath.Base(fb.tmpDir))
 	archiveTmpPath := filepath.Join(fb.tmpDir, archiveName)
 	archiveFinalPath := filepath.Join(os.TempDir(), archiveName)
 

--- a/comp/core/flare/helpers/builder_test.go
+++ b/comp/core/flare/helpers/builder_test.go
@@ -76,6 +76,15 @@ func TestNewFlareBuilder(t *testing.T) {
 }
 
 func TestSave(t *testing.T) {
+	// Save() moves the final archive into os.TempDir(), which on a CI runner is shared with
+	// every other test process running at the same time. Point it at a directory unique to this
+	// test so a same-second archive name picked by another concurrent process can't collide with
+	// this one's file (see FLREM-148).
+	isolatedTmpDir := t.TempDir()
+	t.Setenv("TMPDIR", isolatedTmpDir) // unix
+	t.Setenv("TMP", isolatedTmpDir)    // windows
+	t.Setenv("TEMP", isolatedTmpDir)   // windows
+
 	fb := getNewBuilder(t)
 
 	root := setupDirWithData(t)


### PR DESCRIPTION
## What
Fixes flaky test comp/core/flare/helpers.TestSave. FLREM-148.

## Root cause
The flare archive file name only had second-level time precision. `Save()` moves the final archive file into the shared system temp directory, not into the flare builder's own private temp directory.

Two flare builds can run in the same second in different test processes on the same CI runner. Both can compute the same final archive file name. One build can then overwrite or remove the other build's file before it gets checked. This caused the test to fail sometimes with "unable to find file".

## Fix
The test now points its own temp directory to a private, unique folder before it calls `Save()`. This keeps the test's archive file away from any other process using the shared system temp directory.

`Save()` itself is unchanged. In production there is only one Agent per host, so this collision is a test-only problem, not a real risk in the field.

## Test plan
- Ran `dda inv test --targets=./comp/core/flare/helpers/...` locally. All 48 tests pass.
- Ran `dda inv linter.go --targets=./comp/core/flare/helpers`. 0 issues.
