### PR TITLE
[procmgr] Restore runtime ReloadConfig for processes.d

### DIFF
--- a/pkg/procmgr/rust/src/bins/dd-procmgr.rs
+++ b/pkg/procmgr/rust/src/bins/dd-procmgr.rs
@@ -643,11 +643,43 @@ async fn cmd_create(
     Ok(())
 }
 
-async fn cmd_reload(client: &mut ProcessManagerClient<Channel>, _json: bool) -> Result<(), String> {
-    client
+async fn cmd_reload(client: &mut ProcessManagerClient<Channel>, json: bool) -> Result<(), String> {
+    let resp = client
         .reload_config(proto::ReloadConfigRequest {})
         .await
-        .map_err(grpc_err)?;
+        .map_err(grpc_err)?
+        .into_inner();
+
+    if json {
+        let val = serde_json::json!({
+            "added": resp.added,
+            "removed": resp.removed,
+            "modified": resp.modified,
+            "unchanged": resp.unchanged,
+        });
+        println!("{}", serde_json::to_string_pretty(&val).unwrap());
+        return Ok(());
+    }
+
+    if !resp.added.is_empty() {
+        println!("Added:     {}", resp.added.join(", "));
+    }
+    if !resp.removed.is_empty() {
+        println!("Removed:   {}", resp.removed.join(", "));
+    }
+    if !resp.modified.is_empty() {
+        println!("Modified:  {}", resp.modified.join(", "));
+    }
+    if !resp.unchanged.is_empty() {
+        println!("Unchanged: {}", resp.unchanged.join(", "));
+    }
+    if resp.added.is_empty()
+        && resp.removed.is_empty()
+        && resp.modified.is_empty()
+        && resp.unchanged.is_empty()
+    {
+        println!("No changes");
+    }
     Ok(())
 }
 

--- a/pkg/procmgr/rust/src/command.rs
+++ b/pkg/procmgr/rust/src/command.rs
@@ -8,6 +8,13 @@ use crate::state::ProcessState;
 use tokio::sync::oneshot;
 use tonic::Status;
 
+pub struct ReloadResult {
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+    pub modified: Vec<String>,
+    pub unchanged: Vec<String>,
+}
+
 #[derive(Debug)]
 pub struct CreateResult {
     pub uuid: String,
@@ -41,6 +48,9 @@ pub enum Command {
         name_or_uuid: String,
         reply: oneshot::Sender<Result<StopResult, Status>>,
     },
+    ReloadConfig {
+        reply: oneshot::Sender<Result<ReloadResult, Status>>,
+    },
 }
 
 impl Command {
@@ -53,6 +63,9 @@ impl Command {
                 let _ = reply.send(Err(status));
             }
             Self::Stop { reply, .. } => {
+                let _ = reply.send(Err(status));
+            }
+            Self::ReloadConfig { reply } => {
                 let _ = reply.send(Err(status));
             }
         }

--- a/pkg/procmgr/rust/src/grpc/mod.rs
+++ b/pkg/procmgr/rust/src/grpc/mod.rs
@@ -483,14 +483,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_reload_config_unimplemented() {
-        let (mut client, _shutdown) = start_test_server(vec![]).await;
-        let err = client
+    async fn test_reload_config_reports_unchanged() {
+        let (cmd, args) = test_helpers::sleep_cmd(60);
+        let (mut client, _shutdown) = start_test_server(vec![ProcessDefinition {
+            name: "svc".to_string(),
+            config: ProcessConfig {
+                command: cmd.to_string(),
+                args,
+                auto_start: false,
+                ..Default::default()
+            },
+        }])
+        .await;
+        let resp = client
             .reload_config(proto::ReloadConfigRequest {})
             .await
-            .unwrap_err();
-        assert_eq!(err.code(), tonic::Code::Unimplemented);
-        assert!(err.message().contains("restart dd-procmgr-service"));
+            .unwrap()
+            .into_inner();
+        assert_eq!(resp.unchanged, vec!["svc"]);
+        assert!(resp.added.is_empty());
+        assert!(resp.removed.is_empty());
+        assert!(resp.modified.is_empty());
     }
 
     #[tokio::test]

--- a/pkg/procmgr/rust/src/grpc/service.rs
+++ b/pkg/procmgr/rust/src/grpc/service.rs
@@ -193,9 +193,20 @@ impl proto::process_manager_server::ProcessManager for ProcessManagerService {
     ) -> Result<Response<proto::ReloadConfigResponse>, Status> {
         require_mutating_pipe_client(&request)?;
         let _ = request.into_inner();
-        Err(Status::unimplemented(
-            "config reload is not implemented; restart dd-procmgr-service instead",
-        ))
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(Command::ReloadConfig { reply: reply_tx })
+            .await
+            .map_err(|_| Status::internal("event loop not available"))?;
+        let result = reply_rx
+            .await
+            .map_err(|_| Status::internal("event loop dropped reply"))??;
+        Ok(Response::new(proto::ReloadConfigResponse {
+            added: result.added,
+            removed: result.removed,
+            modified: result.modified,
+            unchanged: result.unchanged,
+        }))
     }
 
     async fn get_config(

--- a/pkg/procmgr/rust/src/manager/catalog.rs
+++ b/pkg/procmgr/rust/src/manager/catalog.rs
@@ -18,12 +18,13 @@ pub(in crate::manager) struct ProcessCatalog {
     processes: RwLock<Vec<ManagedProcess>>,
     startup_order: RwLock<Vec<usize>>,
     uuid_gen: Arc<dyn UuidGenerator>,
+    config_loader: Arc<dyn ConfigLoader>,
     config_source: String,
     config_location: String,
 }
 
 impl ProcessCatalog {
-    pub fn load(config_loader: &dyn ConfigLoader, uuid_gen: Arc<dyn UuidGenerator>) -> Self {
+    pub fn load(config_loader: Arc<dyn ConfigLoader>, uuid_gen: Arc<dyn UuidGenerator>) -> Self {
         let config_source = config_loader.source().to_string();
         let config_location = config_loader.location();
         let processes: Vec<ManagedProcess> = config_loader
@@ -36,6 +37,7 @@ impl ProcessCatalog {
             processes: RwLock::new(processes),
             startup_order: RwLock::new(startup_order),
             uuid_gen,
+            config_loader,
             config_source,
             config_location,
         }
@@ -47,6 +49,20 @@ impl ProcessCatalog {
 
     pub(crate) fn config_location(&self) -> &str {
         &self.config_location
+    }
+
+    pub(in crate::manager) fn config_loader(&self) -> &dyn ConfigLoader {
+        self.config_loader.as_ref()
+    }
+
+    pub(in crate::manager) fn generate_uuid(&self) -> String {
+        self.uuid_gen.generate()
+    }
+
+    pub(in crate::manager) async fn update_startup_order(&self) -> Vec<String> {
+        let procs = self.processes.read().await;
+        let mut order = self.startup_order.write().await;
+        Self::sync_startup_order(&procs, &mut order)
     }
 
     pub(in crate::manager) async fn read_processes(
@@ -231,7 +247,7 @@ mod startup_order_tests {
     #[test]
     fn load_builds_matching_startup_order() {
         let catalog = ProcessCatalog::load(
-            &StaticConfigLoader::new(vec![
+            Arc::new(StaticConfigLoader::new(vec![
                 ProcessDefinition {
                     name: "alpha".to_string(),
                     config: ProcessConfig::default(),
@@ -240,7 +256,7 @@ mod startup_order_tests {
                     name: "bravo".to_string(),
                     config: ProcessConfig::default(),
                 },
-            ]),
+            ])),
             Arc::new(V4UuidGenerator),
         );
 

--- a/pkg/procmgr/rust/src/manager/mod.rs
+++ b/pkg/procmgr/rust/src/manager/mod.rs
@@ -9,6 +9,7 @@ mod catalog;
 pub(crate) mod deferred_cleanup;
 mod lifecycle;
 mod process_manager;
+mod reload;
 mod runtime;
 mod spawn;
 mod startup;
@@ -39,6 +40,7 @@ pub(crate) type ExitEvent = crate::process::ProcessExit;
 pub(crate) struct PendingRestart {
     pub(crate) uuid: String,
     pub(crate) spawn_seq: u64,
+    pub(crate) config_generation: u64,
 }
 
 pub fn looks_like_uuid_prefix(s: &str) -> bool {
@@ -76,11 +78,12 @@ fn resolve_index(procs: &[ManagedProcess], name_or_uuid: &str) -> Result<usize, 
         .ok_or_else(|| Status::not_found(format!("process '{name_or_uuid}' not found")))
 }
 
-fn enqueue_pending_restart(proc: &mut ManagedProcess, ctx: &RuntimeContext) {
+pub(in crate::manager) fn enqueue_pending_restart(proc: &mut ManagedProcess, ctx: &RuntimeContext) {
     if let Some(delay) = proc.schedule_restart() {
         let pending = PendingRestart {
             uuid: proc.uuid().to_owned(),
             spawn_seq: proc.spawn_seq(),
+            config_generation: proc.config_generation(),
         };
         let tx = ctx.restart_tx.clone();
         tokio::spawn(async move {

--- a/pkg/procmgr/rust/src/manager/process_manager.rs
+++ b/pkg/procmgr/rust/src/manager/process_manager.rs
@@ -30,7 +30,7 @@ pub struct ProcessManager {
 impl ProcessManager {
     pub fn new(config_loader: Arc<dyn ConfigLoader>, uuid_gen: Arc<dyn UuidGenerator>) -> Self {
         Self {
-            catalog: Arc::new(ProcessCatalog::load(config_loader.as_ref(), uuid_gen)),
+            catalog: Arc::new(ProcessCatalog::load(config_loader, uuid_gen)),
         }
     }
 
@@ -70,6 +70,9 @@ impl ProcessManager {
                 reply,
             } => {
                 let _ = reply.send(self.handle_stop(&name_or_uuid).await);
+            }
+            Command::ReloadConfig { reply } => {
+                let _ = reply.send(self.handle_reload_config(ctx).await);
             }
         }
     }

--- a/pkg/procmgr/rust/src/manager/reload.rs
+++ b/pkg/procmgr/rust/src/manager/reload.rs
@@ -1,0 +1,284 @@
+use super::catalog::ProcessCatalog;
+use super::spawn::{SpawnKind, spawn_process};
+use super::{ProcessManager, RuntimeContext};
+use crate::command::ReloadResult;
+use crate::config::ProcessDefinition;
+use crate::process::{ManagedProcess, ProcessOrigin};
+use crate::state::ProcessState;
+use log::{info, warn};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use tonic::Status;
+
+/// Pre-reload snapshot for a process whose config file changed.
+pub(super) struct ModifiedReloadContext {
+    was_running: bool,
+    auto_start_before: bool,
+}
+
+impl ModifiedReloadContext {
+    fn capture(proc: &ManagedProcess) -> Self {
+        Self {
+            was_running: proc.is_running(),
+            auto_start_before: proc.config().auto_start,
+        }
+    }
+
+    /// True when reload did not toggle `auto_start`, so a failed process may
+    /// inherit a pre-reload crash retry. Skips bootstrap failures that reload
+    /// disables via `auto_start: true` → `false`.
+    fn allows_failed_manual_retry(&self, proc: &ManagedProcess) -> bool {
+        self.auto_start_before == proc.config().auto_start
+    }
+}
+
+pub(super) struct ReloadConfigApplyResult {
+    pub added: Vec<String>,
+    pub modified: HashMap<String, ModifiedReloadContext>,
+    pub unchanged: Vec<String>,
+    added_start: Vec<usize>,
+}
+
+pub(super) fn detach_removed_config_processes(
+    procs: &mut Vec<ManagedProcess>,
+    new_names: &HashSet<&str>,
+) -> (Vec<String>, Vec<ManagedProcess>) {
+    let mut removed = Vec::new();
+    let mut procs_to_stop = Vec::new();
+    let mut i = 0;
+    while i < procs.len() {
+        if procs[i].origin() == ProcessOrigin::Config && !new_names.contains(procs[i].name()) {
+            let proc = procs.remove(i);
+            info!("[{}] config removed, stopping", proc.name());
+            removed.push(proc.name().to_owned());
+            procs_to_stop.push(proc);
+        } else {
+            i += 1;
+        }
+    }
+    (removed, procs_to_stop)
+}
+
+fn should_stop_running_after_reload(
+    proc: &ManagedProcess,
+    start_conditions_was: Option<bool>,
+) -> bool {
+    if !proc.config().auto_start {
+        return !proc.start_conditions_met() && start_conditions_was == Some(true);
+    }
+    !proc.start_conditions_met()
+}
+
+fn should_resume_after_running_reload(proc: &ManagedProcess) -> bool {
+    if proc.config().auto_start {
+        proc.may_auto_start()
+    } else {
+        proc.start_conditions_met()
+    }
+}
+
+fn should_retry_failed_after_reload(proc: &ManagedProcess, ctx: &ModifiedReloadContext) -> bool {
+    if proc.config().auto_start {
+        return proc.may_auto_start();
+    }
+    ctx.allows_failed_manual_retry(proc) && proc.should_complete_pending_restart()
+}
+
+fn should_start_after_config_reload(proc: &ManagedProcess, ctx: &ModifiedReloadContext) -> bool {
+    if ctx.was_running {
+        return should_resume_after_running_reload(proc);
+    }
+    if proc.state() == ProcessState::Failed {
+        return should_retry_failed_after_reload(proc, ctx);
+    }
+    false
+}
+
+fn reload_spawn_kind(proc: &ManagedProcess) -> SpawnKind {
+    if proc.may_auto_start() {
+        SpawnKind::CreateAutoStart
+    } else {
+        SpawnKind::Manual
+    }
+}
+
+async fn spawn_reload_process(
+    catalog: Arc<ProcessCatalog>,
+    idx: usize,
+    ctx: &RuntimeContext,
+    kind: SpawnKind,
+    failure_context: &str,
+) {
+    if let Err(e) = spawn_process(catalog, idx, ctx, kind, None).await {
+        warn!("[idx={idx}] {failure_context}: {e:#}");
+    }
+}
+
+async fn restart_after_config_change(
+    proc: &mut ManagedProcess,
+    modified_ctx: &ModifiedReloadContext,
+) -> Option<SpawnKind> {
+    if modified_ctx.was_running {
+        proc.stop().await;
+    }
+
+    let kind = if should_start_after_config_reload(proc, modified_ctx) {
+        info!("[{}] starting after config reload", proc.name());
+        Some(reload_spawn_kind(proc))
+    } else {
+        info!("[{}] skipping start after config reload", proc.name());
+        None
+    };
+
+    proc.record_config_gate_met();
+    kind
+}
+
+async fn reconcile_process_after_reload(
+    proc: &mut ManagedProcess,
+    modified_ctx: Option<&ModifiedReloadContext>,
+) -> Option<SpawnKind> {
+    if proc.origin() != ProcessOrigin::Config {
+        return None;
+    }
+
+    if let Some(modified) = modified_ctx {
+        return restart_after_config_change(proc, modified).await;
+    }
+
+    let want_start = proc.may_auto_start();
+    let start_conditions_was = proc.last_start_conditions_met();
+
+    if proc.is_running() && should_stop_running_after_reload(proc, start_conditions_was) {
+        info!("[{}] start conditions no longer met, stopping", proc.name());
+        proc.stop().await;
+    } else if !proc.is_running() && want_start && start_conditions_was == Some(false) {
+        info!("[{}] start conditions now met, starting", proc.name());
+        proc.record_config_gate_met();
+        return Some(SpawnKind::CreateAutoStart);
+    }
+
+    proc.record_config_gate_met();
+    None
+}
+
+impl ProcessManager {
+    pub(crate) async fn handle_reload_config(
+        &self,
+        ctx: &RuntimeContext,
+    ) -> Result<ReloadResult, Status> {
+        crate::config_gate::clear_secret_caches();
+
+        let new_configs = self.catalog.config_loader().load();
+
+        let removed = self
+            .remove_and_stop_dropped_config_processes(&new_configs)
+            .await;
+
+        let apply = self.apply_reloaded_config_processes(new_configs).await;
+        for idx in apply.added_start.iter().copied() {
+            spawn_reload_process(
+                Arc::clone(&self.catalog),
+                idx,
+                ctx,
+                SpawnKind::CreateAutoStart,
+                "failed to start",
+            )
+            .await;
+        }
+
+        self.reconcile_processes_after_reload(&apply, ctx).await;
+
+        self.catalog.update_startup_order().await;
+        Ok(ReloadResult {
+            added: apply.added,
+            removed,
+            modified: apply.modified.keys().cloned().collect(),
+            unchanged: apply.unchanged,
+        })
+    }
+
+    async fn remove_and_stop_dropped_config_processes(
+        &self,
+        new_configs: &[ProcessDefinition],
+    ) -> Vec<String> {
+        let new_names: HashSet<&str> = new_configs.iter().map(|c| c.name.as_str()).collect();
+        let (removed, mut procs_to_stop) = {
+            let mut procs = self.catalog.write_processes().await;
+            detach_removed_config_processes(&mut procs, &new_names)
+        };
+        for proc in &mut procs_to_stop {
+            proc.stop().await;
+        }
+        removed
+    }
+
+    async fn apply_reloaded_config_processes(
+        &self,
+        new_configs: Vec<ProcessDefinition>,
+    ) -> ReloadConfigApplyResult {
+        let mut procs = self.catalog.write_processes().await;
+        let mut added = Vec::new();
+        let mut added_start = Vec::new();
+        let mut modified = HashMap::new();
+        let mut unchanged = Vec::new();
+        for np in new_configs {
+            if let Some(existing) = procs.iter_mut().find(|p| p.name() == np.name) {
+                if existing.config() != &np.config {
+                    info!("[{}] config changed, updating", np.name);
+                    modified.insert(np.name.clone(), ModifiedReloadContext::capture(existing));
+                    existing.set_config(np.config);
+                } else {
+                    unchanged.push(np.name);
+                }
+            } else {
+                info!("[{}] new config found, adding", np.name);
+                let mut proc = ManagedProcess::new_config(
+                    np.name.clone(),
+                    self.catalog.generate_uuid(),
+                    np.config,
+                );
+                if proc.may_auto_start() {
+                    added_start.push(procs.len());
+                }
+                proc.record_config_gate_met();
+                added.push(np.name);
+                procs.push(proc);
+            }
+        }
+        ReloadConfigApplyResult {
+            added,
+            modified,
+            unchanged,
+            added_start,
+        }
+    }
+
+    async fn reconcile_processes_after_reload(
+        &self,
+        apply: &ReloadConfigApplyResult,
+        ctx: &RuntimeContext,
+    ) {
+        let mut to_start = Vec::new();
+        {
+            let mut procs = self.catalog.write_processes().await;
+            for (idx, proc) in procs.iter_mut().enumerate() {
+                if let Some(kind) =
+                    reconcile_process_after_reload(proc, apply.modified.get(proc.name())).await
+                {
+                    to_start.push((idx, kind));
+                }
+            }
+        }
+        for (idx, kind) in to_start {
+            spawn_reload_process(
+                Arc::clone(&self.catalog),
+                idx,
+                ctx,
+                kind,
+                "failed to start after config reload",
+            )
+            .await;
+        }
+    }
+}

--- a/pkg/procmgr/rust/src/manager/runtime.rs
+++ b/pkg/procmgr/rust/src/manager/runtime.rs
@@ -562,10 +562,10 @@ mod tests {
 
         let (cmd, args) = test_helpers::sleep_cmd(60);
         let catalog = Arc::new(ProcessCatalog::load(
-            &StaticConfigLoader::new(vec![ProcessDefinition {
+            Arc::new(StaticConfigLoader::new(vec![ProcessDefinition {
                 name: "svc".into(),
                 config: test_helpers::make_config(cmd, args),
-            }]),
+            }])),
             Arc::new(V4UuidGenerator),
         ));
 
@@ -623,10 +623,10 @@ mod tests {
 
         let (cmd, args) = test_helpers::sleep_cmd(60);
         let catalog = ProcessCatalog::load(
-            &StaticConfigLoader::new(vec![ProcessDefinition {
+            Arc::new(StaticConfigLoader::new(vec![ProcessDefinition {
                 name: "svc".into(),
                 config: test_helpers::make_config(cmd, args),
-            }]),
+            }])),
             Arc::new(V4UuidGenerator),
         );
 

--- a/pkg/procmgr/rust/src/manager/spawn.rs
+++ b/pkg/procmgr/rust/src/manager/spawn.rs
@@ -11,7 +11,7 @@ use crate::platform;
 use crate::process::{ManagedChildSpawn, ManagedProcess, SpawnReservationToken};
 use crate::state::ProcessState;
 use anyhow::Result;
-use log::{info, warn};
+use log::{debug, info, warn};
 use std::sync::Arc;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -71,6 +71,10 @@ pub(in crate::manager) fn log_skipped_pending_restart(
     };
     let name = proc.name();
     match reason {
+        PendingRestartSkip::StaleConfigGeneration => debug!(
+            "[{name}] ignoring stale restart for config generation {}",
+            pending.config_generation
+        ),
         PendingRestartSkip::StaleSpawnSeq => info!(
             "[{name}] ignoring stale queued restart (spawn_seq {} != {})",
             pending.spawn_seq,
@@ -86,6 +90,7 @@ pub(in crate::manager) fn log_skipped_pending_restart(
 }
 
 enum PendingRestartSkip {
+    StaleConfigGeneration,
     StaleSpawnSeq,
     AlreadyRunning,
     PolicyOrConditions,
@@ -105,7 +110,9 @@ fn pending_restart_skip_reason(
     proc: &ManagedProcess,
     pending: &PendingRestart,
 ) -> Option<PendingRestartSkip> {
-    if !pending_restart_matches(proc, pending) {
+    if proc.config_generation() != pending.config_generation {
+        Some(PendingRestartSkip::StaleConfigGeneration)
+    } else if !pending_restart_matches(proc, pending) {
         Some(PendingRestartSkip::StaleSpawnSeq)
     } else if matches!(proc.state(), ProcessState::Running | ProcessState::Stopping) {
         Some(PendingRestartSkip::AlreadyRunning)

--- a/pkg/procmgr/rust/src/manager/startup.rs
+++ b/pkg/procmgr/rust/src/manager/startup.rs
@@ -70,6 +70,13 @@ pub(in crate::manager) async fn run(
                 log_spawn_task_result(spawn_handle.await, &name);
             }
         }
+
+        {
+            let mut procs = manager.catalog.write_processes().await;
+            if let Some(proc) = procs.get_mut(idx) {
+                proc.record_config_gate_met();
+            }
+        }
     }
 
     info!("startup: auto-start complete");

--- a/pkg/procmgr/rust/src/manager/stop_wait.rs
+++ b/pkg/procmgr/rust/src/manager/stop_wait.rs
@@ -98,10 +98,10 @@ mod tests {
         let mut config = test_helpers::make_config(cmd, args);
         config.stop_timeout = Some(1);
         ProcessCatalog::load(
-            &StaticConfigLoader::new(vec![ProcessDefinition {
+            Arc::new(StaticConfigLoader::new(vec![ProcessDefinition {
                 name: "svc".into(),
                 config,
-            }]),
+            }])),
             Arc::new(V4UuidGenerator),
         )
     }

--- a/pkg/procmgr/rust/src/manager/tests/config_gate.rs
+++ b/pkg/procmgr/rust/src/manager/tests/config_gate.rs
@@ -10,7 +10,7 @@ use crate::config_gate::ConditionConfigFile;
 use crate::test_helpers;
 use std::io::Write;
 
-fn gated_sleep_def(name: &str, agent_yaml: &str) -> ProcessDefinition {
+pub(crate) fn gated_sleep_def(name: &str, agent_yaml: &str) -> ProcessDefinition {
     let (cmd, args) = test_helpers::sleep_cmd(60);
     ProcessDefinition {
         name: name.to_string(),
@@ -26,7 +26,7 @@ fn gated_sleep_def(name: &str, agent_yaml: &str) -> ProcessDefinition {
     }
 }
 
-fn write_agent_yaml(dir: &std::path::Path, process_collection_enabled: bool) -> String {
+pub(crate) fn write_agent_yaml(dir: &std::path::Path, process_collection_enabled: bool) -> String {
     let path = dir.join("datadog.yaml");
     let body = format!(
         "process_config:\n  process_collection:\n    enabled: {process_collection_enabled}\n  container_collection:\n    enabled: false\n  process_discovery:\n    enabled: false\n"

--- a/pkg/procmgr/rust/src/manager/tests/mod.rs
+++ b/pkg/procmgr/rust/src/manager/tests/mod.rs
@@ -59,6 +59,7 @@ pub fn current_pending_restart(proc: &ManagedProcess) -> PendingRestart {
     PendingRestart {
         uuid: proc.uuid().to_owned(),
         spawn_seq: proc.spawn_seq(),
+        config_generation: proc.config_generation(),
     }
 }
 
@@ -102,7 +103,7 @@ pub fn sleep_def(name: &str) -> ProcessDefinition {
     }
 }
 
-fn sleep_def_secs(name: &str, secs: u32) -> ProcessDefinition {
+pub fn sleep_def_secs(name: &str, secs: u32) -> ProcessDefinition {
     let (cmd, args) = test_helpers::sleep_cmd(secs);
     ProcessDefinition {
         name: name.to_string(),
@@ -134,6 +135,7 @@ mod boot;
 #[cfg(not(windows))]
 mod config_gate;
 mod create;
+mod reload;
 mod resolve;
 #[cfg(not(windows))]
 mod restart;

--- a/pkg/procmgr/rust/src/manager/tests/reload.rs
+++ b/pkg/procmgr/rust/src/manager/tests/reload.rs
@@ -1,0 +1,184 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+use super::super::*;
+#[cfg(not(windows))]
+use super::auto_start_for_test;
+#[cfg(not(windows))]
+use super::config_gate::{gated_sleep_def, write_agent_yaml};
+use super::{loader, sleep_def, sleep_def_secs, test_runtime_context, uuid_gen};
+use crate::config::{MutableConfigLoader, ProcessConfig, ProcessDefinition, RestartPolicy};
+use crate::test_helpers;
+use std::sync::Arc;
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn test_reload_starts_when_config_gate_opens() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let yaml = write_agent_yaml(dir.path(), false);
+
+    let config_loader = Arc::new(MutableConfigLoader::new(vec![gated_sleep_def(
+        "svc-gated",
+        &yaml,
+    )]));
+    let mgr = ProcessManager::new(config_loader.clone(), uuid_gen());
+    let (handles, _rx) = test_runtime_context();
+    auto_start_for_test(&mgr, &handles).await;
+    assert!(
+        !mgr.processes().await[0].is_running(),
+        "gated process should not auto-start when collection is disabled"
+    );
+
+    write_agent_yaml(dir.path(), true);
+    config_loader.set(vec![gated_sleep_def("svc-gated", &yaml)]);
+    mgr.handle_reload_config(&handles).await?;
+    assert!(
+        mgr.processes().await[0].is_running(),
+        "reload should start the process when the config gate opens"
+    );
+
+    test_helpers::cleanup_process(mgr.processes().await[0].pid().unwrap());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_reload_updates_modified_config() -> anyhow::Result<()> {
+    let config_loader = Arc::new(MutableConfigLoader::new(vec![sleep_def("svc-a")]));
+    let mgr = ProcessManager::new(config_loader.clone(), uuid_gen());
+    let (handles, _rx) = test_runtime_context();
+
+    mgr.handle_start("svc-a", &handles).await?;
+    let old_pid = {
+        let procs = mgr.processes().await;
+        assert!(procs[0].is_running());
+        procs[0].pid().unwrap()
+    };
+
+    config_loader.set(vec![sleep_def_secs("svc-a", 120)]);
+    let result = mgr.handle_reload_config(&handles).await?;
+    assert!(result.modified.contains(&"svc-a".to_string()));
+    assert!(result.added.is_empty());
+    assert!(result.removed.is_empty());
+    assert!(result.unchanged.is_empty());
+
+    let procs = mgr.processes().await;
+    let expected_args = sleep_def_secs("_", 120).config.args;
+    assert_eq!(procs[0].config().args, expected_args);
+    assert!(
+        procs[0].is_running(),
+        "modified running process should be restarted"
+    );
+    assert_ne!(
+        procs[0].pid().unwrap(),
+        old_pid,
+        "restarted process should have a different PID"
+    );
+
+    test_helpers::cleanup_process(procs[0].pid().unwrap());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_reload_unchanged_config_not_modified() -> anyhow::Result<()> {
+    let config_loader = Arc::new(MutableConfigLoader::new(vec![sleep_def("svc-a")]));
+    let mgr = ProcessManager::new(config_loader.clone(), uuid_gen());
+    let (handles, _rx) = test_runtime_context();
+
+    mgr.handle_start("svc-a", &handles).await?;
+    config_loader.set(vec![sleep_def("svc-a")]);
+    let result = mgr.handle_reload_config(&handles).await?;
+    assert!(result.unchanged.contains(&"svc-a".to_string()));
+    assert!(result.modified.is_empty());
+    assert!(mgr.processes().await[0].is_running());
+
+    test_helpers::cleanup_process(mgr.processes().await[0].pid().unwrap());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_reload_preserves_runtime_created_processes() -> anyhow::Result<()> {
+    let mgr = ProcessManager::new(loader(vec![]), uuid_gen());
+    let (cmd, args) = test_helpers::true_cmd();
+    let config = ProcessConfig {
+        command: cmd.to_string(),
+        args,
+        ..Default::default()
+    };
+    let (handles, _rx) = test_runtime_context();
+    mgr.handle_create("runtime-svc".to_string(), config, &handles)
+        .await?;
+
+    let result = mgr.handle_reload_config(&handles).await?;
+    assert!(
+        !result.removed.contains(&"runtime-svc".to_string()),
+        "runtime-created process should not be removed by reload"
+    );
+
+    let procs = mgr.processes().await;
+    assert_eq!(procs.len(), 1);
+    assert_eq!(procs[0].name(), "runtime-svc");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_reload_discards_stale_restart_after_config_change() -> anyhow::Result<()> {
+    let (cmd, _) = test_helpers::sleep_cmd(60);
+    let make_def = |secs: u32| ProcessDefinition {
+        name: "svc".to_string(),
+        config: ProcessConfig {
+            command: cmd.to_string(),
+            args: test_helpers::sleep_cmd(secs).1,
+            auto_start: true,
+            restart: RestartPolicy::Always,
+            restart_sec: Some(0.3),
+            runtime_success_sec: Some(0),
+            ..Default::default()
+        },
+    };
+    let config_loader = Arc::new(MutableConfigLoader::new(vec![make_def(60)]));
+    let mgr = ProcessManager::new(config_loader.clone(), uuid_gen());
+    let (handles, mut rx) = test_runtime_context();
+
+    mgr.handle_start("svc", &handles).await?;
+    let (pid, name) = {
+        let procs = mgr.processes().await;
+        assert!(procs[0].is_running());
+        (procs[0].pid().unwrap(), procs[0].name().to_owned())
+    };
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    test_helpers::cleanup_process(pid);
+    mgr.handle_exit(
+        ExitEvent {
+            name,
+            pid,
+            status: test_helpers::exit_status(1),
+        },
+        &handles,
+    )
+    .await;
+
+    let stale_pending =
+        tokio::time::timeout(std::time::Duration::from_secs(1), rx.restart_rx.recv())
+            .await
+            .expect("timed out waiting for queued restart")
+            .expect("expected queued restart event");
+
+    config_loader.set(vec![make_def(120)]);
+    mgr.handle_reload_config(&handles).await?;
+    assert_ne!(
+        mgr.processes().await[0].config_generation(),
+        stale_pending.config_generation
+    );
+    assert!(
+        mgr.processes().await[0].is_running(),
+        "reload should start the process with fresh counters"
+    );
+
+    mgr.complete_restart(stale_pending, &handles).await;
+    let pid = mgr.processes().await[0].pid().unwrap();
+    test_helpers::cleanup_process(pid);
+    Ok(())
+}

--- a/pkg/procmgr/rust/src/manager/tests/restart.rs
+++ b/pkg/procmgr/rust/src/manager/tests/restart.rs
@@ -132,6 +132,7 @@ async fn test_stale_restart_timer_invalidated_after_manual_start() -> anyhow::Re
     let stale_pending = PendingRestart {
         uuid: uuid.clone(),
         spawn_seq: 1,
+        config_generation: 0,
     };
 
     mgr.handle_start("action-executor", &handles).await?;

--- a/pkg/procmgr/rust/src/process.rs
+++ b/pkg/procmgr/rust/src/process.rs
@@ -419,6 +419,8 @@ pub struct ManagedProcess {
     spawn_reservation: Option<SpawnReservationToken>,
     origin: ProcessOrigin,
     last_exit_status: Option<std::process::ExitStatus>,
+    last_start_conditions_met: Option<bool>,
+    config_generation: u64,
     #[cfg(windows)]
     job_object: Option<platform::JobObject>,
     #[cfg(windows)]
@@ -459,6 +461,8 @@ impl ManagedProcess {
             spawn_reservation: None,
             origin,
             last_exit_status: None,
+            last_start_conditions_met: None,
+            config_generation: 0,
             #[cfg(windows)]
             job_object: None,
             #[cfg(windows)]
@@ -501,6 +505,24 @@ impl ManagedProcess {
 
     pub fn config(&self) -> &ProcessConfig {
         &self.config
+    }
+
+    pub fn set_config(&mut self, config: ProcessConfig) {
+        self.config_generation += 1;
+        self.restarts = RestartTracker::new(config.restart_delay());
+        self.config = config;
+    }
+
+    pub(crate) fn config_generation(&self) -> u64 {
+        self.config_generation
+    }
+
+    pub(crate) fn record_config_gate_met(&mut self) {
+        self.last_start_conditions_met = Some(self.start_conditions_met());
+    }
+
+    pub(crate) fn last_start_conditions_met(&self) -> Option<bool> {
+        self.last_start_conditions_met
     }
 
     #[cfg(windows)]

--- a/pkg/procmgr/rust/tests/e2e.rs
+++ b/pkg/procmgr/rust/tests/e2e.rs
@@ -6,7 +6,7 @@
 mod helpers;
 
 use dd_procmgrd::test_helpers;
-use helpers::{CliRunner, TestEnv, kill_pid_force, pid_is_alive, wait_for_pid_gone};
+use helpers::{CliRunner, TestEnv, kill_pid_force, pid_is_alive, wait_for_pid_gone, write_config};
 use std::path::Path;
 use std::time::Duration;
 
@@ -982,6 +982,252 @@ fn test_cli_create_env_vars() {
     let env_map = json["env"].as_object().expect("env should be an object");
     assert_eq!(env_map.get("FOO").and_then(|v| v.as_str()), Some("bar"));
     assert_eq!(env_map.get("BAZ").and_then(|v| v.as_str()), Some("qux"));
+}
+
+#[test]
+fn test_cli_reload_no_changes() {
+    let env = TestEnv::new()
+        .with_config("sleeper", test_helpers::sleep_config_yaml())
+        .start();
+
+    env.daemon().wait_for_log_default("[sleeper] spawned");
+
+    env.cli(&["reload"])
+        .assert_success()
+        .assert_field("Unchanged", "sleeper");
+}
+
+#[test]
+fn test_cli_reload_add_process() {
+    let env = TestEnv::new()
+        .with_config("existing", test_helpers::sleep_config_yaml())
+        .start();
+
+    env.daemon().wait_for_log_default("[existing] spawned");
+
+    write_config(
+        env.config_dir(),
+        "new-svc",
+        test_helpers::sleep_config_yaml(),
+    );
+
+    env.cli(&["reload"])
+        .assert_success()
+        .assert_field("Added", "new-svc");
+
+    env.daemon().wait_for_log_default("[new-svc] spawned");
+
+    let out = env.cli(&["list"]);
+    out.assert_success()
+        .assert_table_row("new-svc", &[("STATE", "Running")])
+        .assert_table_row("existing", &[("STATE", "Running")])
+        .assert_table_row_count(2);
+
+    let pid_new = out.pid_from_table_row("new-svc");
+    let pid_existing = out.pid_from_table_row("existing");
+    assert!(
+        pid_is_alive(pid_new),
+        "new-svc PID {pid_new} should be alive"
+    );
+    assert!(
+        pid_is_alive(pid_existing),
+        "existing PID {pid_existing} should be alive"
+    );
+}
+
+#[test]
+fn test_cli_reload_remove_process() {
+    let env = TestEnv::new()
+        .with_config("keeper", test_helpers::sleep_config_yaml())
+        .with_config("doomed", test_helpers::sleep_config_yaml())
+        .start();
+
+    env.daemon().wait_for_log_default("[keeper] spawned");
+    env.daemon().wait_for_log_default("[doomed] spawned");
+
+    let doomed_pid = env.cli(&["list"]).pid_from_table_row("doomed");
+
+    std::fs::remove_file(env.config_dir().join("doomed.yaml"))
+        .expect("failed to remove doomed.yaml");
+
+    env.cli(&["reload"])
+        .assert_success()
+        .assert_field("Removed", "doomed");
+
+    assert!(
+        wait_for_pid_gone(doomed_pid, Duration::from_secs(5)),
+        "removed process PID {doomed_pid} should be gone"
+    );
+
+    env.cli(&["list"])
+        .assert_success()
+        .assert_table_row_count(1)
+        .assert_table_row("keeper", &[("STATE", "Running")]);
+}
+
+#[test]
+fn test_cli_reload_modify_process() {
+    let env = TestEnv::new()
+        .with_config("svc", test_helpers::sleep_config_yaml())
+        .start();
+
+    env.daemon().wait_for_log_default("[svc] spawned");
+
+    let old_pid = env.cli(&["list"]).pid_from_table_row("svc");
+
+    let (cmd, args) = dd_procmgrd::test_helpers::sleep_cmd(600);
+    write_config(
+        env.config_dir(),
+        "svc",
+        &test_helpers::cmd_yaml(cmd, &args, ""),
+    );
+
+    env.cli(&["reload"])
+        .assert_success()
+        .assert_field("Modified", "svc");
+
+    assert!(
+        env.daemon()
+            .wait_for_log_count("[svc] spawned", 2, Duration::from_secs(10)),
+        "svc should have been respawned after modify"
+    );
+
+    assert!(
+        wait_for_pid_gone(old_pid, Duration::from_secs(5)),
+        "old PID {old_pid} should be gone after modify+reload"
+    );
+
+    let new_pid = env.cli(&["list"]).pid_from_table_row("svc");
+    assert!(pid_is_alive(new_pid), "new PID {new_pid} should be alive");
+    assert_ne!(old_pid, new_pid, "PID should change after modify+reload");
+}
+
+#[test]
+fn test_cli_reload_add_and_remove() {
+    let env = TestEnv::new()
+        .with_config("old", test_helpers::sleep_config_yaml())
+        .start();
+
+    env.daemon().wait_for_log_default("[old] spawned");
+
+    let old_pid = env.cli(&["list"]).pid_from_table_row("old");
+
+    std::fs::remove_file(env.config_dir().join("old.yaml")).expect("failed to remove old.yaml");
+    write_config(env.config_dir(), "new", test_helpers::sleep_config_yaml());
+
+    let out = env.cli(&["reload"]);
+    out.assert_success()
+        .assert_field("Added", "new")
+        .assert_field("Removed", "old");
+
+    assert!(
+        wait_for_pid_gone(old_pid, Duration::from_secs(5)),
+        "old PID {old_pid} should be gone after removal"
+    );
+
+    env.daemon().wait_for_log_default("[new] spawned");
+
+    let new_pid = env.cli(&["list"]).pid_from_table_row("new");
+    assert!(pid_is_alive(new_pid), "new PID {new_pid} should be alive");
+}
+
+#[test]
+fn test_cli_reload_json() {
+    let env = TestEnv::new()
+        .with_config("existing", test_helpers::sleep_config_yaml())
+        .start();
+
+    env.daemon().wait_for_log_default("[existing] spawned");
+
+    write_config(env.config_dir(), "added", test_helpers::sleep_config_yaml());
+
+    let out = env.cli(&["reload", "--json"]);
+    out.assert_success();
+    let json = out.stdout_json();
+
+    let added = json["added"].as_array().expect("added should be an array");
+    assert!(
+        added.iter().any(|v| v.as_str() == Some("added")),
+        "expected 'added' in added array: {json}"
+    );
+
+    let unchanged = json["unchanged"]
+        .as_array()
+        .expect("unchanged should be an array");
+    assert!(
+        unchanged.iter().any(|v| v.as_str() == Some("existing")),
+        "expected 'existing' in unchanged array: {json}"
+    );
+
+    assert!(json["removed"].as_array().expect("array").is_empty());
+    assert!(json["modified"].as_array().expect("array").is_empty());
+}
+
+#[test]
+fn test_cli_reload_new_process_starts() {
+    let env = TestEnv::new().start();
+
+    write_config(env.config_dir(), "late", test_helpers::sleep_config_yaml());
+
+    env.cli(&["reload"]).assert_success();
+    env.daemon().wait_for_log_default("[late] spawned");
+
+    let out = env.cli(&["list"]);
+    out.assert_success()
+        .assert_table_row("late", &[("STATE", "Running")]);
+
+    let pid = out.pid_from_table_row("late");
+    assert!(pid_is_alive(pid), "PID {pid} should be alive");
+}
+
+#[test]
+fn test_cli_reload_removed_process_stopped() {
+    let env = TestEnv::new()
+        .with_config("ephemeral", test_helpers::sleep_config_yaml())
+        .start();
+
+    env.daemon().wait_for_log_default("[ephemeral] spawned");
+
+    let pid = env.cli(&["list"]).pid_from_table_row("ephemeral");
+
+    std::fs::remove_file(env.config_dir().join("ephemeral.yaml"))
+        .expect("failed to remove ephemeral.yaml");
+
+    env.cli(&["reload"]).assert_success();
+
+    assert!(
+        wait_for_pid_gone(pid, Duration::from_secs(5)),
+        "removed process PID {pid} should be gone"
+    );
+
+    env.cli(&["list"])
+        .assert_success()
+        .assert_stdout_contains("No processes");
+}
+
+#[test]
+fn test_cli_reload_then_start() {
+    let env = TestEnv::new().start();
+
+    write_config(
+        env.config_dir(),
+        "late",
+        &test_helpers::sleep_config_with("auto_start: false\n"),
+    );
+
+    env.cli(&["reload"])
+        .assert_success()
+        .assert_field("Added", "late");
+
+    env.cli(&["list"])
+        .assert_success()
+        .assert_table_row("late", &[("STATE", "Created"), ("PID", "-")]);
+
+    env.cli(&["start", "late"]).assert_success();
+    env.daemon().wait_for_log_default("[late] spawned");
+
+    let pid = env.cli(&["list"]).pid_from_table_row("late");
+    assert!(pid_is_alive(pid), "PID {pid} should be alive");
 }
 
 #[test]

--- a/releasenotes/notes/procmgr-reload-config-236ec6fdc5264c14.yaml
+++ b/releasenotes/notes/procmgr-reload-config-236ec6fdc5264c14.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    ``dd-procmgr reload`` now re-reads ``processes.d`` at runtime. Added,
+    removed, and modified definitions are applied without restarting
+    ``dd-procmgr-service``. Config gates and secret-backend values are
+    re-evaluated on reload.

--- a/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_win_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_win_test.go
@@ -60,6 +60,9 @@ description: should not start
 
 	winUserProfileEnvMarkerDir = `C:/ProgramData/Datadog`
 
+	windowsADPDescOriginalLine = "description: Datadog Agent Data Plane"
+	windowsADPDescE2ELine      = "description: E2E-reload-after-yaml"
+
 	adpProcessName = "datadog-agent-data-plane"
 )
 
@@ -415,6 +418,46 @@ func (s *procmgrWindowsSuite) TestADPProcessDescribe() {
 		assertHasField(ct, out, "PID")
 		assertHasField(ct, out, "UUID")
 	}, 90*time.Second, 2*time.Second)
+}
+
+func (s *procmgrWindowsSuite) TestADPReloadAfterYamlChange() {
+	originalPID := s.waitWindowsADPRunning(90 * time.Second)
+
+	installPath, err := windowsagent.GetInstallPathFromRegistry(s.Env().RemoteHost)
+	require.NoError(s.T(), err)
+	yamlPath := joinWindowsPath(installPath, "processes.d", "datadog-agent-data-plane.yaml")
+
+	s.T().Cleanup(func() {
+		_, _ = s.Env().RemoteHost.Execute(psRemote(
+			`$ErrorActionPreference='Stop'; $p='%s'; $c=[IO.File]::ReadAllText($p); $c=$c.Replace('%s','%s'); $enc=New-Object System.Text.UTF8Encoding $false; [IO.File]::WriteAllText($p,$c,$enc)`,
+			yamlPath, windowsADPDescE2ELine, windowsADPDescOriginalLine,
+		))
+		_, _ = s.Env().RemoteHost.Execute(s.platform.cliCmd("reload"))
+	})
+
+	s.Env().RemoteHost.MustExecute(psRemote(
+		`$ErrorActionPreference='Stop'; $p='%s'; $c=[IO.File]::ReadAllText($p); $c=$c.Replace('%s','%s'); $enc=New-Object System.Text.UTF8Encoding $false; [IO.File]::WriteAllText($p,$c,$enc)`,
+		yamlPath, windowsADPDescOriginalLine, windowsADPDescE2ELine,
+	))
+
+	reloadOut := s.Env().RemoteHost.MustExecute(s.platform.cliCmd("reload"))
+	assert.Contains(s.T(), reloadOut, adpProcessName, "reload output: %s", reloadOut)
+	assert.Contains(s.T(), reloadOut, "Modified", "reload output: %s", reloadOut)
+
+	require.EventuallyWithT(s.T(), func(ct *assert.CollectT) {
+		out := s.Env().RemoteHost.MustExecuteOn(ct, s.platform.cliCmd("describe "+adpProcessName))
+		assertField(ct, out, "State", "Running")
+		p := fieldValue(out, "PID")
+		if !assert.NotEmpty(ct, p) || !assert.NotEqual(ct, "-", p) {
+			return
+		}
+		assert.NotEqual(ct, originalPID, p, "ADP should respawn with a new PID after reload")
+	}, 90*time.Second, 2*time.Second)
+
+	assertField(s.T(),
+		s.Env().RemoteHost.MustExecute(s.platform.cliCmd("describe "+adpProcessName)),
+		"Description", "E2E-reload-after-yaml",
+	)
 }
 
 func windowsProcessOwnerByPID(host *e2ecomponents.RemoteHost, pid string) (string, error) {


### PR DESCRIPTION
### What does this PR do?

Implements **`ReloadConfig` / `dd-procmgr reload`**: re-read `processes.d`, apply add/remove/restart, re-evaluate gates, clear secret caches, discard stale restarts.

### Motivation

Fleet and operators should update `processes.d` without restarting `dd-procmgr-service`.

### Describe how you validated your changes

- Rust reload unit tests and CLI e2e
- Windows/Linux ADP and DDOT reload E2E

