### PR TITLE
fix(logonduration): make the boot_timeline offset axis monotone

### DIFF
--- a/comp/logonduration/impl/analyzer_test.go
+++ b/comp/logonduration/impl/analyzer_test.go
@@ -556,7 +556,8 @@ func TestCollector_FullBootSequence(t *testing.T) {
 		}
 	}
 	require.Equal(t, "computer_group_policy", parent.ID)
-	assert.Equal(t, int64(14000), inv.OffsetMs)
+	// Raw 14000, less the 2000ms of login screen elided between LoginUIDone and the pass.
+	assert.Equal(t, int64(12000), inv.OffsetMs)
 	assert.GreaterOrEqual(t, float64(inv.OffsetMs), parent.OffsetMs)
 	assert.LessOrEqual(t, float64(inv.OffsetMs+inv.DurationMs), parent.OffsetMs+parent.DurationMs)
 

--- a/comp/logonduration/impl/grouppolicy_test.go
+++ b/comp/logonduration/impl/grouppolicy_test.go
@@ -479,6 +479,62 @@ func TestCSEOffsetsShareTheBootTimelineAxis(t *testing.T) {
 		"invocation ends at or before its pass")
 }
 
+// assertNested requires an invocation to lie inside its pass milestone on the shared axis.
+func assertNested(t *testing.T, inv CSEInvocation, parent Milestone) {
+	t.Helper()
+	assert.GreaterOrEqualf(t, float64(inv.OffsetMs), parent.OffsetMs,
+		"%s starts at or after %s", inv.CSEName, parent.ID)
+	assert.LessOrEqualf(t, float64(inv.OffsetMs+inv.DurationMs), parent.OffsetMs+parent.DurationMs,
+		"%s ends at or before %s", inv.CSEName, parent.ID)
+}
+
+// The reported shape: a computer pass that ran during the login screen wait, with the user pass
+// after logon. Collapsing the wait in one step left the computer pass on the raw axis while
+// pulling the user pass left by the whole wait, so the earlier pass and its extensions rendered
+// after the later ones.
+func TestCSEOffsetsKeepPassesInOrderAcrossTheLoginScreen(t *testing.T) {
+	f := newGPFixture(t)
+	f.coll.timeline.LoginUIDone = gpTestBoot.Add(10 * time.Second)
+	f.coll.timeline.SessionLogon = gpTestBoot.Add(30 * time.Second)
+
+	f.startComputerPass()
+	f.cseStart(gpTestActivity, 13*time.Second, cseRegistryGUID, "Registry", false, "")
+	f.cseStop(gpTestActivity, 14*time.Second, evtCSEStopSuccess, cseRegistryGUID, "Registry")
+	f.cseStart(gpTestActivity, 15*time.Second, cseFolderRedGUID, "Folder Redirection", false, "")
+	f.cseStop(gpTestActivity, 17*time.Second, evtCSEStopSuccess, cseFolderRedGUID, "Folder Redirection")
+	f.endComputerPass()
+
+	f.send(gpUserActivity, evtUserGPStart, 31*time.Second)
+	f.cseStart(gpUserActivity, 31500*time.Millisecond, cseRegistryGUID, "Registry", false, "")
+	f.cseStop(gpUserActivity, 32*time.Second, evtCSEStopSuccess, cseRegistryGUID, "Registry")
+	f.send(gpUserActivity, evtUserGPEnd, 33*time.Second)
+
+	d := f.details()
+	require.Len(t, d.Computer, 2)
+	require.Len(t, d.User, 1)
+
+	milestones := make(map[string]Milestone)
+	for _, m := range buildTimelineMilestones(f.coll.timeline) {
+		milestones[m.ID] = m
+	}
+	computer, user := milestones["computer_group_policy"], milestones["user_group_policy"]
+
+	// The 2000ms before the pass and the 10000ms after it are elided; the pass itself is not.
+	assert.Equal(t, float64(10000), computer.OffsetMs)
+	assert.Equal(t, float64(19000), user.OffsetMs)
+
+	for _, inv := range d.Computer {
+		assertNested(t, inv, computer)
+	}
+	for _, inv := range d.User {
+		assertNested(t, inv, user)
+	}
+
+	lastComputer := d.Computer[len(d.Computer)-1]
+	assert.Less(t, lastComputer.OffsetMs+lastComputer.DurationMs, d.User[0].OffsetMs,
+		"the computer pass and its extensions finish before the user pass begins")
+}
+
 // --- Group Policy objects ---
 
 func TestGPOInlinedPerInvocation(t *testing.T) {

--- a/comp/logonduration/impl/grouppolicy_test.go
+++ b/comp/logonduration/impl/grouppolicy_test.go
@@ -479,7 +479,6 @@ func TestCSEOffsetsShareTheBootTimelineAxis(t *testing.T) {
 		"invocation ends at or before its pass")
 }
 
