### PR TITLE
Add PostgreSQL collector for Config Files Discovery

### DIFF
--- a/comp/core/configfilesdiscovery/fx/BUILD.bazel
+++ b/comp/core/configfilesdiscovery/fx/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "fx",
-    srcs = ["fx.go"],
+    srcs = [
+        "fx.go",
+        "fx_unsupported.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/fx",
     visibility = ["//visibility:public"],
     deps = [

--- a/comp/core/configfilesdiscovery/fx/fx_unsupported.go
+++ b/comp/core/configfilesdiscovery/fx/fx_unsupported.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
-//go:build docker || (cri && containerd) || test
+//go:build !docker && (!cri || !containerd) && !test
 
 // Package fx provides fx wiring for the config files discovery component.
 package fx
@@ -15,7 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	configfilesdiscovery "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/def"
 	configfilesdiscoveryimpl "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/impl"
-	"github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/impl/collectors"
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
@@ -64,11 +63,6 @@ func newOptionalComponent(reqs Requires) Provides {
 		Hostname:      reqs.Hostname,
 		WorkloadMeta:  reqs.WorkloadMeta,
 		EventPlatform: reqs.EventPlatform,
-		Collectors: map[string]configfilesdiscoveryimpl.ConfigCollector{
-			collectors.KafkaIntegrationName:    collectors.NewKafka(),
-			collectors.PostgresIntegrationName: collectors.NewPostgres(),
-			collectors.RedisIntegrationName:    collectors.NewRedis(),
-		},
 	})
 	return Provides{Comp: option.New(provides.Comp)}
 }

