### PR TITLE
Add PostgreSQL collector for Config Files Discovery

### DIFF
--- a/comp/core/configfilesdiscovery/fx/fx.go
+++ b/comp/core/configfilesdiscovery/fx/fx.go
@@ -65,8 +65,9 @@ func newOptionalComponent(reqs Requires) Provides {
 		WorkloadMeta:  reqs.WorkloadMeta,
 		EventPlatform: reqs.EventPlatform,
 		Collectors: map[string]configfilesdiscoveryimpl.ConfigCollector{
-			collectors.KafkaIntegrationName: collectors.NewKafka(),
-			collectors.RedisIntegrationName: collectors.NewRedis(),
+			collectors.KafkaIntegrationName:    collectors.NewKafka(),
+			collectors.PostgresIntegrationName: collectors.NewPostgres(),
+			collectors.RedisIntegrationName:    collectors.NewRedis(),
 		},
 	})
 	return Provides{Comp: option.New(provides.Comp)}

--- a/comp/core/configfilesdiscovery/impl/collectors/BUILD.bazel
+++ b/comp/core/configfilesdiscovery/impl/collectors/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "doc.go",
         "helpers.go",
         "kafka.go",
+        "postgres.go",
         "redis.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/impl/collectors",
@@ -23,6 +24,7 @@ dd_agent_go_test(
     srcs = [
         "helpers_test.go",
         "kafka_test.go",
+        "postgres_test.go",
         "redis_test.go",
     ],
     embed = [":collectors"],

--- a/comp/core/configfilesdiscovery/impl/collectors/postgres.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/postgres.go
@@ -1,0 +1,212 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package collectors
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/DataDog/agent-payload/v5/agentdiscovery"
+	configfilesdiscoveryimpl "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	PostgresIntegrationName     = "postgres"
+	postgresConfigPayloadFormat = agentdiscovery.AgentDiscoveryConfigFilePayloadFormat_PAYLOAD_FORMAT_PROPERTIES
+	postgresConfigFileName      = "postgresql.conf"
+)
+
+type postgresConfigCollector struct{}
+
+// postgresEnvAllow lists the only environment variables this collector ever
+// forwards. PostgreSQL's official image and PGDATA/PG* variables otherwise
+// carry credentials, connection strings, or arbitrary argument bags.
+var postgresEnvAllow = map[string]struct{}{
+	"PGDATA":                    {},
+	"POSTGRES_DB":               {},
+	"POSTGRES_USER":             {},
+	"POSTGRES_HOST_AUTH_METHOD": {},
+	"POSTGRES_INITDB_WALDIR":    {},
+}
+
+// postgresEnvDeny is defense in depth and documentation: the allow-list above
+// already excludes every name here. Keeping the exclusion explicit protects
+// against the allow-list being loosened later without revisiting these.
+var postgresEnvDeny = map[string]struct{}{
+	"POSTGRES_PASSWORD":      {},
+	"POSTGRES_PASSWORD_FILE": {},
+	"POSTGRES_INITDB_ARGS":   {},
+	"PGPASSWORD":             {},
+	"PGPASSFILE":             {},
+	"PGSERVICE":              {},
+	"PGSERVICEFILE":          {},
+	"PGOPTIONS":              {},
+	"PGSSLKEY":               {},
+	"PGSSLCERT":              {},
+	"PGSSLROOTCERT":          {},
+	"PGREQUIRESSL":           {},
+	"DATABASE_URL":           {},
+	"POSTGRES_URL":           {},
+}
+
+func NewPostgres() configfilesdiscoveryimpl.ConfigCollector {
+	return postgresConfigCollector{}
+}
+
+// CanCollectFromProcess returns whether the command line contains an explicit,
+// resolvable PostgreSQL config source.
+func (postgresConfigCollector) CanCollectFromProcess(commandline configfilesdiscoveryimpl.TargetCommandline) bool {
+	configArg, ok := postgresGetConfigArgFromCommandline(commandline.Args)
+	if !ok {
+		return false
+	}
+	_, resolved := resolveConfigPath(configArg, commandline.WorkingDir)
+	return resolved
+}
+
+func (c postgresConfigCollector) Collect(ctx context.Context, reader configfilesdiscoveryimpl.ConfigReader) (configfilesdiscoveryimpl.CollectedConfig, error) {
+	envVars, envErr := readEnvVars(ctx, reader, includePostgresEnvVar)
+	if envErr != nil {
+		log.Debugf("config files discovery skipped postgres env var collection: %v", envErr)
+		envVars = nil
+	}
+
+	fallbackConfigArg := ""
+	for _, envVar := range envVars {
+		if envVar.Name == "PGDATA" && path.IsAbs(envVar.Value) {
+			fallbackConfigArg = path.Join(envVar.Value, postgresConfigFileName)
+			break
+		}
+	}
+
+	file, ok, err := readConfigFile(
+		ctx,
+		reader,
+		postgresGetConfigArgFromCommandline,
+		postgresMatchesCommandline,
+		fallbackConfigArg,
+	)
+	if err != nil {
+		return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("collect postgres config file: %w", err)
+	}
+	if !ok {
+		// Without a config file, env vars are the only PostgreSQL config
+		// source. Return the error so the scheduler retries.
+		if envErr != nil {
+			return configfilesdiscoveryimpl.CollectedConfig{}, fmt.Errorf("read postgres env vars: %w", envErr)
+		}
+		if len(envVars) == 0 {
+			log.Debugf("config files discovery skipped postgres config collection: no config file or selected env vars detected")
+			return configfilesdiscoveryimpl.CollectedConfig{}, nil
+		}
+
+		log.Debugf("config files discovery collected postgres env vars without a config file")
+		return configfilesdiscoveryimpl.CollectedConfig{
+			EnvVars: envVars,
+		}, nil
+	}
+
+	file.PayloadFormat = postgresConfigPayloadFormat
+
+	return configfilesdiscoveryimpl.CollectedConfig{
+		ConfigFiles: []configfilesdiscoveryimpl.ConfigFile{file},
+		EnvVars:     envVars,
+	}, nil
+}
+
+func includePostgresEnvVar(name string) bool {
+	if configfilesdiscoveryimpl.IsSecretEnvVarName(name) {
+		return false
+	}
+	if _, denied := postgresEnvDeny[name]; denied {
+		return false
+	}
+	_, allowed := postgresEnvAllow[name]
+	return allowed
+}
+
+// postgresGetConfigArgFromCommandline returns the explicit PostgreSQL config
+// source found in argv, in resolvable-path form: an explicit config_file
+// setting, or the postgresql.conf implied by an explicit data directory.
+func postgresGetConfigArgFromCommandline(args []string) (string, bool) {
+	args = unwrapShellCommandline(args)
+	postgresArgs, ok := postgresGetArgs(args)
+	if !ok {
+		return "", false
+	}
+	return postgresGetConfigArg(postgresArgs)
+}
+
+func postgresMatchesCommandline(args []string) bool {
+	_, ok := postgresGetArgs(unwrapShellCommandline(args))
+	return ok
+}
+
+func postgresGetArgs(args []string) ([]string, bool) {
+	for i, arg := range args {
+		if path.Base(arg) == "postgres" {
+			return args[i+1:], true
+		}
+	}
+	return nil, false
+}
+
+// postgresGetConfigArg scans postgres argv for an explicit config_file
+// run-time parameter (`-c config_file=...` or `--config_file=...`) or an
+// explicit data directory (`-D ...`), the last occurrence of either winning.
+// An explicit config_file always takes precedence over a data directory, and
+// an empty or otherwise unusable explicit value is still reported as found so
+// the shared helper blocks the PGDATA fallback and default paths rather than
+// guessing.
+func postgresGetConfigArg(postgresArgs []string) (string, bool) {
+	configFileFound := false
+	configFileArg := ""
+	dataDirFound := false
+	dataDirArg := ""
+
+	for i := 0; i < len(postgresArgs); i++ {
+		arg := postgresArgs[i]
+
+		if value, ok := strings.CutPrefix(arg, "--config_file="); ok {
+			configFileFound = true
+			configFileArg = value
+			continue
+		}
+		if arg == "-c" && i+1 < len(postgresArgs) {
+			if value, ok := strings.CutPrefix(postgresArgs[i+1], "config_file="); ok {
+				configFileFound = true
+				configFileArg = value
+				i++
+				continue
+			}
+		}
+		if arg == "-D" && i+1 < len(postgresArgs) {
+			dataDirFound = true
+			dataDirArg = postgresArgs[i+1]
+			i++
+			continue
+		}
+		if value, ok := strings.CutPrefix(arg, "-D"); ok && value != "" {
+			dataDirFound = true
+			dataDirArg = value
+			continue
+		}
+	}
+
+	if configFileFound {
+		return configFileArg, true
+	}
+	if dataDirFound {
+		if dataDirArg == "" {
+			return "", true
+		}
+		return path.Join(dataDirArg, postgresConfigFileName), true
+	}
+	return "", false
+}

