### PR TITLE
Use subprocess to run bazel commands instead of ctx.run

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -11,6 +11,7 @@ import os
 import re
 import shlex
 import shutil
+import signal
 import subprocess
 import sys
 import time
@@ -464,10 +465,10 @@ def test_flavor(
                 ignore_errors=True,
             )
             # early stop on SIGINT: exit code is 128 + signal number, SIGINT is 2, so 130
-            if res is not None and res.returncode == 130:
+            if res is not None and res.returncode in (130, -signal.SIGINT):
                 raise KeyboardInterrupt()
 
-        if res is not None and res.returncode > 0:
+        if res is not None and res.returncode != 0:
             result.failed = True
         elif not skip_tests_covered_by_bazel:
             lines = res.stdout.splitlines()

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -464,10 +464,10 @@ def test_flavor(
                 ignore_errors=True,
             )
             # early stop on SIGINT: exit code is 128 + signal number, SIGINT is 2, so 130
-            if res is not None and res.exited == 130:
+            if res is not None and res.returncode == 130:
                 raise KeyboardInterrupt()
 
-        if res is not None and (res.exited is None or res.exited > 0):
+        if res is not None and res.returncode > 0:
             result.failed = True
         elif not skip_tests_covered_by_bazel:
             lines = res.stdout.splitlines()

