### PR TITLE
add package object

### DIFF
--- a/pkg/privateactionrunner/bundle-support/authoredscripts/BUILD.bazel
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/BUILD.bazel
@@ -13,10 +13,69 @@ go_library(
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundle-support/authoredscripts",
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
-        "@in_yaml_go_yaml_v3//:yaml",
-    ],
+    deps = select({
+        "@rules_go//go/platform:aix": [
+            "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
+            "@in_yaml_go_yaml_v3//:yaml",
+        ],
+        "@rules_go//go/platform:android": [
+            "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
+            "@in_yaml_go_yaml_v3//:yaml",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
+            "@in_yaml_go_yaml_v3//:yaml",
+        ],
+        "@rules_go//go/platform:dragonfly": [
+            "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
+            "@in_yaml_go_yaml_v3//:yaml",
+        ],
+        "@rules_go//go/platform:freebsd": [
+            "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
+            "@in_yaml_go_yaml_v3//:yaml",
+        ],
+        "@rules_go//go/platform:illumos": [
+            "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
+            "@in_yaml_go_yaml_v3//:yaml",
+        ],
+        "@rules_go//go/platform:ios": [
+            "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
+            "@in_yaml_go_yaml_v3//:yaml",
+        ],
+        "@rules_go//go/platform:js": [
+            "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
+            "@in_yaml_go_yaml_v3//:yaml",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
+            "@in_yaml_go_yaml_v3//:yaml",
+        ],
+        "@rules_go//go/platform:netbsd": [
+            "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
+            "@in_yaml_go_yaml_v3//:yaml",
+        ],
+        "@rules_go//go/platform:openbsd": [
+            "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
+            "@in_yaml_go_yaml_v3//:yaml",
+        ],
+        "@rules_go//go/platform:osx": [
+            "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
+            "@in_yaml_go_yaml_v3//:yaml",
+        ],
+        "@rules_go//go/platform:plan9": [
+            "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
+            "@in_yaml_go_yaml_v3//:yaml",
+        ],
+        "@rules_go//go/platform:qnx": [
+            "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
+            "@in_yaml_go_yaml_v3//:yaml",
+        ],
+        "@rules_go//go/platform:solaris": [
+            "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
+            "@in_yaml_go_yaml_v3//:yaml",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 dd_agent_go_test(
@@ -27,8 +86,67 @@ dd_agent_go_test(
         "package_test.go",
     ],
     embed = [":authoredscripts"],
-    deps = [
-        "@com_github_stretchr_testify//assert",
-        "@com_github_stretchr_testify//require",
-    ],
+    deps = select({
+        "@rules_go//go/platform:aix": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:android": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:darwin": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:dragonfly": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:freebsd": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:illumos": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:ios": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:js": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:linux": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:netbsd": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:openbsd": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:osx": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:plan9": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:qnx": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "@rules_go//go/platform:solaris": [
+            "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/BUILD.bazel
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/BUILD.bazel
@@ -3,7 +3,12 @@ load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "authoredscripts",
-    srcs = ["manifest.go"],
+    srcs = [
+        "catalog.go",
+        "local_store.go",
+        "manifest.go",
+        "package.go",
+    ],
     importpath = "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundle-support/authoredscripts",
     visibility = ["//visibility:public"],
     deps = ["@in_yaml_go_yaml_v3//:yaml"],
@@ -11,7 +16,10 @@ go_library(
 
 dd_agent_go_test(
     name = "authoredscripts_test",
-    srcs = ["manifest_test.go"],
+    srcs = [
+        "manifest_test.go",
+        "package_test.go",
+    ],
     embed = [":authoredscripts"],
     deps = [
         "@com_github_stretchr_testify//assert",

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/BUILD.bazel
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/BUILD.bazel
@@ -5,18 +5,24 @@ go_library(
     name = "authoredscripts",
     srcs = [
         "catalog.go",
+        "environment.go",
         "local_store.go",
         "manifest.go",
         "package.go",
+        "session.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundle-support/authoredscripts",
     visibility = ["//visibility:public"],
-    deps = ["@in_yaml_go_yaml_v3//:yaml"],
+    deps = [
+        "@com_github_cyphar_filepath_securejoin//:filepath-securejoin",
+        "@in_yaml_go_yaml_v3//:yaml",
+    ],
 )
 
 dd_agent_go_test(
     name = "authoredscripts_test",
     srcs = [
+        "environment_test.go",
         "manifest_test.go",
         "package_test.go",
     ],

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/catalog.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/catalog.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package authoredscripts
+
+// Descriptor identifies an immutable published artifact variant.
+type Descriptor struct {
+	Package string
+	Version string
+	URL     string
+	SHA256  string
+}

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/catalog.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/catalog.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+//go:build !windows
+
 package authoredscripts
 
 // Descriptor identifies an immutable published artifact variant.

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/environment.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/environment.go
@@ -1,0 +1,159 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package authoredscripts
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
+)
+
+const (
+	defaultExecutablePath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+)
+
+// managedEnvironmentVariables are set by BuildEnvironment from session/package state.
+// AllowedEnvVars entries with these names will error out, since the script cannot pass through
+// the runner's own value for them; setSessionEnvVars may still use these names to override
+// HOME & TMPDIR the managed value. For PATH, the value from setSessionEnvVars will be appended
+// to the PATH env var.
+var managedEnvironmentVariables = map[string]struct{}{
+	"HOME":   {},
+	"PATH":   {},
+	"TMPDIR": {},
+}
+
+// BuildEnvironment creates the environment available to an authored script.
+func (pkg *Package) BuildEnvironment(session *Session) ([]string, error) {
+	if pkg == nil || pkg.Manifest == nil {
+		return nil, errors.New("authored-script package is required")
+	}
+	if session == nil {
+		return nil, errors.New("authored-script session is required")
+	}
+
+	executablePath, err := buildExecutablePath(pkg.ToolPaths)
+	if err != nil {
+		return nil, err
+	}
+	environment := map[string]string{
+		"HOME":   session.HomeDirectory,
+		"PATH":   executablePath,
+		"TMPDIR": session.TempDirectory,
+	}
+	for _, name := range pkg.Manifest.Config.AllowedEnvVars {
+		if _, managed := managedEnvironmentVariables[name]; managed {
+			return nil, fmt.Errorf("authored-script environment variable %q is managed by PAR and cannot be declared as an allowed environment variable", name)
+		}
+		if value, found := os.LookupEnv(name); found {
+			environment[name] = value
+		}
+	}
+
+	for _, variable := range pkg.Manifest.Config.SetSessionEnvVars {
+		value, err := materializeEnvironmentVariable(session.RootDirectory, "session", variable)
+		if err != nil {
+			return nil, err
+		}
+		setEnvironmentVariable(environment, variable.Name, value)
+	}
+
+	result := make([]string, 0, len(environment))
+	for name, value := range environment {
+		if strings.IndexByte(value, 0) >= 0 {
+			return nil, fmt.Errorf("authored-script environment variable %q contains a NUL byte", name)
+		}
+		result = append(result, name+"="+value)
+	}
+	return result, nil
+}
+
+func buildExecutablePath(toolPaths []string) (string, error) {
+	seenDirectories := make(map[string]struct{}, len(toolPaths)+1)
+	executablePaths := make([]string, 0, len(toolPaths)+1)
+	for _, toolPath := range toolPaths {
+		directory := filepath.Dir(toolPath)
+		if strings.ContainsRune(directory, os.PathListSeparator) {
+			return "", fmt.Errorf("authored-script tool directory %q contains a path separator", directory)
+		}
+		if _, seen := seenDirectories[directory]; seen {
+			continue
+		}
+		seenDirectories[directory] = struct{}{}
+		executablePaths = append(executablePaths, directory)
+	}
+	executablePaths = append(executablePaths, defaultExecutablePath)
+	return strings.Join(executablePaths, string(os.PathListSeparator)), nil
+}
+
+func setEnvironmentVariable(environment map[string]string, name, value string) {
+	if name == "PATH" {
+		environment[name] = environment[name] + string(os.PathListSeparator) + value
+		return
+	}
+	environment[name] = value
+}
+
+func materializeEnvironmentVariable(root, scope string, variable EnvironmentVariable) (string, error) {
+	if variable.Kind == environmentKindValue {
+		return variable.Value, nil
+	}
+	if !filepath.IsLocal(variable.Value) {
+		return "", fmt.Errorf("authored-script %s environment variable %q path %q is not relative to its session directory", scope, variable.Name, variable.Value)
+	}
+
+	resolvedPath, err := securejoin.SecureJoin(root, variable.Value)
+	if err != nil {
+		return "", fmt.Errorf("could not resolve authored-script %s environment variable %q: %w", scope, variable.Name, err)
+	}
+	if resolvedPath == root {
+		return "", fmt.Errorf("authored-script %s environment variable %q cannot use its session directory root", scope, variable.Name)
+	}
+	if err := os.MkdirAll(filepath.Dir(resolvedPath), sessionDirectoryMode); err != nil {
+		return "", fmt.Errorf("could not create parent directory for authored-script %s environment variable %q: %w", scope, variable.Name, err)
+	}
+
+	switch variable.Kind {
+	case environmentKindFile:
+		if err := ensureEnvironmentFile(resolvedPath); err != nil {
+			return "", fmt.Errorf("could not prepare file for authored-script %s environment variable %q: %w", scope, variable.Name, err)
+		}
+	case environmentKindDirectory:
+		if err := ensureEnvironmentDirectory(resolvedPath); err != nil {
+			return "", fmt.Errorf("could not prepare directory for authored-script %s environment variable %q: %w", scope, variable.Name, err)
+		}
+	default:
+		return "", fmt.Errorf("authored-script %s environment variable %q has unsupported kind %q", scope, variable.Name, variable.Kind)
+	}
+	return resolvedPath, nil
+}
+
+func ensureEnvironmentFile(path string) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err == nil {
+		return file.Close()
+	}
+	if !errors.Is(err, os.ErrExist) {
+		return err
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("path %q is not a regular file", path)
+	}
+	return nil
+}
+
+func ensureEnvironmentDirectory(path string) error {
+	return os.MkdirAll(path, sessionDirectoryMode)
+}

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/environment.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/environment.go
@@ -20,10 +20,10 @@ const (
 )
 
 // managedEnvironmentVariables are set by BuildEnvironment from session/package state.
-// AllowedEnvVars entries with these names will error out, since the script cannot pass through
-// the runner's own value for them; setSessionEnvVars may still use these names to override
-// HOME & TMPDIR the managed value. For PATH, the value from setSessionEnvVars will be appended
-// to the PATH env var.
+// AllowedEnvVars or setSessionEnvVars entries with these names will error out, since the
+// script cannot pass through the runner's own value for them. PATH is the only
+// exception: setSessionEnvVars may extend it, and its value is appended rather than
+// replacing the runner's computed PATH.
 var managedEnvironmentVariables = map[string]struct{}{
 	"HOME":   {},
 	"PATH":   {},
@@ -58,6 +58,9 @@ func (pkg *Package) BuildEnvironment(session *Session) ([]string, error) {
 	}
 
 	for _, variable := range pkg.Manifest.Config.SetSessionEnvVars {
+		if variable.Name == "HOME" || variable.Name == "TMPDIR" {
+			return nil, fmt.Errorf("authored-script session environment variable %q cannot override the managed %q value", variable.Name, variable.Name)
+		}
 		value, err := materializeEnvironmentVariable(session.RootDirectory, "session", variable)
 		if err != nil {
 			return nil, err

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/environment.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/environment.go
@@ -23,9 +23,7 @@ const (
 
 // managedEnvironmentVariables are set by BuildEnvironment from session/package state.
 // AllowedEnvVars or setSessionEnvVars entries with these names will error out, since the
-// script cannot pass through the runner's own value for them. PATH is the only
-// exception: setSessionEnvVars may extend it, and its value is appended rather than
-// replacing the runner's computed PATH.
+// script cannot pass through or override the runner's own value for them.
 var managedEnvironmentVariables = map[string]struct{}{
 	"HOME":   {},
 	"PATH":   {},
@@ -60,14 +58,14 @@ func (pkg *Package) BuildEnvironment(session *Session) ([]string, error) {
 	}
 
 	for _, variable := range pkg.Manifest.Config.SetSessionEnvVars {
-		if variable.Name == "HOME" || variable.Name == "TMPDIR" {
+		if _, managed := managedEnvironmentVariables[variable.Name]; managed {
 			return nil, fmt.Errorf("authored-script session environment variable %q cannot override the managed %q value", variable.Name, variable.Name)
 		}
 		value, err := materializeEnvironmentVariable(session.RootDirectory, "session", variable)
 		if err != nil {
 			return nil, err
 		}
-		setEnvironmentVariable(environment, variable.Name, value)
+		environment[variable.Name] = value
 	}
 
 	result := make([]string, 0, len(environment))
@@ -96,14 +94,6 @@ func buildExecutablePath(toolPaths []string) (string, error) {
 	}
 	executablePaths = append(executablePaths, defaultExecutablePath)
 	return strings.Join(executablePaths, string(os.PathListSeparator)), nil
-}
-
-func setEnvironmentVariable(environment map[string]string, name, value string) {
-	if name == "PATH" {
-		environment[name] = environment[name] + string(os.PathListSeparator) + value
-		return
-	}
-	environment[name] = value
 }
 
 func materializeEnvironmentVariable(root, scope string, variable EnvironmentVariable) (string, error) {

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/environment.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/environment.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+//go:build !windows
+
 package authoredscripts
 
 import (

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/environment_test.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/environment_test.go
@@ -1,0 +1,232 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package authoredscripts
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestSession(t *testing.T) *Session {
+	t.Helper()
+	session, err := NewSession()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = session.Cleanup() })
+	return session
+}
+
+func lookupEnv(t *testing.T, environment []string, name string) (string, bool) {
+	t.Helper()
+	prefix := name + "="
+	for _, entry := range environment {
+		if value, ok := strings.CutPrefix(entry, prefix); ok {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func TestBuildEnvironment_ManagedVariables(t *testing.T) {
+	session := newTestSession(t)
+	pkg := &Package{Manifest: &Manifest{}}
+
+	environment, err := pkg.BuildEnvironment(session)
+
+	require.NoError(t, err)
+	home, ok := lookupEnv(t, environment, "HOME")
+	require.True(t, ok)
+	assert.Equal(t, session.HomeDirectory, home)
+	tmpdir, ok := lookupEnv(t, environment, "TMPDIR")
+	require.True(t, ok)
+	assert.Equal(t, session.TempDirectory, tmpdir)
+	path, ok := lookupEnv(t, environment, "PATH")
+	require.True(t, ok)
+	assert.Equal(t, defaultExecutablePath, path)
+}
+
+func TestBuildEnvironment_RejectsManagedAllowedEnvVar(t *testing.T) {
+	session := newTestSession(t)
+	pkg := &Package{Manifest: &Manifest{Config: ScriptConfig{AllowedEnvVars: []string{"PATH"}}}}
+
+	_, err := pkg.BuildEnvironment(session)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "managed by PAR")
+}
+
+func TestBuildEnvironment_PassesThroughAllowedEnvVar(t *testing.T) {
+	t.Setenv("MY_TOKEN", "secret-value")
+	session := newTestSession(t)
+	pkg := &Package{Manifest: &Manifest{Config: ScriptConfig{AllowedEnvVars: []string{"MY_TOKEN"}}}}
+
+	environment, err := pkg.BuildEnvironment(session)
+
+	require.NoError(t, err)
+	value, ok := lookupEnv(t, environment, "MY_TOKEN")
+	require.True(t, ok)
+	assert.Equal(t, "secret-value", value)
+}
+
+func TestBuildEnvironment_SessionEnvVarAppendsPath(t *testing.T) {
+	session := newTestSession(t)
+	pkg := &Package{Manifest: &Manifest{Config: ScriptConfig{
+		SetSessionEnvVars: []EnvironmentVariable{{Name: "PATH", Value: "/extra/bin", Kind: environmentKindValue}},
+	}}}
+
+	environment, err := pkg.BuildEnvironment(session)
+
+	require.NoError(t, err)
+	path, ok := lookupEnv(t, environment, "PATH")
+	require.True(t, ok)
+	assert.Equal(t, defaultExecutablePath+string(os.PathListSeparator)+"/extra/bin", path)
+}
+
+func TestBuildEnvironment_SessionEnvVarOverridesHome(t *testing.T) {
+	session := newTestSession(t)
+	pkg := &Package{Manifest: &Manifest{Config: ScriptConfig{
+		SetSessionEnvVars: []EnvironmentVariable{{Name: "HOME", Value: "/custom/home", Kind: environmentKindValue}},
+	}}}
+
+	environment, err := pkg.BuildEnvironment(session)
+
+	require.NoError(t, err)
+	home, ok := lookupEnv(t, environment, "HOME")
+	require.True(t, ok)
+	assert.Equal(t, "/custom/home", home)
+}
+
+func TestBuildEnvironment_SessionEnvVarFileIsCreatedUnderSessionRoot(t *testing.T) {
+	session := newTestSession(t)
+	pkg := &Package{Manifest: &Manifest{Config: ScriptConfig{
+		SetSessionEnvVars: []EnvironmentVariable{{Name: "OUTPUT_FILE", Value: "output/result.json", Kind: environmentKindFile}},
+	}}}
+
+	environment, err := pkg.BuildEnvironment(session)
+
+	require.NoError(t, err)
+	value, ok := lookupEnv(t, environment, "OUTPUT_FILE")
+	require.True(t, ok)
+	expectedPath := filepath.Join(session.RootDirectory, "output/result.json")
+	assert.Equal(t, expectedPath, value)
+	info, err := os.Stat(expectedPath)
+	require.NoError(t, err)
+	assert.True(t, info.Mode().IsRegular())
+}
+
+func TestBuildEnvironment_SessionEnvVarDirectoryIsCreatedUnderSessionRoot(t *testing.T) {
+	session := newTestSession(t)
+	pkg := &Package{Manifest: &Manifest{Config: ScriptConfig{
+		SetSessionEnvVars: []EnvironmentVariable{{Name: "WORKDIR", Value: "workdir", Kind: environmentKindDirectory}},
+	}}}
+
+	environment, err := pkg.BuildEnvironment(session)
+
+	require.NoError(t, err)
+	value, ok := lookupEnv(t, environment, "WORKDIR")
+	require.True(t, ok)
+	expectedPath := filepath.Join(session.RootDirectory, "workdir")
+	assert.Equal(t, expectedPath, value)
+	info, err := os.Stat(expectedPath)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestBuildEnvironment_SessionEnvVarRejectsPathTraversal(t *testing.T) {
+	session := newTestSession(t)
+	pkg := &Package{Manifest: &Manifest{Config: ScriptConfig{
+		SetSessionEnvVars: []EnvironmentVariable{{Name: "OUTPUT_FILE", Value: "../escape.json", Kind: environmentKindFile}},
+	}}}
+
+	_, err := pkg.BuildEnvironment(session)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not relative to its session directory")
+}
+
+func TestBuildExecutablePath_DedupsDirectories(t *testing.T) {
+	path, err := buildExecutablePath([]string{
+		"/tools/a/helm",
+		"/tools/a/jq",
+		"/tools/b/kubectl",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "/tools/a"+string(os.PathListSeparator)+"/tools/b"+string(os.PathListSeparator)+defaultExecutablePath, path)
+}
+
+func TestBuildExecutablePath_RejectsPathSeparatorInDirectory(t *testing.T) {
+	directory := "/tools" + string(os.PathListSeparator) + "a"
+
+	_, err := buildExecutablePath([]string{directory + "/helm"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "path separator")
+}
+
+func TestMaterializeEnvironmentVariable_Value(t *testing.T) {
+	root := t.TempDir()
+
+	value, err := materializeEnvironmentVariable(root, "session", EnvironmentVariable{Name: "X", Value: "plain-value", Kind: environmentKindValue})
+
+	require.NoError(t, err)
+	assert.Equal(t, "plain-value", value)
+}
+
+func TestMaterializeEnvironmentVariable_RejectsRoot(t *testing.T) {
+	root := t.TempDir()
+
+	_, err := materializeEnvironmentVariable(root, "session", EnvironmentVariable{Name: "X", Value: ".", Kind: environmentKindDirectory})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot use its session directory")
+}
+
+func TestMaterializeEnvironmentVariable_FileAlreadyExistsIsReused(t *testing.T) {
+	root := t.TempDir()
+	variable := EnvironmentVariable{Name: "X", Value: "state.json", Kind: environmentKindFile}
+
+	first, err := materializeEnvironmentVariable(root, "session", variable)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(first, []byte("data"), 0o600))
+
+	second, err := materializeEnvironmentVariable(root, "session", variable)
+
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	contents, err := os.ReadFile(second)
+	require.NoError(t, err)
+	assert.Equal(t, "data", string(contents))
+}
+
+func TestMaterializeEnvironmentVariable_RejectsUnsupportedKind(t *testing.T) {
+	root := t.TempDir()
+
+	_, err := materializeEnvironmentVariable(root, "session", EnvironmentVariable{Name: "X", Value: "socket-path", Kind: "socket"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported kind")
+}
+
+func TestSetEnvironmentVariable_AppendsPath(t *testing.T) {
+	environment := map[string]string{"PATH": "/existing/bin"}
+
+	setEnvironmentVariable(environment, "PATH", "/extra/bin")
+
+	assert.Equal(t, "/existing/bin"+string(os.PathListSeparator)+"/extra/bin", environment["PATH"])
+}
+
+func TestSetEnvironmentVariable_ReplacesOtherNames(t *testing.T) {
+	environment := map[string]string{"HOME": "/old/home"}
+
+	setEnvironmentVariable(environment, "HOME", "/new/home")
+
+	assert.Equal(t, "/new/home", environment["HOME"])
+}

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/environment_test.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/environment_test.go
@@ -77,18 +77,16 @@ func TestBuildEnvironment_PassesThroughAllowedEnvVar(t *testing.T) {
 	assert.Equal(t, "secret-value", value)
 }
 
-func TestBuildEnvironment_SessionEnvVarAppendsPath(t *testing.T) {
+func TestBuildEnvironment_SessionEnvVarRejectsPathOverride(t *testing.T) {
 	session := newTestSession(t)
 	pkg := &Package{Manifest: &Manifest{Config: ScriptConfig{
 		SetSessionEnvVars: []EnvironmentVariable{{Name: "PATH", Value: "/extra/bin", Kind: environmentKindValue}},
 	}}}
 
-	environment, err := pkg.BuildEnvironment(session)
+	_, err := pkg.BuildEnvironment(session)
 
-	require.NoError(t, err)
-	path, ok := lookupEnv(t, environment, "PATH")
-	require.True(t, ok)
-	assert.Equal(t, defaultExecutablePath+string(os.PathListSeparator)+"/extra/bin", path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot override the managed")
 }
 
 func TestBuildEnvironment_SessionEnvVarRejectsHomeOverride(t *testing.T) {

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/environment_test.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/environment_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+//go:build !windows
+
 package authoredscripts
 
 import (

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/environment_test.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/environment_test.go
@@ -89,18 +89,28 @@ func TestBuildEnvironment_SessionEnvVarAppendsPath(t *testing.T) {
 	assert.Equal(t, defaultExecutablePath+string(os.PathListSeparator)+"/extra/bin", path)
 }
 
-func TestBuildEnvironment_SessionEnvVarOverridesHome(t *testing.T) {
+func TestBuildEnvironment_SessionEnvVarRejectsHomeOverride(t *testing.T) {
 	session := newTestSession(t)
 	pkg := &Package{Manifest: &Manifest{Config: ScriptConfig{
 		SetSessionEnvVars: []EnvironmentVariable{{Name: "HOME", Value: "/custom/home", Kind: environmentKindValue}},
 	}}}
 
-	environment, err := pkg.BuildEnvironment(session)
+	_, err := pkg.BuildEnvironment(session)
 
-	require.NoError(t, err)
-	home, ok := lookupEnv(t, environment, "HOME")
-	require.True(t, ok)
-	assert.Equal(t, "/custom/home", home)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot override the managed")
+}
+
+func TestBuildEnvironment_SessionEnvVarRejectsTmpdirOverride(t *testing.T) {
+	session := newTestSession(t)
+	pkg := &Package{Manifest: &Manifest{Config: ScriptConfig{
+		SetSessionEnvVars: []EnvironmentVariable{{Name: "TMPDIR", Value: "/custom/tmp", Kind: environmentKindValue}},
+	}}}
+
+	_, err := pkg.BuildEnvironment(session)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot override the managed")
 }
 
 func TestBuildEnvironment_SessionEnvVarFileIsCreatedUnderSessionRoot(t *testing.T) {
@@ -213,20 +223,4 @@ func TestMaterializeEnvironmentVariable_RejectsUnsupportedKind(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported kind")
-}
-
-func TestSetEnvironmentVariable_AppendsPath(t *testing.T) {
-	environment := map[string]string{"PATH": "/existing/bin"}
-
-	setEnvironmentVariable(environment, "PATH", "/extra/bin")
-
-	assert.Equal(t, "/existing/bin"+string(os.PathListSeparator)+"/extra/bin", environment["PATH"])
-}
-
-func TestSetEnvironmentVariable_ReplacesOtherNames(t *testing.T) {
-	environment := map[string]string{"HOME": "/old/home"}
-
-	setEnvironmentVariable(environment, "HOME", "/new/home")
-
-	assert.Equal(t, "/new/home", environment["HOME"])
 }

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/local_store.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/local_store.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package authoredscripts
+
+// LocalArtifact identifies an immutable artifact directory that is ready for use.
+type LocalArtifact struct {
+	Directory string
+}

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/local_store.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/local_store.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+//go:build !windows
+
 package authoredscripts
 
 // LocalArtifact identifies an immutable artifact directory that is ready for use.

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/manifest.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/manifest.go
@@ -62,9 +62,9 @@ type Dependency struct {
 	Version string `yaml:"version"`
 }
 
-// LoadManifest reads and validates the package.yaml manifest for an authored-script
+// loadManifest reads and validates the package.yaml manifest for an authored-script
 // package that has already been downloaded and extracted to artifactDirectory.
-func LoadManifest(artifactDirectory string) (*Manifest, error) {
+func loadManifest(artifactDirectory string) (*Manifest, error) {
 	file, err := openPackageFile(artifactDirectory, filepath.Join(scriptDirectory, manifestFile))
 	if err != nil {
 		return nil, fmt.Errorf("could not open authored-script manifest: %w", err)

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/manifest.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/manifest.go
@@ -44,12 +44,11 @@ type ScriptConfig struct {
 	Command           []string               `yaml:"command"`
 	ParameterSchema   map[string]interface{} `yaml:"parameterSchema"`
 	AllowedEnvVars    []string               `yaml:"allowedEnvVars"`
-	SetGlobalEnvVars  []EnvironmentVariable  `yaml:"setGlobalEnvVars"`
 	SetSessionEnvVars []EnvironmentVariable  `yaml:"setSessionEnvVars"`
 }
 
 // EnvironmentVariable describes an environment value created for a script. File and
-// directory values are paths relative to their global or session state directory.
+// directory values are paths relative to the session directory.
 type EnvironmentVariable struct {
 	Name  string `yaml:"name"`
 	Value string `yaml:"value"`
@@ -110,9 +109,6 @@ func validateManifest(manifest *Manifest) error {
 	}
 	if len(manifest.Config.Command) == 0 || manifest.Config.Command[0] == "" {
 		return errors.New("authored-script manifest command is required")
-	}
-	if err := validateManifestEnvironmentVariables("global", manifest.Config.SetGlobalEnvVars); err != nil {
-		return err
 	}
 	if err := validateManifestEnvironmentVariables("session", manifest.Config.SetSessionEnvVars); err != nil {
 		return err

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/manifest.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/manifest.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+//go:build !windows
+
 package authoredscripts
 
 import (

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/manifest_test.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/manifest_test.go
@@ -48,12 +48,8 @@ func TestLoadManifest_Valid(t *testing.T) {
 	assert.Equal(t, []string{"HOME"}, manifest.Config.AllowedEnvVars)
 }
 
-func TestLoadManifest_WithGlobalAndSessionEnvVars(t *testing.T) {
+func TestLoadManifest_WithSessionEnvVars(t *testing.T) {
 	artifactDirectory := writeManifest(t, validManifest+`
-  setGlobalEnvVars:
-    - name: EXAMPLE_FILE
-      value: path/to/file
-      kind: file
   setSessionEnvVars:
     - name: SESSION_EXAMPLE_VALUE
       value: example-session-value
@@ -63,8 +59,6 @@ func TestLoadManifest_WithGlobalAndSessionEnvVars(t *testing.T) {
 	manifest, err := loadManifest(artifactDirectory)
 
 	require.NoError(t, err)
-	require.Len(t, manifest.Config.SetGlobalEnvVars, 1)
-	assert.Equal(t, environmentKindFile, manifest.Config.SetGlobalEnvVars[0].Kind)
 	require.Len(t, manifest.Config.SetSessionEnvVars, 1)
 	assert.Equal(t, environmentKindValue, manifest.Config.SetSessionEnvVars[0].Kind)
 }
@@ -175,18 +169,18 @@ func TestValidateManifest(t *testing.T) {
 			expectError: "command is required",
 		},
 		{
-			name: "unsupported global env var kind",
+			name: "unsupported session env var kind",
 			manifest: &Manifest{
 				SchemaVersion: manifestSchemaVersion,
 				Package:       "dd-par-scripts-echo",
 				Version:       "0.0.1",
 				FQN:           "com.datadoghq.authoredscripts.echo",
 				Config: ScriptConfig{
-					Command:          validCommand,
-					SetGlobalEnvVars: []EnvironmentVariable{{Name: "X", Value: "y", Kind: "socket"}},
+					Command:           validCommand,
+					SetSessionEnvVars: []EnvironmentVariable{{Name: "X", Value: "y", Kind: "socket"}},
 				},
 			},
-			expectError: "global environment variable",
+			expectError: "session environment variable",
 		},
 		{
 			name: "incomplete session env var",

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/manifest_test.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/manifest_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+//go:build !windows
+
 package authoredscripts
 
 import (

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/manifest_test.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/manifest_test.go
@@ -39,7 +39,7 @@ func writeManifest(t *testing.T, contents string) string {
 func TestLoadManifest_Valid(t *testing.T) {
 	artifactDirectory := writeManifest(t, validManifest)
 
-	manifest, err := LoadManifest(artifactDirectory)
+	manifest, err := loadManifest(artifactDirectory)
 
 	require.NoError(t, err)
 	assert.Equal(t, "v1", manifest.SchemaVersion)
@@ -60,7 +60,7 @@ func TestLoadManifest_WithGlobalAndSessionEnvVars(t *testing.T) {
       kind: value
 `)
 
-	manifest, err := LoadManifest(artifactDirectory)
+	manifest, err := loadManifest(artifactDirectory)
 
 	require.NoError(t, err)
 	require.Len(t, manifest.Config.SetGlobalEnvVars, 1)
@@ -72,7 +72,7 @@ func TestLoadManifest_WithGlobalAndSessionEnvVars(t *testing.T) {
 func TestLoadManifest_MissingManifestFile(t *testing.T) {
 	artifactDirectory := t.TempDir()
 
-	_, err := LoadManifest(artifactDirectory)
+	_, err := loadManifest(artifactDirectory)
 
 	require.Error(t, err)
 }
@@ -80,7 +80,7 @@ func TestLoadManifest_MissingManifestFile(t *testing.T) {
 func TestLoadManifest_RejectsUnknownField(t *testing.T) {
 	artifactDirectory := writeManifest(t, validManifest+"\nunexpectedField: true\n")
 
-	_, err := LoadManifest(artifactDirectory)
+	_, err := loadManifest(artifactDirectory)
 
 	require.Error(t, err)
 }
@@ -88,7 +88,7 @@ func TestLoadManifest_RejectsUnknownField(t *testing.T) {
 func TestLoadManifest_RejectsMultipleDocuments(t *testing.T) {
 	artifactDirectory := writeManifest(t, validManifest+"\n---\nschema-version: v1\n")
 
-	_, err := LoadManifest(artifactDirectory)
+	_, err := loadManifest(artifactDirectory)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exactly one YAML document")
@@ -98,7 +98,7 @@ func TestLoadManifest_RejectsOversizedManifest(t *testing.T) {
 	padding := strings.Repeat("a", maxManifestSize+1)
 	artifactDirectory := writeManifest(t, validManifest+"\n# "+padding+"\n")
 
-	_, err := LoadManifest(artifactDirectory)
+	_, err := loadManifest(artifactDirectory)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "byte limit")

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/package.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/package.go
@@ -1,0 +1,97 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package authoredscripts
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Package contains a validated authored script and the paths needed to execute it.
+type Package struct {
+	Manifest       *Manifest
+	Directory      string
+	ArtifactDigest string
+	Command        []string
+	ToolPaths      []string
+}
+
+func LoadPackage(fqn string, descriptor Descriptor, artifact LocalArtifact) (*Package, error) {
+	manifest, err := loadManifest(artifact.Directory)
+	if err != nil {
+		return nil, err
+	}
+	if err := validatePackageIdentity(fqn, descriptor, manifest); err != nil {
+		return nil, err
+	}
+
+	manifestCommand := manifest.Config.Command[0]
+	if !filepath.IsLocal(manifestCommand) {
+		return nil, fmt.Errorf("invalid authored-script command path %q: path must be local to the script directory", manifestCommand)
+	}
+	commandPath, err := resolvePackageFile(artifact.Directory, filepath.Join(scriptDirectory, manifestCommand))
+	if err != nil {
+		return nil, fmt.Errorf("invalid authored-script command: %w", err)
+	}
+	command := append([]string{commandPath}, manifest.Config.Command[1:]...)
+
+	toolPaths := make([]string, 0, len(manifest.Dependencies))
+	for _, dependency := range manifest.Dependencies {
+		if !isDependencyName(dependency.Name) {
+			return nil, fmt.Errorf("invalid authored-script dependency name %q: name must be a single path component", dependency.Name)
+		}
+		toolPath, err := resolvePackageFile(artifact.Directory, filepath.Join(scriptDirectory, dependency.Name))
+		if err != nil {
+			return nil, fmt.Errorf("invalid authored-script dependency %q: %w", dependency.Name, err)
+		}
+		toolPaths = append(toolPaths, toolPath)
+	}
+
+	return &Package{
+		Manifest:       manifest,
+		Directory:      artifact.Directory,
+		ArtifactDigest: descriptor.SHA256,
+		Command:        command,
+		ToolPaths:      toolPaths,
+	}, nil
+}
+
+func isDependencyName(name string) bool {
+	return name != "." && filepath.IsLocal(name) && !strings.ContainsAny(name, `/\\`)
+}
+
+func validatePackageIdentity(fqn string, descriptor Descriptor, manifest *Manifest) error {
+	if descriptor.Package != fqn {
+		return fmt.Errorf("authored-script descriptor package %q does not match catalog key %q", descriptor.Package, fqn)
+	}
+	if manifest.FQN != fqn {
+		return fmt.Errorf("authored-script manifest FQN %q does not match catalog key %q", manifest.FQN, fqn)
+	}
+	if manifest.Version != descriptor.Version {
+		return fmt.Errorf("authored-script manifest version %q does not match artifact version %q", manifest.Version, descriptor.Version)
+	}
+	return nil
+}
+
+func resolvePackageFile(root, path string) (string, error) {
+	rootHandle, err := os.OpenRoot(root)
+	if err != nil {
+		return "", fmt.Errorf("could not open package root: %w", err)
+	}
+	defer rootHandle.Close()
+
+	info, err := rootHandle.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("could not access file %q: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("path %q is not a regular file", path)
+	}
+
+	return filepath.Join(root, path), nil
+}

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/package.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/package.go
@@ -14,11 +14,10 @@ import (
 
 // Package contains a validated authored script and the paths needed to execute it.
 type Package struct {
-	Manifest       *Manifest
-	Directory      string
-	ArtifactDigest string
-	Command        []string
-	ToolPaths      []string
+	Manifest  *Manifest
+	Directory string
+	Command   []string
+	ToolPaths []string
 }
 
 func LoadPackage(fqn string, descriptor Descriptor, artifact LocalArtifact) (*Package, error) {
@@ -53,11 +52,10 @@ func LoadPackage(fqn string, descriptor Descriptor, artifact LocalArtifact) (*Pa
 	}
 
 	return &Package{
-		Manifest:       manifest,
-		Directory:      artifact.Directory,
-		ArtifactDigest: descriptor.SHA256,
-		Command:        command,
-		ToolPaths:      toolPaths,
+		Manifest:  manifest,
+		Directory: artifact.Directory,
+		Command:   command,
+		ToolPaths: toolPaths,
 	}, nil
 }
 

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/package.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/package.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+//go:build !windows
+
 package authoredscripts
 
 import (

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/package_test.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/package_test.go
@@ -1,0 +1,145 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package authoredscripts
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadPackage_WithFlatExtractedDependencies(t *testing.T) {
+	const fqn = "com.datadoghq.authoredscripts.echo"
+	artifactDirectory := writeManifest(t, validManifest+`
+dependencies:
+  - name: helm
+    version: "3.17.2"
+  - name: jq
+    version: "1.7.1"
+`)
+	scriptDir := filepath.Join(artifactDirectory, scriptDirectory)
+	commandPath := filepath.Join(scriptDir, "run.sh")
+	require.NoError(t, os.WriteFile(commandPath, []byte("#!/bin/sh\n"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(scriptDir, "helm"), []byte("helm"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(scriptDir, "jq"), []byte("jq"), 0o755))
+	descriptor := Descriptor{
+		Package: fqn,
+		Version: "0.0.1",
+		SHA256:  "sha256",
+	}
+
+	pkg, err := LoadPackage(fqn, descriptor, LocalArtifact{Directory: artifactDirectory})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{commandPath}, pkg.Command)
+	assert.Equal(t, []string{
+		filepath.Join(scriptDir, "helm"),
+		filepath.Join(scriptDir, "jq"),
+	}, pkg.ToolPaths)
+}
+
+func TestLoadPackage_RejectsEscapingSymlinkCommand(t *testing.T) {
+	const fqn = "com.datadoghq.authoredscripts.echo"
+	artifactDirectory := writeManifest(t, validManifest)
+	scriptDir := filepath.Join(artifactDirectory, scriptDirectory)
+	externalDirectory := t.TempDir()
+	externalCommand := filepath.Join(externalDirectory, "run.sh")
+	require.NoError(t, os.WriteFile(externalCommand, []byte("#!/bin/sh\n"), 0o755))
+	if err := os.Symlink(externalCommand, filepath.Join(scriptDir, "run.sh")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+	descriptor := Descriptor{Package: fqn, Version: "0.0.1"}
+
+	_, err := LoadPackage(fqn, descriptor, LocalArtifact{Directory: artifactDirectory})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid authored-script command")
+}
+
+func TestLoadPackage_RejectsCommandPathTraversal(t *testing.T) {
+	const fqn = "com.datadoghq.authoredscripts.echo"
+	manifest := strings.Replace(validManifest, `command: ["run.sh"]`, `command: ["../run.sh"]`, 1)
+	artifactDirectory := writeManifest(t, manifest)
+	require.NoError(t, os.WriteFile(filepath.Join(artifactDirectory, "run.sh"), []byte("#!/bin/sh\n"), 0o755))
+	descriptor := Descriptor{Package: fqn, Version: "0.0.1"}
+
+	_, err := LoadPackage(fqn, descriptor, LocalArtifact{Directory: artifactDirectory})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "command path")
+}
+
+func TestLoadPackage_RejectsDependencyPathComponents(t *testing.T) {
+	const fqn = "com.datadoghq.authoredscripts.echo"
+	artifactDirectory := writeManifest(t, validManifest+`
+dependencies:
+  - name: ../helm
+    version: "3.17.2"
+`)
+	scriptDir := filepath.Join(artifactDirectory, scriptDirectory)
+	require.NoError(t, os.WriteFile(filepath.Join(scriptDir, "run.sh"), []byte("#!/bin/sh\n"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(artifactDirectory, "helm"), []byte("helm"), 0o755))
+	descriptor := Descriptor{Package: fqn, Version: "0.0.1"}
+
+	_, err := LoadPackage(fqn, descriptor, LocalArtifact{Directory: artifactDirectory})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dependency name")
+}
+
+func TestValidatePackageIdentity(t *testing.T) {
+	const fqn = "com.datadoghq.authoredscripts.echo"
+	tests := []struct {
+		name        string
+		mutate      func(*Descriptor, *Manifest)
+		expectError string
+	}{
+		{
+			name: "descriptor package mismatch",
+			mutate: func(descriptor *Descriptor, _ *Manifest) {
+				descriptor.Package = "com.datadoghq.authoredscripts.other"
+			},
+			expectError: "descriptor package",
+		},
+		{
+			name: "manifest FQN mismatch",
+			mutate: func(_ *Descriptor, manifest *Manifest) {
+				manifest.FQN = "com.datadoghq.authoredscripts.other"
+			},
+			expectError: "manifest FQN",
+		},
+		{
+			name: "manifest version mismatch",
+			mutate: func(_ *Descriptor, manifest *Manifest) {
+				manifest.Version = "0.0.2"
+			},
+			expectError: "manifest version",
+		},
+		{name: "valid identity"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			descriptor := Descriptor{Package: fqn, Version: "0.0.1"}
+			manifest := &Manifest{FQN: fqn, Version: descriptor.Version}
+			if tt.mutate != nil {
+				tt.mutate(&descriptor, manifest)
+			}
+
+			err := validatePackageIdentity(fqn, descriptor, manifest)
+			if tt.expectError == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+		})
+	}
+}

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/package_test.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/package_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+//go:build !windows
+
 package authoredscripts
 
 import (

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/session.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/session.go
@@ -25,7 +25,8 @@ type Session struct {
 	HomeDirectory string
 	TempDirectory string
 
-	cleanupOnce sync.Once
+	cleanupMutex sync.Mutex
+	cleaned      bool
 }
 
 func NewSession() (*Session, error) {
@@ -57,11 +58,15 @@ func NewSession() (*Session, error) {
 }
 
 func (s *Session) Cleanup() error {
-	var err error
-	s.cleanupOnce.Do(func() {
-		if removeErr := os.RemoveAll(s.RootDirectory); removeErr != nil {
-			err = fmt.Errorf("could not remove authored-script session directory %q: %w", s.RootDirectory, removeErr)
-		}
-	})
-	return err
+	s.cleanupMutex.Lock()
+	defer s.cleanupMutex.Unlock()
+
+	if s.cleaned {
+		return nil
+	}
+	if err := os.RemoveAll(s.RootDirectory); err != nil {
+		return fmt.Errorf("could not remove authored-script session directory %q: %w", s.RootDirectory, err)
+	}
+	s.cleaned = true
+	return nil
 }

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/session.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/session.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package authoredscripts
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+const (
+	sessionDirectoryPrefix = "dd-authored-script-"
+	homeDirectoryName      = "home"
+	tempDirectoryName      = "tmp"
+	sessionDirectoryMode   = 0700
+)
+
+// Session provides isolated writable directories for one script execution.
+type Session struct {
+	RootDirectory string
+	HomeDirectory string
+	TempDirectory string
+
+	cleanupOnce sync.Once
+}
+
+func NewSession() (*Session, error) {
+	rootDirectory, err := os.MkdirTemp("", sessionDirectoryPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("could not create authored-script session directory: %w", err)
+	}
+
+	created := false
+	defer func() {
+		if !created {
+			_ = os.RemoveAll(rootDirectory)
+		}
+	}()
+
+	session := &Session{
+		RootDirectory: rootDirectory,
+		HomeDirectory: filepath.Join(rootDirectory, homeDirectoryName),
+		TempDirectory: filepath.Join(rootDirectory, tempDirectoryName),
+	}
+	for _, directory := range []string{session.HomeDirectory, session.TempDirectory} {
+		if err := os.Mkdir(directory, sessionDirectoryMode); err != nil {
+			return nil, fmt.Errorf("could not create authored-script session directory %q: %w", directory, err)
+		}
+	}
+
+	created = true
+	return session, nil
+}
+
+func (s *Session) Cleanup() error {
+	var err error
+	s.cleanupOnce.Do(func() {
+		if removeErr := os.RemoveAll(s.RootDirectory); removeErr != nil {
+			err = fmt.Errorf("could not remove authored-script session directory %q: %w", s.RootDirectory, removeErr)
+		}
+	})
+	return err
+}

--- a/pkg/privateactionrunner/bundle-support/authoredscripts/session.go
+++ b/pkg/privateactionrunner/bundle-support/authoredscripts/session.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2026-present Datadog, Inc.
 
+//go:build !windows
+
 package authoredscripts
 
 import (


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
Adds package and enviroment var handling.

Related PRs: https://github.com/DataDog/datadog-agent/pull/54863, https://github.com/DataDog/datadog-agent/pull/54675

### Motivation
How will this be used:
After the files are downloaded and available in local cache, we will load the package object which contains all the dependencies, script references. Enviroment variables are parsed and setup. This will be used when building the command to execute the script and eventually in run authored script action

See the RFC for the broader intergration: [RFC Authored script download, storage and isolation](https://datadoghq.atlassian.net/wiki/spaces/ACT/pages/7060063493/RFC+Authored+script+download+storage+and+isolation)

### Describe how you validated your changes
Mostly based on code coverage as this is not integrated with the rest of code base. We will have a few more followup PR to wire things up

### Additional Notes