### PR TITLE
Remote Queries proof-only PAR harness and live tests

### DIFF
--- a/comp/remotequeries/impl/BUILD.bazel
+++ b/comp/remotequeries/impl/BUILD.bazel
@@ -6,12 +6,15 @@ go_library(
     srcs = [
         "remote_query_execute.go",
         "remote_query_match.go",
+        "remote_query_par_poc.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/comp/remotequeries/impl",
     visibility = ["//visibility:public"],
     deps = [
         "//comp/api/api/def",
         "//comp/core/config",
+        "//comp/core/ipc/def",
+        "//comp/core/ipc/httphelpers",
         "//pkg/collector/check",
         "@in_gopkg_yaml_v3//:yaml_v3",
         "@org_uber_go_fx//:fx",
@@ -21,6 +24,7 @@ go_library(
 dd_agent_go_test(
     name = "impl_test",
     srcs = [
+        "remote_query_par_poc_test.go",
         "remote_query_test.go",
     ],
     embed = [":impl"],
@@ -28,6 +32,8 @@ dd_agent_go_test(
         "//comp/core/autodiscovery/integration",
         "//comp/core/config",
         "//comp/core/diagnose/def",
+        "//comp/core/ipc/def",
+        "//comp/core/ipc/mock",
         "//pkg/aggregator/sender",
         "//pkg/collector/check",
         "//pkg/collector/check/id",

--- a/comp/remotequeries/impl/remote_query_par_poc.go
+++ b/comp/remotequeries/impl/remote_query_par_poc.go
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package remotequeriesimpl
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	ipchttp "github.com/DataDog/datadog-agent/comp/core/ipc/httphelpers"
+)
+
+const (
+	// AgentRemoteQueryExecuteEndpointPath is the POC-only caller path for the core-Agent command API mount.
+	// This deliberately documents the current dev proof shape and is not a production IPC API commitment.
+	AgentRemoteQueryExecuteEndpointPath = "/agent" + RemoteQueryExecuteEndpointPath
+)
+
+// remoteQueryPARIPCClient is the narrow Agent IPC client surface this POC caller needs.
+type remoteQueryPARIPCClient interface {
+	Post(url string, contentType string, body io.Reader, opts ...ipc.RequestOption) (resp []byte, err error)
+}
+
+// RemoteQueryPARHarness is a dev-only, PAR-shaped proof caller for the remote query execute bridge.
+// It accepts credential-free action-like inputs, sends them through the injected Agent IPC HTTP client,
+// and decodes the execute bridge response without depending on PAR's production runner/bundle registry.
+type RemoteQueryPARHarness struct {
+	client      remoteQueryPARIPCClient
+	endpointURL string
+}
+
+// RemoteQueryPARInputs is the credential-free task input shape for the PAR-shaped POC harness.
+type RemoteQueryPARInputs struct {
+	Integration string                            `json:"integration"`
+	Operation   string                            `json:"operation"`
+	Format      string                            `json:"format"`
+	Target      remoteQueryTargetJSON             `json:"target"`
+	Query       string                            `json:"query"`
+	CopyLimits  *remoteQueryExecuteCopyLimitsJSON `json:"copyLimits,omitempty"`
+}
+
+// RemoteQueryPARResult is the decoded execute bridge result or sanitized bridge error.
+type RemoteQueryPARResult struct {
+	HTTPStatus int              `json:"-"`
+	Status     string           `json:"status"`
+	Rows       []map[string]any `json:"rows,omitempty"`
+	Error      *responseError   `json:"error,omitempty"`
+	Raw        json.RawMessage  `json:"-"`
+}
+
+// NewRemoteQueryPARHarness creates a dev-only PAR-shaped IPC execute proof caller.
+func NewRemoteQueryPARHarness(client remoteQueryPARIPCClient, endpointURL string) *RemoteQueryPARHarness {
+	return &RemoteQueryPARHarness{client: client, endpointURL: endpointURL}
+}
+
+// Execute sends a credential-free target/query request through the injected Agent IPC HTTP client.
+func (h *RemoteQueryPARHarness) Execute(ctx context.Context, inputs RemoteQueryPARInputs) (RemoteQueryPARResult, error) {
+	if h == nil || h.client == nil {
+		return RemoteQueryPARResult{}, errors.New("remote query PAR harness requires an IPC client")
+	}
+	if h.endpointURL == "" {
+		return RemoteQueryPARResult{}, errors.New("remote query PAR harness requires an endpoint URL")
+	}
+
+	payload, err := json.Marshal(inputs)
+	if err != nil {
+		return RemoteQueryPARResult{}, fmt.Errorf("marshal remote query PAR inputs: %w", err)
+	}
+
+	body, postErr := h.client.Post(h.endpointURL, "application/json", bytes.NewReader(payload), ipchttp.WithContext(ctx))
+	result, decodeErr := decodeRemoteQueryPARResponse(body)
+	if decodeErr == nil {
+		// IPC HTTPClient returns both the response body and an error for HTTP >= 400.
+		// The execute bridge body is the sanitized contract, so propagate that decoded body.
+		return result, nil
+	}
+	if postErr != nil {
+		if len(body) > 0 {
+			return RemoteQueryPARResult{}, errors.New("remote query IPC request failed with undecodable response")
+		}
+		return RemoteQueryPARResult{}, fmt.Errorf("remote query IPC request failed: %w", postErr)
+	}
+	return RemoteQueryPARResult{}, decodeErr
+}
+
+func decodeRemoteQueryPARResponse(body []byte) (RemoteQueryPARResult, error) {
+	if len(body) == 0 {
+		return RemoteQueryPARResult{}, errors.New("empty remote query response")
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+
+	var result RemoteQueryPARResult
+	if err := decoder.Decode(&result); err != nil {
+		return RemoteQueryPARResult{}, fmt.Errorf("decode remote query response: %w", err)
+	}
+	if result.Status == "" {
+		return RemoteQueryPARResult{}, errors.New("remote query response missing status")
+	}
+	result.Raw = append(result.Raw[:0], body...)
+	return result, nil
+}

--- a/comp/remotequeries/impl/remote_query_par_poc_test.go
+++ b/comp/remotequeries/impl/remote_query_par_poc_test.go
@@ -1,0 +1,144 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package remotequeriesimpl
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+)
+
+func TestRemoteQueryPARHarnessUsesCredentialFreeIPCPostShape(t *testing.T) {
+	client := &capturePostClient{response: []byte(`{"status":"SUCCEEDED","rows":[{"value":1}]}`)}
+	harness := NewRemoteQueryPARHarness(client, "https://localhost:5001"+AgentRemoteQueryExecuteEndpointPath)
+
+	result, err := harness.Execute(context.Background(), RemoteQueryPARInputs{
+		Integration: "postgres",
+		Operation:   "copy_stream",
+		Format:      "csv",
+		Target:      remoteQueryTargetJSON{Host: "localhost", Port: 5432, DBName: "postgres"},
+		Query:       remoteQueryProofSeedQuery,
+		CopyLimits:  &remoteQueryExecuteCopyLimitsJSON{ChunkBytes: 1024, MaxBytes: 1024, MaxRowBytes: 1024, TimeoutMs: 1000},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://localhost:5001"+AgentRemoteQueryExecuteEndpointPath, client.url)
+	assert.Equal(t, "application/json", client.contentType)
+	assert.JSONEq(t, `{"integration":"postgres","operation":"copy_stream","format":"csv","target":{"host":"localhost","port":5432,"dbname":"postgres"},"query":"SELECT 1 AS value","copyLimits":{"chunkBytes":1024,"maxBytes":1024,"maxRowBytes":1024,"timeoutMs":1000}}`, client.body)
+	assert.NotContains(t, client.body, "password")
+	assert.NotContains(t, client.body, "secret")
+	assert.Equal(t, "SUCCEEDED", result.Status)
+	assert.JSONEq(t, `{"status":"SUCCEEDED","rows":[{"value":1}]}`, string(result.Raw))
+}
+
+func TestRemoteQueryPARHarnessWithRealAgentIPCClientRejectsHTTPExecution(t *testing.T) {
+	handler := &remoteQueryExecuteHandler{enabled: true, collector: fakeCollector{checks: []check.Check{fakeWrappedCheck{Check: &fakeRunnerCheck{fakeCheck: fakeCheck{name: "postgres", loader: "python", provider: "file", instance: "host: localhost\nport: 5432\ndbname: postgres\npassword: datastore-secret\n"}}}}}}
+	ipc := ipcmock.New(t)
+	mux := http.NewServeMux()
+	mux.HandleFunc(AgentRemoteQueryExecuteEndpointPath, handler.handle)
+	server := ipc.NewMockServer(ipc.HTTPMiddleware(mux))
+	harness := NewRemoteQueryPARHarness(ipc.GetClient(), server.URL+AgentRemoteQueryExecuteEndpointPath)
+
+	result, err := harness.Execute(context.Background(), RemoteQueryPARInputs{
+		Integration: "postgres",
+		Operation:   "copy_stream",
+		Format:      "csv",
+		Target:      remoteQueryTargetJSON{Host: "LOCALHOST.", Port: 5432, DBName: "postgres"},
+		Query:       remoteQueryProofSeedQuery,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, statusInvalidRequest, result.Status)
+	require.NotNil(t, result.Error)
+	assert.Contains(t, result.Error.Message, "streaming executor")
+	assert.NotContains(t, string(result.Raw), "datastore-secret")
+}
+
+func TestRemoteQueryPARHarnessPropagatesSanitizedBridgeErrors(t *testing.T) {
+	handler := &remoteQueryExecuteHandler{enabled: true, collector: fakeCollector{checks: []check.Check{
+		&fakeRunnerCheck{fakeCheck: fakeCheck{name: "postgres", loader: "python", provider: "file", instance: "host: localhost\nport: 5432\ndbname: postgres\npassword: datastore-secret\n"}},
+	}}}
+	ipc := ipcmock.New(t)
+	mux := http.NewServeMux()
+	mux.HandleFunc(AgentRemoteQueryExecuteEndpointPath, handler.handle)
+	server := ipc.NewMockServer(ipc.HTTPMiddleware(mux))
+	harness := NewRemoteQueryPARHarness(ipc.GetClient(), server.URL+AgentRemoteQueryExecuteEndpointPath)
+
+	tests := []struct {
+		name       string
+		inputs     RemoteQueryPARInputs
+		wantStatus string
+		wantCode   string
+	}{
+		{
+			name: "target not found",
+			inputs: RemoteQueryPARInputs{
+				Integration: "postgres",
+				Operation:   "copy_stream",
+				Format:      "csv",
+				Target:      remoteQueryTargetJSON{Host: "localhost", Port: 5432, DBName: "other"},
+				Query:       remoteQueryProofSeedQuery,
+			},
+			wantStatus: statusInvalidRequest,
+			wantCode:   statusInvalidRequest,
+		},
+		{
+			name: "invalid query",
+			inputs: RemoteQueryPARInputs{
+				Integration: "postgres",
+				Operation:   "copy_stream",
+				Format:      "csv",
+				Target:      remoteQueryTargetJSON{Host: "localhost", Port: 5432, DBName: "postgres"},
+				Query:       "SELECT 2 AS value",
+			},
+			wantStatus: statusInvalidRequest,
+			wantCode:   statusInvalidRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := harness.Execute(context.Background(), tt.inputs)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantStatus, result.Status)
+			require.NotNil(t, result.Error)
+			assert.Equal(t, tt.wantCode, result.Error.Code)
+			assert.NotContains(t, string(result.Raw), "datastore-secret")
+			assert.NotContains(t, string(result.Raw), tt.inputs.Target.DBName)
+			assert.NotContains(t, string(result.Raw), tt.inputs.Query)
+		})
+	}
+}
+
+type capturePostClient struct {
+	response    []byte
+	err         error
+	url         string
+	contentType string
+	body        string
+}
+
+func (c *capturePostClient) Post(url string, contentType string, body io.Reader, _ ...ipc.RequestOption) ([]byte, error) {
+	c.url = url
+	c.contentType = contentType
+	payload, err := io.ReadAll(body)
+	if err != nil {
+		return nil, err
+	}
+	c.body = string(payload)
+	return c.response, c.err
+}
+
+var _ remoteQueryPARIPCClient = (*capturePostClient)(nil)

--- a/pkg/privateactionrunner/bundles/remoteaction/queries/live_agent_ipc_par_loop_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/queries/live_agent_ipc_par_loop_test.go
@@ -1,0 +1,300 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build remoteaction_queries_live && !windows
+
+package com_datadoghq_remoteaction_queries_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	parapp "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/constants"
+	com_datadoghq_remoteaction_queries "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/remoteaction/queries"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/opms"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/runners"
+	taskverifier "github.com/DataDog/datadog-agent/pkg/privateactionrunner/task-verifier"
+	fakeintakeclient "github.com/DataDog/datadog-agent/test/fakeintake/client"
+	fakeintakeserver "github.com/DataDog/datadog-agent/test/fakeintake/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	fusedLocalProofEnv                   = "RQ_FUSED_PROOF"
+	remoteQueriesSeedProofQuery          = "SELECT 1 AS value"
+	remoteQueriesFixtureTableProofQuery  = "SELECT city, country FROM cities ORDER BY city"
+	remoteQueriesBinaryPayloadProofQuery = "SELECT decode('00ff80', 'hex') AS payload"
+	remoteQueriesProofQueryOverrideEnv   = "RQ_REMOTE_QUERY"
+)
+
+var remoteQueriesLargePayloadProofQueries = map[string]int{
+	"SELECT repeat('x', 1048576) AS payload":  1 << 20,  // 1 MiB.
+	"SELECT repeat('x', 2097152) AS payload":  2 << 20,  // 2 MiB.
+	"SELECT repeat('x', 4194304) AS payload":  4 << 20,  // 4 MiB.
+	"SELECT repeat('x', 8388608) AS payload":  8 << 20,  // 8 MiB.
+	"SELECT repeat('x', 16777216) AS payload": 16 << 20, // 16 MiB.
+	"SELECT repeat('x', 33554432) AS payload": 32 << 20, // 32 MiB.
+}
+
+func TestRemoteQueriesActionRunsThroughLivePARLoopWithRealAgentIPC(t *testing.T) {
+	if os.Getenv(fusedLocalProofEnv) != "1" {
+		t.Skipf("set %s=1 and start a local Agent with a loaded Postgres check to run the fused local proof", fusedLocalProofEnv)
+	}
+
+	cmdPort := getenvRequired(t, "RQ_FUSED_AGENT_CMD_PORT")
+	authTokenFile := getenvRequired(t, "RQ_FUSED_AGENT_AUTH_TOKEN_FILE")
+	ipcCertFile := getenvRequired(t, "RQ_FUSED_AGENT_IPC_CERT_FILE")
+	cmdPortInt, err := strconv.Atoi(cmdPort)
+	require.NoError(t, err)
+
+	// NewDefaultBridgeClient reads the process-wide Datadog config. Point it at the
+	// separate local Agent process started by the fused proof harness so the PAR
+	// action uses the real Agent IPC HTTP endpoint, not an httptest bridge.
+	cfg := pkgconfigsetup.Datadog()
+	cfg.SetWithoutSource("cmd_host", "127.0.0.1")
+	cfg.SetWithoutSource("cmd_port", cmdPortInt)
+	cfg.SetWithoutSource("auth_token_file_path", authTokenFile)
+	cfg.SetWithoutSource("ipc_cert_file_path", ipcCertFile)
+
+	t.Setenv(parapp.InternalSkipTaskVerificationEnvVar, "true")
+
+	fakeintake, _ := fakeintakeserver.InitialiseForTests(t)
+	defer func() { require.NoError(t, fakeintake.Stop()) }()
+	fakeintakeClient := fakeintakeclient.NewClient(fakeintake.URL())
+	require.NoError(t, fakeintakeClient.FlushPAR())
+
+	cfgPAR := newLivePARTestConfig(t, fakeintake.URL())
+	keysManager := taskverifier.NewKeyManager(nil)
+	verifier := taskverifier.NewTaskVerifier(keysManager, cfgPAR)
+	workflowRunner, err := runners.NewWorkflowRunner(cfgPAR, keysManager, verifier, opms.NewClient(cfgPAR), nil, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, workflowRunner.Start(ctx))
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer stopCancel()
+		require.NoError(t, workflowRunner.Stop(stopCtx))
+	}()
+
+	taskID := fmt.Sprintf("remoteaction-queries-fused-local-proof-%d", time.Now().UnixNano())
+	proofQuery := remoteQueriesProofQueryFromEnv()
+	inputs := map[string]interface{}{
+		"integration": "postgres",
+		"operation":   "copy_stream",
+		"format":      "csv",
+		"target":      remoteQueriesPostgresTargetFromEnv(t),
+		"query":       proofQuery,
+		"copyLimits":  remoteQueriesProofCopyLimits(proofQuery),
+	}
+	requestEvidence, err := json.Marshal(inputs)
+	require.NoError(t, err)
+	require.NotContains(t, string(requestEvidence), "password")
+	require.NotContains(t, string(requestEvidence), "token")
+	require.NotContains(t, string(requestEvidence), "secret")
+
+	fqn := com_datadoghq_remoteaction_queries.BundleID + "." + com_datadoghq_remoteaction_queries.ExecuteActionName
+	t.Logf("fakeintake task enqueued: task_id=%s action_fqn=%s inputs=%s", taskID, fqn, requestEvidence)
+	t.Logf("real AgentSecure IPC configured: 127.0.0.1:%d RemoteQueryExecuteStream", cmdPortInt)
+	require.NoError(t, fakeintakeClient.EnqueuePARTask(taskID, fqn, inputs))
+
+	result, err := fakeintakeClient.GetPARTaskResult(taskID, remoteQueriesProofResultTimeout(proofQuery))
+	require.NoError(t, err)
+	if !result.Success {
+		t.Logf("failed PAR task result: %+v", summarizeRemoteQueriesProofPayload(map[string]interface{}{
+			"task_id":       result.TaskID,
+			"success":       result.Success,
+			"outputs":       result.Outputs,
+			"error_code":    result.ErrorCode,
+			"error_details": result.ErrorDetails,
+		}))
+	}
+	require.True(t, result.Success)
+	require.Equal(t, taskID, result.TaskID)
+	assert.Equal(t, "SUCCEEDED", result.Outputs["status"])
+	require.Contains(t, result.Outputs, "data")
+
+	data, ok := result.Outputs["data"].(string)
+	require.True(t, ok)
+	assertRemoteQueriesProofCopyData(t, proofQuery, data)
+
+	resultEvidence, err := json.Marshal(summarizeRemoteQueriesProofPayload(result.Outputs))
+	require.NoError(t, err)
+	require.NotContains(t, string(resultEvidence), "password")
+	require.NotContains(t, string(resultEvidence), "token")
+	require.NotContains(t, string(resultEvidence), "secret")
+	t.Logf("fakeintake captured successful PAR task result: %s", resultEvidence)
+
+	dequeueCalls, err := fakeintakeClient.GetPARDequeueCount()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, dequeueCalls, 1)
+	t.Logf("live PAR loop dequeued from fakeintake: dequeue_calls=%d", dequeueCalls)
+	writeFusedEvidence(t, getenvOptional("RQ_FUSED_EVIDENCE_FILE"), []string{
+		fmt.Sprintf("fakeintake task enqueued: task_id=%s action_fqn=%s inputs=%s", taskID, fqn, requestEvidence),
+		"live PAR loop dequeued the fakeintake OPMS task and invoked the registered action",
+		fmt.Sprintf("real AgentSecure IPC called via NewDefaultBridgeClient: 127.0.0.1:%d RemoteQueryExecuteStream", cmdPortInt),
+		fmt.Sprintf("fakeintake captured successful PAR task result: %s", resultEvidence),
+		fmt.Sprintf("dequeue_calls=%d", dequeueCalls),
+		"task verification skipped locally with DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION=true",
+	})
+}
+
+func getenvOptional(name string) string {
+	return os.Getenv(name)
+}
+
+func remoteQueriesProofQueryFromEnv() string {
+	if query := os.Getenv(remoteQueriesProofQueryOverrideEnv); query != "" {
+		return query
+	}
+	return remoteQueriesFixtureTableProofQuery
+}
+
+func remoteQueriesProofCopyLimits(query string) map[string]interface{} {
+	maxBytes := 4 << 10 // 4 KiB.
+	timeoutMs := 5_000
+	if payloadBytes, ok := remoteQueriesLargePayloadBytes(query); ok {
+		maxBytes = payloadBytes + (1 << 20) // Add 1 MiB headroom.
+		timeoutMs = 60_000
+	}
+	chunkBytes := 256 << 10 // 256 KiB.
+	if value := os.Getenv("RQ_REMOTE_CHUNK_BYTES"); value != "" {
+		parsed, err := strconv.Atoi(value)
+		if err == nil && parsed > 0 {
+			chunkBytes = parsed
+		}
+	}
+	return map[string]interface{}{
+		"chunkBytes":  chunkBytes,
+		"maxBytes":    maxBytes,
+		"maxRowBytes": maxBytes,
+		"timeoutMs":   timeoutMs,
+	}
+}
+
+func remoteQueriesProofResultTimeout(query string) time.Duration {
+	if _, ok := remoteQueriesLargePayloadBytes(query); ok {
+		return 2 * time.Minute
+	}
+	return 30 * time.Second
+}
+
+func remoteQueriesLargePayloadBytes(query string) (int, bool) {
+	payloadBytes, ok := remoteQueriesLargePayloadProofQueries[query]
+	return payloadBytes, ok
+}
+
+func assertRemoteQueriesProofBinaryCopyData(t *testing.T, query string, dataBase64 string) {
+	t.Helper()
+
+	data, err := base64.StdEncoding.DecodeString(dataBase64)
+	require.NoError(t, err)
+	switch query {
+	case remoteQueriesBinaryPayloadProofQuery:
+		assert.True(t, bytes.HasPrefix(data, []byte("PGCOPY\n\xff\r\n\x00")), "binary COPY payload should keep the PostgreSQL binary header")
+		assert.Contains(t, data, byte(0x00))
+		assert.True(t, bytes.Contains(data, []byte{0x00, 0xff, 0x80}), "binary COPY payload should contain the row bytes from decode('00ff80','hex')")
+	default:
+		require.FailNowf(t, "unsupported binary COPY proof query", "%s=%q must use a binary COPY bridge-allowlisted proof query", remoteQueriesProofQueryOverrideEnv, query)
+	}
+}
+
+func assertRemoteQueriesProofCopyData(t *testing.T, query string, data string) {
+	t.Helper()
+
+	switch query {
+	case remoteQueriesFixtureTableProofQuery:
+		assert.Equal(t, "Beautiful city of lights,France\nNew York,USA\n", data)
+	case remoteQueriesSeedProofQuery:
+		assert.Equal(t, "1\n", data)
+	default:
+		expectedPayloadBytes, ok := remoteQueriesLargePayloadBytes(query)
+		if ok {
+			assert.Len(t, data, expectedPayloadBytes+1)
+			assert.Equal(t, "\n", data[len(data)-1:])
+			return
+		}
+		require.FailNowf(t, "unsupported COPY proof query", "%s=%q must use a COPY bridge-allowlisted proof query", remoteQueriesProofQueryOverrideEnv, query)
+	}
+}
+
+func summarizeRemoteQueriesProofPayload(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		copy := make(map[string]interface{}, len(typed))
+		for key, nested := range typed {
+			copy[key] = summarizeRemoteQueriesProofPayload(nested)
+		}
+		return copy
+	case []interface{}:
+		copy := make([]interface{}, 0, len(typed))
+		for _, nested := range typed {
+			copy = append(copy, summarizeRemoteQueriesProofPayload(nested))
+		}
+		return copy
+	case string:
+		if len(typed) > 4096 {
+			return fmt.Sprintf("<%d bytes>", len(typed))
+		}
+	}
+	return value
+}
+
+func remoteQueriesPostgresTargetFromEnv(t *testing.T) map[string]interface{} {
+	t.Helper()
+
+	port := 5432
+	if value := os.Getenv("RQ_POSTGRES_PORT"); value != "" {
+		parsed, err := strconv.Atoi(value)
+		require.NoError(t, err)
+		port = parsed
+	}
+
+	host := os.Getenv("RQ_POSTGRES_HOST")
+	if host == "" {
+		host = "localhost"
+	}
+	dbname := os.Getenv("RQ_POSTGRES_DBNAME")
+	if dbname == "" {
+		dbname = "datadog_test"
+	}
+
+	return map[string]interface{}{
+		"host":   host,
+		"port":   port,
+		"dbname": dbname,
+	}
+}
+
+func writeFusedEvidence(t *testing.T, path string, lines []string) {
+	t.Helper()
+	if path == "" {
+		return
+	}
+	var payload strings.Builder
+	for _, line := range lines {
+		payload.WriteString(line)
+		payload.WriteByte('\n')
+	}
+	require.NoError(t, os.WriteFile(path, []byte(payload.String()), 0o600))
+}
+
+func getenvRequired(t *testing.T, name string) string {
+	t.Helper()
+	value := os.Getenv(name)
+	require.NotEmptyf(t, value, "%s is required", name)
+	return value
+}

--- a/pkg/privateactionrunner/bundles/remoteaction/queries/live_par_loop_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/queries/live_par_loop_test.go
@@ -1,0 +1,185 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build remoteaction_queries_live && !windows
+
+package com_datadoghq_remoteaction_queries_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"io"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/structpb"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	parconfig "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
+	app "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/constants"
+	com_datadoghq_remoteaction_queries "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/remoteaction/queries"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/observability"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/opms"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/runners"
+	taskverifier "github.com/DataDog/datadog-agent/pkg/privateactionrunner/task-verifier"
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	fakeintakeclient "github.com/DataDog/datadog-agent/test/fakeintake/client"
+	fakeintakeserver "github.com/DataDog/datadog-agent/test/fakeintake/server"
+	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteQueriesActionRunsThroughLivePARLoopAndFakeintake(t *testing.T) {
+	t.Setenv(app.InternalSkipTaskVerificationEnvVar, "true")
+
+	row, err := structpb.NewStruct(map[string]interface{}{"value": 1})
+	require.NoError(t, err)
+	bridgeRequests := make(chan *pb.RemoteQueryExecuteRequest, 1)
+	restoreFactory := com_datadoghq_remoteaction_queries.SetBridgeClientFactoryForTest(func() (com_datadoghq_remoteaction_queries.BridgeClient, error) {
+		return &captureAgentSecureClient{
+			requests: bridgeRequests,
+			response: &pb.RemoteQueryExecuteResponse{Status: "SUCCEEDED", Rows: []*structpb.Struct{row}},
+		}, nil
+	})
+	defer restoreFactory()
+
+	fakeintake, _ := fakeintakeserver.InitialiseForTests(t)
+	defer func() { require.NoError(t, fakeintake.Stop()) }()
+	fakeintakeClient := fakeintakeclient.NewClient(fakeintake.URL())
+	require.NoError(t, fakeintakeClient.FlushPAR())
+
+	cfg := newLivePARTestConfig(t, fakeintake.URL())
+	keysManager := taskverifier.NewKeyManager(nil)
+	verifier := taskverifier.NewTaskVerifier(keysManager, cfg)
+	workflowRunner, err := runners.NewWorkflowRunner(cfg, keysManager, verifier, opms.NewClient(cfg), nil, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, workflowRunner.Start(ctx))
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer stopCancel()
+		require.NoError(t, workflowRunner.Stop(stopCtx))
+	}()
+
+	taskID := "remoteaction-queries-live-par-local-proof"
+	require.NoError(t, fakeintakeClient.EnqueuePARTask(taskID, com_datadoghq_remoteaction_queries.BundleID+"."+com_datadoghq_remoteaction_queries.ExecuteActionName, map[string]interface{}{
+		"integration": "postgres",
+		"target": map[string]interface{}{
+			"host":   "localhost",
+			"port":   5432,
+			"dbname": "postgres",
+		},
+		"operation": "copy_stream",
+		"format":    "csv",
+		"query":     "SELECT 1 AS value",
+		"copyLimits": map[string]interface{}{
+			"chunkBytes":  1024,
+			"maxBytes":    1024,
+			"maxRowBytes": 1024,
+			"timeoutMs":   1000,
+		},
+	}))
+
+	result, err := fakeintakeClient.GetPARTaskResult(taskID, 10*time.Second)
+	require.NoError(t, err)
+	require.True(t, result.Success)
+	require.Equal(t, taskID, result.TaskID)
+	assert.Equal(t, "SUCCEEDED", result.Outputs["status"])
+	require.Contains(t, result.Outputs, "events")
+
+	select {
+	case req := <-bridgeRequests:
+		requestEvidence, err := json.Marshal(req)
+		require.NoError(t, err)
+		require.NotContains(t, string(requestEvidence), "password")
+		require.NotContains(t, string(requestEvidence), "token")
+		require.NotContains(t, string(requestEvidence), "secret")
+		assert.Equal(t, "postgres", req.GetIntegration())
+		assert.Equal(t, "copy_stream", req.GetOperation())
+		assert.Equal(t, "csv", req.GetFormat())
+		assert.Equal(t, "SELECT 1 AS value", req.GetQuery())
+		assert.Equal(t, "localhost", req.GetTarget().GetHost())
+		assert.Equal(t, int32(5432), req.GetTarget().GetPort())
+		assert.Equal(t, "postgres", req.GetTarget().GetDbname())
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "remote query action did not call the AgentSecure client")
+	}
+
+	dequeueCalls, err := fakeintakeClient.GetPARDequeueCount()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, dequeueCalls, 1)
+}
+
+func newLivePARTestConfig(t *testing.T, fakeintakeURL string) *parconfig.Config {
+	t.Helper()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	taskTimeoutSeconds := int32(5)
+
+	return &parconfig.Config{
+		ActionsAllowlist: map[string]sets.Set[string]{
+			com_datadoghq_remoteaction_queries.BundleID: sets.New[string](com_datadoghq_remoteaction_queries.ExecuteActionName),
+		},
+		DDHost:             fakeintakeURL,
+		DDApiHost:          "unused.local",
+		DatadogSite:        "local",
+		OrgId:              123456,
+		PrivateKey:         privateKey,
+		RunnerId:           "remoteaction-queries-live-par-local-proof-runner",
+		Urn:                "urn:dd:apps:on-prem-runner:us1:123456:remoteaction-queries-live-par-local-proof-runner",
+		LoopInterval:       10 * time.Millisecond,
+		MinBackoff:         10 * time.Millisecond,
+		MaxBackoff:         50 * time.Millisecond,
+		WaitBeforeRetry:    50 * time.Millisecond,
+		MaxAttempts:        3,
+		OpmsRequestTimeout: 1000,
+		RunnerPoolSize:     1,
+		HeartbeatInterval:  time.Hour,
+		TaskTimeoutSeconds: &taskTimeoutSeconds,
+		MetricsClient:      &statsd.NoOpClient{},
+		Tags:               []observability.Tag{},
+	}
+}
+
+type captureAgentSecureClient struct {
+	requests chan<- *pb.RemoteQueryExecuteRequest
+	response *pb.RemoteQueryExecuteResponse
+}
+
+func (c *captureAgentSecureClient) RemoteQueryExecute(_ context.Context, req *pb.RemoteQueryExecuteRequest, _ ...grpc.CallOption) (*pb.RemoteQueryExecuteResponse, error) {
+	c.requests <- req
+	return c.response, nil
+}
+
+func (c *captureAgentSecureClient) RemoteQueryExecuteStream(_ context.Context, req *pb.RemoteQueryExecuteRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[pb.RemoteQueryExecuteChunk], error) {
+	c.requests <- req
+	return &captureRemoteQueryExecuteStream{chunks: []*pb.RemoteQueryExecuteChunk{
+		{Event: &pb.RemoteQueryExecuteStreamEvent{Sequence: 0, Event: &pb.RemoteQueryExecuteStreamEvent_Metadata{Metadata: &pb.RemoteQueryStreamMetadata{Operation: "copy_stream", Integration: "postgres", Format: "csv"}}}, ChunkIndex: 0},
+		{Event: &pb.RemoteQueryExecuteStreamEvent{Sequence: 1, Event: &pb.RemoteQueryExecuteStreamEvent_Data{Data: &pb.RemoteQueryStreamData{Payload: []byte("1\n"), Offset: 0, Bytes: 2}}}, ChunkIndex: 1},
+		{Event: &pb.RemoteQueryExecuteStreamEvent{Sequence: 2, Event: &pb.RemoteQueryExecuteStreamEvent_Final{Final: &pb.RemoteQueryStreamFinal{Status: c.response.GetStatus(), BytesEmitted: 2, ChunksEmitted: 1}}}, ChunkIndex: 2},
+		{ChunkIndex: 3, Final: true},
+	}}, nil
+}
+
+type captureRemoteQueryExecuteStream struct {
+	grpc.ClientStream
+	chunks []*pb.RemoteQueryExecuteChunk
+}
+
+func (s *captureRemoteQueryExecuteStream) Recv() (*pb.RemoteQueryExecuteChunk, error) {
+	if len(s.chunks) == 0 {
+		return nil, io.EOF
+	}
+	chunk := s.chunks[0]
+	s.chunks = s.chunks[1:]
+	return chunk, nil
+}

