### PR TITLE
Pass the lint build tags to --only-modified-packages discovery

### DIFF
--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -14,7 +14,9 @@ import yaml
 from invoke.exceptions import Exit
 from invoke.tasks import task
 
+from tasks.build_tags import UNIT_TEST_TAGS, compute_build_tags_for_flavor
 from tasks.devcontainer import run_on_devcontainer
+from tasks.flavor import AgentFlavor
 from tasks.libs.ciproviders.ci_config import CILintersConfig
 from tasks.libs.ciproviders.github_api import GithubAPI
 from tasks.libs.ciproviders.gitlab_api import (
@@ -102,13 +104,26 @@ def go(
 
     check_tools_version(ctx, ['golangci-lint', 'go'], debug=debug)
 
+    # Compute the tags golangci-lint will run with once, and hand them to package
+    # discovery too: a modified package whose files are all excluded by them has
+    # to be skipped, or it reaches golangci-lint as an explicit target and fails
+    # with "build constraints exclude all Go files".
+    linter_tags = build_tags or compute_build_tags_for_flavor(
+        flavor=AgentFlavor[flavor] if flavor else AgentFlavor.base,
+        build=build,
+        build_include=build_include,
+        build_exclude=build_exclude,
+    )
+    if isinstance(linter_tags, str):  # --build-tags is a comma-separated CLI string
+        linter_tags = linter_tags.split(",")
+
     modules, flavor = process_input_args(
         ctx,
         module,
         targets,
         flavor,
         headless_mode,
-        build_tags=build_tags,
+        build_tags=linter_tags + list(UNIT_TEST_TAGS),
         only_modified_packages=only_modified_packages,
         lint=True,
     )
@@ -122,7 +137,7 @@ def go(
         modules=modules,
         flavor=flavor,
         build=build,
-        build_tags=build_tags,
+        build_tags=linter_tags,
         build_include=build_include,
         build_exclude=build_exclude,
         rtloader_root=rtloader_root,


### PR DESCRIPTION
### What does this PR do?

Passes the build tags `golangci-lint` will use to the package discovery done by
`dda inv linter.go --only-modified-packages`.

### Motivation

`linter.go` passes no build tags, so `process_input_args` turns them into `[]`
and `get_modified_packages` skips its `go list` filter (gated on `if build_tags:`
since #54890). A modified package whose files are all excluded by the lint tags
is then handed to `golangci-lint` as an explicit target, and the run fails with:

```
level=error msg="[linters_context] typechecking error: build constraints exclude all Go files in .../pkg/security/tests/syscall_tester/go"
```

A `./pkg/...` wildcard skips such packages silently, an explicit package name
does not, which is why CI (explicit `--targets`, recursive) is unaffected and
only the `go-linter` pre-push hook fails.

Callers that intentionally pass no tags, such as the Bazel-driven test task,
keep skipping the filter.

### Describe how you validated your changes

On a branch that modifies `pkg/security/tests/syscall_tester/go`, whose only
file is behind `//go:build syscalltesters`:

- before: the hook fails with the error above
- after: `All linters passed`, and the target list is identical to the one
  produced before #54890

### Additional Notes

Only affects `--only-modified-packages`, which CI does not use.
