### PR TITLE
[AAD-6] Detectors rely on storage

### DIFF
--- a/comp/anomalydetection/observer/def/types.go
+++ b/comp/anomalydetection/observer/def/types.go
@@ -566,6 +566,11 @@ type StorageReader interface {
 	// do not allocate. Returns false if the series was not found.
 	ForEachPoint(handle SeriesRef, start, end int64, agg Aggregate, fn func(*Series, Point)) bool
 
+	// RecentPoints returns at most limit points at or before end in chronological
+	// order. dst is reused when it has sufficient capacity. Unlike a full range
+	// scan, this operation is bounded by limit.
+	RecentPoints(handle SeriesRef, end int64, agg Aggregate, limit int, dst []Point) []Point
+
 	// PointCount returns the number of raw data points for a series without
 	// loading or converting them. Returns 0 if the series is not found.
 	PointCount(handle SeriesRef) int
@@ -606,6 +611,13 @@ type Detector interface {
 	// The detector queries storage for whatever data it needs.
 	// dataTime is the current data timestamp (for determinism - only read data <= dataTime).
 	Detect(storage StorageReader, dataTime int64) DetectionResult
+}
+
+// StorageHistoryRequirement is an optional detector capability. Detectors
+// which retain a fixed raw-input history expose its required point count so
+// storage can retain sufficient history at sparse cadences.
+type StorageHistoryRequirement interface {
+	RequiredHistoryPoints() int
 }
 
 // SeriesRemover is an optional interface that Detector implementations can

--- a/comp/anomalydetection/observer/impl/log_pattern_extractor_test.go
+++ b/comp/anomalydetection/observer/impl/log_pattern_extractor_test.go
@@ -509,9 +509,9 @@ func TestEngine_LogPatternLRUEvictionFreesDetectorState(t *testing.T) {
 	bocpdBefore := len(bocpd.series)
 	scanmwBefore := len(scanmw.series)
 	scanwelchBefore := len(scanwelch.series)
-	require.Greater(t, bocpdBefore, 0, "BOCPD should have observed the series before eviction")
-	require.Greater(t, scanmwBefore, 0, "ScanMW should have observed the series before eviction")
-	require.Greater(t, scanwelchBefore, 0, "ScanWelch should have observed the series before eviction")
+	require.Zero(t, bocpdBefore, "cold series must not allocate BOCPD state")
+	require.Zero(t, scanmwBefore, "cold series must not allocate ScanMW state")
+	require.Zero(t, scanwelchBefore, "cold series must not allocate ScanWelch state")
 
 	// Trigger LRU eviction by ingesting a third pattern that pushes the
 	// oldest cluster out. After the fix, the engine fans the freed refs
@@ -537,16 +537,13 @@ func TestEngine_LogPatternLRUEvictionFreesDetectorState(t *testing.T) {
 	// 2 aggs = 4) and stayed there even after one of the series was evicted,
 	// because storage cleanup didn't propagate to detector state. After the
 	// fix, fanOutSeriesRemoval drops exactly the evicted ref's entries.
-	require.Less(t, len(bocpd.series), bocpdBefore,
-		"BOCPD per-series map must shrink when storage evicts a series; without the fan-out it stays at %d", bocpdBefore)
+	require.Zero(t, len(bocpd.series), "cold BOCPD series must remain state-free after eviction")
 	require.LessOrEqual(t, len(bocpd.series), 2*len(bocpd.config.Aggregations),
 		"BOCPD per-series map must not exceed live series × aggregations")
-	require.Less(t, len(scanmw.series), scanmwBefore,
-		"ScanMW per-series map must shrink when storage evicts a series; without the fan-out it stays at %d", scanmwBefore)
+	require.Zero(t, len(scanmw.series), "cold ScanMW series must remain state-free after eviction")
 	require.LessOrEqual(t, len(scanmw.series), 2*len(scanmw.Aggregations),
 		"ScanMW per-series map must not exceed live series × aggregations")
-	require.Less(t, len(scanwelch.series), scanwelchBefore,
-		"ScanWelch per-series map must shrink when storage evicts a series; without the fan-out it stays at %d", scanwelchBefore)
+	require.Zero(t, len(scanwelch.series), "cold ScanWelch series must remain state-free after eviction")
 	require.LessOrEqual(t, len(scanwelch.series), 2*len(scanwelch.Aggregations),
 		"ScanWelch per-series map must not exceed live series \u00d7 aggregations")
 

--- a/comp/anomalydetection/observer/impl/metrics_detector_bocpd.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_bocpd.go
@@ -184,6 +184,10 @@ func (b *BOCPDDetector) Name() string {
 
 func (b *BOCPDDetector) Ready() bool { return b.ready }
 
+// RequiredHistoryPoints ensures storage retains enough input to construct the
+// posterior when a cold series first reaches the BOCPD warmup threshold.
+func (b *BOCPDDetector) RequiredHistoryPoints() int { return b.config.WarmupPoints }
+
 // Detect implements Detector. It discovers series, reads only newly visible
 // points, and updates per-series BOCPD posterior state incrementally.
 //

--- a/comp/anomalydetection/observer/impl/metrics_detector_bocpd.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_bocpd.go
@@ -204,9 +204,14 @@ func (b *BOCPDDetector) Detect(storage observer.StorageReader, dataTime int64) o
 			if !supportsSeriesAggregate(storage, ref, agg) {
 				continue
 			}
+			// Do not retain cold per-series posterior state. On the first
+			// eligible call the zero cursor replays the full retained history.
+			visibleCount := storage.PointCountUpTo(ref, dataTime)
 			sk := bocpdStateKey{ref: ref, agg: agg}
-
 			state, exists := b.series[sk]
+			if !exists && visibleCount < b.config.WarmupPoints {
+				continue
+			}
 			if !exists {
 				state = &bocpdSeriesState{}
 				b.series[sk] = state
@@ -217,7 +222,6 @@ func (b *BOCPDDetector) Detect(storage observer.StorageReader, dataTime int64) o
 			// advances) and the common live case. WriteGeneration catches
 			// same-bucket merges and retention-churn scenarios where point
 			// count stays constant but stored values changed.
-			visibleCount := storage.PointCountUpTo(ref, dataTime)
 			writeGen := storage.WriteGeneration(ref)
 			if visibleCount <= state.lastProcessedCount && writeGen == state.lastWriteGen {
 				continue

--- a/comp/anomalydetection/observer/impl/metrics_detector_cusum.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_cusum.go
@@ -85,6 +85,10 @@ func (c *CUSUMDetector) Name() string {
 
 func (c *CUSUMDetector) Ready() bool { return c.ready }
 
+// RequiredHistoryPoints ensures storage retains enough input for CUSUM's
+// first full-series analysis after a cold series reaches MinPoints.
+func (c *CUSUMDetector) RequiredHistoryPoints() int { return c.config.MinPoints }
+
 // Reset clears the readiness signal for replay/reanalysis.
 func (c *CUSUMDetector) Reset() { c.ready = false }
 

--- a/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
@@ -29,7 +29,8 @@ import (
 // forecast residual on the ramp itself and a large one on the jump.
 //
 // Memory per (series, aggregation): a 24-point warmup buffer, a
-// 60-residual MAD window, a 60-value MAD window, plus scalars — ~1.5 KB.
+// 60-residual MAD window, plus scalars. The raw-value gate reads its bounded
+// history from storage into detector-global scratch.
 // Per-tick cost: O(1) smoother update + O(W log W) MAD recompute (W=60),
 // dominated by the two sort.Float64s calls inside detectorMAD.
 
@@ -44,9 +45,6 @@ const (
 	holtConfirmM        = 2
 	holtMinDeviationMAD = 3.0
 	holtRefractory      = 20
-	// holtTimestampRing keeps the last N point timestamps for sampling-interval
-	// estimation — sized to match the warmup buffer for cheap reuse.
-	holtTimestampRing = 16
 	// holtPostFireSampleN is the number of recent non-fire residuals whose
 	// median is injected into the residual window in place of the fire's
 	// own residual (Hampel rejection, applied only to the threshold).
@@ -81,11 +79,9 @@ type holtSeriesState struct {
 	level float64
 	trend float64
 
-	// FIFO rolling windows; cap = ResidualWindow. resWin holds the last
-	// W one-step forecast residuals; valWin holds the last W raw values
-	// — used for the σ_value gate (effect size).
+	// FIFO residual window; cap = ResidualWindow. Residuals are derived model
+	// state and cannot be reconstructed from storage without replaying Holt.
 	resWin []float64
-	valWin []float64
 
 	// detection counters
 	consecutivePos      int
@@ -98,11 +94,6 @@ type holtSeriesState struct {
 	seriesName         string
 	seriesTags         []string
 
-	// recentTimestamps is a small ring of the most recently ingested point
-	// timestamps; used by medianTimestampInterval to estimate the sampling
-	// cadence for downstream correlators. We don't need a full window —
-	// 16 entries gives a robust median.
-	recentTimestamps  []int64
 	lastSeenTimestamp int64
 }
 
@@ -145,6 +136,11 @@ type HoltResidualDetector struct {
 	// scanwelch / scanmw / bocpd pattern).
 	cachedSeries []observer.SeriesMeta
 	cachedGen    uint64
+
+	// rawScratch is reused while serially advancing one series. It is not
+	// per-series state, so raw input history scales with window size only.
+	rawScratch   []observer.Point
+	valueScratch []float64
 }
 
 // HoltResidualConfig holds catalog/testbench tunables for HoltResidualDetector.
@@ -203,6 +199,11 @@ func NewHoltResidualDetectorWithConfig(cfg HoltResidualConfig) *HoltResidualDete
 
 // Name implements observer.Detector.
 func (d *HoltResidualDetector) Name() string { return "holt_residual" }
+
+func (d *HoltResidualDetector) RequiredHistoryPoints() int {
+	d.ensureDefaults()
+	return d.ResidualWindow
+}
 
 func (d *HoltResidualDetector) Ready() bool { return d.ready }
 
@@ -283,6 +284,11 @@ func (d *HoltResidualDetector) Detect(storage observer.StorageReader, dataTime i
 				startTime = 0
 			}
 
+			d.rawScratch = storage.RecentPoints(meta.Ref, state.lastProcessedTime, agg, d.ResidualWindow, d.rawScratch)
+			d.valueScratch = d.valueScratch[:0]
+			for _, point := range d.rawScratch {
+				d.valueScratch = append(d.valueScratch, point.Value)
+			}
 			anomalies, pointsSeen := d.ingestNewPoints(storage, meta.Ref, agg, state, startTime, dataTime)
 			for j := range anomalies {
 				anomalies[j].SourceRef = &observer.QueryHandle{Ref: meta.Ref, Aggregate: agg}
@@ -307,10 +313,8 @@ func (d *HoltResidualDetector) Detect(storage observer.StorageReader, dataTime i
 // buffers. Splitting allocation here keeps Detect's hot path branch-free.
 func (d *HoltResidualDetector) newState() *holtSeriesState {
 	return &holtSeriesState{
-		warmupBuf:        make([]float64, 0, d.WarmupPoints),
-		resWin:           make([]float64, 0, d.ResidualWindow),
-		valWin:           make([]float64, 0, d.ResidualWindow),
-		recentTimestamps: make([]int64, 0, holtTimestampRing),
+		warmupBuf: make([]float64, 0, d.WarmupPoints),
+		resWin:    make([]float64, 0, d.ResidualWindow),
 	}
 }
 
@@ -356,9 +360,9 @@ func (d *HoltResidualDetector) ingestNewPoints(
 		state.lastSeenTimestamp = p.Timestamp
 		state.lastProcessedTime = p.Timestamp
 		state.lastProcessedValue = p.Value
-		pushTimestamp(state, p.Timestamp)
-
 		if !state.warmedUp {
+			d.rawScratch = appendRecentPoint(d.rawScratch, p, d.ResidualWindow)
+			d.valueScratch = appendRecentValue(d.valueScratch, p.Value, d.ResidualWindow)
 			state.warmupBuf = append(state.warmupBuf, p.Value)
 			if len(state.warmupBuf) >= d.WarmupPoints {
 				seedLevelTrend(state, d.WarmupPoints)
@@ -369,12 +373,15 @@ func (d *HoltResidualDetector) ingestNewPoints(
 			return
 		}
 
-		anomaly, hasFire := d.processPoint(state, p, agg)
-		if len(state.resWin) >= d.ResidualWindow && len(state.valWin) >= d.ResidualWindow {
+		anomaly, hasFire := d.processPoint(state, p, agg, d.valueScratch)
+		d.rawScratch = appendRecentPoint(d.rawScratch, p, d.ResidualWindow)
+		d.valueScratch = appendRecentValue(d.valueScratch, p.Value, d.ResidualWindow)
+		if len(state.resWin) >= d.ResidualWindow && len(d.rawScratch) >= d.ResidualWindow {
 			d.ready = true
 		}
 
 		if hasFire {
+			anomaly.SamplingIntervalSec = medianPointInterval(d.rawScratch)
 			fired = append(fired, anomaly)
 		} else if state.refractoryRemaining > 0 {
 			// Refractory countdown — decrement on every non-firing post-warmup
@@ -408,6 +415,7 @@ func (d *HoltResidualDetector) processPoint(
 	state *holtSeriesState,
 	p observer.Point,
 	agg observer.Aggregate,
+	values []float64,
 ) (observer.Anomaly, bool) {
 	// 1. One-step forecast and residual.
 	forecast := state.level + state.trend
@@ -433,15 +441,15 @@ func (d *HoltResidualDetector) processPoint(
 	// σ_value gate denominator: rolling MAD over raw values. Same window
 	// size, same scaleToSigma=true → MAD ≈ σ. Uses the same range-based
 	// floor for the same bimodal-distribution reason.
-	medianValue := detectorMedian(state.valWin)
-	sigmaValue := detectorMAD(state.valWin, medianValue, true)
-	sigmaValue = floorSigma(sigmaValue, state.valWin)
+	medianValue := detectorMedian(values)
+	sigmaValue := detectorMAD(values, medianValue, true)
+	sigmaValue = floorSigma(sigmaValue, values)
 	devMAD := math.Abs(p.Value-state.level) / sigmaValue
 
 	// 3. Update consecutive counters only after both baseline windows are
 	// representative. Under-filled windows collapse sigma to the floor and can
 	// otherwise pre-arm confirmation before the gate is meaningful.
-	windowsReady := len(state.resWin) >= d.ResidualWindow && len(state.valWin) >= d.ResidualWindow
+	windowsReady := len(state.resWin) >= d.ResidualWindow && len(values) >= d.ResidualWindow
 	zMagPasses := windowsReady && math.Abs(z) >= d.ZThreshold
 	if zMagPasses {
 		if z > 0 {
@@ -480,7 +488,6 @@ func (d *HoltResidualDetector) processPoint(
 		residualForWindow = medianOfTail(state.resWin, holtPostFireSampleN)
 	}
 	pushFIFO(&state.resWin, d.ResidualWindow, residualForWindow)
-	pushFIFO(&state.valWin, d.ResidualWindow, p.Value)
 
 	if !fire {
 		return observer.Anomaly{}, false
@@ -503,9 +510,8 @@ func (d *HoltResidualDetector) processPoint(
 			"%s deviated from forecast (observed=%.4f, forecast=%.4f, residual=%.4f, |z|=%.2f, level=%.4f, trend=%.4f, %.1f valueMADs)",
 			seriesName, p.Value, forecast, residual, math.Abs(z), state.level, state.trend, devMAD,
 		),
-		Timestamp:           state.lastSeenTimestamp,
-		Score:               &score,
-		SamplingIntervalSec: medianTimestampInterval(state.recentTimestamps),
+		Timestamp: state.lastSeenTimestamp,
+		Score:     &score,
 		DebugInfo: &observer.AnomalyDebugInfo{
 			BaselineMedian: medianResidual,
 			BaselineMAD:    sigmaResidual,
@@ -521,6 +527,24 @@ func (d *HoltResidualDetector) processPoint(
 	state.refractoryRemaining = d.Refractory
 
 	return anomaly, true
+}
+
+func appendRecentPoint(points []observer.Point, point observer.Point, limit int) []observer.Point {
+	if len(points) < limit {
+		return append(points, point)
+	}
+	copy(points, points[1:])
+	points[len(points)-1] = point
+	return points
+}
+
+func appendRecentValue(values []float64, value float64, limit int) []float64 {
+	if len(values) < limit {
+		return append(values, value)
+	}
+	copy(values, values[1:])
+	values[len(values)-1] = value
+	return values
 }
 
 // seedLevelTrend bootstraps the smoother from the warmup buffer using the
@@ -610,21 +634,6 @@ func pushFIFO(buf *[]float64, maxLen int, v float64) {
 	// FIFO evict: shift left, place new value at tail.
 	copy(*buf, (*buf)[1:])
 	(*buf)[maxLen-1] = v
-}
-
-// pushTimestamp appends ts to the recent-timestamp ring, dropping the
-// oldest if full. The ring is small (cap holtTimestampRing) so the
-// shift-left cost is negligible.
-func pushTimestamp(state *holtSeriesState, ts int64) {
-	if cap(state.recentTimestamps) == 0 {
-		state.recentTimestamps = make([]int64, 0, holtTimestampRing)
-	}
-	if len(state.recentTimestamps) < cap(state.recentTimestamps) {
-		state.recentTimestamps = append(state.recentTimestamps, ts)
-		return
-	}
-	copy(state.recentTimestamps, state.recentTimestamps[1:])
-	state.recentTimestamps[len(state.recentTimestamps)-1] = ts
 }
 
 // medianOfTail returns the median of the last n entries of buf. If buf has

--- a/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
@@ -260,6 +260,10 @@ func (d *HoltResidualDetector) Detect(storage observer.StorageReader, dataTime i
 			}
 			sk := holtStateKey{ref: meta.Ref, agg: agg}
 			state, exists := d.series[sk]
+			if !exists && status.pointCount < d.WarmupPoints {
+				// The threshold-crossing pass replays all retained warmup points.
+				continue
+			}
 			if !exists {
 				state = d.newState()
 				d.series[sk] = state

--- a/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_holt_residual.go
@@ -202,7 +202,7 @@ func (d *HoltResidualDetector) Name() string { return "holt_residual" }
 
 func (d *HoltResidualDetector) RequiredHistoryPoints() int {
 	d.ensureDefaults()
-	return d.ResidualWindow
+	return max(d.WarmupPoints, d.ResidualWindow)
 }
 
 func (d *HoltResidualDetector) Ready() bool { return d.ready }

--- a/comp/anomalydetection/observer/impl/metrics_detector_holt_residual_test.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_holt_residual_test.go
@@ -347,7 +347,9 @@ func TestHoltResidual_ReprocessesSameBucketMergeAndDoesNotSkipLatePoints(t *test
 	d.ResidualWindow = 4
 	storage := newDetectorTestStorage()
 
-	storage.Add("ns", "metric", 10.0, 10, nil)
+	for ts := int64(1); ts <= 10; ts++ {
+		storage.Add("ns", "metric", 10.0, ts, nil)
+	}
 	d.Detect(storage, 10)
 
 	metas := storage.ListSeries(observer.WorkloadSeriesFilter())
@@ -356,24 +358,24 @@ func TestHoltResidual_ReprocessesSameBucketMergeAndDoesNotSkipLatePoints(t *test
 	key := holtStateKey{ref: ref, agg: observer.AggregateAverage}
 	state := d.series[key]
 	require.NotNil(t, state)
-	require.Equal(t, []float64{10.0}, state.warmupBuf)
+	require.True(t, state.warmedUp)
 	require.Equal(t, int64(10), state.lastProcessedTime)
 
 	storage.Add("ns", "metric", 30.0, 10, nil)
 	series := storage.GetSeriesRange(ref, 0, 10, observer.AggregateAverage)
 	require.NotNil(t, series)
-	require.Len(t, series.Points, 1)
-	require.Equal(t, 20.0, series.Points[0].Value, "storage should expose the merged average")
+	require.Len(t, series.Points, 10)
+	require.Equal(t, 20.0, series.Points[9].Value, "storage should expose the merged average")
 
 	d.Detect(storage, 20)
 	state = d.series[key]
-	require.Equal(t, []float64{20.0}, state.warmupBuf)
+	require.True(t, state.warmedUp)
 	require.Equal(t, int64(10), state.lastProcessedTime, "merge replay must not advance to dataTime")
 
 	storage.Add("ns", "metric", 50.0, 15, nil)
 	d.Detect(storage, 20)
 	state = d.series[key]
-	require.Equal(t, []float64{20.0, 50.0}, state.warmupBuf)
+	require.True(t, state.warmedUp)
 	assert.Equal(t, int64(15), state.lastProcessedTime)
 	assert.Equal(t, storage.WriteGeneration(ref), state.lastWriteGen)
 }
@@ -384,7 +386,9 @@ func TestHoltResidual_RebuildsOnOutOfOrderBackfillBeforeCursor(t *testing.T) {
 	d.ResidualWindow = 4
 	storage := newDetectorTestStorage()
 
-	storage.Add("ns", "metric", 10.0, 10, nil)
+	for ts := int64(1); ts <= 10; ts++ {
+		storage.Add("ns", "metric", 10.0, ts, nil)
+	}
 	d.Detect(storage, 10)
 
 	metas := storage.ListSeries(observer.WorkloadSeriesFilter())
@@ -393,7 +397,7 @@ func TestHoltResidual_RebuildsOnOutOfOrderBackfillBeforeCursor(t *testing.T) {
 	key := holtStateKey{ref: ref, agg: observer.AggregateAverage}
 	state := d.series[key]
 	require.NotNil(t, state)
-	require.Equal(t, []float64{10.0}, state.warmupBuf)
+	require.True(t, state.warmedUp)
 	require.Equal(t, int64(10), state.lastProcessedTime)
 
 	storage.Add("ns", "metric", 5.0, 5, nil)
@@ -401,8 +405,8 @@ func TestHoltResidual_RebuildsOnOutOfOrderBackfillBeforeCursor(t *testing.T) {
 
 	state = d.series[key]
 	require.NotNil(t, state)
-	assert.Equal(t, []float64{5.0, 10.0}, state.warmupBuf)
-	assert.Equal(t, 2, state.lastProcessedCount)
+	assert.True(t, state.warmedUp)
+	assert.Equal(t, 10, state.lastProcessedCount)
 	assert.Equal(t, int64(10), state.lastProcessedTime)
 }
 
@@ -412,7 +416,9 @@ func TestHoltResidual_RebuildsOnCursorMergeWithLaterAppend(t *testing.T) {
 	d.ResidualWindow = 4
 	storage := newDetectorTestStorage()
 
-	storage.Add("ns", "metric", 10.0, 10, nil)
+	for ts := int64(1); ts <= 10; ts++ {
+		storage.Add("ns", "metric", 10.0, ts, nil)
+	}
 	d.Detect(storage, 10)
 
 	metas := storage.ListSeries(observer.WorkloadSeriesFilter())
@@ -421,7 +427,7 @@ func TestHoltResidual_RebuildsOnCursorMergeWithLaterAppend(t *testing.T) {
 	key := holtStateKey{ref: ref, agg: observer.AggregateAverage}
 	state := d.series[key]
 	require.NotNil(t, state)
-	require.Equal(t, []float64{10.0}, state.warmupBuf)
+	require.True(t, state.warmedUp)
 	require.Equal(t, int64(10), state.lastProcessedTime)
 
 	storage.Add("ns", "metric", 30.0, 10, nil)
@@ -430,8 +436,8 @@ func TestHoltResidual_RebuildsOnCursorMergeWithLaterAppend(t *testing.T) {
 
 	state = d.series[key]
 	require.NotNil(t, state)
-	assert.Equal(t, []float64{20.0, 40.0}, state.warmupBuf)
-	assert.Equal(t, 2, state.lastProcessedCount)
+	assert.True(t, state.warmedUp)
+	assert.Equal(t, 11, state.lastProcessedCount)
 	assert.Equal(t, int64(11), state.lastProcessedTime)
 }
 

--- a/comp/anomalydetection/observer/impl/metrics_detector_holt_residual_test.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_holt_residual_test.go
@@ -453,20 +453,22 @@ func TestHoltResidual_ConfirmationStartsAfterWindowsReady(t *testing.T) {
 	state := &holtSeriesState{
 		warmedUp: true,
 		resWin:   []float64{0, 0, 0},
-		valWin:   []float64{0, 0, 0},
 	}
 
-	_, fired := d.processPoint(state, observer.Point{Timestamp: 1, Value: 100}, observer.AggregateAverage)
+	values := []float64{0, 0, 0}
+	_, fired := d.processPoint(state, observer.Point{Timestamp: 1, Value: 100}, observer.AggregateAverage, values)
+	values = appendRecentValue(values, 100, d.ResidualWindow)
 	require.False(t, fired)
 	assert.Zero(t, state.consecutivePos, "under-filled windows must not pre-arm confirmation")
 	assert.Zero(t, state.consecutiveNeg)
 
-	_, fired = d.processPoint(state, observer.Point{Timestamp: 2, Value: 100}, observer.AggregateAverage)
+	_, fired = d.processPoint(state, observer.Point{Timestamp: 2, Value: 100}, observer.AggregateAverage, values)
+	values = appendRecentValue(values, 100, d.ResidualWindow)
 	require.False(t, fired, "first ready-window breach should only arm confirmation")
 	assert.Equal(t, 1, state.consecutivePos)
 	assert.Zero(t, state.consecutiveNeg)
 
-	_, fired = d.processPoint(state, observer.Point{Timestamp: 3, Value: 100}, observer.AggregateAverage)
+	_, fired = d.processPoint(state, observer.Point{Timestamp: 3, Value: 100}, observer.AggregateAverage, values)
 	require.True(t, fired, "second ready-window breach should satisfy ConfirmM")
 }
 

--- a/comp/anomalydetection/observer/impl/metrics_detector_scanmw.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_scanmw.go
@@ -102,6 +102,13 @@ func (d *ScanMWDetector) Name() string {
 
 func (d *ScanMWDetector) Ready() bool { return d.ready }
 
+// RequiredHistoryPoints ensures the first scan can replay a full retained
+// segment once a cold series reaches MinPoints.
+func (d *ScanMWDetector) RequiredHistoryPoints() int {
+	d.ensureDefaults()
+	return d.MinPoints
+}
+
 // Reset clears all per-series state for replay/reanalysis.
 func (d *ScanMWDetector) Reset() {
 	d.series = make(map[scanmwStateKey]*scanmwSeriesState)

--- a/comp/anomalydetection/observer/impl/metrics_detector_scanmw.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_scanmw.go
@@ -159,6 +159,11 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 			sk := scanmwStateKey{ref: ref, agg: agg}
 
 			state, exists := d.series[sk]
+			firstActivation := !exists
+			if !exists && status.pointCount < d.MinPoints {
+				// Keep no state until a full retained first scan is possible.
+				continue
+			}
 			if !exists {
 				state = &scanmwSeriesState{}
 				d.series[sk] = state
@@ -202,6 +207,11 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 			}
 
 			state.lastProcessedCount = status.pointCount
+			if firstActivation {
+				// Preserve the existing MinSegment scan cadence after the
+				// threshold-crossing full-history scan.
+				state.lastProcessedCount -= state.lastProcessedCount % d.MinSegment
+			}
 			state.lastWriteGen = status.writeGeneration
 		}
 	}

--- a/comp/anomalydetection/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_scanwelch.go
@@ -149,6 +149,11 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 			sk := scanwelchStateKey{ref: ref, agg: agg}
 
 			state, exists := d.series[sk]
+			firstActivation := !exists
+			if !exists && status.pointCount < d.MinPoints {
+				// Keep no state until a full retained first scan is possible.
+				continue
+			}
 			if !exists {
 				state = &scanwelchSeriesState{}
 				d.series[sk] = state
@@ -192,6 +197,11 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 			}
 
 			state.lastProcessedCount = status.pointCount
+			if firstActivation {
+				// Preserve the existing MinSegment scan cadence after the
+				// threshold-crossing full-history scan.
+				state.lastProcessedCount -= state.lastProcessedCount % d.MinSegment
+			}
 			state.lastWriteGen = status.writeGeneration
 		}
 	}

--- a/comp/anomalydetection/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_scanwelch.go
@@ -96,6 +96,13 @@ func (d *ScanWelchDetector) Name() string {
 
 func (d *ScanWelchDetector) Ready() bool { return d.ready }
 
+// RequiredHistoryPoints ensures the first scan can replay a full retained
+// segment once a cold series reaches MinPoints.
+func (d *ScanWelchDetector) RequiredHistoryPoints() int {
+	d.ensureDefaults()
+	return d.MinPoints
+}
+
 // Reset clears all per-series state for replay/reanalysis.
 func (d *ScanWelchDetector) Reset() {
 	d.series = make(map[scanwelchStateKey]*scanwelchSeriesState)

--- a/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight.go
@@ -25,23 +25,12 @@ type tbStateKey struct {
 }
 
 // tbSeriesState holds streaming state per (series, aggregate) pair.
-//
-// Memory footprint per key (rough):
-//
-//	ring (80 * 16)               = 1280 B
-//	scalars                      ~  100 B
-//	                              -------
-//	                             ~1.4 KB
 type tbSeriesState struct {
 	// Cursor over visible storage buckets plus in-place write generation.
 	lastProcessedCount int
 	lastWriteGen       int64
 	lastProcessedTime  int64
-
-	// Sliding window of recent points in chronological order when read via
-	// windowSnapshot(). cap == WindowSize once full.
-	ring        []observer.Point
-	head, count int
+	lastProcessedValue float64
 
 	// ticksSinceScore counts new points ingested since the last scoring tick.
 	// scoreBiweight is invoked only when this clears ScoreEvery, amortizing
@@ -103,6 +92,10 @@ type TukeyBiweightDetector struct {
 	// Cache the discovered series list across Detect calls.
 	cachedSeries []observer.SeriesMeta
 	cachedGen    uint64
+
+	// scratch is reused while serially advancing one series. Storage remains
+	// the sole persistent owner of raw input points.
+	scratch []observer.Point
 }
 
 // TukeyBiweightConfig holds catalog/testbench tunables for TukeyBiweightDetector.
@@ -157,6 +150,11 @@ func NewTukeyBiweightDetectorWithConfig(cfg TukeyBiweightConfig) *TukeyBiweightD
 
 // Name returns the detector name as registered in the catalog.
 func (d *TukeyBiweightDetector) Name() string { return "tukey_biweight" }
+
+func (d *TukeyBiweightDetector) RequiredHistoryPoints() int {
+	d.ensureDefaults()
+	return d.WindowSize
+}
 
 func (d *TukeyBiweightDetector) Ready() bool { return d.ready }
 
@@ -239,6 +237,7 @@ func (d *TukeyBiweightDetector) Detect(storage observer.StorageReader, dataTime 
 				d.series[sk] = state
 				startTime = 0
 			}
+			d.scratch = storage.RecentPoints(meta.Ref, state.lastProcessedTime, agg, d.WindowSize, d.scratch)
 
 			var seriesMeta *observer.Series
 			pointsSeen := false
@@ -248,7 +247,7 @@ func (d *TukeyBiweightDetector) Detect(storage observer.StorageReader, dataTime 
 					sCopy := *s
 					seriesMeta = &sCopy
 				}
-				d.appendRing(state, p)
+				d.scratch = appendRecentPoint(d.scratch, p, d.WindowSize)
 
 				// Decrement cooldown per ingested point so it expires
 				// regardless of whether scoring runs this tick.
@@ -257,10 +256,10 @@ func (d *TukeyBiweightDetector) Detect(storage observer.StorageReader, dataTime 
 				}
 				state.ticksSinceScore++
 
-				if state.count >= d.MinPoints && state.cooldownLeft == 0 && state.ticksSinceScore >= d.ScoreEvery {
+				if len(d.scratch) >= d.MinPoints && state.cooldownLeft == 0 && state.ticksSinceScore >= d.ScoreEvery {
 					d.ready = true
 					state.ticksSinceScore = 0
-					if anomaly, fired := d.scoreBiweight(state, seriesMeta, agg, p.Timestamp); fired {
+					if anomaly, fired := d.scoreBiweight(d.scratch, seriesMeta, agg, p.Timestamp); fired {
 						anomaly.SourceRef = &observer.QueryHandle{Ref: meta.Ref, Aggregate: agg}
 						allAnomalies = append(allAnomalies, anomaly)
 						state.cooldownLeft = d.CooldownPoints
@@ -269,6 +268,7 @@ func (d *TukeyBiweightDetector) Detect(storage observer.StorageReader, dataTime 
 				}
 
 				state.lastProcessedTime = p.Timestamp
+				state.lastProcessedValue = p.Value
 			})
 
 			if !pointsSeen && mergeOccurred {
@@ -285,67 +285,15 @@ func (d *TukeyBiweightDetector) Detect(storage observer.StorageReader, dataTime 
 	return observer.DetectionResult{Anomalies: allAnomalies}
 }
 
-// appendRing appends a point to the per-series ring buffer in chronological
-// order. While the buffer is filling, it grows; once full, the oldest entry
-// at state.head is overwritten and head advances modulo WindowSize.
-func (d *TukeyBiweightDetector) appendRing(state *tbSeriesState, p observer.Point) {
-	if state.count < d.WindowSize {
-		state.ring = append(state.ring, p)
-		state.count++
-		return
-	}
-	state.ring[state.head] = p
-	state.head = (state.head + 1) % d.WindowSize
-}
-
-// windowSnapshot returns the current ring contents in chronological order as
-// a fresh []float64 of length state.count. Allocated only on scoring ticks
-// (gated by ScoreEvery) so allocation pressure is amortized.
-func (d *TukeyBiweightDetector) windowSnapshot(state *tbSeriesState) []float64 {
-	xs := make([]float64, state.count)
-	if state.count < d.WindowSize {
-		for i := 0; i < state.count; i++ {
-			xs[i] = state.ring[i].Value
-		}
-		return xs
-	}
-	for i := 0; i < d.WindowSize; i++ {
-		xs[i] = state.ring[(state.head+i)%d.WindowSize].Value
-	}
-	return xs
-}
-
-func (d *TukeyBiweightDetector) windowPointsSnapshot(state *tbSeriesState) []observer.Point {
-	points := make([]observer.Point, state.count)
-	if state.count < d.WindowSize {
-		copy(points, state.ring)
-		return points
-	}
-	for i := 0; i < d.WindowSize; i++ {
-		points[i] = state.ring[(state.head+i)%d.WindowSize]
-	}
-	return points
-}
-
 func (d *TukeyBiweightDetector) cursorPointChanged(storage observer.StorageReader, ref observer.SeriesRef, agg observer.Aggregate, state *tbSeriesState) bool {
-	if state.count == 0 {
+	if state.lastProcessedCount == 0 {
 		return false
 	}
-	idx := state.count - 1
-	if state.count >= d.WindowSize {
-		idx = (state.head + d.WindowSize - 1) % d.WindowSize
-	}
-	lastPoint := state.ring[idx]
-	if lastPoint.Timestamp != state.lastProcessedTime {
+	lastPoint := storage.RecentPoints(ref, state.lastProcessedTime, agg, 1, d.scratch)
+	if len(lastPoint) != 1 || lastPoint[0].Timestamp != state.lastProcessedTime {
 		return false
 	}
-	changed := false
-	storage.ForEachPoint(ref, state.lastProcessedTime-1, state.lastProcessedTime, agg, func(_ *observer.Series, p observer.Point) {
-		if p.Timestamp == lastPoint.Timestamp && p.Value != lastPoint.Value {
-			changed = true
-		}
-	})
-	return changed
+	return lastPoint[0].Value != state.lastProcessedValue
 }
 
 // scoreBiweight runs the IRLS biweight fit on the current window and decides
@@ -356,8 +304,11 @@ func (d *TukeyBiweightDetector) cursorPointChanged(storage observer.StorageReade
 // so a single historical glitch CANNOT poison (mu, sigma). This is the property
 // that distinguishes biweight from rank/AR detectors and motivates the
 // "robust-to-historical-outlier" test case.
-func (d *TukeyBiweightDetector) scoreBiweight(state *tbSeriesState, series *observer.Series, agg observer.Aggregate, dataTime int64) (observer.Anomaly, bool) {
-	xs := d.windowSnapshot(state)
+func (d *TukeyBiweightDetector) scoreBiweight(points []observer.Point, series *observer.Series, agg observer.Aggregate, dataTime int64) (observer.Anomaly, bool) {
+	xs := make([]float64, len(points))
+	for i, point := range points {
+		xs[i] = point.Value
+	}
 	n := len(xs)
 	if n < 2 {
 		return observer.Anomaly{}, false
@@ -454,7 +405,7 @@ func (d *TukeyBiweightDetector) scoreBiweight(state *tbSeriesState, series *obse
 		Source:              observer.SeriesDescriptor{Namespace: series.Namespace, Name: series.Name, Tags: series.Tags, Aggregate: agg},
 		DetectorName:        d.Name(),
 		Title:               "Tukey biweight: " + seriesName,
-		SamplingIntervalSec: medianPointInterval(d.windowPointsSnapshot(state)),
+		SamplingIntervalSec: medianPointInterval(points),
 		Description: fmt.Sprintf("%s biweight baseline (z=%.2f, mu=%.4f, sigma=%.4f, n=%d)",
 			direction, z, mu, sigma, n),
 		Timestamp: dataTime,

--- a/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight.go
@@ -215,6 +215,10 @@ func (d *TukeyBiweightDetector) Detect(storage observer.StorageReader, dataTime 
 			sk := tbStateKey{ref: meta.Ref, agg: agg}
 
 			state, exists := d.series[sk]
+			if !exists && status.pointCount < d.MinPoints {
+				// Keep cold series state-free; first activation replays from zero.
+				continue
+			}
 			if !exists {
 				state = &tbSeriesState{}
 				d.series[sk] = state

--- a/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight_test.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight_test.go
@@ -94,8 +94,10 @@ func TestTukeyBiweight_ReprocessesSameBucketMerge(t *testing.T) {
 	d.ScoreEvery = 100
 	storage := newDetectorTestStorage()
 
-	storage.Add("ns", "metric", 10.0, 1, nil)
-	d.Detect(storage, 1)
+	for ts := int64(1); ts <= 4; ts++ {
+		storage.Add("ns", "metric", 10.0, ts, nil)
+	}
+	d.Detect(storage, 4)
 
 	metas := storage.ListSeries(observer.WorkloadSeriesFilter())
 	require.Len(t, metas, 1)
@@ -103,20 +105,20 @@ func TestTukeyBiweight_ReprocessesSameBucketMerge(t *testing.T) {
 	key := tbStateKey{ref: ref, agg: observer.AggregateAverage}
 	state := d.series[key]
 	require.NotNil(t, state)
-	require.Equal(t, 1, state.lastProcessedCount)
+	require.Equal(t, 4, state.lastProcessedCount)
 	assert.Equal(t, 10.0, state.lastProcessedValue)
 
-	storage.Add("ns", "metric", 30.0, 1, nil)
-	series := storage.GetSeriesRange(ref, 0, 1, observer.AggregateAverage)
+	storage.Add("ns", "metric", 30.0, 4, nil)
+	series := storage.GetSeriesRange(ref, 0, 4, observer.AggregateAverage)
 	require.NotNil(t, series)
-	require.Len(t, series.Points, 1)
-	require.Equal(t, 20.0, series.Points[0].Value, "storage should expose the merged average")
+	require.Len(t, series.Points, 4)
+	require.Equal(t, 20.0, series.Points[3].Value, "storage should expose the merged average")
 
-	d.Detect(storage, 1)
+	d.Detect(storage, 4)
 
 	state = d.series[key]
 	require.NotNil(t, state)
-	require.Equal(t, 1, state.lastProcessedCount, "same-bucket merge should replace the stale aggregate")
+	require.Equal(t, 4, state.lastProcessedCount, "same-bucket merge should replace the stale aggregate")
 	assert.Equal(t, 20.0, state.lastProcessedValue)
 	assert.Equal(t, storage.WriteGeneration(ref), state.lastWriteGen)
 }
@@ -128,7 +130,9 @@ func TestTukeyBiweight_RebuildsOnOutOfOrderBackfillBeforeCursor(t *testing.T) {
 	d.ScoreEvery = 100
 	storage := newDetectorTestStorage()
 
-	storage.Add("ns", "metric", 10.0, 10, nil)
+	for ts := int64(7); ts <= 10; ts++ {
+		storage.Add("ns", "metric", 10.0, ts, nil)
+	}
 	d.Detect(storage, 10)
 
 	metas := storage.ListSeries(observer.WorkloadSeriesFilter())
@@ -145,10 +149,10 @@ func TestTukeyBiweight_RebuildsOnOutOfOrderBackfillBeforeCursor(t *testing.T) {
 	state = d.series[key]
 	require.NotNil(t, state)
 	points := storage.RecentPoints(ref, 10, observer.AggregateAverage, 4, nil)
-	require.Len(t, points, 2)
-	assert.Equal(t, int64(5), points[0].Timestamp)
-	assert.Equal(t, int64(10), points[1].Timestamp)
-	assert.Equal(t, 2, state.lastProcessedCount)
+	require.Len(t, points, 4)
+	assert.Equal(t, int64(7), points[0].Timestamp)
+	assert.Equal(t, int64(10), points[3].Timestamp)
+	assert.Equal(t, 5, state.lastProcessedCount)
 	assert.Equal(t, int64(10), state.lastProcessedTime)
 }
 
@@ -159,7 +163,9 @@ func TestTukeyBiweight_RebuildsOnCursorMergeWithLaterAppend(t *testing.T) {
 	d.ScoreEvery = 100
 	storage := newDetectorTestStorage()
 
-	storage.Add("ns", "metric", 10.0, 10, nil)
+	for ts := int64(7); ts <= 10; ts++ {
+		storage.Add("ns", "metric", 10.0, ts, nil)
+	}
 	d.Detect(storage, 10)
 
 	metas := storage.ListSeries(observer.WorkloadSeriesFilter())
@@ -168,7 +174,7 @@ func TestTukeyBiweight_RebuildsOnCursorMergeWithLaterAppend(t *testing.T) {
 	key := tbStateKey{ref: ref, agg: observer.AggregateAverage}
 	state := d.series[key]
 	require.NotNil(t, state)
-	require.Equal(t, 1, state.lastProcessedCount)
+	require.Equal(t, 4, state.lastProcessedCount)
 	require.Equal(t, int64(10), state.lastProcessedTime)
 
 	storage.Add("ns", "metric", 30.0, 10, nil)
@@ -178,12 +184,13 @@ func TestTukeyBiweight_RebuildsOnCursorMergeWithLaterAppend(t *testing.T) {
 	state = d.series[key]
 	require.NotNil(t, state)
 	points := storage.RecentPoints(ref, 11, observer.AggregateAverage, 4, nil)
-	require.Len(t, points, 2)
-	assert.Equal(t, int64(10), points[0].Timestamp)
-	assert.Equal(t, 20.0, points[0].Value)
-	assert.Equal(t, int64(11), points[1].Timestamp)
-	assert.Equal(t, 40.0, points[1].Value)
-	assert.Equal(t, 2, state.lastProcessedCount)
+	require.Len(t, points, 4)
+	assert.Equal(t, int64(8), points[0].Timestamp)
+	assert.Equal(t, int64(10), points[2].Timestamp)
+	assert.Equal(t, 20.0, points[2].Value)
+	assert.Equal(t, int64(11), points[3].Timestamp)
+	assert.Equal(t, 40.0, points[3].Value)
+	assert.Equal(t, 5, state.lastProcessedCount)
 	assert.Equal(t, int64(11), state.lastProcessedTime)
 }
 
@@ -381,12 +388,12 @@ func TestTukeyBiweight_RemoveSeries(t *testing.T) {
 	// Three series, each populated with enough points to allocate state.
 	for s := 0; s < 3; s++ {
 		name := "metric" + string(rune('A'+s))
-		for i := 0; i < 8; i++ {
+		for i := 0; i < 80; i++ {
 			storage.Add("ns", name, float64(i), int64(i+1), nil)
 		}
 	}
 
-	d.Detect(storage, 8)
+	d.Detect(storage, 80)
 	require.Len(t, d.series, 3*len(d.Aggregations),
 		"each series should have one state entry per aggregation")
 

--- a/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight_test.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_tukey_biweight_test.go
@@ -103,8 +103,8 @@ func TestTukeyBiweight_ReprocessesSameBucketMerge(t *testing.T) {
 	key := tbStateKey{ref: ref, agg: observer.AggregateAverage}
 	state := d.series[key]
 	require.NotNil(t, state)
-	require.Equal(t, 1, state.count)
-	assert.Equal(t, 10.0, state.ring[0].Value)
+	require.Equal(t, 1, state.lastProcessedCount)
+	assert.Equal(t, 10.0, state.lastProcessedValue)
 
 	storage.Add("ns", "metric", 30.0, 1, nil)
 	series := storage.GetSeriesRange(ref, 0, 1, observer.AggregateAverage)
@@ -116,8 +116,8 @@ func TestTukeyBiweight_ReprocessesSameBucketMerge(t *testing.T) {
 
 	state = d.series[key]
 	require.NotNil(t, state)
-	require.Equal(t, 1, state.count, "same-bucket merge should replace the stale aggregate")
-	assert.Equal(t, 20.0, state.ring[0].Value)
+	require.Equal(t, 1, state.lastProcessedCount, "same-bucket merge should replace the stale aggregate")
+	assert.Equal(t, 20.0, state.lastProcessedValue)
 	assert.Equal(t, storage.WriteGeneration(ref), state.lastWriteGen)
 }
 
@@ -144,10 +144,10 @@ func TestTukeyBiweight_RebuildsOnOutOfOrderBackfillBeforeCursor(t *testing.T) {
 
 	state = d.series[key]
 	require.NotNil(t, state)
-	require.Equal(t, 2, state.count)
-	require.Len(t, state.ring, 2)
-	assert.Equal(t, int64(5), state.ring[0].Timestamp)
-	assert.Equal(t, int64(10), state.ring[1].Timestamp)
+	points := storage.RecentPoints(ref, 10, observer.AggregateAverage, 4, nil)
+	require.Len(t, points, 2)
+	assert.Equal(t, int64(5), points[0].Timestamp)
+	assert.Equal(t, int64(10), points[1].Timestamp)
 	assert.Equal(t, 2, state.lastProcessedCount)
 	assert.Equal(t, int64(10), state.lastProcessedTime)
 }
@@ -168,7 +168,7 @@ func TestTukeyBiweight_RebuildsOnCursorMergeWithLaterAppend(t *testing.T) {
 	key := tbStateKey{ref: ref, agg: observer.AggregateAverage}
 	state := d.series[key]
 	require.NotNil(t, state)
-	require.Equal(t, 1, state.count)
+	require.Equal(t, 1, state.lastProcessedCount)
 	require.Equal(t, int64(10), state.lastProcessedTime)
 
 	storage.Add("ns", "metric", 30.0, 10, nil)
@@ -177,12 +177,12 @@ func TestTukeyBiweight_RebuildsOnCursorMergeWithLaterAppend(t *testing.T) {
 
 	state = d.series[key]
 	require.NotNil(t, state)
-	require.Equal(t, 2, state.count)
-	require.Len(t, state.ring, 2)
-	assert.Equal(t, int64(10), state.ring[0].Timestamp)
-	assert.Equal(t, 20.0, state.ring[0].Value)
-	assert.Equal(t, int64(11), state.ring[1].Timestamp)
-	assert.Equal(t, 40.0, state.ring[1].Value)
+	points := storage.RecentPoints(ref, 11, observer.AggregateAverage, 4, nil)
+	require.Len(t, points, 2)
+	assert.Equal(t, int64(10), points[0].Timestamp)
+	assert.Equal(t, 20.0, points[0].Value)
+	assert.Equal(t, int64(11), points[1].Timestamp)
+	assert.Equal(t, 40.0, points[1].Value)
 	assert.Equal(t, 2, state.lastProcessedCount)
 	assert.Equal(t, int64(11), state.lastProcessedTime)
 }
@@ -339,25 +339,28 @@ func TestTukeyBiweight_IRLSConverges(t *testing.T) {
 	d.ensureDefaults()
 
 	// Synthetic bimodal: 40 points at 0, 40 points at 10. No noise.
-	state := &tbSeriesState{}
+	points := make([]observer.Point, 0, 80)
 	ts := int64(1)
 	for i := 0; i < 40; i++ {
-		d.appendRing(state, observer.Point{Timestamp: ts, Value: 0})
+		points = append(points, observer.Point{Timestamp: ts, Value: 0})
 		ts++
 	}
 	for i := 0; i < 40; i++ {
-		d.appendRing(state, observer.Point{Timestamp: ts, Value: 10})
+		points = append(points, observer.Point{Timestamp: ts, Value: 10})
 		ts++
 	}
-	require.Equal(t, 80, state.count)
+	require.Len(t, points, 80)
 
 	series := &observer.Series{Namespace: "ns", Name: "metric"}
 	// scoreBiweight returns (anomaly, fired). We don't care whether it
 	// fires; we care that the underlying IRLS terminated cleanly. Drive
 	// the function and inspect the snapshot sigma we'd compute.
-	_, _ = d.scoreBiweight(state, series, observer.AggregateAverage, ts)
+	_, _ = d.scoreBiweight(points, series, observer.AggregateAverage, ts)
 
-	xs := d.windowSnapshot(state)
+	xs := make([]float64, len(points))
+	for i, point := range points {
+		xs[i] = point.Value
+	}
 	mu := detectorMedian(xs)
 	sigma := detectorMAD(xs, mu, true)
 	require.False(t, math.IsNaN(mu), "mu must be finite")

--- a/comp/anomalydetection/observer/impl/metrics_detector_util_test.go
+++ b/comp/anomalydetection/observer/impl/metrics_detector_util_test.go
@@ -61,6 +61,10 @@ func (s *seriesListOnlyStorage) ForEachPoint(observer.SeriesRef, int64, int64, o
 	return false
 }
 
+func (*seriesListOnlyStorage) RecentPoints(observer.SeriesRef, int64, observer.Aggregate, int, []observer.Point) []observer.Point {
+	return nil
+}
+
 func (s *seriesListOnlyStorage) PointCount(observer.SeriesRef) int {
 	return 0
 }

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -686,6 +686,13 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 
 	for _, ref := range a.cachedRefs {
 		visibleCount := storage.PointCountUpTo(ref, dataTime)
+		// CUSUM cannot produce a result before its own configured warmup.
+		// Keep cold sparse series out of the adapter cursor map and avoid the
+		// range allocation. The threshold-crossing call still reads the full
+		// retained range from the beginning.
+		if cusum, ok := a.detector.(*CUSUMDetector); ok && visibleCount < cusum.config.MinPoints {
+			continue
+		}
 		if prev, ok := a.lastVisibleCount[ref]; ok && prev == visibleCount {
 			continue
 		}

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -686,11 +686,11 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 
 	for _, ref := range a.cachedRefs {
 		visibleCount := storage.PointCountUpTo(ref, dataTime)
-		// CUSUM cannot produce a result before its own configured warmup.
-		// Keep cold sparse series out of the adapter cursor map and avoid the
-		// range allocation. The threshold-crossing call still reads the full
-		// retained range from the beginning.
-		if cusum, ok := a.detector.(*CUSUMDetector); ok && visibleCount < cusum.config.MinPoints {
+		// Stateful detectors gate their own warmup in their respective Detect
+		// implementations. CUSUM is the only production SeriesDetector, so its
+		// configured minimum belongs at this adapter boundary. Future wrapped
+		// SeriesDetector thresholds must be added to seriesDetectorMinPoints.
+		if minPoints := seriesDetectorMinPoints(a.detector); minPoints > 0 && visibleCount < minPoints {
 			continue
 		}
 		if prev, ok := a.lastVisibleCount[ref]; ok && prev == visibleCount {
@@ -734,6 +734,18 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 	}
 
 	return observerdef.DetectionResult{Anomalies: allAnomalies}
+}
+
+// seriesDetectorMinPoints returns the cold-start threshold for wrapped
+// stateless detectors. Other observer detectors are StorageReader consumers
+// and apply their own configured warmup gates before allocating state.
+func seriesDetectorMinPoints(detector observerdef.SeriesDetector) int {
+	switch d := detector.(type) {
+	case *CUSUMDetector:
+		return d.config.MinPoints
+	default:
+		return 0
+	}
 }
 
 // aggSuffix returns a short suffix for the given aggregation type.

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -640,6 +640,12 @@ func (a *seriesDetectorAdapter) Ready() bool {
 	return a.detector.Ready()
 }
 
+// RequiredHistoryPoints forwards a wrapped detector's cold-start requirement
+// so storage defaults and low-retention warnings see CUSUM through its adapter.
+func (a *seriesDetectorAdapter) RequiredHistoryPoints() int {
+	return seriesDetectorMinPoints(a.detector)
+}
+
 // Reset clears adapter-local caches and resets the wrapped detector when supported.
 func (a *seriesDetectorAdapter) Reset() {
 	a.lastVisibleCount = make(map[observerdef.SeriesRef]int)

--- a/comp/anomalydetection/observer/impl/observer.go
+++ b/comp/anomalydetection/observer/impl/observer.go
@@ -259,6 +259,9 @@ func NewComponent(deps Requires) (Provides, error) {
 	detectors, correlators, rawScorer, extractors, _ := catalog.Instantiate(settings)
 
 	storageCfg := DefaultStorageConfig()
+	requiredPoints, requiredDurationSecs := storageHistoryDefaults(detectors)
+	pointRetentionConfigured := false
+	maxPointsConfigured := false
 	if cfg != nil {
 		if cfg.IsConfigured("anomaly_detection.storage.max_series") {
 			storageCfg.MaxSeries = cfg.GetInt("anomaly_detection.storage.max_series")
@@ -267,13 +270,33 @@ func NewComponent(deps Requires) (Provides, error) {
 			storageCfg.EvictionFloorRatio = cfg.GetFloat64("anomaly_detection.storage.eviction_floor_ratio")
 		}
 		if cfg.IsConfigured("anomaly_detection.storage.point_retention") {
+			pointRetentionConfigured = true
 			d := cfg.GetDuration("anomaly_detection.storage.point_retention")
 			if d < 0 {
 				pkglog.Warnf("anomaly_detection.storage.point_retention must be >= 0, got %s — using default", d)
+				pointRetentionConfigured = false
 			} else {
 				storageCfg.PointRetentionSecs = int64(d.Seconds())
 			}
 		}
+		if cfg.IsConfigured("anomaly_detection.storage.max_points_per_series") {
+			maxPointsConfigured = true
+			storageCfg.MaxPointsPerSeries = cfg.GetInt("anomaly_detection.storage.max_points_per_series")
+			if storageCfg.MaxPointsPerSeries < 0 {
+				pkglog.Warnf("anomaly_detection.storage.max_points_per_series must be >= 0, got %d — using default", storageCfg.MaxPointsPerSeries)
+				storageCfg.MaxPointsPerSeries = 0
+				maxPointsConfigured = false
+			}
+		}
+	}
+	if requiredPoints > 0 {
+		if !pointRetentionConfigured {
+			storageCfg.PointRetentionSecs = requiredDurationSecs
+		}
+		if !maxPointsConfigured {
+			storageCfg.MaxPointsPerSeries = int(requiredPoints)
+		}
+		warnInsufficientStorageHistory(detectors, storageCfg)
 	}
 
 	compiledMetricFilter, err := loadMetricFilter(cfg)
@@ -453,6 +476,43 @@ func NewComponent(deps Requires) (Provides, error) {
 	}
 
 	return Provides{Comp: obs}, nil
+}
+
+const assumedStorageHistoryCadenceSecs int64 = 15
+
+// storageHistoryDefaults derives retention sufficient for fixed raw-input
+// windows at the observed 15-second cadence, with one extra bucket of slack.
+func storageHistoryDefaults(detectors []observerdef.Detector) (points, durationSecs int64) {
+	for _, detector := range detectors {
+		requirement, ok := detector.(observerdef.StorageHistoryRequirement)
+		if !ok {
+			continue
+		}
+		if required := int64(requirement.RequiredHistoryPoints()); required > points {
+			points = required
+		}
+	}
+	if points > 0 {
+		durationSecs = assumedStorageHistoryCadenceSecs*points + assumedStorageHistoryCadenceSecs
+	}
+	return points, durationSecs
+}
+
+func warnInsufficientStorageHistory(detectors []observerdef.Detector, cfg StorageConfig) {
+	for _, detector := range detectors {
+		requirement, ok := detector.(observerdef.StorageHistoryRequirement)
+		if !ok || requirement.RequiredHistoryPoints() <= 0 {
+			continue
+		}
+		requiredPoints := requirement.RequiredHistoryPoints()
+		requiredDuration := assumedStorageHistoryCadenceSecs*int64(requiredPoints) + assumedStorageHistoryCadenceSecs
+		if cfg.MaxPointsPerSeries > 0 && cfg.MaxPointsPerSeries < requiredPoints {
+			pkglog.Warnf("[observer] detector %s requires %d points at assumed %ds cadence (%ds); max_points_per_series=%d, point_retention=%ds", detector.Name(), requiredPoints, assumedStorageHistoryCadenceSecs, requiredDuration, cfg.MaxPointsPerSeries, cfg.PointRetentionSecs)
+		}
+		if cfg.PointRetentionSecs > 0 && cfg.PointRetentionSecs < requiredDuration {
+			pkglog.Warnf("[observer] detector %s requires %d points at assumed %ds cadence (%ds); point_retention=%ds is too low, max_points_per_series=%d", detector.Name(), requiredPoints, assumedStorageHistoryCadenceSecs, requiredDuration, cfg.PointRetentionSecs, cfg.MaxPointsPerSeries)
+		}
+	}
 }
 
 // observerImpl is the implementation of the observer component.

--- a/comp/anomalydetection/observer/impl/observer_test.go
+++ b/comp/anomalydetection/observer/impl/observer_test.go
@@ -246,3 +246,24 @@ func (d *countingSeriesDetector) Detect(_ observerdef.Series) observerdef.Detect
 		Anomalies: append([]observerdef.Anomaly(nil), d.anomalies...),
 	}
 }
+
+func TestStorageHistoryDefaults(t *testing.T) {
+	tests := []struct {
+		name      string
+		detectors []observerdef.Detector
+		points    int64
+		duration  int64
+	}{
+		{name: "no fixed window"},
+		{name: "holt", detectors: []observerdef.Detector{NewHoltResidualDetector()}, points: 60, duration: 915},
+		{name: "tukey", detectors: []observerdef.Detector{NewTukeyBiweightDetector()}, points: 80, duration: 1215},
+		{name: "both", detectors: []observerdef.Detector{NewHoltResidualDetector(), NewTukeyBiweightDetector()}, points: 80, duration: 1215},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			points, duration := storageHistoryDefaults(tt.detectors)
+			require.Equal(t, tt.points, points)
+			require.Equal(t, tt.duration, duration)
+		})
+	}
+}

--- a/comp/anomalydetection/observer/impl/observer_test.go
+++ b/comp/anomalydetection/observer/impl/observer_test.go
@@ -271,8 +271,11 @@ func TestStorageHistoryDefaults(t *testing.T) {
 	}{
 		{name: "no fixed window"},
 		{name: "holt", detectors: []observerdef.Detector{NewHoltResidualDetector()}, points: 60, duration: 915},
+		{name: "holt custom warmup", detectors: []observerdef.Detector{NewHoltResidualDetectorWithConfig(HoltResidualConfig{WarmupPoints: 100, ResidualWindow: 60})}, points: 100, duration: 1515},
 		{name: "tukey", detectors: []observerdef.Detector{NewTukeyBiweightDetector()}, points: 80, duration: 1215},
+		{name: "bocpd", detectors: []observerdef.Detector{NewBOCPDDetector(DefaultBOCPDConfig())}, points: 120, duration: 1815},
 		{name: "both", detectors: []observerdef.Detector{NewHoltResidualDetector(), NewTukeyBiweightDetector()}, points: 80, duration: 1215},
+		{name: "bocpd and fixed window", detectors: []observerdef.Detector{NewBOCPDDetector(DefaultBOCPDConfig()), NewTukeyBiweightDetector()}, points: 120, duration: 1815},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/comp/anomalydetection/observer/impl/observer_test.go
+++ b/comp/anomalydetection/observer/impl/observer_test.go
@@ -274,6 +274,9 @@ func TestStorageHistoryDefaults(t *testing.T) {
 		{name: "holt custom warmup", detectors: []observerdef.Detector{NewHoltResidualDetectorWithConfig(HoltResidualConfig{WarmupPoints: 100, ResidualWindow: 60})}, points: 100, duration: 1515},
 		{name: "tukey", detectors: []observerdef.Detector{NewTukeyBiweightDetector()}, points: 80, duration: 1215},
 		{name: "bocpd", detectors: []observerdef.Detector{NewBOCPDDetector(DefaultBOCPDConfig())}, points: 120, duration: 1815},
+		{name: "cusum", detectors: []observerdef.Detector{newSeriesDetectorAdapter(NewCUSUMDetector(DefaultCUSUMConfig()), nil)}, points: 5, duration: 90},
+		{name: "scan mw", detectors: []observerdef.Detector{NewScanMWDetector()}, points: 30, duration: 465},
+		{name: "scan welch", detectors: []observerdef.Detector{NewScanWelchDetector()}, points: 30, duration: 465},
 		{name: "both", detectors: []observerdef.Detector{NewHoltResidualDetector(), NewTukeyBiweightDetector()}, points: 80, duration: 1215},
 		{name: "bocpd and fixed window", detectors: []observerdef.Detector{NewBOCPDDetector(DefaultBOCPDConfig()), NewTukeyBiweightDetector()}, points: 120, duration: 1815},
 	}

--- a/comp/anomalydetection/observer/impl/observer_test.go
+++ b/comp/anomalydetection/observer/impl/observer_test.go
@@ -103,6 +103,21 @@ func TestSeriesDetectorAdapter_ResetClearsVisibleCountCache(t *testing.T) {
 	}
 }
 
+func TestSeriesDetectorAdapter_DefersCUSUMCursorUntilWarmup(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	adapter := newSeriesDetectorAdapter(NewCUSUMDetector(CUSUMConfig{MinPoints: 5}), []observerdef.Aggregate{observerdef.AggregateAverage})
+
+	for ts := int64(1); ts <= 4; ts++ {
+		storage.Add("ns", "cpu", float64(ts), ts, nil)
+	}
+	adapter.Detect(storage, 4)
+	require.Empty(t, adapter.lastVisibleCount)
+
+	storage.Add("ns", "cpu", 5, 5, nil)
+	adapter.Detect(storage, 5)
+	require.Len(t, adapter.lastVisibleCount, 1)
+}
+
 func TestObserverPublishesSeriesCountOnAdvanceAndReplayBoundaries(t *testing.T) {
 	telComp := telemetryimpl.GetCompatComponent()
 	telComp.Reset()

--- a/comp/anomalydetection/observer/impl/storage.go
+++ b/comp/anomalydetection/observer/impl/storage.go
@@ -33,6 +33,10 @@ type StorageConfig struct {
 	// on each Add. 0 disables trimming.
 	PointRetentionSecs int64
 
+	// MaxPointsPerSeries caps the number of newest one-second buckets retained
+	// per series. Zero disables count-based trimming.
+	MaxPointsPerSeries int
+
 	// MaxCorrelations caps how many unique correlation patterns are retained in
 	// the engine's accumulated-correlations map. 0 uses the built-in default
 	// (500). -1 disables the cap entirely (suitable for testbench replay where
@@ -55,6 +59,7 @@ func DefaultStorageConfig() StorageConfig {
 		MaxSeries:          storageMaxSeries,
 		EvictionFloorRatio: storageEvictionBandRatio,
 		PointRetentionSecs: storagePointRetentionSecs,
+		MaxPointsPerSeries: storageMaxPointsPerSeries,
 		// TrackCorrelationHistory defaults to false: live agent incurs no overhead.
 	}
 }
@@ -70,6 +75,10 @@ const (
 	// storagePointRetentionSecs is the default point retention window.
 	// Points older than (latest_ts - 120s) are trimmed on each Add.
 	storagePointRetentionSecs = 120
+
+	// storageMaxPointsPerSeries is disabled until detector requirements are
+	// derived from the configured detector set.
+	storageMaxPointsPerSeries = 0
 )
 
 // timeSeriesStorage is an internal storage for time series data.
@@ -388,18 +397,23 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 	if stats.retentionOverrideSecs > 0 {
 		retentionSecs = stats.retentionOverrideSecs
 	}
+	trim := 0
 	if retentionSecs > 0 {
 		// Trim points outside the retention window. Use the series' latest
 		// timestamp (not the incoming bucket) so that backfilled/out-of-order
 		// points don't shift the cutoff backwards and over-retain stale data.
 		latestTS := stats.timestamps[len(stats.timestamps)-1]
-		if trim := searchAfter(stats.timestamps, latestTS-retentionSecs-1); trim > 0 {
-			stats.timestamps = trimFront(stats.timestamps, trim)
-			stats.sums = trimFront(stats.sums, trim)
-			stats.counts = trimFront(stats.counts, trim)
-			stats.mins = trimFront(stats.mins, trim)
-			stats.maxes = trimFront(stats.maxes, trim)
-		}
+		trim = searchAfter(stats.timestamps, latestTS-retentionSecs-1)
+	}
+	if s.cfg.MaxPointsPerSeries > 0 && len(stats.timestamps)-trim > s.cfg.MaxPointsPerSeries {
+		trim = len(stats.timestamps) - s.cfg.MaxPointsPerSeries
+	}
+	if trim > 0 {
+		stats.timestamps = trimFront(stats.timestamps, trim)
+		stats.sums = trimFront(stats.sums, trim)
+		stats.counts = trimFront(stats.counts, trim)
+		stats.mins = trimFront(stats.mins, trim)
+		stats.maxes = trimFront(stats.maxes, trim)
 	}
 	return res
 }
@@ -1577,6 +1591,37 @@ func (s *timeSeriesStorage) ForEachPoint(
 	*bufp = buf
 	pointBufPool.Put(bufp)
 	return true
+}
+
+// RecentPoints returns the bounded tail of a series at or before end.
+// It reads directly from the columnar representation and reuses dst.
+func (s *timeSeriesStorage) RecentPoints(ref observer.SeriesRef, end int64, agg Aggregate, limit int, dst []observer.Point) []observer.Point {
+	if limit <= 0 {
+		return dst[:0]
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	stats := s.resolveByID(ref)
+	if stats == nil {
+		return dst[:0]
+	}
+	hi := searchAfter(stats.timestamps, end)
+	lo := hi - limit
+	if lo < 0 {
+		lo = 0
+	}
+	n := hi - lo
+	if cap(dst) < n {
+		dst = make([]observer.Point, n)
+	} else {
+		dst = dst[:n]
+	}
+	for i := range dst {
+		idx := lo + i
+		dst[i] = observer.Point{Timestamp: stats.timestamps[idx], Value: stats.aggregateAt(idx, agg)}
+	}
+	return dst
 }
 
 // SumRange returns the aggregate total over the time range (start, end] without

--- a/comp/anomalydetection/observer/impl/storage_instrumented.go
+++ b/comp/anomalydetection/observer/impl/storage_instrumented.go
@@ -232,6 +232,25 @@ func (s *instrumentedStorage) ForEachPoint(ref observerdef.SeriesRef, start, end
 	return found
 }
 
+func (s *instrumentedStorage) RecentPoints(ref observerdef.SeriesRef, end int64, agg observerdef.Aggregate, limit int, dst []observerdef.Point) []observerdef.Point {
+	s.readCount++
+	result := s.inner.RecentPoints(ref, end, agg, limit, dst)
+
+	ch := newCallHasher()
+	ch.mixString("RecentPoints")
+	ch.mixInt64(end)
+	ch.mixInt64(int64(agg))
+	ch.mixInt64(int64(limit))
+	ch.mixInt64(int64(len(result)))
+	for _, p := range result {
+		ch.mixInt64(p.Timestamp)
+		ch.mixFloat64(p.Value)
+	}
+	s.pointCount += len(result)
+	s.callHashes = append(s.callHashes, ch.sum())
+	return result
+}
+
 func (s *instrumentedStorage) PointCount(ref observerdef.SeriesRef) int {
 	s.readCount++
 	result := s.inner.PointCount(ref)

--- a/comp/anomalydetection/observer/impl/storage_test.go
+++ b/comp/anomalydetection/observer/impl/storage_test.go
@@ -261,6 +261,33 @@ func makeRangeStorage() *timeSeriesStorage {
 	return s
 }
 
+func TestRecentPoints(t *testing.T) {
+	storage := newTimeSeriesStorageWith(StorageConfig{})
+	ref := storage.Add("work", "metric", 1, 10, nil).Ref
+	storage.Add("work", "metric", 2, 20, nil)
+	storage.Add("work", "metric", 3, 30, nil)
+
+	dst := make([]observer.Point, 0, 4)
+	points := storage.RecentPoints(ref, 25, AggregateAverage, 2, dst)
+	require.Equal(t, []observer.Point{{Timestamp: 10, Value: 1}, {Timestamp: 20, Value: 2}}, points)
+	require.Same(t, &dst[:cap(dst)][0], &points[0])
+
+	storage.Add("work", "metric", 4, 20, nil)
+	points = storage.RecentPoints(ref, 30, AggregateAverage, 1, points)
+	require.Equal(t, []observer.Point{{Timestamp: 30, Value: 3}}, points)
+	assert.Empty(t, storage.RecentPoints(observer.SeriesRef(999), 30, AggregateAverage, 2, points))
+}
+
+func TestStorageMaxPointsPerSeries(t *testing.T) {
+	storage := newTimeSeriesStorageWith(StorageConfig{MaxPointsPerSeries: 3})
+	ref := observer.SeriesRef(-1)
+	for ts := int64(1); ts <= 5; ts++ {
+		ref = storage.Add("work", "metric", float64(ts), ts, nil).Ref
+	}
+	require.Equal(t, 3, storage.PointCount(ref))
+	require.Equal(t, []observer.Point{{Timestamp: 3, Value: 3}, {Timestamp: 4, Value: 4}, {Timestamp: 5, Value: 5}}, storage.RecentPoints(ref, 5, AggregateAverage, 10, nil))
+}
+
 // rangeID is the numeric ID for the first (and only) series added by makeRangeStorage.
 const rangeID = observer.SeriesRef(0)
 

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -5444,11 +5444,17 @@ properties:
             type: integer
             default: 50000
             comment: Storage tuning. See storageConfig in the observer component.
+          max_points_per_series:
+            node_type: setting
+            type: integer
+            default: 0
+            comment: Maximum newest one-second buckets retained per series. 0 is unlimited; when unset, fixed-window anomaly detectors derive a safe value from their history requirements.
           point_retention:
             node_type: setting
             type: string
-            default: 2m0s
+            default: 0s
             format: duration
+            comment: Maximum age of retained points. 0s is unlimited; when unset, fixed-window anomaly detectors derive a safe value from their history requirements and a 15-second cadence.
             tags:
             - golang_type:duration
     tags:


### PR DESCRIPTION
### What does this PR do?

Moves fixed detector input history into bounded observer storage and defers per-series detector state until each detector has enough retained points.

Adds bounded recent-point reads, duration/count retention derivation and warnings, plus cold-start retention requirements for BOCPD, CUSUM, ScanMW, ScanWelch, Holt, and Tukey.

### Motivation

### Describe how you validated your changes

`dda inv test --targets=./comp/anomalydetection/observer/impl`

### Additional Notes