### PR TITLE
Revert ineffective "drop DWARF from Windows Go test binary links"

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -667,9 +667,6 @@ def test(
     build_cpus_opt = f"-p {cpus}" if cpus else ""
     test_cpus_opt = f"-parallel {cpus}" if cpus else ""
     trimpath_opt = "-trimpath" if 'DELVE' not in os.environ else ""
-    if sys.platform == "win32" and "DELVE" not in os.environ:
-        # incident-59224: omit DWARF to deflate peak link memory, while preserving symbol table diagnostics
-        ldflags += "-w"
 
     nocache = '-count=1' if not cache else ''
 


### PR DESCRIPTION
This reverts commit 078d86b4fa11aeef88c5150bbc4091c93bfde84b (#54903).

### Motivation
`-w` was measured inert against the failure it was meant to mitigate.

The OOM is in Go's own linker, not mingw `ld`: all 25 `errno=1455` dumps in job [1951788199](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1951788199) sit in `loadlib` -> `LoadSyms` -> `preloadSyms`.

`-w` suppresses `DwarfGenerateDebugSyms`, which runs after `loadlib`, and it does not shrink the linker input either, because the compiler emits DWARF into the object files regardless (`-dwarf` defaults to true).

### Describe how you validated your changes
Windows VM, 20 GB commit ceiling, `GOMEMLIMIT=2560MiB`, 3 reps each of:
```
go test -p 8 -race -cover -covermode=atomic ./cmd/...
```
```
without -w   2/3 OOM   peaks 16,581-17,299 MB
with -w      2/3 OOM   peaks 16,768-17,240 MB
```
Per-phase linker heap on Linux, `-ldflags=-benchmark=mem`, `-race`:
```
                Loadlib live   DwarfGenerateDebugSyms alloc
baseline            420.2 MB                       412.9 MB
-w                  420.5 MB                              0
```
`Loadlib` is unchanged to within 0.3 MB, which is why the OOM rate does not move.

### Additional Notes
`-w` does cut peak link heap by 19 percent on Linux, 637 MB to 518 MB, and costs no diagnostics because `pclntab` is untouched.

That saving is real but sits on the **wrong side of the failing phase**.

Capping build concurrency is what addresses the OOM: `-p 5` was 0/8 clean where `-p 8` was 3/3 OOM, hence:
- #55054.

Measured on a 20 GB bare host over `./cmd/...` without the `python` tag, so the ordering transfers but the absolute numbers are not CI's.