### PR TITLE
fix(aix): read ADP version from MODULE.bazel after Bazel migration

### DIFF
--- a/packaging/aix/stages/00-checkout.sh
+++ b/packaging/aix/stages/00-checkout.sh
@@ -65,7 +65,7 @@ fi
 log "Agent source found at $AGENT_SRC"
 log "  go.mod: $(head -1 "$AGENT_SRC"/go.mod)"
 
-# ─── Step 2: Read dependency versions from release.json ───────────────────────
+# ─── Step 2: Read dependency versions from release.json and MODULE.bazel ───────
 
 RELEASE_JSON="$AGENT_SRC/release.json"
 if [ ! -f "$RELEASE_JSON" ]; then
@@ -84,17 +84,16 @@ fi
 
 log "INTEGRATIONS_CORE_VERSION = $INTEGRATIONS_CORE_VERSION"
 
-ADP_JSON="$AGENT_SRC/deps/adp.json"
+ADP_MODULE="$AGENT_SRC/deps/agent_data_plane/agent_data_plane.MODULE.bazel"
 if [ -z "${AGENT_DATA_PLANE_VERSION:-}" ]; then
-    if [ ! -f "$ADP_JSON" ]; then
-        log "ERROR: $ADP_JSON not found — is the source tree complete?"
+    if [ ! -f "$ADP_MODULE" ]; then
+        log "ERROR: $ADP_MODULE not found — is the source tree complete?"
         exit 1
     fi
-    AGENT_DATA_PLANE_VERSION=$(python3.12 -c \
-        "import json; print(json.load(open('$ADP_JSON'))['version'])")
+    AGENT_DATA_PLANE_VERSION=$(sed -n 's/^VERSION = "\(.*\)".*/\1/p' "$ADP_MODULE" | head -1)
 fi
 if [ -z "$AGENT_DATA_PLANE_VERSION" ]; then
-    log "ERROR: Could not read AGENT_DATA_PLANE_VERSION from $ADP_JSON"
+    log "ERROR: Could not read AGENT_DATA_PLANE_VERSION from $ADP_MODULE"
     exit 1
 fi
 log "AGENT_DATA_PLANE_VERSION = $AGENT_DATA_PLANE_VERSION"


### PR DESCRIPTION
## What does this PR do?

Updates `packaging/aix/stages/00-checkout.sh` to read the Agent Data Plane (ADP) version from `deps/agent_data_plane/agent_data_plane.MODULE.bazel` instead of the removed `deps/adp.json`.

## Motivation

`deps/adp.json` was deleted when ADP was migrated to Bazel (commit `7c46576c1a0`), but the AIX checkout stage still read it, breaking the BFF build at stage 00.

## Validate

Full clean BFF build on the AIX host (latest `main`): all 12 stages + `mkinstallp` succeeded, producing a valid `datadog-agent` installp fileset (VRMF `7.83.0.1`).