### PR TITLE
[ABLD-328] Migrate more of the dogstatsd build from omnibus to bazel

### DIFF
--- a/.gitlab/windows/build/package_build/windows.yml
+++ b/.gitlab/windows/build/package_build/windows.yml
@@ -151,7 +151,7 @@ windows_msi_and_bosh_zip_x64-a7-fips:
 
 # azure-app-services build for Windows
 windows_zip_agent_binaries_x64-a7:
-  extends: .windows_zip_base
+  extends: .windows_zip_bazel_base
   variables:
     OMNIBUS_TARGET: agent-binaries
 

--- a/omnibus/config/software/datadog-dogstatsd.rb
+++ b/omnibus/config/software/datadog-dogstatsd.rb
@@ -17,37 +17,14 @@ relative_path 'src/github.com/DataDog/datadog-agent'
 build do
   license :project_license
 
-  # set GOPATH on the omnibus source dir for this software
-  gopath = Pathname.new(project_dir) + '../../../..'
-  env = {
-    'GOPATH' => gopath.to_path,
-    'PATH' => ["#{gopath.to_path}/bin", ENV['PATH']].join(File::PATH_SEPARATOR),
-  }
-
-  unless ENV["OMNIBUS_GOMODCACHE"].nil? || ENV["OMNIBUS_GOMODCACHE"].empty?
-    gomodcache = Pathname.new(ENV["OMNIBUS_GOMODCACHE"])
-    env["GOMODCACHE"] = gomodcache.to_path
-  end
-
-  # we assume the go deps are already installed before running omnibus
-  command "invoke dogstatsd.build", env: env, :live_stream => Omnibus.logger.live_stream(:info)
-
-  # move around bin and config files
-  if windows_target?
-    mkdir "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
-    copy 'bin/dogstatsd/dogstatsd.exe', "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
-  else
-    copy 'bin/dogstatsd/dogstatsd', "#{install_dir}/bin"
-  end
-
   if linux_target?
     if debian_target?
       install_target = "//packages/dogstatsd/linux:install_debian"
     else
       install_target = "//packages/dogstatsd/linux:install_redhat"
     end
-    # Bazel places the yaml example, init scripts, service file, and creates
-    # /etc/datadog-dogstatsd/ and /var/log/datadog/.
+    # Bazel places the binary, yaml example, init scripts, service file, and
+    # creates /etc/datadog-dogstatsd/ and /var/log/datadog/.
     command "bazel run #{omnibazel_flags} -- #{install_target} --destdir=/",
       :live_stream => Omnibus.logger.live_stream(:info)
     mkdir "#{install_dir}/run"
@@ -55,15 +32,25 @@ build do
     project.extra_package_file '/etc/init/datadog-dogstatsd.conf'
     project.extra_package_file '/lib/systemd/system/datadog-dogstatsd.service'
   elsif windows_target?
-    mkdir "#{install_dir}/etc/datadog-dogstatsd"
-    move 'bin/dogstatsd/dist/dogstatsd.yaml', "#{install_dir}/etc/datadog-dogstatsd/dogstatsd.yaml.example"
-    conf_dir_root = "#{Omnibus::Config.source_dir()}/etc/datadog-dogstatsd"
-    conf_dir = "#{conf_dir_root}/extra_package_files/EXAMPLECONFSLOCATION"
-    mkdir conf_dir
-    move "#{install_dir}/etc/datadog-dogstatsd/dogstatsd.yaml.example", conf_dir_root, :force => true
+    # dogstatsd.exe is not installed under install_dir on Windows: it is
+    # staged into the agent's WiX harvest directory (see
+    # omnibus/config/projects/{dogstatsd,agent-binaries}.rb, 'BinFiles'). The
+    # example config's final home (source_dir/etc/datadog-dogstatsd) matches
+    # the Bazel target's own layout, so install straight into source_dir and
+    # only the binary needs an explicit copy into the WiX-specific path.
+    source_dir = Omnibus::Config.source_dir()
+    command "bazel run #{omnibazel_flags} -- //packages/dogstatsd/windows:install --destdir=#{source_dir}",
+      :live_stream => Omnibus.logger.live_stream(:info)
+
+    mkdir "#{source_dir}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
+    copy "#{source_dir}/bin/dogstatsd.exe", "#{source_dir}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
+
+    conf_dir_root = "#{source_dir}/etc/datadog-dogstatsd"
+    mkdir "#{conf_dir_root}/extra_package_files/EXAMPLECONFSLOCATION"
   else
