### PR TITLE
[WP] Don't allow empty scope in network actions

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3933,6 +3933,9 @@ func (p *EBPFProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 					dropActionFilter.CGroupPathKey = ev.ProcessContext.Process.CGroup.CGroupPathKey
 				} else {
 					dropActionFilter.Pid = ev.ProcessContext.Pid
+					if action.Def.NetworkFilter.Scope != "process" {
+						seclog.Warnf("unsupported scope '%s' for rule '%s'", action.Def.NetworkFilter.Scope, rule.ID)
+					}
 				}
 				if err := p.addRawPacketActionFilter(dropActionFilter); err != nil {
 					seclog.Errorf("failed to setup raw packet action programs: %s", err)

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -399,7 +399,10 @@ func (n *NetworkFilterDefinition) PreCheck(opts PolicyLoaderOpts) error {
 	}
 
 	// default scope to process
-	if n.Scope != "" && n.Scope != "process" && n.Scope != "cgroup" {
+	if n.Scope == "" {
+		n.Scope = "process"
+	}
+	if n.Scope != "process" && n.Scope != "cgroup" {
 		return fmt.Errorf("invalid scope '%s'", n.Scope)
 	}
 

--- a/pkg/security/secl/rules/model_test.go
+++ b/pkg/security/secl/rules/model_test.go
@@ -207,3 +207,32 @@ func TestSetDefinitionCapture(t *testing.T) {
 		assert.EqualError(t, setDef.PreCheck(PolicyLoaderOpts{}), "either 'value', 'field' or 'expression' must be specified")
 	})
 }
+
+func TestNetworkFilterDefinitionEmptyScopeDefault(t *testing.T) {
+	n := &NetworkFilterDefinition{
+		BPFFilter: "tcp port 80",
+		Policy:    "drop",
+	}
+	opts := PolicyLoaderOpts{
+		ValidateBPFFilter: func(_ string) error { return nil },
+	}
+	err := n.PreCheck(opts)
+	assert.NoError(t, err)
+	assert.Equal(t, "process", n.Scope)
+}
+
+func TestNetworkFilterDefinitionEmptyScopeDefaultOnRuleLoad(t *testing.T) {
+	actionDef := &ActionDefinition{
+		NetworkFilter: &NetworkFilterDefinition{
+			BPFFilter: "tcp port 80",
+			Policy:    "drop",
+		},
+	}
+
+	opts := PolicyLoaderOpts{
+		ValidateBPFFilter: func(_ string) error { return nil },
+	}
+	err := actionDef.PreCheck(opts)
+	assert.NoError(t, err)
+	assert.Equal(t, "process", actionDef.NetworkFilter.Scope)
+}


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
This PR remove the empty scope from the allowed scope in network isolation actions.

### Motivation
This empty scope could create issues since the scope is used in the keys to identify a unique action. In addition, setting up an action with an empty scope was misleading and dangerous by design since the customers had no visibility on what was happening.