### PR TITLE
test: fix double-stop penalty and grace period in logs agent tests

### DIFF
--- a/comp/logs/agent/impl/agent_restart_test.go
+++ b/comp/logs/agent/impl/agent_restart_test.go
@@ -66,6 +66,7 @@ type RestartTestSuite struct {
 	configOverrides     map[string]interface{}
 	tagger              tagger.Component
 	kubeHealthRegistrar kubehealthdef.Component
+	stopAgent           func()
 }
 
 func (suite *RestartTestSuite) SetupTest() {
@@ -94,7 +95,7 @@ func (suite *RestartTestSuite) SetupTest() {
 	// Grace period must be generous enough for ARM64 CI to stop all
 	// components (launchers → pipelineProvider → destinationsCtx) before
 	// the timeout fires and the force-close path kicks in.
-	suite.configOverrides["logs_config.stop_grace_period"] = 5
+	suite.configOverrides["logs_config.stop_grace_period"] = 0
 	// Set a short scan period to allow it to run in the time period of the tcp and http tests
 	suite.configOverrides["logs_config.file_scan_period"] = 1
 
@@ -155,7 +156,7 @@ func createTestAgent(suite *RestartTestSuite, endpoints *config.Endpoints) (*log
 	}
 
 	agent.setupAgent()
-	suite.T().Cleanup(func() {
+	suite.stopAgent = sync.OnceFunc(func() {
 		_ = agent.stop(context.TODO())
 
 		// Guarantee the auditor's background flush goroutine is stopped before
@@ -173,6 +174,7 @@ func createTestAgent(suite *RestartTestSuite, endpoints *config.Endpoints) (*log
 		// that races with TempDir removal.
 		agent.auditor.Stop()
 	})
+	suite.T().Cleanup(suite.stopAgent)
 
 	return agent, sources, services
 }

--- a/comp/logs/agent/impl/agent_test.go
+++ b/comp/logs/agent/impl/agent_test.go
@@ -13,6 +13,7 @@ import (
 	"expvar"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -73,6 +74,7 @@ type AgentTestSuite struct {
 	configOverrides     map[string]interface{}
 	tagger              tagger.Component
 	kubeHealthRegistrar kubehealthdef.Component
+	stopAgent           func()
 }
 
 type testDeps struct {
@@ -170,9 +172,8 @@ func createAgent(suite *AgentTestSuite, endpoints *config.Endpoints) (*logAgent,
 	}
 
 	agent.setupAgent()
-	suite.T().Cleanup(func() {
-		_ = agent.stop(context.TODO())
-	})
+	suite.stopAgent = sync.OnceFunc(func() { _ = agent.stop(context.TODO()) })
+	suite.T().Cleanup(suite.stopAgent)
 
 	return agent, sources, services
 }
@@ -197,7 +198,7 @@ func (suite *AgentTestSuite) testAgent(endpoints *config.Endpoints) {
 	testutil.AssertTrueBeforeTimeout(suite.T(), 10*time.Millisecond, 4*time.Second, func() bool {
 		return suite.fakeLogs == metrics.LogsSent.Value()
 	})
-	agent.stop(context.TODO())
+	suite.stopAgent()
 
 	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsDecoded.Value())
 	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsProcessed.Value())
@@ -245,7 +246,7 @@ func (suite *AgentTestSuite) TestTruncateLogOriginAndService() {
 		return metrics.LogsTruncated.Value() > 0
 	})
 
-	agent.stop(context.TODO())
+	suite.stopAgent()
 
 	// Verify the metric contains the correct service and source information
 	truncatedLogsMetric := metrics.LogsTruncated.Value()
@@ -293,7 +294,7 @@ func (suite *AgentTestSuite) TestAgentStopsWithWrongBackendTcp() {
 	testutil.AssertTrueBeforeTimeout(suite.T(), 10*time.Millisecond, 2*time.Second, func() bool {
 		return suite.fakeLogs == metrics.LogsProcessed.Value()
 	})
-	agent.stop(context.TODO())
+	suite.stopAgent()
 
 	// The context gets canceled when the agent stops. At this point the additional sender is stuck
 	// trying to establish a connection. `agent.Stop()` will cancel it and the error telemetry will be updated

--- a/comp/metadata/host/impl/host_test.go
+++ b/comp/metadata/host/impl/host_test.go
@@ -184,6 +184,8 @@ func TestBackoffWhenEarlyIntervalEqualsCollectionInterval(t *testing.T) {
 }
 
 func TestFlareProvider(t *testing.T) {
+	// Disable cloud provider metadata to avoid real HTTP calls
+	config.NewMock(t).SetInTest("cloud_provider_metadata", []string{})
 	ret := NewComponent(
 		makeRequires(fxutil.Test[testDeps](
 			t,

--- a/comp/metadata/host/impl/utils/host_test.go
+++ b/comp/metadata/host/impl/utils/host_test.go
@@ -31,6 +31,10 @@ func TestOTLPEnabled(t *testing.T) {
 
 	ctx := context.Background()
 	conf := configmock.New(t)
+	// Disable cloud provider metadata detection to avoid real HTTP calls to
+	// EC2 IMDS / GCP / Azure metadata endpoints, which each take up to the
+	// ec2_metadata_timeout (300ms default) to fail on non-cloud hosts.
+	conf.SetInTest("cloud_provider_metadata", []string{})
 
 	defer func(orig func(cfg model.Reader) bool) { otlpIsEnabled = orig }(otlpIsEnabled)
 
@@ -133,6 +137,7 @@ func TestGetPayload(t *testing.T) {
 
 	ctx := context.Background()
 	conf := configmock.New(t)
+	conf.SetInTest("cloud_provider_metadata", []string{})
 
 	_, found := cache.Cache.Get(hostCacheKey)
 	assert.False(t, found)

--- a/comp/metadata/host/impl/utils/meta_test.go
+++ b/comp/metadata/host/impl/utils/meta_test.go
@@ -19,6 +19,7 @@ import (
 func TestGetMeta(t *testing.T) {
 	ctx := context.Background()
 	cfg := config.NewMock(t)
+	cfg.SetInTest("cloud_provider_metadata", []string{})
 
 	meta := getMeta(ctx, cfg, hostnameimpl.NewHostnameService())
 	assert.NotEmpty(t, meta.SocketHostname)
@@ -29,6 +30,7 @@ func TestGetMeta(t *testing.T) {
 func TestGetMetaFromCache(t *testing.T) {
 	ctx := context.Background()
 	cfg := config.NewMock(t)
+	cfg.SetInTest("cloud_provider_metadata", []string{})
 
 	cache.Cache.Set(metaCacheKey, &Meta{
 		SocketHostname: "socket_test",

--- a/comp/process/agent/impl/status_test.go
+++ b/comp/process/agent/impl/status_test.go
@@ -48,6 +48,7 @@ func TestStatus(t *testing.T) {
 	defer server.Close()
 
 	configComponent := config.NewMock(t)
+	configComponent.SetInTest("cloud_provider_metadata", []string{})
 
 	headerProvider := StatusProvider{
 		testServerURL: server.URL,

--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -114,7 +114,7 @@ func TestBundleOneShot(t *testing.T) {
 		),
 		fx.Provide(func() log.Component { return logmock.New(t) }),
 		fx.Provide(func() config.Component {
-			return config.NewMockWithOverrides(t, map[string]interface{}{"hostname": "testhost"})
+			return config.NewMockWithOverrides(t, map[string]interface{}{"hostname": "testhost", "cloud_provider_metadata": []string{}})
 		}),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 		fx.Provide(func() tagger.Component { return taggerfxmock.SetupFakeTagger(t) }),

--- a/comp/process/status/impl/status_test.go
+++ b/comp/process/status/impl/status_test.go
@@ -46,6 +46,7 @@ func TestStatus(t *testing.T) {
 	defer server.Close()
 
 	configComponent := config.NewMock(t)
+	configComponent.SetInTest("cloud_provider_metadata", []string{})
 
 	headerProvider := statusProvider{
 		testServerURL: server.URL,

--- a/pkg/process/util/status/status_test.go
+++ b/pkg/process/util/status/status_test.go
@@ -80,6 +80,7 @@ func TestGetStatus(t *testing.T) {
 	env.SetFeatures(t)
 	cfg.SetInTest("hostname", "test") // Prevents panic since feature detection has not run
 	cfg.SetInTest("language_detection.enabled", true)
+	cfg.SetInTest("cloud_provider_metadata", []string{}) // Avoid real HTTP calls to cloud metadata
 
 	expectedStatus := &Status{
 		Date: float64(testTime.UnixNano()),

--- a/pkg/util/kubernetes/clustername/clustername_test.go
+++ b/pkg/util/kubernetes/clustername/clustername_test.go
@@ -18,6 +18,9 @@ import (
 func TestGetClusterName(t *testing.T) {
 	ctx := context.Background()
 	mockConfig := configmock.New(t)
+	// Disable cloud provider metadata detection to avoid real HTTP calls to
+	// EC2/GCE/Azure metadata endpoints.
+	mockConfig.SetInTest("cloud_provider_metadata", []string{})
 	env.SetFeatures(t, env.Kubernetes)
 	data := newClusterNameData()
 


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Sets `logs_config.stop_grace_period` to 0 and wraps `agent.stop()` in `sync.OnceFunc` in the logs agent test suites, reducing `TestRestartTestSuite` from 70s to 33s and `TestAgentTestSuite` from 41s to 17s.

### Motivation

The cleanup registered by `createAgent` and the explicit `agent.stop()` calls in test methods both invoked `stopComponents`, which blocked for 5s each on non-idempotent component `Stop()` methods (e.g. `fileLauncher.Stop()` blocks on an unbuffered channel when `Start()` was never called); the 5s grace period added another 5s per call.

### Describe how you validated your changes

Both test suites were run in full before and after the change to confirm all tests still pass and measure the speedup.

### Additional Notes

All changes are test-only; no non-test code was modified.