--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -95,7 +95,6 @@ def bazel_not_found_message(color: str) -> str:
 def _run_command(
     cmd: tuple[str, ...],
     *,
-    cmdline: str,
     capture_stdout: bool,
     capture_for_result: bool,
     env: dict[str, str] | None,
@@ -107,7 +106,6 @@ def _run_command(
     if capture_for_result:
         return _run_command_with_tee(
             cmd,
-            cmdline=cmdline,
             input=input,
             env=subprocess_env,
             tee_stdout=not capture_stdout,
@@ -152,7 +150,6 @@ async def _collect_output(
 async def _run_command_with_tee_async(
     cmd: tuple[str, ...],
     *,
-    cmdline: str,
     input: str | None,
     env: dict[str, str] | None,
     tee_stdout: bool,
@@ -186,13 +183,12 @@ async def _run_command_with_tee_async(
     returncode = await proc.wait()
     stdout, stderr = await asyncio.gather(*output_tasks)
 
-    return subprocess.CompletedProcess(cmdline, returncode, stdout, stderr)
+    return subprocess.CompletedProcess(cmd, returncode, stdout, stderr)
 
 
 def _run_command_with_tee(
     cmd: tuple[str, ...],
     *,
-    cmdline: str,
     input: str | None,
     env: dict[str, str] | None,
     tee_stdout: bool,
@@ -201,7 +197,6 @@ def _run_command_with_tee(
     return asyncio.run(
         _run_command_with_tee_async(
             cmd,
-            cmdline=cmdline,
             input=input,
             env=env,
             tee_stdout=tee_stdout,
@@ -236,7 +231,6 @@ def bazel(
 
     completed = _run_command(
         cmd,
-        cmdline=cmdline,
         capture_stdout=capture_output,
         capture_for_result=ignore_errors,
         env=env,

--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -238,7 +238,7 @@ def bazel(
         cmd,
         cmdline=cmdline,
         capture_stdout=capture_output,
-        capture_for_result=ignore_errors and not capture_output,
+        capture_for_result=ignore_errors,
         env=env,
         input=input,
     )

--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import codecs
 import os
 import shlex
 import shutil
@@ -9,10 +11,6 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import IO, NamedTuple
-
-from invoke import Exit
-from invoke.context import Context
-from invoke.runners import Result
 
 from tasks.libs.common.color import color_message
 from tasks.libs.common.utils import get_repo_root
@@ -94,39 +92,161 @@ def bazel_not_found_message(color: str) -> str:
     return color_message("Please run `inv install-tools` for `bazel` support!", color)
 
 
+def _run_command(
+    cmd: tuple[str, ...],
+    *,
+    cmdline: str,
+    capture_stdout: bool,
+    capture_for_result: bool,
+    env: dict[str, str] | None,
+    input: str | None,
+) -> subprocess.CompletedProcess[str]:
+    # Merge the provided `env` with the current outside environment.
+    subprocess_env = {**os.environ, **env} if env else None
+
+    if capture_for_result:
+        return _run_command_with_tee(
+            cmd,
+            cmdline=cmdline,
+            input=input,
+            env=subprocess_env,
+            tee_stdout=not capture_stdout,
+            tee_stderr=True,
+        )
+
+    return subprocess.run(
+        cmd,
+        env=subprocess_env,
+        input=input,
+        stdin=subprocess.DEVNULL if input is None else None,
+        stdout=subprocess.PIPE if capture_stdout else None,
+        stderr=None,
+        encoding="utf-8",
+        errors="backslashreplace",
+    )
+
+
+async def _collect_output(
+    stream: asyncio.StreamReader,
+    sink: IO[str] | None,
+) -> str:
+    decoder = codecs.getincrementaldecoder("utf-8")("backslashreplace")
+    chunks: list[str] = []
+    while data := await stream.read(8192):
+        chunk = decoder.decode(data)
+        chunks.append(chunk)
+        if sink is not None:
+            sink.write(chunk)
+            sink.flush()
+
+    tail = decoder.decode(b"", final=True)
+    if tail:
+        chunks.append(tail)
+        if sink is not None:
+            sink.write(tail)
+            sink.flush()
+
+    return "".join(chunks)
+
+
+async def _run_command_with_tee_async(
+    cmd: tuple[str, ...],
+    *,
+    cmdline: str,
+    input: str | None,
+    env: dict[str, str] | None,
+    tee_stdout: bool,
+    tee_stderr: bool,
+) -> subprocess.CompletedProcess[str]:
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        env=env,
+        stdin=asyncio.subprocess.PIPE if input is not None else subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    # Manage stdout and stderr in separate async tasks that tee output while collecting it.
+    output_tasks = [
+        asyncio.create_task(_collect_output(proc.stdout, sys.stdout if tee_stdout else None)),
+        asyncio.create_task(_collect_output(proc.stderr, sys.stderr if tee_stderr else None)),
+    ]
+
+    # Feed input to the process stdin
+    if input is not None and proc.stdin is not None:
+        try:
+            proc.stdin.write(input.encode("utf-8"))
+            await proc.stdin.drain()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+        finally:
+            proc.stdin.close()
+            await proc.stdin.wait_closed()
+
+    returncode = await proc.wait()
+    stdout, stderr = await asyncio.gather(*output_tasks)
+
+    return subprocess.CompletedProcess(cmdline, returncode, stdout, stderr)
+
+
+def _run_command_with_tee(
+    cmd: tuple[str, ...],
+    *,
+    cmdline: str,
+    input: str | None,
+    env: dict[str, str] | None,
+    tee_stdout: bool,
+    tee_stderr: bool,
+) -> subprocess.CompletedProcess[str]:
+    return asyncio.run(
+        _run_command_with_tee_async(
+            cmd,
+            cmdline=cmdline,
+            input=input,
+            env=env,
+            tee_stdout=tee_stdout,
+            tee_stderr=tee_stderr,
+        )
+    )
+
+
 def bazel(
-    ctx: Context,
+    ctx: object,
     *args: str,
     capture_output: bool = False,
     env: dict[str, str] | None = None,
     ignore_errors: bool = False,
-    input_stream: IO[str] | bool = False,
+    input: str | None = None,
     sudo: bool = False,
-) -> str | Result:
+) -> str | subprocess.CompletedProcess[str]:
     """Execute a bazel command.
 
+    ctx: retained for compatibility with existing invoke task callers; command execution uses subprocess.
     env: environment variables when passing them through the corresponding Bazel `--*_env=` flags is not suitable.
-    ignore_errors: do not fail fast, but instead return the raw `Result`, whether the Bazel command succeeded or not.
+    input: text to pass to the Bazel subprocess stdin.
+    ignore_errors: do not fail fast, but instead return the raw `CompletedProcess`, whether the Bazel command
+        succeeded or not.
     """
 
     if not (bazelisk := shutil.which("bazelisk")):  # `/usr/bin/bazel` may otherwise take precedence in DD Workspaces
-        raise Exit(bazel_not_found_message("red"))
+        raise SystemExit(bazel_not_found_message("red"))
     cmd = (("sudo",) if sudo else ()) + (bazelisk, *_insert_omnibazel_flags(args))
     cmdline = (subprocess.list2cmdline if sys.platform == "win32" else shlex.join)(cmd)
     print(color_message(cmdline.replace(bazelisk, "bazel", 1), "bold"), file=sys.stderr)  # brevity: abspath -> bazel
-    kwargs = {}
-    # Invoke terminolgy is subtle. "hide" means hide from the user.
-    # In every other libray, that would be called capture, and the
-    # act of capturing it would hide it from the user.
-    # https://docs.pyinvoke.org/en/stable/api/runners.html#invoke.runners.Runner.run
-    if capture_output:
-        kwargs["hide"] = "out"
-    elif not sudo and sys.stdout.isatty() and sys.platform != "win32":
-        kwargs["pty"] = True
-    result = ctx.run(cmdline, echo=False, env=env, in_stream=input_stream, warn=ignore_errors, **kwargs)
+
+    completed = _run_command(
+        cmd,
+        cmdline=cmdline,
+        capture_stdout=capture_output,
+        capture_for_result=ignore_errors and not capture_output,
+        env=env,
+        input=input,
+    )
     if ignore_errors:
-        return result
-    return result.stdout if capture_output else ""
+        return completed
+    if completed.returncode != 0:
+        raise SystemExit(completed.returncode)
+    return completed.stdout if capture_output else ""
 
 
 def _insert_omnibazel_flags(args: tuple[str, ...]) -> tuple[str, ...]:

--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import codecs
 import os
-import shlex
 import shutil
 import subprocess
 import sys
@@ -13,7 +12,7 @@ from pathlib import Path
 from typing import IO, NamedTuple
 
 from tasks.libs.common.color import color_message
-from tasks.libs.common.utils import get_repo_root
+from tasks.libs.common.utils import get_repo_root, join_command
 
 
 class Label(NamedTuple):
@@ -226,7 +225,7 @@ def bazel(
     if not (bazelisk := shutil.which("bazelisk")):  # `/usr/bin/bazel` may otherwise take precedence in DD Workspaces
         raise SystemExit(bazel_not_found_message("red"))
     cmd = (("sudo",) if sudo else ()) + (bazelisk, *_insert_omnibazel_flags(args))
-    cmdline = (subprocess.list2cmdline if sys.platform == "win32" else shlex.join)(cmd)
+    cmdline = join_command(cmd)
     print(color_message(cmdline.replace(bazelisk, "bazel", 1), "bold"), file=sys.stderr)  # brevity: abspath -> bazel
 
     completed = _run_command(

--- a/tasks/libs/common/go.py
+++ b/tasks/libs/common/go.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import io
 import os
 import os.path
 import platform
@@ -222,13 +221,13 @@ def _handle_pipe_to_whydeadcode(ctx: Context, name: str, cmd: str, env: dict[str
     # it returns 0, even if dead code elimination is disabled
     # so we check whether stdout is empty to know if dead code elimination is disabled
     whydeadcode_out = bazel(
-        runner,
+        ctx,
         "run",
         *(f"--run_env={k}={v}" for k, v in (env or {}).items()),
         "@com_github_aarzilli_whydeadcode//:whydeadcode",
         "--",
         "--ignore-unrecognized-input",
-        input_stream=CustomReader(result.stderr),
+        input=result.stderr,
         capture_output=True,
     )
     if whydeadcode_out:
@@ -237,17 +236,3 @@ def _handle_pipe_to_whydeadcode(ctx: Context, name: str, cmd: str, env: dict[str
         )
 
     return result
-
-
-class CustomReader(io.StringIO):
-    """
-    Custom reader to read 10MiB at a time.
-    This is a workaround to increase invoke performance at reading from stdin
-    See https://github.com/pyinvoke/invoke/issues/819
-    """
-
-    def __init__(self, data: str):
-        super().__init__(data)
-
-    def read(self, n: int | None = None) -> str:
-        return super().read(1024 * 1024 * 10)

--- a/tasks/unit_tests/libs/build/bazel_tests.py
+++ b/tasks/unit_tests/libs/build/bazel_tests.py
@@ -1,9 +1,7 @@
-import io
 import os
+import subprocess
 import unittest
-from unittest.mock import MagicMock, patch
-
-from invoke import Context, Exit, MockContext
+from unittest.mock import patch
 
 from tasks.libs.build.bazel import bazel, package_from_path, split_label
 from tasks.libs.common.utils import get_repo_root
@@ -11,68 +9,85 @@ from tasks.libs.common.utils import get_repo_root
 
 class TestBazel(unittest.TestCase):
     def test_bazel_call(self):
-        self.assertEqual(bazel(Context(), "info", "release"), "")
+        self.assertEqual(bazel(None, "info", "release"), "")
 
     def test_bazel_output(self):
         expected_version = (get_repo_root() / ".bazelversion").read_text().strip()
-        actual_output = bazel(Context(), "info", "release", capture_output=True).strip()
+        actual_output = bazel(None, "info", "release", capture_output=True).strip()
         self.assertEqual(actual_output, f"release {expected_version}")
 
     @patch.dict(os.environ, {"PATH": os.devnull})
     def test_bazel_not_found(self):
-        with self.assertRaises(Exit) as cm:
-            bazel(MockContext(), "info")
-        self.assertIn("Please run `inv install-tools` for `bazel` support!", cm.exception.message)
+        with self.assertRaises(SystemExit) as cm:
+            bazel(None, "info")
+        self.assertIn("Please run `inv install-tools` for `bazel` support!", str(cm.exception.code))
 
+    @patch("tasks.libs.build.bazel._run_command")
     @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
-    def test_capture_output(self, _):
-        self.assertEqual(bazel(self._ctx(), "info", capture_output=True), "out\n")
+    def test_capture_output(self, _, run_command):
+        run_command.return_value = subprocess.CompletedProcess("/bzlx info", 0, "out\n", "")
+        self.assertEqual(bazel(None, "info", capture_output=True), "out\n")
 
+    @patch("tasks.libs.build.bazel._run_command")
     @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
-    def test_ignore_errors_returns_raw_result(self, _):
-        res = bazel(self._ctx(exit=1), "info", ignore_errors=True, capture_output=True)
-        self.assertFalse(res.ok)
+    def test_ignore_errors_returns_completed_process(self, _, run_command):
+        run_command.return_value = subprocess.CompletedProcess("/bzlx info", 1, "out\n", "err\n")
+        res = bazel(None, "info", ignore_errors=True, capture_output=True)
+        self.assertEqual(res.returncode, 1)
         self.assertEqual(res.stdout, "out\n")
         self.assertEqual(res.stderr, "err\n")
 
+    @patch("tasks.libs.build.bazel._run_command")
     @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
-    def test_input_stream_disabled_by_default(self, _):
-        ctx = self._ctx()
-        bazel(ctx, "info")
-        self.assertIs(ctx.run.call_args.kwargs["in_stream"], False)
+    def test_input_disabled_by_default(self, _, run_command):
+        run_command.return_value = subprocess.CompletedProcess("/bzlx info", 0, "", "")
+        bazel(None, "info")
+        self.assertIsNone(run_command.call_args.kwargs["input"])
 
+    @patch("tasks.libs.build.bazel._run_command")
     @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
-    def test_input_stream_forwarding(self, _):
-        ctx = self._ctx()
-        stdin = io.StringIO("some input")
-        bazel(ctx, "info", input_stream=stdin)
-        self.assertIs(ctx.run.call_args.kwargs["in_stream"], stdin)
+    def test_input_forwarding(self, _, run_command):
+        run_command.return_value = subprocess.CompletedProcess("/bzlx info", 0, "", "")
+        bazel(None, "info", input="some input")
+        self.assertEqual(run_command.call_args.kwargs["input"], "some input")
 
+    @patch("tasks.libs.build.bazel._run_command")
     @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
     @patch.dict(os.environ, {}, clear=True)
-    def test_no_omnibazel_flag_to_insert(self, _):
-        ctx = self._ctx()
-        bazel(ctx, "run", "//:go")
-        self.assertEqual(ctx.run.call_args[0][0], "/bzlx run //:go")
+    def test_no_omnibazel_flag_to_insert(self, _, run_command):
+        run_command.return_value = subprocess.CompletedProcess("/bzlx run //:go", 0, "", "")
+        bazel(None, "run", "//:go")
+        self.assertEqual(run_command.call_args.args[0], ("/bzlx", "run", "//:go"))
+        self.assertEqual(run_command.call_args.kwargs["cmdline"], "/bzlx run //:go")
 
+    @patch("tasks.libs.build.bazel._run_command")
     @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
     @patch.dict(os.environ, {"AGENT_FLAVOR": "fips", "INSTALL_DIR": "/opt"})
-    def test_inserted_omnibazel_flags(self, _):
-        ctx = self._ctx()
-        bazel(ctx, "--batch", "run", "//:go")
+    def test_inserted_omnibazel_flags(self, _, run_command):
+        run_command.return_value = subprocess.CompletedProcess(
+            "/bzlx --batch run --//packages/agent:flavor=fips --//:install_dir=/opt --//:output_config_dir= //:go",
+            0,
+            "",
+            "",
+        )
+        with patch("tasks.libs.build.bazel.sys.platform", "linux"):
+            bazel(None, "--batch", "run", "//:go")
         self.assertEqual(
-            ctx.run.call_args[0][0],
+            run_command.call_args.args[0],
+            (
+                "/bzlx",
+                "--batch",
+                "run",
+                "--//packages/agent:flavor=fips",
+                "--//:install_dir=/opt",
+                "--//:output_config_dir=",
+                "//:go",
+            ),
+        )
+        self.assertEqual(
+            run_command.call_args.kwargs["cmdline"],
             "/bzlx --batch run --//packages/agent:flavor=fips --//:install_dir=/opt --//:output_config_dir= //:go",
         )
-
-    def _ctx(self, *, exit=0, stdout="out\n", stderr="err\n"):
-        result = MagicMock()
-        result.ok = exit == 0
-        result.stdout = stdout
-        result.stderr = stderr
-        ctx = MagicMock()
-        ctx.run.return_value = result
-        return ctx
 
 
 class TestSplitLabel(unittest.TestCase):

--- a/tasks/unit_tests/libs/build/bazel_tests.py
+++ b/tasks/unit_tests/libs/build/bazel_tests.py
@@ -58,7 +58,6 @@ class TestBazel(unittest.TestCase):
         run_command.return_value = subprocess.CompletedProcess("/bzlx run //:go", 0, "", "")
         bazel(None, "run", "//:go")
         self.assertEqual(run_command.call_args.args[0], ("/bzlx", "run", "//:go"))
-        self.assertEqual(run_command.call_args.kwargs["cmdline"], "/bzlx run //:go")
 
     @patch("tasks.libs.build.bazel._run_command")
     @patch("tasks.libs.build.bazel.shutil.which", return_value="/bzlx")
@@ -83,10 +82,6 @@ class TestBazel(unittest.TestCase):
                 "--//:output_config_dir=",
                 "//:go",
             ),
-        )
-        self.assertEqual(
-            run_command.call_args.kwargs["cmdline"],
-            "/bzlx --batch run --//packages/agent:flavor=fips --//:install_dir=/opt --//:output_config_dir= //:go",
         )
 
 


### PR DESCRIPTION
### What does this PR do?

It switches the `bazel` helper to use stdlib `subprocess` to run bazel instead of `ctx.run`.

### Motivation

The main motivation for this change is that invoke relies on the stdlib [pty](https://docs.python.org/3/library/pty.html) module for handling the pseudo-terminal, and this library is only available on Unix. The consequence of this is that Bazel's output significantly degrades on Windows, with no color and notably with no rewriting of the output, causing very verbose output that is way harder to read than the default Bazel experience. Switching to `subprocess` sidesteps the need for explicit pty-like handling on Windows (at least as long as we don't want to also capture the output of the command). 

### Describe how you validated your changes

I ran both `dda inv test` and `dda inv test-new` locally, both on macos and on Windows, and the behavior looks right. And nothing broke in CI.

### Additional Notes

This PR attempts to reduce the number of callers modified at once by maintaining the `ctx` argument but not using it. A follow-up PR will remove this argument and fix all callers. The goal was to keep the review for this PR focused on the  subprocess handling without having to bring in a bunch of other reviewers. But other changes that affected only a limited number of callers (and which would have require more adaptation code to make work) have been kept as part of this PR.

All the extra handling to be able to "tee" the output is targeting the use case from `gotest.py` where output is both meant to be streamed in real time as well as captured for some post-processing logic. This is possibly the most useful feature that invoke was giving us here. In this case, Bazel output will also lose its interactive behavior. However, we're likely to not need this in the near future, once tests are run entirely with Bazel and/or finding other ways to achieve the same.
