### PR TITLE
[BARX-2009] Drop Agent 6 RC tags on Go modules

### DIFF
--- a/docs/public/how-to/go/modules.md
+++ b/docs/public/how-to/go/modules.md
@@ -123,6 +123,10 @@ A few invoke tasks are available that help with automatically updating module ve
 
     /// info
     For Agent version `7.X.Y` the module will have version `v0.X.Y`.
+
+    Agent 6 release candidates do not receive nested module tags. Use the commit
+    referenced by the global release candidate tag to derive a Go pseudo-version
+    instead. Final Agent 6 releases continue to receive nested module tags.
     ///
 
 * `dda inv release.update-modules`

--- a/docs/public/how-to/go/modules.md
+++ b/docs/public/how-to/go/modules.md
@@ -127,8 +127,9 @@ A few invoke tasks are available that help with automatically updating module ve
     Agent 6 release candidates do not receive nested module tags. Use the commit
     referenced by the global release candidate tag to derive a Go pseudo-version
     instead. During an Agent 6 release candidate, internal module requirements
-    remain pinned to the last published module versions so they stay resolvable.
-    Final Agent 6 releases continue to receive nested module tags.
+    use pseudo-versions derived from the release branch commit so same-RC module
+    changes remain available. Final Agent 6 releases continue to receive nested
+    module tags.
     ///
 
 * `dda inv release.update-modules`

--- a/docs/public/how-to/go/modules.md
+++ b/docs/public/how-to/go/modules.md
@@ -126,7 +126,9 @@ A few invoke tasks are available that help with automatically updating module ve
 
     Agent 6 release candidates do not receive nested module tags. Use the commit
     referenced by the global release candidate tag to derive a Go pseudo-version
-    instead. Final Agent 6 releases continue to receive nested module tags.
+    instead. During an Agent 6 release candidate, internal module requirements
+    remain pinned to the last published module versions so they stay resolvable.
+    Final Agent 6 releases continue to receive nested module tags.
     ///
 
 * `dda inv release.update-modules`

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -39,7 +39,7 @@ from tasks.libs.common.git import (
 )
 from tasks.libs.common.gomodules import get_default_modules
 from tasks.libs.common.user_interactions import yes_no_question
