### PR TITLE
fix(secret-backend): reject directory paths in file backend

### DIFF
--- a/cmd/secret-generic-connector/backend/file/text.go
+++ b/cmd/secret-generic-connector/backend/file/text.go
@@ -77,6 +77,10 @@ func (b *TextFileBackend) GetSecretOutput(_ context.Context, secretString string
 		es := fmt.Sprintf("failed to stat secret file '%s': %s", secretString, err.Error())
 		return secret.Output{Value: nil, Error: &es}
 	}
+	if info.IsDir() {
+		es := fmt.Sprintf("secret '%s' is a directory, not a file", secretString)
+		return secret.Output{Value: nil, Error: &es}
+	}
 
 	if info.Size() > b.Config.MaxFileReadSize {
 		es := fmt.Sprintf("secret file '%s' exceeds maximum size limit of %d bytes (actual: %d bytes)", secretString, b.Config.MaxFileReadSize, info.Size())

--- a/releasenotes/notes/aix-secret-backend-reject-directory-2c9e1f4a8b3d6e5f.yaml
+++ b/releasenotes/notes/aix-secret-backend-reject-directory-2c9e1f4a8b3d6e5f.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The file-based secret backend now rejects directory paths passed as a secret name.
+    On AIX, reading a directory with ``os.ReadFile`` returns raw directory bytes instead
+    of an error, which could cause a directory's contents to be returned as a secret value.


### PR DESCRIPTION
### What does this PR do?

Rejects directory paths in the file-based secret backend's `GetSecretOutput`.

### Motivation

On AIX, `os.ReadFile` on a directory returns raw directory bytes without an error, so an empty secret name (resolving to the secrets base directory) was returned as a non-empty secret value.

### Describe how you validated your changes

Ran `invoke test --targets=./cmd/secret-generic-connector/backend/file` on an AIX host; the previously failing `TestFileBackendGetSecretOutput/empty_secret_name` now passes.

### Additional Notes

N/A
