### PR TITLE
Container image annotations as tags

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -312,7 +312,16 @@ func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*types.
 // that they are refreshed and cleaned up together with the image entity: the
 // container is registered as a child of the image, letting the parent/children
 // machinery re-emit or delete them when the image entity changes or goes away.
-func (c *WorkloadMetaCollector) imageAnnotationTagsForContainer(container *workloadmeta.Container, isComplete bool) *types.TagInfo {
+//
+// rawComplete is the container's own event completeness. It is intentionally
+// run through containerCompleteness so this TagInfo carries the same effective
+// completeness as the base container TagInfo emitted in handleContainer: on
+// Kubernetes/ECS a container is only "complete" once its pod/task metadata is
+// also complete. Publishing raw completeness here would let this later TagInfo
+// overwrite the entity's completeness in the tag store with true before the
+// parent tags have arrived, which can affect custom-metrics billing and
+// cardinality for consumers that gate on completeness.
+func (c *WorkloadMetaCollector) imageAnnotationTagsForContainer(container *workloadmeta.Container, rawComplete bool) *types.TagInfo {
 	if len(c.containerImageAnnotationsAsTags) == 0 {
 		return nil
 	}
@@ -344,7 +353,7 @@ func (c *WorkloadMetaCollector) imageAnnotationTagsForContainer(container *workl
 		OrchestratorCardTags: orch,
 		LowCardTags:          low,
 		StandardTags:         standard,
-		IsComplete:           isComplete,
+		IsComplete:           c.containerCompleteness(container.ID, rawComplete),
 	}
 }
 
@@ -474,8 +483,11 @@ func (c *WorkloadMetaCollector) handleContainerImage(ev workloadmeta.Event) []*t
 			return container.Image.ID == image.ID
 		})
 		for _, container := range containers {
-			containerComplete := c.entityCompleteness[container.EntityID]
-			if imageTagInfo := c.imageAnnotationTagsForContainer(container, containerComplete); imageTagInfo != nil {
+			// entityCompleteness stores the container's raw event completeness;
+			// imageAnnotationTagsForContainer runs it through containerCompleteness
+			// to match the base container TagInfo's effective completeness.
+			rawComplete := c.entityCompleteness[container.EntityID]
+			if imageTagInfo := c.imageAnnotationTagsForContainer(container, rawComplete); imageTagInfo != nil {
 				tagInfos = append(tagInfos, imageTagInfo)
 			}
 		}

--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -390,6 +390,11 @@ func (c *WorkloadMetaCollector) handleContainerImage(ev workloadmeta.Event) []*t
 
 	c.labelsToTags(image.Labels, tagList)
 
+	// image annotations as tags
+	for annotation, value := range image.Annotations {
+		k8smetadata.AddMetadataAsTags(annotation, value, c.containerImageAnnotationsAsTags, c.globContainerImageAnnotations, tagList)
+	}
+
 	low, orch, high, standard := tagList.Compute()
 	return []*types.TagInfo{
 		{

--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -280,7 +280,7 @@ func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*types.
 	}
 
 	low, orch, high, standard := tagList.Compute()
-	return []*types.TagInfo{
+	tagInfos := []*types.TagInfo{
 		{
 			Source:               containerSource,
 			EntityID:             common.BuildTaggerEntityID(container.EntityID),
@@ -290,6 +290,61 @@ func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*types.
 			StandardTags:         standard,
 			IsComplete:           c.containerCompleteness(container.ID, ev.IsComplete),
 		},
+	}
+
+	// Propagate container image annotation tags to the container so they are
+	// applied to container.* metrics. This handles the common case where the
+	// image metadata is already available when the container starts; late or
+	// changed image metadata is handled from handleContainerImage.
+	if imageTagInfo := c.imageAnnotationTagsForContainer(container, ev.IsComplete); imageTagInfo != nil {
+		tagInfos = append(tagInfos, imageTagInfo)
+	}
+
+	return tagInfos
+}
+
+// imageAnnotationTagsForContainer builds the TagInfo that maps a container's
+// image OCI annotations to tags on the container entity, or nil when the
+// feature is disabled, the image metadata is not (yet) in the store, or no
+// annotation matches the configured mapping.
+//
+// The tags are published under containerImageSource (not containerSource) so
+// that they are refreshed and cleaned up together with the image entity: the
+// container is registered as a child of the image, letting the parent/children
+// machinery re-emit or delete them when the image entity changes or goes away.
+func (c *WorkloadMetaCollector) imageAnnotationTagsForContainer(container *workloadmeta.Container, isComplete bool) *types.TagInfo {
+	if len(c.containerImageAnnotationsAsTags) == 0 {
+		return nil
+	}
+
+	image, err := c.store.GetImage(container.Image.ID)
+	if err != nil || len(image.Annotations) == 0 {
+		return nil
+	}
+
+	tagList := taglist.NewTagList()
+	for annotation, value := range image.Annotations {
+		k8smetadata.AddMetadataAsTags(annotation, value, c.containerImageAnnotationsAsTags, c.globContainerImageAnnotations, tagList)
+	}
+
+	low, orch, high, standard := tagList.Compute()
+	if len(low)+len(orch)+len(high)+len(standard) == 0 {
+		return nil
+	}
+
+	c.registerChild(image.EntityID, container.EntityID)
+
+	return &types.TagInfo{
+		// containerImageSource here is not a mistake: image annotation tags are
+		// owned by the image entity, so the container inherits them from that
+		// source.
+		Source:               containerImageSource,
+		EntityID:             common.BuildTaggerEntityID(container.EntityID),
+		HighCardTags:         high,
+		OrchestratorCardTags: orch,
+		LowCardTags:          low,
+		StandardTags:         standard,
+		IsComplete:           isComplete,
 	}
 }
 
@@ -396,7 +451,7 @@ func (c *WorkloadMetaCollector) handleContainerImage(ev workloadmeta.Event) []*t
 	}
 
 	low, orch, high, standard := tagList.Compute()
-	return []*types.TagInfo{
+	tagInfos := []*types.TagInfo{
 		{
 			Source:               containerImageSource,
 			EntityID:             common.BuildTaggerEntityID(image.EntityID),
@@ -407,6 +462,26 @@ func (c *WorkloadMetaCollector) handleContainerImage(ev workloadmeta.Event) []*t
 			IsComplete:           ev.IsComplete,
 		},
 	}
+
+	// Re-apply the image annotation tags to every container currently using
+	// this image, so that image metadata that arrives or changes after a
+	// container has already been tagged still propagates to container.*
+	// metrics. Containers are registered as children of the image above, in
+	// imageAnnotationTagsForContainer, so the parent/children machinery cleans
+	// them up when the image is deleted.
+	if len(c.containerImageAnnotationsAsTags) > 0 {
+		containers := c.store.ListContainersWithFilter(func(container *workloadmeta.Container) bool {
+			return container.Image.ID == image.ID
+		})
+		for _, container := range containers {
+			containerComplete := c.entityCompleteness[container.EntityID]
+			if imageTagInfo := c.imageAnnotationTagsForContainer(container, containerComplete); imageTagInfo != nil {
+				tagInfos = append(tagInfos, imageTagInfo)
+			}
+		}
+	}
+
+	return tagInfos
 }
 
 func (c *WorkloadMetaCollector) labelsToTags(labels map[string]string, tags *taglist.TagList) {
@@ -1359,6 +1434,18 @@ func (c *WorkloadMetaCollector) handleDelete(ev workloadmeta.Event) []*types.Tag
 		DeleteEntity: true,
 	})
 	tagInfos = append(tagInfos, c.handleDeleteChildren(source, children)...)