--- a/comp/core/configfilesdiscovery/impl/collectors/postgres_test.go
+++ b/comp/core/configfilesdiscovery/impl/collectors/postgres_test.go
@@ -1,0 +1,464 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package collectors
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	configfilesdiscoveryimpl "github.com/DataDog/datadog-agent/comp/core/configfilesdiscovery/impl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresGetConfigPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		commandline configfilesdiscoveryimpl.TargetCommandline
+		wantPath    string
+		wantOK      bool
+	}{
+		{
+			name: "official image bare startup",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"postgres"},
+			},
+		},
+		{
+			name: "shell form",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"/bin/sh", "-c", "postgres -c config_file=/etc/postgresql/postgresql.conf"},
+			},
+			wantPath: "/etc/postgresql/postgresql.conf",
+			wantOK:   true,
+		},
+		{
+			name: "explicit config_file short option",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"},
+			},
+			wantPath: "/etc/postgresql/postgresql.conf",
+			wantOK:   true,
+		},
+		{
+			name: "explicit config_file long option",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"postgres", "--config_file=/etc/postgresql/postgresql.conf"},
+			},
+			wantPath: "/etc/postgresql/postgresql.conf",
+			wantOK:   true,
+		},
+		{
+			name: "explicit data directory",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"postgres", "-D", "/var/lib/postgresql/data"},
+			},
+			wantPath: "/var/lib/postgresql/data/postgresql.conf",
+			wantOK:   true,
+		},
+		{
+			name: "config_file wins over data directory",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"postgres", "-D", "/var/lib/postgresql/data", "-c", "config_file=/etc/postgresql/postgresql.conf"},
+			},
+			wantPath: "/etc/postgresql/postgresql.conf",
+			wantOK:   true,
+		},
+		{
+			name: "relative config_file resolved with working dir",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args:       []string{"postgres", "-c", "config_file=postgresql.conf"},
+				WorkingDir: "/etc/postgresql",
+			},
+			wantPath: "/etc/postgresql/postgresql.conf",
+			wantOK:   true,
+		},
+		{
+			name: "relative data directory resolved with working dir",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args:       []string{"postgres", "-D", "data"},
+				WorkingDir: "/var/lib/postgresql",
+			},
+			wantPath: "/var/lib/postgresql/data/postgresql.conf",
+			wantOK:   true,
+		},
+		{
+			name: "relative config_file without absolute working dir",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"postgres", "-c", "config_file=postgresql.conf"},
+			},
+		},
+		{
+			name: "empty explicit config_file value",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"postgres", "-c", "config_file="},
+			},
+		},
+		{
+			name: "postgres not present",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"pg_ctl", "start"},
+			},
+		},
+		{
+			name: "flags only, no explicit source",
+			commandline: configfilesdiscoveryimpl.TargetCommandline{
+				Args: []string{"postgres", "-p", "5432"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configArg, gotOK := postgresGetConfigArgFromCommandline(tt.commandline.Args)
+			var gotPath string
+			if gotOK {
+				gotPath, gotOK = resolveConfigPath(configArg, tt.commandline.WorkingDir)
+			}
+
+			assert.Equal(t, tt.wantOK, gotOK)
+			assert.Equal(t, tt.wantPath, gotPath)
+		})
+	}
+}
+
+func TestIncludePostgresEnvVar(t *testing.T) {
+	tests := []struct {
+		name    string
+		envName string
+		want    bool
+	}{
+		{name: "data directory", envName: "PGDATA", want: true},
+		{name: "database name", envName: "POSTGRES_DB", want: true},
+		{name: "user", envName: "POSTGRES_USER", want: true},
+		{name: "host auth method", envName: "POSTGRES_HOST_AUTH_METHOD", want: true},
+		{name: "initdb waldir", envName: "POSTGRES_INITDB_WALDIR", want: true},
+		{name: "unrelated", envName: "UNREQUESTED"},
+		{name: "lowercase", envName: "postgres_db"},
+		{name: "password", envName: "POSTGRES_PASSWORD"},
+		{name: "password file", envName: "POSTGRES_PASSWORD_FILE"},
+		{name: "initdb args", envName: "POSTGRES_INITDB_ARGS"},
+		{name: "libpq password", envName: "PGPASSWORD"},
+		{name: "libpq passfile", envName: "PGPASSFILE"},
+		{name: "libpq service", envName: "PGSERVICE"},
+		{name: "libpq servicefile", envName: "PGSERVICEFILE"},
+		{name: "libpq options", envName: "PGOPTIONS"},
+		{name: "libpq ssl key", envName: "PGSSLKEY"},
+		{name: "libpq ssl cert", envName: "PGSSLCERT"},
+		{name: "libpq ssl root cert", envName: "PGSSLROOTCERT"},
+		{name: "libpq require ssl", envName: "PGREQUIRESSL"},
+		{name: "database url", envName: "DATABASE_URL"},
+		{name: "postgres url", envName: "POSTGRES_URL"},
+		{name: "secret-shaped unrelated name", envName: "PGDATA_TOKEN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, includePostgresEnvVar(tt.envName))
+		})
+	}
+}
+
+func TestPostgresCollectorResolvesAndReadsRelativeProcessConfig(t *testing.T) {
+	eventArgs := []string{"postgres", "-D", "data"}
+	eventCommandline := configfilesdiscoveryimpl.TargetCommandline{
+		Args:       eventArgs,
+		WorkingDir: "/var/lib/postgresql",
+	}
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/usr/local/bin/docker-entrypoint.sh"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{eventCommandline},
+		file:                    configfilesdiscoveryimpl.ConfigFile{Path: "/var/lib/postgresql/data/postgresql.conf"},
+	}
+
+	collector := postgresConfigCollector{}
+	assert.False(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{Args: eventArgs}))
+	assert.True(t, collector.CanCollectFromProcess(eventCommandline))
+	assert.True(t, collector.CanCollectFromProcess(configfilesdiscoveryimpl.TargetCommandline{
+		Args: []string{"postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"},
+	}))
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/var/lib/postgresql/data/postgresql.conf"}, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+}
+
+func TestPostgresCollectorReadsDetectedConfig(t *testing.T) {
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path:    "/etc/postgresql/postgresql.conf",
+			Content: []byte("port = 5432\n"),
+		},
+		env: map[string]string{
+			"POSTGRES_USER": "app",
+			"PGDATA":        "/var/lib/postgresql/data",
+			"POSTGRES_DB":   "app",
+			"UNREQUESTED":   "value",
+		},
+	}
+	collector := NewPostgres()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/postgresql/postgresql.conf"}, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, configfilesdiscoveryimpl.ConfigFile{
+		Path:          "/etc/postgresql/postgresql.conf",
+		Content:       []byte("port = 5432\n"),
+		PayloadFormat: postgresConfigPayloadFormat,
+	}, collected.ConfigFiles[0])
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "PGDATA", Value: "/var/lib/postgresql/data"},
+		{Name: "POSTGRES_DB", Value: "app"},
+		{Name: "POSTGRES_USER", Value: "app"},
+	}, collected.EnvVars)
+}
+
+func TestPostgresCollectorCollectsEnvOnly(t *testing.T) {
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"postgres"},
+		},
+		env: map[string]string{
+			"POSTGRES_DB": "app",
+		},
+	}
+	collector := NewPostgres()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Empty(t, collected.ConfigFiles)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "POSTGRES_DB", Value: "app"},
+	}, collected.EnvVars)
+}
+
+func TestPostgresCollectorSkipsWhenNoConfigAndNoEnv(t *testing.T) {
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"postgres"},
+		},
+	}
+
+	collected, err := NewPostgres().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
+}
+
+func TestPostgresCollectorUsesPGDataFallback(t *testing.T) {
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"postgres"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path:    "/var/lib/postgresql/data/postgresql.conf",
+			Content: []byte("port = 5432\n"),
+		},
+		env: map[string]string{
+			"PGDATA": "/var/lib/postgresql/data",
+		},
+	}
+
+	collected, err := NewPostgres().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/var/lib/postgresql/data/postgresql.conf"}, reader.readFileCalls)
+	require.Len(t, collected.ConfigFiles, 1)
+	assert.Equal(t, postgresConfigPayloadFormat, collected.ConfigFiles[0].PayloadFormat)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "PGDATA", Value: "/var/lib/postgresql/data"},
+	}, collected.EnvVars)
+}
+
+func TestPostgresCollectorBlocksPGDataFallbackWhenArgvSourceUnusable(t *testing.T) {
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"postgres", "-c", "config_file="},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path: "/var/lib/postgresql/data/postgresql.conf",
+		},
+		env: map[string]string{
+			"PGDATA": "/var/lib/postgresql/data",
+		},
+	}
+
+	collected, err := NewPostgres().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Empty(t, collected.ConfigFiles)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigEnvVar{
+		{Name: "PGDATA", Value: "/var/lib/postgresql/data"},
+	}, collected.EnvVars)
+}
+
+func TestPostgresCollectorSkipsConflictingProcessConfigPaths(t *testing.T) {
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"/usr/local/bin/docker-entrypoint.sh"},
+		},
+		liveProcessCommandlines: []configfilesdiscoveryimpl.TargetCommandline{
+			{Args: []string{"postgres", "-D", "/data1"}},
+			{Args: []string{"postgres", "-D", "/data2"}},
+		},
+	}
+
+	collected, err := NewPostgres().Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Empty(t, collected.ConfigFiles)
+	assert.Empty(t, collected.EnvVars)
+}
+
+func TestPostgresCollectorReturnsCommandlineErrors(t *testing.T) {
+	expectedErr := errors.New("command line unavailable")
+	reader := &postgresCollectorTestReader{commandlineErr: expectedErr}
+	collector := NewPostgres()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Equal(t, 1, reader.processCommandlineCalls)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
+}
+
+func TestPostgresCollectorReadsDetectedConfigWhenEnvVarsFail(t *testing.T) {
+	expectedErr := errors.New("env unavailable")
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"},
+		},
+		file: configfilesdiscoveryimpl.ConfigFile{
+			Path:    "/etc/postgresql/postgresql.conf",
+			Content: []byte("port = 5432\n"),
+		},
+		readEnvVarsErr: expectedErr,
+	}
+	collector := NewPostgres()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/postgresql/postgresql.conf"}, reader.readFileCalls)
+	assert.Equal(t, []configfilesdiscoveryimpl.ConfigFile{
+		{
+			Path:          "/etc/postgresql/postgresql.conf",
+			Content:       []byte("port = 5432\n"),
+			PayloadFormat: postgresConfigPayloadFormat,
+		},
+	}, collected.ConfigFiles)
+	assert.Empty(t, collected.EnvVars)
+}
+
+func TestPostgresCollectorReturnsEnvVarErrorsWithoutConfigPath(t *testing.T) {
+	expectedErr := errors.New("env unavailable")
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"postgres"},
+		},
+		readEnvVarsErr: expectedErr,
+	}
+	collector := NewPostgres()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Empty(t, reader.readFileCalls)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
+}
+
+func TestPostgresCollectorReturnsReadFileErrors(t *testing.T) {
+	expectedErr := errors.New("read failed")
+	reader := &postgresCollectorTestReader{
+		runtimeCommandline: configfilesdiscoveryimpl.TargetCommandline{
+			Args: []string{"postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"},
+		},
+		readFileErr: expectedErr,
+	}
+	collector := NewPostgres()
+
+	collected, err := collector.Collect(context.Background(), reader)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Equal(t, []string{"/etc/postgresql/postgresql.conf"}, reader.readFileCalls)
+	assert.Equal(t, configfilesdiscoveryimpl.CollectedConfig{}, collected)
+}
+
+type postgresCollectorTestReader struct {
+	runtimeCommandline      configfilesdiscoveryimpl.TargetCommandline
+	liveProcessCommandlines []configfilesdiscoveryimpl.TargetCommandline
+	commandlineErr          error
+	runtimeCommandlineCalls int
+	processCommandlineCalls int
+	readFileCalls           []string
+	file                    configfilesdiscoveryimpl.ConfigFile
+	readFileErr             error
+	env                     map[string]string
+	readEnvVarsErr          error
+}
+
+func (r *postgresCollectorTestReader) Runtime() configfilesdiscoveryimpl.RuntimeType {
+	return configfilesdiscoveryimpl.RuntimeDocker
+}
+
+func (r *postgresCollectorTestReader) Close() {}
+
+func (r *postgresCollectorTestReader) ReadFile(_ context.Context, path string) (configfilesdiscoveryimpl.ConfigFile, error) {
+	r.readFileCalls = append(r.readFileCalls, path)
+	if r.readFileErr != nil {
+		return configfilesdiscoveryimpl.ConfigFile{}, r.readFileErr
+	}
+	if r.file.Path == path {
+		return r.file, nil
+	}
+	return configfilesdiscoveryimpl.ConfigFile{}, errors.New("file not found")
+}
+
+func (r *postgresCollectorTestReader) ReadEnvVars(_ context.Context, predicate configfilesdiscoveryimpl.ConfigEnvVarPredicate) (map[string]string, error) {
+	if r.readEnvVarsErr != nil {
+		return nil, r.readEnvVarsErr
+	}
+
+	env := make(map[string]string)
+	for name, value := range r.env {
+		if configfilesdiscoveryimpl.IsSecretEnvVarName(name) {
+			continue
+		}
+		if predicate != nil && !predicate(name) {
+			continue
+		}
+		env[name] = value
+	}
+	return env, nil
+}
+
+func (r *postgresCollectorTestReader) ReadRuntimeCommandline(context.Context) (configfilesdiscoveryimpl.TargetCommandline, error) {
+	r.runtimeCommandlineCalls++
+	if r.commandlineErr != nil {
+		return configfilesdiscoveryimpl.TargetCommandline{}, r.commandlineErr
+	}
+	return r.runtimeCommandline, nil
+}
+
+func (r *postgresCollectorTestReader) ReadLiveProcessCommandlines(context.Context) []configfilesdiscoveryimpl.TargetCommandline {
+	r.processCommandlineCalls++
+	return r.liveProcessCommandlines
+}

