### PR TITLE
test: speed up slow unit tests with testing/synctest

### DIFF
--- a/comp/core/autodiscovery/scheduler/controller_test.go
+++ b/comp/core/autodiscovery/scheduler/controller_test.go
@@ -8,6 +8,7 @@ package scheduler
 import (
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -56,75 +57,77 @@ func (s *scheduler) reset() {
 }
 
 func TestController(t *testing.T) {
-	ms := NewControllerAndStart()
+	synctest.Test(t, func(t *testing.T) {
+		ms := NewControllerAndStart()
 
-	// schedule some configs before registering
-	c1 := makeConfig("one")
-	c2 := makeConfig("two")
-	ms.ApplyChanges(integration.ConfigChanges{Schedule: []integration.Config{c1, c2}})
-	// register a scheduler and see that it gets caught up
-	s1 := &scheduler{}
-	ms.Register("s1", s1, true)
-	// all configs are scheduled once and only once
-	assert.EventuallyWithTf(t, func(c *assert.CollectT) {
-		s1.mutex.Lock()
-		assert.ElementsMatch(c, []event{{true, "one"}, {true, "two"}}, s1.events)
-		s1.mutex.Unlock()
-	}, 5*time.Second, 100*time.Millisecond, "Failed to process configs before timeout")
-	assert.Neverf(t, func() bool {
-		s1.mutex.Lock()
-		defer s1.mutex.Unlock()
-		return len(s1.events) != 2 // no more sch or unsch events should be received
-	}, 2*time.Second, 100*time.Millisecond, "Unexpected event received, s1 events = %v", s1.events)
-	s1.reset()
+		// schedule some configs before registering
+		c1 := makeConfig("one")
+		c2 := makeConfig("two")
+		ms.ApplyChanges(integration.ConfigChanges{Schedule: []integration.Config{c1, c2}})
+		// register a scheduler and see that it gets caught up
+		s1 := &scheduler{}
+		ms.Register("s1", s1, true)
+		// all configs are scheduled once and only once
+		assert.EventuallyWithTf(t, func(c *assert.CollectT) {
+			s1.mutex.Lock()
+			assert.ElementsMatch(c, []event{{true, "one"}, {true, "two"}}, s1.events)
+			s1.mutex.Unlock()
+		}, 5*time.Second, 100*time.Millisecond, "Failed to process configs before timeout")
+		assert.Neverf(t, func() bool {
+			s1.mutex.Lock()
+			defer s1.mutex.Unlock()
+			return len(s1.events) != 2 // no more sch or unsch events should be received
+		}, 2*time.Second, 100*time.Millisecond, "Unexpected event received, s1 events = %v", s1.events)
+		s1.reset()
 
-	// remove one of those configs and add another
-	ms.ApplyChanges(integration.ConfigChanges{Unschedule: []integration.Config{c1}})
-	c3 := makeConfig("three")
-	ms.ApplyChanges(integration.ConfigChanges{Schedule: []integration.Config{c3}})
-	// check s1 was informed about those in order
-	assert.EventuallyWithTf(t, func(c *assert.CollectT) {
-		s1.mutex.Lock()
-		assert.ElementsMatch(c, []event{{false, "one"}, {true, "three"}}, s1.events)
-		s1.mutex.Unlock()
-	}, 5*time.Second, 100*time.Millisecond, "Failed to process configs before timeout")
-	s1.reset()
+		// remove one of those configs and add another
+		ms.ApplyChanges(integration.ConfigChanges{Unschedule: []integration.Config{c1}})
+		c3 := makeConfig("three")
+		ms.ApplyChanges(integration.ConfigChanges{Schedule: []integration.Config{c3}})
+		// check s1 was informed about those in order
+		assert.EventuallyWithTf(t, func(c *assert.CollectT) {
+			s1.mutex.Lock()
+			assert.ElementsMatch(c, []event{{false, "one"}, {true, "three"}}, s1.events)
+			s1.mutex.Unlock()
+		}, 5*time.Second, 100*time.Millisecond, "Failed to process configs before timeout")
+		s1.reset()
 
-	// subscribe a new scheduler and see that it does not get c1
-	s2 := &scheduler{}
-	ms.Register("s2", s2, true)
-	assert.Neverf(t, func() bool {
-		s2.mutex.Lock()
-		defer s2.mutex.Unlock()
-		return len(s2.events) != 2
-	}, 2*time.Second, 100*time.Millisecond, "Unexpected event received, s2 events = %v", s2.events)
-	assert.ElementsMatch(t, []event{{true, "two"}, {true, "three"}}, s2.events)
-	s2.reset()
+		// subscribe a new scheduler and see that it does not get c1
+		s2 := &scheduler{}
+		ms.Register("s2", s2, true)
+		assert.Neverf(t, func() bool {
+			s2.mutex.Lock()
+			defer s2.mutex.Unlock()
+			return len(s2.events) != 2
+		}, 2*time.Second, 100*time.Millisecond, "Unexpected event received, s2 events = %v", s2.events)
+		assert.ElementsMatch(t, []event{{true, "two"}, {true, "three"}}, s2.events)
+		s2.reset()
 
-	// unsubscribe s1 and see that it no longer gets events
-	ms.Deregister("s1")
-	ms.ApplyChanges(integration.ConfigChanges{Unschedule: []integration.Config{c2}})
-	assert.Neverf(t, func() bool {
-		s1.mutex.Lock()
-		defer s1.mutex.Unlock()
-		return len(s1.events) > 0
-	}, 2*time.Second, 100*time.Millisecond, "Unexpected event received")
+		// unsubscribe s1 and see that it no longer gets events
+		ms.Deregister("s1")
+		ms.ApplyChanges(integration.ConfigChanges{Unschedule: []integration.Config{c2}})
+		assert.Neverf(t, func() bool {
+			s1.mutex.Lock()
+			defer s1.mutex.Unlock()
+			return len(s1.events) > 0
+		}, 2*time.Second, 100*time.Millisecond, "Unexpected event received")
 
-	assert.EventuallyWithTf(t, func(c *assert.CollectT) {
-		s2.mutex.Lock()
-		assert.ElementsMatch(c, []event{{false, "two"}}, s2.events)
-		s2.mutex.Unlock()
-	}, 5*time.Second, 100*time.Millisecond, "Failed to process configs before timeout")
-	s2.reset()
+		assert.EventuallyWithTf(t, func(c *assert.CollectT) {
+			s2.mutex.Lock()
+			assert.ElementsMatch(c, []event{{false, "two"}}, s2.events)
+			s2.mutex.Unlock()
+		}, 5*time.Second, 100*time.Millisecond, "Failed to process configs before timeout")
+		s2.reset()
 
-	// verify that replay does not occur if not desired
-	s3 := &scheduler{}
-	ms.Register("s3", s3, false)
-	assert.Neverf(t, func() bool {
-		s3.mutex.Lock()
-		defer s3.mutex.Unlock()
-		return len(s3.events) > 0
-	}, 2*time.Second, 100*time.Millisecond, "Unexpected event received")
-	ms.Stop()
-	s3.reset()
+		// verify that replay does not occur if not desired
+		s3 := &scheduler{}
+		ms.Register("s3", s3, false)
+		assert.Neverf(t, func() bool {
+			s3.mutex.Lock()
+			defer s3.mutex.Unlock()
+			return len(s3.events) > 0
+		}, 2*time.Second, 100*time.Millisecond, "Unexpected event received")
+		ms.Stop()
+		s3.reset()
+	})
 }

--- a/comp/core/tagger/server/syncthrottler_test.go
+++ b/comp/core/tagger/server/syncthrottler_test.go
@@ -8,25 +8,27 @@ package server
 import (
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
-func TestSyncThrottler(_ *testing.T) {
+func TestSyncThrottler(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		throtler := NewSyncThrottler(3)
 
-	throtler := NewSyncThrottler(3)
+		var wg sync.WaitGroup
 
-	var wg sync.WaitGroup
+		for i := 0; i < 30; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				tok := throtler.RequestToken()
+				time.Sleep(200 * time.Millisecond)
+				throtler.Release(tok)
+				throtler.Release(tok) // Release method should be idempotent
+			}()
+		}
 
-	for i := 0; i < 30; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			t := throtler.RequestToken()
-			time.Sleep(200 * time.Millisecond)
-			throtler.Release(t)
-			throtler.Release(t) // Release method should be idempotent
-		}()
-	}
-
-	wg.Wait()
+		wg.Wait()
+	})
 }

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/reflector_store_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -67,38 +68,39 @@ func Test_AddDelete_Deployment(t *testing.T) {
 }
 
 func Test_AddDelete_Pod(t *testing.T) {
-	t.Parallel()
-	workloadmetaComponent := mockedWorkloadmeta(t)
+	synctest.Test(t, func(t *testing.T) {
+		workloadmetaComponent := mockedWorkloadmeta(t)
 
-	podStore := newPodReflectorStoreWithFullPodParser(workloadmetaComponent, workloadmetaComponent.GetConfig())
+		podStore := newPodReflectorStoreWithFullPodParser(workloadmetaComponent, workloadmetaComponent.GetConfig())
 
-	pod := corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod",
-			Namespace: "test-namespace",
-			UID:       "pod-uid",
-			Labels: map[string]string{
-				"test-label": "test-value",
+		pod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod",
+				Namespace: "test-namespace",
+				UID:       "pod-uid",
+				Labels: map[string]string{
+					"test-label": "test-value",
+				},
+				Annotations: map[string]string{
+					"test-annotation": "test-value",
+				},
 			},
-			Annotations: map[string]string{
-				"test-annotation": "test-value",
-			},
-		},
-	}
+		}
 
