### PR TITLE
Revert "Fail fast for real on unusable `XDG_CACHE_HOME` on Windows"

### DIFF
--- a/.gitlab/windows/build/lint/windows.yml
+++ b/.gitlab/windows/build/lint/windows.yml
@@ -1,7 +1,7 @@
 .lint_windows_base:
   stage: lint
   needs: ["go_deps", "go_tools_deps"]
-  extends: [.windows_docker_default, .bazel:defs:cache:windows]
+  extends: .windows_docker_default
   script:
     - $ErrorActionPreference = "Stop"
     - !reference [.sanitize_goproxy_windows]
@@ -11,9 +11,11 @@
     # Windows jobs are using either 8Gb or 16Gb of memory so we can limit memory to 16Gb on this job because even if we decided to limit to 10Gb for instance,
     # it would leave 6Gb free but we could not fit another job with these 6Gb remaining.
     - >
-      .\tools\ci\docker-run-with-bazel-cache.ps1
+      docker run --rm
       -m 24576M
+      --storage-opt "size=50GB"
       -v "$(Get-Location):c:\mnt"
+      -e CI
       -e GITLAB_CI
       -e DDA_FEATURE_FLAGS_CI_SSM_KEY_WINDOWS="${DDA_FEATURE_FLAGS_CI_SSM_KEY_WINDOWS}"
       -e AWS_NETWORKING=true

--- a/.gitlab/windows/build/package_build/windows.yml
+++ b/.gitlab/windows/build/package_build/windows.yml
@@ -1,7 +1,7 @@
 ---
 .windows_msi_base:
   stage: package_build
-  extends: [.windows_docker_default, .bazel:defs:cache:windows]
+  extends: [.windows_docker_default, .bazel:defs:cache:windows]  # the latter for `bazel run @openssl//:install`
   needs: ["go_deps"]
   script:
     - $ErrorActionPreference = 'Stop'
@@ -93,7 +93,7 @@ windows_msi_and_bosh_zip_x64-a7-fips:
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
-  extends: [.windows_docker_default, .bazel:defs:cache:windows]
+  extends: .windows_docker_default
   needs: ["go_deps"]
   variables:
     ARCH: "x64"
@@ -105,9 +105,10 @@ windows_msi_and_bosh_zip_x64-a7-fips:
     - if (Test-Path omnibus\pkg) { remove-item -recurse -force omnibus\pkg }
     - mkdir omnibus\pkg
     - >
-      .\tools\ci\docker-run-with-bazel-cache.ps1
+      docker run --rm
       -m 24576M
       -v "$(Get-Location):c:\mnt"
+      -e CI
       -e GITLAB_CI
       -e CI_COMMIT_BRANCH
       -e CI_PIPELINE_ID

--- a/.gitlab/windows/test/integration_test/windows.yml
+++ b/.gitlab/windows/test/integration_test/windows.yml
@@ -5,7 +5,7 @@
     - !reference [.except_mergequeue]
     - when: on_success
   needs: ["go_deps", "go_tools_deps"]
-  extends: [.windows_docker_default, .bazel:defs:cache:windows]
+  extends: .windows_docker_default
   before_script:
     - $tmpfile = [System.IO.Path]::GetTempFileName()
     - (& "$CI_PROJECT_DIR\tools\ci\fetch_secret.ps1" -parameterName "$Env:VCPKG_BLOB_SAS_URL" -parameterField url -tempFile "$tmpfile")
@@ -18,9 +18,10 @@
     # we pass in CI_JOB_URL and CI_JOB_NAME so that they can be added to additional tags
     # inside JUNIT_TAR and then later used by datadog-ci
     - >
-      .\tools\ci\docker-run-with-bazel-cache.ps1
+      docker run --rm
       -m 16384M
       -v "$(Get-Location):c:\mnt"
+      -e CI
       -e GITLAB_CI
       -e DDA_FEATURE_FLAGS_CI_SSM_KEY_WINDOWS="${DDA_FEATURE_FLAGS_CI_SSM_KEY_WINDOWS}"
       -e CI_JOB_URL

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -11,7 +11,10 @@ exit /b 2
 :: Ensure `XDG_CACHE_HOME` denotes a directory
 if not defined DOTNET_RUNNING_IN_CONTAINER >nul 2>&1 sc query CExecSvc && set DOTNET_RUNNING_IN_CONTAINER=1
 if not exist "%XDG_CACHE_HOME%" (
-  if defined CI goto :error_xdg_cache_home_must_exist
+  if defined CI (
+    >&2 echo 🔴 XDG_CACHE_HOME ^(!XDG_CACHE_HOME!^) must denote a directory in CI!
+    exit /b 2
+  )
   if defined DOTNET_RUNNING_IN_CONTAINER (
     >&2 echo 💡 To persist caches across restarts, please set XDG_CACHE_HOME pointing to a mounted directory, e.g.:
     >&2 echo     docker.exe run --env=XDG_CACHE_HOME=C:\cache --volume="$HOME\.cache:C:\cache" ...
@@ -22,7 +25,10 @@ if not exist "%XDG_CACHE_HOME%" (
 set "extra_args="
 if defined XDG_CACHE_HOME (
   set "XDG_CACHE_HOME=!XDG_CACHE_HOME:/=\!"
-  if "!XDG_CACHE_HOME:~1,2!" neq ":\" if "!XDG_CACHE_HOME:~0,2!" neq "\\" goto :error_xdg_cache_home_must_be_absolute
+  if "!XDG_CACHE_HOME:~1,2!" neq ":\" if "!XDG_CACHE_HOME:~0,2!" neq "\\" (
+    >&2 echo 🔴 XDG_CACHE_HOME ^(!XDG_CACHE_HOME!^) must denote an absolute path!
+    exit /b 2
+  )
   set "GOCACHE=!XDG_CACHE_HOME!\go-build"
   set "GOMODCACHE=!XDG_CACHE_HOME!\go\mod"
   set "PIP_CACHE_DIR=!XDG_CACHE_HOME!\pip"
@@ -76,14 +82,6 @@ set "args=%*"
 if defined args if defined extra_args call :insert_extra_args
 "%BAZEL_REAL%" !startup_options! !args!
 exit /b !errorlevel!
-
-:error_xdg_cache_home_must_exist
->&2 echo 🔴 XDG_CACHE_HOME ^(!XDG_CACHE_HOME!^) must denote a directory in CI
-exit /b 2
-
-:error_xdg_cache_home_must_be_absolute
->&2 echo 🔴 XDG_CACHE_HOME ^(!XDG_CACHE_HOME!^) must denote an absolute path
-exit /b 2
 
 :: "--startup cmd ..." -> "--startup cmd --config=ci ..."
 :insert_extra_args


### PR DESCRIPTION
Reverts DataDog/datadog-agent#54958
#incident-59369
Since this PR was merged it seems the memory allocation error is more consistent.
Tentative revert to assess the impact