### PR TITLE
Extend bazel go coverage jobs to linux-arm64

### DIFF
--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -35,8 +35,8 @@
 .bazel:test:reporting:ci_links:
   - dda inv -- -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH
 
-bazel:coverage:linux-amd64:
-  extends: [.bazel:test:reporting, .bazel:runner:linux-amd64, .bazel:test]
+.bazel:coverage:linux:
+  extends: [.bazel:test:reporting, .bazel:test]
   script:
     - !reference [.bazel:test:reporting:ci_links]
     - bazel coverage --config=go --config=gorace --config=dd-agent-go-tests-only --jobs=$KUBERNETES_CPU_REQUEST --build_tests_only --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE //... -- -//test/new-e2e/...
@@ -53,17 +53,23 @@ bazel:coverage:linux-amd64:
   variables:
     KUBERNETES_CPU_REQUEST: 16
 
-bazel:test:linux-amd64:
-  extends: [.bazel:test:reporting, .bazel:runner:linux-amd64, .bazel:test]
+bazel:coverage:linux-amd64:
+  extends: [.bazel:runner:linux-amd64, .bazel:coverage:linux]
+
+bazel:coverage:linux-arm64:
+  extends: [.bazel:runner:linux-arm64, .bazel:coverage:linux]
+
+.bazel:test:linux:
+  extends: [.bazel:test:reporting, .bazel:test]
   script:
     - !reference [.bazel:test:reporting:ci_links]
     - bazel test --config=gorace --jobs=$KUBERNETES_CPU_REQUEST --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE //... -- -//test/new-e2e/...
 
+bazel:test:linux-amd64:
+  extends: [.bazel:runner:linux-amd64, .bazel:test:linux]
+
 bazel:test:linux-arm64:
-  extends: [.bazel:test:reporting, .bazel:runner:linux-arm64, .bazel:test]
-  script:
-    - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --config=gorace --jobs=$KUBERNETES_CPU_REQUEST --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE //... -- -//test/new-e2e/...
+  extends: [.bazel:runner:linux-arm64, .bazel:test:linux]
 
 bazel:test:macos-amd64:
   extends: [.bazel:test:reporting, .bazel:runner:macos-amd64, .bazel:test]


### PR DESCRIPTION
### What does this PR do?

It adds bazel coverage job for linux-arm64 and refactors remaining bazel linux test jobs to reuse common template.

### Motivation

Moving towards replacing go test jobs with bazel-run ones.

### Describe how you validated your changes

Passing CI with new job added.

### Additional Notes