--- a/test/new-e2e/tests/discovery/configfilesdiscovery_docker_test.go
+++ b/test/new-e2e/tests/discovery/configfilesdiscovery_docker_test.go
@@ -64,11 +64,24 @@ const (
 	kafkaTokenEndpoint    = "https://identity.example/oauth2/token"
 )
 
+const (
+	postgresConfigDir       = "/tmp/configfilesdiscovery-postgres"
+	postgresContainerName   = "postgres-configfilesdiscovery"
+	postgresContainerPGData = "/var/lib/postgresql/data"
+	postgresContainerPath   = postgresContainerPGData + "/postgresql.conf"
+	postgresIntegrationName = "postgres"
+	postgresDBName          = "configfilesdiscovery"
+	postgresUser            = "configfilesdiscovery"
+)
+
 //go:embed testdata/compose/docker-compose.configfilesdiscovery-redis.yaml
 var redisComposeTemplate string
 
 //go:embed testdata/compose/docker-compose.configfilesdiscovery-kafka.yaml
 var kafkaCompose string
+
+//go:embed testdata/compose/docker-compose.configfilesdiscovery-postgres.yaml
+var postgresCompose string
 
 const redisExplicitConfig = `port 6379
 appendonly no
@@ -152,6 +165,7 @@ func TestConfigFilesDiscoveryDockerSuite(t *testing.T) {
 		dockeragentparams.WithAgentServiceEnvVariable("DD_CONFIG_FILES_DISCOVERY_STARTUP_JITTER", pulumi.StringPtr("0s")),
 		dockeragentparams.WithExtraComposeManifest("configfilesdiscovery-redis", pulumi.String(redisCompose)),
 		dockeragentparams.WithExtraComposeManifest("configfilesdiscovery-kafka", pulumi.String(kafkaCompose)),
+		dockeragentparams.WithExtraComposeManifest("configfilesdiscovery-postgres", pulumi.String(postgresCompose)),
 		dockeragentparams.WithEnvironmentVariables(pulumi.StringMap{
 			"CONFIG_FILES_DISCOVERY_REDIS_CONFIG_DIR": pulumi.String(redisConfigDir),
 			"CONFIG_FILES_DISCOVERY_KAFKA_CONFIG_DIR": pulumi.String(kafkaConfigDir),
@@ -496,6 +510,50 @@ func (s *configFilesDiscoveryDockerSuite) TestRedisConfigFilesDiscoveredAndHeart
 			}
 		}
 	}, 3*time.Minute, 10*time.Second, "timed out waiting for config files discovery payload")
+}
+
+func (s *configFilesDiscoveryDockerSuite) TestPostgresConfigFilePayloadSentToEventPlatform() {
+	t := s.T()
+	s.prepareConfigFilesDiscoveryContainers(t, configFilesDiscoveryContainerFixture{
+		integrationName: postgresIntegrationName,
+		configDir:       postgresConfigDir,
+		containerNames:  []string{postgresContainerName},
+	})
+
+	expectedPostgresPayload := configFilePayloadExpectation{
+		integrationName: postgresIntegrationName,
+		configPath:      postgresContainerPath,
+		payloadFormat:   agentdiscovery.AgentDiscoveryConfigFilePayloadFormat_PAYLOAD_FORMAT_PROPERTIES,
+	}
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, isIntegrationScheduled(s.Env().Agent.Client.ConfigCheck(), postgresIntegrationName))
+
+		payloads, err := s.Env().FakeIntake.Client().GetAgentDiscoveryPayloads()
+		if !assert.NoError(c, err) {
+			return
+		}
+		postgresPayloads := findConfigFilePayloads(payloads, postgresIntegrationName, postgresContainerPath)
+		if !assert.NotEmpty(c, postgresPayloads, "no postgres config payload found in %+v", payloads) {
+			return
+		}
+
+		for _, postgresPayload := range postgresPayloads {
+			assertConfigFilePayload(c, postgresPayload, expectedPostgresPayload)
+			assert.NotEmpty(c, postgresPayload.config.Content)
+
+			envVars := make(map[string]string, len(postgresPayload.payload.EnvVars))
+			for _, envVar := range postgresPayload.payload.EnvVars {
+				envVars[envVar.Name] = envVar.Value
+			}
+			assert.Equal(c, postgresContainerPGData, envVars["PGDATA"])
+			assert.Equal(c, postgresDBName, envVars["POSTGRES_DB"])
+			assert.Equal(c, postgresUser, envVars["POSTGRES_USER"])
+			assert.NotContains(c, envVars, "POSTGRES_PASSWORD")
+			for name := range envVars {
+				assert.NotContains(c, strings.ToUpper(name), "PASSWORD")
+			}
+		}
+	}, 3*time.Minute, 10*time.Second, "timed out waiting for postgres config file discovery payload")
 }
 
 type configFilePayload struct {

--- a/test/new-e2e/tests/discovery/testdata/compose/docker-compose.configfilesdiscovery-postgres.yaml
+++ b/test/new-e2e/tests/discovery/testdata/compose/docker-compose.configfilesdiscovery-postgres.yaml
@@ -1,0 +1,25 @@
+services:
+  postgres-configfilesdiscovery:
+    image: 669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/postgres:16@sha256:e17e86066e5ef83e0952a9347f5c792b7ece00972e2aa787a6986f471b3dd3d5
+    container_name: postgres-configfilesdiscovery
+    # No command override: the image's normal bare `postgres` startup (PGDATA,
+    # initdb, postgresql.conf generation) is the realistic deployment scenario.
+    environment:
+      POSTGRES_DB: configfilesdiscovery
+      POSTGRES_USER: configfilesdiscovery
+      POSTGRES_PASSWORD: must-not-be-forwarded
+    labels:
+      com.datadoghq.ad.checks: |
+        {
+          "postgres": {
+            "instances": [
+              {
+                "host": "%%host%%",
+                "port": 5432,
+                "username": "configfilesdiscovery",
+                "password": "must-not-be-forwarded",
+                "dbname": "configfilesdiscovery"
+              }
+            ]
+          }
+        }


### PR DESCRIPTION
## What does this PR do?

Adds a PostgreSQL collector to Config Files Discovery, following the model established by the Redis collector (#54375). It locates `postgresql.conf` from the `postgres` process's argv (`-c config_file=...` or `-D <data-dir>`), falling back to `PGDATA`-derived path only when no explicit argv source is present, and forwards a small allow-listed set of non-secret environment variables (`PGDATA`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_HOST_AUTH_METHOD`, `POSTGRES_INITDB_WALDIR`), filtered again through the shared secret-name heuristic. No config file is ever guessed, and no credentials or secret-shaped variables are ever forwarded.

