### PR TITLE
fix(e2e): Avoid secret propagation to copy file paths

### DIFF
--- a/test/e2e-framework/components/command/filemanager.go
+++ b/test/e2e-framework/components/command/filemanager.go
@@ -99,7 +99,12 @@ func (fm *FileManager) CopyInlineFile(fileContent pulumi.StringInput, remotePath
 			return "", err
 		}
 		return tempFilePath, nil
-	}).(pulumi.StringInput)
+	}).(pulumi.StringOutput)
+
+	// The generated path does not contain the secret file contents. Avoid
+	// propagating their secrecy to CopyFile's triggers, as secret unknown arrays
+	// cannot be decoded by the command provider during previews.
+	localTempPath = pulumi.Unsecret(localTempPath).(pulumi.StringOutput)
 
 	return fm.CopyFile(remotePath, localTempPath, pulumi.String(remotePath), opts...)
 }


### PR DESCRIPTION
### What does this PR do?

Removes secret propagation from the temporary pathname generated by `CopyInlineFile` while preserving secrecy on the inline file contents.

This prevents the pathname from tainting the `CopyFile` triggers array as secret and allows Pulumi to serialize the remote copy resource during previews.

### Motivation

Inline Agent configuration includes secret values such as the API key. Because the temporary pathname is produced by an `ApplyT` on that content, Pulumi marks the pathname secret even though it contains no file contents. Passing that secret pathname through the remote copy triggers caused previews to fail with `malformed RPC secret: missing value for "triggers"`.

### Describe how you validated your changes

- Ran `dda inv test --module=./test/e2e-framework --targets=./components/command/...`.
- Reproduced the preview failure with both Pulumi CLI 3.257.0 and 3.253.0 before the change.
- Ran `dda inv aws.create-vm --use-fakeintake` after the change. Pulumi preview completed and the update successfully created all 29 resources, including the EC2 host, healthy fakeintake ECS service, and running Agent.