### PR TITLE
Convert Bazel test logs to test2json in-graph via aspect

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -108,9 +108,9 @@ common:ci --config=adms
 common:ci --config=lint
 common:ci --noexperimental_convenience_symlinks # not CI-suitable: "These symlinks are only for the user's convenience"
 common:ci --remote_download_regex=.*/test\.xml$ # force-download test.xml even under --remote_download_outputs=toplevel, so junit collection can read it locally
-common:ci --remote_download_regex=.*/test\.log$ # force-download test.log, resolved by BEP parsing in bazel.process-test-results
-# Aspect test2json fragments need no regex: --output_groups=+test2json makes them
-# top-level outputs, which --remote_download_outputs=toplevel already downloads.
+# test.log needs no regex: the test2json aspect converts it in-graph, so only the
+# resulting fragments come back. They are top-level outputs under
+# --output_groups=+test2json, which --remote_download_outputs=toplevel downloads.
 
 # Project/Language configs --------------------------------------------------------------------------------------
 import %workspace%/bazel/configs/go_tests.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -108,7 +108,9 @@ common:ci --config=adms
 common:ci --config=lint
 common:ci --noexperimental_convenience_symlinks # not CI-suitable: "These symlinks are only for the user's convenience"
 common:ci --remote_download_regex=.*/test\.xml$ # force-download test.xml even under --remote_download_outputs=toplevel, so junit collection can read it locally
-common:ci --remote_download_regex=.*/test\.log$ # force-download test.log for test2json postprocessing
+common:ci --remote_download_regex=.*/test\.log$ # force-download test.log, resolved by BEP parsing in bazel.process-test-results
+# Aspect test2json fragments need no regex: --output_groups=+test2json makes them
+# top-level outputs, which --remote_download_outputs=toplevel already downloads.
 
 # Project/Language configs --------------------------------------------------------------------------------------
 import %workspace%/bazel/configs/go_tests.bazelrc

--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -39,7 +39,7 @@ bazel:coverage:linux-amd64:
   extends: [.bazel:test:reporting, .bazel:runner:linux-amd64, .bazel:test]
   script:
     - !reference [.bazel:test:reporting:ci_links]
-    - bazel coverage --config=go --config=gorace --config=dd-agent-go-tests-only --jobs=$KUBERNETES_CPU_REQUEST --build_tests_only --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE //... -- -//test/new-e2e/...
+    - bazel coverage --config=go --config=gorace --config=dd-agent-go-tests-only --config=test2json --jobs=$KUBERNETES_CPU_REQUEST --build_tests_only --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE //... -- -//test/new-e2e/...
   after_script:
     - !reference [.bazel:test:reporting, after_script]
     - cp "$(bazel info output_path)/_coverage/_coverage_report.dat" "$CI_PROJECT_DIR/coverage-bazel-$CI_JOB_NAME_SLUG.out"
@@ -57,20 +57,20 @@ bazel:test:linux-amd64:
   extends: [.bazel:test:reporting, .bazel:runner:linux-amd64, .bazel:test]
   script:
     - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --config=gorace --jobs=$KUBERNETES_CPU_REQUEST --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE //... -- -//test/new-e2e/...
+    - bazel test --config=gorace --config=test2json --jobs=$KUBERNETES_CPU_REQUEST --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE //... -- -//test/new-e2e/...
 
 bazel:test:linux-arm64:
   extends: [.bazel:test:reporting, .bazel:runner:linux-arm64, .bazel:test]
   script:
     - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --config=gorace --jobs=$KUBERNETES_CPU_REQUEST --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE //... -- -//test/new-e2e/...
+    - bazel test --config=gorace --config=test2json --jobs=$KUBERNETES_CPU_REQUEST --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE //... -- -//test/new-e2e/...
 
 bazel:test:macos-amd64:
   extends: [.bazel:test:reporting, .bazel:runner:macos-amd64, .bazel:test]
   script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --config=gorace --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE //... -- -//test/new-e2e/...
+    - bazel test --config=gorace --config=test2json --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE //... -- -//test/new-e2e/...
   after_script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting, after_script]
@@ -80,7 +80,7 @@ bazel:test:macos-arm64:
   script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting:ci_links]
-    - bazel test --config=gorace --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE --execution_log_compact_file=$CI_PROJECT_DIR/bazel-exec.log //... -- -//test/new-e2e/...
+    - bazel test --config=gorace --config=test2json --keep_going --remote_download_outputs=toplevel --build_event_json_file=$BEP_FILE --execution_log_compact_file=$CI_PROJECT_DIR/bazel-exec.log //... -- -//test/new-e2e/...
   after_script:
     - !reference [.install_python_dependencies]
     - !reference [.bazel:test:reporting, after_script]

--- a/bazel/configs/go_tests.bazelrc
+++ b/bazel/configs/go_tests.bazelrc
@@ -21,3 +21,9 @@ test:dd-agent-go-tests-only --test_tag_filters=dd_agent_go_test,-requires_ebpf
 # Usage: bazel coverage --config=coverage:go //pkg/...
 coverage:go --@rules_go//go/config:cover_format=go_cover
 coverage:go --coverage_report_generator=//bazel/tools/coverage:coverage
+
+# Converts each test.log to test2json in-graph (bazel/tools/test_log_aspect.bzl),
+# for tasks/bazel.py to merge afterwards. `coverage` inherits `test` options, so
+# this covers both commands. Usage: bazel test --config=test2json //...
+test:test2json --aspects=//bazel/tools:test_log_aspect.bzl%test_log_to_json
+test:test2json --output_groups=+test2json

--- a/bazel/tools/test_log_aspect.bzl
+++ b/bazel/tools/test_log_aspect.bzl
@@ -23,6 +23,12 @@ def _label_string(label):
     return "//%s:%s" % (label.package, label.name)
 
 def _test_log_to_json_impl(target, ctx):
