### PR TITLE
trace/api: forward DD-EVP-ORIGIN and DD-EVP-ORIGIN-VERSION through EVP proxy

### DIFF
--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -34,7 +34,7 @@ const (
 )
 
 // EvpProxyAllowedHeaders contains the headers that the proxy will forward. All others will be cleared.
-var EvpProxyAllowedHeaders = []string{"Content-Type", "Accept-Encoding", "Content-Encoding", "User-Agent", "DD-CI-PROVIDER-NAME"}
+var EvpProxyAllowedHeaders = []string{"Content-Type", "Accept-Encoding", "Content-Encoding", "User-Agent", "DD-CI-PROVIDER-NAME", "DD-EVP-ORIGIN", "DD-EVP-ORIGIN-VERSION"}
 
 // evpProxyEndpointsFromConfig returns the configured list of endpoints to forward payloads to.
 func evpProxyEndpointsFromConfig(conf *config.AgentConfig) []config.Endpoint {

--- a/pkg/trace/api/evp_proxy_test.go
+++ b/pkg/trace/api/evp_proxy_test.go
@@ -450,6 +450,123 @@ func TestEVPProxyForwarder(t *testing.T) {
 		assert.Equal(t, "", logs)
 	})
 
+	t.Run("origin-headers-forwarded", func(t *testing.T) {
+		stats.Reset()
+
+		conf := newTestReceiverConfig()
+		conf.Site = "us3.datadoghq.com"
+		conf.Endpoints[0].APIKey = "test_api_key"
+
+		req := httptest.NewRequest("POST", "/mypath/mysubpath?arg=test", bytes.NewReader(randBodyBuf))
+		req.Header.Set("X-Datadog-EVP-Subdomain", "my.subdomain")
+		req.Header.Set("DD-EVP-ORIGIN", "my-server-sdk")
+		req.Header.Set("DD-EVP-ORIGIN-VERSION", "1.2.3")
+		proxyreqs, resp, logs := sendRequestThroughForwarderWithMockRoundTripper(conf, req, stats)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode, "Got: ", strconv.Itoa(resp.StatusCode))
+		resp.Body.Close()
+		require.Len(t, proxyreqs, 1)
+		proxyreq := proxyreqs[0]
+		assert.Equal(t, "my-server-sdk", proxyreq.Header.Get("DD-EVP-ORIGIN"))
+		assert.Equal(t, "1.2.3", proxyreq.Header.Get("DD-EVP-ORIGIN-VERSION"))
+		assert.Equal(t, "", logs)
+	})
+
+	t.Run("origin-headers-casing", func(t *testing.T) {
+		// Go's http.Header.Get/Set canonicalize header keys, so a caller sending
+		// lowercase headers should still be matched by the allowlist and forwarded.
+		stats.Reset()
+
+		conf := newTestReceiverConfig()
+		conf.Site = "us3.datadoghq.com"
+		conf.Endpoints[0].APIKey = "test_api_key"
+
+		req := httptest.NewRequest("POST", "/mypath/mysubpath?arg=test", bytes.NewReader(randBodyBuf))
+		req.Header.Set("X-Datadog-EVP-Subdomain", "my.subdomain")
+		req.Header.Set("dd-evp-origin", "my-server-sdk")
+		req.Header.Set("dd-evp-origin-version", "1.2.3")
+		proxyreqs, resp, logs := sendRequestThroughForwarderWithMockRoundTripper(conf, req, stats)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode, "Got: ", strconv.Itoa(resp.StatusCode))
+		resp.Body.Close()
+		require.Len(t, proxyreqs, 1)
+		proxyreq := proxyreqs[0]
+		assert.Equal(t, "my-server-sdk", proxyreq.Header.Get("DD-EVP-ORIGIN"))
+		assert.Equal(t, "1.2.3", proxyreq.Header.Get("DD-EVP-ORIGIN-VERSION"))
+		assert.Equal(t, "", logs)
+	})
+
+	t.Run("origin-headers-dual-shipping", func(t *testing.T) {
+		stats.Reset()
+
+		conf := newTestReceiverConfig()
+		conf.Site = "us3.datadoghq.com"
+		conf.Endpoints[0].APIKey = "test_api_key"
+		conf.EVPProxy.AdditionalEndpoints = map[string][]string{
+			"datadoghq.eu": {"test_api_key_1", "test_api_key_2"},
+		}
+
+		req := httptest.NewRequest("POST", "/mypath/mysubpath?arg=test", bytes.NewReader(randBodyBuf))
+		req.Header.Set("X-Datadog-EVP-Subdomain", "my.subdomain")
+		req.Header.Set("DD-EVP-ORIGIN", "my-server-sdk")
+		req.Header.Set("DD-EVP-ORIGIN-VERSION", "1.2.3")
+		proxyreqs, resp, logs := sendRequestThroughForwarderWithMockRoundTripper(conf, req, stats)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode, "Got: ", strconv.Itoa(resp.StatusCode))
+		resp.Body.Close()
+		require.Len(t, proxyreqs, 3)
+		for _, pr := range proxyreqs {
+			assert.Equal(t, "my-server-sdk", pr.Header.Get("DD-EVP-ORIGIN"))
+			assert.Equal(t, "1.2.3", pr.Header.Get("DD-EVP-ORIGIN-VERSION"))
+		}
+		assert.Equal(t, "", logs)
+	})
+
+	t.Run("origin-headers-stripped-unrelated", func(t *testing.T) {
+		stats.Reset()
+
+		conf := newTestReceiverConfig()
+		conf.Site = "us3.datadoghq.com"
+		conf.Endpoints[0].APIKey = "test_api_key"
+
+		req := httptest.NewRequest("POST", "/mypath/mysubpath?arg=test", bytes.NewReader(randBodyBuf))
+		req.Header.Set("X-Datadog-EVP-Subdomain", "my.subdomain")
+		req.Header.Set("DD-EVP-ORIGIN", "my-server-sdk")
+		req.Header.Set("DD-EVP-ORIGIN-VERSION", "1.2.3")
+		req.Header.Set("Unexpected-Header", "To-Be-Discarded")
+		proxyreqs, resp, logs := sendRequestThroughForwarderWithMockRoundTripper(conf, req, stats)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode, "Got: ", strconv.Itoa(resp.StatusCode))
+		resp.Body.Close()
+		require.Len(t, proxyreqs, 1)
+		proxyreq := proxyreqs[0]
+		assert.Equal(t, "my-server-sdk", proxyreq.Header.Get("DD-EVP-ORIGIN"))
+		assert.Equal(t, "1.2.3", proxyreq.Header.Get("DD-EVP-ORIGIN-VERSION"))
+		assert.NotContains(t, proxyreq.Header, "Unexpected-Header")
+		assert.Equal(t, "", logs)
+	})
+
+	t.Run("origin-headers-absent", func(t *testing.T) {
+		stats.Reset()
+
+		conf := newTestReceiverConfig()
+		conf.Site = "us3.datadoghq.com"
+		conf.Endpoints[0].APIKey = "test_api_key"
+
+		req := httptest.NewRequest("POST", "/mypath/mysubpath?arg=test", bytes.NewReader(randBodyBuf))
+		req.Header.Set("X-Datadog-EVP-Subdomain", "my.subdomain")
+		proxyreqs, resp, logs := sendRequestThroughForwarderWithMockRoundTripper(conf, req, stats)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode, "Got: ", strconv.Itoa(resp.StatusCode))
+		resp.Body.Close()
+		require.Len(t, proxyreqs, 1)
+		proxyreq := proxyreqs[0]
+		// Headers are not synthesized; absent on the inbound request means absent on the outbound request.
+		assert.NotContains(t, proxyreq.Header, "DD-EVP-ORIGIN")
+		assert.NotContains(t, proxyreq.Header, "DD-EVP-ORIGIN-VERSION")
+		assert.Equal(t, "", logs)
+	})
+
 	t.Run("error-tracking-standalone-header-added", func(t *testing.T) {
 		stats.Reset()
 

--- a/releasenotes/notes/apm-evp-proxy-forward-origin-headers-c56005b19439cd8a.yaml
+++ b/releasenotes/notes/apm-evp-proxy-forward-origin-headers-c56005b19439cd8a.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    APM : The trace-agent EVP proxy now forwards the ``DD-EVP-ORIGIN`` and
+    ``DD-EVP-ORIGIN-VERSION`` request headers to Event Platform intake.
+    Previously these headers were stripped by the proxy allowlist, so server
+    SDK metadata (SDK name and version) was lost at the Agent even when the
+    SDK sent it. Values are forwarded unchanged; the Agent does not
+    synthesize defaults for requests that omit them.


### PR DESCRIPTION
## Summary

Add `DD-EVP-ORIGIN` and `DD-EVP-ORIGIN-VERSION` to `EvpProxyAllowedHeaders` in `pkg/trace/api/evp_proxy.go` so server SDK metadata (SDK name and version) survives forwarding to Event Platform intake. Previously these headers were stripped by the allowlist, losing caller-supplied origin identity at the Agent even when the SDK sent them.

Closes [FFL-3014](https://datadoghq.atlassian.net/browse/FFL-3014).

## Why the general allowlist (not flagevaluation-specific)

There is a single shared EVP proxy handler: `/evp_proxy/v1/`–`/v4/` all route to the same `evpProxyHandler` → `evpProxyForwarder` → `evpProxyTransport.RoundTrip`, which applies `EvpProxyAllowedHeaders` uniformly. There is no path-specific branching, so flagevaluation (`/evp_proxy/v2/api/v2/flagevaluation`) hits the exact same code path as every other EVP-proxied destination. This change therefore affects **all** EVP proxy traffic, not just the Feature Flags & Experimentation team's. This is intentional and we discuss tradeoffs below.

## Tradeoff considerations

**Why we feel the blast radius is low:**

- **Purely additive.** Headers are only forwarded *if the caller sends them*.
- **Consistent with existing posture.** The allowlist already relays caller-supplied identity headers verbatim (`User-Agent`, `DD-CI-PROVIDER-NAME`). Adding origin/version is the same kind of operation: "relay what the caller sent"
- **`DD-EVP-ORIGIN` is a general EVP convention, not an FFL-specific concept.** The agent itself sets it on its own outbound EVP calls (the logs, dyninst, and otel paths set it too). Letting it pass through the proxy is consistent with how the rest of the platform treats the header.
- The Agent never invents these values, it only relays what the SDK sent. A rogue/unrelated client that doesn't send them is unaffected.

**One thing worth flagging:**

If any *other* EVP consumer were relying on these headers being **stripped** at the agent (e.g., to prevent clients from spoofing origin identity upstream), this change would loosen that guarantee. We assessed this as a non-issue: the current allowlist already forwards `User-Agent` and `DD-CI-PROVIDER-NAME` from callers, so "relay caller-supplied identity headers" is already the established posture, and there is no evidence any consumer depends on `DD-EVP-ORIGIN` being dropped. If such a consumer is later identified, the fix would be to gate forwarding on `req.URL.Path` but that additional complexity is not needed today.

## Test strategy

- All tests use the existing `sendRequestThroughForwarderWithMockRoundTripper` harness (mock round-tripper captures outbound requests). No new infrastructure.

## Acceptance criteria (from FFL-3014)

- [x] Captured outbound requests contain the exact incoming origin and version values.
- [x] Existing EVP proxy tests pass.
- [x] No request payload is modified (only headers).

[FFL-3014]: https://datadoghq.atlassian.net/browse/FFL-3014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