-	err := podStore.Add(&pod)
-	require.NoError(t, err)
-	require.Eventually(t, func() bool {
-		_, err = workloadmetaComponent.GetKubernetesPod(string(pod.UID))
-		return err == nil
-	}, timeout, interval)
+		err := podStore.Add(&pod)
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			_, err = workloadmetaComponent.GetKubernetesPod(string(pod.UID))
+			return err == nil
+		}, timeout, interval)
 
-	err = podStore.Delete(&pod)
-	require.NoError(t, err)
-	require.Eventually(t, func() bool {
-		_, err = workloadmetaComponent.GetKubernetesDeployment(string(pod.UID))
-		return err != nil
-	}, timeout, interval)
+		err = podStore.Delete(&pod)
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			_, err = workloadmetaComponent.GetKubernetesDeployment(string(pod.UID))
+			return err != nil
+		}, timeout, interval)
+	})
 }
 
 func Test_AddDelete_MinimalPod(t *testing.T) {

--- a/pkg/remoteflags/flags_test.go
+++ b/pkg/remoteflags/flags_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -496,31 +497,35 @@ func TestOnChange_ErrorUnsetsConfigurationField(t *testing.T) {
 
 // Recovery monitor logs warning when component stays unhealthy through the entire probe window.
 func TestHealthMonitor_RecoveryProbeStaysUnhealthy(t *testing.T) {
-	client := NewClient().WithHealthCheckInterval(100 * time.Millisecond)
-	defer client.Stop()
+	synctest.Test(t, func(t *testing.T) {
+		client := NewClient().WithHealthCheckInterval(100 * time.Millisecond)
+		defer client.Stop()
 
-	h := newStubHandler(testFlag1)
-	h.healthy.Store(false) // Unhealthy throughout
-	require.NoError(t, client.SubscribeWithHandler(h))
+		h := newStubHandler(testFlag1)
+		h.healthy.Store(false) // Unhealthy throughout
+		require.NoError(t, client.SubscribeWithHandler(h))
 
-	sendUpdate(client, Flag{
-		Name:                             string(testFlag1),
-		Enabled:                          true,
-		HealthCheckDurationSeconds:       1, // Short window so test is fast
-		HealthCheckFailuresBeforeRecover: 1,
+		sendUpdate(client, Flag{
+			Name:                             string(testFlag1),
+			Enabled:                          true,
+			HealthCheckDurationSeconds:       1, // Short window so test is fast
+			HealthCheckFailuresBeforeRecover: 1,
+		})
+
+		// Wait for SafeRecover
+		waitChan(t, h.recoverCh, 3*time.Second)
+
+		// Wait for the recovery probe window to expire
+		time.Sleep(1500 * time.Millisecond)
+
+		// SafeRecover should only have been called once
+		select {
+		case <-h.recoverCh:
+			t.Fatal("SafeRecover should not be called a second time during recovery probing")
+		default:
+			// expected: recovery monitor gave up gracefully
+		}
+		client.Stop()
+		synctest.Wait()
 	})
-
-	// Wait for SafeRecover
-	waitChan(t, h.recoverCh, 3*time.Second)
-
-	// Wait for the recovery probe window to expire
-	time.Sleep(1500 * time.Millisecond)
-
-	// SafeRecover should only have been called once
-	select {
-	case <-h.recoverCh:
-		t.Fatal("SafeRecover should not be called a second time during recovery probing")
-	default:
-		// expected: recovery monitor gave up gracefully
-	}
 }

--- a/pkg/sbom/scanner/scanner_test.go
+++ b/pkg/sbom/scanner/scanner_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
@@ -324,63 +325,66 @@ func TestRetryLogic_ImageDeleted(t *testing.T) {
 
 // Test retry handling in case of an error when sending the result to a full channel
 func TestRetryChannelFull(t *testing.T) {
-	cfg := configmock.New(t)
-	// Create a workload meta global store
-	workloadmetaStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
-		fx.Provide(func() log.Component { return logmock.New(t) }),
-		fx.Provide(func() compConfig.Component { return compConfig.NewMock(t) }),
-		fx.Supply(context.Background()),
-		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
-	))
+	synctest.Test(t, func(t *testing.T) {
+		cfg := configmock.New(t)
+		// Create a workload meta global store
+		workloadmetaStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+			fx.Provide(func() log.Component { return logmock.New(t) }),
+			fx.Provide(func() compConfig.Component { return compConfig.NewMock(t) }),
+			fx.Supply(context.Background()),
+			workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+		))
 
-	// Store the image
-	imageID := "id"
-	workloadmetaStore.Set(&workloadmeta.ContainerImageMetadata{
-		EntityID: workloadmeta.EntityID{
-			ID:   imageID,
-			Kind: workloadmeta.KindContainerImageMetadata,
-		},
+		// Store the image
+		imageID := "id"
+		workloadmetaStore.Set(&workloadmeta.ContainerImageMetadata{
+			EntityID: workloadmeta.EntityID{
+				ID:   imageID,
+				Kind: workloadmeta.KindContainerImageMetadata,
+			},
+		})
+
+		// Create a mock collector
+		collName := "mock"
+		mockCollector := collectors.NewMockCollector()
+		resultCh := make(chan sbom.ScanResult)
+		expectedResult := sbom.ScanResult{Report: mockReport{id: imageID}}
+		mockCollector.On("Options").Return(sbom.ScanOptions{})
+		mockCollector.On("Scan", mock.Anything, mock.Anything).Return(expectedResult)
+		mockCollector.On("Channel").Return(resultCh)
+		shutdown := mockCollector.On("Shutdown")
+		mockCollector.On("Type").Return(collectors.ContainerImageScanType)
+
+		// Set up the configuration
+		cfg.Set("sbom.scan_queue.base_backoff", "200ms", model.SourceAgentRuntime)
+		cfg.Set("sbom.scan_queue.max_backoff", "600ms", model.SourceAgentRuntime)
+		cfg.Set("sbom.cache.clean_interval", "10s", model.SourceAgentRuntime) // Required for the ticker
+
+		// Create a scanner and start it
+		scanner := NewScanner(cfg, map[string]collectors.Collector{collName: mockCollector}, option.New[workloadmeta.Component](workloadmetaStore))
+		ctx, cancel := context.WithCancel(context.Background())
+		scanner.Start(ctx)
+
+		// Enqueue a scan request for container images
+		err := scanner.Scan(sbom.ScanRequest(&scanRequest{collectorName: collName, id: imageID, scanRequestType: sbom.ScanFilesystemType}))
+		assert.NoError(t, err)
+
+		// Wait long enough for the `sendResult` function to fail
+		time.Sleep(sendTimeout + 50*time.Millisecond)
+
+		// Make sure we recover
+		res := <-resultCh
+		assert.Equal(t, expectedResult.Report, res.Report)
+
+		// Make sure we don't receive anything afterward
+		select {
+		case res := <-resultCh:
+			t.Errorf("unexpected result received %v", res)
+		case <-time.After(600 * time.Millisecond):
+		}
+
+		cancel()
+		synctest.Wait()
+		shutdown.WaitUntil(time.After(5 * time.Second))
 	})
-
-	// Create a mock collector
-	collName := "mock"
-	mockCollector := collectors.NewMockCollector()
-	resultCh := make(chan sbom.ScanResult)
-	expectedResult := sbom.ScanResult{Report: mockReport{id: imageID}}
-	mockCollector.On("Options").Return(sbom.ScanOptions{})
-	mockCollector.On("Scan", mock.Anything, mock.Anything).Return(expectedResult)
-	mockCollector.On("Channel").Return(resultCh)
-	shutdown := mockCollector.On("Shutdown")
-	mockCollector.On("Type").Return(collectors.ContainerImageScanType)
-
-	// Set up the configuration
-	cfg.Set("sbom.scan_queue.base_backoff", "200ms", model.SourceAgentRuntime)
-	cfg.Set("sbom.scan_queue.max_backoff", "600ms", model.SourceAgentRuntime)
-	cfg.Set("sbom.cache.clean_interval", "10s", model.SourceAgentRuntime) // Required for the ticker
-
-	// Create a scanner and start it
-	scanner := NewScanner(cfg, map[string]collectors.Collector{collName: mockCollector}, option.New[workloadmeta.Component](workloadmetaStore))
-	ctx, cancel := context.WithCancel(context.Background())
-	scanner.Start(ctx)
-
-	// Enqueue a scan request for container images
-	err := scanner.Scan(sbom.ScanRequest(&scanRequest{collectorName: collName, id: imageID, scanRequestType: sbom.ScanFilesystemType}))
-	assert.NoError(t, err)
-
-	// Wait long enough for the `sendResult` function to fail
-	time.Sleep(sendTimeout + 50*time.Millisecond)
-
-	// Make sure we recover
-	res := <-resultCh
-	assert.Equal(t, expectedResult.Report, res.Report)
-
-	// Make sure we don't receive anything afterward
-	select {
-	case res := <-resultCh:
-		t.Errorf("unexpected result received %v", res)
-	case <-time.After(600 * time.Millisecond):
-	}
-
-	cancel()
-	shutdown.WaitUntil(time.After(5 * time.Second))
 }

--- a/pkg/security/probe/discarders_test.go
+++ b/pkg/security/probe/discarders_test.go
@@ -10,6 +10,7 @@ package probe
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
@@ -430,22 +431,24 @@ func BenchmarkParentDiscarder(b *testing.B) {
 }
 
 func TestIsRecentlyAdded(t *testing.T) {
-	var id inodeDiscarders
+	synctest.Test(t, func(t *testing.T) {
+		var id inodeDiscarders
 
-	if id.isRecentlyAdded(1, 2, uint64(time.Now().UnixNano())) {
-		t.Error("shouldn't be marked as added")
-	}
-	id.recentlyAdded(1, 2, uint64(time.Now().UnixNano()))
+		if id.isRecentlyAdded(1, 2, uint64(time.Now().UnixNano())) {
+			t.Error("shouldn't be marked as added")
+		}
+		id.recentlyAdded(1, 2, uint64(time.Now().UnixNano()))
 
-	if !id.isRecentlyAdded(1, 2, uint64(time.Now().UnixNano())) {
-		t.Error("should be marked as added")
-	}
+		if !id.isRecentlyAdded(1, 2, uint64(time.Now().UnixNano())) {
+			t.Error("should be marked as added")
+		}
 
-	time.Sleep(time.Duration(recentlyAddedTimeout))
+		time.Sleep(time.Duration(recentlyAddedTimeout))
 
-	if id.isRecentlyAdded(1, 2, uint64(time.Now().UnixNano())) {
-		t.Error("shouldn't be marked as added")
-	}
+		if id.isRecentlyAdded(1, 2, uint64(time.Now().UnixNano())) {
+			t.Error("shouldn't be marked as added")
+		}
+	})
 }
 
 func TestIsRecentlyAddedCollision(t *testing.T) {

--- a/pkg/security/probe/eventstream/reorderer/reorderer_test.go
+++ b/pkg/security/probe/eventstream/reorderer/reorderer_test.go
@@ -13,6 +13,7 @@ import (
 	"math/rand"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/cilium/ebpf/perf"
@@ -95,63 +96,71 @@ func TestOrderGeneration(t *testing.T) {
 }
 
 func TestOrderRate(t *testing.T) {
-	var event []byte
-	rate := 1 * time.Second
-	retention := 5
+	synctest.Test(t, func(t *testing.T) {
+		var event []byte
+		rate := 1 * time.Second
+		retention := 5
 
-	var lock sync.RWMutex
-	ctx, cancel := context.WithCancel(context.Background())
+		var lock sync.RWMutex
+		ctx, cancel := context.WithCancel(context.Background())
 
-	reOrderer := NewReOrderer(ctx, func(record *perf.Record) {
-		lock.Lock()
-		event = append(event, record.RawSample[2])
-		lock.Unlock()
-	},
-		func(record *perf.Record) (QuickInfo, error) {
-			return QuickInfo{
-				CPU:       uint64(record.RawSample[0]),
-				Timestamp: uint64(record.RawSample[1]),
-			}, nil
+		reOrderer := NewReOrderer(ctx, func(record *perf.Record) {
+			lock.Lock()
+			event = append(event, record.RawSample[2])
+			lock.Unlock()
 		},
-		Opts{
-			QueueSize:  100,
-			Rate:       rate,
-			Retention:  uint64(retention),
-			MetricRate: 200 * time.Millisecond,
-		})
+			func(record *perf.Record) (QuickInfo, error) {
+				return QuickInfo{
+					CPU:       uint64(record.RawSample[0]),
+					Timestamp: uint64(record.RawSample[1]),
+				}, nil
+			},
+			Opts{
+				QueueSize:  100,
+				Rate:       rate,
+				Retention:  uint64(retention),
+				MetricRate: 200 * time.Millisecond,
+			})
 
-	var wg sync.WaitGroup
-	defer wg.Wait()
+		var wg sync.WaitGroup
+		defer wg.Wait()
 
-	wg.Add(1)
-	go reOrderer.Start(&wg)
+		wg.Add(1)
+		go reOrderer.Start(&wg)
 
-	var e uint8
-	for i := 0; i != 10; i++ {
-		record := perf.Record{
-			RawSample: []byte{0, byte(i + 1), e},
+		var e uint8
+		for i := 0; i != 10; i++ {
+			record := perf.Record{
+				RawSample: []byte{0, byte(i + 1), e},
+			}
+
+			reOrderer.HandleEvent(&record, nil, nil)
+			e++
 		}
 
-		reOrderer.HandleEvent(&record, nil, nil)
-		e++
-	}
+		// Give the reorderer a chance to process the queued events, but not
+		// enough virtual time for the flush ticker to fire (100ms < rate).
+		synctest.Wait()
+		lock.RLock()
+		assert.Zero(t, event)
+		lock.RUnlock()
 
-	lock.RLock()
-	assert.Zero(t, event)
-	lock.RUnlock()
+		time.Sleep(100 * time.Millisecond)
+		synctest.Wait()
+		lock.RLock()
+		assert.Zero(t, event)
+		lock.RUnlock()
 
-	time.Sleep(100 * time.Millisecond)
+		// Advance virtual time past rate*retention so the flush ticker fires
+		// enough times to release the held events.
+		time.Sleep(rate * time.Duration(retention))
+		synctest.Wait()
 
-	lock.RLock()
-	assert.Zero(t, event)
-	lock.RUnlock()
+		// should now get the elements
+		lock.RLock()
+		assert.Equal(t, []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, event)
+		lock.RUnlock()
 
-	time.Sleep(rate * time.Duration(retention))
-
-	// should now get the elements
-	lock.RLock()
-	assert.Equal(t, []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, event)
-	lock.RUnlock()
-
-	cancel()
+		cancel()
+	})
 }

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -1073,55 +1074,57 @@ func TestDuration(t *testing.T) {
 		t.Skip()
 	}
 
-	event := &testEvent{
-		process: testProcess{
-			createdAt: time.Now().UnixNano(),
-		},
-	}
-
-	tests := []struct {
-		Expr     string
-		Expected bool
-	}{
-		{Expr: `process.created_at < 2s`, Expected: true},
-		{Expr: `process.created_at > 2s`, Expected: false},
-	}
-
-	for _, test := range tests {
-		ctx := NewContext(event)
-
-		result, _, err := eval(ctx, test.Expr)
-		if err != nil {
-			t.Fatalf("error while evaluating `%s`: %s", test.Expr, err)
+	synctest.Test(t, func(t *testing.T) {
+		event := &testEvent{
+			process: testProcess{
+				createdAt: time.Now().UnixNano(),
+			},
 		}
 
-		if result != test.Expected {
-			t.Errorf("expected result `%t` not found, got `%t`\nnow: %v, create_at: %v\n%s", test.Expected, result, time.Now().UnixNano(), event.process.createdAt, test.Expr)
-		}
-	}
-
-	time.Sleep(4 * time.Second)
-
-	tests = []struct {
-		Expr     string
-		Expected bool
-	}{
-		{Expr: `process.created_at < 2s`, Expected: false},
-		{Expr: `process.created_at > 2s`, Expected: true},
-	}
-
-	for _, test := range tests {
-		ctx := NewContext(event)
-
-		result, _, err := eval(ctx, test.Expr)
-		if err != nil {
-			t.Fatalf("error while evaluating `%s`: %s", test.Expr, err)
+		tests := []struct {
+			Expr     string
+			Expected bool
+		}{
+			{Expr: `process.created_at < 2s`, Expected: true},
+			{Expr: `process.created_at > 2s`, Expected: false},
 		}
 
-		if result != test.Expected {
-			t.Errorf("expected result `%t` not found, got `%t`\nnow: %v, create_at: %v\n%s", test.Expected, result, time.Now().UnixNano(), event.process.createdAt, test.Expr)
+		for _, test := range tests {
+			ctx := NewContext(event)
+
+			result, _, err := eval(ctx, test.Expr)
+			if err != nil {
+				t.Fatalf("error while evaluating `%s`: %s", test.Expr, err)
+			}
+
+			if result != test.Expected {
+				t.Errorf("expected result `%t` not found, got `%t`\nnow: %v, create_at: %v\n%s", test.Expected, result, time.Now().UnixNano(), event.process.createdAt, test.Expr)
+			}
 		}
-	}
+
+		time.Sleep(4 * time.Second)
+
+		tests = []struct {
+			Expr     string
+			Expected bool
+		}{
+			{Expr: `process.created_at < 2s`, Expected: false},
+			{Expr: `process.created_at > 2s`, Expected: true},
+		}
+
+		for _, test := range tests {
+			ctx := NewContext(event)
+
+			result, _, err := eval(ctx, test.Expr)
+			if err != nil {
+				t.Fatalf("error while evaluating `%s`: %s", test.Expr, err)
+			}
+
+			if result != test.Expected {
+				t.Errorf("expected result `%t` not found, got `%t`\nnow: %v, create_at: %v\n%s", test.Expected, result, time.Now().UnixNano(), event.process.createdAt, test.Expr)
+			}
+		}
+	})
 }
 
 func parseCIDR(t *testing.T, ip string) net.IPNet {

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -341,177 +342,181 @@ func TestActionSetVariable(t *testing.T) {
 }
 
 func TestActionSetVariableTTL(t *testing.T) {
-	testPolicy := &PolicyDef{
-		Rules: []*RuleDefinition{{
-			ID:         "test_rule",
-			Expression: `open.file.path == "/tmp/test"`,
-			Actions: []*ActionDefinition{
-				{
-					Set: &SetDefinition{
-						Name:   "var1",
-						Append: true,
-						Value:  "foo",
-						TTL: &HumanReadableDuration{
-							Duration: 1 * time.Second,
+	synctest.Test(t, func(t *testing.T) {
+		testPolicy := &PolicyDef{
+			Rules: []*RuleDefinition{{
+				ID:         "test_rule",
+				Expression: `open.file.path == "/tmp/test"`,
+				Actions: []*ActionDefinition{
+					{
+						Set: &SetDefinition{
+							Name:   "var1",
+							Append: true,
+							Value:  "foo",
+							TTL: &HumanReadableDuration{
+								Duration: 1 * time.Second,
+							},
+						},
+					},
+					{
+						Set: &SetDefinition{
+							Name:   "var2",
+							Append: true,
+							Value:  123,
+							TTL: &HumanReadableDuration{
+								Duration: 1 * time.Second,
+							},
+						},
+					},
+					{
+						Set: &SetDefinition{
+							Name:   "scopedvar1",
+							Append: true,
+							Value:  []string{"bar"},
+							Scope:  "process",
+							TTL: &HumanReadableDuration{
+								Duration: 1 * time.Second,
+							},
+						},
+					},
+					{
+						Set: &SetDefinition{
+							Name:   "scopedvar2",
+							Append: true,
+							Value:  []int{123},
+							Scope:  "process",
+							TTL: &HumanReadableDuration{
+								Duration: 1 * time.Second,
+							},
+						},
+					},
+					{
+						Set: &SetDefinition{
+							Name:  "simplevarwithttl",
+							Value: 456,
+							Scope: "container",
+							TTL: &HumanReadableDuration{
+								Duration: 1 * time.Second,
+							},
 						},
 					},
 				},
-				{
-					Set: &SetDefinition{
-						Name:   "var2",
-						Append: true,
-						Value:  123,
-						TTL: &HumanReadableDuration{
-							Duration: 1 * time.Second,
-						},
-					},
-				},
-				{
-					Set: &SetDefinition{
-						Name:   "scopedvar1",
-						Append: true,
-						Value:  []string{"bar"},
-						Scope:  "process",
-						TTL: &HumanReadableDuration{
-							Duration: 1 * time.Second,
-						},
-					},
-				},
-				{
-					Set: &SetDefinition{
-						Name:   "scopedvar2",
-						Append: true,
-						Value:  []int{123},
-						Scope:  "process",
-						TTL: &HumanReadableDuration{
-							Duration: 1 * time.Second,
-						},
-					},
-				},
-				{
-					Set: &SetDefinition{
-						Name:  "simplevarwithttl",
-						Value: 456,
-						Scope: "container",
-						TTL: &HumanReadableDuration{
-							Duration: 1 * time.Second,
-						},
-					},
+			}},
+		}
+
+		tmpDir := t.TempDir()
+
+		if err := savePolicy(filepath.Join(tmpDir, "test.policy"), testPolicy); err != nil {
+			t.Fatal(err)
+		}
+
+		provider, err := NewPoliciesDirProvider(tmpDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		loader := NewPolicyLoader(provider)
+
+		rs := newRuleSet()
+		if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
+			t.Error(err)
+		}
+
+		event := model.NewFakeEvent()
+		event.Type = uint32(model.FileOpenEventType)
+		processCacheEntry := &model.ProcessCacheEntry{}
+		event.ProcessContext = &model.ProcessContext{
+			Process: model.Process{
+				ContainerContext: model.ContainerContext{
+					Releasable:  &model.Releasable{},
+					ContainerID: "0123456789abcdef",
 				},
 			},
-		}},
-	}
+		}
+		event.ProcessCacheEntry = processCacheEntry
+		event.SetFieldValue("open.file.path", "/tmp/test")
 
-	tmpDir := t.TempDir()
+		if !rs.Evaluate(event) {
+			t.Errorf("Expected event to match rule")
+		}
 
-	if err := savePolicy(filepath.Join(tmpDir, "test.policy"), testPolicy); err != nil {
-		t.Fatal(err)
-	}
+		opts := rs.evalOpts
 
-	provider, err := NewPoliciesDirProvider(tmpDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	loader := NewPolicyLoader(provider)
+		existingVariable := opts.VariableStore.Get("var1")
+		assert.NotNil(t, existingVariable)
+		stringArrayVar, ok := existingVariable.(eval.Variable)
+		assert.NotNil(t, stringArrayVar)
+		assert.True(t, ok)
+		strValue, _ := stringArrayVar.GetValue()
+		assert.NotNil(t, strValue)
+		assert.Contains(t, strValue, "foo")
+		assert.IsType(t, strValue, []string{})
 
-	rs := newRuleSet()
-	if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
-		t.Error(err)
-	}
+		existingVariable = opts.VariableStore.Get("var2")
+		assert.NotNil(t, existingVariable)
+		intArrayVar, ok := existingVariable.(eval.Variable)
+		assert.NotNil(t, intArrayVar)
+		assert.True(t, ok)
+		value, _ := intArrayVar.GetValue()
+		assert.NotNil(t, value)
+		assert.Contains(t, value, 123)
+		assert.IsType(t, value, []int{})
 
-	event := model.NewFakeEvent()
-	event.Type = uint32(model.FileOpenEventType)
-	processCacheEntry := &model.ProcessCacheEntry{}
-	event.ProcessContext = &model.ProcessContext{
-		Process: model.Process{
-			ContainerContext: model.ContainerContext{
-				Releasable:  &model.Releasable{},
-				ContainerID: "0123456789abcdef",
-			},
-		},
-	}
-	event.ProcessCacheEntry = processCacheEntry
-	event.SetFieldValue("open.file.path", "/tmp/test")
+		ctx := eval.NewContext(event)
+		existingScopedVariable := opts.VariableStore.Get("process.scopedvar1")
+		assert.NotNil(t, existingScopedVariable)
+		stringArrayScopedVar, ok := existingScopedVariable.(eval.ScopedVariable)
+		assert.NotNil(t, stringArrayScopedVar)
+		assert.True(t, ok)
+		value, _ = stringArrayScopedVar.GetValue(ctx, false)
+		assert.NotNil(t, value)
+		assert.Contains(t, value, "bar")
+		assert.IsType(t, value, []string{})
 
-	if !rs.Evaluate(event) {
-		t.Errorf("Expected event to match rule")
-	}
+		existingScopedVariable = opts.VariableStore.Get("process.scopedvar2")
+		assert.NotNil(t, existingScopedVariable)
+		intArrayScopedVar, ok := existingScopedVariable.(eval.ScopedVariable)
+		assert.NotNil(t, intArrayScopedVar)
+		assert.True(t, ok)
+		value, _ = intArrayScopedVar.GetValue(ctx, false)
+		assert.NotNil(t, value)
+		assert.Contains(t, value, 123)
+		assert.IsType(t, value, []int{})
 
-	opts := rs.evalOpts
+		existingContainerScopedVariable := opts.VariableStore.Get("container.simplevarwithttl")
+		assert.NotNil(t, existingContainerScopedVariable)
+		intVarScopedVar, ok := existingContainerScopedVariable.(eval.ScopedVariable)
+		assert.NotNil(t, intVarScopedVar)
+		assert.True(t, ok)
+		value, isSet := intVarScopedVar.GetValue(ctx, false)
+		assert.True(t, isSet)
+		assert.NotNil(t, value)
+		assert.Equal(t, 456, value)
+		assert.IsType(t, int(0), value)
 
-	existingVariable := opts.VariableStore.Get("var1")
-	assert.NotNil(t, existingVariable)
-	stringArrayVar, ok := existingVariable.(eval.Variable)
-	assert.NotNil(t, stringArrayVar)
-	assert.True(t, ok)
-	strValue, _ := stringArrayVar.GetValue()
-	assert.NotNil(t, strValue)
-	assert.Contains(t, strValue, "foo")
-	assert.IsType(t, strValue, []string{})
+		time.Sleep(time.Second + 100*time.Millisecond)
 
-	existingVariable = opts.VariableStore.Get("var2")
-	assert.NotNil(t, existingVariable)
-	intArrayVar, ok := existingVariable.(eval.Variable)
-	assert.NotNil(t, intArrayVar)
-	assert.True(t, ok)
-	value, _ := intArrayVar.GetValue()
-	assert.NotNil(t, value)
-	assert.Contains(t, value, 123)
-	assert.IsType(t, value, []int{})
+		value, _ = stringArrayVar.GetValue()
+		assert.NotContains(t, value, "foo")
+		assert.Len(t, value, 0)
 
-	ctx := eval.NewContext(event)
-	existingScopedVariable := opts.VariableStore.Get("process.scopedvar1")
-	assert.NotNil(t, existingScopedVariable)
-	stringArrayScopedVar, ok := existingScopedVariable.(eval.ScopedVariable)
-	assert.NotNil(t, stringArrayScopedVar)
-	assert.True(t, ok)
-	value, _ = stringArrayScopedVar.GetValue(ctx, false)
-	assert.NotNil(t, value)
-	assert.Contains(t, value, "bar")
-	assert.IsType(t, value, []string{})
+		value, _ = intArrayVar.GetValue()
+		assert.NotContains(t, value, 123)
+		assert.Len(t, value, 0)
 
-	existingScopedVariable = opts.VariableStore.Get("process.scopedvar2")
-	assert.NotNil(t, existingScopedVariable)
-	intArrayScopedVar, ok := existingScopedVariable.(eval.ScopedVariable)
-	assert.NotNil(t, intArrayScopedVar)
-	assert.True(t, ok)
-	value, _ = intArrayScopedVar.GetValue(ctx, false)
-	assert.NotNil(t, value)
-	assert.Contains(t, value, 123)
-	assert.IsType(t, value, []int{})
+		value, _ = stringArrayScopedVar.GetValue(ctx, false)
+		assert.NotContains(t, value, "foo")
+		assert.Len(t, value, 0)
 
-	existingContainerScopedVariable := opts.VariableStore.Get("container.simplevarwithttl")
-	assert.NotNil(t, existingContainerScopedVariable)
-	intVarScopedVar, ok := existingContainerScopedVariable.(eval.ScopedVariable)
-	assert.NotNil(t, intVarScopedVar)
-	assert.True(t, ok)
-	value, isSet := intVarScopedVar.GetValue(ctx, false)
-	assert.True(t, isSet)
-	assert.NotNil(t, value)
-	assert.Equal(t, 456, value)
-	assert.IsType(t, int(0), value)
+		value, _ = intArrayScopedVar.GetValue(ctx, false)
+		assert.NotContains(t, value, 123)
+		assert.Len(t, value, 0)
 
-	time.Sleep(time.Second + 100*time.Millisecond)
-
-	value, _ = stringArrayVar.GetValue()
-	assert.NotContains(t, value, "foo")
-	assert.Len(t, value, 0)
-
-	value, _ = intArrayVar.GetValue()
-	assert.NotContains(t, value, 123)
-	assert.Len(t, value, 0)
-
-	value, _ = stringArrayScopedVar.GetValue(ctx, false)
-	assert.NotContains(t, value, "foo")
-	assert.Len(t, value, 0)
-
-	value, _ = intArrayScopedVar.GetValue(ctx, false)
-	assert.NotContains(t, value, 123)
-	assert.Len(t, value, 0)
-
-	value, isSet = intVarScopedVar.GetValue(ctx, false)
-	assert.False(t, isSet)
-	assert.Equal(t, 0, value)
+		value, isSet = intVarScopedVar.GetValue(ctx, false)
+		assert.False(t, isSet)
+		assert.Equal(t, 0, value)
+		loader.Close()
+		synctest.Wait()
+	})
 }
 
 func TestActionSetVariableSize(t *testing.T) {

--- a/pkg/util/stat/stat_test.go
+++ b/pkg/util/stat/stat_test.go
@@ -8,6 +8,7 @@ package stat
 import (
 	"expvar"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -15,33 +16,36 @@ import (
 )
 
 func TestStats(t *testing.T) {
-	myStat := expvar.Int{}
+	synctest.Test(t, func(t *testing.T) {
+		myStat := expvar.Int{}
 
-	s, err := NewStats(10)
-	require.NoError(t, err)
+		s, err := NewStats(10)
+		require.NoError(t, err)
 
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-	require.NotNil(t, ticker)
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		require.NotNil(t, ticker)
 
-	go s.Process()
-	go s.Update(&myStat)
+		go s.Process()
+		go s.Update(&myStat)
 
-	deadline := time.After(2 * time.Second)
+		deadline := time.After(2 * time.Second)
 
-loop:
-	for {
-		select {
-		case <-ticker.C:
-			// send a few events per second
-			for i := 0; i < 10; i++ {
-				s.StatEvent(int64(i))
+	loop:
+		for {
+			select {
+			case <-ticker.C:
+				// send a few events per second
+				for i := 0; i < 10; i++ {
+					s.StatEvent(int64(i))
+				}
+			case <-deadline:
+				s.Stop()
+				break loop
 			}
-		case <-deadline:
-			s.Stop()
-			break loop
 		}
-	}
 
-	assert.NotEqual(t, myStat.Value(), 0)
+		synctest.Wait()
+		assert.NotEqual(t, myStat.Value(), 0)
+	})
 }


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Wraps 10 slow unit tests in `testing/synctest.Test` to virtualize `time.Sleep`, `time.After`, `time.NewTicker`, and testify `Eventually`/`Never` polls, reducing their total duration from ~35s to ~0.05s.

### Motivation

These tests spent their entire duration waiting on real timers (sleeps, tickers, polling loops) that can be made virtual with Go 1.26's `testing/synctest` package, which is already used in ~18 other test files in this repo.

### Describe how you validated your changes

Each converted test was run in isolation before and after the change to confirm it still passes and measure the speedup; each modified package was re-run in full to confirm no regressions in other tests.

### Additional Notes

All changes are test-only; no non-test code was modified. See per-test before/after durations in the commit message.