### PR TITLE
chore(agent-integrations): add contacts to Python upgrade PRs

### DIFF
--- a/.github/workflows/upgrade-python-patch-version.yml
+++ b/.github/workflows/upgrade-python-patch-version.yml
@@ -89,8 +89,7 @@ jobs:
             ### Describe how you validated your changes
             CI is considered enough to validate changes.
 
-            ### Ownership
-            - Embedded Python upgrade and generated changes: @DataDog/agent-integrations
-            - GitHub workflow infrastructure: @DataDog/agent-devx
+            ### Owners
+            @DataDog/agent-integrations and @DataDog/agent-devx
           team-reviewers: agent-integrations
           labels: team/agent-integrations,changelog/no-changelog

--- a/.github/workflows/upgrade-python-patch-version.yml
+++ b/.github/workflows/upgrade-python-patch-version.yml
@@ -88,5 +88,9 @@ jobs:
             
             ### Describe how you validated your changes
             CI is considered enough to validate changes.
+
+            ### Ownership
+            - Embedded Python upgrade and generated changes: @DataDog/agent-integrations
+            - GitHub workflow infrastructure: @DataDog/agent-devx
           team-reviewers: agent-integrations
           labels: team/agent-integrations,changelog/no-changelog


### PR DESCRIPTION
### What does this PR do?

Adds an owners section to PRs generated by the embedded Python patch-upgrade workflow, listing:

- @DataDog/agent-integrations
- @DataDog/agent-devx

Future automated backports copy the source PR body, so they will retain this routing information.

### Motivation

Automated Python-upgrade PRs have no human author or explicit point of contact. This makes failures such as manual backport conflicts harder to route. Both teams are listed as owners of the workflow in CODEOWNERS.

### Describe how you validated your changes

Repository commit and pre-push hooks passed, including GitHub Actions workflow linting, Go tests, and Go lint.