### PR TITLE
Remove ensure-test-parity task

### DIFF
--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -2,96 +2,18 @@ from __future__ import annotations
 
 import json
 import os
-import platform
-import re
 import sys
 import tempfile
 import xml.etree.ElementTree as ET
-from datetime import datetime
 from pathlib import Path
 from typing import TypedDict
 
 from invoke import task
 
-from tasks.build_tags import compute_build_tags_for_flavor
-from tasks.flavor import AgentFlavor
 from tasks.libs.build.bazel import bazel
 from tasks.libs.common.gomodules import AGENT_MODULE_PATH_PREFIX
 
-# Top-level Test* declarations in Go source files — Go side of the parity comparison.
-_TEST_FUNC_RE = re.compile(r'^func (Test\w*)\(', re.MULTILINE)
-# Matches json.decoder.WHITESPACE, an undocumented/unstubbed cpython internal.
-_JSON_WHITESPACE_RE = re.compile(r"[ \t\n\r]*")
 _IMPORT_PREFIX = AGENT_MODULE_PATH_PREFIX.rstrip("/")
-# Tag the dd_agent_go_test macro stamps on every variant it emits
-# (bazel/rules/go/dd_agent_go_test.bzl). Used to distinguish its generated
-# go_test rules from other custom wrappers (rtloader_go_test, ...).
-_DD_AGENT_GO_TEST_TAG = "dd_agent_go_test"
-
-
-# cmd.exe on Windows caps command lines at 8191 chars; stay safely under that
-# per 'go list' invocation so the command line doesn't grow unbounded with
-# the tracked package set.
-_MAX_CMDLINE_CHARS = 6000
-
-
-def _chunk_import_paths(import_paths: list[str]) -> list[list[str]]:
-    """Split import paths into batches that keep each 'go list' command line
-    under the Windows cmd.exe length limit."""
-    chunks: list[list[str]] = []
-    current: list[str] = []
-    current_len = 0
-    for path in import_paths:
-        if current and current_len + len(path) + 1 > _MAX_CMDLINE_CHARS:
-            chunks.append(current)
-            current, current_len = [], 0
-        current.append(path)
-        current_len += len(path) + 1
-    if current:
-        chunks.append(current)
-    return chunks
-
-
-def _go_test_packages(ctx, tags: list[str], import_paths: set[str]) -> dict[str, set[str]]:
-    """Return {import_path: {Test* func names}} for the given import paths
-    compiled under the given build tags."""
-    if not import_paths:
-        return {}
-    pkgs: dict[str, set[str]] = {}
-    decoder = json.JSONDecoder()
-    for chunk in _chunk_import_paths(sorted(import_paths)):
-        text = bazel(
-            ctx,
-            "run",
-            "--config=gorace",  # to use same analysis cache across test & run commands
-            "//:go",
-            "--",
-            "list",
-            "-json",
-            "-e",
-            f"-tags={','.join(sorted(tags))}",
-            *chunk,
-            capture_output=True,
-        )
-        pos = 0
-        while pos < len(text):
-            pos = _JSON_WHITESPACE_RE.match(text, pos).end()
-            if pos >= len(text):
-                break
-            obj, pos = decoder.raw_decode(text, pos)
-            import_path = obj["ImportPath"]
-            if import_path not in import_paths:
-                continue
-            pkg_dir = Path(obj["Dir"])
-            test_files = obj.get("TestGoFiles", []) + obj.get("XTestGoFiles", [])
-            funcs: set[str] = set()
-            for f in test_files:
-                funcs.update(_TEST_FUNC_RE.findall((pkg_dir / f).read_text()))
-            # TestMain is Go's test harness entry point, never dispatched as a test case.
-            funcs.discard("TestMain")
-            if funcs:
-                pkgs[import_path] = funcs
-    return pkgs
 
 
 def _label_to_import_path(label: str) -> str:
