### PR TITLE
fix(traceutil): resolve Azure App Service runtime on AIX

### DIFF
--- a/pkg/trace/traceutil/azure.go
+++ b/pkg/trace/traceutil/azure.go
@@ -101,7 +101,7 @@ func getRuntime(websiteOS string) (rt string) {
 	switch websiteOS {
 	case "windows":
 		rt = getWindowsRuntime()
-	case "linux", "darwin":
+	case "linux", "darwin", "aix":
 		rt = getLinuxRuntime()
 	default:
 		rt = unknown

--- a/releasenotes/notes/aix-azure-runtime-7d2a3b5c9e1f4a6b.yaml
+++ b/releasenotes/notes/aix-azure-runtime-7d2a3b5c9e1f4a6b.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    ``getRuntime`` in ``pkg/trace/traceutil`` now resolves the runtime on AIX
+    using the Linux code path instead of returning ``unknown``.


### PR DESCRIPTION
### What does this PR do?

Adds `aix` to the Linux/darwin case in `getRuntime` so the Azure App Service runtime is resolved on AIX.

### Motivation

`getRuntime` only handled `linux` and `darwin` in the Linux code path, so on AIX it returned `unknown`.

### Describe how you validated your changes

Ran `invoke test --targets=./pkg/trace/traceutil` on an AIX host; the previously failing `TestGetAppServiceTags` now passes.

### Additional Notes

N/A