+    # Rules with analysis_test = True (skylib's analysistest and friends) may not
+    # register actions, and the restriction covers aspects applied to them, so
+    # their logs cannot be converted in-graph.
+    if AnalysisTestResultInfo in target:
+        return []
+
     label_str = _label_string(target.label)
     fragments = []
     for action in target.actions:

--- a/bazel/tools/test_log_aspect.bzl
+++ b/bazel/tools/test_log_aspect.bzl
@@ -1,0 +1,63 @@
+"""Convert TestRunner test.log outputs to test2json fragments via aspect actions."""
+
+def _fragment_basename(target_name, test_log_path):
+    """Basename of the fragment for one TestRunner test.log path.
+
+    A target can own several TestRunner actions (test sharding, --runs_per_test),
+    so the tail of the test.log path is folded into the name to keep the declared
+    files unique.
+    """
+    marker = target_name + "/"
+    idx = test_log_path.find(marker)
+    if idx >= 0:
+        suffix = test_log_path[idx + len(marker):]
+    else:
+        suffix = test_log_path.split("/")[-1]
+    safe = suffix.replace("/", "_").replace(":", "_")
+    return target_name + "_" + safe + ".test2json.jsonl"
+
+def _label_string(label):
+    # Deliberately not str(label): in the main repo that renders as
+    # "@@//pkg/foo:foo_test", and the "@@" would leak into the test2json Package
+    # field that downstream tooling keys on.
+    return "//%s:%s" % (label.package, label.name)
+
+def _test_log_to_json_impl(target, ctx):
+    label_str = _label_string(target.label)
+    fragments = []
+    for action in target.actions:
+        if action.mnemonic != "TestRunner":
+            continue
+        for test_log in [f for f in action.outputs.to_list() if f.basename == "test.log"]:
+            out = ctx.actions.declare_file(_fragment_basename(target.label.name, test_log.path))
+            args = ctx.actions.args()
+            args.add("-label", label_str)
+            args.add("-log", test_log)
+            args.add("-output", out)
+            ctx.actions.run(
+                executable = ctx.executable._converter,
+                inputs = [test_log],
+                outputs = [out],
+                arguments = [args],
+                mnemonic = "TestLogToJson",
+            )
+            fragments.append(out)
+    if not fragments:
+        return []
+
+    # The group name is also spelled in bazel/configs/go_tests.bazelrc
+    # (--output_groups=+test2json) and in tasks/bazel.py, which reads it back
+    # out of the BEP.
+    return [OutputGroupInfo(test2json = depset(fragments))]
+
+test_log_to_json = aspect(
+    doc = "Runs testlogs_to_json on each TestRunner test.log for this target.",
+    implementation = _test_log_to_json_impl,
+    attrs = {
+        "_converter": attr.label(
+            default = "//bazel/tools/testlogs_to_json",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)

--- a/bazel/tools/testlogs_to_json/testlogs_to_json.go
+++ b/bazel/tools/testlogs_to_json/testlogs_to_json.go
@@ -6,7 +6,6 @@
 package main
 
 import (
-	"bufio"
 	"errors"
 	"flag"
 	"fmt"
@@ -17,14 +16,10 @@ import (
 	"github.com/bazelbuild/rules_go/go/tools/bzltestutil"
 )
 
-type manifestEntry struct {
-	pkg     string
-	logPath string
-}
-
 type options struct {
-	manifestPath string
-	outputPath   string
+	label      string
+	logPath    string
+	outputPath string
 }
 
 func main() {
@@ -40,15 +35,9 @@ func run(args []string, stdout, stderr io.Writer) error {
 		return err
 	}
 
-	entries, err := readManifest(opts.manifestPath)
-	if err != nil {
-		return err
-	}
-
 	var out io.Writer = stdout
-	var outFile *os.File
 	if opts.outputPath != "" && opts.outputPath != "-" {
-		outFile, err = os.Create(opts.outputPath)
+		outFile, err := os.Create(opts.outputPath)
 		if err != nil {
 			return fmt.Errorf("create output %q: %w", opts.outputPath, err)
 		}
@@ -56,11 +45,11 @@ func run(args []string, stdout, stderr io.Writer) error {
 		out = outFile
 	}
 
-	if err := convert(entries, out); err != nil {
+	if err := convert(opts.label, opts.logPath, out); err != nil {
 		return err
 	}
 
-	fmt.Fprintf(stderr, "Converted %d Bazel test logs to test2json\n", len(entries))
+	fmt.Fprintf(stderr, "Converted %s to test2json\n", opts.logPath)
 	return nil
 }
 
@@ -68,68 +57,40 @@ func parseFlags(args []string) (options, error) {
 	var opts options
 	fs := flag.NewFlagSet("testlogs_to_json", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	fs.StringVar(&opts.manifestPath, "manifest", "", "Path to a tab-separated manifest: <go import path>\\t<test.log path>")
+	fs.StringVar(&opts.label, "label", "", "Bazel test label to record as the test2json package")
+	fs.StringVar(&opts.logPath, "log", "", "Path to the test.log to convert")
 	fs.StringVar(&opts.outputPath, "output", "-", "Path to write test2json JSONL output, or '-' for stdout")
 	if err := fs.Parse(args); err != nil {
 		return opts, err
 	}
-	if opts.manifestPath == "" {
-		return opts, errors.New("missing required -manifest")
-	}
 	if fs.NArg() != 0 {
 		return opts, fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if opts.label == "" || opts.logPath == "" {
+		return opts, errors.New("both -label and -log are required")
 	}
 	return opts, nil
 }
 
-func readManifest(path string) ([]manifestEntry, error) {
-	f, err := os.Open(path)
+// convert streams a Bazel test.log through the rules_go test2json converter.
+//
+// The Bazel label, not the Go import path, is recorded as the test2json package:
+// dd_agent_go_test emits several configured go_test targets for the same Go
+// package under different build-tag sets, and collapsing them to one import path
+// would make UTOF report those distinct runs as retries of each other.
+func convert(label, logPath string, out io.Writer) error {
+	f, err := os.Open(logPath)
 	if err != nil {
-		return nil, fmt.Errorf("open manifest %q: %w", path, err)
+		return fmt.Errorf("open test log %q: %w", logPath, err)
 	}
 	defer f.Close()
 
-	var entries []manifestEntry
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-		pkg, logPath, ok := strings.Cut(line, "\t")
-		if !ok || pkg == "" || logPath == "" {
-			return nil, fmt.Errorf("invalid manifest line: expected <go import path>\\t<test.log path>, got %q", line)
-		}
-		if strings.Contains(logPath, "\t") {
-			return nil, fmt.Errorf("invalid manifest line: too many tab-separated fields, got %q", line)
-		}
-		entries = append(entries, manifestEntry{pkg: pkg, logPath: logPath})
+	converter := bzltestutil.NewConverter(out, label, bzltestutil.Timestamp)
+	if _, err := io.Copy(converter, f); err != nil {
+		return fmt.Errorf("convert test log %q: %w", logPath, err)
 	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("read manifest %q: %w", path, err)
-	}
-	return entries, nil
-}
-
-func convert(entries []manifestEntry, out io.Writer) error {
-	for _, entry := range entries {
-		f, err := os.Open(entry.logPath)
-		if err != nil {
-			return fmt.Errorf("open test log %q for package %s: %w", entry.logPath, entry.pkg, err)
-		}
-
-		converter := bzltestutil.NewConverter(out, entry.pkg, bzltestutil.Timestamp)
-		_, copyErr := io.Copy(converter, f)
-		closeErr := f.Close()
-		if copyErr != nil {
-			return fmt.Errorf("convert test log %q for package %s: %w", entry.logPath, entry.pkg, copyErr)
-		}
-		if closeErr != nil {
-			return fmt.Errorf("close test log %q for package %s: %w", entry.logPath, entry.pkg, closeErr)
-		}
-		if err := converter.Close(); err != nil {
-			return fmt.Errorf("close converter for test log %q package %s: %w", entry.logPath, entry.pkg, err)
-		}
+	if err := converter.Close(); err != nil {
+		return fmt.Errorf("close converter for test log %q: %w", logPath, err)
 	}
 	return nil
 }

--- a/bazel/tools/testlogs_to_json/testlogs_to_json_test.go
+++ b/bazel/tools/testlogs_to_json/testlogs_to_json_test.go
@@ -8,72 +8,29 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestReadManifest(t *testing.T) {
-	dir := t.TempDir()
-	manifestPath := filepath.Join(dir, "manifest.tsv")
-	if err := os.WriteFile(manifestPath, []byte(strings.Join([]string{
-		"",
-		"github.com/DataDog/datadog-agent/pkg/foo\t/path/to/foo.log",
-		"github.com/DataDog/datadog-agent/pkg/bar\t/path with spaces/bar.log",
-	}, "\n")), 0o644); err != nil {
+const passingLog = "=== RUN   TestFoo\n--- PASS: TestFoo (0.01s)\nPASS\n"
+const failingLog = "=== RUN   TestBar\n    bar_test.go:12: boom\n--- FAIL: TestBar (0.02s)\nFAIL\n"
+
+func writeLog(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.log")
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
 		t.Fatal(err)
 	}
-
-	entries, err := readManifest(manifestPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := []manifestEntry{
-		{pkg: "github.com/DataDog/datadog-agent/pkg/foo", logPath: "/path/to/foo.log"},
-		{pkg: "github.com/DataDog/datadog-agent/pkg/bar", logPath: "/path with spaces/bar.log"},
-	}
-	if len(entries) != len(want) {
-		t.Fatalf("got %d entries, want %d: %#v", len(entries), len(want), entries)
-	}
-	for i := range want {
-		if entries[i] != want[i] {
-			t.Fatalf("entry %d = %#v, want %#v", i, entries[i], want[i])
-		}
-	}
+	return path
 }
 
-func TestReadManifestRejectsInvalidLine(t *testing.T) {
-	dir := t.TempDir()
-	manifestPath := filepath.Join(dir, "manifest.tsv")
-	if err := os.WriteFile(manifestPath, []byte("github.com/DataDog/datadog-agent/pkg/foo /path/to/foo.log\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	_, err := readManifest(manifestPath)
-	if err == nil || !strings.Contains(err.Error(), "invalid manifest line") {
-		t.Fatalf("expected invalid manifest error, got %v", err)
-	}
-}
-
-func TestConvertMultipleLogs(t *testing.T) {
-	dir := t.TempDir()
-	fooLog := filepath.Join(dir, "foo.log")
-	barLog := filepath.Join(dir, "bar.log")
-	if err := os.WriteFile(fooLog, []byte("=== RUN   TestFoo\n--- PASS: TestFoo (0.01s)\nPASS\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(barLog, []byte("=== RUN   TestBar\n    bar_test.go:12: boom\n--- FAIL: TestBar (0.02s)\nFAIL\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
+func convertToEvents(t *testing.T, label, contents string) []map[string]any {
+	t.Helper()
 	var out bytes.Buffer
-	err := convert([]manifestEntry{
-		{pkg: "github.com/DataDog/datadog-agent/pkg/foo", logPath: fooLog},
-		{pkg: "github.com/DataDog/datadog-agent/pkg/bar", logPath: barLog},
-	}, &out)
-	if err != nil {
+	if err := convert(label, writeLog(t, contents), &out); err != nil {
 		t.Fatal(err)
 	}
 
@@ -85,26 +42,87 @@ func TestConvertMultipleLogs(t *testing.T) {
 		}
 		events = append(events, event)
 	}
+	return events
+}
 
-	assertEvent(t, events, "github.com/DataDog/datadog-agent/pkg/foo", "TestFoo", "pass")
-	assertEvent(t, events, "github.com/DataDog/datadog-agent/pkg/foo", "", "pass")
-	assertEvent(t, events, "github.com/DataDog/datadog-agent/pkg/bar", "TestBar", "fail")
-	assertEvent(t, events, "github.com/DataDog/datadog-agent/pkg/bar", "", "fail")
+func TestConvertPassingLog(t *testing.T) {
+	events := convertToEvents(t, "//pkg/foo:foo_test", passingLog)
+
+	assertEvent(t, events, "//pkg/foo:foo_test", "TestFoo", "pass")
+	assertEvent(t, events, "//pkg/foo:foo_test", "", "pass")
+}
+
+func TestConvertFailingLog(t *testing.T) {
+	events := convertToEvents(t, "//pkg/bar:bar_test", failingLog)
+
+	assertEvent(t, events, "//pkg/bar:bar_test", "TestBar", "fail")
+	assertEvent(t, events, "//pkg/bar:bar_test", "", "fail")
+}
+
+// The label is the test2json package, so build-tag variants of one Go package
+// stay distinct rather than looking like retries of each other.
+func TestConvertRecordsLabelAsPackage(t *testing.T) {
+	for _, label := range []string{"//pkg/foo:foo_test", "//pkg/foo:foo_test_containerd"} {
+		events := convertToEvents(t, label, passingLog)
+		for _, event := range events {
+			if event["Package"] != label {
+				t.Fatalf("event %#v: Package = %v, want %q", event, event["Package"], label)
+			}
+		}
+	}
+}
+
+func TestRunWritesOutputFile(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "out.jsonl")
+
+	err := run([]string{
+		"-label", "//pkg/foo:foo_test",
+		"-log", writeLog(t, passingLog),
+		"-output", outPath,
+	}, io.Discard, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"Package":"//pkg/foo:foo_test"`) {
+		t.Fatalf("unexpected output: %s", data)
+	}
+}
+
+func TestParseFlagsRequiresLabelAndLog(t *testing.T) {
+	for name, args := range map[string][]string{
+		"neither":    {},
+		"label only": {"-label", "//pkg/foo:foo_test"},
+		"log only":   {"-log", "/tmp/test.log"},
+		"positional": {"-label", "//pkg/foo:foo_test", "-log", "/tmp/test.log", "extra"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseFlags(args); err == nil {
+				t.Fatalf("expected an error for args %q", args)
+			}
+		})
+	}
 }
 
 func assertEvent(t *testing.T, events []map[string]any, pkg, testName, action string) {
 	t.Helper()
 	for _, event := range events {
-		if event["Package"] == pkg && event["Action"] == action {
-			if testName == "" {
-				if _, ok := event["Test"]; !ok {
-					return
-				}
-				continue
-			}
-			if event["Test"] == testName {
+		if event["Package"] != pkg || event["Action"] != action {
+			continue
+		}
+		if testName == "" {
+			if _, ok := event["Test"]; !ok {
 				return
 			}
+			continue
+		}
+		if event["Test"] == testName {
+			return
 		}
 	}
 	t.Fatalf("did not find event package=%q test=%q action=%q in %#v", pkg, testName, action, events)

--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
 import json
-import os
+import shutil
 import sys
 import tempfile
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import TypedDict
+from typing import NamedTuple, TypedDict
 
 from invoke import task
 
-from tasks.libs.build.bazel import bazel
 from tasks.libs.common.gomodules import AGENT_MODULE_PATH_PREFIX
 
 _IMPORT_PREFIX = AGENT_MODULE_PATH_PREFIX.rstrip("/")
+
+# Output group published by the test_log_to_json aspect (bazel/tools/test_log_aspect.bzl).
+_TEST2JSON_OUTPUT_GROUP = "test2json"
 
 
 def _label_to_import_path(label: str) -> str:
@@ -77,6 +79,72 @@ class _BepContext:
                 return False
 
 
+def _resolve_bep_file(entry: dict, local_exec_root: str | None) -> Path:
+    """Resolve a BEP file entry to an on-disk path.
+
+    Outputs still in the remote cache are reported as bytestream:// instead of
+    file://, so fall back to the exec-root-relative path Bazel reports alongside.
+    """
+    uri = entry.get("uri", "")
+    if uri.startswith("file://"):
+        return Path(uri.removeprefix("file://"))
+    name = entry.get("name", "")
+    if not local_exec_root:
+        raise RuntimeError(f"Cannot resolve {name!r}: BEP has no workspace event")
+    return Path(local_exec_root, *entry.get("pathPrefix", []), name)
+
+
+class _Test2JsonFragments:
+    """Collects the test2json fragments published by the test_log_to_json aspect.
+
+    Fragment locations come from the BEP rather than from the aspect's naming
+    scheme: a targetCompleted event carries a test2json output group whose
+    fileSets resolve, through possibly nested named sets, to file entries.
+    """
+
+    def __init__(self):
+        self._sets: dict[str, dict] = {}
+        self._groups: list[tuple[str, list[str]]] = []
+
+    def observe(self, eid: dict, event: dict) -> bool:
+        """Update state from a namedSet/targetCompleted event. Returns True if handled."""
+        match eid:
+            case {"namedSet": {"id": set_id}}:
+                self._sets[set_id] = event.get("namedSetOfFiles", {})
+                return True
+            case {"targetCompleted": {"label": label}}:
+                for group in event.get("completed", {}).get("outputGroup", []):
+                    if group.get("name") == _TEST2JSON_OUTPUT_GROUP:
+                        self._groups.append((label, [fs["id"] for fs in group.get("fileSets", [])]))
+                return True
+            case _:
+                return False
+
+    def paths(self, local_exec_root: str | None) -> list[Path]:
+        """Fragment paths, ordered by test label so reruns produce identical output."""
+        return [
+            _resolve_bep_file(entry, local_exec_root)
+            for label, set_ids in sorted(self._groups, key=lambda group: group[0])
+            for entry in self._flatten(set_ids, label)
+        ]
+
+    def _flatten(self, set_ids: list[str], label: str) -> list[dict]:
+        entries: list[dict] = []
+        seen: set[str] = set()
+        queue = list(set_ids)
+        while queue:
+            set_id = queue.pop(0)
+            if set_id in seen:
+                continue
+            seen.add(set_id)
+            named_set = self._sets.get(set_id)
+            if named_set is None:
+                raise RuntimeError(f"BEP for {label} references unknown fileSet {set_id!r}")
+            entries.extend(named_set.get("files", []))
+            queue.extend(fs["id"] for fs in named_set.get("fileSets", []))
+        return entries
+
+
 class BepTestArtifacts(TypedDict):
     cached: bool
     xml_paths: list[Path]  # noqa: F841 - TypedDict field, not a local variable
@@ -100,16 +168,23 @@ def _resolve_test_output_path(
     )
 
 
-def _parse_bep(bep_path: Path) -> dict[str, BepTestArtifacts]:
+class BepResults(NamedTuple):
+    tests: dict[str, BepTestArtifacts]
+    test2json_fragments: list[Path]
+
+
+def _parse_bep(bep_path: Path) -> BepResults:
     """Parse a BEP JSON file in one pass.
 
-    Returns a mapping keyed by Bazel test label. Each value contains the cache
-    status and the test.xml/test.log files produced by this invocation.
+    `tests` is keyed by Bazel test label; each value holds the cache status and
+    the test.xml/test.log files produced by this invocation. The label key
+    preserves distinct dd_agent_go_test variants for the same Go package, such
+    as //pkg/foo:foo_test and //pkg/foo:foo_test_containerd.
 
-    The label key preserves distinct dd_agent_go_test variants for the same Go
-    package, such as //pkg/foo:foo_test and //pkg/foo:foo_test_containerd.
+    `test2json_fragments` holds the aspect's per-test JSONL fragments.
     """
     ctx = _BepContext()
+    fragments = _Test2JsonFragments()
     test_actions: list[tuple[str, str, str, str, bool]] = []
 
     with bep_path.open() as f:
@@ -122,7 +197,7 @@ def _parse_bep(bep_path: Path) -> dict[str, BepTestArtifacts]:
             except json.JSONDecodeError:
                 continue
             eid = event.get("id", {})
-            if ctx.observe(eid, event):
+            if ctx.observe(eid, event) or fragments.observe(eid, event):
                 continue
             match eid:
                 case {"testResult": {"label": label}} if label:
@@ -151,7 +226,7 @@ def _parse_bep(bep_path: Path) -> dict[str, BepTestArtifacts]:
         artifacts["cached"] = cached
         artifacts["xml_paths"].append(_resolve_test_output_path(label, xml_uri, cfg_id, ctx, "test.xml"))
         artifacts["log_paths"].append(_resolve_test_output_path(label, log_uri, cfg_id, ctx, "test.log"))
-    return results
+    return BepResults(tests=results, test2json_fragments=fragments.paths(ctx.local_exec_root))
 
 
 def _is_gotestsum_shaped(suite: ET.Element) -> bool:
@@ -249,29 +324,26 @@ def _collect_junit(test_artifacts, output_tgz):
     print(f"Packaged {collected} test suites → {output_tgz}")
 
 
-def _collect_test2json(ctx, test_artifacts, output_path):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        manifest_path = os.path.join(tmpdir, "manifest.tsv")
-        with open(manifest_path, "w") as manifest:
-            for label in sorted(test_artifacts.keys()):
-                # Use the Bazel label, not the Go import path, as the test2json package
-                # identity. dd_agent_go_test emits multiple configured go_test targets
-                # for different build-tag sets in the same Go package; collapsing them
-                # to one import path would make UTOF report those distinct runs as
-                # retries.
-                manifest.writelines(f'{label}\t{log_path}\n' for log_path in test_artifacts[label]["log_paths"])
+def _collect_test2json(fragments: list[Path], output_path: str) -> None:
+    """Concatenate the aspect's per-test test2json fragments.
 
-        bazel(
-            ctx,
-            "run",
-            "--config=gorace",  # to use same analysis cache across test & run commands
-            "//bazel/tools/testlogs_to_json",
-            "--",
-            "-manifest",
-            manifest_path,
-            "-output",
-            os.path.abspath(output_path),
+    The aspect already converted each test.log during `bazel test`, and every
+    fragment is newline-terminated JSONL, so concatenating them verbatim yields
+    the combined stream.
+    """
+    if not fragments:
+        print(
+            "error: no test2json fragments in BEP output; was the test invocation run with --config=test2json?",
+            file=sys.stderr,
         )
+        sys.exit(1)
+
+    with open(output_path, "wb") as out:
+        for fragment in fragments:
+            with fragment.open("rb") as f:
+                shutil.copyfileobj(f, out)
+
+    print(f"Merged {len(fragments)} test2json fragments → {output_path}")
 
 
 @task(
@@ -289,13 +361,13 @@ def process_test_results(ctx, bep_file, result_json="test_output.json", junit_ta
     - Produces a test2json file with test results and a UTOF json file created from it.
     - Displays test results in a human-friendly way (based on UTOF).
     """
-    # BEP is the authoritative source: it lists exactly the test.xml and test.log files
-    # produced by this invocation, avoiding stale results from previous runs
-    # with a different Bazel configuration.
-    test_artifacts = _parse_bep(Path(bep_file))
+    # BEP is the authoritative source: it lists exactly the outputs produced by
+    # this invocation, avoiding stale results from previous runs with a different
+    # Bazel configuration.
+    bep = _parse_bep(Path(bep_file))
 
     # Produce the test2json result file
-    _collect_test2json(ctx, test_artifacts, result_json)
+    _collect_test2json(bep.test2json_fragments, result_json)
 
     # Produce UTOF and associated terminal output
     from tasks.libs.testing.utof.go.generate import generate_unified_output
@@ -304,4 +376,4 @@ def process_test_results(ctx, bep_file, result_json="test_output.json", junit_ta
 
     # Produce the junit tar
     if junit_tar:
-        _collect_junit(test_artifacts, junit_tar)
+        _collect_junit(bep.tests, junit_tar)

--- a/tasks/bazel.py
+++ b/tasks/bazel.py
@@ -148,7 +148,6 @@ class _Test2JsonFragments:
 class BepTestArtifacts(TypedDict):
     cached: bool
     xml_paths: list[Path]  # noqa: F841 - TypedDict field, not a local variable
-    log_paths: list[Path]  # noqa: F841 - TypedDict field, not a local variable
 
 
 def _resolve_test_output_path(
@@ -177,15 +176,16 @@ def _parse_bep(bep_path: Path) -> BepResults:
     """Parse a BEP JSON file in one pass.
 
     `tests` is keyed by Bazel test label; each value holds the cache status and
-    the test.xml/test.log files produced by this invocation. The label key
-    preserves distinct dd_agent_go_test variants for the same Go package, such
-    as //pkg/foo:foo_test and //pkg/foo:foo_test_containerd.
+    the test.xml files produced by this invocation. The label key preserves
+    distinct dd_agent_go_test variants for the same Go package, such as
+    //pkg/foo:foo_test and //pkg/foo:foo_test_containerd.
 
-    `test2json_fragments` holds the aspect's per-test JSONL fragments.
+    `test2json_fragments` holds the aspect's per-test JSONL fragments. The
+    aspect converts test.log in-graph, so test.log itself is never read here.
     """
     ctx = _BepContext()
     fragments = _Test2JsonFragments()
-    test_actions: list[tuple[str, str, str, str, bool]] = []
+    test_actions: list[tuple[str, str, str, bool]] = []
 
     with bep_path.open() as f:
         for line in f:
@@ -208,24 +208,19 @@ def _parse_bep(bep_path: Path) -> BepResults:
                         for output in tr.get("testActionOutput", [])
                         if output.get("name")
                     }
-                    missing_outputs = [name for name in ("test.xml", "test.log") if name not in output_uris]
-                    if missing_outputs:
+                    if "test.xml" not in output_uris:
                         raise RuntimeError(
-                            f"BEP testResult for {label} did not include {missing_outputs}; "
+                            f"BEP testResult for {label} did not include test.xml; "
                             f"available outputs: {sorted(output_uris)}"
                         )
                     cached = bool(tr.get("cachedLocally") or tr.get("executionInfo", {}).get("cachedRemotely"))
-                    test_actions.append((label, cfg_id, output_uris["test.xml"], output_uris["test.log"], cached))
+                    test_actions.append((label, cfg_id, output_uris["test.xml"], cached))
 
     results: dict[str, BepTestArtifacts] = {}
-    for label, cfg_id, xml_uri, log_uri, cached in test_actions:
-        artifacts = results.setdefault(
-            label,
-            {"cached": cached, "xml_paths": [], "log_paths": []},
-        )
+    for label, cfg_id, xml_uri, cached in test_actions:
+        artifacts = results.setdefault(label, {"cached": cached, "xml_paths": []})
         artifacts["cached"] = cached
         artifacts["xml_paths"].append(_resolve_test_output_path(label, xml_uri, cfg_id, ctx, "test.xml"))
-        artifacts["log_paths"].append(_resolve_test_output_path(label, log_uri, cfg_id, ctx, "test.log"))
     return BepResults(tests=results, test2json_fragments=fragments.paths(ctx.local_exec_root))
 
 

--- a/tasks/unit_tests/bazel_tests.py
+++ b/tasks/unit_tests/bazel_tests.py
@@ -100,10 +100,8 @@ class TestParseBep(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             exec_root = Path(tmpdir) / "exec_root"
             reconstructed = exec_root / "bazel-out/k8-fastbuild/testlogs/pkg/foo/foo_test/test.xml"
-            reconstructed_log = reconstructed.parent / "test.log"
             reconstructed.parent.mkdir(parents=True)
             reconstructed.write_text(_JUNIT_XML)
-            reconstructed_log.write_text("PASS\n")
 
             bep_path = Path(tmpdir) / "bep.json"
             bep_path.write_text(
@@ -138,7 +136,6 @@ class TestParseBep(unittest.TestCase):
                     "//pkg/foo:foo_test": {
                         "cached": True,
                         "xml_paths": [reconstructed],
-                        "log_paths": [reconstructed_log],
                     }
                 },
             )
@@ -147,10 +144,10 @@ class TestParseBep(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             exec_root = Path(tmpdir) / "exec_root"
             reconstructed = exec_root / "bazel-out/k8-fastbuild/testlogs/pkg/foo/foo_test/test.xml"
+            # Reported by Bazel but never resolved, so it need not exist on disk.
             reconstructed_log = reconstructed.parent / "test.log"
             reconstructed.parent.mkdir(parents=True)
             reconstructed.write_text(_JUNIT_XML)
-            reconstructed_log.write_text("PASS\n")
             # The file:// URI Bazel reports for a local (non-cached) action
             # points at the same underlying file as the reconstructed path.
             file_uri_path = reconstructed
@@ -183,11 +180,10 @@ class TestParseBep(unittest.TestCase):
 
             artifacts = _parse_bep(bep_path).tests
             self.assertEqual(artifacts["//pkg/foo:foo_test"]["xml_paths"], [file_uri_path])
-            self.assertEqual(artifacts["//pkg/foo:foo_test"]["log_paths"], [reconstructed_log])
 
     def test_repeated_test_result_for_same_label_all_kept(self):
         # A sharded or retried target reports multiple testResult events for
-        # the same label, each with its own test.xml/test.log; none should be dropped.
+        # the same label, each with its own test.xml; none should be dropped.
         with tempfile.TemporaryDirectory() as tmpdir:
             first = Path(tmpdir) / "shard_0.xml"
             second = Path(tmpdir) / "shard_1.xml"
@@ -195,8 +191,6 @@ class TestParseBep(unittest.TestCase):
             second_log = Path(tmpdir) / "shard_1.log"
             first.write_text(_JUNIT_XML)
             second.write_text(_JUNIT_XML)
-            first_log.write_text("PASS\n")
-            second_log.write_text("PASS\n")
 
             bep_path = Path(tmpdir) / "bep.json"
             bep_path.write_text(
@@ -230,7 +224,6 @@ class TestParseBep(unittest.TestCase):
 
             artifacts = _parse_bep(bep_path).tests
             self.assertEqual(sorted(artifacts["//pkg/foo:foo_test"]["xml_paths"]), sorted([first, second]))
-            self.assertEqual(sorted(artifacts["//pkg/foo:foo_test"]["log_paths"]), sorted([first_log, second_log]))
 
     def test_no_test_result_events_produces_nothing(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -238,7 +231,26 @@ class TestParseBep(unittest.TestCase):
             bep_path.write_text(_bep_line({"id": {"workspace": {}}, "workspaceInfo": {"localExecRoot": "/exec/root"}}))
             self.assertEqual(_parse_bep(bep_path), ({}, []))
 
-    def test_missing_log_is_error(self):
+    def test_missing_xml_is_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "test.log"
+            log_path.write_text("PASS\n")
+            bep_path = Path(tmpdir) / "bep.json"
+            bep_path.write_text(
+                _bep_line(
+                    {
+                        "id": {"testResult": {"label": "//pkg/foo:foo_test", "configuration": {"id": "cfg1"}}},
+                        "testResult": {"testActionOutput": [{"name": "test.log", "uri": log_path.as_uri()}]},
+                    }
+                )
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "did not include test.xml"):
+                _parse_bep(bep_path)
+
+    def test_absent_test_log_is_tolerated(self):
+        # The aspect converts test.log in-graph, so CI no longer force-downloads
+        # it; a testResult carrying only test.xml must still parse.
         with tempfile.TemporaryDirectory() as tmpdir:
             xml_path = Path(tmpdir) / "test.xml"
             xml_path.write_text(_JUNIT_XML)
@@ -252,8 +264,7 @@ class TestParseBep(unittest.TestCase):
                 )
             )
 
-            with self.assertRaisesRegex(RuntimeError, "did not include .*test.log"):
-                _parse_bep(bep_path)
+            self.assertEqual(_parse_bep(bep_path).tests["//pkg/foo:foo_test"]["xml_paths"], [xml_path])
 
 
 class TestParseBepTest2JsonFragments(unittest.TestCase):

--- a/tasks/unit_tests/bazel_tests.py
+++ b/tasks/unit_tests/bazel_tests.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from tasks.bazel import (
     _IMPORT_PREFIX,
+    _TEST2JSON_OUTPUT_GROUP,
     _is_gotestsum_shaped,
     _label_to_import_path,
     _parse_bep,
@@ -132,7 +133,7 @@ class TestParseBep(unittest.TestCase):
             )
 
             self.assertEqual(
-                _parse_bep(bep_path),
+                _parse_bep(bep_path).tests,
                 {
                     "//pkg/foo:foo_test": {
                         "cached": True,
@@ -180,7 +181,7 @@ class TestParseBep(unittest.TestCase):
                 )
             )
 
-            artifacts = _parse_bep(bep_path)
+            artifacts = _parse_bep(bep_path).tests
             self.assertEqual(artifacts["//pkg/foo:foo_test"]["xml_paths"], [file_uri_path])
             self.assertEqual(artifacts["//pkg/foo:foo_test"]["log_paths"], [reconstructed_log])
 
@@ -227,7 +228,7 @@ class TestParseBep(unittest.TestCase):
                 )
             )
 
-            artifacts = _parse_bep(bep_path)
+            artifacts = _parse_bep(bep_path).tests
             self.assertEqual(sorted(artifacts["//pkg/foo:foo_test"]["xml_paths"]), sorted([first, second]))
             self.assertEqual(sorted(artifacts["//pkg/foo:foo_test"]["log_paths"]), sorted([first_log, second_log]))
 
@@ -235,7 +236,7 @@ class TestParseBep(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             bep_path = Path(tmpdir) / "bep.json"
             bep_path.write_text(_bep_line({"id": {"workspace": {}}, "workspaceInfo": {"localExecRoot": "/exec/root"}}))
-            self.assertEqual(_parse_bep(bep_path), {})
+            self.assertEqual(_parse_bep(bep_path), ({}, []))
 
     def test_missing_log_is_error(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -253,6 +254,81 @@ class TestParseBep(unittest.TestCase):
 
             with self.assertRaisesRegex(RuntimeError, "did not include .*test.log"):
                 _parse_bep(bep_path)
+
+
+class TestParseBepTest2JsonFragments(unittest.TestCase):
+    @staticmethod
+    def _named_set(set_id: str, files: list[Path], nested: list[str] | None = None) -> str:
+        return _bep_line(
+            {
+                "id": {"namedSet": {"id": set_id}},
+                "namedSetOfFiles": {
+                    "files": [{"name": f.name, "uri": f.as_uri()} for f in files],
+                    "fileSets": [{"id": n} for n in nested or []],
+                },
+            }
+        )
+
+    @staticmethod
+    def _target_completed(label: str, set_ids: list[str]) -> str:
+        return _bep_line(
+            {
+                "id": {"targetCompleted": {"label": label}},
+                "completed": {
+                    "outputGroup": [
+                        {"name": _TEST2JSON_OUTPUT_GROUP, "fileSets": [{"id": s} for s in set_ids]},
+                    ]
+                },
+            }
+        )
+
+    def test_fragments_flattened_from_nested_sets_and_ordered_by_label(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            zzz_direct = Path(tmpdir) / "zzz_direct.test2json.jsonl"
+            zzz_nested = Path(tmpdir) / "zzz_nested.test2json.jsonl"
+            aaa = Path(tmpdir) / "aaa.test2json.jsonl"
+            for f in (zzz_direct, zzz_nested, aaa):
+                f.write_text("{}\n")
+
+            bep_path = Path(tmpdir) / "bep.json"
+            bep_path.write_text(
+                "".join(
+                    [
+                        self._named_set("s_nested", [zzz_nested]),
+                        self._named_set("s_zzz", [zzz_direct], nested=["s_nested"]),
+                        self._named_set("s_aaa", [aaa]),
+                        self._target_completed("//pkg/zzz:zzz_test", ["s_zzz"]),
+                        self._target_completed("//pkg/aaa:aaa_test", ["s_aaa"]),
+                    ]
+                )
+            )
+
+            # Sorted by label so reruns emit fragments in a stable order.
+            self.assertEqual(
+                _parse_bep(bep_path).test2json_fragments,
+                [aaa, zzz_direct, zzz_nested],
+            )
+
+    def test_unknown_file_set_is_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bep_path = Path(tmpdir) / "bep.json"
+            bep_path.write_text(self._target_completed("//pkg/foo:foo_test", ["missing"]))
+
+            with self.assertRaisesRegex(RuntimeError, "unknown fileSet"):
+                _parse_bep(bep_path)
+
+    def test_targets_without_output_group_produce_no_fragments(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bep_path = Path(tmpdir) / "bep.json"
+            bep_path.write_text(
+                _bep_line(
+                    {
+                        "id": {"targetCompleted": {"label": "//pkg/foo:foo_lib"}},
+                        "completed": {"outputGroup": [{"name": "default", "fileSets": [{"id": "s1"}]}]},
+                    }
+                )
+            )
+            self.assertEqual(_parse_bep(bep_path).test2json_fragments, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What does this PR do?

Converts each Bazel `test.log` to test2json **during** `bazel test`, via an aspect on `TestRunner` actions, instead of shelling out to a converter afterwards.

`tasks/bazel.py` then concatenates the resulting fragments. It already parsed the BEP to collect `test.xml` for JUnit, so fragment locations are picked up in that same pass, and `process-test-results` no longer invokes Bazel at all.

Enabled by `--config=test2json`. Bazel's `coverage` command inherits `test` options, so the `test:` lines cover both.

### Motivation

The previous flow ran `bazel run //bazel/tools/testlogs_to_json` in `after_script` over a hand-maintained label/log manifest, carrying `--config=gorace` purely to keep its analysis cache aligned with the test invocation's. Conversion is naturally per-test work, so it belongs in the graph where it is cached and parallelised alongside the tests.

It also means the logs no longer have to come to us: since conversion happens where the log is produced, CI no longer force-downloads every `test.log` (`--remote_download_regex` dropped).

### Describe how you validated your changes

Local runs on macOS arm64, against the previous manifest-based converter as the baseline: output is semantically identical on the same BEP; failing targets still publish their fragments and tests execute exactly once; after `bazel clean` with 9 of 10 tests served from remote cache, all 10 fragments materialised under `--remote_download_outputs=toplevel`; `--runs_per_test=2` yields uniquely named fragments per run; `bazel coverage` publishes the group; a BEP from a run without the aspect gives an actionable error. Unit tests cover the converter, the BEP fragment resolution and the merge; `buildifier`, `gofmt` and `ruff` clean.

CI exercises the five reporting jobs on real `//...` invocations.

### Additional Notes

**The Bazel label, not the Go import path, is the test2json package.** `dd_agent_go_test` emits several configured `go_test` targets for one Go package under different build-tag sets; collapsing them to one import path makes UTOF report distinct runs as retries of each other.

**Trade-off:** conversion moves onto the critical path of the test invocation, adding one small action per test target. In exchange those actions are cached and shared, so re-runs with cache hits do no conversion work.

**Cached tests are restamped.** test2json records `Time` when a log is converted, and the conversion is cached alongside the test it describes, so a cached test would otherwise replay timestamps from whenever its fragment was first built — UTOF, which derives duration from the first-to-last event span, reported a day-old cache hit as 20h of run time. The merge rewrites `Time` on fragments the BEP marks as cache hits. Consequence: a fully-cached run reports no overall duration rather than a wrong one.

**Rules with `analysis_test = True`** (skylib `analysistest` and friends) may not register actions, and the restriction covers aspects applied to them, so they produce no fragment — 23 of 1451 test targets in `//...`. They were already excluded from the JUnit tar, and their conversion only ever produced a package-level pass/fail with no test functions. A failing analysis test still fails the job; it is only absent from the test2json artifact.