--- a/pkg/privateactionrunner/bundles/remoteaction/queries/standalone_par_process_proof_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/queries/standalone_par_process_proof_test.go
@@ -1,0 +1,221 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build remoteaction_queries_live && !windows
+
+package com_datadoghq_remoteaction_queries_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/constants"
+	com_datadoghq_remoteaction_queries "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/remoteaction/queries"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
+	fakeintakeclient "github.com/DataDog/datadog-agent/test/fakeintake/client"
+	fakeintakeserver "github.com/DataDog/datadog-agent/test/fakeintake/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const standaloneLocalProofEnv = "RQ_STANDALONE_PROOF"
+
+func TestRemoteQueriesActionRunsThroughStandalonePARProcessWithRealAgentIPC(t *testing.T) {
+	if os.Getenv(standaloneLocalProofEnv) != "1" {
+		t.Skipf("set %s=1 and start a local Agent with a loaded Postgres check to run the standalone PAR process proof", standaloneLocalProofEnv)
+	}
+
+	parBin := getenvRequired(t, "RQ_STANDALONE_PAR_BIN")
+	cmdPort := getenvRequired(t, "RQ_STANDALONE_AGENT_CMD_PORT")
+	authTokenFile := getenvRequired(t, "RQ_STANDALONE_AGENT_AUTH_TOKEN_FILE")
+	ipcCertFile := getenvRequired(t, "RQ_STANDALONE_AGENT_IPC_CERT_FILE")
+	agentPID := getenvOptional("RQ_STANDALONE_AGENT_PID")
+	cmdPortInt, err := strconv.Atoi(cmdPort)
+	require.NoError(t, err)
+
+	fakeintake, _ := fakeintakeserver.InitialiseForTests(t)
+	defer func() { require.NoError(t, fakeintake.Stop()) }()
+	fakeintakeClient := fakeintakeclient.NewClient(fakeintake.URL())
+	require.NoError(t, fakeintakeClient.FlushPAR())
+
+	parDir := t.TempDir()
+	parLog := filepath.Join(parDir, "private-action-runner.log")
+	writeStandalonePARConfig(t, parDir, parLog, fakeintake.URL(), cmdPortInt, authTokenFile, ipcCertFile)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, parBin, "run", "-c", parDir)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Env = append(os.Environ(), constants.InternalSkipTaskVerificationEnvVar+"=true")
+	require.NoError(t, cmd.Start())
+	defer func() {
+		cancel()
+		_ = cmd.Wait()
+	}()
+	require.NotNil(t, cmd.Process)
+	parPID := cmd.Process.Pid
+	t.Logf("standalone private-action-runner process started: pid=%d bin=%s cfg=%s", parPID, parBin, parDir)
+	if agentPID != "" {
+		parsedAgentPID, err := strconv.Atoi(agentPID)
+		require.NoError(t, err)
+		require.NotEqual(t, parsedAgentPID, parPID, "PAR must be a separate OS process from the Agent")
+	}
+
+	waitForStandalonePARPolling(t, fakeintakeClient, cmd, parLog, &stdout, &stderr)
+
+	taskID := fmt.Sprintf("remoteaction-queries-standalone-par-proof-%d", time.Now().UnixNano())
+	proofQuery := remoteQueriesProofQueryFromEnv()
+	format := os.Getenv("RQ_REMOTE_FORMAT")
+	if format == "" {
+		format = "csv"
+	}
+	inputs := map[string]interface{}{
+		"integration": "postgres",
+		"operation":   "copy_stream",
+		"format":      format,
+		"target":      remoteQueriesPostgresTargetFromEnv(t),
+		"query":       proofQuery,
+		"copyLimits":  remoteQueriesProofCopyLimits(proofQuery),
+	}
+	requestEvidence, err := json.Marshal(inputs)
+	require.NoError(t, err)
+	requireNoCredentialShape(t, requestEvidence)
+
+	fqn := com_datadoghq_remoteaction_queries.BundleID + "." + com_datadoghq_remoteaction_queries.ExecuteActionName
+	t.Logf("fakeintake task enqueued: task_id=%s action_fqn=%s inputs=%s", taskID, fqn, requestEvidence)
+	t.Logf("real AgentSecure IPC configured for standalone PAR: 127.0.0.1:%d RemoteQueryExecuteStream", cmdPortInt)
+	require.NoError(t, fakeintakeClient.EnqueuePARTask(taskID, fqn, inputs))
+
+	result, err := fakeintakeClient.GetPARTaskResult(taskID, remoteQueriesProofResultTimeout(proofQuery))
+	require.NoError(t, err)
+	if !result.Success {
+		t.Logf("failed PAR task result: %+v", summarizeRemoteQueriesProofPayload(map[string]interface{}{
+			"task_id":       result.TaskID,
+			"success":       result.Success,
+			"outputs":       result.Outputs,
+			"error_code":    result.ErrorCode,
+			"error_details": result.ErrorDetails,
+		}))
+		t.Logf("PAR log tail:\n%s", readTail(parLog, 120))
+	}
+	require.True(t, result.Success)
+	require.Equal(t, taskID, result.TaskID)
+	assert.Equal(t, "SUCCEEDED", result.Outputs["status"])
+	t.Logf("copy stream PAR outputs: %+v", summarizeRemoteQueriesProofPayload(result.Outputs))
+	if os.Getenv("RQ_REMOTE_FORMAT") == "binary" {
+		dataBytes, ok := result.Outputs["data_bytes"].(string)
+		require.True(t, ok)
+		assertRemoteQueriesProofBinaryCopyData(t, proofQuery, dataBytes)
+	} else {
+		data, ok := result.Outputs["data"].(string)
+		require.True(t, ok)
+		assertRemoteQueriesProofCopyData(t, proofQuery, data)
+	}
+
+	resultEvidence, err := json.Marshal(summarizeRemoteQueriesProofPayload(result.Outputs))
+	require.NoError(t, err)
+	requireNoCredentialShape(t, resultEvidence)
+	t.Logf("fakeintake captured successful PAR task result: %s", resultEvidence)
+
+	dequeueCalls, err := fakeintakeClient.GetPARDequeueCount()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, dequeueCalls, 1)
+	t.Logf("standalone PAR process dequeued from fakeintake: dequeue_calls=%d", dequeueCalls)
+
+	writeFusedEvidence(t, getenvOptional("RQ_STANDALONE_EVIDENCE_FILE"), []string{
+		fmt.Sprintf("standalone private-action-runner process pid=%d", parPID),
+		"separate Agent process pid=" + agentPID,
+		fmt.Sprintf("fakeintake task enqueued: task_id=%s action_fqn=%s inputs=%s", taskID, fqn, requestEvidence),
+		"standalone PAR process dequeued the fakeintake OPMS task and invoked the registered action",
+		fmt.Sprintf("real AgentSecure IPC called by standalone PAR: 127.0.0.1:%d RemoteQueryExecuteStream", cmdPortInt),
+		fmt.Sprintf("fakeintake captured successful PAR task result: %s", resultEvidence),
+		fmt.Sprintf("dequeue_calls=%d", dequeueCalls),
+		"task verification skipped for this standalone tracer bullet with DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION=true",
+	})
+}
+
+func writeStandalonePARConfig(t *testing.T, dir, logFile, fakeintakeURL string, cmdPort int, authTokenFile, ipcCertFile string) {
+	t.Helper()
+	privateJWK, _, err := util.GenerateKeys()
+	require.NoError(t, err)
+	privateJWKJSON, err := json.Marshal(privateJWK)
+	require.NoError(t, err)
+	privateKeyB64 := base64.RawURLEncoding.EncodeToString(privateJWKJSON)
+
+	cfg := fmt.Sprintf(`api_key: '00000000000000000000000000000000'
+dd_url: %q
+hostname: rq-standalone-par-proof
+cmd_host: 127.0.0.1
+cmd_port: %d
+auth_token_file_path: %q
+ipc_cert_file_path: %q
+log_level: debug
+telemetry.enabled: false
+inventories_enabled: false
+process_config.enabled: 'false'
+logs_enabled: false
+apm_config.enabled: false
+private_action_runner:
+  enabled: true
+  self_enroll: false
+  urn: "urn:dd:apps:on-prem-runner:us1:123456:remoteaction-queries-standalone-par-local-proof-runner"
+  private_key: %q
+  log_file: %q
+  default_actions_enabled: false
+  actions_allowlist:
+    - "com.datadoghq.remoteaction.queries.execute"
+  task_concurrency: 1
+  task_timeout_seconds: 120
+`, fakeintakeURL, cmdPort, authTokenFile, ipcCertFile, privateKeyB64, logFile)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "datadog.yaml"), []byte(cfg), 0o600))
+}
+
+func waitForStandalonePARPolling(t *testing.T, client *fakeintakeclient.Client, cmd *exec.Cmd, parLog string, stdout, stderr *bytes.Buffer) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
+			require.FailNowf(t, "standalone PAR process exited before polling fakeintake", "stdout:\n%s\nstderr:\n%s\nlog tail:\n%s", stdout.String(), stderr.String(), readTail(parLog, 120))
+		}
+		if count, err := client.GetPARDequeueCount(); err == nil && count > 0 {
+			t.Logf("standalone PAR process is polling fakeintake: dequeue_calls=%d", count)
+			return
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	require.FailNowf(t, "timed out waiting for standalone PAR process to poll fakeintake", "stdout:\n%s\nstderr:\n%s\nlog tail:\n%s", stdout.String(), stderr.String(), readTail(parLog, 120))
+}
+
+func requireNoCredentialShape(t *testing.T, payload []byte) {
+	t.Helper()
+	lower := strings.ToLower(string(payload))
+	require.NotContains(t, lower, "password")
+	require.NotContains(t, lower, "token")
+	require.NotContains(t, lower, "secret")
+}
+
+func readTail(path string, maxLines int) string {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Sprintf("<unable to read %s: %v>", path, err)
+	}
+	lines := strings.Split(string(content), "\n")
+	if len(lines) <= maxLines {
+		return string(content)
+	}
+	return strings.Join(lines[len(lines)-maxLines:], "\n")
+}


### PR DESCRIPTION
Proof-only Go files: the PAR-shaped harness and live/standalone test fixtures. Live tests are build-tagged `remoteaction_queries_live` and auto-excluded from CI Bazel.

Stacked on the proper PR. Merge the base PR first.


---

### Consolidation note

Live proof orchestration moved to the internal [`nubtron/remote-queries-intake-tooling`](https://github.com/enrico-donnici_ddog/remote-queries-poc/tree/nubtron/remote-queries-intake-tooling) branch. Production Agent behavior is consolidated in draft [#55094](https://github.com/DataDog/datadog-agent/pull/55094).
