### PR TITLE
fix(ci): make Oracle functional test manual

### DIFF
--- a/.gitlab/test/functional_test/oracle.yml
+++ b/.gitlab/test/functional_test/oracle.yml
@@ -6,7 +6,7 @@ oracle:
   needs: ["go_deps"]
   rules:
     - !reference [.except_mergequeue]
-    - when: on_success
+    - when: manual
   services:
     - alias: "oracle"
       name: "registry.ddbuild.io/images/mirror/oracle:${DBMS_VERSION}"


### PR DESCRIPTION
### What does this PR do?

Changes the `oracle: [21.3.0-xe]` functional-test job from automatically scheduled to manually triggered. The job remains excluded from merge queues and allowed to fail.

### Motivation

The Oracle functional test is currently failing consistently across unrelated branches with `ORA-12514` connection errors. Running it automatically consumes CI resources without providing an actionable signal. Making it manual keeps the job available for investigation while avoiding automatic runs until the underlying issue is fixed.

The tradeoff is that Oracle functional-test coverage must be triggered explicitly during this period.

### Describe how you validated your changes

- Ran `dda inv linter.gitlab-ci`.
- Ran the repository pre-commit and pre-push hooks, including GitLab configuration validation, Go tests, and Go lint.
- Ran `codex review --base main`; no issues were found.