### PR TITLE
test: disable cloud provider metadata in unit tests to avoid real HTTP calls

### DIFF
--- a/comp/metadata/host/impl/host_test.go
+++ b/comp/metadata/host/impl/host_test.go
@@ -184,6 +184,8 @@ func TestBackoffWhenEarlyIntervalEqualsCollectionInterval(t *testing.T) {
 }
 
 func TestFlareProvider(t *testing.T) {
+	// Disable cloud provider metadata to avoid real HTTP calls
+	config.NewMock(t).SetInTest("cloud_provider_metadata", []string{})
 	ret := NewComponent(
 		makeRequires(fxutil.Test[testDeps](
 			t,

--- a/comp/metadata/host/impl/utils/host_test.go
+++ b/comp/metadata/host/impl/utils/host_test.go
@@ -31,6 +31,10 @@ func TestOTLPEnabled(t *testing.T) {
 
 	ctx := context.Background()
 	conf := configmock.New(t)
+	// Disable cloud provider metadata detection to avoid real HTTP calls to
+	// EC2 IMDS / GCP / Azure metadata endpoints, which each take up to the
+	// ec2_metadata_timeout (300ms default) to fail on non-cloud hosts.
+	conf.SetInTest("cloud_provider_metadata", []string{})
 
 	defer func(orig func(cfg model.Reader) bool) { otlpIsEnabled = orig }(otlpIsEnabled)
 
@@ -133,6 +137,7 @@ func TestGetPayload(t *testing.T) {
 
 	ctx := context.Background()
 	conf := configmock.New(t)
+	conf.SetInTest("cloud_provider_metadata", []string{})
 
 	_, found := cache.Cache.Get(hostCacheKey)
 	assert.False(t, found)

--- a/comp/metadata/host/impl/utils/meta_test.go
+++ b/comp/metadata/host/impl/utils/meta_test.go
@@ -19,6 +19,7 @@ import (
 func TestGetMeta(t *testing.T) {
 	ctx := context.Background()
 	cfg := config.NewMock(t)
+	cfg.SetInTest("cloud_provider_metadata", []string{})
 
 	meta := getMeta(ctx, cfg, hostnameimpl.NewHostnameService())
 	assert.NotEmpty(t, meta.SocketHostname)
@@ -29,6 +30,7 @@ func TestGetMeta(t *testing.T) {
 func TestGetMetaFromCache(t *testing.T) {
 	ctx := context.Background()
 	cfg := config.NewMock(t)
+	cfg.SetInTest("cloud_provider_metadata", []string{})
 
 	cache.Cache.Set(metaCacheKey, &Meta{
 		SocketHostname: "socket_test",

--- a/comp/process/agent/impl/status_test.go
+++ b/comp/process/agent/impl/status_test.go
@@ -48,6 +48,7 @@ func TestStatus(t *testing.T) {
 	defer server.Close()
 
 	configComponent := config.NewMock(t)
+	configComponent.SetInTest("cloud_provider_metadata", []string{})
 
 	headerProvider := StatusProvider{
 		testServerURL: server.URL,

--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -114,7 +114,7 @@ func TestBundleOneShot(t *testing.T) {
 		),
 		fx.Provide(func() log.Component { return logmock.New(t) }),
 		fx.Provide(func() config.Component {
-			return config.NewMockWithOverrides(t, map[string]interface{}{"hostname": "testhost"})
+			return config.NewMockWithOverrides(t, map[string]interface{}{"hostname": "testhost", "cloud_provider_metadata": []string{}})
 		}),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 		fx.Provide(func() tagger.Component { return taggerfxmock.SetupFakeTagger(t) }),

--- a/comp/process/status/impl/status_test.go
+++ b/comp/process/status/impl/status_test.go
@@ -46,6 +46,7 @@ func TestStatus(t *testing.T) {
 	defer server.Close()
 
 	configComponent := config.NewMock(t)
+	configComponent.SetInTest("cloud_provider_metadata", []string{})
 
 	headerProvider := statusProvider{
 		testServerURL: server.URL,

--- a/pkg/process/util/status/status_test.go
+++ b/pkg/process/util/status/status_test.go
@@ -80,6 +80,7 @@ func TestGetStatus(t *testing.T) {
 	env.SetFeatures(t)
 	cfg.SetInTest("hostname", "test") // Prevents panic since feature detection has not run
 	cfg.SetInTest("language_detection.enabled", true)
+	cfg.SetInTest("cloud_provider_metadata", []string{}) // Avoid real HTTP calls to cloud metadata
 
 	expectedStatus := &Status{
 		Date: float64(testTime.UnixNano()),

--- a/pkg/util/kubernetes/clustername/clustername_test.go
+++ b/pkg/util/kubernetes/clustername/clustername_test.go
@@ -18,6 +18,9 @@ import (
 func TestGetClusterName(t *testing.T) {
 	ctx := context.Background()
 	mockConfig := configmock.New(t)
+	// Disable cloud provider metadata detection to avoid real HTTP calls to
+	// EC2/GCE/Azure metadata endpoints.
+	mockConfig.SetInTest("cloud_provider_metadata", []string{})
 	env.SetFeatures(t, env.Kubernetes)
 	data := newClusterNameData()
 


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Sets `cloud_provider_metadata` to empty in 10 unit tests that transitively call EC2/GCP/Azure IMDS HTTP endpoints, reducing their total duration from ~77s to ~2s.

### Motivation

These tests call `GetPayload` or `hostname.Get` which transitively attempt real HTTP calls to cloud metadata endpoints (169.254.169.254) with 300ms timeouts; on non-cloud or AWS hosts these calls fail after timing out, wasting ~75 × 300ms = ~22s per test.

### Describe how you validated your changes

Each fixed test was run in isolation before and after the change to confirm it still passes and measure the speedup; each modified package was re-run in full to confirm no regressions.

### Additional Notes

All changes are test-only (one-line `SetInTest` config override per test); no non-test code was modified. See per-test before/after durations in the commit message.