--- a/comp/core/configfilesdiscovery/impl/BUILD.bazel
+++ b/comp/core/configfilesdiscovery/impl/BUILD.bazel
@@ -7,9 +7,13 @@ go_library(
         "configfilesdiscovery.go",
         "docker_reader.go",
         "docker_reader_nodocker.go",
+        "env_vars.go",
         "evp_reporter.go",
         "kubernetes_reader.go",
         "kubernetes_reader_noop.go",
+        "process_commandline.go",
+        "process_retry.go",
+        "process_retry_noop.go",
         "reader_helpers.go",
         "scheduler.go",
         "types.go",
@@ -20,6 +24,7 @@ go_library(
         "//comp/core/autodiscovery/def",
         "//comp/core/autodiscovery/integration",
         "//comp/core/autodiscovery/scheduler",
+        "//comp/core/config",
         "//comp/core/configfilesdiscovery/def",
         "//comp/core/hostname",
         "//comp/core/workloadmeta/def",
@@ -30,6 +35,7 @@ go_library(
         "//pkg/util/containers/cri",
         "//pkg/util/docker",
         "//pkg/util/log",
+        "@com_github_benbjohnson_clock//:clock",
         "@com_github_containerd_containerd_v2//pkg/oci",
         "@com_github_datadog_agent_payload_v5//agentdiscovery",
         "@org_golang_google_protobuf//proto",
@@ -39,7 +45,10 @@ go_library(
 
 go_test(
     name = "docker_reader_test",
-    srcs = ["docker_reader_test.go"],
+    srcs = [
+        "docker_reader_test.go",
+        "reader_helpers_test.go",
+    ],
     embed = [":impl"],
     gotags = [
         "docker",
@@ -56,7 +65,10 @@ dd_agent_go_test(
     srcs = [
         "configfilesdiscovery_test.go",
         "docker_reader_test.go",
+        "env_vars_test.go",
         "kubernetes_reader_test.go",
+        "process_commandline_test.go",
+        "reader_helpers_test.go",
     ],
     embed = [":impl"],
     deps = [
@@ -73,6 +85,7 @@ dd_agent_go_test(
         "//comp/def",
         "//comp/forwarder/eventplatform/def",
         "//pkg/logs/message",
+        "@com_github_benbjohnson_clock//:clock",
         "@com_github_containerd_containerd_v2//pkg/oci",
         "@com_github_datadog_agent_payload_v5//agentdiscovery",
         "@com_github_opencontainers_runtime_spec//specs-go",
@@ -85,7 +98,10 @@ dd_agent_go_test(
 
 go_test(
     name = "kubernetes_reader_test",
-    srcs = ["kubernetes_reader_test.go"],
+    srcs = [
+        "kubernetes_reader_test.go",
+        "reader_helpers_test.go",
+    ],
     embed = [":impl"],
     gotags = [
         "containerd",
@@ -97,7 +113,5 @@ go_test(
         "@com_github_opencontainers_runtime_spec//specs-go",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-        "@org_golang_google_protobuf//proto",
-        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )

--- a/comp/core/configfilesdiscovery/impl/collectors/BUILD.bazel
+++ b/comp/core/configfilesdiscovery/impl/collectors/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "doc.go",
         "helpers.go",
         "kafka.go",
+        "postgres.go",
         "redis.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/impl/collectors",
@@ -21,7 +22,9 @@ go_library(
 dd_agent_go_test(
     name = "collectors_test",
     srcs = [
+        "helpers_test.go",
         "kafka_test.go",
+        "postgres_test.go",
         "redis_test.go",
     ],
     embed = [":collectors"],

--- a/comp/core/configfilesdiscovery/impl/collectors/helpers.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/helpers.go
@@ -6,14 +6,40 @@
 package collectors
 
 import (
+	"context"
+	"fmt"
 	"path"
+	"sort"
 	"strings"
 
 	configfilesdiscoveryimpl "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/impl"
 )
 
-func commandlineArgs(commandline configfilesdiscoveryimpl.TargetCommandline) []string {
-	return unwrapShellCommandline(commandline.Args)
+// readEnvVars returns selected environment variables in deterministic name order.
+func readEnvVars(
+	ctx context.Context,
+	reader configfilesdiscoveryimpl.ConfigReader,
+	predicate configfilesdiscoveryimpl.ConfigEnvVarPredicate,
+) ([]configfilesdiscoveryimpl.ConfigEnvVar, error) {
+	env, err := reader.ReadEnvVars(ctx, predicate)
+	if err != nil {
+		return nil, err
+	}
+	if len(env) == 0 {
+		return nil, nil
+	}
+
+	names := make([]string, 0, len(env))
+	for name := range env {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	envVars := make([]configfilesdiscoveryimpl.ConfigEnvVar, 0, len(env))
+	for _, name := range names {
+		envVars = append(envVars, configfilesdiscoveryimpl.ConfigEnvVar{Name: name, Value: env[name]})
+	}
+	return envVars, nil
 }
 
 func unwrapShellCommandline(args []string) []string {
@@ -43,4 +69,112 @@ func resolveConfigPath(configPath string, workingDir string) (string, bool) {
 		return "", false
 	}
 	return path.Clean(path.Join(workingDir, configPath)), true
+}
+
+// readConfigFile discovers and reads a command-line config file, then considers
+// fallbackConfigArg before ordered groups of default paths. The first group with
+// readable files wins, and exactly one file must be readable within that group.
+// Returns the file and whether one was selected.
+func readConfigFile(
+	ctx context.Context,
+	reader configfilesdiscoveryimpl.ConfigReader,
+	findConfigArg func([]string) (string, bool),
+	matchesCommandline func([]string) bool,
+	fallbackConfigArg string,
+	defaultPathGroups ...[]string,
+) (configfilesdiscoveryimpl.ConfigFile, bool, error) {
+	// Runtime metadata has highest precedence and provides the working directory
+	// needed to resolve a relative config argument or fallbackConfigArg.
+	commandline, commandlineErr := reader.ReadRuntimeCommandline(ctx)
+	runtimeWorkingDir := ""
+	commandMatched := false
+	configArgFound := false
+	configPath := ""
+	if commandlineErr == nil {
+		runtimeWorkingDir = commandline.WorkingDir
+		commandMatched = matchesCommandline(commandline.Args)
+		if configArg, found := findConfigArg(commandline.Args); found {
+			commandMatched = true
+			configArgFound = true
+			if resolvedPath, resolved := resolveConfigPath(configArg, commandline.WorkingDir); resolved {
+				configPath = resolvedPath
+			}
+		}
+	}
+
+	// If runtime metadata has no resolvable path, inspect live process command
+	// lines. Every discovered path must resolve, and multiple paths must agree.
+	if configPath == "" {
+		for _, commandline := range reader.ReadLiveProcessCommandlines(ctx) {
+			if matchesCommandline(commandline.Args) {
+				commandMatched = true
+			}
+			configArg, found := findConfigArg(commandline.Args)
+			if !found {
+				continue
+			}
+			configArgFound = true
+			resolvedPath, resolved := resolveConfigPath(configArg, commandline.WorkingDir)
+			if !resolved {
+				return configfilesdiscoveryimpl.ConfigFile{}, false, commandlineErr
+			}
+			if configPath != "" && configPath != resolvedPath {
+				return configfilesdiscoveryimpl.ConfigFile{}, false, commandlineErr
+			}
+			configPath = resolvedPath
+		}
+	}
+
+	// Only use the caller-provided fallback when argv did not explicitly name a
+	// config file. An unresolved argv path is authoritative and blocks guessing.
+	if configPath == "" && !configArgFound && fallbackConfigArg != "" {
+		var resolved bool
+		configPath, resolved = resolveConfigPath(fallbackConfigArg, runtimeWorkingDir)
+		if !resolved {
+			return configfilesdiscoveryimpl.ConfigFile{}, false, commandlineErr
+		}
+	}
+
+	// Explicit paths are authoritative. A read failure must not fall through to
+	// conventional defaults that the process might not have loaded.
+	if configPath != "" {
+		file, err := reader.ReadFile(ctx, configPath)
+		if err != nil {
+			return configfilesdiscoveryimpl.ConfigFile{}, false, fmt.Errorf("read explicit config file %q: %w", configPath, err)
+		}
+		return file, true, nil
+	}
+
+	// A matching command line or an explicit but unusable source also blocks
+	// defaults, since selecting one would only be a guess.
+	if configArgFound || fallbackConfigArg != "" || commandMatched {
+		return configfilesdiscoveryimpl.ConfigFile{}, false, nil
+	}
+
+	// Default groups are ordered by priority. The first group with readable files
+	// wins, but collection is suppressed when that group is ambiguous.
+	for _, defaultPaths := range defaultPathGroups {
+		files := make([]configfilesdiscoveryimpl.ConfigFile, 0, len(defaultPaths))
+		for _, path := range defaultPaths {
+			file, err := reader.ReadFile(ctx, path)
+			if err != nil {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return configfilesdiscoveryimpl.ConfigFile{}, false, ctxErr
+				}
+				continue
+			}
+			files = append(files, file)
+		}
+
+		switch len(files) {
+		case 0:
+			continue
+		case 1:
+			return files[0], true, nil
+		default:
+			return configfilesdiscoveryimpl.ConfigFile{}, false, commandlineErr
+		}
+	}
+
+	return configfilesdiscoveryimpl.ConfigFile{}, false, commandlineErr
 }

--- a/comp/core/configfilesdiscovery/impl/collectors/helpers_test.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/helpers_test.go
@@ -1,0 +1,280 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package collectors
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	configfilesdiscoveryimpl "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/impl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadConfigFile(t *testing.T) {
+	commandlineErr := errors.New("command line unavailable")
+	readErr := errors.New("read failed")
+	defaultPaths := []string{"/default/one.conf", "/default/two.conf"}
+
+	tests := []struct {
+		name                    string
+		commandline             configfilesdiscoveryimpl.TargetCommandline
+		commandlineErr          error
+		commandlines            []configfilesdiscoveryimpl.TargetCommandline
+		files                   map[string]configfilesdiscoveryimpl.ConfigFile
+		readErrors              map[string]error
+		defaultPathGroups       [][]string
+		cancelContext           bool
+		wantFile                configfilesdiscoveryimpl.ConfigFile
+		wantOK                  bool
+		wantErr                 error
+		wantReadFileCalls       []string
+		wantProcessCommandCalls int
+	}{
+		{
+			name: "runtime explicit path wins",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"service", "/runtime.conf"},
+			},
+			commandlines: []configfilesdiscoveryimpl.TargetCommandline{{
+				Args: []string{"service", "/process.conf"},
+			}},
+			files: map[string]configfilesdiscoveryimpl.ConfigFile{
+				"/runtime.conf": {Path: "/runtime.conf"},
+			},
+			wantFile:          configfilesdiscoveryimpl.ConfigFile{Path: "/runtime.conf"},
+			wantOK:            true,
+			wantReadFileCalls: []string{"/runtime.conf"},
+		},
+		{
+			name: "explicit read error does not fall back",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"service", "/runtime.conf"},
+			},
+			readErrors: map[string]error{
+				"/runtime.conf": readErr,
+			},
+			wantErr:           readErr,
+			wantReadFileCalls: []string{"/runtime.conf"},
+		},
+		{
+			name: "unresolved explicit path does not fall back",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"service", "relative.conf"},
+			},
+			files: map[string]configfilesdiscoveryimpl.ConfigFile{
+				"/default/one.conf": {Path: "/default/one.conf"},
+			},
+			wantProcessCommandCalls: 1,
+		},
+		{
+			name: "recognized command without explicit path does not fall back",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"service"},
+			},
+			files: map[string]configfilesdiscoveryimpl.ConfigFile{
+				"/default/one.conf": {Path: "/default/one.conf"},
+			},
+			wantProcessCommandCalls: 1,
+		},
+		{
+			name:           "recognized live command without explicit path recovers command line error",
+			commandlineErr: commandlineErr,
+			commandlines: []configfilesdiscoveryimpl.TargetCommandline{{
+				Args: []string{"service"},
+			}},
+			files: map[string]configfilesdiscoveryimpl.ConfigFile{
+				"/default/one.conf": {Path: "/default/one.conf"},
+			},
+			wantProcessCommandCalls: 1,
+		},
+		{
+			name: "live path resolves unresolved runtime path",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"service", "relative.conf"},
+			},
+			commandlines: []configfilesdiscoveryimpl.TargetCommandline{{
+				Args: []string{"service", "/process.conf"},
+			}},
+			files: map[string]configfilesdiscoveryimpl.ConfigFile{
+				"/process.conf": {Path: "/process.conf"},
+			},
+			wantFile:                configfilesdiscoveryimpl.ConfigFile{Path: "/process.conf"},
+			wantOK:                  true,
+			wantReadFileCalls:       []string{"/process.conf"},
+			wantProcessCommandCalls: 1,
+		},
+		{
+			name: "conflicting live paths do not fall back",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"wrapper"},
+			},
+			commandlines: []configfilesdiscoveryimpl.TargetCommandline{
+				{Args: []string{"service", "/one.conf"}},
+				{Args: []string{"service", "/two.conf"}},
+			},
+			files: map[string]configfilesdiscoveryimpl.ConfigFile{
+				"/default/one.conf": {Path: "/default/one.conf"},
+			},
+			wantProcessCommandCalls: 1,
+		},
+		{
+			name: "higher priority default group wins",
+			defaultPathGroups: [][]string{
+				{"/preferred/config.conf"},
+				defaultPaths,
+			},
+			files: map[string]configfilesdiscoveryimpl.ConfigFile{
+				"/preferred/config.conf": {Path: "/preferred/config.conf"},
+				"/default/one.conf":      {Path: "/default/one.conf"},
+			},
+			wantFile:                configfilesdiscoveryimpl.ConfigFile{Path: "/preferred/config.conf"},
+			wantOK:                  true,
+			wantReadFileCalls:       []string{"/preferred/config.conf"},
+			wantProcessCommandCalls: 1,
+		},
+		{
+			name:           "unique default path recovers command line error",
+			commandlineErr: commandlineErr,
+			files: map[string]configfilesdiscoveryimpl.ConfigFile{
+				"/default/two.conf": {Path: "/default/two.conf", Content: []byte("config")},
+			},
+			wantFile: configfilesdiscoveryimpl.ConfigFile{
+				Path:    "/default/two.conf",
+				Content: []byte("config"),
+			},
+			wantOK:                  true,
+			wantReadFileCalls:       defaultPaths,
+			wantProcessCommandCalls: 1,
+		},
+		{
+			name:                    "missing default paths preserve command line error",
+			commandlineErr:          commandlineErr,
+			wantErr:                 commandlineErr,
+			wantReadFileCalls:       defaultPaths,
+			wantProcessCommandCalls: 1,
+		},
+		{
+			name: "multiple default paths are ambiguous",
+			files: map[string]configfilesdiscoveryimpl.ConfigFile{
+				"/default/one.conf": {Path: "/default/one.conf"},
+				"/default/two.conf": {Path: "/default/two.conf"},
+			},
+			wantReadFileCalls:       defaultPaths,
+			wantProcessCommandCalls: 1,
+		},
+		{
+			name:           "multiple default paths preserve command line error",
+			commandlineErr: commandlineErr,
+			files: map[string]configfilesdiscoveryimpl.ConfigFile{
+				"/default/one.conf": {Path: "/default/one.conf"},
+				"/default/two.conf": {Path: "/default/two.conf"},
+			},
+			wantErr:                 commandlineErr,
+			wantReadFileCalls:       defaultPaths,
+			wantProcessCommandCalls: 1,
+		},
+		{
+			name:                    "context cancellation stops default probing",
+			cancelContext:           true,
+			wantErr:                 context.Canceled,
+			wantReadFileCalls:       []string{"/default/one.conf"},
+			wantProcessCommandCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.cancelContext {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+			reader := &configFileTestReader{
+				commandline:    tt.commandline,
+				commandlineErr: tt.commandlineErr,
+				commandlines:   tt.commandlines,
+				files:          tt.files,
+				readErrors:     tt.readErrors,
+			}
+
+			defaultPathGroups := tt.defaultPathGroups
+			if defaultPathGroups == nil {
+				defaultPathGroups = [][]string{defaultPaths}
+			}
+			file, ok, err := readConfigFile(ctx, reader, getTestConfigArg, matchesTestCommandline, "", defaultPathGroups...)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantFile, file)
+			assert.Equal(t, tt.wantReadFileCalls, reader.readFileCalls)
+			assert.Equal(t, tt.wantProcessCommandCalls, reader.processCommandlineCalls)
+		})
+	}
+}
+
+func getTestConfigArg(args []string) (string, bool) {
+	if len(args) != 2 || args[0] != "service" {
+		return "", false
+	}
+	return args[1], true
+}
+
+func matchesTestCommandline(args []string) bool {
+	return len(args) > 0 && args[0] == "service"
+}
+
+type configFileTestReader struct {
+	commandline             configfilesdiscoveryimpl.TargetCommandline
+	commandlineErr          error
+	commandlines            []configfilesdiscoveryimpl.TargetCommandline
+	files                   map[string]configfilesdiscoveryimpl.ConfigFile
+	readErrors              map[string]error
+	readFileCalls           []string
+	processCommandlineCalls int
+}
+
+func (r *configFileTestReader) Runtime() configfilesdiscoveryimpl.RuntimeType {
+	return configfilesdiscoveryimpl.RuntimeDocker
+}
+
+func (r *configFileTestReader) Close() {}
+
+func (r *configFileTestReader) ReadFile(ctx context.Context, path string) (configfilesdiscoveryimpl.ConfigFile, error) {
+	r.readFileCalls = append(r.readFileCalls, path)
+	if err := ctx.Err(); err != nil {
+		return configfilesdiscoveryimpl.ConfigFile{}, err
+	}
+	if err, found := r.readErrors[path]; found {
+		return configfilesdiscoveryimpl.ConfigFile{}, err
+	}
+	if file, found := r.files[path]; found {
+		return file, nil
+	}
+	return configfilesdiscoveryimpl.ConfigFile{}, errors.New("file not found")
+}
+
+func (r *configFileTestReader) ReadEnvVars(context.Context, configfilesdiscoveryimpl.ConfigEnvVarPredicate) (map[string]string, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r *configFileTestReader) ReadRuntimeCommandline(context.Context) (configfilesdiscoveryimpl.TargetCommandline, error) {
+	if r.commandlineErr != nil {
+		return configfilesdiscoveryimpl.TargetCommandline{}, r.commandlineErr
+	}
+	return r.commandline, nil
+}
+
+func (r *configFileTestReader) ReadLiveProcessCommandlines(context.Context) []configfilesdiscoveryimpl.TargetCommandline {
+	r.processCommandlineCalls++
+	return r.commandlines
+}

--- a/comp/core/configfilesdiscovery/impl/collectors/kafka.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/kafka.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"regexp"
 
 	"github.com/DataDog/agent-payload/v5/agentdiscovery"
 	configfilesdiscoveryimpl "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/impl"
@@ -20,50 +21,128 @@ const (
 	kafkaConfigPayloadFormat = agentdiscovery.AgentDiscoveryConfigFilePayloadFormat_PAYLOAD_FORMAT_PROPERTIES
 )
 
+// kafkaDefaultConfigPathGroups contains final config paths passed to Kafka by
+// known distribution image startup scripts, ordered by priority. Strimzi's
+// generated config takes precedence over the packaged Apache config that its
+// image also contains. Apache and Confluent images ship other example configs,
+// but their startup scripts do not pass those files to Kafka.
+var kafkaDefaultConfigPathGroups = [][]string{
+	{"/tmp/strimzi.properties"},
+	{
+		"/opt/kafka/config/server.properties",
+		"/etc/kafka/kafka.properties",
+		"/opt/bitnami/kafka/config/server.properties",
+	},
+}
+
 type kafkaConfigCollector struct{}
+
+var kafkaEnvAllow = []*regexp.Regexp{
+	regexp.MustCompile(`^KAFKA_[A-Z0-9_]+$`),
+	regexp.MustCompile(`^CONFLUENT_[A-Z0-9_]+$`),
+}
+
+var kafkaEnvDeny = []*regexp.Regexp{
+	// Option and command bags can contain arbitrary JVM/broker args, shell code,
+	// and inline credentials.
+	// Leave collection of safe sub-parts to a future, explicit design.
+	regexp.MustCompile(`^(KAFKA|CONFLUENT)(_[A-Z0-9]+)*_(OPTS|COMMAND|EXTRA_(ARGS|FLAGS))$`),
+	// Confluent basic.auth.user.info values are username:password pairs.
+	regexp.MustCompile(`^(KAFKA|CONFLUENT)(_[A-Z0-9]+)*_BASIC_AUTH_USER_INFO$`),
+	regexp.MustCompile(`^(KAFKA|KAFKA_CFG)_SUPER_USERS$`),
+}
 
 func NewKafka() configfilesdiscoveryimpl.ConfigCollector {
 	return kafkaConfigCollector{}
 }
 
-func (c kafkaConfigCollector) Collect(ctx context.Context, reader configfilesdiscoveryimpl.ConfigReader) (configfilesdiscoveryimpl.CollectedConfig, error) {
-	commandline, err := reader.ReadCommandline(ctx)
-	if err != nil {
-		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read kafka command line: %w", err)
-	}
-
-	configPath, ok := kafkaGetConfigPath(commandline)
+// CanCollectFromProcess returns whether the command line contains an explicit,
+// resolvable Kafka broker properties path.
+func (kafkaConfigCollector) CanCollectFromProcess(commandline configfilesdiscoveryimpl.TargetCommandline) bool {
+	configArg, ok := kafkaGetConfigArgFromCommandline(commandline.Args)
 	if !ok {
-		log.Debugf("config files discovery skipped kafka config collection: no explicit broker properties file path detected")
-		return configfilesdiscoveryimpl.CollectedConfig{}, nil
+		return false
+	}
+	_, resolved := resolveConfigPath(configArg, commandline.WorkingDir)
+	return resolved
+}
+
+func (c kafkaConfigCollector) Collect(ctx context.Context, reader configfilesdiscoveryimpl.ConfigReader) (configfilesdiscoveryimpl.CollectedConfig, error) {
+	file, ok, err := readConfigFile(ctx, reader, kafkaGetConfigArgFromCommandline, kafkaMatchesCommandline, "", kafkaDefaultConfigPathGroups...)
+	if err != nil {
+		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("collect kafka config file: %w", err)
 	}
 
-	file, err := reader.ReadFile(ctx, configPath)
+	envVars, err := readEnvVars(ctx, reader, includeKafkaEnvVar)
 	if err != nil {
-		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read kafka config file %q: %w", configPath, err)
+		log.Debugf("config files discovery skipped kafka env var collection: %v", err)
+		envVars = nil
 	}
+	if !ok {
+		// Without a broker properties file, env vars are the only
+		// Kafka config source. Return the error so the scheduler retries.
+		if err != nil {
+			return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read kafka env vars: %w", err)
+		}
+		if len(envVars) == 0 {
+			log.Debugf("config files discovery skipped kafka config collection: no broker properties file or selected env vars detected")
+			return configfilesdiscoveryimpl.CollectedConfig{}, nil
+		}
+
+		log.Debugf("config files discovery collected kafka env vars without an explicit broker properties file path")
+		return configfilesdiscoveryimpl.CollectedConfig{
+			EnvVars: envVars,
+		}, nil
+	}
+
 	file.PayloadFormat = kafkaConfigPayloadFormat
 
 	return configfilesdiscoveryimpl.CollectedConfig{
 		ConfigFiles: []configfilesdiscoveryimpl.ConfigFile{file},
+		EnvVars:     envVars,
 	}, nil
 }
 
-// kafkaGetConfigPath returns the broker properties file passed to the Kafka
-// server launcher. It intentionally ignores command-line --override values:
-// those mutate runtime config but do not identify an additional file to read.
-func kafkaGetConfigPath(commandline configfilesdiscoveryimpl.TargetCommandline) (string, bool) {
-	args := commandlineArgs(commandline)
+func includeKafkaEnvVar(name string) bool {
+	if denyKafkaEnvVar(name) {
+		return false
+	}
+	if name == "CLUSTER_ID" {
+		return true
+	}
+	for _, re := range kafkaEnvAllow {
+		if re.MatchString(name) {
+			return true
+		}
+	}
+	return false
+}
+
+func denyKafkaEnvVar(name string) bool {
+	for _, re := range kafkaEnvDeny {
+		if re.MatchString(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// kafkaGetConfigArgFromCommandline returns the broker properties argument
+// passed to the Kafka server launcher. It intentionally ignores command-line
+// --override values: those mutate runtime config but do not identify an
+// additional file to read.
+func kafkaGetConfigArgFromCommandline(args []string) (string, bool) {
+	args = unwrapShellCommandline(args)
 	kafkaArgs, ok := kafkaGetArgs(args)
 	if !ok {
 		return "", false
 	}
+	return kafkaGetConfigArg(kafkaArgs)
+}
 
-	configPath, ok := kafkaGetConfigArg(kafkaArgs)
-	if !ok {
-		return "", false
-	}
-	return resolveConfigPath(configPath, commandline.WorkingDir)
+func kafkaMatchesCommandline(args []string) bool {
+	_, ok := kafkaGetArgs(unwrapShellCommandline(args))
+	return ok
 }
 
 func kafkaGetArgs(args []string) ([]string, bool) {

--- a/comp/core/configfilesdiscovery/impl/collectors/kafka_test.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/kafka_test.go
@@ -8,6 +8,7 @@ package collectors
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	configfilesdiscoveryimpl "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/impl"
@@ -142,7 +143,11 @@ func TestKafkaGetConfigPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotPath, gotOK := kafkaGetConfigPath(tt.commandline)
+			configArg, gotOK := kafkaGetConfigArgFromCommandline(tt.commandline.Args)
+			var gotPath string
+			if gotOK {
+				gotPath, gotOK = resolveConfigPath(configArg, tt.commandline.WorkingDir)
+			}
 
 			assert.Equal(t, tt.wantOK, gotOK)
 			assert.Equal(t, tt.wantPath, gotPath)
@@ -150,9 +155,70 @@ func TestKafkaGetConfigPath(t *testing.T) {
 	}
 }
 
+func TestKafkaCollectorResolvesAndReadsRelativeProcessConfig(t *testing.T) {
+	eventArgs := []string{"kafka-server-start.sh", "config/server.properties"}
+	eventCommandline := configfilesdiscoveryimpl.TargetCommandline{
+		Args:       eventArgs,
+		WorkingDir: "/opt/kafka",
+	}
+	reader := &kafkaCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/bin/bash", "/mnt/kafka-wrapper/start-kafka.sh"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{eventCommandline},
+		file:                    configfilesdiscoveryimpl.ConfigFile{Path: "/opt/kafka/config/server.properties"},
+	}
+
+	collector := kafkaConfigCollector{}
+	assert.False(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{Args: eventArgs}))
+	assert.True(t, collector.CanCollectFromProcess(eventCommandline))
+	assert.True(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{
+		Args: []string{"kafka-server-start.sh", "/etc/kafka/server.properties"},
+	}))
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/opt/kafka/config/server.properties"}, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+}
+
+func TestIncludeKafkaEnvVar(t *testing.T) {
+	tests := []struct {
+		envName string
+		want    bool
+	}{
+		{envName: "KAFKA_CONTROLLER_LISTENER_NAMES", want: true},
+		{envName: "KAFKA_CFG_PROCESS_ROLES", want: true},
+		{envName: "CONFLUENT_BALANCER_ENABLE", want: true},
+		{envName: "CLUSTER_ID", want: true},
+		{envName: "UNREQUESTED"},
+		{envName: "KAFKA_node_id"},
+		{envName: "KAFKA_OPTS"},
+		{envName: "KAFKA_JMX_OPTS"},
+		{envName: "KAFKA_JVM_PERFORMANCE_OPTS"},
+		{envName: "KAFKA_CFG_JVM_OPTS"},
+		{envName: "CONFLUENT_JVM_OPTS"},
+		{envName: "KAFKA_EXTRA_ARGS"},
+		{envName: "KAFKA_EXTRA_FLAGS"},
+		{envName: "KAFKA_CFG_EXTRA_ARGS"},
+		{envName: "KAFKA_SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO"},
+		{envName: "KAFKA_CONFLUENT_METRICS_REPORTER_BASIC_AUTH_USER_INFO"},
+		{envName: "KAFKA_SUPER_USERS"},
+		{envName: "KAFKA_CFG_SUPER_USERS"},
+		{envName: "KAFKA_SSL_KEYSTORE_LOCATION", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.envName, func(t *testing.T) {
+			assert.Equal(t, tt.want, includeKafkaEnvVar(tt.envName))
+		})
+	}
+}
+
 func TestKafkaCollectorReadsDetectedConfig(t *testing.T) {
 	reader := &kafkaCollectorTestReader{
-		commandline: configfilesdiscoveryimpl.TargetCommandline{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
 			Args: []string{"kafka-server-start.sh", "/etc/kafka/server.properties"},
 		},
 		file: configfilesdiscoveryimpl.ConfigFile{
@@ -160,12 +226,18 @@ func TestKafkaCollectorReadsDetectedConfig(t *testing.T) {
 			Content:   []byte("broker.id=1\n"),
 			Truncated: true,
 		},
+		env: map[string]string{
+			"KAFKA_NODE_ID":       "1",
+			"KAFKA_PROCESS_ROLES": "broker",
+			"UNREQUESTED":         "value",
+		},
 	}
 	collector := NewKafka()
 
 	collected, err := collector.Collect(context.Background(), reader)
 
 	require.NoError(t, err)
+	requireKafkaEnvVarPredicate(t, reader)
 	assert.Equal(t, []string{"/etc/kafka/server.properties"}, reader.readFileCalls)
 	require.Len(t, collected.ConfigFiles, 1)
 	assert.Equal(t, configfilesdiscoveryimpl.ConfigFile{
@@ -174,13 +246,114 @@ func TestKafkaCollectorReadsDetectedConfig(t *testing.T) {
 		Truncated:     true,
 		PayloadFormat: kafkaConfigPayloadFormat,
 	}, collected.ConfigFiles[0])
-	assert.Empty(t, collected.EnvVars)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "KAFKA_NODE_ID", Value: "1"},
+		{Name: "KAFKA_PROCESS_ROLES", Value: "broker"},
+	}, collected.EnvVars)
 }
 
-func TestKafkaCollectorSkipsWhenNoConfigPathIsDetected(t *testing.T) {
+func TestKafkaCollectorCollectsEnvOnly(t *testing.T) {
+	tests := []struct {
+		name        string
+		commandline []string
+		env         map[string]string
+		want        []configfilesdiscoveryimpl.ConfigEnvVar
+	}{
+		{
+			name:        "Confluent",
+			commandline: []string{"/etc/kafka/docker/run"},
+			env: map[string]string{
+				"CLUSTER_ID":          "cluster-id",
+				"KAFKA_NODE_ID":       "1",
+				"KAFKA_PROCESS_ROLES": "broker,controller",
+			},
+			want: []configfilesdiscoveryimpl.ConfigEnvVar{
+				{Name: "CLUSTER_ID", Value: "cluster-id"},
+				{Name: "KAFKA_NODE_ID", Value: "1"},
+				{Name: "KAFKA_PROCESS_ROLES", Value: "broker,controller"},
+			},
+		},
+		{
+			name:        "Bitnami",
+			commandline: []string{"/opt/bitnami/scripts/kafka/run.sh"},
+			env: map[string]string{
+				"KAFKA_CFG_PROCESS_ROLES":                       "broker",
+				"KAFKA_CFG_CONTROLLER_QUORUM_BOOTSTRAP_SERVERS": "controller:9093",
+				"KAFKA_INITIAL_CONTROLLERS":                     "1@controller:9093:dir",
+				"KAFKA_TLS_TYPE":                                "PEM",
+			},
+			want: []configfilesdiscoveryimpl.ConfigEnvVar{
+				{Name: "KAFKA_CFG_CONTROLLER_QUORUM_BOOTSTRAP_SERVERS", Value: "controller:9093"},
+				{Name: "KAFKA_CFG_PROCESS_ROLES", Value: "broker"},
+				{Name: "KAFKA_INITIAL_CONTROLLERS", Value: "1@controller:9093:dir"},
+				{Name: "KAFKA_TLS_TYPE", Value: "PEM"},
+			},
+		},
+		{
+			name:        "Confluent Enterprise",
+			commandline: []string{"/etc/kafka/docker/run"},
+			env: map[string]string{
+				"CONFLUENT_BALANCER_ENABLE": "true",
+				"CONFLUENT_TIER_S3_BUCKET":  "tiered-storage",
+			},
+			want: []configfilesdiscoveryimpl.ConfigEnvVar{
+				{Name: "CONFLUENT_BALANCER_ENABLE", Value: "true"},
+				{Name: "CONFLUENT_TIER_S3_BUCKET", Value: "tiered-storage"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := &kafkaCollectorTestReader{
+				runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{Args: tt.commandline},
+				env:                tt.env,
+			}
+
+			collected, err := NewKafka().Collect(context.Background(), reader)
+
+			require.NoError(t, err)
+			assert.Equal(t, slices.Concat(kafkaDefaultConfigPathGroups...), reader.readFileCalls)
+			assert.Empty(t, collected.ConfigFiles)
+			assert.Equal(t, tt.want, collected.EnvVars)
+		})
+	}
+}
+
+func TestKafkaCollectorFiltersSecretEnvVars(t *testing.T) {
 	reader := &kafkaCollectorTestReader{
-		commandline: configfilesdiscoveryimpl.TargetCommandline{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/etc/kafka/docker/run"},
+		},
+		env: map[string]string{
+			"CONFLUENT_ADMIN_PWD":                              "secret",
+			"KAFKA_CFG_OAUTH_ACCESS_TOKEN":                     "secret",
+			"KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR": "3",
+			"KAFKA_NODE_ID":                                    "1",
+			"KAFKA_OPTS":                                       "-Dsome.token=secret",
+			"KAFKA_SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL":        "https://identity.example/oauth2/token",
+			"KAFKA_SASL_PWD":                                   "secret",
+		},
+	}
+
+	collected, err := NewKafka().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR", Value: "3"},
+		{Name: "KAFKA_NODE_ID", Value: "1"},
+		{Name: "KAFKA_SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL", Value: "https://identity.example/oauth2/token"},
+	}, collected.EnvVars)
+}
+
+func TestKafkaCollectorSkipsDefaultsWhenCommandlineHasNoConfigFile(t *testing.T) {
+	reader := &kafkaCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
 			Args: []string{"kafka-server-start.sh", "--override", "broker.id=1"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path:    "/etc/kafka/server.properties",
+			Content: []byte("broker.id=1\n"),
 		},
 	}
 	collector := NewKafka()
@@ -188,9 +361,216 @@ func TestKafkaCollectorSkipsWhenNoConfigPathIsDetected(t *testing.T) {
 	collected, err := collector.Collect(context.Background(), reader)
 
 	require.NoError(t, err)
+	requireKafkaEnvVarPredicate(t, reader)
 	assert.Empty(t, reader.readFileCalls)
 	assert.Empty(t, collected.ConfigFiles)
 	assert.Empty(t, collected.EnvVars)
+}
+
+func TestKafkaCollectorReadsDefaultConfig(t *testing.T) {
+	reader := &kafkaCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/etc/kafka/docker/run"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path:    "/opt/bitnami/kafka/config/server.properties",
+			Content: []byte("broker.id=1\n"),
+		},
+	}
+
+	collected, err := NewKafka().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, slices.Concat(kafkaDefaultConfigPathGroups...), reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, configfilesdiscoveryimpl.ConfigFile{
+		Path:          "/opt/bitnami/kafka/config/server.properties",
+		Content:       []byte("broker.id=1\n"),
+		PayloadFormat: kafkaConfigPayloadFormat,
+	}, collected.ConfigFiles[0])
+}
+
+func TestKafkaCollectorSelectsActiveDistributionConfig(t *testing.T) {
+	tests := []struct {
+		name               string
+		runtimeCommandline configfilesdiscoveryimpl.TargetCommandline
+		activeConfig       configfilesdiscoveryimpl.ConfigFile
+		exampleConfigs     map[string]configfilesdiscoveryimpl.ConfigFile
+		wantReadFileCalls  []string
+	}{
+		{
+			name: "apache",
+			runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"/etc/kafka/docker/run"},
+			},
+			activeConfig: configfilesdiscoveryimpl.ConfigFile{
+				Path:    "/opt/kafka/config/server.properties",
+				Content: []byte("process.roles=broker,controller\n"),
+			},
+			exampleConfigs: map[string]configfilesdiscoveryimpl.ConfigFile{
+				"/opt/kafka/config/kraft/server.properties": {
+					Path:    "/opt/kafka/config/kraft/server.properties",
+					Content: []byte("process.roles=broker,controller\n"),
+				},
+			},
+		},
+		{
+			name: "confluent",
+			runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"/bin/bash", "/etc/confluent/docker/run"},
+			},
+			activeConfig: configfilesdiscoveryimpl.ConfigFile{
+				Path:    "/etc/kafka/kafka.properties",
+				Content: []byte("node.id=1\n"),
+			},
+			exampleConfigs: map[string]configfilesdiscoveryimpl.ConfigFile{
+				"/etc/kafka/server.properties": {
+					Path:    "/etc/kafka/server.properties",
+					Content: []byte("broker.id=0\n"),
+				},
+				"/etc/kafka/kraft/server.properties": {
+					Path:    "/etc/kafka/kraft/server.properties",
+					Content: []byte("process.roles=broker,controller\n"),
+				},
+			},
+		},
+		{
+			name: "strimzi",
+			runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"/opt/kafka/kafka_run.sh"},
+			},
+			activeConfig: configfilesdiscoveryimpl.ConfigFile{
+				Path:    "/tmp/strimzi.properties",
+				Content: []byte("node.id=1\n"),
+			},
+			exampleConfigs: map[string]configfilesdiscoveryimpl.ConfigFile{
+				"/opt/kafka/config/server.properties": {
+					Path:    "/opt/kafka/config/server.properties",
+					Content: []byte("broker.id=0\n"),
+				},
+			},
+			wantReadFileCalls: []string{"/tmp/strimzi.properties"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := tt.exampleConfigs
+			files[tt.activeConfig.Path] = tt.activeConfig
+			reader := &kafkaCollectorTestReader{
+				runtimeCommandline: tt.runtimeCommandline,
+				files:              files,
+			}
+
+			collected, err := NewKafka().Collect(context.Background(), reader)
+
+			require.NoError(t, err)
+			wantReadFileCalls := tt.wantReadFileCalls
+			if wantReadFileCalls == nil {
+				wantReadFileCalls = slices.Concat(kafkaDefaultConfigPathGroups...)
+			}
+			assert.Equal(t, wantReadFileCalls, reader.readFileCalls)
+			require.Len(t, collected.ConfigFiles, 1)
+			expectedConfig := tt.activeConfig
+			expectedConfig.PayloadFormat = kafkaConfigPayloadFormat
+			assert.Equal(t, expectedConfig, collected.ConfigFiles[0])
+		})
+	}
+}
+
+func TestKafkaCollectorReadsUniqueConfigAcrossProcesses(t *testing.T) {
+	reader := &kafkaCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/bin/bash", "/mnt/kafka-wrapper/start-kafka.sh"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{
+			{Args: []string{"kafka-server-start.sh", "/etc/kafka/server.properties"}},
+			{Args: []string{"java", "kafka.Kafka", "/etc/kafka/server.properties"}},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{Path: "/etc/kafka/server.properties"},
+	}
+
+	collected, err := NewKafka().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/kafka/server.properties"}, reader.readFileCalls)
+	assert.Equal(t, 1, reader.processCommandlineCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+}
+
+func TestKafkaCollectorSkipsConflictingProcessConfigPaths(t *testing.T) {
+	reader := &kafkaCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/bin/bash", "/mnt/kafka-wrapper/start-kafka.sh"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{
+			{Args: []string{"java", "kafka.Kafka", "/etc/kafka/server.properties"}},
+			{Args: []string{"java", "kafka.Kafka", "/etc/kafka/other.properties"}},
+		},
+	}
+
+	collected, err := NewKafka().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Empty(t, collected.ConfigFiles)
+}
+
+func TestKafkaCollectorSkipsUnresolvedMatchingProcessConfigPath(t *testing.T) {
+	reader := &kafkaCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/bin/bash", "/mnt/kafka-wrapper/start-kafka.sh"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{
+			{Args: []string{"java", "kafka.Kafka", "/etc/kafka/server.properties"}},
+			{Args: []string{"java", "kafka.Kafka", "config/server.properties"}},
+		},
+	}
+
+	collected, err := NewKafka().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Empty(t, collected.ConfigFiles)
+}
+
+func TestKafkaCollectorUsesRuntimeConfigBeforeProcessConfig(t *testing.T) {
+	reader := &kafkaCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"kafka-server-start.sh", "/etc/kafka/runtime.properties"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{
+			{Args: []string{"java", "kafka.Kafka", "/etc/kafka/process.properties"}},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{Path: "/etc/kafka/runtime.properties"},
+	}
+
+	collected, err := NewKafka().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/kafka/runtime.properties"}, reader.readFileCalls)
+	assert.Zero(t, reader.processCommandlineCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+}
+
+func TestKafkaCollectorFallsBackToProcessCommandlineOnRuntimeCommandlineError(t *testing.T) {
+	expectedErr := errors.New("command line unavailable")
+	reader := &kafkaCollectorTestReader{
+		commandlineErr: expectedErr,
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{{
+			Args: []string{"java", "kafka.Kafka", "/etc/kafka/server.properties"},
+		}},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path: "/etc/kafka/server.properties",
+		},
+	}
+
+	collected, err := NewKafka().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, reader.processCommandlineCalls)
+	assert.Equal(t, []string{"/etc/kafka/server.properties"}, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
 }
 
 func TestKafkaCollectorReturnsCommandlineErrors(t *testing.T) {
@@ -201,13 +581,60 @@ func TestKafkaCollectorReturnsCommandlineErrors(t *testing.T) {
 	collected, err := collector.Collect(context.Background(), reader)
 
 	require.ErrorIs(t, err, expectedErr)
+	assert.Equal(t, 1, reader.processCommandlineCalls)
+	assert.Empty(t, reader.readEnvVarPredicates)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
+}
+
+func TestKafkaCollectorReadsDetectedConfigWhenEnvVarsFail(t *testing.T) {
+	expectedErr := errors.New("env unavailable")
+	reader := &kafkaCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"kafka-server-start.sh", "/etc/kafka/server.properties"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path:    "/etc/kafka/server.properties",
+			Content: []byte("broker.id=1\n"),
+		},
+		readEnvVarsErr: expectedErr,
+	}
+	collector := NewKafka()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/kafka/server.properties"}, reader.readFileCalls)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigFile{
+		{
+			Path:          "/etc/kafka/server.properties",
+			Content:       []byte("broker.id=1\n"),
+			PayloadFormat: kafkaConfigPayloadFormat,
+		},
+	}, collected.ConfigFiles)
+	assert.Empty(t, collected.EnvVars)
+}
+
+func TestKafkaCollectorReturnsEnvVarErrorsWithoutConfigPath(t *testing.T) {
+	expectedErr := errors.New("env unavailable")
+	reader := &kafkaCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/etc/kafka/docker/run"},
+		},
+		readEnvVarsErr: expectedErr,
+	}
+	collector := NewKafka()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Equal(t, slices.Concat(kafkaDefaultConfigPathGroups...), reader.readFileCalls)
 	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
 }
 
 func TestKafkaCollectorReturnsReadFileErrors(t *testing.T) {
 	expectedErr := errors.New("read failed")
 	reader := &kafkaCollectorTestReader{
-		commandline: configfilesdiscoveryimpl.TargetCommandline{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
 			Args: []string{"kafka-server-start.sh", "/etc/kafka/server.properties"},
 		},
 		readFileErr: expectedErr,
@@ -222,11 +649,17 @@ func TestKafkaCollectorReturnsReadFileErrors(t *testing.T) {
 }
 
 type kafkaCollectorTestReader struct {
-	commandline    configfilesdiscoveryimpl.TargetCommandline
-	commandlineErr error
-	readFileCalls  []string
-	file           configfilesdiscoveryimpl.ConfigFile
-	readFileErr    error
+	runtimeCommandline      configfilesdiscoveryimpl.TargetCommandline
+	liveProcessCommandlines []configfilesdiscoveryimpl.TargetCommandline
+	commandlineErr          error
+	processCommandlineCalls int
+	readFileCalls           []string
+	file                    configfilesdiscoveryimpl.ConfigFile
+	files                   map[string]configfilesdiscoveryimpl.ConfigFile
+	readFileErr             error
+	env                     map[string]string
+	readEnvVarPredicates    []configfilesdiscoveryimpl.ConfigEnvVarPredicate
+	readEnvVarsErr          error
 }
 
 func (r *kafkaCollectorTestReader) Runtime() configfilesdiscoveryimpl.RuntimeType {
@@ -240,16 +673,49 @@ func (r *kafkaCollectorTestReader) ReadFile(_ context.Context, path string) (con
 	if r.readFileErr != nil {
 		return configfilesdiscoveryimpl.ConfigFile{}, r.readFileErr
 	}
-	return r.file, nil
+	if r.file.Path == path {
+		return r.file, nil
+	}
+	if file, ok := r.files[path]; ok {
+		return file, nil
+	}
+	return configfilesdiscoveryimpl.ConfigFile{}, errors.New("file not found")
 }
 
-func (r *kafkaCollectorTestReader) ReadEnvVars(context.Context, []string) (map[string]string, error) {
-	return nil, errors.New("not implemented")
+func (r *kafkaCollectorTestReader) ReadEnvVars(_ context.Context, predicate configfilesdiscoveryimpl.ConfigEnvVarPredicate) (map[string]string, error) {
+	r.readEnvVarPredicates = append(r.readEnvVarPredicates, predicate)
+	if r.readEnvVarsErr != nil {
+		return nil, r.readEnvVarsErr
+	}
+
+	env := make(map[string]string)
+	for name, value := range r.env {
+		if configfilesdiscoveryimpl.IsSecretEnvVarName(name) {
+			continue
+		}
+		if predicate == nil || !predicate(name) {
+			continue
+		}
+		env[name] = value
+	}
+	return env, nil
 }
 
-func (r *kafkaCollectorTestReader) ReadCommandline(context.Context) (configfilesdiscoveryimpl.TargetCommandline, error) {
+func (r *kafkaCollectorTestReader) ReadRuntimeCommandline(context.Context) (configfilesdiscoveryimpl.TargetCommandline, error) {
 	if r.commandlineErr != nil {
 		return configfilesdiscoveryimpl.TargetCommandline{}, r.commandlineErr
 	}
-	return r.commandline, nil
+	return r.runtimeCommandline, nil
+}
+
+func (r *kafkaCollectorTestReader) ReadLiveProcessCommandlines(context.Context) []configfilesdiscoveryimpl.TargetCommandline {
+	r.processCommandlineCalls++
+	return r.liveProcessCommandlines
+}
+
+func requireKafkaEnvVarPredicate(t *testing.T, reader *kafkaCollectorTestReader) configfilesdiscoveryimpl.ConfigEnvVarPredicate {
+	t.Helper()
+	require.Len(t, reader.readEnvVarPredicates, 1)
+	require.NotNil(t, reader.readEnvVarPredicates[0])
+	return reader.readEnvVarPredicates[0]
 }

--- a/comp/core/configfilesdiscovery/impl/collectors/postgres.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/postgres.go
@@ -1,0 +1,212 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package collectors
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/DataDog/agent-payload/v5/agentdiscovery"
+	configfilesdiscoveryimpl "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	PostgresIntegrationName     = "postgres"
+	postgresConfigPayloadFormat = agentdiscovery.AgentDiscoveryConfigFilePayloadFormat_PAYLOAD_FORMAT_PROPERTIES
+	postgresConfigFileName      = "postgresql.conf"
+)
+
+type postgresConfigCollector struct{}
+
+// postgresEnvAllow lists the only environment variables this collector ever
+// forwards. PostgreSQL's official image and PGDATA/PG* variables otherwise
+// carry credentials, connection strings, or arbitrary argument bags.
+var postgresEnvAllow = map[string]struct{}{
+	"PGDATA":                    {},
+	"POSTGRES_DB":               {},
+	"POSTGRES_USER":             {},
+	"POSTGRES_HOST_AUTH_METHOD": {},
+	"POSTGRES_INITDB_WALDIR":    {},
+}
+
+// postgresEnvDeny is defense in depth and documentation: the allow-list above
+// already excludes every name here. Keeping the exclusion explicit protects
+// against the allow-list being loosened later without revisiting these.
+var postgresEnvDeny = map[string]struct{}{
+	"POSTGRES_PASSWORD":      {},
+	"POSTGRES_PASSWORD_FILE": {},
+	"POSTGRES_INITDB_ARGS":   {},
+	"PGPASSWORD":             {},
+	"PGPASSFILE":             {},
+	"PGSERVICE":              {},
+	"PGSERVICEFILE":          {},
+	"PGOPTIONS":              {},
+	"PGSSLKEY":               {},
+	"PGSSLCERT":              {},
+	"PGSSLROOTCERT":          {},
+	"PGREQUIRESSL":           {},
+	"DATABASE_URL":           {},
+	"POSTGRES_URL":           {},
+}
+
+func NewPostgres() configfilesdiscoveryimpl.ConfigCollector {
+	return postgresConfigCollector{}
+}
+
+// CanCollectFromProcess returns whether the command line contains an explicit,
+// resolvable PostgreSQL config source.
+func (postgresConfigCollector) CanCollectFromProcess(commandline configfilesdiscoveryimpl.TargetCommandline) bool {
+	configArg, ok := postgresGetConfigArgFromCommandline(commandline.Args)
+	if !ok {
+		return false
+	}
+	_, resolved := resolveConfigPath(configArg, commandline.WorkingDir)
+	return resolved
+}
+
+func (c postgresConfigCollector) Collect(ctx context.Context, reader configfilesdiscoveryimpl.ConfigReader) (configfilesdiscoveryimpl.CollectedConfig, error) {
+	envVars, envErr := readEnvVars(ctx, reader, includePostgresEnvVar)
+	if envErr != nil {
+		log.Debugf("config files discovery skipped postgres env var collection: %v", envErr)
+		envVars = nil
+	}
+
+	fallbackConfigArg := ""
+	for _, envVar := range envVars {
+		if envVar.Name == "PGDATA" && path.IsAbs(envVar.Value) {
+			fallbackConfigArg = path.Join(envVar.Value, postgresConfigFileName)
+			break
+		}
+	}
+
+	file, ok, err := readConfigFile(
+		ctx,
+		reader,
+		postgresGetConfigArgFromCommandline,
+		postgresMatchesCommandline,
+		fallbackConfigArg,
+	)
+	if err != nil {
+		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("collect postgres config file: %w", err)
+	}
+	if !ok {
+		// Without a config file, env vars are the only PostgreSQL config
+		// source. Return the error so the scheduler retries.
+		if envErr != nil {
+			return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read postgres env vars: %w", envErr)
+		}
+		if len(envVars) == 0 {
+			log.Debugf("config files discovery skipped postgres config collection: no config file or selected env vars detected")
+			return configfilesdiscoveryimpl.CollectedConfig{}, nil
+		}
+
+		log.Debugf("config files discovery collected postgres env vars without a config file")
+		return configfilesdiscoveryimpl.CollectedConfig{
+			EnvVars: envVars,
+		}, nil
+	}
+
+	file.PayloadFormat = postgresConfigPayloadFormat
+
+	return configfilesdiscoveryimpl.CollectedConfig{
+		ConfigFiles: []configfilesdiscoveryimpl.ConfigFile{file},
+		EnvVars:     envVars,
+	}, nil
+}
+
+func includePostgresEnvVar(name string) bool {
+	if configfilesdiscoveryimpl.IsSecretEnvVarName(name) {
+		return false
+	}
+	if _, denied := postgresEnvDeny[name]; denied {
+		return false
+	}
+	_, allowed := postgresEnvAllow[name]
+	return allowed
+}
+
+// postgresGetConfigArgFromCommandline returns the explicit PostgreSQL config
+// source found in argv, in resolvable-path form: an explicit config_file
+// setting, or the postgresql.conf implied by an explicit data directory.
+func postgresGetConfigArgFromCommandline(args []string) (string, bool) {
+	args = unwrapShellCommandline(args)
+	postgresArgs, ok := postgresGetArgs(args)
+	if !ok {
+		return "", false
+	}
+	return postgresGetConfigArg(postgresArgs)
+}
+
+func postgresMatchesCommandline(args []string) bool {
+	_, ok := postgresGetArgs(unwrapShellCommandline(args))
+	return ok
+}
+
+func postgresGetArgs(args []string) ([]string, bool) {
+	for i, arg := range args {
+		if path.Base(arg) == "postgres" {
+			return args[i+1:], true
+		}
+	}
+	return nil, false
+}
+
+// postgresGetConfigArg scans postgres argv for an explicit config_file
+// run-time parameter (`-c config_file=...` or `--config_file=...`) or an
+// explicit data directory (`-D ...`), the last occurrence of either winning.
+// An explicit config_file always takes precedence over a data directory, and
+// an empty or otherwise unusable explicit value is still reported as found so
+// the shared helper blocks the PGDATA fallback and default paths rather than
+// guessing.
+func postgresGetConfigArg(postgresArgs []string) (string, bool) {
+	configFileFound := false
+	configFileArg := ""
+	dataDirFound := false
+	dataDirArg := ""
+
+	for i := 0; i < len(postgresArgs); i++ {
+		arg := postgresArgs[i]
+
+		if value, ok := strings.CutPrefix(arg, "--config_file="); ok {
+			configFileFound = true
+			configFileArg = value
+			continue
+		}
+		if arg == "-c" && i+1 < len(postgresArgs) {
+			if value, ok := strings.CutPrefix(postgresArgs[i+1], "config_file="); ok {
+				configFileFound = true
+				configFileArg = value
+				i++
+				continue
+			}
+		}
+		if arg == "-D" && i+1 < len(postgresArgs) {
+			dataDirFound = true
+			dataDirArg = postgresArgs[i+1]
+			i++
+			continue
+		}
+		if value, ok := strings.CutPrefix(arg, "-D"); ok && value != "" {
+			dataDirFound = true
+			dataDirArg = value
+			continue
+		}
+	}
+
+	if configFileFound {
+		return configFileArg, true
+	}
+	if dataDirFound {
+		if dataDirArg == "" {
+			return "", true
+		}
+		return path.Join(dataDirArg, postgresConfigFileName), true
+	}
+	return "", false
+}

--- a/comp/core/configfilesdiscovery/impl/collectors/postgres_test.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/postgres_test.go
@@ -1,0 +1,464 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package collectors
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	configfilesdiscoveryimpl "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/impl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresGetConfigPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		commandline configfilesdiscoveryimpl.TargetCommandline
+		wantPath    string
+		wantOK      bool
+	}{
+		{
+			name: "official image bare startup",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"postgres"},
+			},
+		},
+		{
+			name: "shell form",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"/bin/sh", "-c", "postgres -c config_file=/etc/postgresql/postgresql.conf"},
+			},
+			wantPath: "/etc/postgresql/postgresql.conf",
+			wantOK:   true,
+		},
+		{
+			name: "explicit config_file short option",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"},
+			},
+			wantPath: "/etc/postgresql/postgresql.conf",
+			wantOK:   true,
+		},
+		{
+			name: "explicit config_file long option",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"postgres", "--config_file=/etc/postgresql/postgresql.conf"},
+			},
+			wantPath: "/etc/postgresql/postgresql.conf",
+			wantOK:   true,
+		},
+		{
+			name: "explicit data directory",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"postgres", "-D", "/var/lib/postgresql/data"},
+			},
+			wantPath: "/var/lib/postgresql/data/postgresql.conf",
+			wantOK:   true,
+		},
+		{
+			name: "config_file wins over data directory",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"postgres", "-D", "/var/lib/postgresql/data", "-c", "config_file=/etc/postgresql/postgresql.conf"},
+			},
+			wantPath: "/etc/postgresql/postgresql.conf",
+			wantOK:   true,
+		},
+		{
+			name: "relative config_file resolved with working dir",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args:       []string{"postgres", "-c", "config_file=postgresql.conf"},
+				WorkingDir: "/etc/postgresql",
+			},
+			wantPath: "/etc/postgresql/postgresql.conf",
+			wantOK:   true,
+		},
+		{
+			name: "relative data directory resolved with working dir",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args:       []string{"postgres", "-D", "data"},
+				WorkingDir: "/var/lib/postgresql",
+			},
+			wantPath: "/var/lib/postgresql/data/postgresql.conf",
+			wantOK:   true,
+		},
+		{
+			name: "relative config_file without absolute working dir",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"postgres", "-c", "config_file=postgresql.conf"},
+			},
+		},
+		{
+			name: "empty explicit config_file value",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"postgres", "-c", "config_file="},
+			},
+		},
+		{
+			name: "postgres not present",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"pg_ctl", "start"},
+			},
+		},
+		{
+			name: "flags only, no explicit source",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"postgres", "-p", "5432"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configArg, gotOK := postgresGetConfigArgFromCommandline(tt.commandline.Args)
+			var gotPath string
+			if gotOK {
+				gotPath, gotOK = resolveConfigPath(configArg, tt.commandline.WorkingDir)
+			}
+
+			assert.Equal(t, tt.wantOK, gotOK)
+			assert.Equal(t, tt.wantPath, gotPath)
+		})
+	}
+}
+
+func TestIncludePostgresEnvVar(t *testing.T) {
+	tests := []struct {
+		name    string
+		envName string
+		want    bool
+	}{
+		{name: "data directory", envName: "PGDATA", want: true},
+		{name: "database name", envName: "POSTGRES_DB", want: true},
+		{name: "user", envName: "POSTGRES_USER", want: true},
+		{name: "host auth method", envName: "POSTGRES_HOST_AUTH_METHOD", want: true},
+		{name: "initdb waldir", envName: "POSTGRES_INITDB_WALDIR", want: true},
+		{name: "unrelated", envName: "UNREQUESTED"},
+		{name: "lowercase", envName: "postgres_db"},
+		{name: "password", envName: "POSTGRES_PASSWORD"},
+		{name: "password file", envName: "POSTGRES_PASSWORD_FILE"},
+		{name: "initdb args", envName: "POSTGRES_INITDB_ARGS"},
+		{name: "libpq password", envName: "PGPASSWORD"},
+		{name: "libpq passfile", envName: "PGPASSFILE"},
+		{name: "libpq service", envName: "PGSERVICE"},
+		{name: "libpq servicefile", envName: "PGSERVICEFILE"},
+		{name: "libpq options", envName: "PGOPTIONS"},
+		{name: "libpq ssl key", envName: "PGSSLKEY"},
+		{name: "libpq ssl cert", envName: "PGSSLCERT"},
+		{name: "libpq ssl root cert", envName: "PGSSLROOTCERT"},
+		{name: "libpq require ssl", envName: "PGREQUIRESSL"},
+		{name: "database url", envName: "DATABASE_URL"},
+		{name: "postgres url", envName: "POSTGRES_URL"},
+		{name: "secret-shaped unrelated name", envName: "PGDATA_TOKEN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, includePostgresEnvVar(tt.envName))
+		})
+	}
+}
+
+func TestPostgresCollectorResolvesAndReadsRelativeProcessConfig(t *testing.T) {
+	eventArgs := []string{"postgres", "-D", "data"}
+	eventCommandline := configfilesdiscoveryimpl.TargetCommandline{
+		Args:       eventArgs,
+		WorkingDir: "/var/lib/postgresql",
+	}
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/usr/local/bin/docker-entrypoint.sh"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{eventCommandline},
+		file:                    configfilesdiscoveryimpl.ConfigFile{Path: "/var/lib/postgresql/data/postgresql.conf"},
+	}
+
+	collector := postgresConfigCollector{}
+	assert.False(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{Args: eventArgs}))
+	assert.True(t, collector.CanCollectFromProcess(eventCommandline))
+	assert.True(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{
+		Args: []string{"postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"},
+	}))
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/var/lib/postgresql/data/postgresql.conf"}, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+}
+
+func TestPostgresCollectorReadsDetectedConfig(t *testing.T) {
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path:    "/etc/postgresql/postgresql.conf",
+			Content: []byte("port = 5432\n"),
+		},
+		env: map[string]string{
+			"POSTGRES_USER": "app",
+			"PGDATA":        "/var/lib/postgresql/data",
+			"POSTGRES_DB":   "app",
+			"UNREQUESTED":   "value",
+		},
+	}
+	collector := NewPostgres()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/postgresql/postgresql.conf"}, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, configfilesdiscoveryimpl.ConfigFile{
+		Path:          "/etc/postgresql/postgresql.conf",
+		Content:       []byte("port = 5432\n"),
+		PayloadFormat: postgresConfigPayloadFormat,
+	}, collected.ConfigFiles[0])
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "PGDATA", Value: "/var/lib/postgresql/data"},
+		{Name: "POSTGRES_DB", Value: "app"},
+		{Name: "POSTGRES_USER", Value: "app"},
+	}, collected.EnvVars)
+}
+
+func TestPostgresCollectorCollectsEnvOnly(t *testing.T) {
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"postgres"},
+		},
+		env: map[string]string{
+			"POSTGRES_DB": "app",
+		},
+	}
+	collector := NewPostgres()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Empty(t, collected.ConfigFiles)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "POSTGRES_DB", Value: "app"},
+	}, collected.EnvVars)
+}
+
+func TestPostgresCollectorSkipsWhenNoConfigAndNoEnv(t *testing.T) {
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"postgres"},
+		},
+	}
+
+	collected, err := NewPostgres().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
+}
+
+func TestPostgresCollectorUsesPGDataFallback(t *testing.T) {
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"postgres"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path:    "/var/lib/postgresql/data/postgresql.conf",
+			Content: []byte("port = 5432\n"),
+		},
+		env: map[string]string{
+			"PGDATA": "/var/lib/postgresql/data",
+		},
+	}
+
+	collected, err := NewPostgres().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/var/lib/postgresql/data/postgresql.conf"}, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, postgresConfigPayloadFormat, collected.ConfigFiles[0].PayloadFormat)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "PGDATA", Value: "/var/lib/postgresql/data"},
+	}, collected.EnvVars)
+}
+
+func TestPostgresCollectorBlocksPGDataFallbackWhenArgvSourceUnusable(t *testing.T) {
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"postgres", "-c", "config_file="},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path: "/var/lib/postgresql/data/postgresql.conf",
+		},
+		env: map[string]string{
+			"PGDATA": "/var/lib/postgresql/data",
+		},
+	}
+
+	collected, err := NewPostgres().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Empty(t, collected.ConfigFiles)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "PGDATA", Value: "/var/lib/postgresql/data"},
+	}, collected.EnvVars)
+}
+
+func TestPostgresCollectorSkipsConflictingProcessConfigPaths(t *testing.T) {
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/usr/local/bin/docker-entrypoint.sh"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{
+			{Args: []string{"postgres", "-D", "/data1"}},
+			{Args: []string{"postgres", "-D", "/data2"}},
+		},
+	}
+
+	collected, err := NewPostgres().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Empty(t, collected.ConfigFiles)
+	assert.Empty(t, collected.EnvVars)
+}
+
+func TestPostgresCollectorReturnsCommandlineErrors(t *testing.T) {
+	expectedErr := errors.New("command line unavailable")
+	reader := &postgresCollectorTestReader{commandlineErr: expectedErr}
+	collector := NewPostgres()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Equal(t, 1, reader.processCommandlineCalls)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
+}
+
+func TestPostgresCollectorReadsDetectedConfigWhenEnvVarsFail(t *testing.T) {
+	expectedErr := errors.New("env unavailable")
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path:    "/etc/postgresql/postgresql.conf",
+			Content: []byte("port = 5432\n"),
+		},
+		readEnvVarsErr: expectedErr,
+	}
+	collector := NewPostgres()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/postgresql/postgresql.conf"}, reader.readFileCalls)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigFile{
+		{
+			Path:          "/etc/postgresql/postgresql.conf",
+			Content:       []byte("port = 5432\n"),
+			PayloadFormat: postgresConfigPayloadFormat,
+		},
+	}, collected.ConfigFiles)
+	assert.Empty(t, collected.EnvVars)
+}
+
+func TestPostgresCollectorReturnsEnvVarErrorsWithoutConfigPath(t *testing.T) {
+	expectedErr := errors.New("env unavailable")
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"postgres"},
+		},
+		readEnvVarsErr: expectedErr,
+	}
+	collector := NewPostgres()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
+}
+
+func TestPostgresCollectorReturnsReadFileErrors(t *testing.T) {
+	expectedErr := errors.New("read failed")
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"},
+		},
+		readFileErr: expectedErr,
+	}
+	collector := NewPostgres()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Equal(t, []string{"/etc/postgresql/postgresql.conf"}, reader.readFileCalls)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
+}
+
+type postgresCollectorTestReader struct {
+	runtimeCommandline      configfilesdiscoveryimpl.TargetCommandline
+	liveProcessCommandlines []configfilesdiscoveryimpl.TargetCommandline
+	commandlineErr          error
+	runtimeCommandlineCalls int
+	processCommandlineCalls int
+	readFileCalls           []string
+	file                    configfilesdiscoveryimpl.ConfigFile
+	readFileErr             error
+	env                     map[string]string
+	readEnvVarsErr          error
+}
+
+func (r *postgresCollectorTestReader) Runtime() configfilesdiscoveryimpl.RuntimeType {
+	return configfilesdiscoveryimpl.RuntimeDocker
+}
+
+func (r *postgresCollectorTestReader) Close() {}
+
+func (r *postgresCollectorTestReader) ReadFile(_ context.Context, path string) (configfilesdiscoveryimpl.ConfigFile, error) {
+	r.readFileCalls = append(r.readFileCalls, path)
+	if r.readFileErr != nil {
+		return configfilesdiscoveryimpl.ConfigFile{}, r.readFileErr
+	}
+	if r.file.Path == path {
+		return r.file, nil
+	}
+	return configfilesdiscoveryimpl.ConfigFile{}, errors.New("file not found")
+}
+
+func (r *postgresCollectorTestReader) ReadEnvVars(_ context.Context, predicate configfilesdiscoveryimpl.ConfigEnvVarPredicate) (map[string]string, error) {
+	if r.readEnvVarsErr != nil {
+		return nil, r.readEnvVarsErr
+	}
+
+	env := make(map[string]string)
+	for name, value := range r.env {
+		if configfilesdiscoveryimpl.IsSecretEnvVarName(name) {
+			continue
+		}
+		if predicate != nil && !predicate(name) {
+			continue
+		}
+		env[name] = value
+	}
+	return env, nil
+}
+
+func (r *postgresCollectorTestReader) ReadRuntimeCommandline(context.Context) (configfilesdiscoveryimpl.TargetCommandline, error) {
+	r.runtimeCommandlineCalls++
+	if r.commandlineErr != nil {
+		return configfilesdiscoveryimpl.TargetCommandline{}, r.commandlineErr
+	}
+	return r.runtimeCommandline, nil
+}
+
+func (r *postgresCollectorTestReader) ReadLiveProcessCommandlines(context.Context) []configfilesdiscoveryimpl.TargetCommandline {
+	r.processCommandlineCalls++
+	return r.liveProcessCommandlines
+}

--- a/comp/core/configfilesdiscovery/impl/collectors/redis.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/redis.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"regexp"
 	"strings"
 
 	"github.com/DataDog/agent-payload/v5/agentdiscovery"
