### PR TITLE
Use bazel target name as package name for test2json and UTOF

### DIFF
--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -343,8 +343,11 @@ def _resolve_test_output_path(
 def _parse_bep(bep_path: Path) -> dict[str, BepTestArtifacts]:
     """Parse a BEP JSON file in one pass.
 
-    Returns a mapping keyed by Go import path. Each value contains the cache
+    Returns a mapping keyed by Bazel test label. Each value contains the cache
     status and the test.xml/test.log files produced by this invocation.
+
+    The label key preserves distinct dd_agent_go_test variants for the same Go
+    package, such as //pkg/foo:foo_test and //pkg/foo:foo_test_containerd.
     """
     ctx = _BepContext()
     test_actions: list[tuple[str, str, str, str, bool]] = []
@@ -381,8 +384,10 @@ def _parse_bep(bep_path: Path) -> dict[str, BepTestArtifacts]:
 
     results: dict[str, BepTestArtifacts] = {}
     for label, cfg_id, xml_uri, log_uri, cached in test_actions:
-        import_path = _label_to_import_path(label)
-        artifacts = results.setdefault(import_path, {"cached": cached, "xml_paths": [], "log_paths": []})
+        artifacts = results.setdefault(
+            label,
+            {"cached": cached, "xml_paths": [], "log_paths": []},
+        )
         artifacts["cached"] = cached
         artifacts["xml_paths"].append(_resolve_test_output_path(label, xml_uri, cfg_id, ctx, "test.xml"))
         artifacts["log_paths"].append(_resolve_test_output_path(label, log_uri, cfg_id, ctx, "test.log"))
@@ -438,7 +443,7 @@ def _collect_junit(test_artifacts, output_tgz):
     from tasks.libs.common.junit_upload_core import produce_junit_tar
 
     xml_files = [p for artifacts in test_artifacts.values() for p in artifacts["xml_paths"]]
-    cache_status = {import_path: artifacts["cached"] for import_path, artifacts in test_artifacts.items()}
+    cache_status = {_label_to_import_path(label): artifacts["cached"] for label, artifacts in test_artifacts.items()}
     if not xml_files:
         print("error: no test.xml files found in BEP output", file=sys.stderr)
         sys.exit(1)
@@ -488,10 +493,13 @@ def _collect_test2json(ctx, test_artifacts, output_path):
     with tempfile.TemporaryDirectory() as tmpdir:
         manifest_path = os.path.join(tmpdir, "manifest.tsv")
         with open(manifest_path, "w") as manifest:
-            for import_path in sorted(test_artifacts.keys()):
-                manifest.writelines(
-                    f'{import_path}\t{log_path}\n' for log_path in test_artifacts[import_path]["log_paths"]
-                )
+            for label in sorted(test_artifacts.keys()):
+                # Use the Bazel label, not the Go import path, as the test2json package
+                # identity. dd_agent_go_test emits multiple configured go_test targets
+                # for different build-tag sets in the same Go package; collapsing them
+                # to one import path would make UTOF report those distinct runs as
+                # retries.
+                manifest.writelines(f'{label}\t{log_path}\n' for log_path in test_artifacts[label]["log_paths"])
 
         bazel(
             ctx,

--- a/tasks/unit_tests/bazel_tests.py
+++ b/tasks/unit_tests/bazel_tests.py
@@ -161,7 +161,7 @@ class TestParseBep(unittest.TestCase):
             self.assertEqual(
                 _parse_bep(bep_path),
                 {
-                    f"{_IMPORT_PREFIX}/pkg/foo": {
+                    "//pkg/foo:foo_test": {
                         "cached": True,
                         "xml_paths": [reconstructed],
                         "log_paths": [reconstructed_log],
@@ -208,8 +208,8 @@ class TestParseBep(unittest.TestCase):
             )
 
             artifacts = _parse_bep(bep_path)
-            self.assertEqual(artifacts[f"{_IMPORT_PREFIX}/pkg/foo"]["xml_paths"], [file_uri_path])
-            self.assertEqual(artifacts[f"{_IMPORT_PREFIX}/pkg/foo"]["log_paths"], [reconstructed_log])
+            self.assertEqual(artifacts["//pkg/foo:foo_test"]["xml_paths"], [file_uri_path])
+            self.assertEqual(artifacts["//pkg/foo:foo_test"]["log_paths"], [reconstructed_log])
 
     def test_repeated_test_result_for_same_label_all_kept(self):
         # A sharded or retried target reports multiple testResult events for
@@ -255,10 +255,8 @@ class TestParseBep(unittest.TestCase):
             )
 
             artifacts = _parse_bep(bep_path)
-            self.assertEqual(sorted(artifacts[f"{_IMPORT_PREFIX}/pkg/foo"]["xml_paths"]), sorted([first, second]))
-            self.assertEqual(
-                sorted(artifacts[f"{_IMPORT_PREFIX}/pkg/foo"]["log_paths"]), sorted([first_log, second_log])
-            )
+            self.assertEqual(sorted(artifacts["//pkg/foo:foo_test"]["xml_paths"]), sorted([first, second]))
+            self.assertEqual(sorted(artifacts["//pkg/foo:foo_test"]["log_paths"]), sorted([first_log, second_log]))
 
     def test_no_test_result_events_produces_nothing(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

It switches to using the bazel target name when producing test2json and UTOF output out of Bazel-driven tests. This allows differentiation between tests that run under different tag sets, removing false "retry" labelling of these.

### Motivation

A follow-up for https://github.com/DataDog/datadog-agent/pull/54655. The output for the job after that change became extremely verbose, because under the new model, we're running tests without splitting by flavor, but some tests run more than once with different sets of tags. These were being reported as 

### Describe how you validated your changes

Check that the output on the jobs reports no retries.

### Additional Notes

JUnit output is kept as it was, though it may benefit from encoding similar info about go tags the test run with. Leaving that for a follow-up.