### PR TITLE
Userspace buffering of the ring buffer

### DIFF
--- a/pkg/config/schema/yaml/system-probe_schema.yaml
+++ b/pkg/config/schema/yaml/system-probe_schema.yaml
@@ -1132,6 +1132,44 @@ properties:
             env_vars:
             - DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_BUFFER_SIZE
             - DD_RUNTIME_SECURITY_CONFIG_EVENT_STREAM_BUFFER_SIZE
+          dispatcher_queue:
+            node_type: section
+            type: object
+            properties:
+              enabled:
+                node_type: setting
+                type: boolean
+                default: false
+                env_vars:
+                - DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_DISPATCHER_QUEUE_ENABLED
+                - DD_RUNTIME_SECURITY_CONFIG_EVENT_STREAM_DISPATCHER_QUEUE_ENABLED
+                description: |-
+                  Set to true to enable the user-space ring-buffer dispatcher queue.
+                  Off by default. When disabled, events are handled inline on the kernel read loop.
+              size:
+                node_type: setting
+                type: integer
+                default: 500000
+                env_vars:
+                - DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_DISPATCHER_QUEUE_SIZE
+                - DD_RUNTIME_SECURITY_CONFIG_EVENT_STREAM_DISPATCHER_QUEUE_SIZE
+                description: Dispatcher queue capacity in bytes. Multiplied by CPU count when size_per_core is true.
+              size_per_core:
+                node_type: setting
+                type: boolean
+                default: true
+                env_vars:
+                - DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_DISPATCHER_QUEUE_SIZE_PER_CORE
+                - DD_RUNTIME_SECURITY_CONFIG_EVENT_STREAM_DISPATCHER_QUEUE_SIZE_PER_CORE
+                description: Set to true to multiply size by the number of CPUs.
+              size_min:
+                node_type: setting
+                type: integer
+                default: 1048576
+                env_vars:
+                - DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_DISPATCHER_QUEUE_SIZE_MIN
+                - DD_RUNTIME_SECURITY_CONFIG_EVENT_STREAM_DISPATCHER_QUEUE_SIZE_MIN
+                description: Minimum dispatcher queue capacity in bytes, applied after size and optional per-core scaling.
           kretprobe_max_active:
             node_type: setting
             type: integer

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -171,6 +171,21 @@ var (
 	// Tags: map, cause
 	MetricPerfBufferInvalidEventsBytes = newRuntimeMetric(".perf_buffer.invalid_events.bytes")
 
+	// Ring buffer user space dispatcher queue metrics
+
+	// MetricEventStreamDispatcherQueueUsage is the number of events currently held in the user space dispatcher queue
+	// Tags: -
+	MetricEventStreamDispatcherQueueUsage = newRuntimeMetric(".event_stream.dispatcher_queue.usage")
+	// MetricEventStreamDispatcherQueueCapacity is the dispatcher queue capacity in bytes
+	// Tags: -
+	MetricEventStreamDispatcherQueueCapacity = newRuntimeMetric(".event_stream.dispatcher_queue.capacity")
+	// MetricEventStreamDispatcherQueueBytes is the number of bytes currently held in the user space dispatcher queue
+	// Tags: -
+	MetricEventStreamDispatcherQueueBytes = newRuntimeMetric(".event_stream.dispatcher_queue.bytes")
+	// MetricEventStreamDispatcherQueueEnqueued is the number of events pushed onto the user space dispatcher queue
+	// Tags: -
+	MetricEventStreamDispatcherQueueEnqueued = newRuntimeMetric(".event_stream.dispatcher_queue.enqueued")
+
 	// Process Resolver metrics
 
 	// MetricProcessResolverCacheSize is the name of the metric used to report the size of the user space

--- a/pkg/security/probe/config/config.go
+++ b/pkg/security/probe/config/config.go
@@ -91,6 +91,18 @@ type Config struct {
 	// EventStreamBufferSize specifies the buffer size of the eBPF map used for events
 	EventStreamBufferSize int
 
+	// EventStreamDispatcherQueueEnabled enables the user-space dispatcher queue (off by default)
+	EventStreamDispatcherQueueEnabled bool
+
+	// EventStreamDispatcherQueueSize is the dispatcher queue capacity in bytes, multiplied by CPU count when PerCore is set
+	EventStreamDispatcherQueueSize int
+
+	// EventStreamDispatcherQueueSizePerCore multiplies EventStreamDispatcherQueueSize by the number of CPUs
+	EventStreamDispatcherQueueSizePerCore bool
+
+	// EventStreamDispatcherQueueSizeMin is a floor in bytes applied after size and optional per-core scaling
+	EventStreamDispatcherQueueSizeMin int
+
 	// EventStreamUseFentry specifies whether to use eBPF fentry when available instead of kprobes
 	EventStreamUseFentry bool
 
@@ -197,33 +209,37 @@ func NewConfig() (*Config, error) {
 	setEnv()
 
 	c := &Config{
-		Config:                             *ebpf.NewConfig(),
-		EnableAllProbes:                    getBool("enable_all_probes"),
-		EnableKernelFilters:                getBool("enable_kernel_filters"),
-		EnableApprovers:                    getBool("enable_approvers"),
-		BasenameApproversSize:              getInt("basename_approvers_size"),
-		EnableDiscarders:                   getBool("enable_discarders"),
-		FlushDiscarderWindow:               getInt("flush_discarder_window"),
-		PIDCacheSize:                       getInt("pid_cache_size"),
-		StatsTagsCardinality:               getString("events_stats.tags_cardinality"),
-		CustomSensitiveWords:               getStringSlice("custom_sensitive_words"),
-		CustomSensitiveRegexps:             getStringSlice("custom_sensitive_regexps"),
-		ERPCDentryResolutionEnabled:        getBool("erpc_dentry_resolution_enabled"),
-		MapDentryResolutionEnabled:         getBool("map_dentry_resolution_enabled"),
-		DentryCacheSize:                    getInt("dentry_cache_size"),
-		NetworkLazyInterfacePrefixes:       getStringSlice("network.lazy_interface_prefixes"),
-		NetworkClassifierPriority:          uint16(getInt("network.classifier_priority")),
-		NetworkClassifierHandle:            uint16(getInt("network.classifier_handle")),
-		RawNetworkClassifierHandle:         uint16(getInt("network.raw_classifier_handle")),
-		NetworkFlowMonitorPeriod:           getDuration("network.flow_monitor.period"),
-		NetworkFlowMonitorEnabled:          getBool("network.flow_monitor.enabled"),
-		NetworkFlowMonitorSKStorageEnabled: getBool("network.flow_monitor.sk_storage.enabled"),
-		EventStreamUseRingBuffer:           getBool("event_stream.use_ring_buffer"),
-		EventStreamBufferSize:              getInt("event_stream.buffer_size"),
-		EventStreamUseFentry:               getBool("event_stream.use_fentry"),
-		EventStreamUseKprobeFallback:       getBool("event_stream.use_kprobe_fallback"),
-		EventStreamKretprobeMaxActive:      getInt("event_stream.kretprobe_max_active"),
-		EventStreamUseSyscallTaskStorage:   getBool("event_stream.use_syscall_task_storage"),
+		Config:                                *ebpf.NewConfig(),
+		EnableAllProbes:                       getBool("enable_all_probes"),
+		EnableKernelFilters:                   getBool("enable_kernel_filters"),
+		EnableApprovers:                       getBool("enable_approvers"),
+		BasenameApproversSize:                 getInt("basename_approvers_size"),
+		EnableDiscarders:                      getBool("enable_discarders"),
+		FlushDiscarderWindow:                  getInt("flush_discarder_window"),
+		PIDCacheSize:                          getInt("pid_cache_size"),
+		StatsTagsCardinality:                  getString("events_stats.tags_cardinality"),
+		CustomSensitiveWords:                  getStringSlice("custom_sensitive_words"),
+		CustomSensitiveRegexps:                getStringSlice("custom_sensitive_regexps"),
+		ERPCDentryResolutionEnabled:           getBool("erpc_dentry_resolution_enabled"),
+		MapDentryResolutionEnabled:            getBool("map_dentry_resolution_enabled"),
+		DentryCacheSize:                       getInt("dentry_cache_size"),
+		NetworkLazyInterfacePrefixes:          getStringSlice("network.lazy_interface_prefixes"),
+		NetworkClassifierPriority:             uint16(getInt("network.classifier_priority")),
+		NetworkClassifierHandle:               uint16(getInt("network.classifier_handle")),
+		RawNetworkClassifierHandle:            uint16(getInt("network.raw_classifier_handle")),
+		NetworkFlowMonitorPeriod:              getDuration("network.flow_monitor.period"),
+		NetworkFlowMonitorEnabled:             getBool("network.flow_monitor.enabled"),
+		NetworkFlowMonitorSKStorageEnabled:    getBool("network.flow_monitor.sk_storage.enabled"),
+		EventStreamUseRingBuffer:              getBool("event_stream.use_ring_buffer"),
+		EventStreamBufferSize:                 getInt("event_stream.buffer_size"),
+		EventStreamDispatcherQueueEnabled:     getBool("event_stream.dispatcher_queue.enabled"),
+		EventStreamDispatcherQueueSize:        getInt("event_stream.dispatcher_queue.size"),
+		EventStreamDispatcherQueueSizePerCore: getBool("event_stream.dispatcher_queue.size_per_core"),
+		EventStreamDispatcherQueueSizeMin:     getInt("event_stream.dispatcher_queue.size_min"),
+		EventStreamUseFentry:                  getBool("event_stream.use_fentry"),
+		EventStreamUseKprobeFallback:          getBool("event_stream.use_kprobe_fallback"),
+		EventStreamKretprobeMaxActive:         getInt("event_stream.kretprobe_max_active"),
+		EventStreamUseSyscallTaskStorage:      getBool("event_stream.use_syscall_task_storage"),
 
 		EnvsWithValue:                       getStringSlice("envs_with_value"),
 		NetworkEnabled:                      getBool("network.enabled"),

--- a/pkg/security/probe/eventstream/reorderer/perfmap.go
+++ b/pkg/security/probe/eventstream/reorderer/perfmap.go
@@ -90,6 +90,11 @@ func (m *OrderedPerfMap) Resume() error {
 	return m.perfMap.Resume()
 }
 
+// SendStats is a no-op for the ordered perf map.
+func (m *OrderedPerfMap) SendStats() error {
+	return nil
+}
+
 // ExtractEventInfo extracts cpu and timestamp from the raw data event
 func ExtractEventInfo(record *perf.Record) (QuickInfo, error) {
 	if len(record.RawSample) < 8 {

--- a/pkg/security/probe/eventstream/ringbuffer/BUILD.bazel
+++ b/pkg/security/probe/eventstream/ringbuffer/BUILD.bazel
@@ -42,16 +42,10 @@ dd_agent_go_test(
     embed = [":ringbuffer"],
     deps = select({
         "@rules_go//go/platform:android": [
-            "//pkg/security/metrics",
-            "//pkg/security/probe/config",
-            "//pkg/security/tests/statsdclient",
             "@com_github_cilium_ebpf//ringbuf",
             "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:linux": [
-            "//pkg/security/metrics",
-            "//pkg/security/probe/config",
-            "//pkg/security/tests/statsdclient",
             "@com_github_cilium_ebpf//ringbuf",
             "@com_github_stretchr_testify//require",
         ],

--- a/pkg/security/probe/eventstream/ringbuffer/BUILD.bazel
+++ b/pkg/security/probe/eventstream/ringbuffer/BUILD.bazel
@@ -1,26 +1,59 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "ringbuffer",
-    srcs = ["ringbuffer.go"],
+    srcs = [
+        "queue.go",
+        "ringbuffer.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/ringbuffer",
     visibility = ["//visibility:public"],
     deps = select({
         "@rules_go//go/platform:android": [
             "//pkg/ebpf/telemetry",
+            "//pkg/security/metrics",
             "//pkg/security/probe/config",
             "//pkg/security/probe/eventstream",
+            "//pkg/security/seclog",
             "//pkg/util/sync",
             "@com_github_cilium_ebpf//ringbuf",
+            "@com_github_datadog_datadog_go_v5//statsd",
             "@com_github_datadog_ebpf_manager//:ebpf-manager",
         ],
         "@rules_go//go/platform:linux": [
             "//pkg/ebpf/telemetry",
+            "//pkg/security/metrics",
             "//pkg/security/probe/config",
             "//pkg/security/probe/eventstream",
+            "//pkg/security/seclog",
             "//pkg/util/sync",
             "@com_github_cilium_ebpf//ringbuf",
+            "@com_github_datadog_datadog_go_v5//statsd",
             "@com_github_datadog_ebpf_manager//:ebpf-manager",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+dd_agent_go_test(
+    name = "ringbuffer_test",
+    srcs = ["ringbuffer_test.go"],
+    embed = [":ringbuffer"],
+    deps = select({
+        "@rules_go//go/platform:android": [
+            "//pkg/security/metrics",
+            "//pkg/security/probe/config",
+            "//pkg/security/tests/statsdclient",
+            "@com_github_cilium_ebpf//ringbuf",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux": [
+            "//pkg/security/metrics",
+            "//pkg/security/probe/config",
+            "//pkg/security/tests/statsdclient",
+            "@com_github_cilium_ebpf//ringbuf",
+            "@com_github_stretchr_testify//require",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/security/probe/eventstream/ringbuffer/queue.go
+++ b/pkg/security/probe/eventstream/ringbuffer/queue.go
@@ -1,0 +1,133 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build linux
+
+package ringbuffer
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/cilium/ebpf/ringbuf"
+)
+
+type byteQueue struct {
+	mu       sync.Mutex
+	notEmpty *sync.Cond
+	notFull  *sync.Cond
+	buf      []*ringbuf.Record
+	head     int
+	count    int
+	bytes    int64
+	maxBytes int64
+	closed   bool
+	waiters  atomic.Int32
+}
+
+func newByteQueue(maxBytes int64) *byteQueue {
+	if maxBytes < 0 {
+		maxBytes = 0
+	}
+	q := &byteQueue{
+		buf:      make([]*ringbuf.Record, 64),
+		maxBytes: maxBytes,
+	}
+	q.notEmpty = sync.NewCond(&q.mu)
+	q.notFull = sync.NewCond(&q.mu)
+	return q
+}
+
+func (q *byteQueue) canAdmitLocked(size int64) bool {
+	// A single event larger than the budget would otherwise wait forever.
+	if q.count == 0 && size > q.maxBytes {
+		return true
+	}
+	return q.bytes+size <= q.maxBytes
+}
+
+func (q *byteQueue) enqueue(rec *ringbuf.Record) bool {
+	return q.enqueueAndPublish(rec, nil)
+}
+
+func (q *byteQueue) enqueueAndPublish(rec *ringbuf.Record, afterPublish func(int64)) bool {
+	size := int64(len(rec.RawSample))
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for !q.closed && !q.canAdmitLocked(size) {
+		q.waiters.Add(1)
+		q.notFull.Wait()
+		q.waiters.Add(-1)
+	}
+	if q.closed {
+		return false
+	}
+	q.pushLocked(rec)
+	q.bytes += size
+	if afterPublish != nil {
+		afterPublish(size)
+	}
+	q.notEmpty.Signal()
+	return true
+}
+
+func (q *byteQueue) dequeue() (*ringbuf.Record, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for q.count == 0 && !q.closed {
+		q.notEmpty.Wait()
+	}
+	if q.count == 0 {
+		return nil, false
+	}
+	rec := q.popLocked()
+	q.bytes -= int64(len(rec.RawSample))
+	q.notFull.Signal()
+	return rec, true
+}
+
+func (q *byteQueue) close() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return
+	}
+	q.closed = true
+	q.notEmpty.Broadcast()
+	q.notFull.Broadcast()
+}
+
+func (q *byteQueue) capacity() int64 {
+	return q.maxBytes
+}
+
+func (q *byteQueue) pushLocked(rec *ringbuf.Record) {
+	if q.count == len(q.buf) {
+		q.growLocked()
+	}
+	q.buf[(q.head+q.count)%len(q.buf)] = rec
+	q.count++
+}
+
+func (q *byteQueue) popLocked() *ringbuf.Record {
+	rec := q.buf[q.head]
+	q.buf[q.head] = nil
+	q.head = (q.head + 1) % len(q.buf)
+	q.count--
+	return rec
+}
+
+func (q *byteQueue) growLocked() {
+	n := len(q.buf) * 2
+	if n == 0 {
+		n = 64
+	}
+	next := make([]*ringbuf.Record, n)
+	for i := 0; i < q.count; i++ {
+		next[i] = q.buf[(q.head+i)%len(q.buf)]
+	}
+	q.buf = next
+	q.head = 0
+}

--- a/pkg/security/probe/eventstream/ringbuffer/ringbuffer.go
+++ b/pkg/security/probe/eventstream/ringbuffer/ringbuffer.go
@@ -9,15 +9,21 @@
 package ringbuffer
 
 import (
+	"context"
 	"fmt"
+	"runtime"
 	"sync"
+	"sync/atomic"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf/ringbuf"
 
 	ebpfTelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/eventstream"
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	ddsync "github.com/DataDog/datadog-agent/pkg/util/sync"
 )
 
@@ -27,6 +33,14 @@ type RingBuffer struct {
 	ringBuffer *manager.RingBuffer
 	handler    func(int, []byte)
 	recordPool *ddsync.TypedPool[ringbuf.Record]
+
+	ctx        context.Context
+	queue      *byteQueue // nil when the dispatcher is disabled
+	queueBytes atomic.Int64
+	occupancy  atomic.Int64
+	enqueued   atomic.Uint64
+
+	statsdClient statsd.ClientInterface
 }
 
 // Init the ring buffer
@@ -36,11 +50,19 @@ func (rb *RingBuffer) Init(mgr *manager.Manager, config *config.Config) error {
 		return fmt.Errorf("couldn't find %q ring buffer", eventstream.EventStreamMap)
 	}
 
+	recordHandler := rb.handleEvent
+	if config.EventStreamDispatcherQueueEnabled {
+		maxBytes := dispatcherQueueMaxBytes(config)
+		rb.queue = newByteQueue(maxBytes)
+		recordHandler = rb.handleQueuedEvent
+		seclog.Infof("ring buffer dispatcher queue enabled, max_bytes=%d", maxBytes)
+	}
+
 	rb.ringBuffer.RingBufferOptions = manager.RingBufferOptions{
 		RecordGetter: func() *ringbuf.Record {
 			return rb.recordPool.Get()
 		},
-		RecordHandler:    rb.handleEvent,
+		RecordHandler:    recordHandler,
 		TelemetryEnabled: config.InternalTelemetryEnabled,
 	}
 
@@ -48,9 +70,91 @@ func (rb *RingBuffer) Init(mgr *manager.Manager, config *config.Config) error {
 	return nil
 }
 
+func dispatcherQueueMaxBytes(cfg *config.Config) int64 {
+	return dispatcherQueueMaxBytesWithCPU(cfg, runtime.NumCPU())
+}
+
+func dispatcherQueueMaxBytesWithCPU(cfg *config.Config, numCPU int) int64 {
+	size := int64(cfg.EventStreamDispatcherQueueSize)
+
+	if cfg.EventStreamDispatcherQueueSizePerCore {
+		if numCPU <= 0 {
+			numCPU = 1
+		}
+		size *= int64(numCPU)
+	}
+
+	if minBytes := int64(cfg.EventStreamDispatcherQueueSizeMin); minBytes > size {
+		size = minBytes
+	}
+
+	if size < 0 {
+		size = 0
+	}
+
+	return size
+}
+
+func (rb *RingBuffer) dispatch(wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	stop := context.AfterFunc(rb.ctx, rb.queue.close)
+	defer stop()
+
+	for {
+		record, ok := rb.queue.dequeue()
+		if !ok {
+			return
+		}
+		rb.handleRecord(record)
+	}
+}
+
+func (rb *RingBuffer) handleRecord(record *ringbuf.Record) {
+	defer func() {
+		if r := recover(); r != nil {
+			seclog.Errorf("ring buffer dispatcher panic: %v", r)
+		}
+		rb.recordPool.Put(record)
+	}()
+
+	rb.occupancy.Add(-1)
+	rb.queueBytes.Add(-int64(len(record.RawSample)))
+	rb.handler(0, record.RawSample)
+}
+
+// SendStats reports dispatcher queue occupancy and counters.
+func (rb *RingBuffer) SendStats() error {
+	if rb.statsdClient == nil || rb.queue == nil {
+		return nil
+	}
+
+	if err := rb.statsdClient.Gauge(metrics.MetricEventStreamDispatcherQueueUsage, float64(rb.occupancy.Load()), nil, 1.0); err != nil {
+		return err
+	}
+	if err := rb.statsdClient.Gauge(metrics.MetricEventStreamDispatcherQueueCapacity, float64(rb.queue.capacity()), nil, 1.0); err != nil {
+		return err
+	}
+	if err := rb.statsdClient.Gauge(metrics.MetricEventStreamDispatcherQueueBytes, float64(rb.queueBytes.Load()), nil, 1.0); err != nil {
+		return err
+	}
+	return rb.statsdClient.Count(metrics.MetricEventStreamDispatcherQueueEnqueued, int64(rb.enqueued.Swap(0)), nil, 1.0)
+}
+
 // Start the event stream.
-func (rb *RingBuffer) Start(_ *sync.WaitGroup) error {
-	return rb.ringBuffer.Start()
+func (rb *RingBuffer) Start(wg *sync.WaitGroup) error {
+	if err := rb.ringBuffer.Start(); err != nil {
+		return err
+	}
+
+	if rb.queue == nil {
+		return nil
+	}
+
+	wg.Add(1)
+	go rb.dispatch(wg)
+
+	return nil
 }
 
 // SetMonitor set the monitor
@@ -59,6 +163,17 @@ func (rb *RingBuffer) SetMonitor(_ eventstream.LostEventCounter) {}
 func (rb *RingBuffer) handleEvent(record *ringbuf.Record, _ *manager.RingBuffer, _ *manager.Manager) {
 	rb.handler(0, record.RawSample)
 	rb.recordPool.Put(record)
+}
+
+func (rb *RingBuffer) handleQueuedEvent(record *ringbuf.Record, _ *manager.RingBuffer, _ *manager.Manager) {
+	if !rb.queue.enqueueAndPublish(record, func(size int64) {
+		rb.enqueued.Add(1)
+		rb.occupancy.Add(1)
+		rb.queueBytes.Add(size)
+	}) {
+		rb.recordPool.Put(record)
+		return
+	}
 }
 
 // Pause the event stream. Do nothing when using ring buffer
@@ -72,9 +187,11 @@ func (rb *RingBuffer) Resume() error {
 }
 
 // New returns a new ring buffer based event stream.
-func New(handler func(int, []byte)) *RingBuffer {
+func New(ctx context.Context, handler func(int, []byte), statsdClient statsd.ClientInterface) *RingBuffer {
 	return &RingBuffer{
-		recordPool: ddsync.NewDefaultTypedPool[ringbuf.Record](),
-		handler:    handler,
+		ctx:          ctx,
+		recordPool:   ddsync.NewDefaultTypedPool[ringbuf.Record](),
+		handler:      handler,
+		statsdClient: statsdClient,
 	}
 }

--- a/pkg/security/probe/eventstream/ringbuffer/ringbuffer_test.go
+++ b/pkg/security/probe/eventstream/ringbuffer/ringbuffer_test.go
@@ -71,49 +71,6 @@ func TestDispatcherQueueMaxBytes(t *testing.T) {
 	}
 }
 
-func TestHandleEventInlineWhenQueueDisabled(t *testing.T) {
-	var got []byte
-	rb := New(context.Background(), func(_ int, data []byte) {
-		got = append([]byte(nil), data...)
-	}, nil)
-
-	rb.handleEvent(&ringbuf.Record{RawSample: []byte{1, 2, 3}}, nil, nil)
-
-	require.Equal(t, []byte{1, 2, 3}, got)
-	require.Zero(t, rb.enqueued.Load())
-}
-
-func TestHandleEventQueuesWhenEnabled(t *testing.T) {
-	done := make(chan []byte, 1)
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	rb := New(ctx, func(_ int, data []byte) {
-		done <- append([]byte(nil), data...)
-	}, nil)
-	rb.queue = newByteQueue(4096)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go rb.dispatch(&wg)
-
-	rb.handleQueuedEvent(&ringbuf.Record{RawSample: []byte{9, 8, 7}}, nil, nil)
-
-	select {
-	case got := <-done:
-		require.Equal(t, []byte{9, 8, 7}, got)
-	case <-time.After(2 * time.Second):
-		t.Fatal("dispatcher did not process the queued event")
-	}
-
-	require.Equal(t, uint64(1), rb.enqueued.Load())
-	require.Zero(t, rb.occupancy.Load())
-	require.Zero(t, rb.queueBytes.Load())
-
-	cancel()
-	wg.Wait()
-}
-
 func TestDispatcherRecoversFromHandlerPanic(t *testing.T) {
 	done := make(chan []byte, 1)
 	var n int
@@ -150,56 +107,18 @@ func TestDispatcherRecoversFromHandlerPanic(t *testing.T) {
 }
 
 func TestSendStats(t *testing.T) {
-	t.Run("reports occupancy, bytes, capacity and enqueued", func(t *testing.T) {
-		client := statsdclient.NewStatsdClient()
-		rb := New(context.Background(), func(int, []byte) {}, client)
-		rb.queue = newByteQueue(4096)
+	client := statsdclient.NewStatsdClient()
+	rb := New(context.Background(), func(int, []byte) {}, client)
+	rb.queue = newByteQueue(4096)
 
-		rb.handleQueuedEvent(&ringbuf.Record{RawSample: make([]byte, 1000)}, nil, nil)
-		rb.handleQueuedEvent(&ringbuf.Record{RawSample: make([]byte, 500)}, nil, nil)
+	rb.handleQueuedEvent(&ringbuf.Record{RawSample: make([]byte, 1000)}, nil, nil)
+	rb.handleQueuedEvent(&ringbuf.Record{RawSample: make([]byte, 500)}, nil, nil)
 
-		require.NoError(t, rb.SendStats())
-		require.Equal(t, int64(2), client.Get(metrics.MetricEventStreamDispatcherQueueUsage))
-		require.Equal(t, int64(1500), client.Get(metrics.MetricEventStreamDispatcherQueueBytes))
-		require.Equal(t, int64(4096), client.Get(metrics.MetricEventStreamDispatcherQueueCapacity))
-		require.Equal(t, int64(2), client.Get(metrics.MetricEventStreamDispatcherQueueEnqueued))
-	})
-
-	t.Run("is a no-op when the queue is disabled", func(t *testing.T) {
-		client := statsdclient.NewStatsdClient()
-		rb := New(context.Background(), func(int, []byte) {}, client)
-
-		require.NoError(t, rb.SendStats())
-		require.Zero(t, client.Get(metrics.MetricEventStreamDispatcherQueueUsage))
-	})
-}
-
-func TestByteQueueAdmitsOversizedWhenEmpty(t *testing.T) {
-	q := newByteQueue(100)
-	t.Cleanup(q.close)
-	rec := &ringbuf.Record{RawSample: make([]byte, 500)}
-	require.True(t, q.enqueue(rec))
-
-	got, ok := q.dequeue()
-	require.True(t, ok)
-	require.Equal(t, rec, got)
-}
-
-func TestByteQueueGrowsBeyondInitialCapacity(t *testing.T) {
-	q := newByteQueue(1 << 20)
-	t.Cleanup(q.close)
-
-	const n = 200 // exceeds the initial ring capacity of 64 to exercise growLocked
-	for i := 0; i < n; i++ {
-		require.True(t, q.enqueue(&ringbuf.Record{RawSample: []byte{byte(i)}}))
-	}
-	require.Greater(t, len(q.buf), 64)
-
-	for i := 0; i < n; i++ {
-		rec, ok := q.dequeue()
-		require.True(t, ok)
-		require.Equal(t, []byte{byte(i)}, rec.RawSample)
-	}
+	require.NoError(t, rb.SendStats())
+	require.Equal(t, int64(2), client.Get(metrics.MetricEventStreamDispatcherQueueUsage))
+	require.Equal(t, int64(1500), client.Get(metrics.MetricEventStreamDispatcherQueueBytes))
+	require.Equal(t, int64(4096), client.Get(metrics.MetricEventStreamDispatcherQueueCapacity))
+	require.Equal(t, int64(2), client.Get(metrics.MetricEventStreamDispatcherQueueEnqueued))
 }
 
 func waitForEnqueueBlocked(t *testing.T, q *byteQueue) {

--- a/pkg/security/probe/eventstream/ringbuffer/ringbuffer_test.go
+++ b/pkg/security/probe/eventstream/ringbuffer/ringbuffer_test.go
@@ -15,61 +15,7 @@ import (
 
 	"github.com/cilium/ebpf/ringbuf"
 	"github.com/stretchr/testify/require"
-
-	"github.com/DataDog/datadog-agent/pkg/security/metrics"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
-	"github.com/DataDog/datadog-agent/pkg/security/tests/statsdclient"
 )
-
-func TestDispatcherQueueMaxBytes(t *testing.T) {
-	tests := []struct {
-		name     string
-		cfg      config.Config
-		numCPU   int
-		expected int64
-	}{
-		{
-			name:     "zero size stays zero without min",
-			cfg:      config.Config{EventStreamDispatcherQueueSize: 0},
-			numCPU:   8,
-			expected: 0,
-		},
-		{
-			name: "per-core multiplies by cpu count",
-			cfg: config.Config{
-				EventStreamDispatcherQueueSize:        100,
-				EventStreamDispatcherQueueSizePerCore: true,
-			},
-			numCPU:   4,
-			expected: 400,
-		},
-		{
-			name: "min floor applied after per-core",
-			cfg: config.Config{
-				EventStreamDispatcherQueueSize:        100,
-				EventStreamDispatcherQueueSizePerCore: true,
-				EventStreamDispatcherQueueSizeMin:     1000,
-			},
-			numCPU:   2,
-			expected: 1000,
-		},
-		{
-			name: "invalid cpu count treated as 1",
-			cfg: config.Config{
-				EventStreamDispatcherQueueSize:        100,
-				EventStreamDispatcherQueueSizePerCore: true,
-			},
-			numCPU:   0,
-			expected: 100,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expected, dispatcherQueueMaxBytesWithCPU(&tt.cfg, tt.numCPU))
-		})
-	}
-}
 
 func TestDispatcherRecoversFromHandlerPanic(t *testing.T) {
 	done := make(chan []byte, 1)
@@ -104,21 +50,6 @@ func TestDispatcherRecoversFromHandlerPanic(t *testing.T) {
 
 	cancel()
 	wg.Wait()
-}
-
-func TestSendStats(t *testing.T) {
-	client := statsdclient.NewStatsdClient()
-	rb := New(context.Background(), func(int, []byte) {}, client)
-	rb.queue = newByteQueue(4096)
-
-	rb.handleQueuedEvent(&ringbuf.Record{RawSample: make([]byte, 1000)}, nil, nil)
-	rb.handleQueuedEvent(&ringbuf.Record{RawSample: make([]byte, 500)}, nil, nil)
-
-	require.NoError(t, rb.SendStats())
-	require.Equal(t, int64(2), client.Get(metrics.MetricEventStreamDispatcherQueueUsage))
-	require.Equal(t, int64(1500), client.Get(metrics.MetricEventStreamDispatcherQueueBytes))
-	require.Equal(t, int64(4096), client.Get(metrics.MetricEventStreamDispatcherQueueCapacity))
-	require.Equal(t, int64(2), client.Get(metrics.MetricEventStreamDispatcherQueueEnqueued))
 }
 
 func waitForEnqueueBlocked(t *testing.T, q *byteQueue) {

--- a/pkg/security/probe/eventstream/ringbuffer/ringbuffer_test.go
+++ b/pkg/security/probe/eventstream/ringbuffer/ringbuffer_test.go
@@ -1,0 +1,301 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build linux
+
+package ringbuffer
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf/ringbuf"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/security/metrics"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
+	"github.com/DataDog/datadog-agent/pkg/security/tests/statsdclient"
+)
+
+func TestDispatcherQueueMaxBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      config.Config
+		numCPU   int
+		expected int64
+	}{
+		{
+			name:     "zero size stays zero without min",
+			cfg:      config.Config{EventStreamDispatcherQueueSize: 0},
+			numCPU:   8,
+			expected: 0,
+		},
+		{
+			name: "per-core multiplies by cpu count",
+			cfg: config.Config{
+				EventStreamDispatcherQueueSize:        100,
+				EventStreamDispatcherQueueSizePerCore: true,
+			},
+			numCPU:   4,
+			expected: 400,
+		},
+		{
+			name: "min floor applied after per-core",
+			cfg: config.Config{
+				EventStreamDispatcherQueueSize:        100,
+				EventStreamDispatcherQueueSizePerCore: true,
+				EventStreamDispatcherQueueSizeMin:     1000,
+			},
+			numCPU:   2,
+			expected: 1000,
+		},
+		{
+			name: "invalid cpu count treated as 1",
+			cfg: config.Config{
+				EventStreamDispatcherQueueSize:        100,
+				EventStreamDispatcherQueueSizePerCore: true,
+			},
+			numCPU:   0,
+			expected: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, dispatcherQueueMaxBytesWithCPU(&tt.cfg, tt.numCPU))
+		})
+	}
+}
+
+func TestHandleEventInlineWhenQueueDisabled(t *testing.T) {
+	var got []byte
+	rb := New(context.Background(), func(_ int, data []byte) {
+		got = append([]byte(nil), data...)
+	}, nil)
+
+	rb.handleEvent(&ringbuf.Record{RawSample: []byte{1, 2, 3}}, nil, nil)
+
+	require.Equal(t, []byte{1, 2, 3}, got)
+	require.Zero(t, rb.enqueued.Load())
+}
+
+func TestHandleEventQueuesWhenEnabled(t *testing.T) {
+	done := make(chan []byte, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	rb := New(ctx, func(_ int, data []byte) {
+		done <- append([]byte(nil), data...)
+	}, nil)
+	rb.queue = newByteQueue(4096)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go rb.dispatch(&wg)
+
+	rb.handleQueuedEvent(&ringbuf.Record{RawSample: []byte{9, 8, 7}}, nil, nil)
+
+	select {
+	case got := <-done:
+		require.Equal(t, []byte{9, 8, 7}, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("dispatcher did not process the queued event")
+	}
+
+	require.Equal(t, uint64(1), rb.enqueued.Load())
+	require.Zero(t, rb.occupancy.Load())
+	require.Zero(t, rb.queueBytes.Load())
+
+	cancel()
+	wg.Wait()
+}
+
+func TestDispatcherRecoversFromHandlerPanic(t *testing.T) {
+	done := make(chan []byte, 1)
+	var n int
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	rb := New(ctx, func(_ int, data []byte) {
+		n++
+		if n == 1 {
+			panic("boom")
+		}
+		done <- append([]byte(nil), data...)
+	}, nil)
+	rb.queue = newByteQueue(4096)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go rb.dispatch(&wg)
+
+	rb.handleQueuedEvent(&ringbuf.Record{RawSample: []byte{1}}, nil, nil)
+	rb.handleQueuedEvent(&ringbuf.Record{RawSample: []byte{2}}, nil, nil)
+
+	select {
+	case got := <-done:
+		require.Equal(t, []byte{2}, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("dispatcher did not recover from handler panic")
+	}
+
+	require.Zero(t, rb.occupancy.Load())
+
+	cancel()
+	wg.Wait()
+}
+
+func TestSendStats(t *testing.T) {
+	t.Run("reports occupancy, bytes, capacity and enqueued", func(t *testing.T) {
+		client := statsdclient.NewStatsdClient()
+		rb := New(context.Background(), func(int, []byte) {}, client)
+		rb.queue = newByteQueue(4096)
+
+		rb.handleQueuedEvent(&ringbuf.Record{RawSample: make([]byte, 1000)}, nil, nil)
+		rb.handleQueuedEvent(&ringbuf.Record{RawSample: make([]byte, 500)}, nil, nil)
+
+		require.NoError(t, rb.SendStats())
+		require.Equal(t, int64(2), client.Get(metrics.MetricEventStreamDispatcherQueueUsage))
+		require.Equal(t, int64(1500), client.Get(metrics.MetricEventStreamDispatcherQueueBytes))
+		require.Equal(t, int64(4096), client.Get(metrics.MetricEventStreamDispatcherQueueCapacity))
+		require.Equal(t, int64(2), client.Get(metrics.MetricEventStreamDispatcherQueueEnqueued))
+	})
+
+	t.Run("is a no-op when the queue is disabled", func(t *testing.T) {
+		client := statsdclient.NewStatsdClient()
+		rb := New(context.Background(), func(int, []byte) {}, client)
+
+		require.NoError(t, rb.SendStats())
+		require.Zero(t, client.Get(metrics.MetricEventStreamDispatcherQueueUsage))
+	})
+}
+
+func TestByteQueueAdmitsOversizedWhenEmpty(t *testing.T) {
+	q := newByteQueue(100)
+	t.Cleanup(q.close)
+	rec := &ringbuf.Record{RawSample: make([]byte, 500)}
+	require.True(t, q.enqueue(rec))
+
+	got, ok := q.dequeue()
+	require.True(t, ok)
+	require.Equal(t, rec, got)
+}
+
+func TestByteQueueGrowsBeyondInitialCapacity(t *testing.T) {
+	q := newByteQueue(1 << 20)
+	t.Cleanup(q.close)
+
+	const n = 200 // exceeds the initial ring capacity of 64 to exercise growLocked
+	for i := 0; i < n; i++ {
+		require.True(t, q.enqueue(&ringbuf.Record{RawSample: []byte{byte(i)}}))
+	}
+	require.Greater(t, len(q.buf), 64)
+
+	for i := 0; i < n; i++ {
+		rec, ok := q.dequeue()
+		require.True(t, ok)
+		require.Equal(t, []byte{byte(i)}, rec.RawSample)
+	}
+}
+
+func waitForEnqueueBlocked(t *testing.T, q *byteQueue) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return q.waiters.Load() == 1
+	}, time.Second, time.Millisecond)
+}
+
+func TestByteQueueBlocksUntilBytesFreed(t *testing.T) {
+	q := newByteQueue(1000)
+	t.Cleanup(q.close)
+	require.True(t, q.enqueue(&ringbuf.Record{RawSample: make([]byte, 400)}))
+	require.True(t, q.enqueue(&ringbuf.Record{RawSample: make([]byte, 400)}))
+
+	unblocked := make(chan struct{})
+	go func() {
+		require.True(t, q.enqueue(&ringbuf.Record{RawSample: make([]byte, 400)}))
+		close(unblocked)
+	}()
+
+	waitForEnqueueBlocked(t, q)
+	select {
+	case <-unblocked:
+		t.Fatal("enqueue returned while the queue was over budget")
+	default:
+	}
+
+	got, ok := q.dequeue()
+	require.True(t, ok)
+	require.Len(t, got.RawSample, 400)
+
+	select {
+	case <-unblocked:
+	case <-time.After(time.Second):
+		t.Fatal("enqueue did not proceed after bytes were freed")
+	}
+}
+
+func TestByteQueueOversizedWaitsIfNotEmpty(t *testing.T) {
+	q := newByteQueue(100)
+	t.Cleanup(q.close)
+	require.True(t, q.enqueue(&ringbuf.Record{RawSample: make([]byte, 40)}))
+
+	unblocked := make(chan struct{})
+	oversized := &ringbuf.Record{RawSample: make([]byte, 200)}
+	go func() {
+		require.True(t, q.enqueue(oversized))
+		close(unblocked)
+	}()
+
+	waitForEnqueueBlocked(t, q)
+	select {
+	case <-unblocked:
+		t.Fatal("oversized event was admitted while the queue was not empty")
+	default:
+	}
+
+	got, ok := q.dequeue()
+	require.True(t, ok)
+	require.Len(t, got.RawSample, 40)
+
+	select {
+	case <-unblocked:
+	case <-time.After(time.Second):
+		t.Fatal("oversized event was not admitted after the queue became empty")
+	}
+
+	got, ok = q.dequeue()
+	require.True(t, ok)
+	require.Equal(t, oversized, got)
+}
+
+func TestByteQueueCloseUnblocksEnqueue(t *testing.T) {
+	q := newByteQueue(100)
+	t.Cleanup(q.close)
+	require.True(t, q.enqueue(&ringbuf.Record{RawSample: make([]byte, 80)}))
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- q.enqueue(&ringbuf.Record{RawSample: make([]byte, 80)})
+	}()
+
+	waitForEnqueueBlocked(t, q)
+	select {
+	case admitted := <-done:
+		t.Fatalf("enqueue returned %v while the queue was full", admitted)
+	default:
+	}
+
+	q.close()
+
+	select {
+	case admitted := <-done:
+		require.False(t, admitted)
+	case <-time.After(time.Second):
+		t.Fatal("enqueue was not unblocked by close")
+	}
+}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -86,6 +86,7 @@ type EventStream interface {
 	Start(*sync.WaitGroup) error
 	Pause() error
 	Resume() error
+	SendStats() error
 }
 
 const (
@@ -1200,6 +1201,10 @@ func (p *EBPFProbe) SendStats() error {
 
 	valueNameTruncated := p.MetricNameTruncated.Swap(0)
 	if err := p.statsdClient.Count(metrics.MetricNameTruncated, int64(valueNameTruncated), []string{}, 1.0); err != nil {
+		return err
+	}
+
+	if err := p.eventStream.SendStats(); err != nil {
 		return err
 	}
 
@@ -2655,6 +2660,7 @@ func (p *EBPFProbe) Stop() {
 	// wait for the following goroutines to exit:
 	// - the perfmap reorderer (if used/enabled)
 	// - the perfmap reorderer monitor (if used/enabled)
+	// - the ring-buffer dispatcher (if the user-space queue is enabled)
 	// - the security profile manager
 	// - the process killer goroutine
 	// - the startSysCtlSnapshotLoop goroutine
@@ -3573,7 +3579,7 @@ func NewEBPFProbe(probe *Probe, config *config.Config, hostname string, opts Opt
 	})
 
 	if p.useRingBuffers {
-		p.eventStream = ringbuffer.New(p.handleEvent)
+		p.eventStream = ringbuffer.New(p.ctx, p.handleEvent, probe.StatsdClient)
 	} else {
 		p.eventStream, err = reorderer.NewOrderedPerfMap(p.ctx, p.handleEvent, probe.StatsdClient)
 		if err != nil {

--- a/releasenotes/notes/cws-ringbuffer-dispatcher-queue-c934e2659582e316.yaml
+++ b/releasenotes/notes/cws-ringbuffer-dispatcher-queue-c934e2659582e316.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    CWS: added an optional user-space dispatcher queue for the eBPF ring-buffer
+    event stream. When enabled, events are handed off from the kernel read loop
+    to a byte-bounded queue drained by a dedicated goroutine, decoupling kernel
+    reads from user-space processing. It is disabled by default; when disabled,
+    events are handled inline as before.


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Adds an optional user-space dispatcher queue between the CWS eBPF ring-buffer read loop and event handling, so a slow handler does not stall kernel draining under bursts.

The queue is **off by default**. When disabled, events are handled inline on the read loop (same path as before this PR) and the queue is not allocated.

### Configuration

Enable in `system-probe.yaml`:

```yaml
event_monitoring_config:
  event_stream:
    dispatcher_queue_enabled: true
    # dispatcher_queue_size: 500000              # bytes; multiplied by CPU count when size_per_core is true
    # dispatcher_queue_size_per_core: true
    # dispatcher_queue_size_min: 1048576         # 1 MiB floor after optional per-core scaling
```

Equivalent env vars (`DD_RUNTIME_SECURITY_CONFIG_EVENT_STREAM_*` aliases also work):

| Setting | Env | Default |
|---|---|---|
| `dispatcher_queue_enabled` | `DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_DISPATCHER_QUEUE_ENABLED` | `false` |
| `dispatcher_queue_size` | `DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_DISPATCHER_QUEUE_SIZE` | `500000` (bytes) |
| `dispatcher_queue_size_per_core` | `DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_DISPATCHER_QUEUE_SIZE_PER_CORE` | `true` |
| `dispatcher_queue_size_min` | `DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_DISPATCHER_QUEUE_SIZE_MIN` | `1048576` (1 MiB) |

When enabled:

- Capacity is a **byte budget**, not an event-count. Effective size is `dispatcher_queue_size` (× CPU count if `size_per_core`), then raised to `dispatcher_queue_size_min`.
- A full queue applies backpressure by blocking the kernel read loop instead of dropping events.
- A single event larger than the budget is still admitted if the queue is empty, so that case cannot deadlock.
- The dispatcher starts only after `ringBuffer.Start()` succeeds.

### Metrics

Flushed from the probe `SendStats` path as `datadog.runtime_security.event_stream.dispatcher_queue.*` (only when the queue is enabled):

| Metric | Type | Meaning |
|---|---|---|
| `datadog.runtime_security.event_stream.dispatcher_queue.usage` | gauge | Events currently queued |
| `datadog.runtime_security.event_stream.dispatcher_queue.bytes` | gauge | Bytes currently queued |
| `datadog.runtime_security.event_stream.dispatcher_queue.capacity` | gauge | Queue capacity in bytes |
| `datadog.runtime_security.event_stream.dispatcher_queue.enqueued` | count | Events pushed onto the queue |

### Motivation

A slow userspace handler on the ring-buffer read loop can stall kernel draining and lose events. The queue is an opt-in burst cushion so default behavior stays unchanged.

### Describe how you validated your changes

- `dda inv test --targets=./pkg/security/probe/eventstream/ringbuffer`
- Unit coverage for byte sizing (per-core, min floor, invalid CPU count), inline handling when disabled, enqueue/dispatch when enabled, byte/peak occupancy, oversized-event admit-when-empty, and blocking until bytes are freed.

### Additional Notes

Size knobs only apply when `dispatcher_queue_enabled` is true. On a high-core host the default budget is `500000 × NumCPU()`, floored at 1 MiB (for example ~32 MB on 64 CPUs).