## Motivation

Extends Config Files Discovery to PostgreSQL, mirroring the Redis and Kafka collectors already in this component.

## Describe how you validated your changes

- Unit tests: `dda inv test --targets=./comp/core/configfilesdiscovery/...` — 302/302 passed, covering argv parsing/precedence, env-var allow/deny/secret-shaped filtering, and collector-outcome cases.
- `dda inv linter.go --targets=./comp/core/configfilesdiscovery/...` — clean.
- `bazel run //:gazelle -- ./comp/core/configfilesdiscovery/impl/collectors` + `bazel run //bazel/buildifier` — regenerated BUILD.bazel.
- `bazel build //comp/core/configfilesdiscovery/...` — clean.
- `dda inv agent.build --build-exclude=systemd` — full agent build succeeds.
- Added `TestPostgresConfigFilePayloadSentToEventPlatform` Docker E2E test alongside the existing Redis/Kafka ones. Opening as **draft** to let CI run the Docker E2E discovery suite.

## Possible Drawbacks / Trade-offs

- Uses `PAYLOAD_FORMAT_PROPERTIES` since no dedicated PostgreSQL payload format enum exists upstream.
- Only launch commands that literally exec `postgres` are supported; custom wrappers (e.g. `pg_ctlcluster`) are not.
- Host/systemd PostgreSQL is unsupported, since this component has no `RuntimeHost` reader.
- `*_FILE` variants (e.g. `POSTGRES_USER_FILE`) and `POSTGRES_INITDB_ARGS` are intentionally excluded from the allow-list.

## Additional Notes

Rebuilt on current `main` (previous draft PR #55039 was based on a stale branch and picked up unrelated phantom diffs plus a Bazel regression — closed in favor of this clean version).