### PR TITLE
ci: do not fail openshift stack destroy on crc delete error

### DIFF
--- a/test/e2e-framework/components/kubernetes/openshift.go
+++ b/test/e2e-framework/components/kubernetes/openshift.go
@@ -51,7 +51,7 @@ func NewLocalOpenShiftCluster(env config.Env, name string, args OpenShiftCluster
 		// cleanup; without setsid, vfkit gets SIGTERM'd when pulumi exits.
 		startCluster, err := runner.Command(commonEnvironment.CommonNamer().ResourceName("crc-start"), &command.Args{
 			Create: pulumi.Sprintf(`python3 -c "import os,subprocess,sys; os.setsid(); sys.exit(subprocess.call(sys.argv[1:]))" crc start -p %s`, args.PullSecretPath),
-			Delete: pulumi.String("(crc stop || true) && crc delete -f"),
+			Delete: pulumi.String("(crc stop || true) && (crc delete -f || true)"),
 			Triggers: pulumi.Array{
 				pulumi.String(args.PullSecretPath),
 				pulumi.String(args.CPUs),
@@ -125,7 +125,7 @@ func NewOpenShiftCluster(env config.Env, vm *remote.Host, name string, args Open
 
 		startCRC, err := runner.Command(commonEnvironment.CommonNamer().ResourceName("crc-start"), &command.Args{
 			Create: pulumi.String(`crc start -p /tmp/pull-secret.txt`),
-			Delete: pulumi.String("(crc stop || true) && crc delete -f"),
+			Delete: pulumi.String("(crc stop || true) && (crc delete -f || true)"),
 			Triggers: pulumi.Array{
 				pulumi.String(args.PullSecretPath),
 				pulumi.String(args.CPUs),


### PR DESCRIPTION
When deleting an openshift stack we need to stop the crc container, then we need to delete it, if it has already been deleted manually it returns an error and prevents the pulumi stack from being destroyed.

ignore that error and delete the stack, we use the `-f` flag to force deletion anyway.

<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