-from tasks.libs.common.utils import running_in_ci, set_gitconfig_in_ci
+from tasks.libs.common.utils import join_command, running_in_ci, set_gitconfig_in_ci
 from tasks.libs.common.worktree import agent_context
 from tasks.libs.pipeline.notifications import (
     DEFAULT_JIRA_PROJECT,
@@ -80,11 +80,22 @@ from tasks.release_metrics.metrics import get_prs_metrics, get_release_lead_time
 QUALIFICATION_TAG = "qualification"
 
 
+def _get_module_pseudo_version(ctx, module, commit):
+    """Resolve the canonical pseudo-version for a module at a commit."""
+    command = join_command(
+        ["go", "list", "-m", "-mod=mod", "-f={{.Version}}", f"{module.import_path}@{commit}"]
+    )
+    version = ctx.run(command, hide=True).stdout.strip()
+    if not version:
+        raise Exit(f"Could not resolve a pseudo-version for {module.import_path} at {commit}")
+    return version
+
+
 @task
 def update_modules(ctx, release_branch=None, version=None, trust=False):
     """Update internal dependencies between the different Agent modules.
 
-    Agent 6 release candidates are skipped because their nested modules are not tagged.
+    Agent 6 release candidates use pseudo-versions because their nested modules are not tagged.
 
     Args:
         verify: Checks for correctness on the Agent Version (on by default).
@@ -97,14 +108,12 @@ def update_modules(ctx, release_branch=None, version=None, trust=False):
 
     agent_version = version or deduce_version(ctx, release_branch, trust=trust)
 
-    # Agent 6 RCs do not have nested module tags. Keep their dependencies pinned
-    # to the last published versions so pseudo-version consumers can resolve them.
-    if RC_VERSION_RE.match(agent_version) and get_version_major(agent_version) == 6:
-        print(f"Skipping module dependency updates for Agent 6 release candidate {agent_version}")
-        return
+    agent6_rc = RC_VERSION_RE.match(agent_version) and get_version_major(agent_version) == 6
 
     with agent_context(ctx, release_branch, skip_checkout=release_branch is None):
         modules = get_default_modules()
+        commit = ctx.run("git rev-parse HEAD", hide=True).stdout.strip() if agent6_rc else None
+        pseudo_versions = {}
         for module in modules.values():
             for dependency in module.dependencies(ctx):
                 dependency_mod = modules[dependency]
@@ -115,7 +124,13 @@ def update_modules(ctx, release_branch=None, version=None, trust=False):
                 ):
                     # Skip this dependency update in new-e2e for Agent 6, as it's incompatible.
                     continue
-                ctx.run(f"go mod edit -require={dependency_mod.dependency_path(agent_version)} {module.go_mod_path()}")
+                if agent6_rc:
+                    if dependency not in pseudo_versions:
+                        pseudo_versions[dependency] = _get_module_pseudo_version(ctx, dependency_mod, commit)
+                    dependency_path = f"{dependency_mod.import_path}@{pseudo_versions[dependency]}"
+                else:
+                    dependency_path = dependency_mod.dependency_path(agent_version)
+                ctx.run(f"go mod edit -require={dependency_path} {module.go_mod_path()}")
 
 
 def __get_force_option(force: bool) -> str:
@@ -428,9 +443,8 @@ def create_rc(ctx, release_branch, patch_version=False, upstream="origin"):
         is run, then the task will prepare the release entries for 7.32.0-rc.1, and therefore
         will only use 7.32.X tags on the dependency repositories that follow the Agent version scheme.
 
-        Updates internal module dependencies with the new RC, except for Agent 6.
-        Agent 6 RCs keep the last published module dependencies because RC module
-        tags are not created.
+        Updates internal module dependencies with the new RC. Agent 6 RCs use
+        pseudo-versions because RC module tags are not created.
 
         Commits the above changes, and then creates a PR on the upstream repository with the change.
 

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -82,9 +82,7 @@ QUALIFICATION_TAG = "qualification"
 
 def _get_module_pseudo_version(ctx, module, commit):
     """Resolve the canonical pseudo-version for a module at a commit."""
-    command = join_command(
-        ["go", "list", "-m", "-mod=mod", "-f={{.Version}}", f"{module.import_path}@{commit}"]
-    )
+    command = join_command(["go", "list", "-m", "-mod=mod", "-f={{.Version}}", f"{module.import_path}@{commit}"])
     version = ctx.run(command, hide=True).stdout.strip()
     if not version:
         raise Exit(f"Could not resolve a pseudo-version for {module.import_path} at {commit}")

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -84,6 +84,8 @@ QUALIFICATION_TAG = "qualification"
 def update_modules(ctx, release_branch=None, version=None, trust=False):
     """Update internal dependencies between the different Agent modules.
 
+    Agent 6 release candidates are skipped because their nested modules are not tagged.
+
     Args:
         verify: Checks for correctness on the Agent Version (on by default).
 
@@ -94,6 +96,12 @@ def update_modules(ctx, release_branch=None, version=None, trust=False):
     assert release_branch or version
 
     agent_version = version or deduce_version(ctx, release_branch, trust=trust)
+
+    # Agent 6 RCs do not have nested module tags. Keep their dependencies pinned
+    # to the last published versions so pseudo-version consumers can resolve them.
+    if RC_VERSION_RE.match(agent_version) and get_version_major(agent_version) == 6:
+        print(f"Skipping module dependency updates for Agent 6 release candidate {agent_version}")
+        return
 
     with agent_context(ctx, release_branch, skip_checkout=release_branch is None):
         modules = get_default_modules()
@@ -420,7 +428,9 @@ def create_rc(ctx, release_branch, patch_version=False, upstream="origin"):
         is run, then the task will prepare the release entries for 7.32.0-rc.1, and therefore
         will only use 7.32.X tags on the dependency repositories that follow the Agent version scheme.
 
-        Updates internal module dependencies with the new RC.
+        Updates internal module dependencies with the new RC, except for Agent 6.
+        Agent 6 RCs keep the last published module dependencies because RC module
+        tags are not created.
 
         Commits the above changes, and then creates a PR on the upstream repository with the change.
 

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -159,6 +159,8 @@ def tag_modules(
 ):
     """Create tags for Go nested modules for a given Datadog Agent version.
 
+    Agent 6 release candidates are skipped; their modules should use pseudo-versions.
+
     Args:
         commit: Will tag `commit` with the tags (default HEAD).
         verify: Checks for correctness on the Agent version (on by default).
@@ -176,6 +178,12 @@ def tag_modules(
     assert release_branch or version
 
     agent_version = version or deduce_version(ctx, release_branch, trust=trust)
+
+    # Agent 6 consumers can use the global RC tag to find the commit for a pseudo-version.
+    # Final release module tags remain unaffected.
+    if RC_VERSION_RE.match(agent_version) and get_version_major(agent_version) == 6:
+        print(f"Skipping module tags for Agent 6 release candidate {agent_version}")
+        return
 
     def _tag_modules():
         tags = []

--- a/tasks/unit_tests/release_tests.py
+++ b/tasks/unit_tests/release_tests.py
@@ -908,15 +908,32 @@ class TestCheckForChanges(unittest.TestCase):
 
 
 class TestUpdateModules(unittest.TestCase):
-    @patch('tasks.release.get_default_modules')
+    @patch('tasks.release._get_module_pseudo_version', return_value="v0.53.5-0.20260817123456-abcdef123456")
     @patch('tasks.release.agent_context', new=MagicMock())
-    def test_skips_agent6_rc_dependency_updates(self, get_default_modules_mock):
-        c = MockContext(run=Result("yolo"))
+    def test_uses_pseudo_versions_for_agent6_rc_dependencies(self, get_module_pseudo_version_mock):
+        c = MockContext(run=Result("rccommit\n"))
+        consumer = GoModule('pkg/consumer')
+        consumer._dependencies = ['pkg/dependency']
+        dependency = GoModule('pkg/dependency')
+        dependency._dependencies = []
+        with patch('tasks.release.get_default_modules') as mock_modules:
+            mock_dict = MagicMock()
+            mock_dict.values.return_value = [consumer]
+            mock_dict.__getitem__.return_value = dependency
+            mock_modules.return_value = mock_dict
 
-        release.update_modules(c, version="6.53.5-rc.2")
+            release.update_modules(c, version="6.53.5-rc.2")
 
-        get_default_modules_mock.assert_not_called()
-        self.assertEqual(c.run.call_count, 0)
+        get_module_pseudo_version_mock.assert_called_once_with(c, dependency, "rccommit")
+        c.run.assert_has_calls(
+            [
+                call("git rev-parse HEAD", hide=True),
+                call(
+                    "go mod edit -require=github.com/DataDog/datadog-agent/pkg/dependency@v0.53.5-0.20260817123456-abcdef123456 "
+                    + consumer.go_mod_path()
+                ),
+            ]
+        )
 
     @patch('tasks.release.agent_context', new=MagicMock())
     def test_update_module_no_run_for_optional_in_agent_6(self):

--- a/tasks/unit_tests/release_tests.py
+++ b/tasks/unit_tests/release_tests.py
@@ -948,6 +948,16 @@ class TestUpdateModules(unittest.TestCase):
 
 
 class TestTagModules(unittest.TestCase):
+    @patch('tasks.release.__tag_single_module')
+    @patch('tasks.release.agent_context', new=MagicMock())
+    def test_skips_agent6_rc_tags(self, tag_single_module_mock):
+        c = MockContext(run=Result("yolo"))
+
+        release.tag_modules(c, version="6.53.5-rc.2")
+
+        tag_single_module_mock.assert_not_called()
+        self.assertEqual(c.run.call_count, 0)
+
     @patch('tasks.release.__tag_single_module', new=MagicMock(side_effect=[[str(i)] for i in range(2)]))
     @patch('tasks.release.agent_context', new=MagicMock())
     @patch.dict(os.environ, {'GITLAB_CI': 'false', 'GITHUB_ACTIONS': 'false'})

--- a/tasks/unit_tests/release_tests.py
+++ b/tasks/unit_tests/release_tests.py
@@ -908,6 +908,16 @@ class TestCheckForChanges(unittest.TestCase):
 
 
 class TestUpdateModules(unittest.TestCase):
+    @patch('tasks.release.get_default_modules')
+    @patch('tasks.release.agent_context', new=MagicMock())
+    def test_skips_agent6_rc_dependency_updates(self, get_default_modules_mock):
+        c = MockContext(run=Result("yolo"))
+
+        release.update_modules(c, version="6.53.5-rc.2")
+
+        get_default_modules_mock.assert_not_called()
+        self.assertEqual(c.run.call_count, 0)
+
     @patch('tasks.release.agent_context', new=MagicMock())
     def test_update_module_no_run_for_optional_in_agent_6(self):
         c = MockContext(run=Result("yolo"))


### PR DESCRIPTION
## Motivation

- Agent releases create a nested Go module tag for every release candidate. These tags significantly increase the repository's tag count and add pressure to GitHub and GitLab. Agent 7 already drops creating these RC module tags; this PR applies the same behavior to Agent 6. See the [RFC](https://docs.google.com/document/d/15XFZ4AKy8Yhyruo7zilTR84j5kV1dI5eFBhoEFfGzhI/edit?tab=t.0) for more info.

## Important Note
- Agent 6 RC module dependencies use versions backed by RC tags. After removing those tags, the dependencies must use another resolvable version. We use pseudo-versions derived from the release branch commit, ensuring modules in the same RC can consume each other’s changes without creating nested RC tags. 

## Changes

- Skip nested Go module tag creation for Agent 6 release candidates.
- Resolve Agent 6 RC internal module dependencies to canonical pseudo-versions at the current release branch commit.
- Cache each resolved pseudo-version while updating module requirements.
- Keep final Agent 6 release tags
- Document the Agent 6 RC pseudo-version workflow.
- Add unit coverage for tag suppression and pseudo-version dependency updates.

## Tests

- `dda inv invoke-unit-tests.run --tests=release` (46 tests passed)
- `GITLAB_CI=true dda inv linter.python`
- `git diff --check`