-    # macOS: stage yaml in install_dir/etc/ where the .pkg will find it.
-    mkdir "#{install_dir}/etc/datadog-dogstatsd"
-    move 'bin/dogstatsd/dist/dogstatsd.yaml', "#{install_dir}/etc/datadog-dogstatsd/dogstatsd.yaml.example"
+    # macOS: install directly to install_dir (== /opt/datadog-dogstatsd),
+    # where the .pkg will find both the binary and the yaml example.
+    command "bazel run #{omnibazel_flags} -- //packages/dogstatsd/macos:install --destdir=/",
+      :live_stream => Omnibus.logger.live_stream(:info)
   end
 end

--- a/packages/dogstatsd/linux/BUILD.bazel
+++ b/packages/dogstatsd/linux/BUILD.bazel
@@ -8,6 +8,7 @@ load(
     "pkg_files",
     "pkg_mkdirs",
 )
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//bazel/rules:dd_agent_expand_template.bzl", "dd_agent_expand_template")
 
 package(default_visibility = ["//packages:__subpackages__"])
@@ -73,6 +74,29 @@ pkg_files(
 )
 
 # ---------------------------------------------------------------------------
+# Binary
+# ---------------------------------------------------------------------------
+
+# dogstatsd's install root is fixed (unlike the agent's, which varies by
+# flavor), so the prefix is hardcoded rather than driven by --//:install_dir.
+pkg_files(
+    name = "dogstatsd_bin",
+    srcs = ["//cmd/dogstatsd"],
+    attributes = pkg_attributes(mode = "0755"),
+    prefix = "opt/datadog-dogstatsd/bin",
+)
+
+# dogstatsd ships without cgo on Linux (see the `cgo` select on
+# //cmd/dogstatsd:dogstatsd) and must stay statically linked.
+sh_test(
+    name = "dogstatsd_static_link_test",
+    srcs = ["check_static_link.sh"],
+    args = ["$(location //cmd/dogstatsd:dogstatsd)"],
+    data = ["//cmd/dogstatsd"],
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+# ---------------------------------------------------------------------------
 # Install-dir directories
 # ---------------------------------------------------------------------------
 
@@ -91,6 +115,7 @@ pkg_filegroup(
     name = "debian_files",
     srcs = [
         ":config_example_files",
+        ":dogstatsd_bin",
         ":system_dirs",
         ":systemd_service_gen",
         ":upstart_debian_files",
@@ -106,6 +131,7 @@ pkg_filegroup(
     name = "redhat_files",
     srcs = [
         ":config_example_files",
+        ":dogstatsd_bin",
         ":system_dirs",
         ":systemd_service_gen",
         ":upstart_redhat_files",

--- a/packages/dogstatsd/linux/check_static_link.sh
+++ b/packages/dogstatsd/linux/check_static_link.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Fails unless the given binary is statically linked, mirroring the check
+# `tasks/dogstatsd.py:size_test` performs for the omnibus-built binary.
+set -euo pipefail
+
+bin="$(readlink -f "$1")"
+
+if ! file "$bin" | grep -q "statically linked"; then
+  echo "dogstatsd binary is not statically linked:"
+  file "$bin"
+  exit 1
+fi
+
+echo "dogstatsd binary is statically linked"

--- a/packages/dogstatsd/macos/BUILD.bazel
+++ b/packages/dogstatsd/macos/BUILD.bazel
@@ -1,0 +1,42 @@
+"""macOS-specific DogStatsD content: binary and example config."""
+
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load(
+    "@rules_pkg//pkg:mappings.bzl",
+    "pkg_attributes",
+    "pkg_filegroup",
+    "pkg_files",
+)
+
+package(default_visibility = ["//packages:__subpackages__"])
+
+# dogstatsd's install root is fixed (unlike the agent's, which varies by
+# flavor), so the prefix is hardcoded rather than driven by --//:install_dir.
+pkg_files(
+    name = "dogstatsd_bin",
+    srcs = ["//cmd/dogstatsd"],
+    attributes = pkg_attributes(mode = "0755"),
+    prefix = "opt/datadog-dogstatsd/bin",
+)
+
+# dogstatsd always renders its example config with Linux defaults, even on
+# macOS builds — see //pkg/config:dogstatsd_config.
+pkg_files(
+    name = "config_example_files",
+    srcs = ["//pkg/config:dogstatsd_config"],
+    attributes = pkg_attributes(mode = "0644"),
+    renames = {"//pkg/config:dogstatsd_config": "opt/datadog-dogstatsd/etc/datadog-dogstatsd/dogstatsd.yaml.example"},
+)
+
+pkg_filegroup(
+    name = "macos_files",
+    srcs = [
+        ":config_example_files",
+        ":dogstatsd_bin",
+    ],
+)
+
+pkg_install(
+    name = "install",
+    srcs = [":macos_files"],
+)

--- a/packages/dogstatsd/windows/BUILD.bazel
+++ b/packages/dogstatsd/windows/BUILD.bazel
@@ -1,0 +1,51 @@
+"""Windows-specific DogStatsD content: binary and example config.
+
+Unlike Linux/macOS, dogstatsd does not ship as its own standalone install
+tree on Windows: `dogstatsd.exe` is staged into the agent's WiX harvest
+directory (see `omnibus/config/software/datadog-dogstatsd.rb` and
+`omnibus/config/projects/dogstatsd.rb`), which `:install` below does not
+attempt to reproduce. It exists so the binary and config are still
+addressable as ordinary Bazel targets, e.g. to extract with
+`pkg_install`'s `--destdir` for staging.
+"""
+
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load(
+    "@rules_pkg//pkg:mappings.bzl",
+    "pkg_attributes",
+    "pkg_filegroup",
+    "pkg_files",
+)
+
+package(default_visibility = ["//packages:__subpackages__"])
+
+# dogstatsd's install root is fixed (unlike the agent's, which varies by
+# flavor), so the prefix is hardcoded rather than driven by --//:install_dir.
+pkg_files(
+    name = "dogstatsd_bin",
+    srcs = ["//cmd/dogstatsd"],
+    attributes = pkg_attributes(mode = "0755"),
+    prefix = "bin",
+)
+
+# dogstatsd always renders its example config with Linux defaults, even on
+# Windows builds — see //pkg/config:dogstatsd_config.
+pkg_files(
+    name = "config_example_files",
+    srcs = ["//pkg/config:dogstatsd_config"],
+    attributes = pkg_attributes(mode = "0644"),
+    renames = {"//pkg/config:dogstatsd_config": "etc/datadog-dogstatsd/dogstatsd.yaml.example"},
+)
+
+pkg_filegroup(
+    name = "windows_files",
+    srcs = [
+        ":config_example_files",
+        ":dogstatsd_bin",
+    ],
+)
+
+pkg_install(
+    name = "install",
+    srcs = [":windows_files"],
+)


### PR DESCRIPTION
## What this does

- Replace `invoke dogstatsd.build` in `omnibus/config/software/datadog-dogstatsd.rb` with `bazel run //packages/<some appropriate install`
- Add `dogstatsd_bin` `pkg_files` to `packages/dogstatsd/linux/BUILD.bazel`'s `install_debian`/`install_redhat`
- create `packages/dogstatsd/macos/BUILD.bazel` and `packages/dogstatsd/windows/BUILD.bazel` with equivalent `:install` targets.
- Add a `dogstatsd_static_link_test` `sh_test` on Linux verifying the binary stays statically linked. Mirrors the check `tasks/dogstatsd.py:size_test` did for the omnibus-built binary.

## Motivation
Doing some grunt work while blocked on reviews.

## Validating

- CI
- [x] `bazel build //packages/dogstatsd/linux:install_debian //packages/dogstatsd/linux:install_redhat //packages/dogstatsd/macos:install` analyzes and builds successfully
- [x] `bazel run //packages/dogstatsd/macos:install -- --destdir=/tmp/...` produces the expected binary + config layout, and the binary runs
- [ ] CI validates Linux packaging (deb/rpm) end-to-end
- [ ] CI validates Windows packaging (MSI staging via WiX) end-to-end
- [ ] `dogstatsd_static_link_test` passes in CI on Linux

Generated with [Claude Code](https://claude.com/claude-code)