### PR TITLE
fix(installer/config): copy directories in pure Go instead of cp -a

### DIFF
--- a/pkg/fleet/installer/config/config_nix.go
+++ b/pkg/fleet/installer/config/config_nix.go
@@ -10,12 +10,12 @@ package config
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/file"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/symlink"
-	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -98,10 +98,61 @@ func (d *Directories) RemoveExperiment(_ context.Context) error {
 }
 
 // copyDirectory copies a directory from source to target.
-// It preserves the directory structure and file permissions.
+// It preserves the directory structure, file permissions and symlinks,
+// mirroring the behavior of “cp -a“ without relying on a shell “cp“
+// binary (which is not portable, e.g. AIX “cp“ does not support “-a“).
 func copyDirectory(ctx context.Context, sourcePath, targetPath string) error {
-	cmd := telemetry.CommandContext(ctx, "cp", "-a", sourcePath, targetPath)
-	return cmd.Run()
+	return copyDirRecursive(ctx, sourcePath, targetPath)
+}
+
+func copyDirRecursive(ctx context.Context, src, dst string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		link, err := os.Readlink(src)
+		if err != nil {
+			return err
+		}
+		return os.Symlink(link, dst)
+	}
+	if !info.IsDir() {
+		return copyFileWithMode(src, dst, info.Mode())
+	}
+	if err := os.MkdirAll(dst, info.Mode()); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if err := copyDirRecursive(ctx, filepath.Join(src, entry.Name()), filepath.Join(dst, entry.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyFileWithMode(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return nil
 }
 
 func isSameFile(file1, file2 string) bool {

--- a/releasenotes/notes/aix-copydirectory-portable-5e8f2a4b1c9d3e7a.yaml
+++ b/releasenotes/notes/aix-copydirectory-portable-5e8f2a4b1c9d3e7a.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    ``copyDirectory`` in the fleet installer config package no longer shells out to
+    ``cp -a``, which is a GNU-specific flag not available on AIX. It now performs a
+    pure-Go recursive copy that preserves file permissions and symlinks.


### PR DESCRIPTION
### What does this PR do?

Replaces the `cp -a` shell-out in `copyDirectory` with a pure-Go recursive copy that preserves file permissions and symlinks.

### Motivation

`cp -a` is a GNU-specific flag not supported by AIX `cp`, causing `copyDirectory` to fail on AIX.

### Describe how you validated your changes

Ran `invoke test --targets=./pkg/fleet/installer/config` on an AIX host; the previously failing `TestConfigV2ToV3` now passes.

### Additional Notes

N/A