@@ -21,50 +22,117 @@ const (
 	redisConfigPayloadFormat = agentdiscovery.AgentDiscoveryConfigFilePayloadFormat_PAYLOAD_FORMAT_REDIS_CONF
 )
 
+var redisDefaultConfigPaths = []string{
+	"/etc/redis/redis.conf",
+	"/usr/local/etc/redis/redis.conf",
+	"/opt/bitnami/redis/etc/redis.conf",
+}
+
 type redisConfigCollector struct{}
+
+var redisEnvAllow = regexp.MustCompile(`^REDIS_[A-Z0-9_]+$`)
+
+// Deny auth directives, arbitrary option bags, and connection strings that can
+// contain inline credentials.
+var redisEnvDeny = regexp.MustCompile(
+	`^REDIS(_[A-Z0-9]+)*_(` +
+		`AUTH|REQUIREPASS|MASTERAUTH|` +
+		`ARGS|OPTS|FLAGS|` +
+		`URL|URI|DSN|CONNECTION_STRING` +
+		`)$`,
+)
 
 func NewRedis() configfilesdiscoveryimpl.ConfigCollector {
 	return redisConfigCollector{}
 }
 
-func (c redisConfigCollector) Collect(ctx context.Context, reader configfilesdiscoveryimpl.ConfigReader) (configfilesdiscoveryimpl.CollectedConfig, error) {
-	commandline, err := reader.ReadCommandline(ctx)
-	if err != nil {
-		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read redis command line: %w", err)
-	}
-
-	configPath, ok := redisGetConfigPath(commandline)
+// CanCollectFromProcess returns whether the command line contains an explicit,
+// resolvable Redis config path.
+func (redisConfigCollector) CanCollectFromProcess(commandline configfilesdiscoveryimpl.TargetCommandline) bool {
+	configArg, ok := redisGetConfigArgFromCommandline(commandline.Args)
 	if !ok {
-		log.Debugf("config files discovery skipped redis config collection: no explicit config file path detected")
-		return configfilesdiscoveryimpl.CollectedConfig{}, nil
+		return false
+	}
+	_, resolved := resolveConfigPath(configArg, commandline.WorkingDir)
+	return resolved
+}
+
+func (c redisConfigCollector) Collect(ctx context.Context, reader configfilesdiscoveryimpl.ConfigReader) (configfilesdiscoveryimpl.CollectedConfig, error) {
+	envVars, envErr := readEnvVars(ctx, reader, includeRedisEnvVar)
+	if envErr != nil {
+		log.Debugf("config files discovery skipped redis env var collection: %v", envErr)
+		envVars = nil
 	}
 
-	file, err := reader.ReadFile(ctx, configPath)
-	if err != nil {
-		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read redis config file %q: %w", configPath, err)
+	envConfigPath := ""
+	for _, envVar := range envVars {
+		if envVar.Name == "REDIS_CONF_FILE" {
+			envConfigPath = envVar.Value
+			break
+		}
 	}
+
+	file, ok, err := readConfigFile(
+		ctx,
+		reader,
+		redisGetConfigArgFromCommandline,
+		redisMatchesCommandline,
+		envConfigPath,
+		redisDefaultConfigPaths,
+	)
+	if err != nil {
+		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("collect redis config file: %w", err)
+	}
+	if !ok {
+		// Without a config file, env vars are the only Redis config source.
+		// Return the error so the scheduler retries.
+		if envErr != nil {
+			return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read redis env vars: %w", envErr)
+		}
+		if len(envVars) == 0 {
+			log.Debugf("config files discovery skipped redis config collection: no config file or selected env vars detected")
+			return configfilesdiscoveryimpl.CollectedConfig{}, nil
+		}
+
+		log.Debugf("config files discovery collected redis env vars without a config file")
+		return configfilesdiscoveryimpl.CollectedConfig{
+			EnvVars: envVars,
+		}, nil
+	}
+
 	file.PayloadFormat = redisConfigPayloadFormat
 
 	return configfilesdiscoveryimpl.CollectedConfig{
 		ConfigFiles: []configfilesdiscoveryimpl.ConfigFile{file},
+		EnvVars:     envVars,
 	}, nil
 }
 
-// redisGetConfigPath returns the explicit config file path passed to
-// redis-server. Redis also accepts command-line options as temporary config,
+func includeRedisEnvVar(name string) bool {
+	if configfilesdiscoveryimpl.IsSecretEnvVarName(name) || redisEnvDeny.MatchString(name) {
+		return false
+	}
+	if name == "OPENSSL_FIPS" {
+		return true
+	}
+	return redisEnvAllow.MatchString(name)
+}
+
+// redisGetConfigArgFromCommandline returns the explicit config argument passed
+// to redis-server. Redis also accepts command-line options as temporary config,
 // but those options do not identify a file this collector can read.
-func redisGetConfigPath(commandline configfilesdiscoveryimpl.TargetCommandline) (string, bool) {
-	args := commandlineArgs(commandline)
+func redisGetConfigArgFromCommandline(args []string) (string, bool) {
+	args = unwrapShellCommandline(args)
 	redisArgs, ok := redisGetArgs(args)
 	if !ok {
 		return "", false
 	}
+	return redisGetConfigArg(redisArgs)
+}
 
-	configPath, ok := redisGetConfigArg(redisArgs)
-	if !ok {
-		return "", false
-	}
-	return resolveConfigPath(configPath, commandline.WorkingDir)
+func redisMatchesCommandline(args []string) bool {
+	_, ok := redisGetArgs(unwrapShellCommandline(args))
+	return ok
 }
 
 func redisGetArgs(args []string) ([]string, bool) {

--- a/comp/core/configfilesdiscovery/impl/collectors/redis_test.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/redis_test.go
@@ -8,6 +8,7 @@ package collectors
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	configfilesdiscoveryimpl "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/impl"
@@ -118,7 +119,11 @@ func TestRedisGetConfigPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotPath, gotOK := redisGetConfigPath(tt.commandline)
+			configArg, gotOK := redisGetConfigArgFromCommandline(tt.commandline.Args)
+			var gotPath string
+			if gotOK {
+				gotPath, gotOK = resolveConfigPath(configArg, tt.commandline.WorkingDir)
+			}
 
 			assert.Equal(t, tt.wantOK, gotOK)
 			assert.Equal(t, tt.wantPath, gotPath)
@@ -126,15 +131,93 @@ func TestRedisGetConfigPath(t *testing.T) {
 	}
 }
 
+func TestRedisCollectorResolvesAndReadsRelativeProcessConfig(t *testing.T) {
+	eventArgs := []string{"redis-server", "redis.conf"}
+	eventCommandline := configfilesdiscoveryimpl.TargetCommandline{
+		Args:       eventArgs,
+		WorkingDir: "/etc/redis",
+	}
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/usr/local/bin/tini", "--", "/etc/scripts/start_redis.sh"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{eventCommandline},
+		file:                    configfilesdiscoveryimpl.ConfigFile{Path: "/etc/redis/redis.conf"},
+	}
+
+	collector := redisConfigCollector{}
+	assert.False(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{Args: eventArgs}))
+	assert.True(t, collector.CanCollectFromProcess(eventCommandline))
+	assert.True(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{
+		Args: []string{"redis-server", "/etc/redis/redis.conf"},
+	}))
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/redis/redis.conf"}, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+}
+
+func TestIncludeRedisEnvVar(t *testing.T) {
+	tests := []struct {
+		name    string
+		envName string
+		want    bool
+	}{
+		{name: "bitnami config", envName: "REDIS_AOF_ENABLED", want: true},
+		{name: "config file", envName: "REDIS_CONF_FILE", want: true},
+		{name: "cluster config", envName: "REDIS_CLUSTER_ANNOUNCE_HOSTNAME", want: true},
+		{name: "read only image config", envName: "REDIS_DEFAULT_CONF_DIR", want: true},
+		{name: "tls certificate path", envName: "REDIS_TLS_CERT_FILE", want: true},
+		{name: "fips config", envName: "OPENSSL_FIPS", want: true},
+		{name: "unrelated", envName: "UNREQUESTED"},
+		{name: "lowercase", envName: "REDIS_port"},
+		{name: "password", envName: "REDIS_PASSWORD"},
+		{name: "password file", envName: "REDIS_MASTER_PASSWORD_FILE"},
+		{name: "password abbreviation", envName: "REDIS_SENTINEL_PWD"},
+		{name: "requirepass directive", envName: "REDIS_REQUIREPASS"},
+		{name: "masterauth directive", envName: "REDIS_MASTERAUTH"},
+		{name: "auth directive", envName: "REDIS_AUTH"},
+		{name: "allow empty password", envName: "ALLOW_EMPTY_PASSWORD"},
+		{name: "tls key file", envName: "REDIS_TLS_KEY_FILE"},
+		{name: "redis cli auth", envName: "REDISCLI_AUTH"},
+		{name: "redis args", envName: "REDIS_ARGS"},
+		{name: "extra flags", envName: "REDIS_EXTRA_FLAGS"},
+		{name: "custom opts", envName: "REDIS_CUSTOM_OPTS"},
+		{name: "redis search args", envName: "REDISEARCH_ARGS"},
+		{name: "redis json args", envName: "REDISJSON_ARGS"},
+		{name: "redis time series args", envName: "REDISTIMESERIES_ARGS"},
+		{name: "redis bloom args", envName: "REDISBLOOM_ARGS"},
+		{name: "redis url", envName: "REDIS_URL"},
+		{name: "sentinel uri", envName: "REDIS_SENTINEL_URI"},
+		{name: "cluster dsn", envName: "REDIS_CLUSTER_DSN"},
+		{name: "connection string", envName: "REDIS_CONNECTION_STRING"},
+		{name: "valkey", envName: "VALKEY_PORT"},
+		{name: "dragonfly", envName: "DFLY_PORT"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, includeRedisEnvVar(tt.envName))
+		})
+	}
+}
+
 func TestRedisCollectorReadsDetectedConfig(t *testing.T) {
 	reader := &redisCollectorTestReader{
-		commandline: configfilesdiscoveryimpl.TargetCommandline{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
 			Args: []string{"redis-server", "/etc/redis/redis.conf"},
 		},
 		file: configfilesdiscoveryimpl.ConfigFile{
 			Path:      "/etc/redis/redis.conf",
 			Content:   []byte("port 6379\n"),
 			Truncated: true,
+		},
+		env: map[string]string{
+			"REDIS_PORT_NUMBER": "6379",
+			"REDIS_AOF_ENABLED": "yes",
+			"UNREQUESTED":       "value",
 		},
 	}
 	collector := NewRedis()
@@ -150,13 +233,20 @@ func TestRedisCollectorReadsDetectedConfig(t *testing.T) {
 		Truncated:     true,
 		PayloadFormat: redisConfigPayloadFormat,
 	}, collected.ConfigFiles[0])
-	assert.Empty(t, collected.EnvVars)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "REDIS_AOF_ENABLED", Value: "yes"},
+		{Name: "REDIS_PORT_NUMBER", Value: "6379"},
+	}, collected.EnvVars)
 }
 
