### PR TITLE
remove defaults for serverless-init

### DIFF
--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -25,7 +25,7 @@ import (
 	healthprobeDef "github.com/DataDog/datadog-agent/comp/core/healthprobe/def"
 	healthprobeFx "github.com/DataDog/datadog-agent/comp/core/healthprobe/fx"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
+	hostnameinterface "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface/def"
 	logdef "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logfx "github.com/DataDog/datadog-agent/comp/core/log/fx"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
@@ -208,6 +208,10 @@ func preloadEarly() {
 	// hardcodes forceFlushAll=false on ticks, so bucket-aligned flushes during
 	// the run are preserved.
 	setOverride("dogstatsd_flush_incomplete_buckets", true)
+
+	// Agent Data Plane (ADP) is a separate process serverless-init does not support.
+	setOverride("data_plane.enabled", false)
+	setOverride("data_plane.dogstatsd.enabled", false)
 }
 
 // setOverride sets key to val with SourceAgentRuntime priority, logging a

--- a/pkg/config/schema/yaml/core_schema.yaml
+++ b/pkg/config/schema/yaml/core_schema.yaml
@@ -365,7 +365,6 @@ properties:
       (one per container instead of one per host). This may impact your custom metrics billing.
     tags:
     - template_section:Common
-    - full-agent-only:true
     comment: |-
       The cardinality of tags to send for checks.
       Choices are: low, orchestrator, high.
@@ -385,7 +384,6 @@ properties:
       (one per container instead of one per host). This may impact your custom metrics billing.
     tags:
     - template_section:Common
-    - full-agent-only:true
     comment: |-
       The cardinality of tags to send for dogstatsd.
       Choices are: low, orchestrator, high.
@@ -3358,7 +3356,6 @@ properties:
         <HIGH_CARDINALITY_LABEL_NAME>: +<TAG_KEY>
     tags:
     - template_section:DockerTagging
-    - full-agent-only:true
   docker_env_as_tags:
     node_type: setting
     type: object
@@ -3376,7 +3373,6 @@ properties:
         <ENVVAR_NAME>: <TAG_KEY>
     tags:
     - template_section:DockerTagging
-    - full-agent-only:true
   kubernetes_pod_labels_as_tags:
     node_type: setting
     title: Kubernetes tag extraction
@@ -3396,7 +3392,6 @@ properties:
         <HIGH_CARDINALITY_LABEL_NAME>: +<TAG_KEY>
     tags:
     - template_section:KubernetesTagging
-    - full-agent-only:true
   kubernetes_pod_annotations_as_tags:
     node_type: setting
     type: object
@@ -3415,7 +3410,6 @@ properties:
         <HIGH_CARDINALITY_ANNOTATION>: +<TAG_KEY>
     tags:
     - template_section:KubernetesTagging
-    - full-agent-only:true
   kubernetes_namespace_labels_as_tags:
     node_type: setting
     type: object
@@ -3434,7 +3428,6 @@ properties:
         <HIGH_CARDINALITY_NAMESPACE_LABEL_NAME>: +<TAG_KEY>
     tags:
     - template_section:KubernetesTagging
-    - full-agent-only:true
   container_env_as_tags:
     node_type: setting
     type: object
@@ -3503,7 +3496,6 @@ properties:
       ECS Agent for tasks scheduled with the EC2 launch type.
     tags:
     - template_section:ECS
-    - full-agent-only:true
   ecs_resource_tags_replace_colon:
     node_type: setting
     type: boolean
@@ -3925,7 +3917,6 @@ properties:
         beta.kubernetes.io/os: os
     tags:
     - template_section:KubeApiServer
-    - full-agent-only:true
   kubernetes_node_annotations_as_tags:
     node_type: setting
     type: object
@@ -3943,7 +3934,6 @@ properties:
         cluster.k8s.io/machine: machine
     tags:
     - template_section:KubeApiServer
-    - full-agent-only:true
   kubernetes_node_annotations_as_host_aliases:
     node_type: setting
     type: array
@@ -4327,7 +4317,6 @@ properties:
     description: This section configures High Availability Agent feature.
     tags:
     - template_section:CoreAgent
-    - full-agent-only:true
     properties:
       enabled:
         node_type: setting
@@ -6330,8 +6319,6 @@ properties:
         node_type: setting
         type: boolean
         default: true
-    tags:
-    - full-agent-only:true
   data_security:
     node_type: section
     type: object
@@ -6847,8 +6834,6 @@ properties:
         node_type: setting
         type: boolean
         default: false
-    tags:
-    - full-agent-only:true
   dogstatsd_capture_depth:
     node_type: setting
     type: integer
@@ -7638,8 +7623,6 @@ properties:
     node_type: setting
     type: boolean
     default: false
-    tags:
-    - full-agent-only:true
     comment: overridden in Heroku buildpack
   hostname_drift_initial_delay:
     node_type: setting
@@ -8046,8 +8029,6 @@ properties:
     node_type: setting
     type: boolean
     default: false
-    tags:
-    - full-agent-only:true
     comment: overridden in IoT Agent main
   ipc_address:
     node_type: setting
@@ -8279,8 +8260,6 @@ properties:
     default: {}
     additionalProperties:
       type: string
-    tags:
-    - full-agent-only:true
   kubernetes_node_label_as_cluster_name:
     node_type: setting
     type: string
@@ -8291,14 +8270,10 @@ properties:
     node_type: setting
     type: boolean
     default: true
-    tags:
-    - full-agent-only:true
   kubernetes_resources_annotations_as_tags:
     node_type: setting
     type: string
     default: '{}'
-    tags:
-    - full-agent-only:true
     comment: |-
       kubernetes_resources_annotations_as_tags should be parseable as map[string]map[string]string
       it maps group resources to annotations as tags maps
@@ -8312,8 +8287,6 @@ properties:
     node_type: setting
     type: string
     default: '{}'
-    tags:
-    - full-agent-only:true
     comment: |-
       kubernetes_resources_labels_as_tags should be parseable as map[string]map[string]string
       it maps group resources to labels as tags maps
@@ -8422,26 +8395,18 @@ properties:
     default: []
     items:
       type: string
-    tags:
-    - full-agent-only:true
   metric_filterlist_match_prefix:
     node_type: setting
     type: boolean
     default: false
-    tags:
-    - full-agent-only:true
   metric_tag_filterlist:
     node_type: setting
     type: array
     default: []
-    tags:
-    - full-agent-only:true
   metric_tag_filterlist_adp_only:
     node_type: setting
     type: boolean
     default: true
-    tags:
-    - full-agent-only:true
     comment: |-
       When true (default), metric_tag_filterlist tag stripping is only applied when data_plane.enabled is true.
       Set to false to apply tag stripping regardless of whether ADP is running.
@@ -9246,14 +9211,10 @@ properties:
     default: []
     items:
       type: string
-    tags:
-    - full-agent-only:true
   statsd_metric_blocklist_match_prefix:
     node_type: setting
     type: boolean
     default: false
-    tags:
-    - full-agent-only:true
   statsd_metric_namespace_blacklist:
     node_type: setting
     type: array

--- a/pkg/config/schema/yaml/gpu.yaml
+++ b/pkg/config/schema/yaml/gpu.yaml
@@ -8,7 +8,6 @@ description: |-
   Both this section and the gpu_monitoring section in system-probe.yaml must be configured.
 tags:
 - template_section:Common
-- full-agent-only:true
 properties:
   enabled:
     node_type: setting

--- a/pkg/config/schema/yaml/otelcollector.yaml
+++ b/pkg/config/schema/yaml/otelcollector.yaml
@@ -64,5 +64,3 @@ properties:
     type: boolean
     default: false
     comment: dev flag - to be removed
-tags:
-- full-agent-only:true

--- a/pkg/config/setup/config_init_serverless.go
+++ b/pkg/config/setup/config_init_serverless.go
@@ -7,11 +7,6 @@
 
 package setup
 
-import (
-	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-)
-
 func initConfig() {
 	ddcfg := GlobalConfigBuilder()
 	initCommonBase(ddcfg)
@@ -20,32 +15,4 @@ func initConfig() {
 func fixupInitConfig() {
 	ddcfg := Datadog()
 	fixupInitCommonConfigComponents(ddcfg)
-	fixupInitServerlessOnlyComponents(ddcfg)
-}
-
-// called only for full-agent, ONLY for serverless, after declaring settings
-func fixupInitServerlessOnlyComponents(_ pkgconfigmodel.Config) { // nolint:unused,deadcode this is only used by serverless
-	// Do not extend this list !
-	//
-	// Those are legacy behavior that should not be extend. The same config must be compatible with any Agent no
-	// matter its version (serverless, full, IOT, ...). We must be able to look at a configuration and deduce
-	// exactly the Agent behavior. The only acceptable difference are OS defaults (path, port, ...).
-	//
-	// If some product are not compatible with serverless, that difference in behavior must be handle within those
-	// products not through configuration defaults manipulation.
-
-	// Those setting are disable to silence logs but do not entirely disable the data collection for k8s or sbom.
-	pkgconfigmodel.AddOverrideFunc(func(config pkgconfigmodel.Config) {
-
-		for name, defaultVal := range map[string]interface{}{
-			"sbom.container_image.exclude_pause_container": false,
-			"kubernetes_persistent_volume_claims_as_tags":  false,
-			"kubernetes_node_annotations_as_tags":          map[string]string{},
-		} {
-			if !config.IsConfigured(name) {
-				log.Debugf("Disabling %s by default since we are in serverless mode", name)
-				config.Set(name, defaultVal, pkgconfigmodel.SourceConfigPostInit)
-			}
-		}
-	})
 }


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

- Remove default values specific to serverless-init config.
- Remove `full-agent-only:true` for configs that are read by serverless-init to suppress warnings around unknown config keys

### Motivation

https://datadoghq.atlassian.net/browse/SVLS-9498

### Describe how you validated your changes

Built in serverless-init-ci, ran against end to end tests.

### Additional Notes

Follows https://github.com/DataDog/datadog-agent/pull/53729 and https://github.com/DataDog/datadog-agent/pull/51526.

Investigation into how serverless-init initialization times are affected in https://github.com/DataDog/datadog-agent/pull/55787#issuecomment-5516012929

```
pkg: github.com/DataDog/datadog-agent/cmd/serverless-init
           │ baseline/perf.log │           current/perf.log            │
           │      sec/op       │    sec/op     vs base                 │
ConfigLoad         8.452m ± 2%   12.492m ± 1%  +47.81% (p=0.000 n=100)
Startup            23.14m ± 1%    31.40m ± 1%  +35.65% (p=0.000 n=100)
```

Direct tag removal (22 settings, each individually tagged):

1. checks_tag_cardinality
2. dogstatsd_tag_cardinality
3. docker_labels_as_tags
4. docker_env_as_tags
5. kubernetes_pod_labels_as_tags
6. kubernetes_pod_annotations_as_tags
7. kubernetes_namespace_labels_as_tags
8. kubernetes_namespace_annotations_as_tags
9. ecs_collect_resource_tags_ec2
10. kubernetes_node_labels_as_tags
11. kubernetes_node_annotations_as_tags
12. kubernetes_persistent_volume_claims_as_tags
13. kubernetes_resources_annotations_as_tags
14. kubernetes_resources_labels_as_tags
15. heroku_dyno
16. iot_host
17. metric_filterlist
18. metric_filterlist_match_prefix
19. metric_tag_filterlist
20. metric_tag_filterlist_adp_only
21. statsd_metric_blocklist
22. statsd_metric_blocklist_match_prefix

Section-root tag removal (tag removed from the parent section, affecting every setting nested under it):
23. ha_agent.enabled
24. data_plane.enabled
25. data_plane.stop_timeout
26. djm_config.enabled
27. gpu.*
28. otelcollector.*

<img width="677" height="502" alt="Screenshot 2026-08-31 at 12 48 51 PM" src="https://github.com/user-attachments/assets/ddc38a01-db47-4448-8229-abdbfac1bb98" />