@@ -126,29 +48,6 @@ def _test_output_candidates(
     return paths
 
 
-def _test_xml_funcs(paths: list[Path]) -> set[str]:
-    """Return top-level Test* functions from the first readable test.xml.
-
-    Subtests appear as name="TestFoo/Sub"; filtering to names without '/'
-    gives top-level functions. Requires --test_arg=-test.v (or
-    --test_env=GO_TEST_WRAP_TESTV=1) for a complete XML.
-    """
-    for path in paths:
-        try:
-            content = path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            continue
-        if not content.strip():
-            continue
-        root = ET.fromstring(content)
-        return {
-            tc.attrib["name"]
-            for tc in root.iter("testcase")
-            if tc.attrib["name"].startswith("Test") and "/" not in tc.attrib["name"]
-        }
-    raise FileNotFoundError(f"no readable test.xml found among candidates: {paths}")
-
-
 class _BepContext:
     """Tracks the workspace/configuration state needed to resolve BEP test.xml paths.
 
@@ -176,145 +75,6 @@ class _BepContext:
                 return True
             case _:
                 return False
-
-
-def _bazel_test_funcs_from_bep(bep_path: Path) -> dict[str, set[str]]:
-    """Parse a Build Event Protocol JSON stream into {import_path: {Test* funcs}}.
-
-    Selects dd_agent_go_test targets that had a testResult event and whose
-    test.xml records at least one Test* function. Plain go_test rules (no
-    `dd_agent_go_test` tag) are ignored.
-    """
-    dd_agent_labels: set[str] = set()
-    test_action: dict[str, tuple[str, str]] = {}
-    ctx = _BepContext()
-
-    with open(bep_path) as fh:
-        for line in fh:
-            if not line.strip():
-                continue
-            event = json.loads(line)
-            eid = event.get("id", {})
-            if ctx.observe(eid, event):
-                continue
-            if "targetConfigured" in eid:
-                label = eid["targetConfigured"].get("label", "")
-                cfg = event.get("configured", {})
-                if cfg.get("targetKind") != "go_test rule":
-                    continue
-                tags = set(cfg.get("tag") or [])
-                if _DD_AGENT_GO_TEST_TAG in tags:
-                    dd_agent_labels.add(label)
-            elif "testResult" in eid:
-                label = eid["testResult"].get("label", "")
-                cfg_id = eid["testResult"].get("configuration", {}).get("id", "")
-                for out in event["testResult"].get("testActionOutput") or []:
-                    if out.get("name") == "test.xml":
-                        test_action[label] = (out.get("uri", ""), cfg_id)
-                        break
-
-    covered: dict[str, set[str]] = {}
-    for label in dd_agent_labels:
-        if label not in test_action:
-            continue
-        uri, cfg_id = test_action[label]
-        funcs = _test_xml_funcs(
-            _test_output_candidates(label, uri, cfg_id, ctx.local_exec_root, ctx.config_testlogs, "test.xml")
-        )
-        covered.setdefault(_label_to_import_path(label), set()).update(funcs)
-
-    return covered
-
-
-def _emit_test_count_metric(flavor: str, count: int) -> None:
-    """Send a datadog.agent.bazel_tests.executed gauge for one flavor job."""
-    from tasks.libs.common.datadog_api import create_gauge
-    from tasks.libs.common.datadog_api import send_metrics as _send_metrics
-
-    if not os.environ.get("DD_API_KEY"):
-        print("DD_API_KEY not set, skipping test count metric", file=sys.stderr)
-        return
-
-    tags = [
-        f"flavor:{flavor}",
-        f"platform:{platform.system().lower()}",
-        f"pipeline_id:{os.environ.get('CI_PIPELINE_ID', 'unknown')}",
-        "repository:datadog-agent",
-    ]
-    timestamp = int(datetime.now().timestamp())
-    try:
-        _send_metrics([create_gauge("datadog.agent.bazel_tests.executed", timestamp, count, tags)])
-    except Exception as e:
-        print(f"Failed to send test count metric: {e}", file=sys.stderr)
-        return
-    print(f"Sent metric: datadog.agent.bazel_tests.executed={count} (flavor={flavor})")
-
-
-@task(
-    help={
-        "flavor_name": f"Agent flavor to check ({', '.join(f.name for f in AgentFlavor)}).",
-        "bep": "Path to the build_event_json_file produced by the preceding "
-        "'bazel test --config=<flavor> ...' invocation.",
-        "verbose": "Print passing packages.",
-        "emit_metrics": "Send a datadog.agent.bazel_tests.executed gauge to Datadog (requires DD_API_KEY).",
-    },
-)
-def ensure_test_parity(ctx, bep, flavor_name, verbose=False, emit_metrics=False):
-    """
-    Verify every Go test visible to 'dda inv test --flavor=<f>' is also
-    present and executed in the matching Bazel per-flavor run.
-
-    Reads test execution from a Bazel Build Event Protocol JSON stream
-    (--build_event_json_file). The BEP determines scope (dd_agent_go_test
-    packages that produced test results); 'go list' is then queried for just
-    those packages to obtain the expected Test* function set. A package
-    compiled with wrong build tags (running a different set of functions) is
-    also reported as a failure.
-
-    Exits 1 if any gap is found.
-    """
-    bep_path = Path(bep)
-    if not bep_path.is_file():
-        print(f"error: BEP file not found: {bep}", file=sys.stderr)
-        sys.exit(2)
-
-    try:
-        flavor = AgentFlavor[flavor_name]
-    except KeyError:
-        print(f"Unknown flavor '{flavor_name}'. Options: {[f.name for f in AgentFlavor]}", file=sys.stderr)
-        sys.exit(1)
-
-    # bazel test runs systematically pass the "race" build tag, so files guarded
-    # by `!race` must be excluded from the expected test set too.
-    tags = [*compute_build_tags_for_flavor("unit-tests", None, None, flavor), "race"]
-    coverage = _bazel_test_funcs_from_bep(bep_path)
-    test_pkgs = _go_test_packages(ctx, tags, set(coverage))
-
-    go_pkgs = set(test_pkgs)
-    extra_in_bazel = {p for p, funcs in coverage.items() if funcs} - go_pkgs
-
-    failed = False
-    test_count = 0
-    for import_path in sorted(go_pkgs):
-        go_funcs = test_pkgs[import_path]
-        bazel_funcs = coverage[import_path]
-        missing_funcs = go_funcs - bazel_funcs
-        test_count += len(bazel_funcs)
-        if missing_funcs:
-            sample = ", ".join(sorted(missing_funcs)[:3]) + (", ..." if len(missing_funcs) > 3 else "")
-            print(f"[FAIL] {import_path} [{flavor_name}] -- tests missing from Bazel: {sample}")
-            failed = True
-        elif verbose:
-            print(f"[PASS] {import_path} [{flavor_name}] ({len(bazel_funcs)} tests)")
-    for import_path in sorted(extra_in_bazel):
-        print(f"[FAIL] {import_path} [{flavor_name}] -- Bazel target exists but not in dda inv test")
-    if extra_in_bazel:
-        failed = True
-
-    if emit_metrics:
-        _emit_test_count_metric(flavor_name, test_count)
-    if failed:
-        sys.exit(1)
 
 
 class BepTestArtifacts(TypedDict):

--- a/tasks/unit_tests/bazel_tests.py
+++ b/tasks/unit_tests/bazel_tests.py
@@ -3,17 +3,13 @@ import tempfile
 import unittest
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 from tasks.bazel import (
     _IMPORT_PREFIX,
-    _bazel_test_funcs_from_bep,
-    _go_test_packages,
     _is_gotestsum_shaped,
     _label_to_import_path,
     _parse_bep,
     _test_output_candidates,
-    _test_xml_funcs,
 )
 
 
@@ -75,29 +71,6 @@ _JUNIT_XML = """<?xml version="1.0"?>
   <testcase name="TestBar"></testcase>
 </testsuite>
 """
-
-
-class TestTestXmlFuncs(unittest.TestCase):
-    def test_top_level_funcs_only(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            xml_path = Path(tmpdir) / "test.xml"
-            xml_path.write_text(_JUNIT_XML)
-            self.assertEqual(_test_xml_funcs([xml_path]), {"TestFoo", "TestBar"})
-
-    def test_falls_through_unreadable_and_empty_candidates(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            missing = Path(tmpdir) / "missing.xml"
-            empty = Path(tmpdir) / "empty.xml"
-            empty.write_text("")
-            real = Path(tmpdir) / "test.xml"
-            real.write_text(_JUNIT_XML)
-            self.assertEqual(_test_xml_funcs([missing, empty, real]), {"TestFoo", "TestBar"})
-
-    def test_raises_when_nothing_readable(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            missing = Path(tmpdir) / "missing.xml"
-            with self.assertRaises(FileNotFoundError):
-                _test_xml_funcs([missing])
 
 
 class TestIsGotestsumShaped(unittest.TestCase):
@@ -282,104 +255,6 @@ class TestParseBep(unittest.TestCase):
 
             with self.assertRaisesRegex(RuntimeError, "did not include .*test.log"):
                 _parse_bep(bep_path)
-
-
-class TestBazelTestFuncsFromBep(unittest.TestCase):
-    def test_extracts_funcs_for_dd_agent_go_test_targets_only(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            xml_path = Path(tmpdir) / "test.xml"
-            xml_path.write_text(_JUNIT_XML)
-
-            bep_path = Path(tmpdir) / "bep.json"
-            bep_path.write_text(
-                "".join(
-                    [
-                        _bep_line({"id": {"workspace": {}}, "workspaceInfo": {"localExecRoot": "/exec/root"}}),
-                        _bep_line(
-                            {
-                                "id": {"targetConfigured": {"label": "//pkg/foo:foo_test"}},
-                                "configured": {"targetKind": "go_test rule", "tag": ["dd_agent_go_test"]},
-                            }
-                        ),
-                        _bep_line(
-                            {
-                                "id": {"targetConfigured": {"label": "//pkg/foo:foo_other_test"}},
-                                "configured": {"targetKind": "go_test rule", "tag": []},
-                            }
-                        ),
-                        _bep_line(
-                            {
-                                "id": {"targetConfigured": {"label": "//pkg/foo:not_a_go_binary"}},
-                                "configured": {"targetKind": "sh_test rule", "tag": ["dd_agent_go_test"]},
-                            }
-                        ),
-                        _bep_line(
-                            {
-                                "id": {"testResult": {"label": "//pkg/foo:foo_test", "configuration": {"id": "cfg1"}}},
-                                "testResult": {"testActionOutput": [{"name": "test.xml", "uri": xml_path.as_uri()}]},
-                            }
-                        ),
-                    ]
-                )
-            )
-
-            covered = _bazel_test_funcs_from_bep(bep_path)
-            self.assertEqual(covered, {f"{_IMPORT_PREFIX}/pkg/foo": {"TestFoo", "TestBar"}})
-
-    def test_configured_but_never_run_is_skipped(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            bep_path = Path(tmpdir) / "bep.json"
-            bep_path.write_text(
-                _bep_line(
-                    {
-                        "id": {"targetConfigured": {"label": "//pkg/foo:foo_test"}},
-                        "configured": {"targetKind": "go_test rule", "tag": ["dd_agent_go_test"]},
-                    }
-                )
-            )
-            self.assertEqual(_bazel_test_funcs_from_bep(bep_path), {})
-
-
-class TestGoTestPackages(unittest.TestCase):
-    def test_empty_import_paths_skips_bazel(self):
-        with patch("tasks.bazel.bazel") as mock_bazel:
-            self.assertEqual(_go_test_packages(MagicMock(), ["race"], set()), {})
-            mock_bazel.assert_not_called()
-
-    def test_bazel_failure_raises(self):
-        with patch("tasks.bazel.bazel", side_effect=RuntimeError("boom")):
-            with self.assertRaises(RuntimeError):
-                _go_test_packages(MagicMock(), ["race"], {"example.com/pkg/foo"})
-
-    def test_parses_concatenated_json_and_filters_by_import_path(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            pkg_dir = Path(tmpdir) / "foo"
-            pkg_dir.mkdir()
-            (pkg_dir / "foo_test.go").write_text(
-                "package foo\nfunc TestFoo(t *testing.T) {}\nfunc TestMain(m *testing.M) {}\n"
-            )
-
-            stdout = "".join(
-                [
-                    json.dumps(
-                        {
-                            "ImportPath": "example.com/pkg/foo",
-                            "Dir": str(pkg_dir),
-                            "TestGoFiles": ["foo_test.go"],
-                        }
-                    ),
-                    "\n",
-                    json.dumps({"ImportPath": "example.com/pkg/bar", "Dir": str(tmpdir)}),
-                    "\n",
-                ]
-            )
-
-            with patch("tasks.bazel.bazel", return_value=stdout):
-                result = _go_test_packages(MagicMock(), ["race"], {"example.com/pkg/foo"})
-
-            # "example.com/pkg/bar" is filtered out: not in import_paths.
-            # TestMain is discarded even though it matched the Test* pattern.
-            self.assertEqual(result, {"example.com/pkg/foo": {"TestFoo"}})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

It drops the ensure-test-parity task and all the code that was only used by it.

### Motivation

#54031 dropped all uses of this task, and in general the switch to "flavorless" tests means the approach implemented by this task is no longer relevant. We've also switched to a more lightweight validation strategy which doesn't involve failing CI, but simply comparing coverage between jobs.

Removing this now that we have it in mind to reduce maintenance burden and letting dead code linger.

### Describe how you validated your changes

Green CI.

### Additional Notes
