### PR TITLE
Resolve sysprobe-functional test assets relative to the package source dir

### DIFF
--- a/test/new-e2e/tests/sysprobe-functional/apmtags_test.go
+++ b/test/new-e2e/tests/sysprobe-functional/apmtags_test.go
@@ -8,7 +8,6 @@ package sysprobefunctional
 import (
 	_ "embed"
 	"fmt"
-	"os"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -30,8 +29,6 @@ import (
 
 type apmvmSuite struct {
 	e2e.BaseSuite[environments.WindowsHost]
-
-	testspath string
 }
 
 //go:embed fixtures/system-probe.yaml
@@ -104,14 +101,30 @@ var sites = []windows.IISSiteDefinition{
 	},
 }
 
+// packagePath resolves rel against this package's source directory.
+//
+// Asset paths must not be resolved against the process working directory. The
+// test binary is only run from the package directory by convention -- `go test`
+// chdirs there, and the prebuilt-binary launcher sets Dir explicitly -- but
+// neither is guaranteed, and when the process starts elsewhere a relative path
+// silently points at nothing. Deriving the directory from this file's own
+// compile-time path keeps asset lookups correct either way.
+//
+// An already-absolute path is returned unchanged, so the helper is safe to apply
+// unconditionally at the copy helpers below.
+func packagePath(rel string) string {
+	if filepath.IsAbs(rel) {
+		return rel
+	}
+	_, srcfile, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("sysprobe-functional: could not determine the test package source path")
+	}
+	return filepath.Join(filepath.Dir(srcfile), rel)
+}
+
 func (v *apmvmSuite) SetupSuite() {
 	t := v.T()
-
-	// Get the absolute path to the test assets directory
-	currDir, err := os.Getwd()
-	require.NoError(t, err)
-
-	v.testspath = filepath.Join(currDir, "artifacts")
 
 	// this creates the VM.
 	v.BaseSuite.SetupSuite()
@@ -121,21 +134,16 @@ func (v *apmvmSuite) SetupSuite() {
 	// get the remote host
 	vm := v.Env().RemoteHost
 
-	err = windows.InstallIIS(vm)
+	err := windows.InstallIIS(vm)
 	require.NoError(t, err)
 	// HEADSUP the paths are windows, but this will execute in linux. So fix the paths
 	t.Log("IIS Installed, continuing")
 
 	t.Log("Creating sites")
-	// figure out where we're being executed from.  These paths should be in
-	// native path separators (i.e. not windows paths if executing in ci/on linux)
-
-	_, srcfile, _, ok := runtime.Caller(0)
-	require.True(t, ok)
-	exPath := filepath.Dir(srcfile)
-
+	// These paths are consumed on the remote windows host but built here on
+	// linux, so they must be in native separators.
 	for idx := range sites {
-		sites[idx].AssetsDir = path.Join(exPath, "assets")
+		sites[idx].AssetsDir = packagePath("assets")
 	}
 
 	err = windows.CreateIISSite(vm, sites)
@@ -164,15 +172,14 @@ func copyFileToSiteRoot(host *components.RemoteHost, sitename, filename, targetf
 		}
 	}
 
-	// test this out.  Should copy path-relative to assets
-	host.CopyFile(filename, sitepath)
+	host.CopyFile(packagePath(filename), sitepath)
 	return nil
 }
 
 func copyFileToAppRoot(host *components.RemoteHost, app windows.IISApplicationDefinition, filename, targetfilename string) error {
 
 	apppath := path.Join(app.PhysicalPath, targetfilename)
-	host.CopyFile(filename, apppath)
+	host.CopyFile(packagePath(filename), apppath)
 	return nil
 }
 
