### PR TITLE
Set GIT_DEPTH: 1000 for bazel jobs that upload junit data via datadog-ci

### DIFF
--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -16,6 +16,7 @@
     EXTERNAL_LINKS_PATH: external_links_$CI_JOB_ID.json
     BEP_FILE: $CI_PROJECT_DIR/bazel-bep.json
     RESULT_JSON: test_output.json
+    GIT_DEPTH: 1000  # Needed by datadog-ci to collect git metadata
   after_script:
     - dda inv -- -e bazel.process-test-results --bep-file=$BEP_FILE --junit-tar=junit-${CI_JOB_NAME}.tgz --result-json=$RESULT_JSON
     - !reference [.upload_junit_source]


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

It changes the GIT_DEPTH for bazel jobs that include junit uploads to 1000, in order to avoid errors and extra job duration time from datadog-ci attempting to retrieve more of the history.

### Motivation

https://github.com/DataDog/datadog-agent/pull/54834 set the default GIT_DEPTH to 1 (shallow clone). That causes errors from datadog-ci junit upload command (like [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1960273838/viewer#L5866)), and makes the savings from the shadow clone be undone by the time that command spends attempting to fetch more git history without success. 

### Describe how you validated your changes

The `coverage` job got faster by ~2 minutes (from 6m to 4m) and the error logs are gone: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1961189801

### Additional Notes

- This is a mitigation, probably not an appropriate longterm solution.
- I also attempted lower numbers of GIT_DEPTH but they hit the same code path.
- The error is coming from [here](https://github.com/DataDog/datadog-ci/blob/d5284b8f22d3981b9adb104434aa859cf37fd0b3/packages/base/src/commands/git-metadata/gitdb.ts#L193-L200). `MAX_HISTORY.oldestCommits` happens to be 1000, which is one of the reasons I ended up settling on this number.
- 1000 is low enough that the git fetching step takes ~40 seconds, while making the job not waste time on the junit upload stage.