### PR TITLE
Drop potentially misleading cache-mount hint from `tools/bazel.bat`

### DIFF
--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -15,10 +15,6 @@ if not exist "%XDG_CACHE_HOME%" (
     >&2 echo 🔴 XDG_CACHE_HOME ^(!XDG_CACHE_HOME!^) must denote a directory in CI!
     exit /b 2
   )
-  if defined DOTNET_RUNNING_IN_CONTAINER (
-    >&2 echo 💡 To persist caches across restarts, please set XDG_CACHE_HOME pointing to a mounted directory, e.g.:
-    >&2 echo     docker.exe run --env=XDG_CACHE_HOME=C:\cache --volume="$HOME\.cache:C:\cache" ...
-  )
 )
 
 :: Ensure `bazel` & managed toolchains honor `XDG_CACHE_HOME`


### PR DESCRIPTION
### Motivation
The wrapper advises Windows container users to point `XDG_CACHE_HOME` at a host directory bind-mounted through `docker run --volume`, which is reported not to work for some users: https://github.com/DataDog/datadog-agent/pull/54958#discussion_r3795458543.

It might be host- or container- dependent because CI uses it without problem.

### What does this PR do?
Remove that hint, leaving the POSIX `tools/bazel` counterpart alone as bind-mounted caches do work in Linux containers.

Container detection stays, as the downstream `--output_base` override and remote-cache eligibility check still rely on it.

### Describe how you validated your changes
On Windows with `DOTNET_RUNNING_IN_CONTAINER=1` and a non-existent `XDG_CACHE_HOME`, the wrapper no longer prints the hint, while the remote-cache hint and the CI guard behave exactly as before.

### Additional Notes
Kept out of #54958 so it can be reverted independently.