### PR TITLE
[datasecurity] resolve autodiscovery configs before matching postgres scan connections

### DIFF
--- a/comp/core/autodiscovery/def/component.go
+++ b/comp/core/autodiscovery/def/component.go
@@ -25,6 +25,8 @@ type Component interface {
 	AddConfigProvider(provider types.ConfigProvider, shouldPoll bool, pollInterval time.Duration)
 	LoadAndRun(ctx context.Context)
 	GetUnresolvedConfigs() []integration.Config
+	// GetAllConfigs returns the scheduled configs: resolved templates (%%VARIABLES%% substituted) plus non-template configs.
+	GetAllConfigs() []integration.Config
 	AddListeners(listenerConfigs []pkgconfigsetup.Listeners)
 	AddScheduler(name string, s scheduler.Scheduler, replayConfigs bool)
 	RemoveScheduler(name string)

--- a/comp/core/autodiscovery/def/component.go
+++ b/comp/core/autodiscovery/def/component.go
@@ -25,7 +25,6 @@ type Component interface {
 	AddConfigProvider(provider types.ConfigProvider, shouldPoll bool, pollInterval time.Duration)
 	LoadAndRun(ctx context.Context)
 	GetUnresolvedConfigs() []integration.Config
-	// GetAllConfigs returns the scheduled configs: resolved templates (%%VARIABLES%% substituted) plus non-template configs.
 	GetAllConfigs() []integration.Config
 	AddListeners(listenerConfigs []pkgconfigsetup.Listeners)
 	AddScheduler(name string, s scheduler.Scheduler, replayConfigs bool)

--- a/comp/core/autodiscovery/noopimpl/autoconfig.go
+++ b/comp/core/autodiscovery/noopimpl/autoconfig.go
@@ -42,6 +42,10 @@ func (n *noopAutoConfig) GetUnresolvedConfigs() []integration.Config {
 	return []integration.Config{}
 }
 
+func (n *noopAutoConfig) GetAllConfigs() []integration.Config {
+	return []integration.Config{}
+}
+
 func (n *noopAutoConfig) AddListeners([]pkgconfigsetup.Listeners) {}
 
 func (n *noopAutoConfig) AddScheduler(string, scheduler.Scheduler, bool) {}

--- a/comp/core/autodiscovery/providers/datasecurity/data_security.go
+++ b/comp/core/autodiscovery/providers/datasecurity/data_security.go
@@ -215,10 +215,11 @@ func (c *controller) buildCheckInstance(payload scanTaskPayload) ([]byte, error)
 	return json.Marshal(inst)
 }
 
-// resolvePostgresConnection builds the scan connection from the local postgres instance
-// matching the entity's host.
+// resolvePostgresConnection builds the scan connection from the resolved local postgres instance
+// matching the entity. It uses GetAllConfigs so templated hosts (e.g. %%kube_pod_name%%) are
+// substituted before matching.
 func (c *controller) resolvePostgresConnection(e entity) (connection, error) {
-	for _, cfg := range c.ac.GetUnresolvedConfigs() {
+	for _, cfg := range c.ac.GetAllConfigs() {
 		if cfg.Name != postgresIntegrationName {
 			continue
 		}
@@ -228,24 +229,38 @@ func (c *controller) resolvePostgresConnection(e entity) (connection, error) {
 				log.Warnf("skipping postgres instance: failed to unmarshal: %v", err)
 				continue
 			}
-			if matchesHost(instance, e.DatabaseHostName) {
+			if matchesEntity(instance, e) {
 				return buildPostgresConnection(instance, e), nil
 			}
 		}
 	}
-	log.Warnf("no postgres integration found with host=%q", e.DatabaseHostName)
-	return connection{}, fmt.Errorf("postgres integration with host=%q not found", e.DatabaseHostName)
+	log.Warnf("no postgres integration found for entity (host=%q, instance=%q, cluster=%q)",
+		e.DatabaseHostName, e.DatabaseInstanceName, e.DatabaseClusterName)
+	return connection{}, fmt.Errorf(
+		"postgres integration for entity (host=%q, instance=%q, cluster=%q) not found",
+		e.DatabaseHostName, e.DatabaseInstanceName, e.DatabaseClusterName)
 }
 
-// matchesHost reports whether a postgres instance targets the given host: an exact match
-// or the "host:port" form some backends send.
-func matchesHost(instance map[string]any, targetHost string) bool {
+// matchesEntity matches the instance's resolved host (and its host:port form) against the entity's
+// host, instance, and cluster identifiers, since the backend may key the entity off any of them.
+func matchesEntity(instance map[string]any, e entity) bool {
 	host, _ := instance["host"].(string)
-	if host == targetHost {
-		return true
+	if host == "" {
+		return false
 	}
+
+	candidates := []string{host}
 	if port, ok := instancePort(instance); ok {
-		return fmt.Sprintf("%s:%d", host, port) == targetHost
+		candidates = append(candidates, fmt.Sprintf("%s:%d", host, port))
+	}
+
+	targets := []string{e.DatabaseHostName, e.DatabaseInstanceName, e.DatabaseClusterName}
+	for _, candidate := range candidates {
+		for _, target := range targets {
+			if target != "" && candidate == target {
+				return true
+			}
+		}
 	}
 	return false
 }

--- a/comp/core/autodiscovery/providers/datasecurity/data_security.go
+++ b/comp/core/autodiscovery/providers/datasecurity/data_security.go
@@ -216,8 +216,8 @@ func (c *controller) buildCheckInstance(payload scanTaskPayload) ([]byte, error)
 }
 
 // resolvePostgresConnection builds the scan connection from the resolved local postgres instance
-// matching the entity. It uses GetAllConfigs so templated hosts (e.g. %%kube_pod_name%%) are
-// substituted before matching.
+// matching the entity's host. It uses GetAllConfigs so templated hosts (e.g. %%kube_pod_name%%)
+// are substituted before matching.
 func (c *controller) resolvePostgresConnection(e entity) (connection, error) {
 	for _, cfg := range c.ac.GetAllConfigs() {
 		if cfg.Name != postgresIntegrationName {
@@ -229,38 +229,24 @@ func (c *controller) resolvePostgresConnection(e entity) (connection, error) {
 				log.Warnf("skipping postgres instance: failed to unmarshal: %v", err)
 				continue
 			}
-			if matchesEntity(instance, e) {
+			if matchesHost(instance, e.DatabaseHostName) {
 				return buildPostgresConnection(instance, e), nil
 			}
 		}
 	}
-	log.Warnf("no postgres integration found for entity (host=%q, instance=%q, cluster=%q)",
-		e.DatabaseHostName, e.DatabaseInstanceName, e.DatabaseClusterName)
-	return connection{}, fmt.Errorf(
-		"postgres integration for entity (host=%q, instance=%q, cluster=%q) not found",
-		e.DatabaseHostName, e.DatabaseInstanceName, e.DatabaseClusterName)
+	log.Warnf("no postgres integration found with host=%q", e.DatabaseHostName)
+	return connection{}, fmt.Errorf("postgres integration with host=%q not found", e.DatabaseHostName)
 }
 
-// matchesEntity matches the instance's resolved host (and its host:port form) against the entity's
-// host, instance, and cluster identifiers, since the backend may key the entity off any of them.
-func matchesEntity(instance map[string]any, e entity) bool {
+// matchesHost reports whether a postgres instance targets the given host: an exact match
+// or the "host:port" form some backends send.
+func matchesHost(instance map[string]any, targetHost string) bool {
 	host, _ := instance["host"].(string)
-	if host == "" {
-		return false
+	if host == targetHost {
+		return true
 	}
-
-	candidates := []string{host}
 	if port, ok := instancePort(instance); ok {
-		candidates = append(candidates, fmt.Sprintf("%s:%d", host, port))
-	}
-
-	targets := []string{e.DatabaseHostName, e.DatabaseInstanceName, e.DatabaseClusterName}
-	for _, candidate := range candidates {
-		for _, target := range targets {
-			if target != "" && candidate == target {
-				return true
-			}
-		}
+		return fmt.Sprintf("%s:%d", host, port) == targetHost
 	}
 	return false
 }

--- a/comp/core/autodiscovery/providers/datasecurity/data_security.go
+++ b/comp/core/autodiscovery/providers/datasecurity/data_security.go
@@ -40,7 +40,7 @@ const (
 
 // isConnectedToPostgres reports whether any postgres integration is configured.
 func isConnectedToPostgres(ac autodiscovery.Component) bool {
-	for _, config := range ac.GetUnresolvedConfigs() {
+	for _, config := range ac.GetAllConfigs() {
 		if config.Name == postgresIntegrationName {
 			return true
 		}
@@ -215,9 +215,8 @@ func (c *controller) buildCheckInstance(payload scanTaskPayload) ([]byte, error)
 	return json.Marshal(inst)
 }
 
-// resolvePostgresConnection builds the scan connection from the resolved local postgres instance
-// matching the entity's host. It uses GetAllConfigs so templated hosts (e.g. %%kube_pod_name%%)
-// are substituted before matching.
+// resolvePostgresConnection builds the scan connection from the local postgres instance
+// matching the entity's host.
 func (c *controller) resolvePostgresConnection(e entity) (connection, error) {
 	for _, cfg := range c.ac.GetAllConfigs() {
 		if cfg.Name != postgresIntegrationName {

--- a/comp/core/autodiscovery/providers/datasecurity/data_security_test.go
+++ b/comp/core/autodiscovery/providers/datasecurity/data_security_test.go
@@ -48,6 +48,10 @@ func (m *mockedAutodiscovery) GetUnresolvedConfigs() []integration.Config {
 	return m.configs
 }
 
+func (m *mockedAutodiscovery) GetAllConfigs() []integration.Config {
+	return m.configs
+}
+
 func getMockedAutodiscovery(t *testing.T, configs []integration.Config) autodiscovery.Component {
 	return &mockedAutodiscovery{
 		Component: fxutil.Test[autodiscovery.Component](t, noopautoconfig.Module()),
@@ -115,6 +119,58 @@ const scanTaskUnknownHostConfig = `{
   ]
 }`
 
+// scanTaskInstanceIdentityConfig matches the instance by database_instance_name, not host.
+const scanTaskInstanceIdentityConfig = `{
+  "task_id": "task-1",
+  "scanning_rules": [
+    {"id": "rule-1", "license": "proprietary", "pattern": "\\d+"}
+  ],
+  "scan_data": [
+    {
+      "sub_task_id": "sub-1",
+      "query": "SELECT * FROM users",
+      "timeout_seconds": 30,
+      "entity": {
+        "platform": "postgres",
+        "database_cluster_name": "cluster",
+        "database_instance_name": "db-host",
+        "database_host_name": "reported-elsewhere",
+        "database": "app",
+        "schema": "public",
+        "table": "users"
+      }
+    }
+  ]
+}`
+
+// wantInstanceIdentityCheckInstance is the check instance expected for scanTaskInstanceIdentityConfig.
+const wantInstanceIdentityCheckInstance = `
+min_collection_interval: 0
+task_id: task-1
+scanning_rules:
+  - id: rule-1
+    license: proprietary
+    pattern: '\d+'
+scan_data:
+  - sub_task_id: sub-1
+    query: SELECT * FROM users
+    timeout_seconds: 30
+    entity:
+      platform: postgres
+      database_cluster_name: cluster
+      database_instance_name: db-host
+      database_host_name: reported-elsewhere
+      database: app
+      schema: public
+      table: users
+    connection:
+      host: db-host
+      port: 5678
+      dbname: app
+      username: datadog
+      password: secret
+`
+
 // wantCheckInstance is the check instance the provider is expected to emit for
 // scanTaskConfig once the local postgres connection has been resolved. The
 // scanning rule (with its license) is forwarded verbatim.
@@ -180,6 +236,10 @@ func TestControllerUpdate(t *testing.T) {
 		Name:      dataSecurityCheckName,
 		Instances: []integration.Data{integration.Data(wantCheckInstance)},
 	}
+	wantInstanceIdentityScheduledConfig := integration.Config{
+		Name:      dataSecurityCheckName,
+		Instances: []integration.Data{integration.Data(wantInstanceIdentityCheckInstance)},
+	}
 	tests := []struct {
 		name          string
 		remoteConfigs []map[string]state.RawConfig // successive RC updates, each keyed by path
@@ -197,9 +257,15 @@ func TestControllerUpdate(t *testing.T) {
 			remoteConfigs: []map[string]state.RawConfig{{"rc-1": rawScanTask("rc-1", scanTaskUnknownHostConfig)}},
 			wantStatus: map[string]state.ApplyStatus{"rc-1": {
 				State: state.ApplyStateError,
-				Error: `failed to build sub task "sub-1": postgres integration with host="unknown-host" not found`,
+				Error: `failed to build sub task "sub-1": postgres integration for entity (host="unknown-host", instance="instance", cluster="cluster") not found`,
 			}},
 			wantChanges: []integration.ConfigChanges{{}},
+		},
+		{
+			name:          "scan task matched by database_instance_name schedules check",
+			remoteConfigs: []map[string]state.RawConfig{{"rc-1": rawScanTask("rc-1", scanTaskInstanceIdentityConfig)}},
+			wantStatus:    map[string]state.ApplyStatus{"rc-1": {State: state.ApplyStateAcknowledged}},
+			wantChanges:   []integration.ConfigChanges{{Schedule: []integration.Config{wantInstanceIdentityScheduledConfig}}},
 		},
 		{
 			name:          "re-delivery at the same RC path unschedules the previous check",

--- a/comp/core/autodiscovery/providers/datasecurity/data_security_test.go
+++ b/comp/core/autodiscovery/providers/datasecurity/data_security_test.go
@@ -119,58 +119,6 @@ const scanTaskUnknownHostConfig = `{
   ]
 }`
 
-// scanTaskInstanceIdentityConfig matches the instance by database_instance_name, not host.
-const scanTaskInstanceIdentityConfig = `{
-  "task_id": "task-1",
-  "scanning_rules": [
-    {"id": "rule-1", "license": "proprietary", "pattern": "\\d+"}
-  ],
-  "scan_data": [
-    {
-      "sub_task_id": "sub-1",
-      "query": "SELECT * FROM users",
-      "timeout_seconds": 30,
-      "entity": {
-        "platform": "postgres",
-        "database_cluster_name": "cluster",
-        "database_instance_name": "db-host",
-        "database_host_name": "reported-elsewhere",
-        "database": "app",
-        "schema": "public",
-        "table": "users"
-      }
-    }
-  ]
-}`
-
-// wantInstanceIdentityCheckInstance is the check instance expected for scanTaskInstanceIdentityConfig.
-const wantInstanceIdentityCheckInstance = `
-min_collection_interval: 0
-task_id: task-1
-scanning_rules:
-  - id: rule-1
-    license: proprietary
-    pattern: '\d+'
-scan_data:
-  - sub_task_id: sub-1
-    query: SELECT * FROM users
-    timeout_seconds: 30
-    entity:
-      platform: postgres
-      database_cluster_name: cluster
-      database_instance_name: db-host
-      database_host_name: reported-elsewhere
-      database: app
-      schema: public
-      table: users
-    connection:
-      host: db-host
-      port: 5678
-      dbname: app
-      username: datadog
-      password: secret
-`
-
 // wantCheckInstance is the check instance the provider is expected to emit for
 // scanTaskConfig once the local postgres connection has been resolved. The
 // scanning rule (with its license) is forwarded verbatim.
@@ -236,10 +184,6 @@ func TestControllerUpdate(t *testing.T) {
 		Name:      dataSecurityCheckName,
 		Instances: []integration.Data{integration.Data(wantCheckInstance)},
 	}
-	wantInstanceIdentityScheduledConfig := integration.Config{
-		Name:      dataSecurityCheckName,
-		Instances: []integration.Data{integration.Data(wantInstanceIdentityCheckInstance)},
-	}
 	tests := []struct {
 		name          string
 		remoteConfigs []map[string]state.RawConfig // successive RC updates, each keyed by path
@@ -257,15 +201,9 @@ func TestControllerUpdate(t *testing.T) {
 			remoteConfigs: []map[string]state.RawConfig{{"rc-1": rawScanTask("rc-1", scanTaskUnknownHostConfig)}},
 			wantStatus: map[string]state.ApplyStatus{"rc-1": {
 				State: state.ApplyStateError,
-				Error: `failed to build sub task "sub-1": postgres integration for entity (host="unknown-host", instance="instance", cluster="cluster") not found`,
+				Error: `failed to build sub task "sub-1": postgres integration with host="unknown-host" not found`,
 			}},
 			wantChanges: []integration.ConfigChanges{{}},
-		},
-		{
-			name:          "scan task matched by database_instance_name schedules check",
-			remoteConfigs: []map[string]state.RawConfig{{"rc-1": rawScanTask("rc-1", scanTaskInstanceIdentityConfig)}},
-			wantStatus:    map[string]state.ApplyStatus{"rc-1": {State: state.ApplyStateAcknowledged}},
-			wantChanges:   []integration.ConfigChanges{{Schedule: []integration.Config{wantInstanceIdentityScheduledConfig}}},
 		},
 		{
 			name:          "re-delivery at the same RC path unschedules the previous check",

--- a/releasenotes/notes/data-security-postgres-matching-9e8ba3441607ec35.yaml
+++ b/releasenotes/notes/data-security-postgres-matching-9e8ba3441607ec35.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    The Data Security check now resolves its PostgreSQL source from fully
+    templated autodiscovery configurations, so scan targets are matched
+    reliably when the PostgreSQL integration is configured with template
+    variables such as ``%%host%%``.


### PR DESCRIPTION
## What
- `resolvePostgresConnection` now reads `GetAllConfigs()` (resolved configs) instead of `GetUnresolvedConfigs()`, so autodiscovery template variables (`%%...%%`) are substituted before matching.
- Adds `GetAllConfigs()` to the autodiscovery `Component` interface (+ noop impl).

## Why
Postgres checks configured through autodiscovery annotations (`ad.datadoghq.com/postgres.checks`) use template variables that are only substituted once a service is matched. The scan-task resolver previously read *unresolved* configs, so a templated instance such as:

```yaml
instances:
  - host: "%%host%%"
    port: 5432
    dbm: true
```

could never match a scan-task entity, whose `database_host_name` is the concrete resolved host. And even if it did, the resulting connection would target `host: "%%host%%"`, which is not connectable. Reading the resolved config fixes both: the host is concrete and matchable.

## Why Backport to 7.83.x is justified
- Tested the agent on my local machine and everything works as expected when using static Postgres check configs.
- Data Security is a new product that is not enabled anywhere yet, so the blast radius of this change is effectively zero as the provider is not started unless data_security.enabled is set to true (default is false)
- The bug was spotted while testing with autodiscovery-generated Postgres check configs. Back-porting allows support of autodiscovery-generated Postgres check configs in the upcoming 7.83.0 release.
