### PR TITLE
Bump Agent Rust version to 1.94

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-rust-version = "1.91"
+rust-version = "1.94"
 
 [workspace.dependencies]
 anyhow = "1.0.98"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -453,11 +453,11 @@ rust.repository_set(
         "@platforms//cpu:x86_64",
     ],
     target_triple = "x86_64-pc-windows-gnu",
-    versions = ["1.92.0"],
+    versions = ["1.94.0"],
 )
 rust.toolchain(
     edition = "2024",
-    versions = ["1.92.0"],
+    versions = ["1.94.0"],
 )
 use_repo(rust, "rust_toolchains")
 

--- a/docs/public/guidelines/languages/RUST.md
+++ b/docs/public/guidelines/languages/RUST.md
@@ -20,7 +20,7 @@ bazel_dep(name = "rules_rust", version = "0.68.1")
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2024",
-    versions = ["1.92.0"],
+    versions = ["1.94.0"],
 )
 use_repo(rust, "rust_toolchains")
 
@@ -29,7 +29,7 @@ register_toolchains("@rust_toolchains//:all")
 
 This configuration:
 - Uses **Rust 2024 edition** as the default
-- Pins to **Rust 1.92.0** for reproducible builds
+- Pins to **Rust 1.94.0** for reproducible builds
 - Registers toolchains for all supported platforms
 
 > **Important:** This is a global toolchain configuration that is used across the entire codebase of `datadog-agent`. The configuration in <<<repo("MODULE.bazel")>>> **should not be changed** without proper testing to ensure


### PR DESCRIPTION
### What does this PR do?
Bumps Agent Rust version from 1.91 to 1.94.

### Motivation
Action Platform wants to use some crates from `saluki` in `par-control`, but `saluki` is set to Rust 1.94 so it would be incompatible with the Agent as-is. Bumping to 1.94 matches `saluki`'s version.

### Describe how you validated your changes
CI