-// assertNested requires an invocation to lie inside its pass milestone on the shared axis.
 func assertNested(t *testing.T, inv CSEInvocation, parent Milestone) {
 	t.Helper()
 	assert.GreaterOrEqualf(t, float64(inv.OffsetMs), parent.OffsetMs,
@@ -488,10 +487,6 @@ func assertNested(t *testing.T, inv CSEInvocation, parent Milestone) {
 		"%s ends at or before %s", inv.CSEName, parent.ID)
 }
 
-// The reported shape: a computer pass that ran during the login screen wait, with the user pass
-// after logon. Collapsing the wait in one step left the computer pass on the raw axis while
-// pulling the user pass left by the whole wait, so the earlier pass and its extensions rendered
-// after the later ones.
 func TestCSEOffsetsKeepPassesInOrderAcrossTheLoginScreen(t *testing.T) {
 	f := newGPFixture(t)
 	f.coll.timeline.LoginUIDone = gpTestBoot.Add(10 * time.Second)
@@ -519,7 +514,7 @@ func TestCSEOffsetsKeepPassesInOrderAcrossTheLoginScreen(t *testing.T) {
 	}
 	computer, user := milestones["computer_group_policy"], milestones["user_group_policy"]
 
-	// The 2000ms before the pass and the 10000ms after it are elided; the pass itself is not.
+	// 2000ms before the pass and 10000ms after it are elided; the pass itself is not.
 	assert.Equal(t, float64(10000), computer.OffsetMs)
 	assert.Equal(t, float64(19000), user.OffsetMs)
 

--- a/comp/logonduration/impl/impl_windows.go
+++ b/comp/logonduration/impl/impl_windows.go
@@ -227,9 +227,6 @@ func durationBetween(start, end time.Time) time.Duration {
 	return end.Sub(start)
 }
 
-// milestoneCandidate is one entry of the boot timeline: what the payload renders and, via its
-// duration, the interval bootOffsetFunc treats as observed activity. Both consumers read the
-// same list so no milestone can be rendered from an interval the offset function did not see.
 type milestoneCandidate struct {
 	id       string
 	name     string
@@ -253,16 +250,13 @@ func timelineCandidates(tl BootTimeline) []milestoneCandidate {
 	}
 }
 
-// interval is a half-open [start, end) span of wall-clock time.
 type interval struct {
 	start time.Time
 	end   time.Time
 }
 
 // unobservedIntervals returns the sub-intervals of [start, end) that no milestone covers,
-// sorted and disjoint. A milestone reaching into the region from either side counts for the
-// part that lies inside it; the rest of its span is outside the region and cannot matter,
-// because elision never happens there.
+// sorted and disjoint - bootOffsetFunc walks them in order and stops at the first one past ts.
 func unobservedIntervals(tl BootTimeline, start, end time.Time) []interval {
 	var busy []interval
 	for _, c := range timelineCandidates(tl) {
@@ -295,14 +289,8 @@ func unobservedIntervals(tl BootTimeline, start, end time.Time) []interval {
 
 // bootOffsetFunc returns the boot-relative offset in milliseconds of a timestamp. The stretches of
 // the login screen wait (LoginUIDone -> SessionLogon) where nothing was observed are elided so the
-// timeline renders contiguously; the per-milestone Timestamp retains wall-clock truth.
-//
-// Eliding only the unobserved stretches, rather than the whole wait, is what keeps the mapping
-// order-preserving: its derivative is 1 outside those stretches and 0 inside, never negative. A
-// single-step shift would place a milestone that ran during the wait - Machine Group Policy does,
-// on every trace we have - on a different axis from everything after logon, so it could render
-// ahead of milestones that happened before it. No milestone span can itself be elided, because
-// elision only happens where nothing was observed and a span is an observation.
+// timeline renders contiguously; the per-milestone Timestamp retains wall-clock truth. Eliding only
+// the unobserved stretches, never an observed span, is what keeps the mapping order-preserving.
 func bootOffsetFunc(tl BootTimeline) func(time.Time) int64 {
 	boot := tl.BootStart
 	if boot.IsZero() {

--- a/comp/logonduration/impl/impl_windows.go
+++ b/comp/logonduration/impl/impl_windows.go
@@ -10,6 +10,7 @@ package logondurationimpl
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -226,40 +227,18 @@ func durationBetween(start, end time.Time) time.Duration {
 	return end.Sub(start)
 }
 
-// bootOffsetFunc returns the boot-relative offset in milliseconds of a timestamp. The idle time at the
-// login screen (LoginUIDone -> SessionLogon) is collapsed out of post-logon offsets so the timeline
-// renders contiguously; the per-milestone Timestamp retains wall-clock truth.
-func bootOffsetFunc(tl BootTimeline) func(time.Time) int64 {
-	boot := tl.BootStart
-	if boot.IsZero() {
-		return func(time.Time) int64 { return 0 }
-	}
-
-	gap := time.Duration(0)
-	if !tl.LoginUIDone.IsZero() && !tl.SessionLogon.IsZero() && tl.SessionLogon.After(tl.LoginUIDone) {
-		gap = tl.SessionLogon.Sub(tl.LoginUIDone)
-	}
-
-	return func(ts time.Time) int64 {
-		offset := ts.Sub(boot).Milliseconds()
-		if gap > 0 && !ts.Before(tl.SessionLogon) {
-			offset -= gap.Milliseconds()
-		}
-		return offset
-	}
+// milestoneCandidate is one entry of the boot timeline: what the payload renders and, via its
+// duration, the interval bootOffsetFunc treats as observed activity. Both consumers read the
+// same list so no milestone can be rendered from an interval the offset function did not see.
+type milestoneCandidate struct {
+	id       string
+	name     string
+	ts       time.Time
+	duration time.Duration
 }
 
-// buildTimelineMilestones returns an ordered slice of boot milestones.
-// Only milestones with a non-zero timestamp are included.
-func buildTimelineMilestones(tl BootTimeline) []Milestone {
-	const tsFmt = "2006-01-02T15:04:05.000Z"
-
-	candidates := []struct {
-		id       string
-		name     string
-		ts       time.Time
-		duration time.Duration
-	}{
+func timelineCandidates(tl BootTimeline) []milestoneCandidate {
+	return []milestoneCandidate{
 		{"boot_duration", "Boot Duration", tl.BootStart, durationBetween(tl.BootStart, tl.LoginUIStart)},
 		{"login_ui_start", "Login UI Start", tl.LoginUIStart, durationBetween(tl.LoginUIStart, tl.LoginUIDone)},
 		{"computer_group_policy", "Computer Group Policy", tl.MachineGPStart, durationBetween(tl.MachineGPStart, tl.MachineGPEnd)},
@@ -272,11 +251,95 @@ func buildTimelineMilestones(tl BootTimeline) []Milestone {
 		{"desktop_visible", "Desktop Visible", tl.DesktopCreateStart, durationBetween(tl.DesktopCreateStart, tl.DesktopVisibleEnd)},
 		{"desktop_startup_apps", "Desktop Startup Apps", tl.DesktopStartupAppsStart, durationBetween(tl.DesktopStartupAppsStart, tl.DesktopStartupAppsEnd)},
 	}
+}
+
+// interval is a half-open [start, end) span of wall-clock time.
+type interval struct {
+	start time.Time
+	end   time.Time
+}
+
+// unobservedIntervals returns the sub-intervals of [start, end) that no milestone covers,
+// sorted and disjoint. A milestone reaching into the region from either side counts for the
+// part that lies inside it; the rest of its span is outside the region and cannot matter,
+// because elision never happens there.
+func unobservedIntervals(tl BootTimeline, start, end time.Time) []interval {
+	var busy []interval
+	for _, c := range timelineCandidates(tl) {
+		if c.ts.IsZero() || c.duration <= 0 {
+			continue
+		}
+		s, e := c.ts, c.ts.Add(c.duration)
+		if !e.After(start) || !s.Before(end) {
+			continue
+		}
+		busy = append(busy, interval{s, e})
+	}
+	sort.Slice(busy, func(i, j int) bool { return busy[i].start.Before(busy[j].start) })
+
+	var idle []interval
+	cursor := start
+	for _, b := range busy {
+		if b.start.After(cursor) {
+			idle = append(idle, interval{cursor, b.start})
+		}
+		if b.end.After(cursor) {
+			cursor = b.end
+		}
+	}
+	if end.After(cursor) {
+		idle = append(idle, interval{cursor, end})
+	}
+	return idle
+}
+
+// bootOffsetFunc returns the boot-relative offset in milliseconds of a timestamp. The stretches of
+// the login screen wait (LoginUIDone -> SessionLogon) where nothing was observed are elided so the
+// timeline renders contiguously; the per-milestone Timestamp retains wall-clock truth.
+//
+// Eliding only the unobserved stretches, rather than the whole wait, is what keeps the mapping
+// order-preserving: its derivative is 1 outside those stretches and 0 inside, never negative. A
+// single-step shift would place a milestone that ran during the wait - Machine Group Policy does,
+// on every trace we have - on a different axis from everything after logon, so it could render
+// ahead of milestones that happened before it. No milestone span can itself be elided, because
+// elision only happens where nothing was observed and a span is an observation.
+func bootOffsetFunc(tl BootTimeline) func(time.Time) int64 {
+	boot := tl.BootStart
+	if boot.IsZero() {
+		return func(time.Time) int64 { return 0 }
+	}
+
+	if tl.LoginUIDone.IsZero() || tl.SessionLogon.IsZero() || !tl.SessionLogon.After(tl.LoginUIDone) {
+		return func(ts time.Time) int64 { return ts.Sub(boot).Milliseconds() }
+	}
+
+	elided := unobservedIntervals(tl, tl.LoginUIDone, tl.SessionLogon)
+
+	return func(ts time.Time) int64 {
+		offset := ts.Sub(boot)
+		for _, iv := range elided {
+			if !ts.After(iv.start) {
+				break
+			}
+			if ts.Before(iv.end) {
+				offset -= ts.Sub(iv.start)
+				break
+			}
+			offset -= iv.end.Sub(iv.start)
+		}
+		return offset.Milliseconds()
+	}
+}
+
+// buildTimelineMilestones returns an ordered slice of boot milestones.
+// Only milestones with a non-zero timestamp are included.
+func buildTimelineMilestones(tl BootTimeline) []Milestone {
+	const tsFmt = "2006-01-02T15:04:05.000Z"
 
 	offsetOf := bootOffsetFunc(tl)
 
 	var milestones []Milestone
-	for _, c := range candidates {
+	for _, c := range timelineCandidates(tl) {
 		if c.ts.IsZero() {
 			continue
 		}

--- a/comp/logonduration/impl/impl_windows_test.go
+++ b/comp/logonduration/impl/impl_windows_test.go
@@ -10,6 +10,7 @@ package logondurationimpl
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -49,6 +50,76 @@ func fullBootTimeline(boot time.Time) BootTimeline {
 		DesktopVisibleEnd:            boot.Add(57 * time.Second),
 		DesktopStartupAppsStart:      boot.Add(58 * time.Second),
 		DesktopStartupAppsEnd:        boot.Add(62 * time.Second),
+	}
+}
+
+// straddlingGPTimeline is the shape a slow domain-joined boot produces: the computer Group
+// Policy pass starts at the login screen and is still running when the session logs on, in
+// milliseconds off boot so the numbers match a real capture.
+func straddlingGPTimeline(boot time.Time) BootTimeline {
+	ms := func(n int) time.Time { return boot.Add(time.Duration(n) * time.Millisecond) }
+	return BootTimeline{
+		BootStart:           boot,
+		LoginUIStart:        ms(8698),
+		LoginUIDone:         ms(8746),
+		MachineGPStart:      ms(10808),
+		MachineGPEnd:        ms(39337),
+		SessionLogon:        ms(36486),
+		DesktopVisibleStart: ms(47159),
+	}
+}
+
+func milestonesByID(milestones []Milestone) map[string]Milestone {
+	byID := make(map[string]Milestone, len(milestones))
+	for _, m := range milestones {
+		byID[m.ID] = m
+	}
+	return byID
+}
+
+// assertMonotoneTimeline fails if any milestone renders ahead of one that happened before it:
+// walked in wall-clock order, OffsetMs must never go backwards.
+func assertMonotoneTimeline(t *testing.T, milestones []Milestone) {
+	t.Helper()
+	ordered := make([]Milestone, len(milestones))
+	copy(ordered, milestones)
+	// Timestamp is fixed-width UTC, so lexical order is chronological order.
+	sort.SliceStable(ordered, func(i, j int) bool { return ordered[i].Timestamp < ordered[j].Timestamp })
+	for i := 1; i < len(ordered); i++ {
+		prev, cur := ordered[i-1], ordered[i]
+		assert.GreaterOrEqualf(t, cur.OffsetMs, prev.OffsetMs,
+			"%s at %s renders at %.0f, behind %s at %s which renders at %.0f",
+			cur.ID, cur.Timestamp, cur.OffsetMs, prev.ID, prev.Timestamp, prev.OffsetMs)
+	}
+}
+
+// The axis must render milestones in the order they happened, for any input. This is the
+// property a single-step collapse of the login screen wait cannot satisfy: it puts anything
+// that ran during the wait on a different axis from everything after logon.
+func TestBootTimelineOffsetsAreMonotone(t *testing.T) {
+	boot := time.Date(2026, 1, 15, 8, 0, 0, 0, time.UTC)
+
+	noMachinePass := fullBootTimeline(boot)
+	noMachinePass.MachineGPStart = time.Time{}
+	noMachinePass.MachineGPEnd = time.Time{}
+
+	unterminatedPass := fullBootTimeline(boot)
+	unterminatedPass.MachineGPEnd = time.Time{}
+
+	passFromBeforeTheWait := fullBootTimeline(boot)
+	passFromBeforeTheWait.MachineGPStart = boot.Add(9 * time.Second)
+	passFromBeforeTheWait.MachineGPEnd = boot.Add(20 * time.Second)
+
+	for name, tl := range map[string]BootTimeline{
+		"full timeline":                  fullBootTimeline(boot),
+		"machine pass straddles logon":   straddlingGPTimeline(boot),
+		"no machine pass":                noMachinePass,
+		"machine pass never ended":       unterminatedPass,
+		"machine pass predates the wait": passFromBeforeTheWait,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assertMonotoneTimeline(t, buildTimelineMilestones(tl))
+		})
 	}
 }
 
@@ -125,23 +196,24 @@ func TestBuildTimelineMilestones(t *testing.T) {
 
 		require.Len(t, milestones, 11)
 
-		// gap = SessionLogon(29s) - LoginUIDone(10s) = 19000ms; milestones
-		// at/after SessionLogon have their offset collapsed by the idle gap.
+		// Region is LoginUIDone(10s) -> SessionLogon(29s). The computer pass occupies
+		// [12s, 20s] of it, so only the 2000ms before it and the 9000ms after it are
+		// elided; everything from 20s on shifts left by 11000ms, not by the full 19000ms.
 		expected := []struct {
 			name     string
 			offsetMs float64
 		}{
 			{"Boot Duration", 0},
 			{"Login UI Start", 8000},
-			{"Computer Group Policy", 12000},
-			{"User Group Policy", 13000},
-			{"Logon Duration", 10000},
-			{"Profile Loaded", 12000},
-			{"Profile Created", 14000},
-			{"Execute Shell Commands", 21000},
-			{"Explorer Initializing", 32000},
-			{"Desktop Visible", 34000},
-			{"Desktop Startup Apps", 39000},
+			{"Computer Group Policy", 10000},
+			{"User Group Policy", 21000},
+			{"Logon Duration", 18000},
+			{"Profile Loaded", 20000},
+			{"Profile Created", 22000},
+			{"Execute Shell Commands", 29000},
+			{"Explorer Initializing", 40000},
+			{"Desktop Visible", 42000},
+			{"Desktop Startup Apps", 47000},
 		}
 		for i, exp := range expected {
 			assert.Equal(t, exp.name, milestones[i].Name, "milestone %d name", i)
@@ -186,6 +258,73 @@ func TestBuildTimelineMilestones(t *testing.T) {
 		assert.InDelta(t, 10000.0, logon.OffsetMs, 0.001)
 		// timestamp stays wall-clock (SessionLogon = boot + 29s)
 		assert.Equal(t, "2026-01-15T08:00:29.000Z", logon.Timestamp)
+	})
+
+	t.Run("machine pass straddling logon keeps its full span", func(t *testing.T) {
+		m := milestonesByID(buildTimelineMilestones(straddlingGPTimeline(boot)))
+
+		// Only the 2062ms of login screen before the pass started is unobserved. From
+		// there the machine is busy right through logon, so nothing else is elided.
+		gp, logon := m["computer_group_policy"], m["logon_duration"]
+		assert.InDelta(t, 8746.0, gp.OffsetMs, 0.001)
+		assert.InDelta(t, 28529.0, gp.DurationMs, 0.001)
+		assert.InDelta(t, 34424.0, logon.OffsetMs, 0.001)
+		assert.InDelta(t, 10673.0, logon.DurationMs, 0.001)
+		assert.InDelta(t, 2851.0, (gp.OffsetMs+gp.DurationMs)-logon.OffsetMs, 0.001,
+			"the pass outlives the start of logon by exactly as long as it really did")
+	})
+
+	t.Run("nothing observed in the region elides all of it", func(t *testing.T) {
+		tl := fullBootTimeline(boot)
+		tl.MachineGPStart = time.Time{}
+		tl.MachineGPEnd = time.Time{}
+
+		m := milestonesByID(buildTimelineMilestones(tl))
+
+		// With no interval to preserve the whole 19000ms wait goes, which is what
+		// collapsing it in one step always did.
+		for id, offset := range map[string]float64{
+			"logon_duration":         10000,
+			"profile_loaded":         12000,
+			"user_group_policy":      13000,
+			"profile_created":        14000,
+			"execute_shell_commands": 21000,
+			"explorer_initializing":  32000,
+			"desktop_visible":        34000,
+			"desktop_startup_apps":   39000,
+		} {
+			require.Contains(t, m, id)
+			assert.InDelta(t, offset, m[id].OffsetMs, 0.001, id)
+		}
+	})
+
+	t.Run("a pass with no end clamps to the start of the region", func(t *testing.T) {
+		tl := fullBootTimeline(boot)
+		tl.MachineGPEnd = time.Time{}
+
+		m := milestonesByID(buildTimelineMilestones(tl))
+
+		// An 8000 that never arrived leaves the pass no span to preserve, so the region
+		// is elided whole and the point lands on its start.
+		assert.InDelta(t, 10000.0, m["computer_group_policy"].OffsetMs, 0.001)
+		assert.InDelta(t, 0.0, m["computer_group_policy"].DurationMs, 0.001)
+		assert.InDelta(t, 10000.0, m["logon_duration"].OffsetMs, 0.001)
+		assert.InDelta(t, 39000.0, m["desktop_startup_apps"].OffsetMs, 0.001)
+	})
+
+	t.Run("a pass reaching into the region from before it keeps its full width", func(t *testing.T) {
+		tl := fullBootTimeline(boot)
+		tl.MachineGPStart = boot.Add(9 * time.Second)
+		tl.MachineGPEnd = boot.Add(20 * time.Second)
+
+		m := milestonesByID(buildTimelineMilestones(tl))
+
+		// Only [20s, 29s) is unobserved. The part of the pass before LoginUIDone lies
+		// outside the region, where nothing is ever elided.
+		gp := m["computer_group_policy"]
+		assert.InDelta(t, 9000.0, gp.OffsetMs, 0.001)
+		assert.InDelta(t, 11000.0, gp.DurationMs, 0.001)
+		assert.InDelta(t, 20000.0, m["logon_duration"].OffsetMs, 0.001)
 	})
 
 	t.Run("desktop_visible merged spans DesktopCreateStart to DesktopVisibleEnd", func(t *testing.T) {

--- a/comp/logonduration/impl/impl_windows_test.go
+++ b/comp/logonduration/impl/impl_windows_test.go
@@ -68,6 +68,34 @@ func straddlingGPTimeline(boot time.Time) BootTimeline {
 	}
 }
 
+func twoBusyIntervalTimeline(boot time.Time) BootTimeline {
+	return BootTimeline{
+		BootStart:           boot,
+		LoginUIStart:        boot.Add(8 * time.Second),
+		LoginUIDone:         boot.Add(10 * time.Second),
+		MachineGPStart:      boot.Add(12 * time.Second),
+		MachineGPEnd:        boot.Add(20 * time.Second),
+		ExplorerInitStart:   boot.Add(30 * time.Second),
+		ExplorerInitEnd:     boot.Add(40 * time.Second),
+		SessionLogon:        boot.Add(50 * time.Second),
+		DesktopVisibleStart: boot.Add(70 * time.Second),
+	}
+}
+
+func nestedBusyIntervalTimeline(boot time.Time) BootTimeline {
+	return BootTimeline{
+		BootStart:           boot,
+		LoginUIStart:        boot.Add(8 * time.Second),
+		LoginUIDone:         boot.Add(10 * time.Second),
+		MachineGPStart:      boot.Add(12 * time.Second),
+		MachineGPEnd:        boot.Add(40 * time.Second),
+		ProfileLoadStart:    boot.Add(20 * time.Second),
+		ProfileLoadEnd:      boot.Add(30 * time.Second),
+		SessionLogon:        boot.Add(50 * time.Second),
+		DesktopVisibleStart: boot.Add(70 * time.Second),
+	}
+}
+
 func milestonesByID(milestones []Milestone) map[string]Milestone {
 	byID := make(map[string]Milestone, len(milestones))
 	for _, m := range milestones {
@@ -110,6 +138,8 @@ func TestBootTimelineOffsetsAreMonotone(t *testing.T) {
 		"no machine pass":                noMachinePass,
 		"machine pass never ended":       unterminatedPass,
 		"machine pass predates the wait": passFromBeforeTheWait,
+		"two busy intervals":             twoBusyIntervalTimeline(boot),
+		"nested busy intervals":          nestedBusyIntervalTimeline(boot),
 	} {
 		t.Run(name, func(t *testing.T) {
 			assertMonotoneTimeline(t, buildTimelineMilestones(tl))
@@ -301,6 +331,27 @@ func TestBuildTimelineMilestones(t *testing.T) {
 		assert.InDelta(t, 0.0, m["computer_group_policy"].DurationMs, 0.001)
 		assert.InDelta(t, 10000.0, m["logon_duration"].OffsetMs, 0.001)
 		assert.InDelta(t, 39000.0, m["desktop_startup_apps"].OffsetMs, 0.001)
+	})
+
+	t.Run("two busy intervals in the region elide the three stretches around them", func(t *testing.T) {
+		m := milestonesByID(buildTimelineMilestones(twoBusyIntervalTimeline(boot)))
+
+		// Elided: [10s,12s), [20s,30s), [40s,50s) = 22000ms. Both spans keep their width.
+		assert.InDelta(t, 10000.0, m["computer_group_policy"].OffsetMs, 0.001)
+		assert.InDelta(t, 8000.0, m["computer_group_policy"].DurationMs, 0.001)
+		assert.InDelta(t, 18000.0, m["explorer_initializing"].OffsetMs, 0.001)
+		assert.InDelta(t, 10000.0, m["explorer_initializing"].DurationMs, 0.001)
+		assert.InDelta(t, 28000.0, m["logon_duration"].OffsetMs, 0.001)
+	})
+
+	t.Run("an interval nested in another does not rewind the merge cursor", func(t *testing.T) {
+		m := milestonesByID(buildTimelineMilestones(nestedBusyIntervalTimeline(boot)))
+
+		// [20s,30s) lies inside [12s,40s), so only [10s,12s) and [40s,50s) go: 12000ms,
+		// not the 22000ms a cursor that stepped back to 30s would elide.
+		assert.InDelta(t, 10000.0, m["computer_group_policy"].OffsetMs, 0.001)
+		assert.InDelta(t, 18000.0, m["profile_loaded"].OffsetMs, 0.001)
+		assert.InDelta(t, 38000.0, m["logon_duration"].OffsetMs, 0.001)
 	})
 
 	t.Run("a pass reaching into the region from before it keeps its full width", func(t *testing.T) {

--- a/comp/logonduration/impl/impl_windows_test.go
+++ b/comp/logonduration/impl/impl_windows_test.go
@@ -53,9 +53,8 @@ func fullBootTimeline(boot time.Time) BootTimeline {
 	}
 }
 
-// straddlingGPTimeline is the shape a slow domain-joined boot produces: the computer Group
-// Policy pass starts at the login screen and is still running when the session logs on, in
-// milliseconds off boot so the numbers match a real capture.
+// straddlingGPTimeline is a real capture, in ms off boot: the computer pass starts at the
+// login screen and is still running when the session logs on.
 func straddlingGPTimeline(boot time.Time) BootTimeline {
 	ms := func(n int) time.Time { return boot.Add(time.Duration(n) * time.Millisecond) }
 	return BootTimeline{
@@ -77,8 +76,6 @@ func milestonesByID(milestones []Milestone) map[string]Milestone {
 	return byID
 }
 
-// assertMonotoneTimeline fails if any milestone renders ahead of one that happened before it:
-// walked in wall-clock order, OffsetMs must never go backwards.
 func assertMonotoneTimeline(t *testing.T, milestones []Milestone) {
 	t.Helper()
 	ordered := make([]Milestone, len(milestones))
@@ -93,9 +90,6 @@ func assertMonotoneTimeline(t *testing.T, milestones []Milestone) {
 	}
 }
 
-// The axis must render milestones in the order they happened, for any input. This is the
-// property a single-step collapse of the login screen wait cannot satisfy: it puts anything
-// that ran during the wait on a different axis from everything after logon.
 func TestBootTimelineOffsetsAreMonotone(t *testing.T) {
 	boot := time.Date(2026, 1, 15, 8, 0, 0, 0, time.UTC)
 
@@ -196,9 +190,8 @@ func TestBuildTimelineMilestones(t *testing.T) {
 
 		require.Len(t, milestones, 11)
 
-		// Region is LoginUIDone(10s) -> SessionLogon(29s). The computer pass occupies
-		// [12s, 20s] of it, so only the 2000ms before it and the 9000ms after it are
-		// elided; everything from 20s on shifts left by 11000ms, not by the full 19000ms.
+		// Region is LoginUIDone(10s) -> SessionLogon(29s) and the computer pass holds
+		// [12s, 20s] of it, so 2000+9000ms is elided, not the full 19000ms.
 		expected := []struct {
 			name     string
 			offsetMs float64
@@ -263,8 +256,8 @@ func TestBuildTimelineMilestones(t *testing.T) {
 	t.Run("machine pass straddling logon keeps its full span", func(t *testing.T) {
 		m := milestonesByID(buildTimelineMilestones(straddlingGPTimeline(boot)))
 
-		// Only the 2062ms of login screen before the pass started is unobserved. From
-		// there the machine is busy right through logon, so nothing else is elided.
+		// Only the 2062ms before the pass is unobserved; from there the machine is busy
+		// through logon.
 		gp, logon := m["computer_group_policy"], m["logon_duration"]
 		assert.InDelta(t, 8746.0, gp.OffsetMs, 0.001)
 		assert.InDelta(t, 28529.0, gp.DurationMs, 0.001)
@@ -281,8 +274,7 @@ func TestBuildTimelineMilestones(t *testing.T) {
 
 		m := milestonesByID(buildTimelineMilestones(tl))
 
-		// With no interval to preserve the whole 19000ms wait goes, which is what
-		// collapsing it in one step always did.
+		// Nothing to preserve, so the whole 19000ms wait goes - the pre-fix numbers.
 		for id, offset := range map[string]float64{
 			"logon_duration":         10000,
 			"profile_loaded":         12000,
@@ -304,8 +296,7 @@ func TestBuildTimelineMilestones(t *testing.T) {
 
 		m := milestonesByID(buildTimelineMilestones(tl))
 
-		// An 8000 that never arrived leaves the pass no span to preserve, so the region
-		// is elided whole and the point lands on its start.
+		// No span to preserve, so the region is elided whole and the point lands on its start.
 		assert.InDelta(t, 10000.0, m["computer_group_policy"].OffsetMs, 0.001)
 		assert.InDelta(t, 0.0, m["computer_group_policy"].DurationMs, 0.001)
 		assert.InDelta(t, 10000.0, m["logon_duration"].OffsetMs, 0.001)
@@ -319,8 +310,7 @@ func TestBuildTimelineMilestones(t *testing.T) {
 
 		m := milestonesByID(buildTimelineMilestones(tl))
 
-		// Only [20s, 29s) is unobserved. The part of the pass before LoginUIDone lies
-		// outside the region, where nothing is ever elided.
+		// Only [20s, 29s) is unobserved; the part before LoginUIDone is outside the region.
 		gp := m["computer_group_policy"]
 		assert.InDelta(t, 9000.0, gp.OffsetMs, 0.001)
 		assert.InDelta(t, 11000.0, gp.DurationMs, 0.001)

--- a/releasenotes/notes/logon-duration-monotonic-boot-timeline-7b41c0d95ea2f386.yaml
+++ b/releasenotes/notes/logon-duration-monotonic-boot-timeline-7b41c0d95ea2f386.yaml
@@ -1,11 +1,7 @@
 ---
 fixes:
   - |
-    The Windows logon duration event no longer reports ``boot_timeline`` milestones out of
-    chronological order. The wait at the login screen was previously removed from the timeline
-    in a single step, which left any milestone that ran during that wait - Computer Group Policy,
-    on a domain-joined machine - on a different axis from everything after logon, so it could
-    render after milestones that actually followed it. Only the stretches of the wait where
-    nothing was observed are now removed, so a milestone that ran during it keeps its real
-    position and duration. The ``group_policy_details`` breakdown shares this axis and is
-    corrected by the same change. ``durations`` and ``total_boot_duration_ms`` are unaffected.
+    Windows: Fix the logon duration event reporting ``boot_timeline`` and
+    ``group_policy_details`` entries out of chronological order. A milestone that ran while the
+    machine sat at the login screen, such as Computer Group Policy on a domain-joined host,
+    could render after milestones that actually followed it.

--- a/releasenotes/notes/logon-duration-monotonic-boot-timeline-7b41c0d95ea2f386.yaml
+++ b/releasenotes/notes/logon-duration-monotonic-boot-timeline-7b41c0d95ea2f386.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    The Windows logon duration event no longer reports ``boot_timeline`` milestones out of
+    chronological order. The wait at the login screen was previously removed from the timeline
+    in a single step, which left any milestone that ran during that wait - Computer Group Policy,
+    on a domain-joined machine - on a different axis from everything after logon, so it could
+    render after milestones that actually followed it. Only the stretches of the wait where
+    nothing was observed are now removed, so a milestone that ran during it keeps its real
+    position and duration. The ``group_policy_details`` breakdown shares this axis and is
+    corrected by the same change. ``durations`` and ``total_boot_duration_ms`` are unaffected.


### PR DESCRIPTION
### What does this PR do?

Makes the `boot_timeline` axis monotone, so a milestone can no longer render ahead of one that happened before it.

`bootOffsetFunc` collapsed the login-screen wait in a **single step**: `ts >= SessionLogon` was pulled left by the whole `SessionLogon - LoginUIDone` gap, everything else kept its raw offset. A step function is not order-preserving, and since the collapse maps `SessionLogon` onto `LoginUIDone`'s raw offset, the payload carried two clocks on one origin — an in-gap milestone at *how deep into the wait it started*, a post-logon one at *how long after logon it happened*. Nothing forces the first to be smaller. On the Aug 17 boot `computer_group_policy` lands at 10807 while `user_group_policy`, 25.7 s later in wall clock, lands at 8839.

The premise the collapse rests on is false: that window is not idle. Machine Group Policy runs in it on all four traces we have, real and synthetic.

**Fix:** elide only the sub-intervals of `[LoginUIDone, SessionLogon)` that no observed milestone covers. `offset(ts) = (ts - BootStart) - (elided time elapsed by ts)`. The derivative is 1 outside those stretches and 0 inside, so it is monotone by construction, and no milestone span can be elided because elision only happens where nothing was observed and a span *is* an observation. Nothing is truncated — an interval running past `SessionLogon` has no idle behind it to remove, so the overlap survives.

It degrades to today's numbers when the region really is empty, and the timeline lengthens by exactly the busy time previously erased: +3483 ms on Aug 17, +49 ms on Aug 4, each the machine pass duration.

The milestone candidate list moves into `timelineCandidates`, consumed by both the renderer and the busy-interval builder, so a milestone can never be rendered from an interval the axis did not know about.

`group_policy_details` is fixed by the same change with no edit to `grouppolicy.go` — `finalize` already calls `bootOffsetFunc` for every CSE offset, so the child inversion clears with the parent. `durations` and `total_boot_duration_ms` are raw pairwise measurements and do not move.

### Motivation

`boot_timeline` is a rendering axis; consumers read left-to-right as chronological. On a domain-joined machine it silently violated that on most boots, and `group_policy_details` now hangs off those milestones, so a wrong parent offset drags a child tree with it.

The defect arrived with #50027 (`9b2dab34afc`), which introduced the login-screen gap collapse. It has never had a WINA ticket — worth filing before merge, since this moves a shipped number.

### Describe how you validated your changes

`dda inv test --targets=./comp/logonduration/impl` — **160 passing, 0 failing**. `dda inv linter.go` — 0 issues.

The primary guard is a property test, `TestBootTimelineOffsetsAreMonotone`: sorted by wall-clock `Timestamp`, `OffsetMs` must be non-decreasing. Stronger than fixed expectations, holds for any input, and **fails on the shipped code** against the exact numbers the old test asserted. Runs over `fullBootTimeline` and all four new fixtures.

`TestCSEOffsetsShareTheBootTimelineAxis` passes **unmodified** — its region has no busy interval, so it is elided whole. That it still passes is the evidence the change is confined to in-region activity.

Four new cases in `TestBuildTimelineMilestones`, plus updated "full timeline" offsets (elided 2000 + 9000, not the full 19000):

- **pass straddles `SessionLogon`** — the case that proves nothing is truncated: `8746..37275` against `logon_duration` at `34424..45097`, overlapping by exactly the 2851 ms the pass ran past logon
- **pass absent** — full region elided, offsets identical to today
- **`MachineGPEnd` absent** — pass has no span, region elided whole, point clamps to region start
- **pass reaching in from before `LoginUIDone`** — only the idle after it is elided, bar keeps its full width

New `TestCSEOffsetsKeepPassesInOrderAcrossTheLoginScreen` covers the reported shape the existing suite misses: a computer pass *inside* the region with CSEs alongside a user pass after logon, asserting each invocation nests in its parent and that the whole computer scope precedes the user scope.

One expectation changed outside the plan: `TestCollector_FullBootSequence` asserted a CSE at 14000; it starts at boot+14s with 2000 ms elided ahead of it, so it is now 12000, still nested in its parent at `10000..18000`.

**Not done:** the analyzer has not been re-run over the WINA-2940 boot ETL against this diff. The Aug 4 / Aug 17 figures come from the investigation that produced the change, not from executing this code on a capture.

### Additional Notes

**`impl_darwin.go` is deliberately left on the single-step pattern.** The fix is a provable no-op there — its only candidates are `boot_duration`, `login_window_ready` (a point at the region start) and `logon_duration`, so nothing can land inside the region and it is elided whole either way.

**CSE invocations are deliberately not in the busy list.** They live inside their pass, so they add nothing while it is present, and wiring `gpAccumulator` into the offset function would invert the current dependency. Follow-up for the case where an 8000 is missing and the pass has no span but its CSEs do.

**Limit:** the rule does not establish the region is idle, only that nothing was observed there. Uninstrumented machine work at the login screen is still elided as think-time — that assumption is the feature's, unchanged since #50027. What this removes is the assumption erasing intervals we *did* observe.

Left for their own PRs: `LoginUIDone` pair selection, `boot_timeline` array ordering (emitted in candidate order, never sorted — now a one-line change with no correctness question attached), unpaired pass endpoints, and WINA-3011 truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
