### PR TITLE
[EBPF] Fix tests_gpu CI OOM during agent.build

### DIFF
--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -220,5 +220,3 @@ tests_gpu:
     FLAVORS: ''
     EXTRA_OPTS: '--targets=./pkg/gpu/integrationtests,./pkg/collector/corechecks/gpu/integrationtests'
     KUBERNETES_CPU_REQUEST: 4
-    KUBERNETES_MEMORY_REQUEST: 8Gi
-    KUBERNETES_MEMORY_LIMIT: 8Gi


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Fixes OOM kills in the `tests_gpu` CI job during `agent.build`.

### Motivation

`tests_gpu` capped memory at 8Gi while inheriting the `.linux_tests` script, which runs `agent.build` before GPU integration tests. Other source test jobs that build the agent use 32Gi.

### Describe how you validated your changes

CI config change only.

### Additional Notes