### PR TITLE
Allow ISC-licensed Rust dependencies

### DIFF
--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -20,6 +20,7 @@ allow = [
   "BSD-2-Clause",
   "BSD-3-Clause",
   "BSL-1.0",
+  "ISC",
   "MIT",
   "MPL-2.0",
   "Unicode-3.0",


### PR DESCRIPTION
### What does this PR do?
Adds ISC license to Rust license allowlist.

### Motivation
ISC is already being used by Saluki components, this just makes the allowlist accurate.

Initial motivation was allowing us to use some `rustls` features needed for `par-control` that are covered by the ISC license.