### PR TITLE
Also stop the coverage job from thrashing Bazel analysis cache

### DIFF
--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -45,12 +45,13 @@ bazel:coverage:linux-amd64:
     - cp "$(bazel info output_path)/_coverage/_coverage_report.dat" "$CI_PROJECT_DIR/coverage-bazel-$CI_JOB_NAME_SLUG.out"
   artifacts:
     paths:
-      - $RESULT_JSON
-      - test_output_unified.json
       - junit-*.tgz
       - bazel-bep.json
       - coverage-bazel-*.out
   variables:
+    # 1. `test2json` cannot replay `--instrumentation_filter` injected by `bazel coverage`
+    # 2. the sibling `bazel:test:linux-amd64` job already reports these very tests anyway
+    RESULT_JSON: ""
     KUBERNETES_CPU_REQUEST: 16
 
 bazel:test:linux-amd64:

--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -265,6 +265,7 @@ def _collect_test2json(ctx, test_artifacts, output_path):
             ctx,
             "run",
             "--config=gorace",  # to use same analysis cache across test & run commands
+            "--noallow_analysis_cache_discard",  # fail fast should configs diverge again
             "//bazel/tools/testlogs_to_json",
             "--",
             "-manifest",
@@ -277,7 +278,7 @@ def _collect_test2json(ctx, test_artifacts, output_path):
 @task(
     help={
         "bep_file": "Path to a Bazel BEP JSON file (--build_event_json_file) used to gather all necessary data.",
-        "result_json": "Path to write test2json JSONL output.",
+        "result_json": "Path to write test2json JSONL output (skipped when empty).",
         "junit_tar": "Path to write the JUnit tgz.",
     },
 )
@@ -294,13 +295,14 @@ def process_test_results(ctx, bep_file, result_json="test_output.json", junit_ta
     # with a different Bazel configuration.
     test_artifacts = _parse_bep(Path(bep_file))
 
-    # Produce the test2json result file
-    _collect_test2json(ctx, test_artifacts, result_json)
+    if result_json:  # empty in `bazel coverage` jobs
+        # Produce the test2json result file
+        _collect_test2json(ctx, test_artifacts, result_json)
 
-    # Produce UTOF and associated terminal output
-    from tasks.libs.testing.utof.go.generate import generate_unified_output
+        # Produce UTOF and associated terminal output
+        from tasks.libs.testing.utof.go.generate import generate_unified_output
 
-    generate_unified_output(ctx, result_json, "bazel", "")
+        generate_unified_output(ctx, result_json, "bazel", "")
 
     # Produce the junit tar
     if junit_tar:


### PR DESCRIPTION
### Motivation
"Bazel analysis cache thrashing on `main` (containerized job)" keeps alerting after #54963 ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1963914110)): all 49 occurrences of the last 24 hours come from `bazel:coverage:linux-amd64`, which now flips `cover_format`, `--collect_code_coverage` and `--instrumentation_filter`.

The last one `bazel coverage` derives from the target patterns, some 400 package regexes that a post-test command cannot replay.

### What does this PR do?
Skip `test2json` and UTOF where their `bazel run` cannot match the test invocation, which is only the coverage job: its tests are a **subset** of `bazel:test:linux-amd64`, still reporting them, while its JUnit tar needs no Bazel and its coverage profile only `bazel info`, which analyzes nothing.

Guard the remaining `bazel run` with `--noallow_analysis_cache_discard`, turning a future divergence into a failure of the job that introduces it, rather than a warning nobody reads until a monitor fires hours later on `main` pipelines.

### Describe how you validated your changes
`dda inv bazel.process-test-results --result-json=` runs no Bazel and still packages JUnit, while a non-empty one keeps converting logs.

With the server left in the coverage configuration, the guarded command exits 2 on "analysis cache would have been discarded", and stays silent after `bazel test --config=gorace`.

### Additional Notes
The guard is safe for the four `bazel:test:*` jobs: `INSTALL_DIR` and `AGENT_FLAVOR` are set by packaging jobs only, so `omnibazel_flags` injects nothing there, and neither monitor has reported a flip in those jobs since #54963.