@@ -228,11 +235,11 @@ func setupTest(vm *components.RemoteHost, test usmTaggingTest) error {
 	removeIfExists(vm, clientAppConfig)
 
 	if test.clientJSONFile != "" {
-		vm.CopyFile(test.clientJSONFile, clientJSONFile)
+		vm.CopyFile(packagePath(test.clientJSONFile), clientJSONFile)
 	}
 
 	if test.clientAppConfig != "" {
-		vm.CopyFile(test.clientAppConfig, clientAppConfig)
+		vm.CopyFile(packagePath(test.clientAppConfig), clientAppConfig)
 	}
 
 	cleanSites(vm)
@@ -295,13 +302,13 @@ func (v *apmvmSuite) TestUSMAutoTaggingSuite() {
 
 	// copy test script
 	testScript := path.Join("c:", "users", "administrator", "test_tags.ps1")
-	vm.CopyFile("usmtest/test_tags.ps1", testScript)
+	vm.CopyFile(packagePath("usmtest/test_tags.ps1"), testScript)
 
 	testExe := path.Join("c:", "users", "administrator", "littleget.exe")
-	vm.CopyFile("usmtest/littleget.exe", testExe)
+	vm.CopyFile(packagePath("usmtest/littleget.exe"), testExe)
 
 	pipeExe := path.Join("c:", "users", "administrator", "NamedPipeCmd.exe")
-	vm.CopyFile("usmtest/NamedPipeCmd.exe", pipeExe)
+	vm.CopyFile(packagePath("usmtest/NamedPipeCmd.exe"), pipeExe)
 
 	pscommand := "%s %s -TargetHost localhost -TargetPort %s -TargetPath %s -ExpectedClientTags %s -ExpectedServerTags %s -ConnExe %s"
 


### PR DESCRIPTION
### What does this PR do?

Makes `TestUSMAutoTaggingSuite` resolve its fixture files against the package's
source directory instead of the process working directory.

The suite pushed fixtures to the remote Windows host using bare relative paths
such as `"usmtest/test_tags.ps1"`. `CopyFile` opens these as ordinary local
files, so they resolve against the *process* working directory.

That directory is only the package directory by convention — `go test` chdirs
there, and the prebuilt-binary launcher sets `command.Dir` explicitly
([`internal/tools/gotest-custom/main.go`](https://github.com/DataDog/datadog-agent/blob/main/internal/tools/gotest-custom/main.go#L77)).
Neither is a guarantee. When the test process started from the repo root
instead, every asset lookup failed:

```
host.go:257: open usmtest/test_tags.ps1: no such file or directory
```

`SetupSuite` already solved this for the `assets` directory by deriving an
absolute path from `runtime.Caller(0)`. This promotes that to a `packagePath`
helper and applies it at the seven `CopyFile` call sites, which is where the
relative strings are consumed — so the ~36 path literals in
`apmtags_testdefs_test.go` are unchanged.

Also drops the `testspath` field, which was assigned from `os.Getwd()` and never
read, and the stale `// test this out` comment above `copyFileToSiteRoot`.

### Motivation

https://datadoghq.atlassian.net/browse/WINA-3035

The failure is deterministic, not flaky. Datadog test data for this suite on
`main` splits cleanly on the reported working directory:

| `@test.working_directory` | fail | pass |
| --- | --- | --- |
| `.` (repo root) | 44 | 0 |
| `test/new-e2e/tests/sysprobe-functional` | 0 | 248 |

292 executions, no exceptions in either direction. The suite failed **only**
when launched from the repo root, and 100% of the time under that condition.

It stopped failing because the runner's working directory reverted, not because
anything was fixed — the relative paths are still on `main` today. The failure
mode is silent-then-total: the next time build tooling moves the test process's
CWD, this suite goes from green to 100% red, and because it is marked
`is_known_flaky` it will block nothing while doing so.

### Describe how you validated your changes

- `dda inv linter.go --module=test/new-e2e --targets=./tests/sysprobe-functional`
  → `0 issues`, all linters passed.
- No behaviour change when the working directory is already correct, which is
  the case in CI today. **A green e2e run here does not exercise the failure
  mode** — both launch paths chdir into the package directory, so the old code
  passes too.
- Reproducing the original failure requires launching the prebuilt test binary
  from the repo root, which is the one context where neither chdir applies:
  ```
  dda inv new-e2e-tests.build-binaries
  ./test-binaries/tests-sysprobe-functional.test -test.run TestUSMAutoTaggingSuite -test.v
  ```
  On `main` this fails at `host.go:257`; on this branch it proceeds into the
  assertions.

### Additional Notes

`sysprobe_test.go` has the same class of defect via `os.Getwd()`
([L50](https://github.com/DataDog/datadog-agent/blob/main/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go#L50),
consumed at [L95](https://github.com/DataDog/datadog-agent/blob/main/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go#L95))
and would break `TestVMSuite` the same way. Left out of this PR to keep it
scoped to WINA-3035 — it is a two-line change now that `packagePath` exists in
the package, and worth a follow-up.

A unit test that chdirs and asserts the fixtures still resolve would guard this
permanently and run in seconds without AWS. Not included here because the
package has no unit-test sibling today and adding one means adopting the
`e2eunit` build-tag convention described in `test/new-e2e/AGENTS.md`. Happy to
add it if reviewers would prefer it in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
