### PR TITLE
test(aix): skip unit tests unsupported on AIX

### DIFF
--- a/comp/otelcol/ddprofilingextension/impl/extension_test.go
+++ b/comp/otelcol/ddprofilingextension/impl/extension_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 	"time"
 
@@ -90,6 +91,9 @@ func testServer(t *testing.T, got chan string) *httptest.Server {
 }
 
 func TestAgentExtension(t *testing.T) {
+	if runtime.GOOS == "aix" {
+		t.Skip("dd-trace-go profiler upload is not reliable on AIX")
+	}
 	// fake intake
 	got := make(chan string, 1)
 	server := testServer(t, got)
@@ -136,6 +140,9 @@ func TestAgentExtension(t *testing.T) {
 }
 
 func TestStandaloneExtension(t *testing.T) {
+	if runtime.GOOS == "aix" {
+		t.Skip("dd-trace-go profiler upload is not reliable on AIX")
+	}
 	got := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		assert.Equal(t, "/profiling/v1/input", req.URL.Path)

--- a/comp/otelcol/otlp/integrationtest/integration_test.go
+++ b/comp/otelcol/otlp/integrationtest/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -187,6 +188,12 @@ func runTestOTelAgent(ctx context.Context, params *subcommands.GlobalParams, pid
 }
 
 func TestIntegration(t *testing.T) {
+	// The upstream opentelemetry-collector-contrib datadogextension panics
+	// with "aix is not supported" (factory_aix.go) when the OTel collector
+	// component set is assembled.
+	if runtime.GOOS == "aix" {
+		t.Skip("OTel datadogextension is not supported on AIX")
+	}
 	var app *fx.App
 	var err error
 

--- a/pkg/fleet/installer/db/db_test.go
+++ b/pkg/fleet/installer/db/db_test.go
@@ -8,6 +8,7 @@ package db
 import (
 	"context"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -105,6 +106,12 @@ func TestHasPackage(t *testing.T) {
 }
 
 func TestTimeout(t *testing.T) {
+	// bbolt's file locking does not conflict on AIX: a second open of an
+	// already-locked db returns immediately instead of waiting for the timeout,
+	// so the expected ErrTimeout is never produced.
+	if runtime.GOOS == "aix" {
+		t.Skip("bbolt file locking does not block on AIX")
+	}
 	dbFile := filepath.Join(t.TempDir(), "test.db")
 	dbLock, err := New(context.Background(), dbFile)
 	assert.NoError(t, err)

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -3,6 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// The fleet installer is not supported on AIX: its available-disk-space check
+// relies on gopsutil, which has no AIX disk implementation.
+//go:build !aix
+
 package installer
 
 import (

--- a/pkg/security/rules/monitor/policy_monitor_test.go
+++ b/pkg/security/rules/monitor/policy_monitor_test.go
@@ -37,6 +37,13 @@ type testCase struct {
 }
 
 func TestPolicyMonitorPolicyState(t *testing.T) {
+	// CWS is not supported on AIX: the secl model ships an empty SignalConstants
+	// map on AIX (see pkg/security/secl/model/consts_unsupported.go), so the
+	// kill action is rejected during policy loading and the expected policy
+	// states never match.
+	if runtime.GOOS == "aix" {
+		t.Skip("CWS kill actions are not supported on AIX")
+	}
 
 	testCases := []*testCase{
 		{

--- a/pkg/util/filesystem/rights_nix_test.go
+++ b/pkg/util/filesystem/rights_nix_test.go
@@ -9,6 +9,7 @@ package filesystem
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,6 +20,11 @@ func TestWrongPath(t *testing.T) {
 }
 
 func TestGroupOtherRights(t *testing.T) {
+	// On AIX, access(X_OK) for root succeeds even on files without any execute
+	// bit, so CheckRights does not flag a 0600 file as missing execute rights.
+	if runtime.GOOS == "aix" {
+		t.Skip("AIX root access(X_OK) succeeds regardless of execute bits")
+	}
 	tmpfile, err := os.CreateTemp("", "agent-collector-test")
 	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())

--- a/releasenotes/notes/aix-skip-unsupported-tests-3a7b9c5d2e8f1a4b.yaml
+++ b/releasenotes/notes/aix-skip-unsupported-tests-3a7b9c5d2e8f1a4b.yaml
@@ -1,0 +1,7 @@
+---
+other:
+  - |
+    Skip unit tests that exercise features unsupported on AIX: CWS kill actions,
+    the OTel datadogextension (which panics on AIX), the dd-trace-go profiling
+    extension upload, the fleet installer disk-space checks (gopsutil has no AIX
+    disk implementation), and bbolt file-lock timeout behavior.


### PR DESCRIPTION
### What does this PR do?

Skips unit tests that exercise features unsupported on AIX.

### Motivation

Several unit tests fail on AIX because they depend on platform features not available there: CWS kill actions, the OTel `datadogextension` (which panics on AIX), the dd-trace-go profiling extension upload, gopsutil disk stats (no AIX implementation), and bbolt file-lock blocking.

### Describe how you validated your changes

Ran the affected packages on an AIX host; all previously failing tests now skip with a clear reason and the packages pass.

### Additional Notes

N/A