+
+	// A container may also carry image annotation tags published under
+	// containerImageSource (see imageAnnotationTagsForContainer). Those are not
+	// covered by the entity's own source above, so expire them explicitly here
+	// rather than waiting for the next image event to prune the stale child.
+	if entityID.Kind == workloadmeta.KindContainer && len(c.containerImageAnnotationsAsTags) > 0 {
+		tagInfos = append(tagInfos, &types.TagInfo{
+			Source:       containerImageSource,
+			EntityID:     taggerEntityID,
+			DeleteEntity: true,
+		})
+	}
 
 	delete(c.children, taggerEntityID)
 	delete(c.entityCompleteness, entityID)

--- a/comp/core/tagger/collectors/workloadmeta_main.go
+++ b/comp/core/tagger/collectors/workloadmeta_main.go
@@ -60,14 +60,16 @@ type WorkloadMetaCollector struct {
 	children     map[types.EntityID]map[types.EntityID]struct{}
 	tagProcessor taggerdef.Processor
 
-	containerEnvAsTags    map[string]string
-	containerLabelsAsTags map[string]string
+	containerEnvAsTags              map[string]string
+	containerLabelsAsTags           map[string]string
+	containerImageAnnotationsAsTags map[string]string
 
 	staticTags                    map[string][]string // for ECS, EKS Fargate, and DCA
 	k8sResourcesAnnotationsAsTags map[string]map[string]string
 	k8sResourcesLabelsAsTags      map[string]map[string]string
 	globContainerLabels           map[string]glob.Glob
 	globContainerEnvLabels        map[string]glob.Glob
+	globContainerImageAnnotations map[string]glob.Glob
 	globK8sResourcesAnnotations   map[string]map[string]glob.Glob
 	globK8sResourcesLabels        map[string]map[string]glob.Glob
 
@@ -88,9 +90,10 @@ type refreshRequest struct {
 	done chan struct{}
 }
 
-func (c *WorkloadMetaCollector) initContainerMetaAsTags(labelsAsTags, envAsTags map[string]string) {
+func (c *WorkloadMetaCollector) initContainerMetaAsTags(labelsAsTags, envAsTags, imageAnnotationsAsTags map[string]string) {
 	c.containerLabelsAsTags, c.globContainerLabels = k8smetadata.InitMetadataAsTags(labelsAsTags)
 	c.containerEnvAsTags, c.globContainerEnvLabels = k8smetadata.InitMetadataAsTags(envAsTags)
+	c.containerImageAnnotationsAsTags, c.globContainerImageAnnotations = k8smetadata.InitMetadataAsTags(imageAnnotationsAsTags)
 }
 
 func (c *WorkloadMetaCollector) initK8sResourcesMetaAsTags(resourcesLabelsAsTags, resourcesAnnotationsAsTags map[string]map[string]string) {
@@ -234,7 +237,8 @@ func NewWorkloadMetaCollector(ctx context.Context, cfg config.Component, store w
 		retrieveMappingFromConfig(cfg, "docker_env_as_tags"),
 		retrieveMappingFromConfig(cfg, "container_env_as_tags"),
 	)
-	c.initContainerMetaAsTags(containerLabelsAsTags, containerEnvAsTags)
+	containerImageAnnotationsAsTags := retrieveMappingFromConfig(cfg, "container_image_annotations_as_tags")
+	c.initContainerMetaAsTags(containerLabelsAsTags, containerEnvAsTags, containerImageAnnotationsAsTags)
 
 	// kubernetes resources metadata as tags
 	metadataAsTags := configutils.GetMetadataAsTags(cfg)

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -3816,6 +3816,223 @@ func TestHandleContainer_IsComplete(t *testing.T) {
 	}
 }
 
+// TestHandleContainer_ImageAnnotationTags_IsComplete verifies that the image
+// annotation TagInfo appended to a container (published under
+// containerImageSource) carries the same effective, parent-aware completeness
+// as the base container TagInfo. Without this, the later-processed image
+// TagInfo could overwrite the entity's completeness in the tag store with true
+// before the pod/task tags have arrived. It covers both the forward path
+// (handleContainer, image already in the store) and the re-apply path
+// (handleContainerImage, image metadata arriving after the container).
+func TestHandleContainer_ImageAnnotationTags_IsComplete(t *testing.T) {
+	const (
+		imageID       = "sha256:imageconfigdigest"
+		annotationKey = "com.datadoghq.test.imageformat"
+		podID         = "test-pod"
+		taskARN       = "test-task-arn"
+	)
+
+	imageAnnotationsAsTags := map[string]string{annotationKey: "image_format"}
+
+	image := &workloadmeta.ContainerImageMetadata{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindContainerImageMetadata,
+			ID:   imageID,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Annotations: map[string]string{annotationKey: "nydus-demo"},
+		},
+	}
+
+	kubeContainer := workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindContainer,
+			ID:   "test-container",
+		},
+		EntityMeta: workloadmeta.EntityMeta{Name: "agent"},
+		Image:      workloadmeta.ContainerImage{ID: imageID},
+		Owner: &workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesPod,
+			ID:   podID,
+		},
+	}
+
+	ecsContainer := workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindContainer,
+			ID:   "test-container",
+		},
+		EntityMeta: workloadmeta.EntityMeta{Name: "agent"},
+		Image:      workloadmeta.ContainerImage{ID: imageID},
+		Owner: &workloadmeta.EntityID{
+			Kind: workloadmeta.KindECSTask,
+			ID:   taskARN,
+		},
+	}
+
+	pod := &workloadmeta.KubernetesPod{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesPod,
+			ID:   podID,
+		},
+		EntityMeta: workloadmeta.EntityMeta{Name: "test-pod", Namespace: "default"},
+	}
+
+	ecsTask := &workloadmeta.ECSTask{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindECSTask,
+			ID:   taskARN,
+		},
+		EntityMeta:  workloadmeta.EntityMeta{Name: "test-task"},
+		ClusterName: "test-cluster",
+	}
+
+	tests := []struct {
+		name                string
+		features            []env.Feature
+		container           workloadmeta.Container
+		pod                 *workloadmeta.KubernetesPod
+		ecsTask             *workloadmeta.ECSTask
+		parentIsComplete    bool
+		containerIsComplete bool
+		reapply             bool // exercise the handleContainerImage re-apply path
+		expectedIsComplete  bool
+	}{
+		{
+			name:                "no orchestrator: follows container completeness",
+			container:           kubeContainer,
+			containerIsComplete: true,
+			expectedIsComplete:  true,
+		},
+		{
+			name:                "kubernetes: container complete but pod incomplete -> incomplete",
+			features:            []env.Feature{env.Kubernetes},
+			container:           kubeContainer,
+			pod:                 pod,
+			parentIsComplete:    false,
+			containerIsComplete: true,
+			expectedIsComplete:  false,
+		},
+		{
+			name:                "kubernetes: both complete -> complete",
+			features:            []env.Feature{env.Kubernetes},
+			container:           kubeContainer,
+			pod:                 pod,
+			parentIsComplete:    true,
+			containerIsComplete: true,
+			expectedIsComplete:  true,
+		},
+		{
+			name:                "ECS EC2: container complete but task incomplete -> incomplete",
+			features:            []env.Feature{env.ECSEC2},
+			container:           ecsContainer,
+			ecsTask:             ecsTask,
+			parentIsComplete:    false,
+			containerIsComplete: true,
+			expectedIsComplete:  false,
+		},
+		{
+			name:                "re-apply path, kubernetes: container complete but pod incomplete -> incomplete",
+			features:            []env.Feature{env.Kubernetes},
+			container:           kubeContainer,
+			pod:                 pod,
+			parentIsComplete:    false,
+			containerIsComplete: true,
+			reapply:             true,
+			expectedIsComplete:  false,
+		},
+		{
+			name:                "re-apply path, kubernetes: both complete -> complete",
+			features:            []env.Feature{env.Kubernetes},
+			container:           kubeContainer,
+			pod:                 pod,
+			parentIsComplete:    true,
+			containerIsComplete: true,
+			reapply:             true,
+			expectedIsComplete:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if len(test.features) > 0 {
+				env.SetFeatures(t, test.features...)
+			}
+
+			cfg := configmock.New(t)
+			wmeta := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+				fx.Provide(func() log.Component { return logmock.New(t) }),
+				fx.Provide(func() config.Component { return cfg }),
+				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+			))
+			wmeta.Set(image)
+			wmeta.Set(&test.container)
+
+			collector := NewWorkloadMetaCollector(context.TODO(), cfg, wmeta, nil)
+			collector.initContainerMetaAsTags(nil, nil, imageAnnotationsAsTags)
+
+			// Register the parent's completeness in the collector.
+			switch test.container.Owner.Kind {
+			case workloadmeta.KindKubernetesPod:
+				if test.pod != nil {
+					wmeta.Set(test.pod)
+					collector.handleKubePod(workloadmeta.Event{
+						Type:       workloadmeta.EventTypeSet,
+						Entity:     test.pod,
+						IsComplete: test.parentIsComplete,
+					})
+				}
+			case workloadmeta.KindECSTask:
+				if test.ecsTask != nil {
+					wmeta.Set(test.ecsTask)
+					collector.handleECSTask(workloadmeta.Event{
+						Type:       workloadmeta.EventTypeSet,
+						Entity:     test.ecsTask,
+						IsComplete: test.parentIsComplete,
+					})
+				}
+			}
+
+			var actual []*types.TagInfo
+			if test.reapply {
+				// First tag the container (records its raw completeness), then
+				// deliver the image event that re-applies annotation tags.
+				collector.handleContainer(workloadmeta.Event{
+					Type:       workloadmeta.EventTypeSet,
+					Entity:     &test.container,
+					IsComplete: test.containerIsComplete,
+				})
+				actual = collector.handleContainerImage(workloadmeta.Event{
+					Type:       workloadmeta.EventTypeSet,
+					Entity:     image,
+					IsComplete: true,
+				})
+			} else {
+				actual = collector.handleContainer(workloadmeta.Event{
+					Type:       workloadmeta.EventTypeSet,
+					Entity:     &test.container,
+					IsComplete: test.containerIsComplete,
+				})
+			}
+
+			// Locate the image annotation TagInfo: published under
+			// containerImageSource and scoped to the container entity.
+			containerEntityID := types.NewEntityID(types.ContainerID, test.container.EntityID.ID)
+			var imageTagInfo *types.TagInfo
+			for _, ti := range actual {
+				if ti.Source == containerImageSource && ti.EntityID == containerEntityID {
+					imageTagInfo = ti
+					break
+				}
+			}
+
+			require.NotNil(t, imageTagInfo, "expected an image annotation TagInfo for the container")
+			assert.Contains(t, imageTagInfo.LowCardTags, "image_format:nydus-demo")
+			assert.Equal(t, test.expectedIsComplete, imageTagInfo.IsComplete)
+		})
+	}
+}
+
 func TestHandleContainerImage(t *testing.T) {
 	entityID := workloadmeta.EntityID{
 		Kind: workloadmeta.KindContainerImageMetadata,

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -3516,7 +3516,7 @@ func TestHandleContainer(t *testing.T) {
 			collector := NewWorkloadMetaCollector(context.Background(), cfg, nil, nil)
 			collector.staticTags = tt.staticTags
 
-			collector.initContainerMetaAsTags(tt.labelsAsTags, tt.envAsTags)
+			collector.initContainerMetaAsTags(tt.labelsAsTags, tt.envAsTags, nil)
 
 			actual := collector.handleContainer(workloadmeta.Event{
 				Type:   workloadmeta.EventTypeSet,
@@ -3752,9 +3752,10 @@ func TestHandleContainerImage(t *testing.T) {
 	taggerEntityID := types.NewEntityID(types.ContainerImageMetadata, entityID.ID)
 
 	tests := []struct {
-		name     string
-		image    workloadmeta.ContainerImageMetadata
-		expected []*types.TagInfo
+		name         string
+		configValues map[string]interface{}
+		image        workloadmeta.ContainerImageMetadata
+		expected     []*types.TagInfo
 	}{
 		{
 			name: "basic",
@@ -3848,11 +3849,63 @@ func TestHandleContainerImage(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Image OCI annotations are turned into tags when they match the
+			// container_image_annotations_as_tags mapping. Annotations that are
+			// not in the mapping are ignored.
+			name: "annotations as tags",
+			configValues: map[string]interface{}{
+				"container_image_annotations_as_tags": map[string]string{
+					"containerd.io/snapshot/nydus-builder-version": "nydus_builder_version",
+					"target": "+image_target",
+				},
+			},
+			image: workloadmeta.ContainerImageMetadata{
+				EntityID: entityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: entityID.ID,
+					Annotations: map[string]string{
+						"containerd.io/snapshot/nydus-builder-version": "v2.3.7",
+						"target": "staging",
+						"org.opencontainers.image.source": "https://github.com/DataDog/images",
+					},
+				},
+				RepoTags: []string{
+					"datadog/agent:main-nydus",
+				},
+				OS:           "linux",
+				OSVersion:    "1",
+				Architecture: "amd64",
+			},
+			expected: []*types.TagInfo{
+				{
+					Source:               containerImageSource,
+					EntityID:             taggerEntityID,
+					HighCardTags: []string{
+						"image_target:staging",
+					},
+					OrchestratorCardTags: []string{},
+					LowCardTags: []string{
+						"architecture:amd64",
+						"image_name:sha256:651c55002cd5deb06bde7258f6ec6e0ff7f4f17a648ce6e2ec01917da9ae5104",
+						"image_tag:main-nydus",
+						"nydus_builder_version:v2.3.7",
+						"os_name:linux",
+						"os_version:1",
+						"short_image:agent",
+					},
+					StandardTags: []string{},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := configmock.New(t)
+			for k, v := range tt.configValues {
+				cfg.SetInTest(k, v)
+			}
 			collector := NewWorkloadMetaCollector(context.Background(), cfg, nil, nil)
 
 			actual := collector.handleContainerImage(workloadmeta.Event{

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -2909,12 +2909,16 @@ func TestHandleContainer(t *testing.T) {
 	taggerEntityID := types.NewEntityID(types.ContainerID, entityID.ID)
 
 	tests := []struct {
-		name         string
-		staticTags   map[string][]string
-		labelsAsTags map[string]string
-		envAsTags    map[string]string
-		container    workloadmeta.Container
-		expected     []*types.TagInfo
+		name                   string
+		staticTags             map[string][]string
+		labelsAsTags           map[string]string
+		envAsTags              map[string]string
+		imageAnnotationsAsTags map[string]string
+		// images seeds workloadmeta so the forward path (handleContainer
+		// looking up its image to inherit annotation tags) can be exercised.
+		images    []*workloadmeta.ContainerImageMetadata
+		container workloadmeta.Container
+		expected  []*types.TagInfo
 	}{
 		{
 			name: "fully formed container",
@@ -3508,15 +3512,84 @@ func TestHandleContainer(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Forward path: a container inherits its image's OCI annotation
+			// tags (mapped via container_image_annotations_as_tags) so they
+			// land on container.* metrics.
+			name: "container inherits image annotation tags",
+			imageAnnotationsAsTags: map[string]string{
+				"containerd.io/snapshot/nydus-builder-version": "nydus_builder_version",
+			},
+			images: []*workloadmeta.ContainerImageMetadata{
+				{
+					EntityID: workloadmeta.EntityID{
+						Kind: workloadmeta.KindContainerImageMetadata,
+						ID:   "sha256:imageconfigdigest",
+					},
+					EntityMeta: workloadmeta.EntityMeta{
+						Annotations: map[string]string{
+							"containerd.io/snapshot/nydus-builder-version": "v2.3.7",
+						},
+					},
+				},
+			},
+			container: workloadmeta.Container{
+				EntityID: entityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: containerName,
+				},
+				Image: workloadmeta.ContainerImage{
+					ID: "sha256:imageconfigdigest",
+				},
+			},
+			expected: []*types.TagInfo{
+				{
+					Source:   containerSource,
+					EntityID: taggerEntityID,
+					HighCardTags: []string{
+						"container_name:" + containerName,
+						"container_id:" + entityID.ID,
+					},
+					OrchestratorCardTags: []string{},
+					LowCardTags: []string{
+						"image_id:sha256:imageconfigdigest",
+					},
+					StandardTags: []string{},
+				},
+				{
+					Source:               containerImageSource,
+					EntityID:             taggerEntityID,
+					HighCardTags:         []string{},
+					OrchestratorCardTags: []string{},
+					LowCardTags: []string{
+						"nydus_builder_version:v2.3.7",
+					},
+					StandardTags: []string{},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := configmock.New(t)
-			collector := NewWorkloadMetaCollector(context.Background(), cfg, nil, nil)
+			var store workloadmetamock.Mock
+			if len(tt.images) > 0 {
+				store = fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+					fx.Provide(func() log.Component { return logmock.New(t) }),
+					fx.Provide(func() config.Component { return cfg }),
+					fx.Supply(context.Background()),
+					workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+				))
+				for _, image := range tt.images {
+					store.Set(image)
+				}
+			}
+
+			collector := NewWorkloadMetaCollector(context.Background(), cfg, store, nil)
 			collector.staticTags = tt.staticTags
 
-			collector.initContainerMetaAsTags(tt.labelsAsTags, tt.envAsTags, nil)
+			collector.initContainerMetaAsTags(tt.labelsAsTags, tt.envAsTags, tt.imageAnnotationsAsTags)
 
 			actual := collector.handleContainer(workloadmeta.Event{
 				Type:   workloadmeta.EventTypeSet,
@@ -3755,7 +3828,11 @@ func TestHandleContainerImage(t *testing.T) {
 		name         string
 		configValues map[string]interface{}
 		image        workloadmeta.ContainerImageMetadata
-		expected     []*types.TagInfo
+		// containers are stored in workloadmeta so the reverse path
+		// (handleContainerImage re-tagging containers using the image) can be
+		// exercised.
+		containers []*workloadmeta.Container
+		expected   []*types.TagInfo
 	}{
 		{
 			name: "basic",
@@ -3866,7 +3943,7 @@ func TestHandleContainerImage(t *testing.T) {
 					Name: entityID.ID,
 					Annotations: map[string]string{
 						"containerd.io/snapshot/nydus-builder-version": "v2.3.7",
-						"target": "staging",
+						"target":                          "staging",
 						"org.opencontainers.image.source": "https://github.com/DataDog/images",
 					},
 				},
@@ -3877,10 +3954,21 @@ func TestHandleContainerImage(t *testing.T) {
 				OSVersion:    "1",
 				Architecture: "amd64",
 			},
+			containers: []*workloadmeta.Container{
+				{
+					EntityID: workloadmeta.EntityID{
+						Kind: workloadmeta.KindContainer,
+						ID:   "container-using-nydus-image",
+					},
+					Image: workloadmeta.ContainerImage{
+						ID: entityID.ID,
+					},
+				},
+			},
 			expected: []*types.TagInfo{
 				{
-					Source:               containerImageSource,
-					EntityID:             taggerEntityID,
+					Source:   containerImageSource,
+					EntityID: taggerEntityID,
 					HighCardTags: []string{
 						"image_target:staging",
 					},
@@ -3896,6 +3984,20 @@ func TestHandleContainerImage(t *testing.T) {
 					},
 					StandardTags: []string{},
 				},
+				{
+					// Reverse path: the container using this image inherits the
+					// annotation tags under containerImageSource.
+					Source:   containerImageSource,
+					EntityID: types.NewEntityID(types.ContainerID, "container-using-nydus-image"),
+					HighCardTags: []string{
+						"image_target:staging",
+					},
+					OrchestratorCardTags: []string{},
+					LowCardTags: []string{
+						"nydus_builder_version:v2.3.7",
+					},
+					StandardTags: []string{},
+				},
 			},
 		},
 	}
@@ -3906,7 +4008,19 @@ func TestHandleContainerImage(t *testing.T) {
 			for k, v := range tt.configValues {
 				cfg.SetInTest(k, v)
 			}
-			collector := NewWorkloadMetaCollector(context.Background(), cfg, nil, nil)
+
+			store := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+				fx.Provide(func() log.Component { return logmock.New(t) }),
+				fx.Provide(func() config.Component { return cfg }),
+				fx.Supply(context.Background()),
+				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+			))
+			store.Set(&tt.image)
+			for _, container := range tt.containers {
+				store.Set(container)
+			}
+
+			collector := NewWorkloadMetaCollector(context.Background(), cfg, store, nil)
 
 			actual := collector.handleContainerImage(workloadmeta.Event{
 				Type:   workloadmeta.EventTypeSet,
@@ -4187,6 +4301,46 @@ func TestHandleDelete(t *testing.T) {
 
 	assertTagInfoListEqual(t, expected, actual)
 	assert.Empty(t, collector.children)
+}
+
+// When container image annotations as tags is enabled, deleting a container
+// must also expire the tags published for it under containerImageSource,
+// otherwise image annotation tags would leak until the next image event.
+func TestHandleDeleteContainerImageAnnotations(t *testing.T) {
+	const containerID = "foobarquux"
+
+	containerEntityID := workloadmeta.EntityID{
+		Kind: workloadmeta.KindContainer,
+		ID:   containerID,
+	}
+	container := &workloadmeta.Container{
+		EntityID: containerEntityID,
+	}
+	containerTaggerEntityID := types.NewEntityID(types.ContainerID, containerID)
+
+	cfg := configmock.New(t)
+	cfg.SetInTest("container_image_annotations_as_tags", map[string]string{"foo": "bar"})
+	collector := NewWorkloadMetaCollector(context.Background(), cfg, nil, nil)
+
+	expected := []*types.TagInfo{
+		{
+			Source:       containerSource,
+			EntityID:     containerTaggerEntityID,
+			DeleteEntity: true,
+		},
+		{
+			Source:       containerImageSource,
+			EntityID:     containerTaggerEntityID,
+			DeleteEntity: true,
+		},
+	}
+
+	actual := collector.handleDelete(workloadmeta.Event{
+		Type:   workloadmeta.EventTypeUnset,
+		Entity: container,
+	})
+
+	assertTagInfoListEqual(t, expected, actual)
 }
 
 func TestHandleDeleteKubernetesNode(t *testing.T) {

--- a/comp/core/workloadmeta/collectors/internal/containerd/image.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image.go
@@ -420,6 +420,7 @@ func extractFromConfigBlob(ctx context.Context, img containerd.Image, manifest o
 
 	outImage.Layers = getLayersWithHistory(ocispecImage, manifest)
 	outImage.Labels = getImageLabels(img, ocispecImage)
+	outImage.Annotations = getImageAnnotations(img, manifest)
 	return nil
 }
 
@@ -521,4 +522,19 @@ func getImageLabels(img containerd.Image, ocispecImage ocispec.Image) map[string
 	maps.Copy(labels, ocispecImage.Config.Labels)
 
 	return labels
+}
+
+func getImageAnnotations(img containerd.Image, manifest ocispec.Manifest) map[string]string {
+	// OCI annotations live on the image descriptors rather than in the config
+	// blob. The target descriptor may carry index-level annotations, while the
+	// platform-specific manifest carries manifest-level annotations (for
+	// example, the containerd.io/snapshot/nydus-* keys). Manifest annotations
+	// take precedence when a key is present in both.
+	annotations := map[string]string{}
+
+	maps.Copy(annotations, img.Target().Annotations)
+
+	maps.Copy(annotations, manifest.Annotations)
+
+	return annotations
 }

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -3477,7 +3477,8 @@ properties:
     visibility: public
     description: |-
       The Agent can extract container image OCI annotation values and set them as tags associated to a <TAG_KEY>.
-      These tags are attached to container image entities and appear on the Container Images page.
+      These tags are attached to container image entities (appearing on the Container Images page) and are also
+      applied to the containers using the image, so they show up on container.* metrics.
       If you prefix your tag name with `+`, it will only be added to high cardinality metrics. (Supported container
       runtimes: Containerd, CRI-O).
     example: |2-

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -3468,6 +3468,24 @@ properties:
         <HIGH_CARDINALITY_LABEL_NAME>: +<TAG_KEY>
     tags:
     - template_section:KubernetesTagging
+  container_image_annotations_as_tags:
+    node_type: setting
+    type: object
+    default: {}
+    additionalProperties:
+      type: string
+    visibility: public
+    description: |-
+      The Agent can extract container image OCI annotation values and set them as tags associated to a <TAG_KEY>.
+      These tags are attached to container image entities and appear on the Container Images page.
+      If you prefix your tag name with `+`, it will only be added to high cardinality metrics. (Supported container
+      runtimes: Containerd, CRI-O).
+    example: |2-
+
+        <ANNOTATION_NAME>: <TAG_KEY>
+        <HIGH_CARDINALITY_ANNOTATION_NAME>: +<TAG_KEY>
+    tags:
+    - template_section:KubernetesTagging
   ecs_agent_container_name:
     node_type: setting
     title: ECS integration Configuration

--- a/releasenotes/notes/container-image-annotations-as-tags-2c12755098055579.yaml
+++ b/releasenotes/notes/container-image-annotations-as-tags-2c12755098055579.yaml
@@ -3,7 +3,9 @@ features:
   - |
     Added a new ``container_image_annotations_as_tags`` configuration option that
     maps container image OCI annotations to tags. The resulting tags are attached
-    to container image entities and appear on the Container Images page. Image
-    annotations are now collected by the Containerd and CRI-O workloadmeta
-    collectors (for example, the ``containerd.io/snapshot/nydus-*`` annotations),
-    enabling fleet-wide tracking of alternative image formats such as Nydus.
+    to container image entities (appearing on the Container Images page) and are
+    also propagated to the containers using the image, so they apply to
+    ``container.*`` metrics. Image annotations are now collected by the Containerd
+    and CRI-O workloadmeta collectors (for example, the
+    ``containerd.io/snapshot/nydus-*`` annotations), enabling fleet-wide tracking
+    of alternative image formats such as Nydus.

--- a/releasenotes/notes/container-image-annotations-as-tags-2c12755098055579.yaml
+++ b/releasenotes/notes/container-image-annotations-as-tags-2c12755098055579.yaml
@@ -5,7 +5,8 @@ features:
     maps container image OCI annotations to tags. The resulting tags are attached
     to container image entities (appearing on the Container Images page) and are
     also propagated to the containers using the image, so they apply to
-    ``container.*`` metrics. Image annotations are now collected by the Containerd
-    and CRI-O workloadmeta collectors (for example, the
-    ``containerd.io/snapshot/nydus-*`` annotations), enabling fleet-wide tracking
-    of alternative image formats such as Nydus.
+    ``container.*`` metrics. Container image annotations (for example, the
+    ``containerd.io/snapshot/nydus-*`` annotations) are exposed by the Containerd
+    and CRI-O workloadmeta collectors, enabling fleet-wide tracking of alternative
+    image formats such as Nydus. This option is not supported with the Docker
+    runtime, which does not expose OCI image annotations.

--- a/releasenotes/notes/container-image-annotations-as-tags-2c12755098055579.yaml
+++ b/releasenotes/notes/container-image-annotations-as-tags-2c12755098055579.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Added a new ``container_image_annotations_as_tags`` configuration option that
+    maps container image OCI annotations to tags. The resulting tags are attached
+    to container image entities and appear on the Container Images page. Image
+    annotations are now collected by the Containerd and CRI-O workloadmeta
+    collectors (for example, the ``containerd.io/snapshot/nydus-*`` annotations),
+    enabling fleet-wide tracking of alternative image formats such as Nydus.


### PR DESCRIPTION
## What does this PR do?

Adds a new `container_image_annotations_as_tags` configuration option that maps
container image **OCI annotations** to Datadog tags.

The resulting tags are:
- attached to the **container image entity** (visible on the Container Images page), and
- propagated to every **container** using that image, so they also apply to `container.*` metrics.

Concretely, the change:
- Collects OCI annotations in the workloadmeta containerd collector
  (`getImageAnnotations`), merging index-level annotations from the target
  descriptor with the platform-specific manifest annotations (manifest wins on
  key conflicts) and storing them on `Image.Annotations`.
- Reads the new `container_image_annotations_as_tags` mapping in the tagger
  workloadmeta collector and builds image-annotation tags via the existing
  `AddMetadataAsTags` machinery (so `+` prefix for high-cardinality tags works
  as with other `*_as_tags` options).
- Propagates those tags from the image entity onto the containers that use it,
  in both directions of arrival order:
  - when the container starts and image metadata is already present, and
  - when image metadata arrives or changes after the container was already
    tagged (re-applied to all containers using the image).
- Registers each container as a child of its image entity so the existing
  parent/child machinery re-emits and cleans up the inherited tags when the
  image changes or is deleted, plus an explicit expiry on container delete
  (tags are published under `containerImageSource`, not `containerSource`).
- Adds the config schema entry and a release note.

## Motivation

Image OCI annotations (for example the `containerd.io/snapshot/nydus-*` keys)
carry useful metadata about alternative image formats such as Nydus. Exposing
them as tags enables fleet-wide tracking and filtering of image format /
snapshotter usage on both the Container Images page and `container.*` metrics.

This is intentionally **not supported with the Docker runtime**, which does not
expose OCI image annotations; the annotations are surfaced by the containerd and
CRI-O workloadmeta collectors.

## Describe how you validated your changes

- **Unit tests** in `comp/core/tagger/collectors/workloadmeta_test.go` covering
  the annotation→tag mapping, propagation to containers, re-application when
  image metadata arrives late, and cleanup on delete.
- **Manual end-to-end test on a live cluster** (runbook:
  `CONTINT-5425-manual-test.md`):
  1. Built a test image carrying a manifest-level OCI annotation
     (`com.datadoghq.test.imageformat=nydus-demo`) with
     `docker buildx --annotation` and pushed it.
  2. Deployed the node Agent (hacky-dev-image build) and a workload pod on a
     **containerd** minikube cluster with
     `container_image_annotations_as_tags: {"com.datadoghq.test.imageformat":"image_format"}`.
  3. Confirmed via the tagger/workloadmeta dumps that:
     - the annotation is captured in workloadmeta
       (`Annotations: com.datadoghq.test.imageformat:nydus-demo`),
     - **Part 1** — `image_format:nydus-demo` is present on the container image
       entity, and
     - **Part 2** — `image_format:nydus-demo` is present on the container
       entity (so it applies to `container.*` metrics).
  4. Verified backend visibility on `datad0g.com` (Container Images page filter
     and `container.uptime` grouped by `image_format`).

  Also confirmed the negative case: on a **Docker**-runtime cluster the manifest
  annotation never reaches workloadmeta and the tags do not appear — matching
  the documented runtime limitation.

## Additional Notes

- Keep mappings **low-cardinality** (no `+` prefix) if you want the tag on
  `container.*` metrics by default; `+`-prefixed tags land only on
  high-cardinality metrics.
- These are OCI **manifest annotations**, not image config **labels** — labels
  are already handled by `container_labels_as_tags`.
- Tags inherited from the image are owned by `containerImageSource` so their
  lifecycle follows the image entity, not the container's own tag source.

