### PR TITLE
Stop thrashing Bazel analysis cache after `bazel test`

### DIFF
--- a/bazel/configs/go_tests.bazelrc
+++ b/bazel/configs/go_tests.bazelrc
@@ -7,7 +7,7 @@ test --test_tag_filters=-tagset_linux_bpf
 test --test_env=GO_TEST_WRAP_TESTV=1
 
 # Go race detector for test invocations. Usage: bazel test --config=gorace //...
-test:gorace --@rules_go//go/config:race
+common:gorace --@rules_go//go/config:race # to use same analysis cache across test & run commands
 test:gorace --test_env=GORACE=atexit_sleep_ms=50
 
 # Complementary filters that partition a `bazel test //...` invocation in two, so

--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -63,7 +63,7 @@ def _go_test_packages(ctx, tags: list[str], import_paths: set[str]) -> dict[str,
         text = bazel(
             ctx,
             "run",
-            "--@rules_go//go/config:race",  # avoid thrashing the analysis cache right after `bazel test`
+            "--config=gorace",  # to use same analysis cache across test & run commands
             "//:go",
             "--",
             "list",
@@ -496,6 +496,7 @@ def _collect_test2json(ctx, test_artifacts, output_path):
         bazel(
             ctx,
             "run",
+            "--config=gorace",  # to use same analysis cache across test & run commands
             "//bazel/tools/testlogs_to_json",
             "--",
             "-manifest",


### PR DESCRIPTION
### Motivation
Both "Bazel analysis cache thrashing on `main`" monitors have been alerting since #54655 landed ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1956497162)): the `bazel run //bazel/tools/testlogs_to_json` it added to the `after_script` of every `.bazel:test:reporting` job carries none of the flags of the test invocation it follows, so Bazel drops the analysis cache and re-analyzes ~15000 targets.

### What does this PR do?
Pin `--config=gorace` on the post-`test` commands, which needs the race flag under `common:` rather than `test:` since `bazel run` never sees the latter.

This is the first of two steps: `bazel:coverage:linux-amd64` still flips 4 options, so the containerized monitor keeps alerting for that job.

`bazel coverage` indeed derives `--instrumentation_filter` from the target patterns, and no post-`test` command can replay a value Bazel computes on its own.

Some monitors are nevertheless expected to recover, their jobs seeing fewer flips.

### Describe how you validated your changes
`bazel run --noallow_analysis_cache_discard --config=gorace` after `bazel test --config=gorace` configures 0 targets, where the unpinned invocation warned and re-analyzed everything.

### Additional Notes
Moving the flag to `common:gorace` also unbreaks `bazel query --config=gorace`, which used to fail with "Config value 'gorace' is not defined in any .rc file" and left `dda inv test --race` **silently** detecting no Bazel-covered test at all.