-func TestRedisCollectorSkipsWhenNoConfigPathIsDetected(t *testing.T) {
+func TestRedisCollectorCollectsEnvOnly(t *testing.T) {
 	reader := &redisCollectorTestReader{
-		commandline: configfilesdiscoveryimpl.TargetCommandline{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
 			Args: []string{"redis-server", "--save", "60", "1"},
+		},
+		env: map[string]string{
+			"REDIS_PORT_NUMBER": "6379",
+			"REDIS_AOF_ENABLED": "yes",
 		},
 	}
 	collector := NewRedis()
@@ -166,7 +256,354 @@ func TestRedisCollectorSkipsWhenNoConfigPathIsDetected(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, reader.readFileCalls)
 	assert.Empty(t, collected.ConfigFiles)
-	assert.Empty(t, collected.EnvVars)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "REDIS_AOF_ENABLED", Value: "yes"},
+		{Name: "REDIS_PORT_NUMBER", Value: "6379"},
+	}, collected.EnvVars)
+}
+
+func TestRedisCollectorDoesNotUseMetadataPathsAsConfigFiles(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "--save", "60", "1"},
+		},
+		env: map[string]string{
+			"REDIS_CONF_DIR":       "/opt/bitnami/redis/etc",
+			"REDIS_OVERRIDES_FILE": "/opt/bitnami/redis/mounted-etc/overrides.conf",
+		},
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Empty(t, collected.ConfigFiles)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "REDIS_CONF_DIR", Value: "/opt/bitnami/redis/etc"},
+		{Name: "REDIS_OVERRIDES_FILE", Value: "/opt/bitnami/redis/mounted-etc/overrides.conf"},
+	}, collected.EnvVars)
+}
+
+func TestRedisCollectorUsesEnvConfigFile(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/opt/bitnami/scripts/redis/run.sh"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path:    "/opt/bitnami/redis/etc/redis.conf",
+			Content: []byte("port 6379\n"),
+		},
+		env: map[string]string{
+			"REDIS_CONF_FILE":   "/opt/bitnami/redis/etc/redis.conf",
+			"REDIS_AOF_ENABLED": "yes",
+		},
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/opt/bitnami/redis/etc/redis.conf"}, reader.readFileCalls)
+	assert.Equal(t, 1, reader.runtimeCommandlineCalls)
+	assert.Equal(t, 1, reader.processCommandlineCalls)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "REDIS_AOF_ENABLED", Value: "yes"},
+		{Name: "REDIS_CONF_FILE", Value: "/opt/bitnami/redis/etc/redis.conf"},
+	}, collected.EnvVars)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, redisConfigPayloadFormat, collected.ConfigFiles[0].PayloadFormat)
+}
+
+func TestRedisCollectorUsesEnvConfigFileWhenCommandlineHasOnlyOptions(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "--save", "60", "1"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path: "/opt/bitnami/redis/etc/redis.conf",
+		},
+		env: map[string]string{
+			"REDIS_CONF_FILE": "/opt/bitnami/redis/etc/redis.conf",
+		},
+	}
+
+	collected, err := NewRedis().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/opt/bitnami/redis/etc/redis.conf"}, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, redisConfigPayloadFormat, collected.ConfigFiles[0].PayloadFormat)
+}
+
+func TestRedisCollectorResolvesRelativeEnvConfigFile(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args:       []string{"/opt/bitnami/scripts/redis/run.sh"},
+			WorkingDir: "/opt/bitnami/redis/etc",
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path: "/opt/bitnami/redis/etc/redis.conf",
+		},
+		env: map[string]string{
+			"REDIS_CONF_FILE": "redis.conf",
+		},
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/opt/bitnami/redis/etc/redis.conf"}, reader.readFileCalls)
+	assert.Equal(t, 1, reader.runtimeCommandlineCalls)
+	assert.Equal(t, 1, reader.processCommandlineCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, redisConfigPayloadFormat, collected.ConfigFiles[0].PayloadFormat)
+}
+
+func TestRedisCollectorDoesNotUseEnvConfigFileWhenProcessConfigIsAmbiguous(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/opt/bitnami/scripts/redis/run.sh"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{
+			{Args: []string{"redis-server", "/etc/redis/one.conf"}},
+			{Args: []string{"redis-server", "/etc/redis/two.conf"}},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path: "/opt/bitnami/redis/etc/redis.conf",
+		},
+		env: map[string]string{
+			"REDIS_CONF_FILE": "/opt/bitnami/redis/etc/redis.conf",
+		},
+	}
+
+	collected, err := NewRedis().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Equal(t, 1, reader.runtimeCommandlineCalls)
+	assert.Equal(t, 1, reader.processCommandlineCalls)
+	assert.Empty(t, collected.ConfigFiles)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "REDIS_CONF_FILE", Value: "/opt/bitnami/redis/etc/redis.conf"},
+	}, collected.EnvVars)
+}
+
+func TestRedisCollectorPrefersCommandlineConfigFile(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "/etc/redis/redis.conf"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path: "/etc/redis/redis.conf",
+		},
+		env: map[string]string{
+			"REDIS_CONF_FILE": "/opt/bitnami/redis/etc/redis.conf",
+		},
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/redis/redis.conf"}, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, redisConfigPayloadFormat, collected.ConfigFiles[0].PayloadFormat)
+}
+
+func TestRedisCollectorDoesNotCollectSensitiveEnvVars(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "--save", "60", "1"},
+		},
+		env: map[string]string{
+			"REDIS_AOF_ENABLED":          "yes",
+			"REDIS_PASSWORD":             "secret",
+			"REDIS_MASTER_PASSWORD_FILE": "/run/secrets/master-password",
+			"REDIS_SENTINEL_PWD":         "secret",
+			"REDIS_REQUIREPASS":          "secret",
+			"REDIS_MASTERAUTH":           "master-secret",
+			"REDIS_TLS_CERT_FILE":        "/etc/redis/tls.crt",
+			"REDIS_TLS_KEY_FILE":         "/run/secrets/redis.key",
+			"REDIS_ARGS":                 "--requirepass secret",
+			"REDIS_EXTRA_FLAGS":          "--masterauth secret",
+			"REDIS_URL":                  "redis://user:secret@redis:6379",
+			"ALLOW_EMPTY_PASSWORD":       "yes",
+		},
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "REDIS_AOF_ENABLED", Value: "yes"},
+		{Name: "REDIS_TLS_CERT_FILE", Value: "/etc/redis/tls.crt"},
+	}, collected.EnvVars)
+}
+
+func TestRedisCollectorSkipsDefaultsWhenCommandlineHasNoConfigFile(t *testing.T) {
+	for _, args := range [][]string{
+		{"redis-server"},
+		{"redis-server", "--save", "60", "1"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			reader := &redisCollectorTestReader{
+				runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{Args: args},
+				file: configfilesdiscoveryimpl.ConfigFile{
+					Path:    "/etc/redis/redis.conf",
+					Content: []byte("port 6379\n"),
+				},
+			}
+
+			collected, err := NewRedis().Collect(context.Background(), reader)
+
+			require.NoError(t, err)
+			assert.Empty(t, reader.readFileCalls)
+			assert.Empty(t, collected.ConfigFiles)
+			assert.Empty(t, collected.EnvVars)
+		})
+	}
+}
+
+func TestRedisCollectorReadsDefaultConfig(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/usr/local/bin/tini", "--", "/etc/scripts/start-redis.sh"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path:    "/etc/redis/redis.conf",
+			Content: []byte("port 6379\n"),
+		},
+	}
+
+	collected, err := NewRedis().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, redisDefaultConfigPaths, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, configfilesdiscoveryimpl.ConfigFile{
+		Path:          "/etc/redis/redis.conf",
+		Content:       []byte("port 6379\n"),
+		PayloadFormat: redisConfigPayloadFormat,
+	}, collected.ConfigFiles[0])
+}
+
+func TestRedisCollectorSkipsDefaultsWhenLiveProcessHasNoConfigFile(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/usr/local/bin/tini", "--", "/etc/scripts/start-redis.sh"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{{
+			Args: []string{"redis-server", "--save", "60", "1"},
+		}},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path:    "/etc/redis/redis.conf",
+			Content: []byte("port 6379\n"),
+		},
+	}
+
+	collected, err := NewRedis().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Empty(t, collected.ConfigFiles)
+}
+
+func TestRedisCollectorReadsUniqueConfigAcrossProcesses(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/usr/local/bin/tini", "--", "/etc/scripts/start_redis.sh"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{
+			{Args: []string{"redis-server", "/etc/redis/redis.conf"}},
+			{Args: []string{"redis-server", "/etc/redis/redis.conf"}},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{Path: "/etc/redis/redis.conf"},
+	}
+
+	collected, err := NewRedis().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/redis/redis.conf"}, reader.readFileCalls)
+	assert.Equal(t, 1, reader.processCommandlineCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+}
+
+func TestRedisCollectorSkipsConflictingProcessConfigPaths(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/usr/local/bin/tini", "--", "/etc/scripts/start_redis.sh"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{
+			{Args: []string{"redis-server", "/etc/redis/redis.conf"}},
+			{Args: []string{"redis-server", "/etc/redis/other.conf"}},
+		},
+	}
+
+	collected, err := NewRedis().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Empty(t, collected.ConfigFiles)
+}
+
+func TestRedisCollectorSkipsUnresolvedMatchingProcessConfigPath(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/usr/local/bin/tini", "--", "/etc/scripts/start_redis.sh"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{
+			{Args: []string{"redis-server", "/etc/redis/redis.conf"}},
+			{Args: []string{"redis-server", "redis.conf"}},
+		},
+	}
+
+	collected, err := NewRedis().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Empty(t, collected.ConfigFiles)
+}
+
+func TestRedisCollectorUsesRuntimeConfigBeforeProcessConfig(t *testing.T) {
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "/etc/redis/runtime.conf"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{
+			{Args: []string{"redis-server", "/etc/redis/process.conf"}},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{Path: "/etc/redis/runtime.conf"},
+	}
+
+	collected, err := NewRedis().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/redis/runtime.conf"}, reader.readFileCalls)
+	assert.Zero(t, reader.processCommandlineCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+}
+
+func TestRedisCollectorFallsBackToProcessCommandlineOnRuntimeCommandlineError(t *testing.T) {
+	expectedErr := errors.New("command line unavailable")
+	reader := &redisCollectorTestReader{
+		commandlineErr: expectedErr,
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{{
+			Args: []string{"redis-server", "/etc/redis/redis.conf"},
+		}},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path: "/etc/redis/redis.conf",
+		},
+	}
+
+	collected, err := NewRedis().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, reader.processCommandlineCalls)
+	assert.Equal(t, []string{"/etc/redis/redis.conf"}, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
 }
 
 func TestRedisCollectorReturnsCommandlineErrors(t *testing.T) {
@@ -177,13 +614,59 @@ func TestRedisCollectorReturnsCommandlineErrors(t *testing.T) {
 	collected, err := collector.Collect(context.Background(), reader)
 
 	require.ErrorIs(t, err, expectedErr)
+	assert.Equal(t, 1, reader.processCommandlineCalls)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
+}
+
+func TestRedisCollectorReadsDetectedConfigWhenEnvVarsFail(t *testing.T) {
+	expectedErr := errors.New("env unavailable")
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "/etc/redis/redis.conf"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path:    "/etc/redis/redis.conf",
+			Content: []byte("port 6379\n"),
+		},
+		readEnvVarsErr: expectedErr,
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/redis/redis.conf"}, reader.readFileCalls)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigFile{
+		{
+			Path:          "/etc/redis/redis.conf",
+			Content:       []byte("port 6379\n"),
+			PayloadFormat: redisConfigPayloadFormat,
+		},
+	}, collected.ConfigFiles)
+	assert.Empty(t, collected.EnvVars)
+}
+
+func TestRedisCollectorReturnsEnvVarErrorsWithoutConfigPath(t *testing.T) {
+	expectedErr := errors.New("env unavailable")
+	reader := &redisCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"redis-server", "--save", "60", "1"},
+		},
+		readEnvVarsErr: expectedErr,
+	}
+	collector := NewRedis()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Empty(t, reader.readFileCalls)
 	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
 }
 
 func TestRedisCollectorReturnsReadFileErrors(t *testing.T) {
 	expectedErr := errors.New("read failed")
 	reader := &redisCollectorTestReader{
-		commandline: configfilesdiscoveryimpl.TargetCommandline{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
 			Args: []string{"redis-server", "/etc/redis/redis.conf"},
 		},
 		readFileErr: expectedErr,
@@ -198,11 +681,16 @@ func TestRedisCollectorReturnsReadFileErrors(t *testing.T) {
 }
 
 type redisCollectorTestReader struct {
-	commandline    configfilesdiscoveryimpl.TargetCommandline
-	commandlineErr error
-	readFileCalls  []string
-	file           configfilesdiscoveryimpl.ConfigFile
-	readFileErr    error
+	runtimeCommandline      configfilesdiscoveryimpl.TargetCommandline
+	liveProcessCommandlines []configfilesdiscoveryimpl.TargetCommandline
+	commandlineErr          error
+	runtimeCommandlineCalls int
+	processCommandlineCalls int
+	readFileCalls           []string
+	file                    configfilesdiscoveryimpl.ConfigFile
+	readFileErr             error
+	env                     map[string]string
+	readEnvVarsErr          error
 }
 
 func (r *redisCollectorTestReader) Runtime() configfilesdiscoveryimpl.RuntimeType {
@@ -216,16 +704,39 @@ func (r *redisCollectorTestReader) ReadFile(_ context.Context, path string) (con
 	if r.readFileErr != nil {
 		return configfilesdiscoveryimpl.ConfigFile{}, r.readFileErr
 	}
-	return r.file, nil
+	if r.file.Path == path {
+		return r.file, nil
+	}
+	return configfilesdiscoveryimpl.ConfigFile{}, errors.New("file not found")
 }
 
-func (r *redisCollectorTestReader) ReadEnvVars(context.Context, []string) (map[string]string, error) {
-	return nil, errors.New("not implemented")
+func (r *redisCollectorTestReader) ReadEnvVars(_ context.Context, predicate configfilesdiscoveryimpl.ConfigEnvVarPredicate) (map[string]string, error) {
+	if r.readEnvVarsErr != nil {
+		return nil, r.readEnvVarsErr
+	}
+
+	env := make(map[string]string)
+	for name, value := range r.env {
+		if configfilesdiscoveryimpl.IsSecretEnvVarName(name) {
+			continue
+		}
+		if predicate != nil && !predicate(name) {
+			continue
+		}
+		env[name] = value
+	}
+	return env, nil
 }
 
-func (r *redisCollectorTestReader) ReadCommandline(context.Context) (configfilesdiscoveryimpl.TargetCommandline, error) {
+func (r *redisCollectorTestReader) ReadRuntimeCommandline(context.Context) (configfilesdiscoveryimpl.TargetCommandline, error) {
+	r.runtimeCommandlineCalls++
 	if r.commandlineErr != nil {
 		return configfilesdiscoveryimpl.TargetCommandline{}, r.commandlineErr
 	}
-	return r.commandline, nil
+	return r.runtimeCommandline, nil
+}
+
+func (r *redisCollectorTestReader) ReadLiveProcessCommandlines(context.Context) []configfilesdiscoveryimpl.TargetCommandline {
+	r.processCommandlineCalls++
+	return r.liveProcessCommandlines
 }

--- a/comp/core/configfilesdiscovery/impl/configfilesdiscovery.go
+++ b/comp/core/configfilesdiscovery/impl/configfilesdiscovery.go
@@ -8,14 +8,22 @@ package configfilesdiscoveryimpl
 
 import (
 	"context"
+	"time"
 
 	autodiscovery "github.com/DataDog/datadog-agent/comp/core/autodiscovery/def"
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	configfilesdiscovery "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/def"
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	eventplatform "github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/def"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	heartbeatIntervalConfigKey = "config_files_discovery.heartbeat_interval"
+	heartbeatJitterConfigKey   = "config_files_discovery.heartbeat_jitter"
+	startupJitterConfigKey     = "config_files_discovery.startup_jitter"
 )
 
 // Requires defines the dependencies for the config files discovery component.
@@ -23,6 +31,7 @@ type Requires struct {
 	compdef.In
 
 	Lifecycle     compdef.Lifecycle
+	Config        config.Component
 	Autodiscovery autodiscovery.Component
 	Hostname      hostname.Component
 	WorkloadMeta  workloadmeta.Component
@@ -38,8 +47,10 @@ type Provides struct {
 }
 
 type component struct {
-	ad        autodiscovery.Component
-	scheduler scheduler.Scheduler
+	ad            autodiscovery.Component
+	scheduler     *adScheduler
+	store         workloadmeta.Component
+	processEvents chan workloadmeta.EventBundle
 }
 
 func newComponent(
@@ -48,38 +59,104 @@ func newComponent(
 	sender collectedConfigSender,
 	configCollectors map[string]ConfigCollector,
 ) *component {
+	return newComponentWithSchedulerConfig(ad, resolver, sender, configCollectors, defaultADSchedulerConfig())
+}
+
+func newComponentWithSchedulerConfig(
+	ad autodiscovery.Component,
+	resolver targetResolver,
+	sender collectedConfigSender,
+	configCollectors map[string]ConfigCollector,
+	schedulerCfg adSchedulerConfig,
+) *component {
 	readers := map[RuntimeType]configReaderFactory{
-		RuntimeDocker:     newDockerConfigReader,
-		RuntimeKubernetes: newKubernetesConfigReader,
+		RuntimeDocker: func(t target) (ConfigReader, error) {
+			return newDockerConfigReader(t, resolver.store)
+		},
+		RuntimeKubernetes: func(t target) (ConfigReader, error) {
+			return newKubernetesConfigReader(t, resolver.store)
+		},
 	}
 	if configCollectors == nil {
 		configCollectors = map[string]ConfigCollector{}
 	}
 	return &component{
 		ad:        ad,
-		scheduler: newADScheduler(resolver, readers, configCollectors, sender),
+		scheduler: newADSchedulerWithConfig(resolver, readers, configCollectors, sender, schedulerCfg),
+		store:     resolver.store,
 	}
 }
 
 // NewComponent creates the config files discovery component.
 func NewComponent(reqs Requires) Provides {
-	c := newComponent(
+	schedulerCfg := defaultADSchedulerConfig()
+	if reqs.Config != nil {
+		schedulerCfg = adSchedulerConfigFromAgentConfig(reqs.Config)
+	}
+
+	c := newComponentWithSchedulerConfig(
 		reqs.Autodiscovery,
 		targetResolver{store: reqs.WorkloadMeta},
 		newEventPlatformCollectedConfigSender(reqs.EventPlatform, reqs.Hostname.GetSafe(context.Background())),
 		reqs.Collectors,
+		schedulerCfg,
 	)
 	reqs.Lifecycle.Append(compdef.Hook{OnStart: c.start, OnStop: c.stop})
 	return Provides{Comp: c}
 }
 
+func adSchedulerConfigFromAgentConfig(agentConfig config.Component) adSchedulerConfig {
+	cfg := defaultADSchedulerConfig()
+	if agentConfig == nil {
+		return cfg
+	}
+
+	heartbeatInterval := agentConfig.GetDuration(heartbeatIntervalConfigKey)
+	if heartbeatInterval <= 0 {
+		log.Warnf("configured %s must be positive, using default %s", heartbeatIntervalConfigKey, defaultHeartbeatInterval)
+	} else {
+		cfg.heartbeatInterval = heartbeatInterval
+	}
+
+	heartbeatJitter := agentConfig.GetDuration(heartbeatJitterConfigKey)
+	jitterLimit := heartbeatJitterLimit(cfg.heartbeatInterval)
+	switch {
+	case heartbeatJitter < 0:
+		log.Warnf("configured %s must be non-negative, using 0", heartbeatJitterConfigKey)
+		cfg.heartbeatJitter = 0
+	case heartbeatJitter > jitterLimit:
+		log.Warnf("configured %s exceeds maximum %s for heartbeat interval %s, clamping", heartbeatJitterConfigKey, jitterLimit, cfg.heartbeatInterval)
+		cfg.heartbeatJitter = jitterLimit
+	default:
+		cfg.heartbeatJitter = heartbeatJitter
+	}
+
+	startupJitter := agentConfig.GetDuration(startupJitterConfigKey)
+	if startupJitter < 0 {
+		log.Warnf("configured %s must be non-negative, using 0", startupJitterConfigKey)
+		cfg.startupJitter = 0
+	} else {
+		cfg.startupJitter = startupJitter
+	}
+
+	if cfg.heartbeatCheckInterval > cfg.heartbeatInterval/10 {
+		cfg.heartbeatCheckInterval = cfg.heartbeatInterval / 10
+	}
+	if cfg.heartbeatCheckInterval <= 0 {
+		cfg.heartbeatCheckInterval = time.Second
+	}
+	return cfg
+}
+
 func (c *component) start(context.Context) error {
+	c.startProcessFallbackListener()
 	c.ad.AddScheduler(schedulerName, c.scheduler, true)
 	return nil
 }
 
 func (c *component) stop(context.Context) error {
 	c.ad.RemoveScheduler(schedulerName)
+	c.stopProcessFallbackListener()
 	c.scheduler.Stop()
 	return nil
 }

--- a/comp/core/configfilesdiscovery/impl/configfilesdiscovery_test.go
+++ b/comp/core/configfilesdiscovery/impl/configfilesdiscovery_test.go
@@ -8,12 +8,12 @@ package configfilesdiscoveryimpl
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/DataDog/agent-payload/v5/agentdiscovery"
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -276,7 +276,7 @@ func TestSchedulerDispatchesKubernetesOwnedContainerToKubernetesReader(t *testin
 
 	collector := &recordingConfigCollector{}
 	readerFactory := &recordingConfigReaderFactory{reader: fakeConfigReader{runtime: RuntimeKubernetes}}
-	s := newADScheduler(
+	s := newTestADScheduler(
 		targetResolver{store: store},
 		map[RuntimeType]configReaderFactory{RuntimeKubernetes: readerFactory.Build},
 		map[string]ConfigCollector{"redis": collector},
@@ -302,7 +302,7 @@ func TestSchedulerClosesReaderAfterCollection(t *testing.T) {
 		collectorErr error
 	}{
 		{
-			name:  "successful collection and report",
+			name:  "successful collection and send",
 			files: []ConfigFile{{Path: "/etc/redis/redis.conf"}},
 		},
 		{
@@ -321,7 +321,7 @@ func TestSchedulerClosesReaderAfterCollection(t *testing.T) {
 					close(closed)
 				},
 			})
-			s := newADScheduler(
+			s := newTestADScheduler(
 				targetResolver{},
 				map[RuntimeType]configReaderFactory{RuntimeDocker: readerFactory},
 				map[string]ConfigCollector{"redis": collector},
@@ -349,7 +349,7 @@ func TestSchedulerClosesReaderAfterCollection(t *testing.T) {
 func TestSchedulerDispatchesRegisteredIntegrationsOnly(t *testing.T) {
 	collector := &recordingConfigCollector{}
 	readerFactory := &recordingConfigReaderFactory{reader: fakeConfigReader{runtime: RuntimeHost}}
-	s := newADScheduler(
+	s := newTestADScheduler(
 		targetResolver{},
 		map[RuntimeType]configReaderFactory{RuntimeHost: readerFactory.Build},
 		map[string]ConfigCollector{"redis": collector},
@@ -374,7 +374,7 @@ func TestSchedulerDispatchesRegisteredIntegrationsOnly(t *testing.T) {
 func TestSchedulerContinuesAfterInvalidConfigInBatch(t *testing.T) {
 	collector := &recordingConfigCollector{}
 	readerFactory := &recordingConfigReaderFactory{reader: fakeConfigReader{runtime: RuntimeDocker}}
-	s := newADScheduler(
+	s := newTestADScheduler(
 		targetResolver{},
 		map[RuntimeType]configReaderFactory{RuntimeDocker: readerFactory.Build},
 		map[string]ConfigCollector{"redis": collector},
@@ -398,7 +398,7 @@ func TestSchedulerRunsCollectorOutsideScheduleCallback(t *testing.T) {
 		unblock: make(chan struct{}),
 	}
 	readerFactory := &recordingConfigReaderFactory{reader: fakeConfigReader{runtime: RuntimeHost}}
-	s := newADScheduler(
+	s := newTestADScheduler(
 		targetResolver{},
 		map[RuntimeType]configReaderFactory{RuntimeHost: readerFactory.Build},
 		map[string]ConfigCollector{"redis": collector},
@@ -425,6 +425,467 @@ func TestSchedulerRunsCollectorOutsideScheduleCallback(t *testing.T) {
 	collector.waitForRuns(t, 1)
 }
 
+func TestSchedulerRecollectsOnMatchingContainerProcess(t *testing.T) {
+	tests := []struct {
+		name      string
+		runtime   RuntimeType
+		serviceID string
+		resolver  func(t *testing.T) targetResolver
+	}{
+		{
+			name:      "docker",
+			runtime:   RuntimeDocker,
+			serviceID: "docker://abc123",
+			resolver:  func(*testing.T) targetResolver { return targetResolver{} },
+		},
+		{
+			name:      "kubernetes",
+			runtime:   RuntimeKubernetes,
+			serviceID: "containerd://abc123",
+			resolver: func(t *testing.T) targetResolver {
+				store := newWorkloadMetaMock(t)
+				store.Set(&workloadmeta.Container{
+					EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainer, ID: "abc123"},
+					Runtime:  workloadmeta.ContainerRuntimeContainerd,
+					Owner:    &workloadmeta.EntityID{Kind: workloadmeta.KindKubernetesPod, ID: "pod-uid"},
+				})
+				store.Set(&workloadmeta.KubernetesPod{EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindKubernetesPod, ID: "pod-uid"}})
+				return targetResolver{store: store}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sender := &recordingCollectedConfigSender{}
+			readerFactory := &recordingConfigReaderFactory{reader: fakeConfigReader{runtime: tt.runtime}}
+			collector := &recordingConfigCollector{
+				filesByRun: [][]ConfigFile{
+					nil,
+					{{Path: "/etc/redis/redis.conf", Content: []byte("port 6379\n")}},
+				},
+				canCollectFromProcess: func(commandline TargetCommandline) bool {
+					return len(commandline.Args) >= 2 && commandline.Args[0] == "redis-server" && commandline.Args[1] == "/etc/redis/redis.conf"
+				},
+			}
+			s := newTestADScheduler(
+				tt.resolver(t),
+				map[RuntimeType]configReaderFactory{tt.runtime: readerFactory.Build},
+				map[string]ConfigCollector{testRedisIntegrationName: collector},
+				sender,
+			)
+			defer s.Stop()
+
+			config := checkConfig(testRedisIntegrationName, tt.serviceID)
+			s.Schedule([]integration.Config{config})
+			collector.waitForRuns(t, 1)
+			waitForNextCollectionScheduled(t, s, config)
+
+			s.handleProcessEventBundle(newProcessEventBundle(&workloadmeta.Process{
+				ContainerID: "other-container",
+				Cmdline:     []string{"redis-server", "/etc/redis/redis.conf"},
+			}))
+			s.handleProcessEventBundle(newProcessEventBundle(&workloadmeta.Process{
+				ContainerID: "abc123",
+				Cmdline:     []string{"nginx", "-c", "/etc/nginx/nginx.conf"},
+			}))
+			waitForNextCollectionScheduled(t, s, config)
+			require.Len(t, collector.recordedRuns(), 1)
+
+			bundle := newProcessEventBundle(&workloadmeta.Process{
+				ContainerID: "abc123",
+				Cmdline:     []string{"redis-server", "/etc/redis/redis.conf"},
+			})
+			s.handleProcessEventBundle(bundle)
+			select {
+			case <-bundle.Ch:
+			default:
+				t.Fatal("process event bundle was not acknowledged")
+			}
+
+			collector.waitForRuns(t, 2)
+			configs := sender.waitForCollectedConfigs(t, 1)
+			require.Len(t, configs, 1)
+			assert.Equal(t, tt.runtime, configs[0].Runtime)
+			assert.Equal(t, "abc123", configs[0].RuntimeID)
+			targets := readerFactory.recordedTargets()
+			require.Len(t, targets, 2)
+			assert.Equal(t, target{runtime: tt.runtime, entityID: "abc123"}, targets[1])
+
+		})
+	}
+}
+
+func TestSchedulerUsesProcessFallbackAfterInitialCollectionError(t *testing.T) {
+	sender := &recordingCollectedConfigSender{}
+	collector := &recordingConfigCollector{
+		errorsByRun: []error{errors.New("initial collection failed"), nil},
+		filesByRun: [][]ConfigFile{
+			nil,
+			{{Path: "/etc/redis/redis.conf"}},
+		},
+		canCollectFromProcess: func(commandline TargetCommandline) bool {
+			return len(commandline.Args) >= 2 && commandline.Args[0] == "redis-server"
+		},
+	}
+	s := newTestADScheduler(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		sender,
+	)
+	defer s.Stop()
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+
+	s.Schedule([]integration.Config{config})
+	collector.waitForRuns(t, 1)
+	waitForNextCollectionScheduled(t, s, config)
+
+	s.handleProcessEventBundle(newProcessEventBundle(&workloadmeta.Process{
+		ContainerID: "abc123",
+		Cmdline:     []string{"redis-server", "/etc/redis/redis.conf"},
+	}))
+
+	collector.waitForRuns(t, 2)
+	configs := sender.waitForCollectedConfigs(t, 1)
+	require.Len(t, configs, 1)
+	assert.Equal(t, []ConfigFile{{Path: "/etc/redis/redis.conf"}}, configs[0].ConfigFiles)
+}
+
+func TestSchedulerRecollectsWhenProcessArrivesDuringInitialCollection(t *testing.T) {
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+	collector := &recordingConfigCollector{
+		started:    started,
+		unblock:    unblock,
+		filesByRun: [][]ConfigFile{nil, {{Path: "/etc/redis/redis.conf"}}},
+		canCollectFromProcess: func(commandline TargetCommandline) bool {
+			return len(commandline.Args) >= 2 && commandline.Args[0] == "redis-server"
+		},
+	}
+	s := newTestADScheduler(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		nil,
+	)
+	defer s.Stop()
+
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+	s.Schedule([]integration.Config{config})
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("initial collection did not start")
+	}
+	firstProcess := &workloadmeta.Process{
+		ContainerID: "abc123",
+		Cmdline:     []string{"redis-server", "/etc/redis/redis.conf"},
+	}
+	secondProcess := &workloadmeta.Process{
+		ContainerID: "abc123",
+		Cmdline:     []string{"redis-server", "/etc/redis/redis-secondary.conf"},
+	}
+	s.handleProcessEventBundle(newProcessEventBundle(firstProcess))
+	s.handleProcessEventBundle(newProcessEventBundle(secondProcess))
+	close(unblock)
+
+	collector.waitForRuns(t, 2)
+	waitForConfigState(t, s, config, configCollected)
+	require.Len(t, collector.recordedRuns(), 2)
+}
+
+func TestSchedulerRecollectsWhenProcessArrivesDuringFailedInitialCollection(t *testing.T) {
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+	sender := &recordingCollectedConfigSender{}
+	collector := &recordingConfigCollector{
+		started:     started,
+		unblock:     unblock,
+		errorsByRun: []error{errors.New("initial collection failed"), nil},
+		filesByRun: [][]ConfigFile{
+			nil,
+			{{Path: "/etc/redis/redis.conf"}},
+		},
+		canCollectFromProcess: func(commandline TargetCommandline) bool {
+			return len(commandline.Args) >= 2 && commandline.Args[0] == "redis-server"
+		},
+	}
+	s := newTestADScheduler(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		sender,
+	)
+	defer s.Stop()
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+
+	s.Schedule([]integration.Config{config})
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("initial collection did not start")
+	}
+	s.handleProcessEventBundle(newProcessEventBundle(&workloadmeta.Process{
+		ContainerID: "abc123",
+		Cmdline:     []string{"redis-server", "/etc/redis/redis.conf"},
+	}))
+	close(unblock)
+
+	collector.waitForRuns(t, 2)
+	configs := sender.waitForCollectedConfigs(t, 1)
+	require.Len(t, configs, 1)
+	assert.Equal(t, []ConfigFile{{Path: "/etc/redis/redis.conf"}}, configs[0].ConfigFiles)
+}
+
+func TestSchedulerDoesNotConsumeProcessFallbackDuringStartupJitter(t *testing.T) {
+	mockClock := clock.NewMock()
+	collector := &recordingConfigCollector{
+		filesByRun: [][]ConfigFile{nil, {{Path: "/etc/redis/redis.conf"}}},
+		canCollectFromProcess: func(commandline TargetCommandline) bool {
+			return len(commandline.Args) >= 2 && commandline.Args[0] == "redis-server"
+		},
+	}
+	cfg := defaultADSchedulerConfig()
+	cfg.startupJitter = time.Minute
+	cfg.heartbeatCheckInterval = time.Hour
+	cfg.clock = mockClock
+	cfg.jitter = fixedJitter(0)
+	s := newADSchedulerWithConfig(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		nil,
+		cfg,
+	)
+	defer s.Stop()
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+	process := &workloadmeta.Process{
+		ContainerID: "abc123",
+		Cmdline:     []string{"redis-server", "/etc/redis/redis.conf"},
+	}
+
+	s.Schedule([]integration.Config{config})
+	s.handleProcessEventBundle(newProcessEventBundle(process))
+
+	assert.Empty(t, collector.recordedRuns())
+
+	mockClock.Add(30 * time.Second)
+	collector.waitForRuns(t, 1)
+	waitForNextCollectionScheduled(t, s, config)
+
+	s.handleProcessEventBundle(newProcessEventBundle(process))
+	collector.waitForRuns(t, 2)
+}
+
+func TestSchedulerDiscardsCollectionUnscheduledWhileRunning(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   []ConfigFile
+		envVars []ConfigEnvVar
+	}{
+		{
+			name:  "config files",
+			files: []ConfigFile{{Path: "/etc/redis/redis.conf"}},
+		},
+		{
+			name:    "env vars",
+			envVars: []ConfigEnvVar{{Name: "REDIS_PORT", Value: "6379"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			started := make(chan struct{})
+			unblock := make(chan struct{})
+			sender := &recordingCollectedConfigSender{}
+			collector := &recordingConfigCollector{
+				started: started,
+				unblock: unblock,
+				files:   tt.files,
+				envVars: tt.envVars,
+			}
+			s := newTestADScheduler(
+				targetResolver{},
+				map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+				map[string]ConfigCollector{testRedisIntegrationName: collector},
+				sender,
+			)
+
+			config := checkConfig(testRedisIntegrationName, "docker://abc123")
+			s.Schedule([]integration.Config{config})
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("collection did not start")
+			}
+
+			s.Unschedule([]integration.Config{config})
+			close(unblock)
+			collector.waitForRuns(t, 1)
+			s.Stop()
+
+			assert.Empty(t, sender.recordedBatches())
+		})
+	}
+}
+
+func TestSchedulerDiscardsConfigUnscheduledWhileWaitingForBatch(t *testing.T) {
+	sender := &recordingCollectedConfigSender{}
+	collector := &recordingConfigCollector{
+		files: []ConfigFile{{Path: "/etc/redis/redis.conf"}},
+	}
+	s := newTestADScheduler(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		sender,
+	)
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+
+	s.Schedule([]integration.Config{config})
+	collector.waitForRuns(t, 1)
+	waitForConfigState(t, s, config, configCollected)
+
+	s.Unschedule([]integration.Config{config})
+	s.Stop()
+
+	assert.Empty(t, sender.recordedBatches())
+}
+
+func TestSchedulerWaitsForUsableProcessInformation(t *testing.T) {
+	collector := &recordingConfigCollector{
+		filesByRun: [][]ConfigFile{nil, {{Path: "/etc/redis/redis.conf"}}},
+		canCollectFromProcess: func(commandline TargetCommandline) bool {
+			return len(commandline.Args) >= 2 &&
+				(commandline.WorkingDir != "" || commandline.Args[1] == "/etc/redis/redis.conf")
+		},
+	}
+	s := newTestADScheduler(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		nil,
+	)
+	defer s.Stop()
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+
+	s.Schedule([]integration.Config{config})
+	collector.waitForRuns(t, 1)
+	waitForNextCollectionScheduled(t, s, config)
+
+	s.handleProcessEventBundle(newProcessEventBundle(&workloadmeta.Process{
+		ContainerID: "abc123",
+		Cmdline:     []string{"redis-server", "redis.conf"},
+	}))
+	waitForNextCollectionScheduled(t, s, config)
+	require.Len(t, collector.recordedRuns(), 1)
+
+	s.handleProcessEventBundle(newProcessEventBundle(&workloadmeta.Process{
+		ContainerID: "abc123",
+		Cmdline:     []string{"redis-server", "/etc/redis/redis.conf"},
+	}))
+	collector.waitForRuns(t, 2)
+}
+
+func TestSchedulerDoesNotRepeatProcessFallback(t *testing.T) {
+	tests := []struct {
+		name          string
+		collectionErr error
+	}{
+		{
+			name: "empty collection",
+		},
+		{
+			name:          "collection error",
+			collectionErr: errors.New("process-triggered collection failed"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClock := clock.NewMock()
+			collector := &recordingConfigCollector{
+				errorsByRun: []error{nil, tt.collectionErr, nil},
+				filesByRun: [][]ConfigFile{
+					nil,
+					nil,
+					{{Path: "/etc/redis/redis.conf"}},
+				},
+				canCollectFromProcess: func(TargetCommandline) bool { return true },
+			}
+			cfg := defaultADSchedulerConfig()
+			cfg.startupJitter = 0
+			cfg.heartbeatInterval = time.Minute
+			cfg.heartbeatJitter = 0
+			cfg.heartbeatRetryInterval = time.Minute
+			cfg.heartbeatCheckInterval = time.Minute
+			cfg.clock = mockClock
+			cfg.jitter = fixedJitter(0)
+			s := newADSchedulerWithConfig(
+				targetResolver{},
+				map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+				map[string]ConfigCollector{testRedisIntegrationName: collector},
+				nil,
+				cfg,
+			)
+			defer s.Stop()
+			config := checkConfig(testRedisIntegrationName, "docker://abc123")
+
+			s.Schedule([]integration.Config{config})
+			collector.waitForRuns(t, 1)
+			waitForNextCollectionScheduled(t, s, config)
+
+			s.handleProcessEventBundle(newProcessEventBundle(&workloadmeta.Process{
+				ContainerID: "abc123",
+				Cmdline:     []string{"redis-server", "/etc/redis/redis.conf"},
+			}))
+			collector.waitForRuns(t, 2)
+			waitForNextCollectionScheduled(t, s, config)
+
+			s.handleProcessEventBundle(newProcessEventBundle(&workloadmeta.Process{
+				ContainerID: "abc123",
+				Cmdline:     []string{"redis-server", "/etc/redis/redis-new.conf"},
+			}))
+			waitForNextCollectionScheduled(t, s, config)
+			require.Len(t, collector.recordedRuns(), 2)
+
+			mockClock.Add(time.Minute)
+			collector.waitForRuns(t, 3)
+		})
+	}
+}
+
+func TestSchedulerRemovesProcessFallbackWhenUnscheduled(t *testing.T) {
+	collector := &recordingConfigCollector{
+		canCollectFromProcess: func(TargetCommandline) bool { return true },
+	}
+	s := newTestADScheduler(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		nil,
+	)
+	defer s.Stop()
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+
+	s.Schedule([]integration.Config{config})
+	collector.waitForRuns(t, 1)
+	waitForNextCollectionScheduled(t, s, config)
+
+	s.handleProcessEventBundle(newProcessEventBundle(&workloadmeta.Process{
+		ContainerID: "other-container",
+		Cmdline:     []string{"redis-server", "/etc/redis/redis.conf"},
+	}))
+	s.Unschedule([]integration.Config{config})
+
+	s.handleProcessEventBundle(newProcessEventBundle(&workloadmeta.Process{
+		ContainerID: "abc123",
+		Cmdline:     []string{"redis-server", "/etc/redis/redis.conf"},
+	}))
+	require.Len(t, collector.recordedRuns(), 1)
+}
+
 func TestSchedulerSendsCollectedConfig(t *testing.T) {
 	sender := &recordingCollectedConfigSender{}
 	collector := &recordingConfigCollector{
@@ -439,7 +900,7 @@ func TestSchedulerSendsCollectedConfig(t *testing.T) {
 			{Name: "REDIS_PORT", Value: "6379"},
 		},
 	}
-	s := newADScheduler(
+	s := newTestADScheduler(
 		targetResolver{},
 		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
 		map[string]ConfigCollector{"redisdb": collector},
@@ -477,7 +938,7 @@ func TestSchedulerSendsEnvOnlyCollectedConfig(t *testing.T) {
 			{Name: "REDIS_TLS_ENABLED", Value: "true"},
 		},
 	}
-	s := newADScheduler(
+	s := newTestADScheduler(
 		targetResolver{},
 		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
 		map[string]ConfigCollector{"redisdb": collector},
@@ -501,10 +962,86 @@ func TestSchedulerSendsEnvOnlyCollectedConfig(t *testing.T) {
 	}, collectedConfigs[0])
 }
 
+func TestSchedulerRecollectsOnNewProcessInformationAfterEnvOnlySend(t *testing.T) {
+	sender := &recordingCollectedConfigSender{}
+	collector := &recordingConfigCollector{
+		filesByRun: [][]ConfigFile{
+			nil,
+			{{Path: "/etc/redis/redis.conf"}},
+		},
+		envVars:               []ConfigEnvVar{{Name: "REDIS_PORT", Value: "6379"}},
+		canCollectFromProcess: func(TargetCommandline) bool { return true },
+	}
+	s := newTestADScheduler(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		sender,
+	)
+	defer s.Stop()
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+
+	s.Schedule([]integration.Config{config})
+	first := sender.waitForCollectedConfigs(t, 1)
+	require.Len(t, first, 1)
+	assert.Empty(t, first[0].ConfigFiles)
+	assert.Equal(t, []ConfigEnvVar{{Name: "REDIS_PORT", Value: "6379"}}, first[0].EnvVars)
+	waitForConfigSent(t, s, config)
+
+	process := &workloadmeta.Process{
+		ContainerID: "abc123",
+		Cmdline:     []string{"redis-server", "/etc/redis/redis.conf"},
+	}
+	s.handleProcessEventBundle(newProcessEventBundle(process))
+
+	configs := sender.waitForCollectedConfigs(t, 2)
+	assert.Equal(t, []ConfigFile{{Path: "/etc/redis/redis.conf"}}, configs[1].ConfigFiles)
+	assert.Equal(t, []ConfigEnvVar{{Name: "REDIS_PORT", Value: "6379"}}, configs[1].EnvVars)
+	waitForConfigSent(t, s, config)
+
+	s.handleProcessEventBundle(newProcessEventBundle(process))
+	waitForConfigSent(t, s, config)
+	require.Len(t, collector.recordedRuns(), 2)
+}
+
+func TestSchedulerSendsCollectedConfigBeforeProcessRecollection(t *testing.T) {
+	sender := &recordingCollectedConfigSender{}
+	collector := &recordingConfigCollector{
+		envVars:               []ConfigEnvVar{{Name: "REDIS_PORT", Value: "6379"}},
+		errorsByRun:           []error{nil, errors.New("process recollection failed")},
+		canCollectFromProcess: func(TargetCommandline) bool { return true },
+	}
+	s := newTestADScheduler(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		sender,
+	)
+	defer s.Stop()
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+
+	s.Schedule([]integration.Config{config})
+	collector.waitForRuns(t, 1)
+	waitForConfigState(t, s, config, configCollected)
+
+	s.handleProcessEventBundle(newProcessEventBundle(&workloadmeta.Process{
+		ContainerID: "abc123",
+		Cmdline:     []string{"redis-server", "/etc/redis/redis.conf"},
+	}))
+
+	configs := sender.waitForCollectedConfigs(t, 1)
+	require.Len(t, configs, 1)
+	assert.Empty(t, configs[0].ConfigFiles)
+	assert.Equal(t, []ConfigEnvVar{{Name: "REDIS_PORT", Value: "6379"}}, configs[0].EnvVars)
+	collector.waitForRuns(t, 2)
+	waitForNextCollectionScheduled(t, s, config)
+	assert.Len(t, sender.recordedCollectedConfigs(), 1)
+}
+
 func TestSchedulerSkipsEmptyCollectedConfig(t *testing.T) {
 	sender := &recordingCollectedConfigSender{}
 	collector := &recordingConfigCollector{}
-	s := newADScheduler(
+	s := newTestADScheduler(
 		targetResolver{},
 		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
 		map[string]ConfigCollector{"redisdb": collector},
@@ -530,7 +1067,7 @@ func TestSchedulerBatchesMultipleCompletedConfigCollections(t *testing.T) {
 			},
 		},
 	}
-	s := newADScheduler(
+	s := newTestADScheduler(
 		targetResolver{},
 		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
 		map[string]ConfigCollector{testRedisIntegrationName: collector},
@@ -557,7 +1094,7 @@ func TestSchedulerFlushesConfigCollectionBatchOnTimeout(t *testing.T) {
 			},
 		},
 	}
-	s := newADScheduler(
+	s := newTestADScheduler(
 		targetResolver{},
 		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
 		map[string]ConfigCollector{testRedisIntegrationName: collector},
@@ -572,32 +1109,15 @@ func TestSchedulerFlushesConfigCollectionBatchOnTimeout(t *testing.T) {
 	assert.Equal(t, "abc123", batches[0][0].RuntimeID)
 }
 
-func TestSchedulerFlushesConfigCollectionBatchOnMaxCollectedConfigs(t *testing.T) {
-	sender := &recordingCollectedConfigSender{}
-	collector := &recordingConfigCollector{
-		files: []ConfigFile{
-			{
-				Path:    "/etc/redis/redis.conf",
-				Content: []byte("port 6379\n"),
-			},
-		},
+func TestConfigCollectionBatchFlushesOnMaxCollectedConfigs(t *testing.T) {
+	var batch collectedConfigBatch
+	for range configCollectionBatchMaxCollectedConfigs - 1 {
+		batch.add(pendingCollectedConfig{})
 	}
-	s := newADScheduler(
-		targetResolver{},
-		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
-		map[string]ConfigCollector{testRedisIntegrationName: collector},
-		sender,
-	)
-	defer s.Stop()
+	assert.False(t, batch.shouldFlush())
 
-	configs := make([]integration.Config, 0, configCollectionBatchMaxCollectedConfigs)
-	for i := 0; i < configCollectionBatchMaxCollectedConfigs; i++ {
-		configs = append(configs, checkConfig(testRedisIntegrationName, fmt.Sprintf("docker://container-%d", i)))
-	}
-	s.Schedule(configs)
-
-	batches := sender.waitForBatches(t, 1)
-	require.Len(t, batches[0], configCollectionBatchMaxCollectedConfigs)
+	batch.add(pendingCollectedConfig{})
+	assert.True(t, batch.shouldFlush())
 }
 
 func TestSchedulerFlushesOversizedConfigCollectionAlone(t *testing.T) {
@@ -610,7 +1130,7 @@ func TestSchedulerFlushesOversizedConfigCollectionAlone(t *testing.T) {
 			},
 		},
 	}
-	s := newADScheduler(
+	s := newTestADScheduler(
 		targetResolver{},
 		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
 		map[string]ConfigCollector{testRedisIntegrationName: collector},
@@ -645,7 +1165,7 @@ func TestSchedulerFlushesPendingConfigCollectionBatchOnStop(t *testing.T) {
 			},
 		},
 	}
-	s := newADScheduler(
+	s := newTestADScheduler(
 		targetResolver{},
 		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
 		map[string]ConfigCollector{testRedisIntegrationName: collector},
@@ -659,6 +1179,565 @@ func TestSchedulerFlushesPendingConfigCollectionBatchOnStop(t *testing.T) {
 	batches := sender.waitForBatches(t, 1)
 	require.Len(t, batches[0], 1)
 	assert.Equal(t, "abc123", batches[0][0].RuntimeID)
+}
+
+func TestSchedulerStartsSharedStartupJitterWithFirstValidConfig(t *testing.T) {
+	mockClock := clock.NewMock()
+	collector := &recordingConfigCollector{
+		files: []ConfigFile{
+			{
+				Path:    "/etc/redis/redis.conf",
+				Content: []byte("port 6379\n"),
+			},
+		},
+	}
+	s := newADSchedulerWithConfig(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		nil,
+		adSchedulerConfig{
+			heartbeatInterval:      time.Hour,
+			heartbeatJitter:        0,
+			startupJitter:          time.Minute,
+			heartbeatRetryInterval: time.Minute,
+			heartbeatCheckInterval: time.Hour,
+			clock:                  mockClock,
+			jitter:                 fixedJitter(0),
+		},
+	)
+	defer s.Stop()
+
+	mockClock.Add(time.Minute)
+
+	firstConfig := checkConfig(testRedisIntegrationName, "docker://abc123")
+	secondConfig := checkConfig(testRedisIntegrationName, "docker://def456")
+	s.Schedule([]integration.Config{firstConfig, secondConfig})
+
+	wantStartup := mockClock.Now().Add(30 * time.Second)
+	for _, config := range []integration.Config{firstConfig, secondConfig} {
+		nextCollection, inFlight, ok := watchedConfigState(s, config)
+		require.True(t, ok)
+		assert.False(t, inFlight)
+		assert.Equal(t, wantStartup, nextCollection)
+	}
+	assert.Empty(t, collector.recordedRuns())
+
+	mockClock.Add(30 * time.Second)
+	collector.waitForRuns(t, 2)
+
+	thirdConfig := checkConfig(testRedisIntegrationName, "docker://ghi789")
+	s.Schedule([]integration.Config{thirdConfig})
+	collector.waitForRuns(t, 3)
+}
+
+func TestSchedulerDoesNotStartStartupJitterForInvalidConfigs(t *testing.T) {
+	mockClock := clock.NewMock()
+	collector := &recordingConfigCollector{
+		files: []ConfigFile{
+			{
+				Path:    "/etc/redis/redis.conf",
+				Content: []byte("port 6379\n"),
+			},
+		},
+	}
+	s := newADSchedulerWithConfig(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		nil,
+		adSchedulerConfig{
+			heartbeatInterval:      time.Hour,
+			heartbeatJitter:        0,
+			startupJitter:          time.Minute,
+			heartbeatRetryInterval: time.Minute,
+			heartbeatCheckInterval: time.Hour,
+			clock:                  mockClock,
+			jitter:                 fixedJitter(0),
+		},
+	)
+	defer s.Stop()
+
+	s.Schedule([]integration.Config{checkConfig("unsupported", "docker://ignored")})
+	s.mu.Lock()
+	startupNotBefore := s.startupNotBefore
+	s.mu.Unlock()
+	assert.True(t, startupNotBefore.IsZero())
+
+	mockClock.Add(time.Minute)
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+	s.Schedule([]integration.Config{config})
+
+	nextCollection, inFlight, ok := watchedConfigState(s, config)
+	require.True(t, ok)
+	assert.False(t, inFlight)
+	assert.Equal(t, mockClock.Now().Add(30*time.Second), nextCollection)
+	assert.Empty(t, collector.recordedRuns())
+}
+
+func TestSchedulerSchedulesBatchHeartbeatsTogether(t *testing.T) {
+	mockClock := clock.NewMock()
+	sender := &recordingCollectedConfigSender{}
+	collector := &recordingConfigCollector{
+		files: []ConfigFile{
+			{
+				Path:    "/etc/redis/redis.conf",
+				Content: []byte("port 6379\n"),
+			},
+		},
+	}
+	var jitterMu sync.Mutex
+	jitterCalls := 0
+	jitter := func(time.Duration) time.Duration {
+		jitterMu.Lock()
+		defer jitterMu.Unlock()
+		jitterCalls++
+		return time.Duration(jitterCalls) * time.Minute
+	}
+	s := newADSchedulerWithConfig(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		sender,
+		adSchedulerConfig{
+			heartbeatInterval:      time.Hour,
+			heartbeatJitter:        10 * time.Minute,
+			startupJitter:          0,
+			heartbeatRetryInterval: time.Minute,
+			heartbeatCheckInterval: time.Minute,
+			clock:                  mockClock,
+			jitter:                 jitter,
+		},
+	)
+	defer s.Stop()
+
+	firstConfig := checkConfig(testRedisIntegrationName, "docker://abc123")
+	secondConfig := checkConfig(testRedisIntegrationName, "docker://def456")
+	s.Schedule([]integration.Config{firstConfig, secondConfig})
+	sender.waitForCollectedConfigs(t, 2)
+	waitForNextCollectionScheduled(t, s, firstConfig)
+	waitForNextCollectionScheduled(t, s, secondConfig)
+
+	firstHeartbeat, _, _ := watchedConfigState(s, firstConfig)
+	secondHeartbeat, _, _ := watchedConfigState(s, secondConfig)
+	assert.Equal(t, firstHeartbeat, secondHeartbeat)
+	assert.Equal(t, mockClock.Now().Add(time.Hour+time.Minute), firstHeartbeat)
+
+	jitterMu.Lock()
+	assert.Equal(t, 1, jitterCalls)
+	jitterMu.Unlock()
+}
+
+func TestSchedulerHeartbeatsCollectedFilesWithJitter(t *testing.T) {
+	mockClock := clock.NewMock()
+	sender := &recordingCollectedConfigSender{}
+	collector := &recordingConfigCollector{
+		files: []ConfigFile{
+			{
+				Path:    "/etc/redis/redis.conf",
+				Content: []byte("port 6379\n"),
+			},
+		},
+	}
+	s := newADSchedulerWithConfig(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		sender,
+		adSchedulerConfig{
+			heartbeatInterval:      time.Hour,
+			heartbeatJitter:        10 * time.Minute,
+			heartbeatRetryInterval: time.Minute,
+			heartbeatCheckInterval: time.Minute,
+			clock:                  mockClock,
+			jitter:                 fixedJitter(10 * time.Minute),
+		},
+	)
+	defer s.Stop()
+
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+	s.Schedule([]integration.Config{
+		config,
+	})
+
+	sender.waitForCollectedConfigs(t, 1)
+	waitForNextCollectionScheduled(t, s, config)
+
+	nextCollection, inFlight, ok := watchedConfigState(s, config)
+	require.True(t, ok)
+	assert.False(t, inFlight)
+	assert.Equal(t, mockClock.Now().Add(70*time.Minute), nextCollection)
+
+	mockClock.Add(70 * time.Minute)
+	collectedConfigs := sender.waitForCollectedConfigs(t, 2)
+	assert.Equal(t, collectedConfigs[0], collectedConfigs[1])
+}
+
+func TestSchedulerCollectsChangedFilesAtNextHeartbeat(t *testing.T) {
+	mockClock := clock.NewMock()
+	sender := &recordingCollectedConfigSender{}
+	collector := &recordingConfigCollector{
+		files: []ConfigFile{
+			{
+				Path:    "/etc/redis/redis.conf",
+				Content: []byte("port 6379\n"),
+			},
+		},
+	}
+	s := newADSchedulerWithConfig(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		sender,
+		adSchedulerConfig{
+			heartbeatInterval:      time.Hour,
+			heartbeatJitter:        0,
+			heartbeatRetryInterval: time.Minute,
+			heartbeatCheckInterval: time.Minute,
+			clock:                  mockClock,
+			jitter:                 fixedJitter(0),
+		},
+	)
+	defer s.Stop()
+
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+	s.Schedule([]integration.Config{
+		config,
+	})
+	sender.waitForCollectedConfigs(t, 1)
+	waitForNextCollectionScheduled(t, s, config)
+
+	collector.setFiles([]ConfigFile{
+		{
+			Path:    "/etc/redis/redis.conf",
+			Content: []byte("port 6380\n"),
+		},
+	})
+	s.Schedule([]integration.Config{
+		config,
+	})
+
+	nextCollection, inFlight, ok := watchedConfigState(s, config)
+	require.True(t, ok)
+	assert.False(t, inFlight)
+	assert.Equal(t, mockClock.Now().Add(time.Hour), nextCollection)
+	assert.Len(t, collector.recordedRuns(), 1)
+
+	mockClock.Add(time.Hour)
+	collectedConfigs := sender.waitForCollectedConfigs(t, 2)
+	assert.Equal(t, []byte("port 6380\n"), collectedConfigs[1].ConfigFiles[0].Content)
+}
+
+func TestSchedulerIgnoresRescheduleReceivedInFlight(t *testing.T) {
+	sender := newBlockingCollectedConfigSender()
+	collector := &recordingConfigCollector{
+		files: []ConfigFile{
+			{
+				Path:    "/etc/redis/redis.conf",
+				Content: []byte("port 6379\n"),
+			},
+		},
+	}
+	s := newTestADScheduler(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		sender,
+	)
+	defer s.Stop()
+	defer sender.release()
+
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+	s.Schedule([]integration.Config{config})
+	sender.waitUntilBlocked(t)
+
+	collector.setFiles([]ConfigFile{
+		{
+			Path:    "/etc/redis/redis.conf",
+			Content: []byte("port 6380\n"),
+		},
+	})
+	s.Schedule([]integration.Config{config})
+	s.Schedule([]integration.Config{config})
+
+	nextCollection, inFlight, ok := watchedConfigState(s, config)
+	require.True(t, ok)
+	assert.True(t, inFlight)
+	assert.True(t, nextCollection.IsZero())
+
+	sender.release()
+	collectedConfigs := sender.waitForCollectedConfigs(t, 1)
+	require.Len(t, collectedConfigs, 1)
+	assert.Equal(t, []byte("port 6379\n"), collectedConfigs[0].ConfigFiles[0].Content)
+	waitForNextCollectionScheduled(t, s, config)
+	assert.Len(t, collector.recordedRuns(), 1)
+}
+
+func TestSchedulerUnscheduleStopsHeartbeats(t *testing.T) {
+	mockClock := clock.NewMock()
+	sender := &recordingCollectedConfigSender{}
+	collector := &recordingConfigCollector{
+		files: []ConfigFile{
+			{
+				Path:    "/etc/redis/redis.conf",
+				Content: []byte("port 6379\n"),
+			},
+		},
+	}
+	s := newADSchedulerWithConfig(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		sender,
+		adSchedulerConfig{
+			heartbeatInterval:      time.Hour,
+			heartbeatJitter:        10 * time.Minute,
+			heartbeatRetryInterval: time.Minute,
+			heartbeatCheckInterval: time.Minute,
+			clock:                  mockClock,
+			jitter:                 fixedJitter(0),
+		},
+	)
+	defer s.Stop()
+
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+	s.Schedule([]integration.Config{config})
+	sender.waitForCollectedConfigs(t, 1)
+	waitForNextCollectionScheduled(t, s, config)
+
+	s.Unschedule([]integration.Config{config})
+	_, _, ok := watchedConfigState(s, config)
+	assert.False(t, ok)
+
+	mockClock.Add(2 * time.Hour)
+	s.enqueueDueCollections()
+
+	assert.Len(t, sender.recordedCollectedConfigs(), 1)
+}
+
+func TestSchedulerContinuesHeartbeatingAfterEmptyCollection(t *testing.T) {
+	mockClock := clock.NewMock()
+	sender := &recordingCollectedConfigSender{}
+	collector := &recordingConfigCollector{
+		files: []ConfigFile{
+			{
+				Path:    "/etc/redis/redis.conf",
+				Content: []byte("port 6379\n"),
+			},
+		},
+	}
+	s := newADSchedulerWithConfig(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		sender,
+		adSchedulerConfig{
+			heartbeatInterval:      time.Hour,
+			heartbeatJitter:        0,
+			heartbeatRetryInterval: time.Minute,
+			heartbeatCheckInterval: time.Minute,
+			clock:                  mockClock,
+			jitter:                 fixedJitter(0),
+		},
+	)
+	defer s.Stop()
+
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+	s.Schedule([]integration.Config{
+		config,
+	})
+
+	sender.waitForCollectedConfigs(t, 1)
+	waitForNextCollectionScheduled(t, s, config)
+	collector.setFiles(nil)
+
+	mockClock.Add(time.Hour)
+	collector.waitForRuns(t, 2)
+	assert.Len(t, sender.recordedCollectedConfigs(), 1)
+	waitForNextCollectionScheduled(t, s, config)
+
+	collector.setFiles([]ConfigFile{
+		{
+			Path:    "/etc/redis/redis.conf",
+			Content: []byte("port 6380\n"),
+		},
+	})
+
+	mockClock.Add(time.Hour)
+	collectedConfigs := sender.waitForCollectedConfigs(t, 2)
+	assert.Equal(t, []byte("port 6380\n"), collectedConfigs[1].ConfigFiles[0].Content)
+}
+
+func TestSchedulerRetriesAfterFailedSend(t *testing.T) {
+	mockClock := clock.NewMock()
+	sender := &recordingCollectedConfigSender{err: errors.New("send failed")}
+	collector := &recordingConfigCollector{
+		files: []ConfigFile{
+			{
+				Path:    "/etc/redis/redis.conf",
+				Content: []byte("port 6379\n"),
+			},
+		},
+	}
+	s := newADSchedulerWithConfig(
+		targetResolver{},
+		map[RuntimeType]configReaderFactory{RuntimeDocker: fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		sender,
+		adSchedulerConfig{
+			heartbeatInterval:      time.Hour,
+			heartbeatJitter:        0,
+			heartbeatRetryInterval: time.Minute,
+			heartbeatCheckInterval: time.Minute,
+			clock:                  mockClock,
+			jitter:                 fixedJitter(0),
+		},
+	)
+	defer s.Stop()
+
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+	s.Schedule([]integration.Config{config})
+	sender.waitForCollectedConfigs(t, 1)
+	require.Eventually(t, func() bool {
+		nextCollection, inFlight, ok := watchedConfigState(s, config)
+		return ok && !inFlight && nextCollection.Equal(mockClock.Now().Add(time.Minute))
+	}, time.Second, 10*time.Millisecond)
+
+	sender.setErr(nil)
+	mockClock.Add(time.Minute)
+
+	collectedConfigs := sender.waitForCollectedConfigs(t, 2)
+	assert.Equal(t, collectedConfigs[0], collectedConfigs[1])
+	waitForNextCollectionScheduled(t, s, config)
+}
+
+func TestSchedulerRetriesFailedSendBeforeExistingHeartbeat(t *testing.T) {
+	mockClock := clock.NewMock()
+	s := newADSchedulerWithConfig(
+		targetResolver{},
+		nil,
+		nil,
+		nil,
+		adSchedulerConfig{
+			heartbeatInterval:      time.Hour,
+			heartbeatJitter:        0,
+			heartbeatRetryInterval: time.Minute,
+			heartbeatCheckInterval: time.Minute,
+			clock:                  mockClock,
+			jitter:                 fixedJitter(0),
+		},
+	)
+	defer s.Stop()
+
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+	oldHeartbeat := mockClock.Now().Add(time.Hour)
+	watch := &watchedConfig{
+		key:            watchKey(config),
+		integration:    config.Name,
+		serviceID:      config.ServiceID,
+		state:          configCollected,
+		nextCollection: oldHeartbeat,
+	}
+	s.mu.Lock()
+	s.watches[watchKey(config)] = watch
+	s.mu.Unlock()
+
+	s.finishSend([]pendingCollectedConfig{
+		{
+			watch: watch,
+		},
+	}, false)
+
+	nextCollection, inFlight, ok := watchedConfigState(s, config)
+	require.True(t, ok)
+	assert.False(t, inFlight)
+	assert.Equal(t, mockClock.Now().Add(time.Minute), nextCollection)
+	assert.True(t, nextCollection.Before(oldHeartbeat))
+}
+
+func TestSchedulerCapsRetryIntervalAtHeartbeatInterval(t *testing.T) {
+	var jitterLimit time.Duration
+	s := &adScheduler{
+		heartbeatInterval:      10 * time.Second,
+		heartbeatJitter:        5 * time.Second,
+		heartbeatRetryInterval: 5 * time.Minute,
+		jitter: func(limit time.Duration) time.Duration {
+			jitterLimit = limit
+			return 0
+		},
+	}
+
+	assert.Equal(t, 10*time.Second, s.nextRetryDelay())
+	assert.Equal(t, 5*time.Second, jitterLimit)
+}
+
+func TestSchedulerRejectsCollectionFromReplacedWatch(t *testing.T) {
+	s := newTestADScheduler(targetResolver{}, nil, nil, nil)
+	defer s.Stop()
+
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+	key := watchKey(config)
+	staleWatch := &watchedConfig{
+		key:         key,
+		integration: config.Name,
+		serviceID:   config.ServiceID,
+		state:       configCollecting,
+	}
+	replacementDeadline := time.Now().Add(time.Hour)
+	replacementWatch := &watchedConfig{
+		key:            key,
+		integration:    config.Name,
+		serviceID:      config.ServiceID,
+		state:          configCollecting,
+		nextCollection: replacementDeadline,
+	}
+	s.mu.Lock()
+	s.watches[key] = replacementWatch
+	s.mu.Unlock()
+
+	_, _, _, ok := s.snapshotWatch(staleWatch)
+	assert.False(t, ok)
+
+	s.finishSend([]pendingCollectedConfig{
+		{
+			watch: staleWatch,
+		},
+	}, true)
+	s.transitionWatch(staleWatch, collectionDeferred, time.Time{})
+
+	s.mu.Lock()
+	activeWatch := s.watches[key]
+	activeDeadline := activeWatch.nextCollection
+	activeInFlight := activeWatch.isCollecting() || activeWatch.hasCollectedConfig()
+	s.mu.Unlock()
+	assert.Same(t, replacementWatch, activeWatch)
+	assert.Equal(t, replacementDeadline, activeDeadline)
+	assert.True(t, activeInFlight)
+}
+
+func TestADSchedulerConfigFromAgentConfigDefaultsAndClampsJitter(t *testing.T) {
+	cfg := adSchedulerConfigFromAgentConfig(config.NewMock(t))
+	assert.Equal(t, time.Hour, cfg.heartbeatInterval)
+	assert.Equal(t, 10*time.Minute, cfg.heartbeatJitter)
+	assert.Equal(t, time.Minute, cfg.startupJitter)
+
+	cfg = adSchedulerConfigFromAgentConfig(config.NewMockWithOverrides(t, map[string]interface{}{
+		heartbeatIntervalConfigKey: 4 * time.Hour,
+		heartbeatJitterConfigKey:   2 * time.Hour,
+	}))
+	assert.Equal(t, time.Hour, cfg.heartbeatJitter)
+
+	cfg = adSchedulerConfigFromAgentConfig(config.NewMockWithOverrides(t, map[string]interface{}{
+		heartbeatIntervalConfigKey: 5 * time.Minute,
+		heartbeatJitterConfigKey:   10 * time.Minute,
+	}))
+	assert.Equal(t, 5*time.Minute, cfg.heartbeatInterval)
+	assert.Equal(t, 2*time.Minute+30*time.Second, cfg.heartbeatJitter)
+
+	cfg = adSchedulerConfigFromAgentConfig(config.NewMockWithOverrides(t, map[string]interface{}{
+		startupJitterConfigKey: -time.Minute,
+	}))
+	assert.Zero(t, cfg.startupJitter)
 }
 
 func TestComponentRegistersAutodiscoverySchedulerOnStart(t *testing.T) {
@@ -682,21 +1761,104 @@ func TestComponentRegistersAutodiscoverySchedulerOnStart(t *testing.T) {
 	assert.Equal(t, schedulerName, ac.removedName)
 }
 
+func TestComponentAppliesStartupJitterToFirstConfigDiscoveredAfterRegistration(t *testing.T) {
+	mockClock := clock.NewMock()
+	collector := &recordingConfigCollector{
+		files: []ConfigFile{
+			{
+				Path:    "/etc/redis/redis.conf",
+				Content: []byte("port 6379\n"),
+			},
+		},
+	}
+	firstConfig := checkConfig(testRedisIntegrationName, "docker://abc123")
+	secondConfig := checkConfig(testRedisIntegrationName, "docker://def456")
+	ac := &fakeAutodiscovery{}
+	c := newComponentWithSchedulerConfig(
+		ac,
+		targetResolver{},
+		nil,
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		adSchedulerConfig{
+			heartbeatInterval:      time.Hour,
+			heartbeatJitter:        0,
+			startupJitter:          time.Minute,
+			heartbeatRetryInterval: time.Minute,
+			heartbeatCheckInterval: time.Hour,
+			clock:                  mockClock,
+			jitter:                 fixedJitter(0),
+		},
+	)
+	adScheduler := c.scheduler
+	adScheduler.readers[RuntimeDocker] = fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})
+	defer func() {
+		require.NoError(t, c.stop(context.Background()))
+	}()
+
+	require.NoError(t, c.start(context.Background()))
+	mockClock.Add(time.Minute)
+	ac.scheduler.Schedule([]integration.Config{firstConfig, secondConfig})
+
+	wantStartup := mockClock.Now().Add(30 * time.Second)
+	for _, config := range []integration.Config{firstConfig, secondConfig} {
+		nextCollection, inFlight, ok := watchedConfigState(adScheduler, config)
+		require.True(t, ok)
+		assert.False(t, inFlight)
+		assert.Equal(t, wantStartup, nextCollection)
+	}
+	assert.Empty(t, collector.recordedRuns())
+
+	mockClock.Add(30 * time.Second)
+	collector.waitForRuns(t, 2)
+}
+
+func TestComponentRecollectsFromSubscribedProcessEventsAndStops(t *testing.T) {
+	store := newWorkloadMetaMock(t)
+	ac := &fakeAutodiscovery{}
+	collector := &recordingConfigCollector{
+		filesByRun: [][]ConfigFile{nil, {{Path: "/etc/redis/redis.conf"}}},
+		canCollectFromProcess: func(commandline TargetCommandline) bool {
+			return len(commandline.Args) >= 2 && commandline.Args[0] == "redis-server"
+		},
+	}
+	cfg := defaultADSchedulerConfig()
+	cfg.startupJitter = 0
+	c := newComponentWithSchedulerConfig(
+		ac,
+		targetResolver{store: store},
+		noopCollectedConfigSender{},
+		map[string]ConfigCollector{testRedisIntegrationName: collector},
+		cfg,
+	)
+	c.scheduler.readers[RuntimeDocker] = fakeConfigReaderFactory(fakeConfigReader{runtime: RuntimeDocker})
+
+	require.NoError(t, c.start(context.Background()))
+	config := checkConfig(testRedisIntegrationName, "docker://abc123")
+	c.scheduler.Schedule([]integration.Config{config})
+	collector.waitForRuns(t, 1)
+	waitForNextCollectionScheduled(t, c.scheduler, config)
+
+	store.Set(&workloadmeta.Process{
+		EntityID:    workloadmeta.EntityID{Kind: workloadmeta.KindProcess, ID: "101"},
+		ContainerID: "abc123",
+		Cmdline:     []string{"redis-server", "/etc/redis/redis.conf"},
+	})
+	collector.waitForRuns(t, 2)
+
+	require.NoError(t, c.stop(context.Background()))
+	assert.Equal(t, schedulerName, ac.removedName)
+	assert.Nil(t, c.processEvents)
+}
+
 func TestComponentRegistersProvidedCollectors(t *testing.T) {
 	collector := &recordingConfigCollector{}
 	c := newComponent(nil, targetResolver{}, noopCollectedConfigSender{}, map[string]ConfigCollector{"custom": collector})
-	adScheduler, ok := c.scheduler.(*adScheduler)
-	require.True(t, ok)
-
-	assert.Same(t, collector, adScheduler.collectors["custom"])
+	assert.Same(t, collector, c.scheduler.collectors["custom"])
 }
 
 func TestComponentRegistersKubernetesConfigReader(t *testing.T) {
 	c := newComponent(nil, targetResolver{}, noopCollectedConfigSender{}, nil)
-	adScheduler, ok := c.scheduler.(*adScheduler)
-	require.True(t, ok)
-
-	assert.Contains(t, adScheduler.readers, RuntimeKubernetes)
+	assert.Contains(t, c.scheduler.readers, RuntimeKubernetes)
 }
 
 func TestComponentUsesEventPlatformSenderWhenAvailable(t *testing.T) {
@@ -705,10 +1867,8 @@ func TestComponentUsesEventPlatformSenderWhenAvailable(t *testing.T) {
 		forwarder: forwarder,
 		ok:        true,
 	}, "test-host"), nil)
-	adScheduler, ok := c.scheduler.(*adScheduler)
-	require.True(t, ok)
 
-	_, ok = adScheduler.sender.(*eventPlatformCollectedConfigSender)
+	_, ok := c.scheduler.sender.(*eventPlatformCollectedConfigSender)
 	require.True(t, ok)
 }
 
@@ -907,12 +2067,17 @@ func (h fakeHostname) GetSafe(context.Context) string {
 }
 
 type recordingConfigCollector struct {
-	mu      sync.Mutex
-	runs    []runCall
-	unblock chan struct{}
-	files   []ConfigFile
-	envVars []ConfigEnvVar
-	err     error
+	mu                    sync.Mutex
+	runs                  []runCall
+	started               chan struct{}
+	startOnce             sync.Once
+	unblock               chan struct{}
+	files                 []ConfigFile
+	filesByRun            [][]ConfigFile
+	envVars               []ConfigEnvVar
+	err                   error
+	errorsByRun           []error
+	canCollectFromProcess func(TargetCommandline) bool
 }
 
 type runCall struct {
@@ -920,6 +2085,9 @@ type runCall struct {
 }
 
 func (c *recordingConfigCollector) Collect(ctx context.Context, reader ConfigReader) (CollectedConfig, error) {
+	if c.started != nil {
+		c.startOnce.Do(func() { close(c.started) })
+	}
 	if c.unblock != nil {
 		select {
 		case <-ctx.Done():
@@ -933,19 +2101,70 @@ func (c *recordingConfigCollector) Collect(ctx context.Context, reader ConfigRea
 	c.runs = append(c.runs, runCall{
 		reader: reader,
 	})
+	run := len(c.runs) - 1
+	if run < len(c.errorsByRun) && c.errorsByRun[run] != nil {
+		return CollectedConfig{}, c.errorsByRun[run]
+	}
 	if c.err != nil {
 		return CollectedConfig{}, c.err
 	}
+	files := c.files
+	if run < len(c.filesByRun) {
+		files = c.filesByRun[run]
+	}
 	return CollectedConfig{
-		ConfigFiles: c.files,
+		ConfigFiles: files,
 		EnvVars:     c.envVars,
 	}, nil
+}
+
+func (c *recordingConfigCollector) CanCollectFromProcess(commandline TargetCommandline) bool {
+	return c.canCollectFromProcess != nil && c.canCollectFromProcess(commandline)
 }
 
 type recordingCollectedConfigSender struct {
 	mu      sync.Mutex
 	batches [][]CollectedConfig
 	err     error
+}
+
+type blockingCollectedConfigSender struct {
+	recordingCollectedConfigSender
+	started     chan struct{}
+	unblock     chan struct{}
+	blockOnce   sync.Once
+	releaseOnce sync.Once
+}
+
+func newBlockingCollectedConfigSender() *blockingCollectedConfigSender {
+	return &blockingCollectedConfigSender{
+		started: make(chan struct{}),
+		unblock: make(chan struct{}),
+	}
+}
+
+func (s *blockingCollectedConfigSender) SendCollectedConfigs(configs []CollectedConfig) error {
+	s.blockOnce.Do(func() {
+		close(s.started)
+		<-s.unblock
+	})
+	return s.recordingCollectedConfigSender.SendCollectedConfigs(configs)
+}
+
+func (s *blockingCollectedConfigSender) waitUntilBlocked(t *testing.T) {
+	t.Helper()
+
+	select {
+	case <-s.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for collected config send")
+	}
+}
+
+func (s *blockingCollectedConfigSender) release() {
+	s.releaseOnce.Do(func() {
+		close(s.unblock)
+	})
 }
 
 func (r *recordingCollectedConfigSender) SendCollectedConfigs(configs []CollectedConfig) error {
@@ -957,6 +2176,26 @@ func (r *recordingCollectedConfigSender) SendCollectedConfigs(configs []Collecte
 	return r.err
 }
 
+func (c *recordingConfigCollector) setFiles(files []ConfigFile) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.files = files
+}
+
+func (c *recordingConfigCollector) recordedRuns() []runCall {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	runs := make([]runCall, len(c.runs))
+	copy(runs, c.runs)
+	return runs
+}
+
+func (r *recordingCollectedConfigSender) setErr(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.err = err
+}
+
 func (r *recordingCollectedConfigSender) waitForCollectedConfigs(t *testing.T, count int) []CollectedConfig {
 	t.Helper()
 
@@ -966,6 +2205,12 @@ func (r *recordingCollectedConfigSender) waitForCollectedConfigs(t *testing.T, c
 		return len(r.flattenCollectedConfigsLocked()) >= count
 	}, 2*time.Second, 10*time.Millisecond)
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.flattenCollectedConfigsLocked()
+}
+
+func (r *recordingCollectedConfigSender) recordedCollectedConfigs() []CollectedConfig {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.flattenCollectedConfigsLocked()
@@ -1048,7 +2293,55 @@ func (f *recordingEventPlatformForwarder) recordedMessages() []eventPlatformSend
 	return messages
 }
 
-func (c *recordingConfigCollector) waitForRuns(t *testing.T, count int) []runCall {
+func newTestADScheduler(resolver targetResolver, readers map[RuntimeType]configReaderFactory, collectors map[string]ConfigCollector, sender collectedConfigSender) *adScheduler {
+	cfg := defaultADSchedulerConfig()
+	cfg.startupJitter = 0
+	return newADSchedulerWithConfig(resolver, readers, collectors, sender, cfg)
+}
+
+func fixedJitter(d time.Duration) func(time.Duration) time.Duration {
+	return func(time.Duration) time.Duration {
+		return d
+	}
+}
+
+func watchedConfigState(s *adScheduler, config integration.Config) (time.Time, bool, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	watch, ok := s.watches[watchKey(config)]
+	if !ok {
+		return time.Time{}, false, false
+	}
+	return watch.nextCollection, watch.isCollecting() || watch.hasCollectedConfig(), true
+}
+
+func waitForNextCollectionScheduled(t *testing.T, s *adScheduler, config integration.Config) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		nextCollection, inFlight, ok := watchedConfigState(s, config)
+		return ok && !inFlight && !nextCollection.IsZero()
+	}, time.Second, 10*time.Millisecond)
+}
+
+func waitForConfigState(t *testing.T, s *adScheduler, config integration.Config, want configCollectionState) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		watch, ok := s.watches[watchKey(config)]
+		return ok && watch.state == want
+	}, time.Second, 10*time.Millisecond)
+}
+
+func waitForConfigSent(t *testing.T, s *adScheduler, config integration.Config) {
+	t.Helper()
+	waitForConfigState(t, s, config, configSent)
+}
+
+func (c *recordingConfigCollector) waitForRuns(t *testing.T, count int) {
 	t.Helper()
 
 	require.Eventually(t, func() bool {
@@ -1056,12 +2349,13 @@ func (c *recordingConfigCollector) waitForRuns(t *testing.T, count int) []runCal
 		defer c.mu.Unlock()
 		return len(c.runs) >= count
 	}, time.Second, 10*time.Millisecond)
+}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	runs := make([]runCall, len(c.runs))
-	copy(runs, c.runs)
-	return runs
+func newProcessEventBundle(process *workloadmeta.Process) workloadmeta.EventBundle {
+	return workloadmeta.EventBundle{
+		Events: []workloadmeta.Event{{Entity: process}},
+		Ch:     make(chan struct{}),
+	}
 }
 
 type fakeConfigReader struct {
@@ -1083,12 +2377,16 @@ func (r fakeConfigReader) ReadFile(context.Context, string) (ConfigFile, error) 
 	return ConfigFile{}, errors.New("not implemented")
 }
 
-func (r fakeConfigReader) ReadEnvVars(context.Context, []string) (map[string]string, error) {
+func (r fakeConfigReader) ReadEnvVars(context.Context, ConfigEnvVarPredicate) (map[string]string, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (r fakeConfigReader) ReadCommandline(context.Context) (TargetCommandline, error) {
+func (r fakeConfigReader) ReadRuntimeCommandline(context.Context) (TargetCommandline, error) {
 	return TargetCommandline{}, errors.New("not implemented")
+}
+
+func (r fakeConfigReader) ReadLiveProcessCommandlines(context.Context) []TargetCommandline {
+	return nil
 }
 
 func fakeConfigReaderFactory(reader ConfigReader) configReaderFactory {

--- a/comp/core/configfilesdiscovery/impl/docker_reader.go
+++ b/comp/core/configfilesdiscovery/impl/docker_reader.go
@@ -16,6 +16,7 @@ import (
 	"path"
 	"strings"
 
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	dockerutil "github.com/DataDog/datadog-agent/pkg/util/docker"
 )
 
@@ -39,13 +40,10 @@ func newDockerConfigClient() (dockerConfigClient, error) {
 type dockerConfigReader struct {
 	containerID string
 	client      dockerConfigClient
+	store       workloadmeta.Component
 }
 
-func newDockerConfigReader(t target) (ConfigReader, error) {
-	return newDockerConfigReaderWithClientFactory(t, newDockerConfigClient)
-}
-
-func newDockerConfigReaderWithClientFactory(t target, newClient func() (dockerConfigClient, error)) (ConfigReader, error) {
+func newDockerConfigReader(t target, store workloadmeta.Component) (ConfigReader, error) {
 	if t.runtime != RuntimeDocker {
 		return nil, fmt.Errorf("unsupported runtime %q", t.runtime)
 	}
@@ -53,19 +51,16 @@ func newDockerConfigReaderWithClientFactory(t target, newClient func() (dockerCo
 		return nil, errors.New("empty docker container id")
 	}
 
-	client, err := newClient()
+	client, err := newDockerConfigClient()
 	if err != nil {
 		return nil, err
 	}
 
-	return newDockerConfigReaderWithClient(t.entityID, client), nil
-}
-
-func newDockerConfigReaderWithClient(containerID string, client dockerConfigClient) ConfigReader {
 	return &dockerConfigReader{
-		containerID: containerID,
+		containerID: t.entityID,
 		client:      client,
-	}
+		store:       store,
+	}, nil
 }
 
 func (r *dockerConfigReader) Runtime() RuntimeType {
@@ -89,8 +84,8 @@ func (r *dockerConfigReader) ReadFile(ctx context.Context, filePath string) (Con
 	return readConfigFileFromDockerArchive(body, cleanPath)
 }
 
-func (r *dockerConfigReader) ReadEnvVars(ctx context.Context, names []string) (map[string]string, error) {
-	if len(names) == 0 {
+func (r *dockerConfigReader) ReadEnvVars(ctx context.Context, predicate ConfigEnvVarPredicate) (map[string]string, error) {
+	if predicate == nil {
 		return map[string]string{}, nil
 	}
 
@@ -99,16 +94,19 @@ func (r *dockerConfigReader) ReadEnvVars(ctx context.Context, names []string) (m
 		return nil, fmt.Errorf("get docker container env: %w", err)
 	}
 
-	return filterEnvVars(envEntries, names), nil
+	return filterEnvVars(envEntries, predicate), nil
 }
 
-func (r *dockerConfigReader) ReadCommandline(ctx context.Context) (TargetCommandline, error) {
+func (r *dockerConfigReader) ReadRuntimeCommandline(ctx context.Context) (TargetCommandline, error) {
 	commandline, err := r.client.getCommandline(ctx, r.containerID)
 	if err != nil {
 		return TargetCommandline{}, fmt.Errorf("get docker container command line: %w", err)
 	}
-
 	return commandline, nil
+}
+
+func (r *dockerConfigReader) ReadLiveProcessCommandlines(context.Context) []TargetCommandline {
+	return readContainerProcessCommandlines(r.store, r.containerID)
 }
 
 func readConfigFileFromDockerArchive(r io.Reader, requestedPath string) (ConfigFile, error) {

--- a/comp/core/configfilesdiscovery/impl/docker_reader_nodocker.go
+++ b/comp/core/configfilesdiscovery/impl/docker_reader_nodocker.go
@@ -7,8 +7,12 @@
 
 package configfilesdiscoveryimpl
 
-import "errors"
+import (
+	"errors"
 
-func newDockerConfigReader(target) (ConfigReader, error) {
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+func newDockerConfigReader(target, workloadmeta.Component) (ConfigReader, error) {
 	return nil, errors.New("no config reader for runtime")
 }

--- a/comp/core/configfilesdiscovery/impl/docker_reader_test.go
+++ b/comp/core/configfilesdiscovery/impl/docker_reader_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestDockerReaderReportsRuntime(t *testing.T) {
-	reader := newDockerConfigReaderWithClient("container-id", &fakeDockerClient{})
+	reader := &dockerConfigReader{containerID: "container-id", client: &fakeDockerClient{}}
 
 	assert.Equal(t, RuntimeDocker, reader.Runtime())
 }
@@ -42,24 +42,12 @@ func TestNewDockerConfigReaderRejectsInvalidTargets(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			reader, err := newDockerConfigReader(tt.target)
+			reader, err := newDockerConfigReader(tt.target, nil)
 
 			require.Error(t, err)
 			assert.Nil(t, reader)
 		})
 	}
-}
-
-func TestNewDockerConfigReaderSurfacesDockerClientErrors(t *testing.T) {
-	expectedErr := errors.New("docker unavailable")
-	newClient := func() (dockerConfigClient, error) {
-		return nil, expectedErr
-	}
-
-	reader, err := newDockerConfigReaderWithClientFactory(target{runtime: RuntimeDocker, entityID: "container-id"}, newClient)
-
-	require.ErrorIs(t, err, expectedErr)
-	assert.Nil(t, reader)
 }
 
 func TestDockerReaderReadFileReturnsFullContent(t *testing.T) {
@@ -86,7 +74,7 @@ func TestDockerReaderReadFileReturnsFullContent(t *testing.T) {
 					content: tt.content,
 				})),
 			}
-			reader := newDockerConfigReaderWithClient("container-id", client)
+			reader := &dockerConfigReader{containerID: "container-id", client: client}
 
 			file, err := reader.ReadFile(context.Background(), "/etc/redis/redis.conf")
 
@@ -112,7 +100,7 @@ func TestDockerReaderReadFileTruncatesLargeContent(t *testing.T) {
 			content: content,
 		})),
 	}
-	reader := newDockerConfigReaderWithClient("container-id", client)
+	reader := &dockerConfigReader{containerID: "container-id", client: client}
 
 	file, err := reader.ReadFile(context.Background(), "/etc/redis/redis.conf")
 
@@ -157,7 +145,7 @@ func TestDockerReaderReadFileClosesArchiveBody(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			body := closeTracker(tt.archive)
 			client := &fakeDockerClient{copyBody: body}
-			reader := newDockerConfigReaderWithClient("container-id", client)
+			reader := &dockerConfigReader{containerID: "container-id", client: client}
 
 			_, _ = reader.ReadFile(context.Background(), "/etc/redis/redis.conf")
 
@@ -247,7 +235,7 @@ func TestDockerReaderReadFileErrors(t *testing.T) {
 				copyBody: tt.copyBody,
 				copyErr:  tt.copyErr,
 			}
-			reader := newDockerConfigReaderWithClient("container-id", client)
+			reader := &dockerConfigReader{containerID: "container-id", client: client}
 
 			file, err := reader.ReadFile(context.Background(), tt.path)
 
@@ -261,9 +249,9 @@ func TestDockerReaderReadFileErrors(t *testing.T) {
 	}
 }
 
-func TestDockerReaderReadEnvVarsSkipsInspectForEmptyWhitelist(t *testing.T) {
+func TestDockerReaderReadEnvVarsSkipsInspectForNilPredicate(t *testing.T) {
 	client := &fakeDockerClient{}
-	reader := newDockerConfigReaderWithClient("container-id", client)
+	reader := &dockerConfigReader{containerID: "container-id", client: client}
 
 	env, err := reader.ReadEnvVars(context.Background(), nil)
 
@@ -272,31 +260,19 @@ func TestDockerReaderReadEnvVarsSkipsInspectForEmptyWhitelist(t *testing.T) {
 	assert.Empty(t, client.getEnvCalls)
 }
 
-func TestDockerReaderReadEnvVarsFiltersRequestedNames(t *testing.T) {
+func TestDockerReaderReadEnvVarsFiltersWithPredicate(t *testing.T) {
 	client := &fakeDockerClient{
-		env: []string{
-			"REDIS_PASSWORD=first",
-			"MALFORMED",
-			"WITH_EQUALS=a=b=c",
-			"EMPTY=",
-			"REDIS_PASSWORD=last",
-			"UNREQUESTED=value",
-		},
+		env: []string{"KAFKA_NODE_ID=1"},
 	}
-	reader := newDockerConfigReaderWithClient("container-id", client)
+	reader := &dockerConfigReader{containerID: "container-id", client: client}
 
-	env, err := reader.ReadEnvVars(context.Background(), []string{
-		"REDIS_PASSWORD",
-		"WITH_EQUALS",
-		"EMPTY",
-		"MISSING",
+	env, err := reader.ReadEnvVars(context.Background(), func(name string) bool {
+		return name == "KAFKA_NODE_ID"
 	})
 
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{
-		"REDIS_PASSWORD": "last",
-		"WITH_EQUALS":    "a=b=c",
-		"EMPTY":          "",
+		"KAFKA_NODE_ID": "1",
 	}, env)
 	assert.Equal(t, []string{"container-id"}, client.getEnvCalls)
 }
@@ -304,78 +280,84 @@ func TestDockerReaderReadEnvVarsFiltersRequestedNames(t *testing.T) {
 func TestDockerReaderReadEnvVarsSurfacesGetEnvErrors(t *testing.T) {
 	expectedErr := errors.New("env unavailable")
 	client := &fakeDockerClient{getEnvErr: expectedErr}
-	reader := newDockerConfigReaderWithClient("container-id", client)
+	reader := &dockerConfigReader{containerID: "container-id", client: client}
 
-	env, err := reader.ReadEnvVars(context.Background(), []string{"REDIS_PASSWORD"})
+	env, err := reader.ReadEnvVars(context.Background(), func(name string) bool {
+		return name == "KAFKA_NODE_ID"
+	})
 
 	require.ErrorIs(t, err, expectedErr)
 	assert.Nil(t, env)
 	assert.Equal(t, []string{"container-id"}, client.getEnvCalls)
 }
 
-func TestDockerReaderReadCommandlineReturnsTargetCommandline(t *testing.T) {
-	client := &fakeDockerClient{
-		commandPath: "/usr/local/bin/redis-server",
-		commandArgs: []string{
-			"/usr/local/etc/redis/redis.conf",
-			"--loglevel",
-			"warning",
+func TestDockerReaderReadRuntimeCommandline(t *testing.T) {
+	tests := []struct {
+		name        string
+		commandPath string
+		commandArgs []string
+		workingDir  string
+		want        TargetCommandline
+	}{
+		{
+			name:        "command and working directory",
+			commandPath: "/usr/local/bin/redis-server",
+			commandArgs: []string{
+				"/usr/local/etc/redis/redis.conf",
+				"--loglevel",
+				"warning",
+			},
+			workingDir: "/usr/local/etc/redis",
+			want: TargetCommandline{
+				Args: []string{
+					"/usr/local/bin/redis-server",
+					"/usr/local/etc/redis/redis.conf",
+					"--loglevel",
+					"warning",
+				},
+				WorkingDir: "/usr/local/etc/redis",
+			},
 		},
-		workingDir: "/usr/local/etc/redis",
-	}
-	reader := newDockerConfigReaderWithClient("container-id", client)
-
-	commandline, err := reader.ReadCommandline(context.Background())
-
-	require.NoError(t, err)
-	assert.Equal(t, TargetCommandline{
-		Args: []string{
-			"/usr/local/bin/redis-server",
-			"/usr/local/etc/redis/redis.conf",
-			"--loglevel",
-			"warning",
+		{
+			name:        "empty command path",
+			commandArgs: []string{"redis-server"},
+			want:        TargetCommandline{Args: []string{"redis-server"}, WorkingDir: "/"},
 		},
-		WorkingDir: "/usr/local/etc/redis",
-	}, commandline)
-	assert.Equal(t, []string{"container-id"}, client.getCommandlineCalls)
-}
-
-func TestDockerReaderReadCommandlineAllowsEmptyCommandPath(t *testing.T) {
-	client := &fakeDockerClient{
-		commandArgs: []string{"redis-server"},
-	}
-	reader := newDockerConfigReaderWithClient("container-id", client)
-
-	commandline, err := reader.ReadCommandline(context.Background())
-
-	require.NoError(t, err)
-	assert.Equal(t, TargetCommandline{Args: []string{"redis-server"}, WorkingDir: "/"}, commandline)
-}
-
-func TestDockerReaderReadCommandlineDefaultsEmptyWorkingDirToRoot(t *testing.T) {
-	client := &fakeDockerClient{
-		commandPath: "redis-server",
-		commandArgs: []string{
-			"redis.conf",
+		{
+			name:        "empty working directory",
+			commandPath: "redis-server",
+			commandArgs: []string{"redis.conf"},
+			want: TargetCommandline{
+				Args:       []string{"redis-server", "redis.conf"},
+				WorkingDir: "/",
+			},
 		},
 	}
-	reader := newDockerConfigReaderWithClient("container-id", client)
 
-	commandline, err := reader.ReadCommandline(context.Background())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeDockerClient{
+				commandPath: tt.commandPath,
+				commandArgs: tt.commandArgs,
+				workingDir:  tt.workingDir,
+			}
+			reader := &dockerConfigReader{containerID: "container-id", client: client}
 
-	require.NoError(t, err)
-	assert.Equal(t, TargetCommandline{
-		Args:       []string{"redis-server", "redis.conf"},
-		WorkingDir: "/",
-	}, commandline)
+			commandline, err := reader.ReadRuntimeCommandline(context.Background())
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, commandline)
+			assert.Equal(t, []string{"container-id"}, client.getCommandlineCalls)
+		})
+	}
 }
 
-func TestDockerReaderReadCommandlineSurfacesGetCommandlineErrors(t *testing.T) {
+func TestDockerReaderReadRuntimeCommandlineSurfacesGetCommandlineErrors(t *testing.T) {
 	expectedErr := errors.New("command line unavailable")
 	client := &fakeDockerClient{getCommandlineErr: expectedErr}
-	reader := newDockerConfigReaderWithClient("container-id", client)
+	reader := &dockerConfigReader{containerID: "container-id", client: client}
 
-	commandline, err := reader.ReadCommandline(context.Background())
+	commandline, err := reader.ReadRuntimeCommandline(context.Background())
 
 	require.ErrorIs(t, err, expectedErr)
 	assert.Empty(t, commandline)

--- a/comp/core/configfilesdiscovery/impl/env_vars.go
+++ b/comp/core/configfilesdiscovery/impl/env_vars.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package configfilesdiscoveryimpl
+
+import "regexp"
+
+// LICENSE and TOKEN only match suffixes because they can namespace safe settings.
+var secretEnvVarNameRegexp = regexp.MustCompile(
+	`(^|_)(ACCESS_KEY|CERTIFICATE(_CHAIN)?|CERTIFICATES?|CREDENTIALS?|JAAS|KEY|` +
+		`PASS(PHRASE|WD)?|PASSWORDS?|PRIVATE|PWD|SECRET)(_|$)|` +
+		`(^|_)(LICENSE|TOKENS?)$`,
+)
+
+// IsSecretEnvVarName applies the common secret-name policy used by environment readers.
+func IsSecretEnvVarName(name string) bool {
+	return secretEnvVarNameRegexp.MatchString(name)
+}

--- a/comp/core/configfilesdiscovery/impl/env_vars_test.go
+++ b/comp/core/configfilesdiscovery/impl/env_vars_test.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package configfilesdiscoveryimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSecretEnvVarName(t *testing.T) {
+	tests := []struct {
+		envName string
+		want    bool
+	}{
+		{envName: "KAFKA_SSL_KEYSTORE_PASSWORD", want: true},
+		{envName: "KAFKA_SSL_KEYSTORE_KEY", want: true},
+		{envName: "KAFKA_SSL_TRUSTSTORE_CERTIFICATES", want: true},
+		{envName: "KAFKA_SASL_JAAS_CONFIG", want: true},
+		{envName: "KAFKA_SASL_OAUTHBEARER_CLIENT_CREDENTIALS_CLIENT_SECRET", want: true},
+		{envName: "CONFLUENT_LICENSE", want: true},
+		{envName: "KAFKA_SASL_PWD", want: true},
+		{envName: "CONFLUENT_ADMIN_PWD", want: true},
+		{envName: "KAFKA_CFG_OAUTH_ACCESS_TOKEN", want: true},
+		{envName: "CONFLUENT_API_TOKEN", want: true},
+		{envName: "KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR"},
+		{envName: "KAFKA_SSL_KEYSTORE_LOCATION"},
+		{envName: "KAFKA_SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL"},
+		{envName: "KAFKA_NODE_ID"},
+		{envName: "KAFKA_MONKEY_PATCH"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.envName, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsSecretEnvVarName(tt.envName))
+		})
+	}
+}

--- a/comp/core/configfilesdiscovery/impl/kubernetes_reader.go
+++ b/comp/core/configfilesdiscovery/impl/kubernetes_reader.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	containerdutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
 	criutil "github.com/DataDog/datadog-agent/pkg/util/containers/cri"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -36,7 +37,7 @@ type kubernetesConfigClient interface {
 	close()
 }
 
-var newKubernetesConfigClient = func() (kubernetesConfigClient, error) {
+func newKubernetesConfigClient() (kubernetesConfigClient, error) {
 	cri, err := criutil.GetUtil()
 	if err != nil {
 		return nil, err
@@ -57,9 +58,10 @@ var newKubernetesConfigClient = func() (kubernetesConfigClient, error) {
 type kubernetesConfigReader struct {
 	containerID string
 	client      kubernetesConfigClient
+	store       workloadmeta.Component
 }
 
-func newKubernetesConfigReader(t target) (ConfigReader, error) {
+func newKubernetesConfigReader(t target, store workloadmeta.Component) (ConfigReader, error) {
 	if t.runtime != RuntimeKubernetes {
 		return nil, fmt.Errorf("unsupported runtime %q", t.runtime)
 	}
@@ -72,14 +74,11 @@ func newKubernetesConfigReader(t target) (ConfigReader, error) {
 		return nil, err
 	}
 
-	return newKubernetesConfigReaderWithClient(t.entityID, client), nil
-}
-
-func newKubernetesConfigReaderWithClient(containerID string, client kubernetesConfigClient) ConfigReader {
 	return &kubernetesConfigReader{
-		containerID: containerID,
+		containerID: t.entityID,
 		client:      client,
-	}
+		store:       store,
+	}, nil
 }
 
 func (r *kubernetesConfigReader) Runtime() RuntimeType {
@@ -120,8 +119,8 @@ func kubernetesReadFileCommand(cleanPath string) []string {
 	return []string{"head", "-c", strconv.Itoa(kubernetesReadFileOutputLimit), cleanPath}
 }
 
-func (r *kubernetesConfigReader) ReadEnvVars(ctx context.Context, names []string) (map[string]string, error) {
-	if len(names) == 0 {
+func (r *kubernetesConfigReader) ReadEnvVars(ctx context.Context, predicate ConfigEnvVarPredicate) (map[string]string, error) {
+	if predicate == nil {
 		return map[string]string{}, nil
 	}
 
@@ -133,29 +132,30 @@ func (r *kubernetesConfigReader) ReadEnvVars(ctx context.Context, names []string
 		return map[string]string{}, nil
 	}
 
-	return filterEnvVars(spec.Process.Env, names), nil
+	return filterEnvVars(spec.Process.Env, predicate), nil
 }
 
-func (r *kubernetesConfigReader) ReadCommandline(ctx context.Context) (TargetCommandline, error) {
+func (r *kubernetesConfigReader) ReadRuntimeCommandline(ctx context.Context) (TargetCommandline, error) {
 	spec, err := r.client.containerSpec(ctx, r.containerID)
 	if err != nil {
 		return TargetCommandline{}, fmt.Errorf("get kubernetes container OCI spec: %w", err)
 	}
 
+	commandline := TargetCommandline{WorkingDir: "/"}
 	if spec == nil || spec.Process == nil {
-		return TargetCommandline{WorkingDir: "/"}, nil
+		return commandline, nil
 	}
 
-	args := append([]string(nil), spec.Process.Args...)
-	workingDir := spec.Process.Cwd
-	if workingDir == "" {
-		workingDir = "/"
+	commandline.Args = append([]string(nil), spec.Process.Args...)
+	if spec.Process.Cwd != "" {
+		commandline.WorkingDir = spec.Process.Cwd
 	}
 
-	return TargetCommandline{
-		Args:       args,
-		WorkingDir: workingDir,
-	}, nil
+	return commandline, nil
+}
+
+func (r *kubernetesConfigReader) ReadLiveProcessCommandlines(context.Context) []TargetCommandline {
+	return readContainerProcessCommandlines(r.store, r.containerID)
 }
 
 func kubernetesExecExitError(exitCode int32, stderr []byte) error {

--- a/comp/core/configfilesdiscovery/impl/kubernetes_reader_noop.go
+++ b/comp/core/configfilesdiscovery/impl/kubernetes_reader_noop.go
@@ -7,8 +7,12 @@
 
 package configfilesdiscoveryimpl
 
-import "errors"
+import (
+	"errors"
 
-func newKubernetesConfigReader(target) (ConfigReader, error) {
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+func newKubernetesConfigReader(target, workloadmeta.Component) (ConfigReader, error) {
 	return nil, errors.New("no config reader for runtime")
 }

--- a/comp/core/configfilesdiscovery/impl/kubernetes_reader_test.go
+++ b/comp/core/configfilesdiscovery/impl/kubernetes_reader_test.go
@@ -22,14 +22,14 @@ import (
 )
 
 func TestKubernetesReaderReportsRuntime(t *testing.T) {
-	reader := newKubernetesConfigReaderWithClient("container-id", &fakeKubernetesClient{})
+	reader := &kubernetesConfigReader{containerID: "container-id", client: &fakeKubernetesClient{}}
 
 	assert.Equal(t, RuntimeKubernetes, reader.Runtime())
 }
 
 func TestKubernetesReaderCloseClosesClient(t *testing.T) {
 	client := &fakeKubernetesClient{}
-	reader := newKubernetesConfigReaderWithClient("container-id", client)
+	reader := &kubernetesConfigReader{containerID: "container-id", client: client}
 
 	reader.Close()
 
@@ -53,28 +53,12 @@ func TestNewKubernetesConfigReaderRejectsInvalidTargets(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			reader, err := newKubernetesConfigReader(tt.target)
+			reader, err := newKubernetesConfigReader(tt.target, nil)
 
 			require.Error(t, err)
 			assert.Nil(t, reader)
 		})
 	}
-}
-
-func TestNewKubernetesConfigReaderSurfacesClientErrors(t *testing.T) {
-	expectedErr := errors.New("cri unavailable")
-	oldNewKubernetesConfigClient := newKubernetesConfigClient
-	newKubernetesConfigClient = func() (kubernetesConfigClient, error) {
-		return nil, expectedErr
-	}
-	t.Cleanup(func() {
-		newKubernetesConfigClient = oldNewKubernetesConfigClient
-	})
-
-	reader, err := newKubernetesConfigReader(target{runtime: RuntimeKubernetes, entityID: "container-id"})
-
-	require.ErrorIs(t, err, expectedErr)
-	assert.Nil(t, reader)
 }
 
 func TestKubernetesReaderReadFileReturnsFullContent(t *testing.T) {
@@ -95,7 +79,7 @@ func TestKubernetesReaderReadFileReturnsFullContent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := &fakeKubernetesClient{stdout: tt.content}
-			reader := newKubernetesConfigReaderWithClient("container-id", client)
+			reader := &kubernetesConfigReader{containerID: "container-id", client: client}
 
 			file, err := reader.ReadFile(context.Background(), "/etc/redis/redis.conf")
 
@@ -116,7 +100,7 @@ func TestKubernetesReaderReadFileReturnsFullContent(t *testing.T) {
 func TestKubernetesReaderReadFileTruncatesLargeContent(t *testing.T) {
 	content := bytes.Repeat([]byte("a"), maxConfigFileSize+1)
 	client := &fakeKubernetesClient{stdout: content}
-	reader := newKubernetesConfigReaderWithClient("container-id", client)
+	reader := &kubernetesConfigReader{containerID: "container-id", client: client}
 
 	file, err := reader.ReadFile(context.Background(), "/etc/redis/redis.conf")
 
@@ -191,7 +175,7 @@ func TestKubernetesReaderReadFileErrors(t *testing.T) {
 				exitCode: tt.exitCode,
 				execErr:  tt.execErr,
 			}
-			reader := newKubernetesConfigReaderWithClient("container-id", client)
+			reader := &kubernetesConfigReader{containerID: "container-id", client: client}
 
 			file, err := reader.ReadFile(context.Background(), tt.path)
 
@@ -208,9 +192,9 @@ func TestKubernetesReaderReadFileErrors(t *testing.T) {
 	}
 }
 
-func TestKubernetesReaderReadEnvVarsSkipsSpecForEmptyWhitelist(t *testing.T) {
+func TestKubernetesReaderReadEnvVarsSkipsSpecForNilPredicate(t *testing.T) {
 	client := &fakeKubernetesClient{}
-	reader := newKubernetesConfigReaderWithClient("container-id", client)
+	reader := &kubernetesConfigReader{containerID: "container-id", client: client}
 
 	env, err := reader.ReadEnvVars(context.Background(), nil)
 
@@ -219,35 +203,23 @@ func TestKubernetesReaderReadEnvVarsSkipsSpecForEmptyWhitelist(t *testing.T) {
 	assert.Empty(t, client.specCalls)
 }
 
-func TestKubernetesReaderReadEnvVarsFiltersRequestedNames(t *testing.T) {
+func TestKubernetesReaderReadEnvVarsFiltersWithPredicate(t *testing.T) {
 	client := &fakeKubernetesClient{
 		spec: &containerdoci.Spec{
 			Process: &specs.Process{
-				Env: []string{
-					"REDIS_PASSWORD=first",
-					"MALFORMED",
-					"WITH_EQUALS=a=b=c",
-					"EMPTY=",
-					"REDIS_PASSWORD=last",
-					"UNREQUESTED=value",
-				},
+				Env: []string{"KAFKA_NODE_ID=1"},
 			},
 		},
 	}
-	reader := newKubernetesConfigReaderWithClient("container-id", client)
+	reader := &kubernetesConfigReader{containerID: "container-id", client: client}
 
-	env, err := reader.ReadEnvVars(context.Background(), []string{
-		"REDIS_PASSWORD",
-		"WITH_EQUALS",
-		"EMPTY",
-		"MISSING",
+	env, err := reader.ReadEnvVars(context.Background(), func(name string) bool {
+		return name == "KAFKA_NODE_ID"
 	})
 
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{
-		"REDIS_PASSWORD": "last",
-		"WITH_EQUALS":    "a=b=c",
-		"EMPTY":          "",
+		"KAFKA_NODE_ID": "1",
 	}, env)
 	assert.Equal(t, []string{"container-id"}, client.specCalls)
 }
@@ -255,19 +227,26 @@ func TestKubernetesReaderReadEnvVarsFiltersRequestedNames(t *testing.T) {
 func TestKubernetesReaderReadEnvVarsSurfacesSpecErrors(t *testing.T) {
 	expectedErr := errors.New("spec unavailable")
 	client := &fakeKubernetesClient{specErr: expectedErr}
-	reader := newKubernetesConfigReaderWithClient("container-id", client)
+	reader := &kubernetesConfigReader{containerID: "container-id", client: client}
 
-	env, err := reader.ReadEnvVars(context.Background(), []string{"REDIS_PASSWORD"})
+	env, err := reader.ReadEnvVars(context.Background(), func(name string) bool {
+		return name == "KAFKA_NODE_ID"
+	})
 
 	require.ErrorIs(t, err, expectedErr)
 	assert.Nil(t, env)
 	assert.Equal(t, []string{"container-id"}, client.specCalls)
 }
 
-func TestKubernetesReaderReadCommandlineReturnsTargetCommandline(t *testing.T) {
-	client := &fakeKubernetesClient{
-		spec: &containerdoci.Spec{
-			Process: &specs.Process{
+func TestKubernetesReaderReadRuntimeCommandline(t *testing.T) {
+	tests := []struct {
+		name    string
+		process *specs.Process
+		want    TargetCommandline
+	}{
+		{
+			name: "command and working directory",
+			process: &specs.Process{
 				Args: []string{
 					"/usr/local/bin/redis-server",
 					"/usr/local/etc/redis/redis.conf",
@@ -276,60 +255,52 @@ func TestKubernetesReaderReadCommandlineReturnsTargetCommandline(t *testing.T) {
 				},
 				Cwd: "/usr/local/etc/redis",
 			},
-		},
-	}
-	reader := newKubernetesConfigReaderWithClient("container-id", client)
-
-	commandline, err := reader.ReadCommandline(context.Background())
-
-	require.NoError(t, err)
-	assert.Equal(t, TargetCommandline{
-		Args: []string{
-			"/usr/local/bin/redis-server",
-			"/usr/local/etc/redis/redis.conf",
-			"--loglevel",
-			"warning",
-		},
-		WorkingDir: "/usr/local/etc/redis",
-	}, commandline)
-	assert.Equal(t, []string{"container-id"}, client.specCalls)
-}
-
-func TestKubernetesReaderReadCommandlineDefaultsEmptyWorkingDirToRoot(t *testing.T) {
-	client := &fakeKubernetesClient{
-		spec: &containerdoci.Spec{
-			Process: &specs.Process{
-				Args: []string{"redis-server", "redis.conf"},
+			want: TargetCommandline{
+				Args: []string{
+					"/usr/local/bin/redis-server",
+					"/usr/local/etc/redis/redis.conf",
+					"--loglevel",
+					"warning",
+				},
+				WorkingDir: "/usr/local/etc/redis",
 			},
 		},
+		{
+			name:    "empty working directory",
+			process: &specs.Process{Args: []string{"redis-server", "redis.conf"}},
+			want: TargetCommandline{
+				Args:       []string{"redis-server", "redis.conf"},
+				WorkingDir: "/",
+			},
+		},
+		{
+			name: "missing process",
+			want: TargetCommandline{WorkingDir: "/"},
+		},
 	}
-	reader := newKubernetesConfigReaderWithClient("container-id", client)
 
-	commandline, err := reader.ReadCommandline(context.Background())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeKubernetesClient{
+				spec: &containerdoci.Spec{Process: tt.process},
+			}
+			reader := &kubernetesConfigReader{containerID: "container-id", client: client}
 
-	require.NoError(t, err)
-	assert.Equal(t, TargetCommandline{
-		Args:       []string{"redis-server", "redis.conf"},
-		WorkingDir: "/",
-	}, commandline)
+			commandline, err := reader.ReadRuntimeCommandline(context.Background())
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, commandline)
+			assert.Equal(t, []string{"container-id"}, client.specCalls)
+		})
+	}
 }
 
-func TestKubernetesReaderReadCommandlineHandlesMissingProcess(t *testing.T) {
-	client := &fakeKubernetesClient{spec: &containerdoci.Spec{}}
-	reader := newKubernetesConfigReaderWithClient("container-id", client)
-
-	commandline, err := reader.ReadCommandline(context.Background())
-
-	require.NoError(t, err)
-	assert.Equal(t, TargetCommandline{WorkingDir: "/"}, commandline)
-}
-
-func TestKubernetesReaderReadCommandlineSurfacesSpecErrors(t *testing.T) {
+func TestKubernetesReaderReadRuntimeCommandlineSurfacesSpecErrors(t *testing.T) {
 	expectedErr := errors.New("command line unavailable")
 	client := &fakeKubernetesClient{specErr: expectedErr}
-	reader := newKubernetesConfigReaderWithClient("container-id", client)
+	reader := &kubernetesConfigReader{containerID: "container-id", client: client}
 
-	commandline, err := reader.ReadCommandline(context.Background())
+	commandline, err := reader.ReadRuntimeCommandline(context.Background())
 
 	require.ErrorIs(t, err, expectedErr)
 	assert.Empty(t, commandline)

--- a/comp/core/configfilesdiscovery/impl/process_commandline.go
+++ b/comp/core/configfilesdiscovery/impl/process_commandline.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build docker || (cri && containerd)
+
+package configfilesdiscoveryimpl
+
+import (
+	"slices"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+// readContainerProcessCommandlines returns workloadmeta command-line snapshots
+// for processes associated with the target container. Workloadmeta owns the
+// process lifecycle and metadata, so consuming its snapshot here avoids
+// duplicating procfs access and keeps each command line paired with the working
+// directory from the same observation. Fields may be empty when the workloadmeta
+// process collector cannot inspect the target process.
+func readContainerProcessCommandlines(store workloadmeta.Component, containerID string) []TargetCommandline {
+	if store == nil {
+		return nil
+	}
+
+	var commandlines []TargetCommandline
+	processes := store.ListProcessesWithFilter(func(process *workloadmeta.Process) bool {
+		return process != nil && process.ContainerID == containerID
+	})
+	for _, workloadmetaProcess := range processes {
+		if workloadmetaProcess.Pid <= 0 || len(workloadmetaProcess.Cmdline) == 0 {
+			continue
+		}
+
+		commandlines = append(commandlines, TargetCommandline{
+			Args:       slices.Clone(workloadmetaProcess.Cmdline),
+			WorkingDir: workloadmetaProcess.Cwd,
+		})
+	}
+	return commandlines
+}

--- a/comp/core/configfilesdiscovery/impl/process_commandline_test.go
+++ b/comp/core/configfilesdiscovery/impl/process_commandline_test.go
@@ -1,0 +1,85 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build docker || (cri && containerd)
+
+package configfilesdiscoveryimpl
+
+import (
+	"strconv"
+	"testing"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadContainerProcessCommandlines(t *testing.T) {
+	redisProcess := &workloadmeta.Process{
+		Pid:         101,
+		ContainerID: "container-id",
+		Cmdline:     []string{"redis-server", "/etc/redis/redis.conf"},
+		Cwd:         "/etc/redis",
+	}
+	store := newProcessCommandlineTestStore(t,
+		redisProcess,
+		&workloadmeta.Process{
+			Pid:         100,
+			ContainerID: "container-id",
+			Cmdline:     []string{"/usr/local/bin/tini", "--", "/etc/scripts/start_redis.sh"},
+		},
+		&workloadmeta.Process{
+			Pid:         102,
+			ContainerID: "other-container",
+			Cmdline:     []string{"other-service", "/etc/other/config"},
+		},
+		nil,
+	)
+	commandlines := readContainerProcessCommandlines(store, "container-id")
+
+	assert.ElementsMatch(t, []TargetCommandline{
+		{Args: []string{"/usr/local/bin/tini", "--", "/etc/scripts/start_redis.sh"}},
+		{Args: []string{"redis-server", "/etc/redis/redis.conf"}, WorkingDir: "/etc/redis"},
+	}, commandlines)
+
+	redisProcess.Cmdline[0] = "changed"
+	assert.Contains(t, commandlines, TargetCommandline{Args: []string{"redis-server", "/etc/redis/redis.conf"}, WorkingDir: "/etc/redis"})
+}
+
+func TestReadContainerProcessCommandlinesRejectsUnavailableStore(t *testing.T) {
+	assert.Empty(t, readContainerProcessCommandlines(nil, "container-id"))
+}
+
+func TestReadContainerProcessCommandlinesRejectsIncompleteProcesses(t *testing.T) {
+	store := newProcessCommandlineTestStore(t,
+		&workloadmeta.Process{
+			Pid:         100,
+			ContainerID: "container-id",
+		},
+		&workloadmeta.Process{
+			Pid:         0,
+			ContainerID: "container-id",
+			Cmdline:     []string{"redis-server", "/etc/redis/redis.conf"},
+		},
+	)
+
+	assert.Empty(t, readContainerProcessCommandlines(store, "container-id"))
+}
+
+func newProcessCommandlineTestStore(t *testing.T, processes ...*workloadmeta.Process) workloadmeta.Component {
+	t.Helper()
+
+	store := newWorkloadMetaMock(t)
+	for _, process := range processes {
+		if process == nil {
+			continue
+		}
+		process.EntityID = workloadmeta.EntityID{
+			Kind: workloadmeta.KindProcess,
+			ID:   strconv.Itoa(int(process.Pid)),
+		}
+		store.Set(process)
+	}
+	return store
+}

--- a/comp/core/configfilesdiscovery/impl/process_retry.go
+++ b/comp/core/configfilesdiscovery/impl/process_retry.go
@@ -1,0 +1,136 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build docker || (cri && containerd) || test
+
+package configfilesdiscoveryimpl
+
+import (
+	"time"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+// processFallbackRegistry tracks container-backed AD configs that are still
+// eligible for their single process-triggered recollection. Each key identifies
+// a watchedConfig, the scheduler state retained from the config's first Schedule
+// call until Unschedule. An entry is added for each newly watched Docker or
+// Kubernetes config, remains while process events are unrelated or unusable,
+// and is removed when the first usable matching event is consumed or the config
+// is unscheduled.
+type processFallbackRegistry map[string]struct{}
+
+// startProcessFallbackListener subscribes to process events used to trigger
+// the one-shot recollection for container-backed configs.
+func (c *component) startProcessFallbackListener() {
+	if c.store == nil {
+		return
+	}
+
+	filter := workloadmeta.NewFilterBuilder().
+		SetEventType(workloadmeta.EventTypeSet).
+		AddKindWithEntityFilter(workloadmeta.KindProcess, func(entity workloadmeta.Entity) bool {
+			process, ok := entity.(*workloadmeta.Process)
+			return ok && process.ContainerID != "" && len(process.Cmdline) > 0
+		}).
+		Build()
+	c.processEvents = c.store.Subscribe(schedulerName, workloadmeta.NormalPriority, filter)
+	c.scheduler.startProcessEventListener(c.processEvents)
+}
+
+// stopProcessFallbackListener removes the process-event subscription, if one
+// was created when the component started.
+func (c *component) stopProcessFallbackListener() {
+	if c.processEvents == nil {
+		return
+	}
+	c.store.Unsubscribe(c.processEvents)
+	c.processEvents = nil
+}
+
+// registerProcessFallbackLocked adds process fallback work for a newly
+// scheduled container watch. The caller must hold s.mu.
+func (s *adScheduler) registerProcessFallbackLocked(watch *watchedConfig) {
+	if watch.target.runtime != RuntimeDocker && watch.target.runtime != RuntimeKubernetes {
+		return
+	}
+	if s.pendingProcessFallbacks == nil {
+		s.pendingProcessFallbacks = make(processFallbackRegistry)
+	}
+	s.pendingProcessFallbacks[watch.key] = struct{}{}
+}
+
+// removeProcessFallbackLocked discards any process fallback work associated
+// with an unscheduled watch. The caller must hold s.mu.
+func (s *adScheduler) removeProcessFallbackLocked(watch *watchedConfig) {
+	delete(s.pendingProcessFallbacks, watch.key)
+}
+
+// startProcessEventListener consumes workloadmeta process events until the
+// scheduler stops or the subscription closes.
+func (s *adScheduler) startProcessEventListener(events <-chan workloadmeta.EventBundle) {
+	s.workerDone.Add(1)
+	go func() {
+		defer s.workerDone.Done()
+		for {
+			select {
+			case <-s.ctx.Done():
+				return
+			case bundle, ok := <-events:
+				if !ok {
+					return
+				}
+				s.handleProcessEventBundle(bundle)
+			}
+		}
+	}()
+}
+
+// handleProcessEventBundle acknowledges one event bundle and forwards container
+// process command lines to matching config watches.
+func (s *adScheduler) handleProcessEventBundle(bundle workloadmeta.EventBundle) {
+	defer bundle.Acknowledge()
+
+	for _, event := range bundle.Events {
+		process, ok := event.Entity.(*workloadmeta.Process)
+		if !ok || process.ContainerID == "" || len(process.Cmdline) == 0 {
+			continue
+		}
+		s.requestProcessFallback(process.ContainerID, TargetCommandline{
+			Args:       process.Cmdline,
+			WorkingDir: process.Cwd,
+		})
+	}
+}
+
+// requestProcessFallback consumes the first usable process command line for
+// each matching watch and asks the collection state machine for one follow-up.
+func (s *adScheduler) requestProcessFallback(containerID string, commandline TargetCommandline) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, watch := range s.watches {
+		if watch.target.runtime != RuntimeDocker && watch.target.runtime != RuntimeKubernetes {
+			continue
+		}
+		if watch.target.entityID != containerID {
+			continue
+		}
+		if _, pending := s.pendingProcessFallbacks[watch.key]; !pending {
+			continue
+		}
+		collector, found := s.collectors[watch.integration]
+		if !found || !collector.CanCollectFromProcess(commandline) {
+			continue
+		}
+		// Consume the one-shot fallback only after the state machine records the
+		// recollection. In particular, a process seen during startup jitter must
+		// not prevent a later process event from triggering the fallback after the
+		// initial collection.
+		if s.transitionWatchLocked(watch, recollectionRequested, time.Time{}) {
+			delete(s.pendingProcessFallbacks, watch.key)
+		}
+	}
+}

--- a/comp/core/configfilesdiscovery/impl/process_retry_noop.go
+++ b/comp/core/configfilesdiscovery/impl/process_retry_noop.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build !docker && (!cri || !containerd) && !test
+
+package configfilesdiscoveryimpl
+
+// processFallbackRegistry is empty when the build has no container reader.
+// Keeping the no-op boundary here avoids linking process-event handling into
+// binaries where a process-triggered recollection could never read a config.
+type processFallbackRegistry struct{}
+
+func (*component) startProcessFallbackListener() {}
+
+func (*component) stopProcessFallbackListener() {}
+
+func (*adScheduler) registerProcessFallbackLocked(*watchedConfig) {}
+
+func (*adScheduler) removeProcessFallbackLocked(*watchedConfig) {}

--- a/comp/core/configfilesdiscovery/impl/reader_helpers.go
+++ b/comp/core/configfilesdiscovery/impl/reader_helpers.go
@@ -17,19 +17,17 @@ import (
 
 const maxConfigFileSize = 1024 * 1024 // 1MiB
 
-func filterEnvVars(envEntries []string, names []string) map[string]string {
-	wanted := make(map[string]struct{}, len(names))
-	for _, name := range names {
-		wanted[name] = struct{}{}
-	}
-
+func filterEnvVars(envEntries []string, predicate ConfigEnvVarPredicate) map[string]string {
 	env := make(map[string]string)
 	for _, entry := range envEntries {
 		name, value, ok := strings.Cut(entry, "=")
 		if !ok {
 			continue
 		}
-		if _, ok := wanted[name]; !ok {
+		if IsSecretEnvVarName(name) {
+			continue
+		}
+		if !predicate(name) {
 			continue
 		}
 		env[name] = value

--- a/comp/core/configfilesdiscovery/impl/reader_helpers_test.go
+++ b/comp/core/configfilesdiscovery/impl/reader_helpers_test.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build docker || (cri && containerd)
+
+package configfilesdiscoveryimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterEnvVars(t *testing.T) {
+	selected := map[string]struct{}{
+		"EMPTY":          {},
+		"MISSING":        {},
+		"REDIS_PASSWORD": {},
+		"REDIS_PORT":     {},
+		"WITH_EQUALS":    {},
+	}
+
+	env := filterEnvVars([]string{
+		"REDIS_PORT=6379",
+		"MALFORMED",
+		"WITH_EQUALS=a=b=c",
+		"EMPTY=",
+		"REDIS_PORT=6380",
+		"REDIS_PASSWORD=secret",
+		"UNREQUESTED=value",
+	}, func(name string) bool {
+		_, ok := selected[name]
+		return ok
+	})
+
+	assert.Equal(t, map[string]string{
+		"EMPTY":       "",
+		"REDIS_PORT":  "6380",
+		"WITH_EQUALS": "a=b=c",
+	}, env)
+}

--- a/comp/core/configfilesdiscovery/impl/scheduler.go
+++ b/comp/core/configfilesdiscovery/impl/scheduler.go
@@ -7,12 +7,14 @@ package configfilesdiscoveryimpl
 
 import (
 	"context"
+	"math/rand"
 	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/benbjohnson/clock"
 )
 
 const (
@@ -21,6 +23,13 @@ const (
 	configCollectionBatchMaxWait             = time.Second
 	configCollectionBatchMaxCollectedConfigs = 100
 	configCollectionBatchMaxRawConfigBytes   = 4 * 1024 * 1024 // 4MiB
+
+	defaultHeartbeatInterval      = time.Hour
+	defaultHeartbeatJitter        = 10 * time.Minute
+	maxHeartbeatJitter            = time.Hour
+	defaultStartupJitter          = time.Minute
+	defaultHeartbeatRetryInterval = 5 * time.Minute
+	defaultHeartbeatCheckInterval = time.Minute
 )
 
 type adScheduler struct {
@@ -29,20 +38,85 @@ type adScheduler struct {
 	collectors map[string]ConfigCollector
 	sender     collectedConfigSender
 
-	ctx             context.Context
-	cancel          context.CancelFunc
-	collectionQueue chan configCollectionWork
-	stopOnce        sync.Once
-	workerDone      sync.WaitGroup
+	heartbeatInterval time.Duration
+	heartbeatJitter   time.Duration
+	// startupDelay is selected once and applied when the first valid config is scheduled.
+	startupDelay time.Duration
+	// startupNotBefore is fixed by the first valid config and shared by other
+	// configs discovered during startup so their first collections stay
+	// batchable while Agents spread their sends.
+	startupNotBefore time.Time
+	// startupTimer releases startup configs at their shared deadline.
+	startupTimer *clock.Timer
+
+	heartbeatRetryInterval time.Duration
+	heartbeatCheckInterval time.Duration
+	clock                  clock.Clock
+	jitter                 func(time.Duration) time.Duration
+
+	ctx                     context.Context
+	cancel                  context.CancelFunc
+	collectionQueue         chan *watchedConfig
+	mu                      sync.Mutex
+	watches                 map[string]*watchedConfig
+	pendingProcessFallbacks processFallbackRegistry
+	stopOnce                sync.Once
+	workerDone              sync.WaitGroup
 }
 
 var _ scheduler.Scheduler = (*adScheduler)(nil)
 
-type configCollectionWork struct {
-	config        integration.Config
-	target        target
-	collector     ConfigCollector
-	readerFactory configReaderFactory
+// configCollectionState tracks one watch from its next scheduled attempt
+// through collection, batching, and successful delivery.
+type configCollectionState uint8
+
+const (
+	configScheduled configCollectionState = iota
+	configCollecting
+	configRecollectAfterCollection
+	configCollected
+	configRecollectAfterSend
+	configSent
+)
+
+// configCollectionEvent tells the state machine what happened to a watched
+// config so it can choose the next configCollectionState.
+type configCollectionEvent uint8
+
+const (
+	collectionRequested configCollectionEvent = iota
+	collectionCompleted
+	collectionDeferred
+	sendSucceeded
+	sendFailed
+	recollectionRequested
+	watchUnscheduled
+)
+
+// watchedConfig holds the durable state needed to recollect one scheduled AD
+// config until it is unscheduled. Collectors and reader factories remain in the
+// scheduler-owned registries and are looked up only when collection runs.
+type watchedConfig struct {
+	// key is the AD config digest used for map membership and generation checks.
+	key string
+	// integration selects the collector and is included in emitted payloads.
+	integration string
+	// serviceID preserves the original AD service identifier for diagnostics.
+	serviceID string
+	// target identifies the runtime and entity to inspect on each collection.
+	target target
+	// state tracks the asynchronous collection and send lifecycle.
+	state configCollectionState
+	// nextCollection is the startup, heartbeat, or retry deadline.
+	nextCollection time.Time
+}
+
+// pendingCollectedConfig holds a collected payload until its batch has been
+// sent. The watch pointer lets delivery update the originating watch while
+// rejecting results from a watch that has since been replaced.
+type pendingCollectedConfig struct {
+	watch  *watchedConfig
+	config CollectedConfig
 }
 
 type collectedConfigSender interface {
@@ -56,31 +130,30 @@ func (noopCollectedConfigSender) SendCollectedConfigs([]CollectedConfig) error {
 }
 
 type collectedConfigBatch struct {
-	configs        []CollectedConfig
+	pendingConfigs []pendingCollectedConfig
 	rawConfigBytes int
 }
 
 func (b *collectedConfigBatch) hasConfigs() bool {
-	return len(b.configs) > 0
+	return len(b.pendingConfigs) > 0
 }
 
-func (b *collectedConfigBatch) add(config CollectedConfig) {
-	b.configs = append(b.configs, config)
-	b.rawConfigBytes += collectedConfigRawBytes(config)
+func (b *collectedConfigBatch) add(config pendingCollectedConfig) {
+	b.pendingConfigs = append(b.pendingConfigs, config)
+	b.rawConfigBytes += collectedConfigRawBytes(config.config)
 }
 
 func (b *collectedConfigBatch) shouldFlush() bool {
-	return len(b.configs) >= configCollectionBatchMaxCollectedConfigs || b.rawConfigBytes >= configCollectionBatchMaxRawConfigBytes
+	return len(b.pendingConfigs) >= configCollectionBatchMaxCollectedConfigs || b.rawConfigBytes >= configCollectionBatchMaxRawConfigBytes
 }
 
-func (b *collectedConfigBatch) wouldExceedByteLimit(config CollectedConfig) bool {
-	return b.hasConfigs() && b.rawConfigBytes+collectedConfigRawBytes(config) > configCollectionBatchMaxRawConfigBytes
+func (b *collectedConfigBatch) wouldExceedByteLimit(config pendingCollectedConfig) bool {
+	return b.hasConfigs() && b.rawConfigBytes+collectedConfigRawBytes(config.config) > configCollectionBatchMaxRawConfigBytes
 }
 
-func (b *collectedConfigBatch) takeConfigs() []CollectedConfig {
-	configs := make([]CollectedConfig, len(b.configs))
-	copy(configs, b.configs)
-	b.configs = nil
+func (b *collectedConfigBatch) takeConfigs() []pendingCollectedConfig {
+	configs := b.pendingConfigs
+	b.pendingConfigs = nil
 	b.rawConfigBytes = 0
 	return configs
 }
@@ -96,34 +169,108 @@ func collectedConfigRawBytes(config CollectedConfig) int {
 	return size
 }
 
-// newADScheduler builds the object registered with autodiscovery.
-// Autodiscovery calls this scheduler when integration configs appear or
-// disappear; this component only uses the scheduled configs as triggers for
-// one-shot config collection.
-func newADScheduler(resolver targetResolver, readers map[RuntimeType]configReaderFactory, collectors map[string]ConfigCollector, sender collectedConfigSender) *adScheduler {
+type adSchedulerConfig struct {
+	heartbeatInterval      time.Duration
+	heartbeatJitter        time.Duration
+	startupJitter          time.Duration
+	heartbeatRetryInterval time.Duration
+	heartbeatCheckInterval time.Duration
+	clock                  clock.Clock
+	jitter                 func(time.Duration) time.Duration
+}
+
+func defaultADSchedulerConfig() adSchedulerConfig {
+	return adSchedulerConfig{
+		heartbeatInterval:      defaultHeartbeatInterval,
+		heartbeatJitter:        defaultHeartbeatJitter,
+		startupJitter:          defaultStartupJitter,
+		heartbeatRetryInterval: defaultHeartbeatRetryInterval,
+		heartbeatCheckInterval: defaultHeartbeatCheckInterval,
+		clock:                  clock.New(),
+		jitter:                 randomJitter,
+	}
+}
+
+func randomJitter(maxJitter time.Duration) time.Duration {
+	if maxJitter <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int63n(int64(2*maxJitter)+1)) - maxJitter //nolint:gosec // Jitter is for scheduling spread, not security.
+}
+
+func startupDelay(maxDelay time.Duration, jitter func(time.Duration) time.Duration) time.Duration {
+	if maxDelay <= 0 {
+		return 0
+	}
+	halfDelay := maxDelay / 2
+	return halfDelay + jitter(halfDelay)
+}
+
+// newADSchedulerWithConfig builds the long-lived config watcher registered with autodiscovery.
+// It collects configs when they are scheduled and retains them for periodic
+// heartbeats until autodiscovery unschedules them or the scheduler stops.
+func newADSchedulerWithConfig(resolver targetResolver, readers map[RuntimeType]configReaderFactory, collectors map[string]ConfigCollector, sender collectedConfigSender, cfg adSchedulerConfig) *adScheduler {
 	if sender == nil {
 		sender = noopCollectedConfigSender{}
 	}
+	cfg = normalizeADSchedulerConfig(cfg)
+	initialDelay := startupDelay(cfg.startupJitter, cfg.jitter)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &adScheduler{
-		resolver:        resolver,
-		readers:         readers,
-		collectors:      collectors,
-		sender:          sender,
-		ctx:             ctx,
-		cancel:          cancel,
-		collectionQueue: make(chan configCollectionWork, configCollectionQueueSize),
+		resolver:               resolver,
+		readers:                readers,
+		collectors:             collectors,
+		sender:                 sender,
+		heartbeatInterval:      cfg.heartbeatInterval,
+		heartbeatJitter:        cfg.heartbeatJitter,
+		startupDelay:           initialDelay,
+		heartbeatRetryInterval: cfg.heartbeatRetryInterval,
+		heartbeatCheckInterval: cfg.heartbeatCheckInterval,
+		clock:                  cfg.clock,
+		jitter:                 cfg.jitter,
+		ctx:                    ctx,
+		cancel:                 cancel,
+		collectionQueue:        make(chan *watchedConfig, configCollectionQueueSize),
+		watches:                make(map[string]*watchedConfig),
 	}
-	s.workerDone.Add(1)
+	s.workerDone.Add(2)
 	go s.runCollectionWorker()
+	go s.runHeartbeatWorker()
 	return s
 }
 
+func normalizeADSchedulerConfig(cfg adSchedulerConfig) adSchedulerConfig {
+	if cfg.heartbeatInterval <= 0 {
+		cfg.heartbeatInterval = defaultHeartbeatInterval
+	}
+	if cfg.heartbeatJitter < 0 {
+		cfg.heartbeatJitter = 0
+	}
+	if jitterLimit := heartbeatJitterLimit(cfg.heartbeatInterval); cfg.heartbeatJitter > jitterLimit {
+		cfg.heartbeatJitter = jitterLimit
+	}
+	if cfg.startupJitter < 0 {
+		cfg.startupJitter = 0
+	}
+	if cfg.heartbeatRetryInterval <= 0 {
+		cfg.heartbeatRetryInterval = defaultHeartbeatRetryInterval
+	}
+	if cfg.heartbeatCheckInterval <= 0 {
+		cfg.heartbeatCheckInterval = defaultHeartbeatCheckInterval
+	}
+	if cfg.clock == nil {
+		cfg.clock = clock.New()
+	}
+	if cfg.jitter == nil {
+		cfg.jitter = randomJitter
+	}
+	return cfg
+}
+
 // Schedule is called by autodiscovery with configs that should run for a
-// service. For each config, it normalizes the AD service information into an
-// internal target, selects the collector and runtime-specific reader factory,
-// and enqueues one-shot collection work outside the AD scheduler callback.
+// service. New configs are collected outside the AD callback. Repeated
+// schedules update the collection target but wait for the next heartbeat.
 func (s *adScheduler) Schedule(configs []integration.Config) {
 	for _, config := range configs {
 		target, ok := s.resolver.Resolve(config)
@@ -131,35 +278,192 @@ func (s *adScheduler) Schedule(configs []integration.Config) {
 			continue
 		}
 
-		collector, ok := s.collectors[config.Name]
-		if !ok {
+		if _, found := s.collectors[config.Name]; !found {
 			log.Debugf("config files discovery has no collector for integration %q service %q", config.Name, config.ServiceID)
 			continue
 		}
 
-		readerFactory, ok := s.readers[target.runtime]
-		if !ok {
+		if _, found := s.readers[target.runtime]; !found {
 			log.Debugf("config files discovery has no config reader for integration %q service %q runtime %q", config.Name, config.ServiceID, target.runtime)
 			continue
 		}
 
-		work := configCollectionWork{
-			config:        config,
-			target:        target,
-			collector:     collector,
-			readerFactory: readerFactory,
-		}
-
-		select {
-		case <-s.ctx.Done():
-			return
-		case s.collectionQueue <- work:
-		default:
-			log.Warnf("config files discovery collection queue is full, dropping integration %q service %q runtime %q", config.Name, config.ServiceID, target.runtime)
-		}
+		s.trackAndEnqueue(config, target)
 	}
 }
 
+// trackAndEnqueue creates or refreshes a watch and starts its initial
+// collection once the shared startup delay has elapsed.
+func (s *adScheduler) trackAndEnqueue(config integration.Config, target target) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := watchKey(config)
+	watch, ok := s.watches[key]
+	if s.startupNotBefore.IsZero() {
+		s.startupNotBefore = s.clock.Now().Add(s.startupDelay)
+		if s.startupDelay > 0 {
+			s.startupTimer = s.clock.AfterFunc(s.startupDelay, s.enqueueDueCollections)
+		}
+	}
+	if !ok {
+		watch = &watchedConfig{
+			key:   key,
+			state: configScheduled,
+		}
+		s.watches[key] = watch
+	}
+	watch.integration = config.Name
+	watch.serviceID = config.ServiceID
+	watch.target = target
+	if !ok {
+		s.registerProcessFallbackLocked(watch)
+	}
+	if !ok && s.clock.Now().Before(s.startupNotBefore) {
+		watch.nextCollection = s.startupNotBefore
+		return
+	}
+
+	if ok && (watch.state != configScheduled || !watch.nextCollection.IsZero()) {
+		return
+	}
+	s.transitionWatchLocked(watch, collectionRequested, time.Time{})
+}
+
+func watchKey(config integration.Config) string {
+	return config.Digest()
+}
+
+func (s *adScheduler) isActiveWatchLocked(watch *watchedConfig) bool {
+	return watch != nil && s.watches[watch.key] == watch
+}
+
+// transitionWatchLocked is the config collection state machine. Asynchronous
+// workers report events here; this function validates and applies every state
+// transition:
+//
+//	Scheduled/ConfigSent      --collectionRequested----> Collecting
+//	Collecting                --collectionCompleted----> ConfigCollected
+//	Collecting                --collectionDeferred-----> Scheduled
+//	ConfigCollected           --sendSucceeded----------> ConfigSent
+//	ConfigCollected           --sendFailed-------------> Scheduled
+//	Scheduled/ConfigSent      --recollectionRequested--> Collecting
+//	Collecting                --recollectionRequested--> RecollectAfterCollection
+//	RecollectAfterCollection  --collectionCompleted----> RecollectAfterSend
+//	RecollectAfterCollection  --collectionDeferred-----> Collecting
+//	ConfigCollected           --recollectionRequested--> RecollectAfterSend
+//	RecollectAfterSend        --sendSucceeded/Failed----> Collecting
+//	Any                       --watchUnscheduled-------> removed
+//
+// A recollection request starts immediately from a resting state. During
+// collection or while awaiting send it is coalesced into a transient state so
+// the current collection reaches a send attempt before recollection starts.
+// Returns true when the event is represented by the resulting state, including
+// a coalesced recollection or a scheduled retry, and false when it is ignored.
+// The caller must hold s.mu.
+func (s *adScheduler) transitionWatchLocked(watch *watchedConfig, event configCollectionEvent, nextCollection time.Time) bool {
+	if !s.isActiveWatchLocked(watch) {
+		return false
+	}
+
+	switch event {
+	case collectionRequested:
+		if watch.state != configScheduled && watch.state != configSent {
+			return false
+		}
+		watch.state = configCollecting
+		watch.nextCollection = time.Time{}
+		select {
+		case <-s.ctx.Done():
+			watch.state = configScheduled
+			return false
+		case s.collectionQueue <- watch:
+		default:
+			watch.state = configScheduled
+			watch.nextCollection = s.clock.Now().Add(s.nextRetryDelay())
+			log.Warnf("config files discovery collection queue is full, retrying integration %q service %q runtime %q later", watch.integration, watch.serviceID, watch.target.runtime)
+		}
+
+	case collectionCompleted:
+		switch watch.state {
+		case configCollecting:
+			watch.state = configCollected
+		case configRecollectAfterCollection:
+			watch.state = configRecollectAfterSend
+		default:
+			return false
+		}
+
+	case collectionDeferred:
+		switch watch.state {
+		case configCollecting:
+			watch.state = configScheduled
+			watch.nextCollection = nextCollection
+		case configRecollectAfterCollection:
+			watch.state = configScheduled
+			watch.nextCollection = nextCollection
+			return s.transitionWatchLocked(watch, collectionRequested, time.Time{})
+		default:
+			return false
+		}
+
+	case sendSucceeded, sendFailed:
+		if watch.state != configCollected && watch.state != configRecollectAfterSend {
+			return false
+		}
+		recollect := watch.state == configRecollectAfterSend
+		if event == sendSucceeded {
+			watch.state = configSent
+		} else {
+			watch.state = configScheduled
+		}
+		watch.nextCollection = nextCollection
+		if recollect {
+			return s.transitionWatchLocked(watch, collectionRequested, time.Time{})
+		}
+
+	case recollectionRequested:
+		switch watch.state {
+		case configCollecting:
+			watch.state = configRecollectAfterCollection
+		case configCollected:
+			watch.state = configRecollectAfterSend
+		case configRecollectAfterCollection, configRecollectAfterSend:
+			return true
+		case configScheduled:
+			if !s.startupNotBefore.IsZero() && s.clock.Now().Before(s.startupNotBefore) {
+				// The initial collection is already scheduled for the end of startup
+				// jitter. Do not record this as the one-shot fallback yet: returning
+				// false keeps that fallback available for a process event after the
+				// initial collection.
+				return false
+			}
+			return s.transitionWatchLocked(watch, collectionRequested, time.Time{})
+		case configSent:
+			return s.transitionWatchLocked(watch, collectionRequested, time.Time{})
+		default:
+			return false
+		}
+
+	case watchUnscheduled:
+		delete(s.watches, watch.key)
+
+	default:
+		return false
+	}
+	return true
+}
+
+// transitionWatch reports an asynchronous worker result to the state machine.
+func (s *adScheduler) transitionWatch(watch *watchedConfig, event configCollectionEvent, nextCollection time.Time) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.transitionWatchLocked(watch, event, nextCollection)
+}
+
+// runCollectionWorker serializes collection and delivery. Configs remain in
+// the collected state while waiting in a batch, then finishSend records either
+// a successful heartbeat deadline or a retry deadline.
 func (s *adScheduler) runCollectionWorker() {
 	defer s.workerDone.Done()
 
@@ -194,15 +498,22 @@ func (s *adScheduler) runCollectionWorker() {
 			return true
 		}
 		stopFlushTimer()
-		configs := batch.takeConfigs()
+		pendingConfigs := s.activePendingConfigs(batch.takeConfigs())
+		if len(pendingConfigs) == 0 {
+			return true
+		}
+		configs := collectedConfigsFromPending(pendingConfigs)
 		if err := s.sender.SendCollectedConfigs(configs); err != nil {
 			select {
 			case <-s.ctx.Done():
 				return false
 			default:
 				log.Warnf("failed to send collected config batch with %d collected configs: %v", len(configs), err)
+				s.finishSend(pendingConfigs, false)
+				return true
 			}
 		}
+		s.finishSend(pendingConfigs, true)
 		return true
 	}
 
@@ -217,15 +528,15 @@ func (s *adScheduler) runCollectionWorker() {
 			if !flushBatch() {
 				return
 			}
-		case work := <-s.collectionQueue:
-			config, ok := s.runCollection(work)
+		case watch := <-s.collectionQueue:
+			pendingConfig, ok := s.runCollection(watch)
 			if !ok {
 				continue
 			}
-			if batch.wouldExceedByteLimit(config) && !flushBatch() {
+			if batch.wouldExceedByteLimit(pendingConfig) && !flushBatch() {
 				return
 			}
-			batch.add(config)
+			batch.add(pendingConfig)
 			startFlushTimer()
 			if batch.shouldFlush() && !flushBatch() {
 				return
@@ -234,46 +545,207 @@ func (s *adScheduler) runCollectionWorker() {
 	}
 }
 
-// runCollection executes one queued config collection. Returns a collected
-// config and true when collection succeeds and produces config data. Returns an
-// empty collected config and false when there is nothing to add to the batch.
-func (s *adScheduler) runCollection(work configCollectionWork) (CollectedConfig, bool) {
-	reader, err := work.readerFactory(work.target)
+func collectedConfigsFromPending(pendingConfigs []pendingCollectedConfig) []CollectedConfig {
+	configs := make([]CollectedConfig, 0, len(pendingConfigs))
+	for _, pendingConfig := range pendingConfigs {
+		configs = append(configs, pendingConfig.config)
+	}
+	return configs
+}
+
+// activePendingConfigs removes configs whose watch was unscheduled or replaced
+// before its batch started sending.
+func (s *adScheduler) activePendingConfigs(pendingConfigs []pendingCollectedConfig) []pendingCollectedConfig {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	active := pendingConfigs[:0]
+	for _, pendingConfig := range pendingConfigs {
+		if s.isActiveWatchLocked(pendingConfig.watch) && pendingConfig.watch.hasCollectedConfig() {
+			active = append(active, pendingConfig)
+		}
+	}
+	return active
+}
+
+func (s *adScheduler) runHeartbeatWorker() {
+	defer s.workerDone.Done()
+
+	ticker := s.clock.Ticker(s.heartbeatCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-ticker.C:
+			s.enqueueDueCollections()
+		}
+	}
+}
+
+// enqueueDueCollections starts every scheduled or sent watch whose collection
+// deadline has elapsed.
+func (s *adScheduler) enqueueDueCollections() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.clock.Now()
+	for _, watch := range s.watches {
+		if !watch.hasDueCollection(now) {
+			continue
+		}
+		s.transitionWatchLocked(watch, collectionRequested, time.Time{})
+	}
+}
+
+// hasDueCollection returns whether a resting watch has reached a non-zero
+// collection deadline.
+func (w *watchedConfig) hasDueCollection(now time.Time) bool {
+	return (w.state == configScheduled || w.state == configSent) && !w.nextCollection.IsZero() && !w.nextCollection.After(now)
+}
+
+// isCollecting returns whether a collection is running, including when another
+// collection has been requested afterward.
+func (w *watchedConfig) isCollecting() bool {
+	return w.state == configCollecting || w.state == configRecollectAfterCollection
+}
+
+// hasCollectedConfig returns whether collected data is waiting to be sent,
+// including when another collection has been requested afterward.
+func (w *watchedConfig) hasCollectedConfig() bool {
+	return w.state == configCollected || w.state == configRecollectAfterSend
+}
+
+// runCollection executes one queued config collection. Returns a pending config
+// and true when collection produces config data to send.
+// Returns an empty config and false when there is nothing to add to the batch.
+func (s *adScheduler) runCollection(watch *watchedConfig) (pendingCollectedConfig, bool) {
+	integration, serviceID, target, ok := s.snapshotWatch(watch)
+	if !ok {
+		return pendingCollectedConfig{}, false
+	}
+
+	readerFactory := s.readers[target.runtime]
+	reader, err := readerFactory(target)
 	if err != nil {
-		log.Warnf("failed to build config reader for integration %q service %q runtime %q: %v", work.config.Name, work.config.ServiceID, work.target.runtime, err)
-		return CollectedConfig{}, false
+		log.Warnf("failed to build config reader for integration %q service %q runtime %q: %v", integration, serviceID, target.runtime, err)
+		s.transitionWatch(watch, collectionDeferred, s.clock.Now().Add(s.nextRetryDelay()))
+		return pendingCollectedConfig{}, false
 	}
 	defer reader.Close()
 
-	collected, err := work.collector.Collect(s.ctx, reader)
+	collector := s.collectors[integration]
+	collected, err := collector.Collect(s.ctx, reader)
 	if err != nil {
 		select {
 		case <-s.ctx.Done():
-			return CollectedConfig{}, false
+			return pendingCollectedConfig{}, false
 		default:
-			log.Warnf("failed to collect config data for integration %q service %q: %v", work.config.Name, work.config.ServiceID, err)
-			return CollectedConfig{}, false
+			log.Warnf("failed to collect config data for integration %q service %q: %v", integration, serviceID, err)
+			s.transitionWatch(watch, collectionDeferred, s.clock.Now().Add(s.nextRetryDelay()))
+			return pendingCollectedConfig{}, false
 		}
 	}
 
 	if len(collected.ConfigFiles) == 0 && len(collected.EnvVars) == 0 {
-		return CollectedConfig{}, false
+		s.transitionWatch(watch, collectionDeferred, s.clock.Now().Add(s.nextHeartbeatDelay()))
+		return pendingCollectedConfig{}, false
+	}
+	if !s.transitionWatch(watch, collectionCompleted, time.Time{}) {
+		return pendingCollectedConfig{}, false
 	}
 
-	collected.Integration = work.config.Name
-	collected.Runtime = work.target.runtime
-	collected.RuntimeID = work.target.entityID
+	collected.Integration = integration
+	collected.Runtime = target.runtime
+	collected.RuntimeID = target.entityID
+	pendingConfig := pendingCollectedConfig{
+		watch:  watch,
+		config: collected,
+	}
 
 	for _, file := range collected.ConfigFiles {
-		log.Debugf("config files discovery collected config file: integration %q path %q size_bytes %d truncated %t", work.config.Name, file.Path, len(file.Content), file.Truncated)
+		log.Debugf("config files discovery collected config file: integration %q path %q size_bytes %d truncated %t", pendingConfig.config.Integration, file.Path, len(file.Content), file.Truncated)
 	}
-	return collected, true
+	return pendingConfig, true
 }
 
-// Unschedule is required by the autodiscovery scheduler interface. Config file
-// discovery does not keep a long-running collection tied to a scheduled AD
-// config, so there is nothing to tear down when AD unschedules it.
-func (s *adScheduler) Unschedule(_ []integration.Config) {}
+// snapshotWatch returns the immutable inputs for an active collection. It
+// rejects queued work for watches that were unscheduled or replaced.
+func (s *adScheduler) snapshotWatch(watch *watchedConfig) (string, string, target, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.isActiveWatchLocked(watch) || !watch.isCollecting() {
+		return "", "", target{}, false
+	}
+	return watch.integration, watch.serviceID, watch.target, true
+}
+
+// finishSend transitions every active watch in a batch to sent on success or
+// scheduled on failure. Watches share the same heartbeat or retry deadline so
+// subsequent collections can remain batched.
+func (s *adScheduler) finishSend(pendingConfigs []pendingCollectedConfig, success bool) {
+	now := s.clock.Now()
+	var event configCollectionEvent
+	var nextDelay time.Duration
+	if success {
+		event = sendSucceeded
+		nextDelay = s.nextHeartbeatDelay()
+	} else {
+		event = sendFailed
+		nextDelay = s.nextRetryDelay()
+	}
+	nextCollection := now.Add(nextDelay)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, pendingConfig := range pendingConfigs {
+		s.transitionWatchLocked(pendingConfig.watch, event, nextCollection)
+	}
+}
+
+func (s *adScheduler) nextHeartbeatDelay() time.Duration {
+	return s.heartbeatInterval + s.jitter(s.heartbeatJitter)
+}
+
+func heartbeatJitterLimit(interval time.Duration) time.Duration {
+	limit := interval / 2
+	if limit > maxHeartbeatJitter {
+		return maxHeartbeatJitter
+	}
+	return limit
+}
+
+func (s *adScheduler) nextRetryDelay() time.Duration {
+	retryInterval := s.heartbeatRetryInterval
+	if retryInterval > s.heartbeatInterval {
+		retryInterval = s.heartbeatInterval
+	}
+
+	retryJitter := s.heartbeatJitter
+	maxRetryJitter := retryInterval / 2
+	if retryJitter > maxRetryJitter {
+		retryJitter = maxRetryJitter
+	}
+	return retryInterval + s.jitter(retryJitter)
+}
+
+// Unschedule is called when autodiscovery removes integration configs. Remove
+// the corresponding watches so future heartbeat ticks do not re-collect
+// configs for services that no longer match.
+func (s *adScheduler) Unschedule(configs []integration.Config) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, config := range configs {
+		if watch := s.watches[watchKey(config)]; watch != nil {
+			s.removeProcessFallbackLocked(watch)
+			s.transitionWatchLocked(watch, watchUnscheduled, time.Time{})
+		}
+	}
+}
 
 // Stop is required by the autodiscovery scheduler interface. The component
 // unregisters this scheduler from autodiscovery during shutdown and cancels any
@@ -281,6 +753,11 @@ func (s *adScheduler) Unschedule(_ []integration.Config) {}
 func (s *adScheduler) Stop() {
 	s.stopOnce.Do(func() {
 		s.cancel()
+		s.mu.Lock()
+		if s.startupTimer != nil {
+			s.startupTimer.Stop()
+		}
+		s.mu.Unlock()
 		s.workerDone.Wait()
 	})
 }

--- a/comp/core/configfilesdiscovery/impl/types.go
+++ b/comp/core/configfilesdiscovery/impl/types.go
@@ -45,6 +45,9 @@ type ConfigEnvVar struct {
 	Value string
 }
 
+// ConfigEnvVarPredicate returns whether an environment variable should be read.
+type ConfigEnvVarPredicate func(name string) bool
+
 // CollectedConfig is the config data collected for one integration target.
 type CollectedConfig struct {
 	Integration string
@@ -54,7 +57,7 @@ type CollectedConfig struct {
 	EnvVars     []ConfigEnvVar
 }
 
-// TargetCommandline is the command line used to start the target service.
+// TargetCommandline is a candidate process command line associated with the target.
 type TargetCommandline struct {
 	Args       []string
 	WorkingDir string
@@ -64,8 +67,9 @@ type TargetCommandline struct {
 type ConfigReader interface {
 	Runtime() RuntimeType
 	ReadFile(context.Context, string) (ConfigFile, error)
-	ReadEnvVars(context.Context, []string) (map[string]string, error)
-	ReadCommandline(context.Context) (TargetCommandline, error)
+	ReadEnvVars(context.Context, ConfigEnvVarPredicate) (map[string]string, error)
+	ReadRuntimeCommandline(context.Context) (TargetCommandline, error)
+	ReadLiveProcessCommandlines(context.Context) []TargetCommandline
 	Close()
 }
 
@@ -73,6 +77,8 @@ type configReaderFactory func(target) (ConfigReader, error)
 
 // ConfigCollector reads integration-specific config data through a collector reader.
 type ConfigCollector interface {
+	// CanCollectFromProcess returns whether the collector can use the process command line for collection.
+	CanCollectFromProcess(TargetCommandline) bool
 	Collect(context.Context, ConfigReader) (CollectedConfig, error)
 }
 

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -6996,6 +6996,27 @@ properties:
             node_type: setting
             type: integer
             default: 1
+      heartbeat_interval:
+        node_type: setting
+        type: string
+        default: 1h0m0s
+        format: duration
+        tags:
+        - golang_type:duration
+      heartbeat_jitter:
+        node_type: setting
+        type: string
+        default: 10m0s
+        format: duration
+        tags:
+        - golang_type:duration
+      startup_jitter:
+        node_type: setting
+        type: string
+        default: 1m0s
+        format: duration
+        tags:
+        - golang_type:duration
   container_exclude:
     node_type: setting
     type: array

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1319,6 +1319,9 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("core_agent.enabled", true)
 
 	config.BindEnvAndSetDefault("config_files_discovery.enabled", false)
+	config.BindEnvAndSetDefault("config_files_discovery.heartbeat_interval", time.Hour)
+	config.BindEnvAndSetDefault("config_files_discovery.heartbeat_jitter", 10*time.Minute)
+	config.BindEnvAndSetDefault("config_files_discovery.startup_jitter", time.Minute)
 	bindEnvAndSetLogsConfigKeys(config, "config_files_discovery.forwarder.")
 
 	config.BindEnvAndSetDefault("software_inventory.enabled", false)

--- a/test/new-e2e/tests/discovery/configfilesdiscovery_docker_test.go
+++ b/test/new-e2e/tests/discovery/configfilesdiscovery_docker_test.go
@@ -6,6 +6,7 @@
 package discovery
 
 import (
+	_ "embed"
 	"encoding/json"
 	"path"
 	"strings"
@@ -25,142 +26,587 @@ import (
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
-	agentDiscoveryEndpoint                    = "/api/v2/agentdiscovery"
-	configFilesDiscoveryRedisConfigDir        = "/tmp/configfilesdiscovery-redis"
-	configFilesDiscoveryRedisContainerPath    = "/usr/local/etc/redis/redis.conf"
-	configFilesDiscoveryRedisConfigFileName   = "redis.conf"
-	configFilesDiscoveryRedisConfigSentinel   = "configfilesdiscovery-e2e-sentinel"
-	configFilesDiscoveryRedisIntegrationName  = "redisdb"
-	configFilesDiscoveryRedisContainerRuntime = "docker"
+	agentDiscoveryEndpoint = "/api/v2/agentdiscovery"
+	startMarkerFileName    = "start"
+	dockerRuntime          = "docker"
 )
 
-const configFilesDiscoveryRedisConfig = `port 6379
+const (
+	redisConfigDir               = "/tmp/configfilesdiscovery-redis"
+	redisExplicitContainerName   = "redis-configfilesdiscovery-explicit"
+	redisDefaultContainerName    = "redis-configfilesdiscovery-default"
+	redisEnvContainerName        = "redis-env-configfilesdiscovery"
+	redisExplicitContainerPath   = "/configfilesdiscovery/redis-explicit.conf"
+	redisDefaultContainerPath    = "/etc/redis/redis.conf"
+	redisExplicitConfigFileName  = "redis-explicit.conf"
+	redisDefaultConfigFileName   = "redis-default.conf"
+	redisExplicitStartScriptName = "start-redis.sh"
+	redisDefaultStartScriptName  = "start-default-redis.sh"
+	redisExplicitConfigSentinel  = "configfilesdiscovery-explicit-e2e-sentinel"
+	redisDefaultConfigSentinel   = "configfilesdiscovery-default-e2e-sentinel"
+	redisIntegrationName         = "redisdb"
+	redisTLSCertFile             = "/etc/redis/tls.crt"
+)
+
+const (
+	kafkaConfigDir        = "/tmp/configfilesdiscovery-kafka"
+	kafkaContainerName    = "kafka-configfilesdiscovery-default"
+	kafkaEnvContainerName = "kafka-env-configfilesdiscovery"
+	kafkaContainerPath    = "/etc/kafka/kafka.properties"
+	kafkaStartScriptName  = "start-kafka.sh"
+	kafkaConfigSentinel   = "configfilesdiscovery-e2e-sentinel"
+	kafkaIntegrationName  = "kafka"
+	kafkaClusterID        = "MkU3OEVBNTcwNTJENDM2Qk"
+	kafkaTokenEndpoint    = "https://identity.example/oauth2/token"
+)
+
+const (
+	postgresConfigDir       = "/tmp/configfilesdiscovery-postgres"
+	postgresContainerName   = "postgres-configfilesdiscovery"
+	postgresContainerPGData = "/var/lib/postgresql/data"
+	postgresContainerPath   = postgresContainerPGData + "/postgresql.conf"
+	postgresIntegrationName = "postgres"
+	postgresDBName          = "configfilesdiscovery"
+	postgresUser            = "configfilesdiscovery"
+)
+
+//go:embed testdata/compose/docker-compose.configfilesdiscovery-redis.yaml
+var redisComposeTemplate string
+
+//go:embed testdata/compose/docker-compose.configfilesdiscovery-kafka.yaml
+var kafkaCompose string
+
+//go:embed testdata/compose/docker-compose.configfilesdiscovery-postgres.yaml
+var postgresCompose string
+
+const redisExplicitConfig = `port 6379
 appendonly no
 maxmemory-policy allkeys-lru
-# configfilesdiscovery-e2e-sentinel
+# configfilesdiscovery-explicit-e2e-sentinel
 `
 
-const configFilesDiscoveryRedisCompose = `version: "3.9"
-services:
-  redis-configfilesdiscovery:
-    image: ghcr.io/datadog/redis:{APPS_VERSION}
-    container_name: redis-configfilesdiscovery
-    command:
-      - redis-server
-      - /usr/local/etc/redis/redis.conf
-    labels:
-      com.datadoghq.ad.checks: |
-        {
-          "redisdb": {
-            "instances": [
-              {
-                "host": "%%host%%",
-                "port": 6379
-              }
-            ]
-          }
-        }
-    volumes:
-      - ${CONFIG_FILES_DISCOVERY_REDIS_CONFIG_DIR}/redis.conf:/usr/local/etc/redis/redis.conf:ro
+const redisDefaultConfig = `port 6379
+appendonly no
+maxmemory-policy allkeys-lru
+# configfilesdiscovery-default-e2e-sentinel
+`
+
+const redisExplicitStartScript = `#!/bin/sh
+set -eu
+
+while [ ! -f /configfilesdiscovery/start ]; do
+  sleep 1
+done
+
+# Redis rewrites its process title by default, which can hide the startup
+# arguments before workloadmeta's periodic process scan observes them.
+exec redis-server /configfilesdiscovery/redis-explicit.conf --set-proc-title no
+`
+
+const redisDefaultStartScript = `#!/bin/sh
+set -eu
+
+while [ ! -f /configfilesdiscovery/start ]; do
+  sleep 1
+done
+
+exec redis-server /etc/redis/redis.conf
+`
+
+const kafkaStartScript = `#!/usr/bin/env bash
+set -euo pipefail
+
+/etc/confluent/docker/configure
+/etc/confluent/docker/ensure
+
+while [ ! -f /configfilesdiscovery/start ]; do
+  sleep 1
+done
+
+exec /etc/confluent/docker/launch
 `
 
 type configFilesDiscoveryDockerSuite struct {
 	e2e.BaseSuite[environments.DockerHost]
 }
 
+type configFilesDiscoveryFixtureFile struct {
+	name    string
+	content string
+}
+
+type configFilesDiscoveryContainerFixture struct {
+	integrationName     string
+	configDir           string
+	containerNames      []string
+	startContainerNames []string
+}
+
+type configFilePayloadExpectation struct {
+	integrationName string
+	configPath      string
+	payloadFormat   agentdiscovery.AgentDiscoveryConfigFilePayloadFormat
+}
+
 func TestConfigFilesDiscoveryDockerSuite(t *testing.T) {
 	t.Parallel()
 
-	redisCompose := strings.ReplaceAll(configFilesDiscoveryRedisCompose, "{APPS_VERSION}", apps.Version)
+	redisCompose := strings.ReplaceAll(redisComposeTemplate, "{APPS_VERSION}", apps.Version)
 	agentOpts := []dockeragentparams.Option{
 		dockeragentparams.WithAgentServiceEnvVariable("DD_CONFIG_FILES_DISCOVERY_ENABLED", pulumi.StringPtr("true")),
 		dockeragentparams.WithAgentServiceEnvVariable("DD_CONFIG_FILES_DISCOVERY_FORWARDER_USE_COMPRESSION", pulumi.StringPtr("false")),
 		dockeragentparams.WithAgentServiceEnvVariable("DD_CONFIG_FILES_DISCOVERY_FORWARDER_BATCH_WAIT", pulumi.StringPtr("0.1")),
+		dockeragentparams.WithAgentServiceEnvVariable("DD_CONFIG_FILES_DISCOVERY_HEARTBEAT_INTERVAL", pulumi.StringPtr("10s")),
+		dockeragentparams.WithAgentServiceEnvVariable("DD_CONFIG_FILES_DISCOVERY_HEARTBEAT_JITTER", pulumi.StringPtr("0s")),
+		dockeragentparams.WithAgentServiceEnvVariable("DD_CONFIG_FILES_DISCOVERY_STARTUP_JITTER", pulumi.StringPtr("0s")),
 		dockeragentparams.WithExtraComposeManifest("configfilesdiscovery-redis", pulumi.String(redisCompose)),
+		dockeragentparams.WithExtraComposeManifest("configfilesdiscovery-kafka", pulumi.String(kafkaCompose)),
+		dockeragentparams.WithExtraComposeManifest("configfilesdiscovery-postgres", pulumi.String(postgresCompose)),
 		dockeragentparams.WithEnvironmentVariables(pulumi.StringMap{
-			"CONFIG_FILES_DISCOVERY_REDIS_CONFIG_DIR": pulumi.String(configFilesDiscoveryRedisConfigDir),
+			"CONFIG_FILES_DISCOVERY_REDIS_CONFIG_DIR": pulumi.String(redisConfigDir),
+			"CONFIG_FILES_DISCOVERY_KAFKA_CONFIG_DIR": pulumi.String(kafkaConfigDir),
 		}),
 	}
 
 	e2e.Run(t, &configFilesDiscoveryDockerSuite{}, e2e.WithProvisioner(awsdocker.Provisioner(
 		awsdocker.WithRunOptions(
 			scendocker.WithPreAgentInstallHook(createConfigFilesDiscoveryRedisConfig),
+			scendocker.WithPreAgentInstallHook(createConfigFilesDiscoveryKafkaConfig),
 			scendocker.WithAgentOptions(agentOpts...),
 		),
 	)))
 }
 
 func createConfigFilesDiscoveryRedisConfig(_ *aws.Environment, host *remote.Host) (pulumi.Resource, error) {
-	fileManager := host.OS.FileManager()
-	createDir, err := fileManager.CreateDirectory(configFilesDiscoveryRedisConfigDir, false)
-	if err != nil {
-		return nil, err
-	}
-
-	configPath := path.Join(configFilesDiscoveryRedisConfigDir, configFilesDiscoveryRedisConfigFileName)
-	configFile, err := fileManager.CopyInlineFile(
-		pulumi.String(configFilesDiscoveryRedisConfig),
-		configPath,
-		utils.PulumiDependsOn(createDir),
+	return createConfigFilesDiscoveryFixtureFiles(
+		host,
+		redisConfigDir,
+		[]configFilesDiscoveryFixtureFile{
+			{name: redisExplicitConfigFileName, content: redisExplicitConfig},
+			{name: redisDefaultConfigFileName, content: redisDefaultConfig},
+			{name: redisExplicitStartScriptName, content: redisExplicitStartScript},
+			{name: redisDefaultStartScriptName, content: redisDefaultStartScript},
+		},
 	)
+}
+
+func createConfigFilesDiscoveryKafkaConfig(_ *aws.Environment, host *remote.Host) (pulumi.Resource, error) {
+	return createConfigFilesDiscoveryFixtureFiles(
+		host,
+		kafkaConfigDir,
+		[]configFilesDiscoveryFixtureFile{
+			{name: kafkaStartScriptName, content: kafkaStartScript},
+		},
+	)
+}
+
+func createConfigFilesDiscoveryFixtureFiles(host *remote.Host, configDir string, files []configFilesDiscoveryFixtureFile) (pulumi.Resource, error) {
+	fileManager := host.OS.FileManager()
+	createDir, err := fileManager.CreateDirectory(configDir, false)
 	if err != nil {
 		return nil, err
 	}
-	return configFile, nil
-}
 
-func (s *configFilesDiscoveryDockerSuite) TestRedisConfigFilePayloadSentToEventPlatform() {
-	t := s.T()
-
-	var payloads []*aggregator.AgentDiscoveryPayload
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		var err error
-		payloads, err = s.Env().FakeIntake.Client().GetAgentDiscoveryPayloads()
-		assert.NoError(c, err)
-		assert.NotEmpty(c, payloads, "no Agent Discovery payloads on %s", agentDiscoveryEndpoint)
-		if err != nil || len(payloads) == 0 {
-			return
+	var dependency pulumi.Resource = createDir
+	for _, file := range files {
+		dependency, err = fileManager.CopyInlineFile(
+			pulumi.String(file.content),
+			path.Join(configDir, file.name),
+			utils.PulumiDependsOn(dependency),
+		)
+		if err != nil {
+			return nil, err
 		}
-
-		payload, config, ok := findRedisConfigPayload(payloads)
-		assert.True(c, ok, "no redis config payload found in %+v", payloads)
-		if !ok {
-			return
-		}
-
-		assert.Equal(c, configFilesDiscoveryRedisIntegrationName, payload.Integration)
-		assert.Equal(c, configFilesDiscoveryRedisContainerRuntime, payload.Runtime)
-		assert.NotEmpty(c, payload.HostID)
-		assert.NotEmpty(c, payload.RuntimeID)
-		assert.False(c, payload.IngestionTimestamp.IsZero())
-
-		assert.Equal(c, configFilesDiscoveryRedisContainerPath, config.Path)
-		assert.Equal(c, agentdiscovery.AgentDiscoveryConfigFilePayloadFormat_PAYLOAD_FORMAT_REDIS_CONF, config.PayloadFormat)
-		assert.False(c, config.Truncated)
-		assert.Equal(c, configFilesDiscoveryRedisConfig, string(config.Content))
-		assert.Contains(c, string(config.Content), configFilesDiscoveryRedisConfigSentinel)
-	}, 3*time.Minute, 10*time.Second, "timed out waiting for config files discovery payload")
-
-	if t.Failed() {
-		s.logConfigFilesDiscoveryDebug(t)
 	}
+
+	return dependency, nil
 }
 
-func findRedisConfigPayload(payloads []*aggregator.AgentDiscoveryPayload) (*aggregator.AgentDiscoveryPayload, aggregator.AgentDiscoveryConfigFile, bool) {
+func (s *configFilesDiscoveryDockerSuite) prepareConfigFilesDiscoveryContainers(t *testing.T, fixture configFilesDiscoveryContainerFixture) string {
+	t.Helper()
+
+	host := s.Env().RemoteHost
+	startFilePath := path.Join(fixture.configDir, startMarkerFileName)
+	containerNames := strings.Join(fixture.containerNames, " ")
+	startContainerNames := containerNames
+	if len(fixture.startContainerNames) > 0 {
+		startContainerNames = strings.Join(fixture.startContainerNames, " ")
+	}
+
+	t.Cleanup(func() {
+		if t.Failed() {
+			s.logConfigFilesDiscoveryDebug(t)
+			for _, containerName := range fixture.containerNames {
+				if logs, logsErr := host.Execute("sudo docker logs --tail 200 " + containerName); logsErr != nil {
+					t.Logf("failed to get %s container logs: %v", containerName, logsErr)
+				} else {
+					t.Logf("%s container logs:\n%s", containerName, logs)
+				}
+			}
+		}
+		if _, cleanupErr := host.Execute("sudo rm -f " + startFilePath); cleanupErr != nil {
+			t.Logf("failed to remove %s start file: %v", fixture.integrationName, cleanupErr)
+		}
+		if _, cleanupErr := host.Execute("sudo docker restart " + containerNames); cleanupErr != nil {
+			t.Logf("failed to restart %s containers: %v", fixture.integrationName, cleanupErr)
+		}
+	})
+
+	_, err := host.Execute("sudo docker stop " + containerNames)
+	require.NoError(t, err)
+	_, err = host.Execute("sudo rm -f " + startFilePath)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return !isIntegrationScheduled(s.Env().Agent.Client.ConfigCheck(), fixture.integrationName)
+	}, time.Minute, time.Second, "%s AD config remained scheduled after its containers stopped", fixture.integrationName)
+	require.NoError(t, s.Env().FakeIntake.Client().FlushServerAndResetAggregators())
+	_, err = host.Execute("sudo docker start " + startContainerNames)
+	require.NoError(t, err)
+
+	return startFilePath
+}
+
+func isIntegrationScheduled(configCheckOutput string, integrationName string) bool {
+	return strings.Contains(configCheckOutput, "=== "+integrationName+" check ===")
+}
+
+func (s *configFilesDiscoveryDockerSuite) TestKafkaEnvVarsDiscoveredWithoutConfigFile() {
+	t := s.T()
+	s.prepareConfigFilesDiscoveryContainers(t, configFilesDiscoveryContainerFixture{
+		integrationName:     kafkaIntegrationName,
+		configDir:           kafkaConfigDir,
+		containerNames:      []string{kafkaContainerName, kafkaEnvContainerName},
+		startContainerNames: []string{kafkaEnvContainerName},
+	})
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, isIntegrationScheduled(s.Env().Agent.Client.ConfigCheck(), kafkaIntegrationName))
+
+		payloads, err := s.Env().FakeIntake.Client().GetAgentDiscoveryPayloads()
+		if !assert.NoError(c, err) {
+			return
+		}
+		kafkaPayloads := findEnvPayloads(payloads, kafkaIntegrationName)
+		if !assert.NotEmpty(c, kafkaPayloads, "no kafka env payloads found in %+v", payloads) {
+			return
+		}
+
+		for _, payload := range kafkaPayloads {
+			assertAgentDiscoveryPayload(c, payload, kafkaIntegrationName)
+			assert.Empty(c, payload.ConfigFiles)
+
+			envVars := make(map[string]string, len(payload.EnvVars))
+			for _, envVar := range payload.EnvVars {
+				envVars[envVar.Name] = envVar.Value
+			}
+			assert.Equal(c, kafkaClusterID, envVars["CLUSTER_ID"])
+			assert.Equal(c, "1", envVars["KAFKA_NODE_ID"])
+			assert.Equal(c, "broker,controller", envVars["KAFKA_PROCESS_ROLES"])
+			assert.Equal(c, kafkaTokenEndpoint, envVars["KAFKA_SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL"])
+			assert.NotContains(c, envVars, "KAFKA_CFG_OAUTH_ACCESS_TOKEN")
+		}
+	}, 3*time.Minute, 10*time.Second, "timed out waiting for kafka env var discovery payload")
+}
+
+func (s *configFilesDiscoveryDockerSuite) TestRedisEnvVarsDiscoveredWithoutConfigFile() {
+	t := s.T()
+	s.prepareConfigFilesDiscoveryContainers(t, configFilesDiscoveryContainerFixture{
+		integrationName: redisIntegrationName,
+		configDir:       redisConfigDir,
+		containerNames: []string{
+			redisExplicitContainerName,
+			redisDefaultContainerName,
+			redisEnvContainerName,
+		},
+		startContainerNames: []string{redisEnvContainerName},
+	})
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, isIntegrationScheduled(s.Env().Agent.Client.ConfigCheck(), redisIntegrationName))
+
+		payloads, err := s.Env().FakeIntake.Client().GetAgentDiscoveryPayloads()
+		if !assert.NoError(c, err) {
+			return
+		}
+		redisPayloads := findEnvPayloads(payloads, redisIntegrationName)
+		if !assert.NotEmpty(c, redisPayloads, "no redis env payloads found in %+v", payloads) {
+			return
+		}
+
+		for _, payload := range redisPayloads {
+			assertAgentDiscoveryPayload(c, payload, redisIntegrationName)
+			assert.Empty(c, payload.ConfigFiles)
+
+			envVars := make(map[string]string, len(payload.EnvVars))
+			for _, envVar := range payload.EnvVars {
+				envVars[envVar.Name] = envVar.Value
+			}
+			assert.Equal(c, "yes", envVars["REDIS_AOF_ENABLED"])
+			assert.Equal(c, "6380", envVars["REDIS_PORT_NUMBER"])
+			assert.Equal(c, redisTLSCertFile, envVars["REDIS_TLS_CERT_FILE"])
+			assert.NotContains(c, envVars, "REDIS_PASSWORD")
+			assert.NotContains(c, envVars, "REDIS_REQUIREPASS")
+		}
+	}, 3*time.Minute, 10*time.Second, "timed out waiting for redis env var discovery payload")
+}
+
+func (s *configFilesDiscoveryDockerSuite) TestKafkaDefaultConfigFileDiscovered() {
+	t := s.T()
+	host := s.Env().RemoteHost
+	startFilePath := s.prepareConfigFilesDiscoveryContainers(t, configFilesDiscoveryContainerFixture{
+		integrationName: kafkaIntegrationName,
+		configDir:       kafkaConfigDir,
+		containerNames:  []string{kafkaContainerName, kafkaEnvContainerName},
+	})
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		processes, processErr := host.Execute("sudo docker top " + kafkaContainerName + " -eo pid,args")
+		if !assert.NoError(c, processErr) {
+			return
+		}
+		assert.Contains(c, processes, kafkaStartScriptName)
+		assert.NotContains(c, processes, "kafka-server-start")
+		assert.NotContains(c, processes, "kafka.Kafka")
+		assert.NotContains(c, processes, kafkaContainerPath)
+
+		config, configErr := host.Execute("sudo docker exec " + kafkaContainerName + " cat " + kafkaContainerPath)
+		if !assert.NoError(c, configErr) {
+			return
+		}
+		assert.Contains(c, config, "broker.rack="+kafkaConfigSentinel)
+		for _, examplePath := range []string{"/etc/kafka/server.properties", "/etc/kafka/kraft/server.properties"} {
+			_, exampleErr := host.Execute("sudo docker exec " + kafkaContainerName + " test -f " + examplePath)
+			assert.NoError(c, exampleErr, "expected Confluent example config %q to be present", examplePath)
+		}
+		assert.True(c, isIntegrationScheduled(s.Env().Agent.Client.ConfigCheck(), kafkaIntegrationName))
+	}, 2*time.Minute, 2*time.Second, "kafka AD config was not scheduled after the image generated its properties file")
+
+	expectedKafkaPayload := configFilePayloadExpectation{
+		integrationName: kafkaIntegrationName,
+		configPath:      kafkaContainerPath,
+		payloadFormat:   agentdiscovery.AgentDiscoveryConfigFilePayloadFormat_PAYLOAD_FORMAT_PROPERTIES,
+	}
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		payloads, payloadErr := s.Env().FakeIntake.Client().GetAgentDiscoveryPayloads()
+		if !assert.NoError(c, payloadErr) {
+			return
+		}
+		kafkaPayloads := findConfigFilePayloads(payloads, kafkaIntegrationName, kafkaContainerPath)
+		if !assert.NotEmpty(c, kafkaPayloads, "kafka default-path config was not collected while the runtime command was opaque") {
+			return
+		}
+
+		for _, kafkaPayload := range kafkaPayloads {
+			assertConfigFilePayload(c, kafkaPayload, expectedKafkaPayload)
+			assert.Contains(c, string(kafkaPayload.config.Content), "broker.rack="+kafkaConfigSentinel)
+		}
+	}, 2*time.Minute, 2*time.Second, "kafka default-path fallback did not run while the wrapper was waiting")
+
+	_, err := host.Execute("sudo touch " + startFilePath)
+	require.NoError(t, err)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		processes, processErr := host.Execute("sudo docker top " + kafkaContainerName + " -eo pid,args")
+		if !assert.NoError(c, processErr) {
+			return
+		}
+		assert.Contains(c, processes, "kafka.Kafka")
+		assert.Contains(c, processes, kafkaContainerPath)
+	}, 2*time.Minute, 2*time.Second, "kafka broker did not start with the generated properties file")
+}
+
+func (s *configFilesDiscoveryDockerSuite) TestRedisConfigFilesDiscoveredAndHeartbeatsSentToEventPlatform() {
+	t := s.T()
+	host := s.Env().RemoteHost
+	startFilePath := s.prepareConfigFilesDiscoveryContainers(t, configFilesDiscoveryContainerFixture{
+		integrationName: redisIntegrationName,
+		configDir:       redisConfigDir,
+		containerNames: []string{
+			redisExplicitContainerName,
+			redisDefaultContainerName,
+			redisEnvContainerName,
+		},
+		startContainerNames: []string{redisExplicitContainerName, redisDefaultContainerName},
+	})
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		// Docker needs the PID column to map the ps output back to container processes,
+		// even though this assertion only inspects the command arguments.
+		wrappers := []struct {
+			containerName   string
+			startScriptName string
+		}{
+			{containerName: redisExplicitContainerName, startScriptName: redisExplicitStartScriptName},
+			{containerName: redisDefaultContainerName, startScriptName: redisDefaultStartScriptName},
+		}
+		for _, wrapper := range wrappers {
+			processes, processErr := host.Execute("sudo docker top " + wrapper.containerName + " -eo pid,args")
+			if !assert.NoError(c, processErr) {
+				return
+			}
+			assert.Contains(c, processes, wrapper.startScriptName)
+			assert.NotContains(c, processes, "redis-server")
+		}
+		assert.True(c, isIntegrationScheduled(s.Env().Agent.Client.ConfigCheck(), redisIntegrationName))
+	}, 2*time.Minute, 2*time.Second, "redis AD config was not scheduled while the wrapper was waiting")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		payloads, payloadErr := s.Env().FakeIntake.Client().GetAgentDiscoveryPayloads()
+		if !assert.NoError(c, payloadErr) {
+			return
+		}
+		defaultPayloads := findConfigFilePayloads(payloads, redisIntegrationName, redisDefaultContainerPath)
+		if !assert.NotEmpty(c, defaultPayloads, "default-path config was not collected while the runtime command was opaque") {
+			return
+		}
+		assert.Equal(c, redisDefaultConfig, string(defaultPayloads[0].config.Content))
+	}, 2*time.Minute, 2*time.Second, "redis default-path fallback did not run while the wrapper was waiting")
+
+	expectedRedisConfigs := []struct {
+		path     string
+		content  string
+		sentinel string
+	}{
+		{
+			path:     redisExplicitContainerPath,
+			content:  redisExplicitConfig,
+			sentinel: redisExplicitConfigSentinel,
+		},
+		{
+			path:     redisDefaultContainerPath,
+			content:  redisDefaultConfig,
+			sentinel: redisDefaultConfigSentinel,
+		},
+	}
+	_, err := host.Execute("sudo touch " + startFilePath)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		payloads, err := s.Env().FakeIntake.Client().GetAgentDiscoveryPayloads()
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotEmpty(c, payloads, "no Agent Discovery payloads on %s", agentDiscoveryEndpoint) {
+			return
+		}
+
+		for _, tt := range expectedRedisConfigs {
+			redisPayloads := findConfigFilePayloads(payloads, redisIntegrationName, tt.path)
+			assert.GreaterOrEqual(c, len(redisPayloads), 2, "fewer than two redis config payloads for %q found in %+v", tt.path, payloads)
+			if len(redisPayloads) < 2 {
+				continue
+			}
+
+			for _, redisPayload := range redisPayloads {
+				assertConfigFilePayload(c, redisPayload, configFilePayloadExpectation{
+					integrationName: redisIntegrationName,
+					configPath:      tt.path,
+					payloadFormat:   agentdiscovery.AgentDiscoveryConfigFilePayloadFormat_PAYLOAD_FORMAT_REDIS_CONF,
+				})
+				assert.Equal(c, tt.content, string(redisPayload.config.Content))
+				assert.Contains(c, string(redisPayload.config.Content), tt.sentinel)
+			}
+		}
+	}, 3*time.Minute, 10*time.Second, "timed out waiting for config files discovery payload")
+}
+
+func (s *configFilesDiscoveryDockerSuite) TestPostgresConfigFilePayloadSentToEventPlatform() {
+	t := s.T()
+	s.prepareConfigFilesDiscoveryContainers(t, configFilesDiscoveryContainerFixture{
+		integrationName: postgresIntegrationName,
+		configDir:       postgresConfigDir,
+		containerNames:  []string{postgresContainerName},
+	})
+
+	expectedPostgresPayload := configFilePayloadExpectation{
+		integrationName: postgresIntegrationName,
+		configPath:      postgresContainerPath,
+		payloadFormat:   agentdiscovery.AgentDiscoveryConfigFilePayloadFormat_PAYLOAD_FORMAT_PROPERTIES,
+	}
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, isIntegrationScheduled(s.Env().Agent.Client.ConfigCheck(), postgresIntegrationName))
+
+		payloads, err := s.Env().FakeIntake.Client().GetAgentDiscoveryPayloads()
+		if !assert.NoError(c, err) {
+			return
+		}
+		postgresPayloads := findConfigFilePayloads(payloads, postgresIntegrationName, postgresContainerPath)
+		if !assert.NotEmpty(c, postgresPayloads, "no postgres config payload found in %+v", payloads) {
+			return
+		}
+
+		for _, postgresPayload := range postgresPayloads {
+			assertConfigFilePayload(c, postgresPayload, expectedPostgresPayload)
+			assert.NotEmpty(c, postgresPayload.config.Content)
+
+			envVars := make(map[string]string, len(postgresPayload.payload.EnvVars))
+			for _, envVar := range postgresPayload.payload.EnvVars {
+				envVars[envVar.Name] = envVar.Value
+			}
+			assert.Equal(c, postgresContainerPGData, envVars["PGDATA"])
+			assert.Equal(c, postgresDBName, envVars["POSTGRES_DB"])
+			assert.Equal(c, postgresUser, envVars["POSTGRES_USER"])
+			assert.NotContains(c, envVars, "POSTGRES_PASSWORD")
+			for name := range envVars {
+				assert.NotContains(c, strings.ToUpper(name), "PASSWORD")
+			}
+		}
+	}, 3*time.Minute, 10*time.Second, "timed out waiting for postgres config file discovery payload")
+}
+
+type configFilePayload struct {
+	payload *aggregator.AgentDiscoveryPayload
+	config  aggregator.AgentDiscoveryConfigFile
+}
+
+func assertAgentDiscoveryPayload(c *assert.CollectT, payload *aggregator.AgentDiscoveryPayload, integrationName string) {
+	c.Helper()
+
+	assert.Equal(c, integrationName, payload.Integration)
+	assert.Equal(c, dockerRuntime, payload.Runtime)
+	assert.NotEmpty(c, payload.HostID)
+	assert.NotEmpty(c, payload.RuntimeID)
+	assert.False(c, payload.IngestionTimestamp.IsZero())
+}
+
+func assertConfigFilePayload(c *assert.CollectT, actual configFilePayload, expected configFilePayloadExpectation) {
+	c.Helper()
+
+	assertAgentDiscoveryPayload(c, actual.payload, expected.integrationName)
+
+	assert.Equal(c, expected.configPath, actual.config.Path)
+	assert.Equal(c, expected.payloadFormat, actual.config.PayloadFormat)
+	assert.False(c, actual.config.Truncated)
+}
+
+func findConfigFilePayloads(payloads []*aggregator.AgentDiscoveryPayload, integrationName string, configPath string) []configFilePayload {
+	var configFilePayloads []configFilePayload
 	for _, payload := range payloads {
-		if payload.Integration != configFilesDiscoveryRedisIntegrationName {
+		if payload.Integration != integrationName {
 			continue
 		}
 		for _, config := range payload.ConfigFiles {
-			if config.Path == configFilesDiscoveryRedisContainerPath {
-				return payload, config, true
+			if config.Path == configPath {
+				configFilePayloads = append(configFilePayloads, configFilePayload{
+					payload: payload,
+					config:  config,
+				})
 			}
 		}
 	}
-	return nil, aggregator.AgentDiscoveryConfigFile{}, false
+	return configFilePayloads
+}
+
+func findEnvPayloads(payloads []*aggregator.AgentDiscoveryPayload, integrationName string) []*aggregator.AgentDiscoveryPayload {
+	var envPayloads []*aggregator.AgentDiscoveryPayload
+	for _, payload := range payloads {
+		if payload.Integration == integrationName && payload.Runtime == dockerRuntime && len(payload.EnvVars) > 0 {
+			envPayloads = append(envPayloads, payload)
+		}
+	}
+	return envPayloads
 }
 
 func (s *configFilesDiscoveryDockerSuite) logConfigFilesDiscoveryDebug(t *testing.T) {

--- a/test/new-e2e/tests/discovery/testdata/compose/docker-compose.configfilesdiscovery-kafka.yaml
+++ b/test/new-e2e/tests/discovery/testdata/compose/docker-compose.configfilesdiscovery-kafka.yaml
@@ -1,0 +1,72 @@
+services:
+  kafka-env-configfilesdiscovery:
+    image: 669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/confluentinc/cp-kafka:7.7.0@sha256:1fa3cdb3ef77b75bc56e7040bbdfa2bd6950b6ee6363381b2493f7a83e07a0b3
+    container_name: kafka-env-configfilesdiscovery
+    # Keep the Kafka image running without a broker process or properties path,
+    # so discovery has to rely on the container environment.
+    entrypoint:
+      - /bin/sh
+      - -c
+    command:
+      - "trap : TERM INT; sleep 2147483647 & wait"
+    environment:
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+      KAFKA_CFG_OAUTH_ACCESS_TOKEN: must-not-be-forwarded
+      KAFKA_NODE_ID: "1"
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL: https://identity.example/oauth2/token
+    labels:
+      com.datadoghq.ad.checks: |
+        {
+          "kafka": {
+            "init_config": {
+              "is_jmx": true,
+              "collect_default_metrics": true
+            },
+            "instances": [
+              {
+                "host": "%%host%%",
+                "port": 9999
+              }
+            ]
+          }
+        }
+
+  kafka-configfilesdiscovery-default:
+    image: 669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/confluentinc/cp-kafka:7.7.0@sha256:1fa3cdb3ef77b75bc56e7040bbdfa2bd6950b6ee6363381b2493f7a83e07a0b3
+    container_name: kafka-configfilesdiscovery-default
+    command:
+      - /bin/bash
+      - /configfilesdiscovery/start-kafka.sh
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-configfilesdiscovery-default:29093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:29093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-configfilesdiscovery-default:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_BROKER_RACK: configfilesdiscovery-e2e-sentinel
+      KAFKA_JMX_PORT: 9999
+      KAFKA_JMX_HOSTNAME: kafka-configfilesdiscovery-default
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+    labels:
+      com.datadoghq.ad.checks: |
+        {
+          "kafka": {
+            "init_config": {
+              "is_jmx": true,
+              "collect_default_metrics": true
+            },
+            "instances": [
+              {
+                "host": "%%host%%",
+                "port": 9999
+              }
+            ]
+          }
+        }
+    volumes:
+      - ${CONFIG_FILES_DISCOVERY_KAFKA_CONFIG_DIR}:/configfilesdiscovery:ro

--- a/test/new-e2e/tests/discovery/testdata/compose/docker-compose.configfilesdiscovery-postgres.yaml
+++ b/test/new-e2e/tests/discovery/testdata/compose/docker-compose.configfilesdiscovery-postgres.yaml
@@ -1,0 +1,25 @@
+services:
+  postgres-configfilesdiscovery:
+    image: 669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/postgres:16@sha256:e17e86066e5ef83e0952a9347f5c792b7ece00972e2aa787a6986f471b3dd3d5
+    container_name: postgres-configfilesdiscovery
+    # No command override: the image's normal bare `postgres` startup (PGDATA,
+    # initdb, postgresql.conf generation) is the realistic deployment scenario.
+    environment:
+      POSTGRES_DB: configfilesdiscovery
+      POSTGRES_USER: configfilesdiscovery
+      POSTGRES_PASSWORD: must-not-be-forwarded
+    labels:
+      com.datadoghq.ad.checks: |
+        {
+          "postgres": {
+            "instances": [
+              {
+                "host": "%%host%%",
+                "port": 5432,
+                "username": "configfilesdiscovery",
+                "password": "must-not-be-forwarded",
+                "dbname": "configfilesdiscovery"
+              }
+            ]
+          }
+        }

--- a/test/new-e2e/tests/discovery/testdata/compose/docker-compose.configfilesdiscovery-redis.yaml
+++ b/test/new-e2e/tests/discovery/testdata/compose/docker-compose.configfilesdiscovery-redis.yaml
@@ -1,0 +1,72 @@
+services:
+  redis-env-configfilesdiscovery:
+    image: ghcr.io/datadog/redis:{APPS_VERSION}
+    container_name: redis-env-configfilesdiscovery
+    # Keep the image running without redis-server or a config path so discovery
+    # has to rely on the container environment.
+    entrypoint:
+      - /bin/sh
+      - -c
+    command:
+      - "trap : TERM INT; sleep 2147483647 & wait"
+    environment:
+      REDIS_AOF_ENABLED: "yes"
+      REDIS_PASSWORD: must-not-be-forwarded
+      REDIS_PORT_NUMBER: "6380"
+      REDIS_REQUIREPASS: must-not-be-forwarded
+      REDIS_TLS_CERT_FILE: /etc/redis/tls.crt
+    labels:
+      com.datadoghq.ad.checks: |
+        {
+          "redisdb": {
+            "instances": [
+              {
+                "host": "%%host%%",
+                "port": 6380
+              }
+            ]
+          }
+        }
+
+  redis-configfilesdiscovery-explicit:
+    image: ghcr.io/datadog/redis:{APPS_VERSION}
+    container_name: redis-configfilesdiscovery-explicit
+    command:
+      - /bin/sh
+      - /configfilesdiscovery/start-redis.sh
+    labels:
+      com.datadoghq.ad.checks: |
+        {
+          "redisdb": {
+            "instances": [
+              {
+                "host": "%%host%%",
+                "port": 6379
+              }
+            ]
+          }
+        }
+    volumes:
+      - ${CONFIG_FILES_DISCOVERY_REDIS_CONFIG_DIR}:/configfilesdiscovery:ro
+
+  redis-configfilesdiscovery-default:
+    image: ghcr.io/datadog/redis:{APPS_VERSION}
+    container_name: redis-configfilesdiscovery-default
+    command:
+      - /bin/sh
+      - /configfilesdiscovery/start-default-redis.sh
+    labels:
+      com.datadoghq.ad.checks: |
+        {
+          "redisdb": {
+            "instances": [
+              {
+                "host": "%%host%%",
+                "port": 6379
+              }
+            ]
+          }
+        }
+    volumes:
+      - ${CONFIG_FILES_DISCOVERY_REDIS_CONFIG_DIR}:/configfilesdiscovery:ro
+      - ${CONFIG_FILES_DISCOVERY_REDIS_CONFIG_DIR}/redis-default.conf:/etc/redis/redis.conf:ro


### PR DESCRIPTION
## What does this PR do?

Adds a PostgreSQL collector to Config Files Discovery (`comp/core/configfilesdiscovery`), modeled on the Redis collector added in #54375.

It collects:
- `postgresql.conf`, resolved via (in order) an explicit `config_file` argv setting, an explicit `-D` data directory, or a `PGDATA`-derived fallback (`$PGDATA/postgresql.conf`). No default path is hardcoded — without an explicit source or a usable `PGDATA`, no file is collected.
- A small allow-listed set of non-secret environment variables: `PGDATA`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_HOST_AUTH_METHOD`, `POSTGRES_INITDB_WALDIR`. Everything else — passwords, `PGSSL*`, `DATABASE_URL`, `POSTGRES_INITDB_ARGS`, etc. — is excluded by an explicit deny-list on top of the shared secret-name filter.

Ambiguous or conflicting config sources (e.g. differing `-D` values across live processes, or an explicit-but-empty `config_file`) block collection rather than guessing.

Also:
- Registers the collector in `fx.go`.
- Regenerates the affected `BUILD.bazel` files via gazelle/buildifier.
- Extends the Docker E2E discovery suite with a Postgres fixture (`postgres:16`, pinned by digest via the ECR pull-through cache) and `TestPostgresConfigFilePayloadSentToEventPlatform`, verifying the payload, allowed env vars, and that no password-shaped variable is ever forwarded.

## Motivation

Extends Config Files Discovery's existing Redis/Kafka coverage to PostgreSQL.

## Describe how you validated your changes

- `dda inv test --targets=./comp/core/configfilesdiscovery/...` — all unit tests pass.
- `dda inv linter.go` — clean.
- `dda inv agent.build --build-exclude=systemd` — builds successfully.
- `bazel build //comp/core/configfilesdiscovery/...` — succeeds.
- Opening as a **draft** to let the Docker E2E discovery suite run in CI (the live/local run against provisioned AWS infra was not run locally).

## Possible Drawbacks / Trade-offs

- Uses `PAYLOAD_FORMAT_PROPERTIES` since no dedicated PostgreSQL payload format enum exists yet.
- Only launch commands that literally exec `postgres` are recognized; custom wrappers that never exec it are unsupported.
- Host/systemd PostgreSQL is unsupported (Config Files Discovery has no `RuntimeHost` reader).
- `*_FILE` variants (e.g. `POSTGRES_DB_FILE`) and locale/timezone/`POSTGRES_INITDB_ARGS` variables are intentionally not allow-listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)