### PR TITLE
Make schema codegen emit uniform line endings

### DIFF
--- a/tasks/schema/codegen_init_settings.py
+++ b/tasks/schema/codegen_init_settings.py
@@ -90,8 +90,18 @@ class CodeGeneratorTarget:
                 continue
             print('Output %s' % filename)
             out_filename = os.path.join(out_dir, filename)
-            with open(out_filename, "w") as f:
-                f.write('\n'.join(self.filesystem[filename]) + '\n')
+            _write_uniform_lines(out_filename, self.filesystem[filename])
+
+
+def _write_uniform_lines(path, lines):
+    """
+    Write lines to path, one per line, so the bytes never depend on the host platform.
+
+    Text mode would otherwise translate newlines to os.linesep, yielding CRLF on Windows.
+    """
+    with open(path, "w", newline="\n") as f:
+        for line in lines:
+            print(line, file=f)
 
 
 def join_key(prefix, field):
@@ -512,7 +522,6 @@ var delegatedAuthKeys = []delegatedAuthConfig{""")
 		description:       "{parent_section_name}",
 	}},""")
         out.append("}")
-        out.append("")
 
     emit(outputs["core"], collect_delegated_auth_keys(core_schema))
 
@@ -575,7 +584,6 @@ def gen_generate_const(core_schema, system_probe_schema, outputs):
         pad_space = magic_value - len(name)
         out.append(f"\t{name}{' ' * pad_space} = {consts[name]['value']}")
     out.append(")")
-    out.append("")
 
 
 # The files produced by the constant generators, keyed by the output name generators use to
@@ -635,8 +643,7 @@ def run_constant_codegen(core_schema, system_probe_schema, outsource_dir):
         print('Output %s' % filename)
         out_filename = os.path.join(outsource_dir, filename)
         os.makedirs(os.path.dirname(out_filename), exist_ok=True)
-        with open(out_filename, "w") as f:
-            f.write('\n'.join(sourcecode))
+        _write_uniform_lines(out_filename, sourcecode)
 
 
 def run_codegen(schema, filename_filter, outsource_dir):


### PR DESCRIPTION
### What does this PR do?
Write the generated `pkg/config/setup` files through a `_write_uniform_lines` helper that opens with `newline="\n"`.

Drop the trailing `out.append("")` from `gen_delegated_auth_map` and `gen_generate_const`: it only existed so a join separator would produce the final newline, and it forced the two write sites to disagree on whether to append one.

### Motivation
`lint_windows-x64` has failed on all nightly main pipelines after #54160 moved the codegen into the lint path and stopped tracking its outputs ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1939819648)):
```
Linter failures:
pkg\config\setup\all_settings.go:1:1: File is not properly formatted (gofmt)
// Unless explicitly stated otherwise all files in this repository are licensed
^
pkg\config\setup\constants\generated.go:1:1: File is not properly formatted (gofmt)
// Unless explicitly stated otherwise all files in this repository are licensed
^
pkg\config\setup\generated.go:1:1: File is not properly formatted (gofmt)
// Unless explicitly stated otherwise all files in this repository are licensed
^
pkg\config\setup\system_probe_settings.go:1:1: File is not properly formatted (gofmt)
// Unless explicitly stated otherwise all files in this repository are licensed
^
4 issues:
* gofmt: 4
Go linter result is 1
go linter failed 1
```
Python text mode translates `\n` to `os.linesep`, so on Windows the freshly generated files land as CRLF and `gofmt` rejects them, whereas a checkout honors the `eol=lf` `.gitattributes`.

Only nightly, deploy, tag and release pipelines run the job (`.on_native_os_linters`), so no pull request surfaced it.

### Describe how you validated your changes
Ran `dda inv schema.codegen` on Linux and on Windows: both now produce the same md5 for all four files, with no CR and `gofmt` clean.

`bazel build //pkg/config/setup:codegen_settings` yields outputs identical to the source tree.

`bazel test //pkg/config/setup/...` and the 134 `tasks/unit_tests/schema_*_tests.py` cases pass.