### PR TITLE
[Backport 7.83.x] [CWS] Fix: handle activity dump endpoint host that already embeds a port

### DIFF
--- a/pkg/security/utils/BUILD.bazel
+++ b/pkg/security/utils/BUILD.bazel
@@ -114,13 +114,13 @@ dd_agent_go_test(
     deps = [
         "//comp/logs/agent/config",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ] + select({
         "@rules_go//go/platform:android": [
             "//pkg/security/secl/containerutils",
             "//pkg/security/utils/cgroup",
             "//pkg/util/archive",
             "//pkg/util/kernel",
-            "@com_github_stretchr_testify//require",
             "@org_golang_x_sys//unix",
         ],
         "@rules_go//go/platform:linux": [
@@ -128,7 +128,6 @@ dd_agent_go_test(
             "//pkg/security/utils/cgroup",
             "//pkg/util/archive",
             "//pkg/util/kernel",
-            "@com_github_stretchr_testify//require",
             "@org_golang_x_sys//unix",
         ],
         "//conditions:default": [],

--- a/pkg/security/utils/endpoint.go
+++ b/pkg/security/utils/endpoint.go
@@ -8,6 +8,7 @@ package utils
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 
 	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
@@ -16,7 +17,18 @@ import (
 
 // GetEndpointURL returns the formatted URL of the provided endpoint
 func GetEndpointURL(endpoint logsconfig.Endpoint, uri string) string {
+	host := endpoint.Host
 	port := endpoint.Port
+
+	if h, p, err := net.SplitHostPort(host); err == nil {
+		host = h
+		if port == 0 {
+			if parsed, perr := strconv.Atoi(p); perr == nil {
+				port = parsed
+			}
+		}
+	}
+
 	var protocol string
 	if endpoint.UseSSL() {
 		protocol = "https"
@@ -29,5 +41,5 @@ func GetEndpointURL(endpoint logsconfig.Endpoint, uri string) string {
 			port = 80 // use default port
 		}
 	}
-	return fmt.Sprintf("%s://%s%s/%s", protocol, hostport.Join(endpoint.Host, strconv.Itoa(port)), endpoint.PathPrefix, uri)
+	return fmt.Sprintf("%s://%s%s/%s", protocol, hostport.Join(host, strconv.Itoa(port)), endpoint.PathPrefix, uri)
 }

--- a/pkg/security/utils/endpoint_test.go
+++ b/pkg/security/utils/endpoint_test.go
@@ -6,9 +6,11 @@
 package utils
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 )
@@ -53,4 +55,33 @@ func TestGetEndpointURLIPv6Bracketed(t *testing.T) {
 	endpoint := config.NewEndpoint("key", "keyPath", "[fd38::1]", 8080, "/prefix/url", false)
 	url := GetEndpointURL(endpoint, "test")
 	assert.Equal(t, "http://[fd38::1]:8080/prefix/url/test", url)
+}
+
+// TestGetEndpointURLHostWithEmbeddedPort mirrors chart-generated `additional_endpoints`
+// entries where the port is baked into the host field ("cws-intake.<site>.:443") and no
+// separate port is set. The embedded port must be honored instead of double-appended.
+func TestGetEndpointURLHostWithEmbeddedPort(t *testing.T) {
+	endpoint := config.NewEndpoint("key", "keyPath", "cws-intake.datadoghq.com.:443", 0, config.EmptyPathPrefix, true)
+	url := GetEndpointURL(endpoint, "api/v2/secdump")
+	assert.Equal(t, "https://cws-intake.datadoghq.com.:443/api/v2/secdump", url)
+
+	// The prod failure was http.NewRequest rejecting the malformed
+	// "https://[cws-intake.datadoghq.com.:443]:443/..." URL. Assert the produced URL
+	// is actually accepted by the same call the forwarder makes.
+	_, err := http.NewRequest("POST", url, nil)
+	require.NoError(t, err)
+}
+
+// TestGetEndpointURLHostWithEmbeddedPortExplicitWins ensures an explicitly configured
+// port takes precedence over a port embedded in the host string.
+func TestGetEndpointURLHostWithEmbeddedPortExplicitWins(t *testing.T) {
+	endpoint := config.NewEndpoint("key", "keyPath", "cws-intake.datadoghq.com.:443", 8443, config.EmptyPathPrefix, true)
+	url := GetEndpointURL(endpoint, "api/v2/secdump")
+	assert.Equal(t, "https://cws-intake.datadoghq.com.:8443/api/v2/secdump", url)
+}
+
+func TestGetEndpointURLIPv6WithEmbeddedPort(t *testing.T) {
+	endpoint := config.NewEndpoint("key", "keyPath", "[fd38::1]:8080", 0, config.EmptyPathPrefix, false)
+	url := GetEndpointURL(endpoint, "test")
+	assert.Equal(t, "http://[fd38::1]:8080/test", url)
 }


### PR DESCRIPTION
Backport of #54774 to `7.83.x`.

### What was broken in 7.83

This is a **bug fix**. CWS activity dump uploads to dual-shipped `additional_endpoints` whose `host` already includes a port (e.g. `cws-intake.datadoghq.com.:443`) fail. `GetEndpointURL` appended the port a second time, producing a malformed `[host:port]:port` authority that failed URL parsing, so every upload to that endpoint failed with an `invalid port` error.

In prod, CWS activity dumps were failing to reach the secondary (dual-ship) endpoint.

### Fix

The host is now split before joining, so an embedded port is honored instead of duplicated. An explicitly configured port still wins, and bare IPv6 literals are untouched.

### Automated testing

Test coverage is included in this backport (`pkg/security/utils/endpoint_test.go`), reproducing the exact prod host and asserting the resulting URL is accepted by `http.NewRequest` — the call that previously failed. Additional cases cover explicit-port precedence and IPv6 with an embedded port.

### Cherry-pick

Cherry-picked cleanly (no conflicts) from `d4251bf9b58f48d1c28070dd662a1ef6d001936f`.

Made with [Cursor](https://cursor.com)