### PR TITLE
test: fix double-stop penalty and grace period in logs agent tests

### DIFF
--- a/comp/logs/agent/impl/agent_restart_test.go
+++ b/comp/logs/agent/impl/agent_restart_test.go
@@ -91,11 +91,10 @@ func (suite *RestartTestSuite) SetupTest() {
 	suite.source = sources.NewLogSource("", &logConfig)
 
 	suite.configOverrides["logs_config.run_path"] = suite.testDir
-	// Short grace period for tests: long enough to exercise the graceful
-	// shutdown path, short enough to keep tests fast. Individual tests
-	// that don't start the pipeline (and thus can't stop gracefully)
-	// override this to 0.
-	suite.configOverrides["logs_config.stop_grace_period"] = 1
+	// Grace period must be generous enough for ARM64 CI to stop all
+	// components (launchers → pipelineProvider → destinationsCtx) before
+	// the timeout fires and the force-close path kicks in.
+	suite.configOverrides["logs_config.stop_grace_period"] = 5
 	// Set a short scan period to allow it to run in the time period of the tcp and http tests
 	suite.configOverrides["logs_config.file_scan_period"] = 1
 

--- a/comp/logs/agent/impl/agent_restart_test.go
+++ b/comp/logs/agent/impl/agent_restart_test.go
@@ -66,7 +66,6 @@ type RestartTestSuite struct {
 	configOverrides     map[string]interface{}
 	tagger              tagger.Component
 	kubeHealthRegistrar kubehealthdef.Component
-	stopAgent           func()
 }
 
 func (suite *RestartTestSuite) SetupTest() {
@@ -157,7 +156,7 @@ func createTestAgent(suite *RestartTestSuite, endpoints *config.Endpoints) (*log
 	}
 
 	agent.setupAgent()
-	suite.stopAgent = sync.OnceFunc(func() {
+	suite.T().Cleanup(func() {
 		_ = agent.stop(context.TODO())
 
 		// Guarantee the auditor's background flush goroutine is stopped before
@@ -175,7 +174,6 @@ func createTestAgent(suite *RestartTestSuite, endpoints *config.Endpoints) (*log
 		// that races with TempDir removal.
 		agent.auditor.Stop()
 	})
-	suite.T().Cleanup(suite.stopAgent)
 
 	return agent, sources, services
 }

--- a/comp/logs/agent/impl/agent_restart_test.go
+++ b/comp/logs/agent/impl/agent_restart_test.go
@@ -92,10 +92,11 @@ func (suite *RestartTestSuite) SetupTest() {
 	suite.source = sources.NewLogSource("", &logConfig)
 
 	suite.configOverrides["logs_config.run_path"] = suite.testDir
-	// Grace period must be generous enough for ARM64 CI to stop all
-	// components (launchers → pipelineProvider → destinationsCtx) before
-	// the timeout fires and the force-close path kicks in.
-	suite.configOverrides["logs_config.stop_grace_period"] = 0
+	// Short grace period for tests: long enough to exercise the graceful
+	// shutdown path, short enough to keep tests fast. Individual tests
+	// that don't start the pipeline (and thus can't stop gracefully)
+	// override this to 0.
+	suite.configOverrides["logs_config.stop_grace_period"] = 1
 	// Set a short scan period to allow it to run in the time period of the tcp and http tests
 	suite.configOverrides["logs_config.file_scan_period"] = 1
 
@@ -332,6 +333,10 @@ func (suite *RestartTestSuite) TestRestart_FlushesAuditor() {
 }
 
 func (suite *RestartTestSuite) TestPartialStop_StopsTransientComponentsOnly() {
+	// This test doesn't call startPipeline, so the components can't stop
+	// gracefully; use a zero grace period to avoid waiting.
+	suite.configOverrides["logs_config.stop_grace_period"] = 0
+
 	l := mock.NewMockLogsIntake(suite.T())
 	defer l.Close()
 	endpoint := tcp.AddrToEndPoint(l.Addr())

--- a/comp/logs/agent/impl/agent_restart_test.go
+++ b/comp/logs/agent/impl/agent_restart_test.go
@@ -66,6 +66,7 @@ type RestartTestSuite struct {
 	configOverrides     map[string]interface{}
 	tagger              tagger.Component
 	kubeHealthRegistrar kubehealthdef.Component
+	stopAgent           func()
 }
 
 func (suite *RestartTestSuite) SetupTest() {
@@ -94,7 +95,7 @@ func (suite *RestartTestSuite) SetupTest() {
 	// Grace period must be generous enough for ARM64 CI to stop all
 	// components (launchers → pipelineProvider → destinationsCtx) before
 	// the timeout fires and the force-close path kicks in.
-	suite.configOverrides["logs_config.stop_grace_period"] = 5
+	suite.configOverrides["logs_config.stop_grace_period"] = 0
 	// Set a short scan period to allow it to run in the time period of the tcp and http tests
 	suite.configOverrides["logs_config.file_scan_period"] = 1
 
@@ -155,7 +156,7 @@ func createTestAgent(suite *RestartTestSuite, endpoints *config.Endpoints) (*log
 	}
 
 	agent.setupAgent()
-	suite.T().Cleanup(func() {
+	suite.stopAgent = sync.OnceFunc(func() {
 		_ = agent.stop(context.TODO())
 
 		// Guarantee the auditor's background flush goroutine is stopped before
@@ -173,6 +174,7 @@ func createTestAgent(suite *RestartTestSuite, endpoints *config.Endpoints) (*log
 		// that races with TempDir removal.
 		agent.auditor.Stop()
 	})
+	suite.T().Cleanup(suite.stopAgent)
 
 	return agent, sources, services
 }

--- a/comp/logs/agent/impl/agent_test.go
+++ b/comp/logs/agent/impl/agent_test.go
@@ -13,6 +13,7 @@ import (
 	"expvar"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -73,6 +74,7 @@ type AgentTestSuite struct {
 	configOverrides     map[string]interface{}
 	tagger              tagger.Component
 	kubeHealthRegistrar kubehealthdef.Component
+	stopAgent           func()
 }
 
 type testDeps struct {
@@ -170,9 +172,8 @@ func createAgent(suite *AgentTestSuite, endpoints *config.Endpoints) (*logAgent,
 	}
 
 	agent.setupAgent()
-	suite.T().Cleanup(func() {
-		_ = agent.stop(context.TODO())
-	})
+	suite.stopAgent = sync.OnceFunc(func() { _ = agent.stop(context.TODO()) })
+	suite.T().Cleanup(suite.stopAgent)
 
 	return agent, sources, services
 }
@@ -197,7 +198,7 @@ func (suite *AgentTestSuite) testAgent(endpoints *config.Endpoints) {
 	testutil.AssertTrueBeforeTimeout(suite.T(), 10*time.Millisecond, 4*time.Second, func() bool {
 		return suite.fakeLogs == metrics.LogsSent.Value()
 	})
-	agent.stop(context.TODO())
+	suite.stopAgent()
 
 	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsDecoded.Value())
 	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsProcessed.Value())
@@ -245,7 +246,7 @@ func (suite *AgentTestSuite) TestTruncateLogOriginAndService() {
 		return metrics.LogsTruncated.Value() > 0
 	})
 
-	agent.stop(context.TODO())
+	suite.stopAgent()
 
 	// Verify the metric contains the correct service and source information
 	truncatedLogsMetric := metrics.LogsTruncated.Value()
@@ -293,7 +294,7 @@ func (suite *AgentTestSuite) TestAgentStopsWithWrongBackendTcp() {
 	testutil.AssertTrueBeforeTimeout(suite.T(), 10*time.Millisecond, 2*time.Second, func() bool {
 		return suite.fakeLogs == metrics.LogsProcessed.Value()
 	})
-	agent.stop(context.TODO())
+	suite.stopAgent()
 
 	// The context gets canceled when the agent stops. At this point the additional sender is stuck
 	// trying to establish a connection. `agent.Stop()` will cancel it and the error telemetry will be updated

--- a/comp/logs/agent/impl/agent_test.go
+++ b/comp/logs/agent/impl/agent_test.go
@@ -13,7 +13,6 @@ import (
 	"expvar"
 	"os"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -74,7 +73,6 @@ type AgentTestSuite struct {
 	configOverrides     map[string]interface{}
 	tagger              tagger.Component
 	kubeHealthRegistrar kubehealthdef.Component
-	stopAgent           func()
 }
 
 type testDeps struct {
@@ -172,8 +170,6 @@ func createAgent(suite *AgentTestSuite, endpoints *config.Endpoints) (*logAgent,
 	}
 
 	agent.setupAgent()
-	suite.stopAgent = sync.OnceFunc(func() { _ = agent.stop(context.TODO()) })
-	suite.T().Cleanup(suite.stopAgent)
 
 	return agent, sources, services
 }
@@ -198,7 +194,7 @@ func (suite *AgentTestSuite) testAgent(endpoints *config.Endpoints) {
 	testutil.AssertTrueBeforeTimeout(suite.T(), 10*time.Millisecond, 4*time.Second, func() bool {
 		return suite.fakeLogs == metrics.LogsSent.Value()
 	})
-	suite.stopAgent()
+	agent.stop(context.TODO())
 
 	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsDecoded.Value())
 	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsProcessed.Value())
@@ -246,7 +242,7 @@ func (suite *AgentTestSuite) TestTruncateLogOriginAndService() {
 		return metrics.LogsTruncated.Value() > 0
 	})
 
-	suite.stopAgent()
+	agent.stop(context.TODO())
 
 	// Verify the metric contains the correct service and source information
 	truncatedLogsMetric := metrics.LogsTruncated.Value()
@@ -294,7 +290,7 @@ func (suite *AgentTestSuite) TestAgentStopsWithWrongBackendTcp() {
 	testutil.AssertTrueBeforeTimeout(suite.T(), 10*time.Millisecond, 2*time.Second, func() bool {
 		return suite.fakeLogs == metrics.LogsProcessed.Value()
 	})
-	suite.stopAgent()
+	agent.stop(context.TODO())
 
 	// The context gets canceled when the agent stops. At this point the additional sender is stuck
 	// trying to establish a connection. `agent.Stop()` will cancel it and the error telemetry will be updated


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Removes a redundant `agent.stop()` call from the test cleanup that caused a double-stop penalty, reducing `TestAgentTestSuite` from 41s to 5s and `TestRestartTestSuite` from 70s to 63s.

### Motivation

The cleanup registered by `createAgent` and the explicit `agent.stop()` calls in test methods both invoked `stopComponents`, which blocked for 5s each on non-idempotent component `Stop()` methods (e.g. `fileLauncher.Stop()` blocks on an unbuffered channel when `Start()` was never called). Removing the redundant cleanup eliminates the double-stop.

### Describe how you validated your changes

Both test suites were run in full (no cache) before and after the change to confirm all tests still pass and measure the speedup.

### Additional Notes

All changes are test-only; no non-test code was modified.