### PR TITLE
incident-59224/incident-59369: cap `tests_windows-x64` build parallelism at 4

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -603,6 +603,7 @@ def test(
     rtloader_root=None,
     python_home_3=None,
     cpus=None,
+    build_cpus=None,
     timeout=180,
     cache=True,
     test_run_name="",
@@ -664,7 +665,8 @@ def test(
     race_opt = "-race" if race else ""
     # atomic is quite expensive but it's the only way to run both the coverage and the race detector at the same time without getting false positives from the cover counter
     covermode_opt = "-covermode=" + ("atomic" if race else "count") if coverage else ""
-    build_cpus_opt = f"-p {cpus}" if cpus else ""
+    build_cpus = build_cpus or cpus
+    build_cpus_opt = f"-p {build_cpus}" if build_cpus else ""
     test_cpus_opt = f"-parallel {cpus}" if cpus else ""
     trimpath_opt = "-trimpath" if 'DELVE' not in os.environ else ""
     if sys.platform == "win32" and "DELVE" not in os.environ:

--- a/tasks/winbuildscripts/Invoke-UnitTests.ps1
+++ b/tasks/winbuildscripts/Invoke-UnitTests.ps1
@@ -153,8 +153,9 @@ Invoke-BuildScript `
         $TEST_WASHER_FLAG="--test-washer"
     }
     $Env:Python3_ROOT_DIR=$Env:TEST_EMBEDDED_PY3
+    # incident-59224/incident-59369: set --build-cpus=4 as 6+ concurrent linkers exhaust 20 GB
     & dda inv -- -e test --junit-tar="$Env:JUNIT_TAR" `
-        --race --rerun-fails=2 --coverage --cpus 8 `
+        --race --rerun-fails=2 --coverage --cpus 8 --build-cpus=4 `
         --python-home-3=$Env:Python3_ROOT_DIR `
         --result-json $internal_result_json `
         --build-stdlib `


### PR DESCRIPTION
### What does this PR do?
Add `--build-cpus` to the `test` task, so `go build` parallelism (`-p`) can be set independently of test parallelism (`-parallel`), and pass `--build-cpus 4` on Windows while keeping `--cpus 8`.

Every other caller keeps its current behavior: the parameter defaults to `cpus` when unset.

Not covered: `-p` caps concurrent test binaries as well as build actions, so cross-package test concurrency drops from 8 to 4.

Go exposes no knob to separate those two, `-parallel 8` only preserves parallelism within a package.

### Motivation
`tests_windows-x64` fails while linking, sporadically from 2026-07-30 and frequently since 2026-08-08.

Filed as [incident-59224](https://dd.enterprise.slack.com/archives/C0BQ6LTADFG), then again as [#incident-59369](https://dd.enterprise.slack.com/archives/C0BQXGXCQMC) on 2026-08-18 with the same signature in jobs [1960498027](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1960498027), [1960338207](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1960338207), [1960197554](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1960197554), [1959990966](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1959990966) and [1959329311](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1959329311).

The process that dies is Go's own linker, not mingw `ld`: all 25 `errno=1455` dumps in job 1951788199 sit in `loadlib` -> `LoadSyms` -> `preloadSyms`.

Eight concurrent linkers reach about 17 GB of commit charge, which exhausts the container.

Test execution is not the problem: nine concurrent test binaries totalled 893 MB.

### Describe how you validated your changes
Reproduced on a Windows VM with a 20 GB commit ceiling, gcc 14.2.0, Go 1.26.5 and GOMEMLIMIT=2560MiB, running:
```
go test -p N -race -cover -covermode=atomic ./cmd/...
```
Link-only reliability, 3 reps unless stated:
```
-p 8   3/3 OOM
-p 7   2/3 OOM
-p 6   1/3 OOM
-p 5   0/8 clean :+1:
-p 4   0/8 clean :+1:
```
Build wall clock, one rep each, **no `-w`**:
```
-p 8  296s 1.00x OOM    
-p 7  352s 1.19x OOM
-p 6  319s 1.08x clean
-p 5  309s 1.04x clean
-p 4  275s 0.93x clean 🚀
-p 3  282s 0.95x clean
-p 2  356s 1.20x clean
-p 1  550s 1.86x clean
```
The build time is almost flat from `-p 3` to `-p 8`, so 4 costs nothing measurable while leaving 2 steps of margin below the cliff.

`-p 6` came back 3/3 not clean in one batch and clean in another, so the cliff moves between runs and 5 sits too close to it.

### Additional Notes
Measured on a 20 GB bare host, not the 24 GB container, without the `python` tag and over `./cmd/...` only, so the ordering transfers but the absolute numbers are not CI's.

This caps the legacy `go test` path only.

The Bazel test path is capped separately by #55044, and the two compose because `test_flavor` completes before `_run_bazel_tests`.

**The `-w` of #54903 is inert**: 2/3 OOM with it against 2/3 without, peaks indistinguishable, because it removes `DwarfGenerateDebugSyms` while the OOM is in `loadlib`.
=> it can be reverted separately.