### PR TITLE
fix(autoscaling/workload): fix data race on processor state in reconcile

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/config_retriever_settings.go
+++ b/pkg/clusteragent/autoscaling/workload/config_retriever_settings.go
@@ -107,8 +107,8 @@ func (p *autoscalingSettingsProcessor) postProcess() {
 }
 
 func (p *autoscalingSettingsProcessor) reconcile(isLeader bool) {
-	// We only reconcile if we are the leader and we have a state
-	if !isLeader || p.state == nil {
+	// We only reconcile if we are the leader
+	if !isLeader {
 		return
 	}
 
@@ -118,6 +118,11 @@ func (p *autoscalingSettingsProcessor) reconcile(isLeader bool) {
 		return
 	}
 	defer p.updateLock.Unlock()
+
+	// Check state under the lock to avoid racing with postProcess which writes p.state
+	if p.state == nil {
+		return
+	}
 
 	inStore := make(map[string]struct{}, len(p.state))
 

--- a/pkg/clusteragent/autoscaling/workload/config_retriever_values.go
+++ b/pkg/clusteragent/autoscaling/workload/config_retriever_values.go
@@ -116,8 +116,8 @@ func (p *autoscalingValuesProcessor) postProcess() {
 }
 
 func (p *autoscalingValuesProcessor) reconcile(isLeader bool) {
-	// We only reconcile if we are the leader and we have a state
-	if !isLeader || p.state == nil {
+	// We only reconcile if we are the leader
+	if !isLeader {
 		return
 	}
 
@@ -127,6 +127,11 @@ func (p *autoscalingValuesProcessor) reconcile(isLeader bool) {
 		return
 	}
 	defer p.updateLock.Unlock()
+
+	// Check state under the lock to avoid racing with postProcess which writes p.state
+	if p.state == nil {
+		return
+	}
 
 	// Update PodAutoscalers with buffered values
 	for paID, item := range p.state {


### PR DESCRIPTION
### What does this PR do?
Fixes a data race on `autoscalingValuesProcessor.state` and `autoscalingSettingsProcessor.state`: `reconcile()` read `p.state` without holding `updateLock` (in the nil check before `TryLock`), racing with `postProcess()` which writes `p.state` under the lock. Moved the nil check inside the lock so `p.state` is only accessed while holding `updateLock`.

### Motivation
Fix a race, found via a race-detector-enabled build in staging (see #54333 for context).

### Describe how you validated your changes
CI