### PR TITLE
fix(autodiscovery): reject null/non-object discovery instances

### DIFF
--- a/comp/core/autodiscovery/discoverer/discovery_json.go
+++ b/comp/core/autodiscovery/discoverer/discovery_json.go
@@ -112,9 +112,24 @@ func parseDiscoveryResult(integrationName, resultJSON string) ([]integration.Con
 			CheckTagCardinality:     raw.CheckTagCardinality,
 		}
 		for _, inst := range raw.Instances {
+			if !isJSONObject(inst) {
+				return nil, fmt.Errorf("decode discovery payload for %s: instance is not a JSON object: %s", integrationName, string(inst))
+			}
 			cfg.Instances = append(cfg.Instances, integration.Data(inst))
 		}
 		configs = append(configs, cfg)
 	}
 	return configs, nil
+}
+
+// isJSONObject reports whether raw decodes to a JSON object. Check instances
+// must be mappings; null, arrays, and scalars are rejected rather than
+// silently passed through to the YAML-based config-resolution pipeline.
+func isJSONObject(raw json.RawMessage) bool {
+	var v interface{}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return false
+	}
+	_, ok := v.(map[string]interface{})
+	return ok
 }

--- a/comp/core/autodiscovery/discoverer/discovery_json.go
+++ b/comp/core/autodiscovery/discoverer/discovery_json.go
@@ -111,9 +111,9 @@ func parseDiscoveryResult(integrationName, resultJSON string) ([]integration.Con
 			IgnoreAutodiscoveryTags: raw.IgnoreAutodiscoveryTags,
 			CheckTagCardinality:     raw.CheckTagCardinality,
 		}
-		for _, inst := range raw.Instances {
+		for i, inst := range raw.Instances {
 			if !isJSONObject(inst) {
-				return nil, fmt.Errorf("decode discovery payload for %s: instance is not a JSON object: %s", integrationName, string(inst))
+				return nil, fmt.Errorf("decode discovery payload for %s: instance %d is not a JSON object", integrationName, i)
 			}
 			cfg.Instances = append(cfg.Instances, integration.Data(inst))
 		}

--- a/comp/core/autodiscovery/discoverer/discovery_json_test.go
+++ b/comp/core/autodiscovery/discoverer/discovery_json_test.go
@@ -59,6 +59,24 @@ func TestParseDiscoveryResult(t *testing.T) {
 			payload:     `not-json`,
 			wantErr:     true,
 		},
+		{
+			name:        "null instance returns error",
+			integration: "redis",
+			payload:     `[{"instances": [null]}]`,
+			wantErr:     true,
+		},
+		{
+			name:        "non-object instance returns error",
+			integration: "redis",
+			payload:     `[{"instances": [42]}]`,
+			wantErr:     true,
+		},
+		{
+			name:        "array instance returns error",
+			integration: "redis",
+			payload:     `[{"instances": [[1,2]]}]`,
+			wantErr:     true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
### What does this PR do?

`parseDiscoveryResult` (`comp/core/autodiscovery/discoverer/discovery_json.go`) now rejects a discovered config whose `instances` array contains an entry that isn't a JSON object (e.g. `null`, a number, or an array), instead of silently wrapping the raw bytes and passing them downstream. A malformed result is treated the same way the existing "invalid JSON" case already is: the discovery worker logs a warning and requeues/retries the probe.

### Motivation

While reviewing [#54837](https://github.com/DataDog/datadog-agent/pull/54837) (a `7.83.x` backport of #54660), Datadog's automated Codex reviewer [flagged](https://github.com/DataDog/datadog-agent/pull/54837#discussion_r3796653045) that a discovery result containing `"instances": [null]` would flow unchanged into `resolved.Instances[i].MergeAdditionalTags(...)` in `applyDiscoveredConfigsLocked`. `MergeAdditionalTags` unmarshals YAML `null` into a map pointer, which resets it to a nil map, and the following `rawConfig["tags"] = []string{}` then panics on that nil map — crashing the whole Agent, with no recovery anywhere in that call chain.

An examination of `datadog_checks_base`'s discovery pipeline (`utils/discovery/probe.py`) confirmed that a null instance can't actually reach the Agent today from shipped integrations: a candidate is only accepted after the real check runs successfully against it and submits a metric, and `AgentCheck.run()` fails immediately (`self.instance.get(...)`) on a `None` instance, so such a candidate is always rejected before it's returned. This is therefore defense-in-depth hardening rather than a fix for an observed crash.

### Describe how you validated your changes

Added cases to the existing table-driven `TestParseDiscoveryResult` in `discovery_json_test.go` covering a `null` instance, a scalar instance, and an array instance, all asserting `parseDiscoveryResult` returns an error.

---
🤖 This PR description and fix were generated with assistance from Claude Code.