### PR TITLE
Add concurrency test for flare archive name uniqueness

### DIFF
--- a/comp/core/flare/helpers/builder_test.go
+++ b/comp/core/flare/helpers/builder_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -132,6 +133,38 @@ func TestGetArchiveNameIsUniqueWithinSameSecond(t *testing.T) {
 			t.Fatalf("archive name %q was generated more than once", name)
 		}
 		names[name] = struct{}{}
+	}
+}
+
+// TestGetArchiveNameIsUniqueUnderConcurrency exercises the same race that a real Agent can hit in
+// production: the /agent/flare HTTP handler and the remote-config listener can independently call
+// Save() around the same time, each generating an archive name via getArchiveName(). Releasing many
+// goroutines through a shared barrier makes them call getArchiveName() as close to simultaneously as
+// the Go scheduler allows.
+func TestGetArchiveNameIsUniqueUnderConcurrency(t *testing.T) {
+	const n = 200
+
+	start := make(chan struct{})
+	names := make(chan string, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			names <- getArchiveName()
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(names)
+
+	seen := make(map[string]struct{}, n)
+	for name := range names {
+		if _, dup := seen[name]; dup {
+			t.Fatalf("duplicate archive name: %s", name)
+		}
+		seen[name] = struct{}{}
 	}
 }
 

--- a/comp/core/flare/helpers/builder_test.go
+++ b/comp/core/flare/helpers/builder_test.go
@@ -142,12 +142,12 @@ func TestGetArchiveNameIsUniqueWithinSameSecond(t *testing.T) {
 // goroutines through a shared barrier makes them call getArchiveName() as close to simultaneously as
 // the Go scheduler allows.
 func TestGetArchiveNameIsUniqueUnderConcurrency(t *testing.T) {
-	const n = 200
+	const totalConcurrentRuns = 200
 
 	start := make(chan struct{})
-	names := make(chan string, n)
+	names := make(chan string, totalConcurrentRuns)
 	var wg sync.WaitGroup
-	for i := 0; i < n; i++ {
+	for i := 0; i < totalConcurrentRuns; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -159,7 +159,7 @@ func TestGetArchiveNameIsUniqueUnderConcurrency(t *testing.T) {
 	wg.Wait()
 	close(names)
 
-	seen := make(map[string]struct{}, n)
+	seen := make(map[string]struct{}, totalConcurrentRuns)
 	for name := range names {
 		if _, dup := seen[name]; dup {
 			t.Fatalf("duplicate archive name: %s", name)

--- a/releasenotes/notes/flare-archive-name-pid-counter-suffix-dfac82ba958035dd.yaml
+++ b/releasenotes/notes/flare-archive-name-pid-counter-suffix-dfac82ba958035dd.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Flare archive filenames now include a process ID and counter suffix
+    (``datadog-agent-<timestamp>-<pid>-<counter>-<loglevel>.zip``), preventing
+    two archives created by the same Agent process at the same second from
+    overwriting each other.


### PR DESCRIPTION
### What does this PR do?

* Adds a test that races many goroutines through `getArchiveName()` in `comp/core/flare/helpers/builder.go`, asserting no two calls ever produce the same archive filename.
* Update the changelog to include changes from #54911 

No production code changes: #54911's PID+counter suffix already guarantees this, but it was only covered by a single-threaded, same-timestamp test (`TestGetArchiveNameIsUniqueWithinSameSecond`). This adds a companion test that exercises real concurrent callers instead.

### Motivation

We considered reverting #54911 in favor of relying on a higher-precision timestamp alone, but a concurrency test proved that `time.Now()`'s effective resolution is not a reliable uniqueness mechanism on its own — even on Linux, concurrent goroutines can read the identical nanosecond value. #54911's PID+counter suffix is what actually guarantees uniqueness, so we're keeping it as-is and locking in the guarantee with a test that mirrors the real production race: the `/agent/flare` HTTP handler and the remote-config listener independently calling `Save()` around the same time.

Jira: FLREM-148, FLREM-150

### Describe how you validated your changes

- `dda inv test --targets=./comp/core/flare/... --no-cache --race`, repeated multiple times, all passing.