### PR TITLE
[AAD-6] Add CPU profile to testbench

### DIFF
--- a/internal/qbranch/anomalydetection-testbench/README.md
+++ b/internal/qbranch/anomalydetection-testbench/README.md
@@ -73,6 +73,7 @@ $ dda inv anomalydetection.eval-component-workspace-report evals # This will fet
 | `--output` | _(empty)_ | Path for observer JSON output |
 | `--verbose` | `false` | Include full detail in JSON output (titles, member series, individual anomalies) |
 | `--memprofile` | _(empty)_ | Write a heap profile to this file after the run |
+| `--cpuprofile` | _(empty)_ | Write a CPU profile covering the scenario replay to this file |
 | `--retain-parquet` | `false` | Retain and sort all parquet rows in headless mode. Use for unordered local recordings; headless runs stream by default. |
 
 ## Components
@@ -128,13 +129,21 @@ Run a scenario without the HTTP server — load data, run the full detector→co
 # Via invoke (builds automatically with --build)
 dda inv -- anomalydetection.launch-testbench --headless-scenario <scenario-name>
 dda inv -- anomalydetection.launch-testbench --headless-scenario <scenario-name> --headless-output /tmp/out.json
-dda inv -- anomalydetection.launch-testbench --headless-scenario <scenario-name> --profile  # write heap profile
+dda inv -- anomalydetection.launch-testbench --headless-scenario <scenario-name> --mem-profile  # write heap profile
+dda inv -- anomalydetection.launch-testbench --headless-scenario <scenario-name> --cpu-profile  # write CPU profile
 
 # Direct binary
 ./bin/anomalydetection-testbench \
   --headless <scenario-name> \
   --output results.json \
   --scenarios-dir ./comp/anomalydetection/observer/scenarios
+
+# Capture a CPU profile for the scenario replay
+./bin/anomalydetection-testbench \
+  --headless <scenario-name> \
+  --cpuprofile /tmp/observer.cpu.pprof \
+  --scenarios-dir ./comp/anomalydetection/observer/scenarios
+go tool pprof /tmp/observer.cpu.pprof
 
 # Same, but only ingest logs from parquet (ignore metrics and trace stats)
 ./bin/anomalydetection-testbench \

--- a/internal/qbranch/anomalydetection-testbench/main.go
+++ b/internal/qbranch/anomalydetection-testbench/main.go
@@ -260,6 +260,7 @@ func run(
 
 	// Headless mode: run scenario, write output, exit (no HTTP server)
 	if params.Headless != "" {
+		var stopCPUProfile func()
 		if params.CPUProfile != "" {
 			f, err := os.Create(params.CPUProfile)
 			if err != nil {
@@ -269,14 +270,23 @@ func run(
 				_ = f.Close()
 				return fmt.Errorf("could not start CPU profile: %w", err)
 			}
-			defer func() {
+			stopCPUProfile = func() {
 				pprof.StopCPUProfile()
 				_ = f.Close()
 				fmt.Printf("CPU profile written to %s\n", params.CPUProfile)
+			}
+			defer func() {
+				if stopCPUProfile != nil {
+					stopCPUProfile()
+				}
 			}()
 		}
 		if err := tb.RunHeadless(params.Headless, params.Output, params.Verbose); err != nil {
 			return err
+		}
+		if stopCPUProfile != nil {
+			stopCPUProfile()
+			stopCPUProfile = nil
 		}
 		if params.MemProfile != "" {
 			f, err := os.Create(params.MemProfile)

--- a/internal/qbranch/anomalydetection-testbench/main.go
+++ b/internal/qbranch/anomalydetection-testbench/main.go
@@ -48,6 +48,7 @@ type CLIParams struct {
 	Output     string // path for observer JSON output
 	Verbose    bool   // include full detail in JSON output (headless mode only)
 	MemProfile string // path to write heap profile after headless run (empty = disabled)
+	CPUProfile string // path to write CPU profile during headless run (empty = disabled)
 
 	// SendAnomalyEvent mode: run scenario and send one Datadog event per correlation
 	SendAnomalyEvent string // scenario name to run (empty = disabled)
@@ -75,6 +76,7 @@ func main() {
 	output := flag.String("output", "", "Path for eval JSON output (headless mode only)")
 	verbose := flag.Bool("verbose", false, "Include full detail in JSON output (headless mode only)")
 	memProfile := flag.String("memprofile", "", "Write heap profile to this file after headless run (headless mode only)")
+	cpuProfile := flag.String("cpuprofile", "", "Write CPU profile during headless run (headless mode only)")
 	sendAnomalyEvent := flag.String("send-anomaly-event", "", "Run scenario and send one Datadog event per correlation, then exit")
 	skipDropped := flag.Bool("skip-dropped", true, "Skip metrics marked as dropped by the live observer's channel during parquet load")
 	logsOnly := flag.Bool("logs-only", false, "Load only log rows from scenarios; skip parquet metrics and trace stats (interactive and headless)")
@@ -205,6 +207,7 @@ func main() {
 			Output:             *output,
 			Verbose:            *verbose,
 			MemProfile:         *memProfile,
+			CPUProfile:         *cpuProfile,
 			SendAnomalyEvent:   *sendAnomalyEvent,
 			SkipDroppedMetrics: *skipDropped,
 			LogsOnly:           *logsOnly,
@@ -257,6 +260,21 @@ func run(
 
 	// Headless mode: run scenario, write output, exit (no HTTP server)
 	if params.Headless != "" {
+		if params.CPUProfile != "" {
+			f, err := os.Create(params.CPUProfile)
+			if err != nil {
+				return fmt.Errorf("could not create CPU profile: %w", err)
+			}
+			if err := pprof.StartCPUProfile(f); err != nil {
+				_ = f.Close()
+				return fmt.Errorf("could not start CPU profile: %w", err)
+			}
+			defer func() {
+				pprof.StopCPUProfile()
+				_ = f.Close()
+				fmt.Printf("CPU profile written to %s\n", params.CPUProfile)
+			}()
+		}
 		if err := tb.RunHeadless(params.Headless, params.Output, params.Verbose); err != nil {
 			return err
 		}

--- a/tasks/anomalydetection.py
+++ b/tasks/anomalydetection.py
@@ -95,10 +95,12 @@ def launch_testbench(
     build: bool = False,
     headless_scenario: str = "",
     headless_output: str = "",
-    profile: bool = False,
+    mem_profile: bool = False,
+    cpu_profile: bool = False,
     open_pprof: bool = False,
     verbose: bool = False,
-    profile_path: str = "",
+    mem_profile_path: str = "",
+    cpu_profile_path: str = "",
     config: str = "",
     enable: str = "",
     disable: str = "",
@@ -112,10 +114,12 @@ def launch_testbench(
     Args:
         scenarios_dir: Directory containing the scenarios to load.
         build: Whether to build the binary before launching.
-        profile: Whether to capture a heap profile (headless mode only).
-        open_pprof: Open pprof UI after headless run (requires --profile).
+        mem_profile: Whether to capture a heap profile (headless mode only).
+        cpu_profile: Whether to capture a CPU profile (headless mode only).
+        open_pprof: Open pprof UI after headless run (requires exactly one profile type).
         verbose: Pass --verbose to the testbench.
-        profile_path: Override the default heap-profile output path.
+        mem_profile_path: Override the default heap-profile output path.
+        cpu_profile_path: Override the default CPU-profile output path.
         config: JSON params file; overrides --enable/--disable when set.
         enable: Comma-separated components to enable (passed as --enable).
         disable: Comma-separated components to disable (passed as --disable).
@@ -126,6 +130,11 @@ def launch_testbench(
     if build:
         print("Building anomalydetection-testbench...")
         build_testbench(ctx)
+
+    if open_pprof and not (mem_profile or cpu_profile):
+        raise Exit("--open-pprof requires --mem-profile or --cpu-profile")
+    if open_pprof and mem_profile and cpu_profile:
+        raise Exit("--open-pprof supports one profile type at a time; choose --mem-profile or --cpu-profile")
 
     flags = ""
     if verbose:
@@ -145,10 +154,14 @@ def launch_testbench(
     if headless_scenario:
         if not headless_output:
             headless_output = f"/tmp/anomalydetection-testbench-headless-{headless_scenario}.json"
-        if profile:
-            if not profile_path:
-                profile_path = f"/tmp/anomalydetection-testbench-headless-{headless_scenario}.prof"
-            flags += f" --memprofile {profile_path}"
+        if mem_profile:
+            if not mem_profile_path:
+                mem_profile_path = f"/tmp/anomalydetection-testbench-headless-{headless_scenario}.mem.prof"
+            flags += f" --memprofile {shlex.quote(mem_profile_path)}"
+        if cpu_profile:
+            if not cpu_profile_path:
+                cpu_profile_path = f"/tmp/anomalydetection-testbench-headless-{headless_scenario}.cpu.prof"
+            flags += f" --cpuprofile {shlex.quote(cpu_profile_path)}"
         print(
             f"Launching anomalydetection-testbench in headless mode for scenario {headless_scenario}, output to {headless_output}"
         )
@@ -162,12 +175,13 @@ def launch_testbench(
                 print(color_message(f"testbench timed out after {timeout}s", Color.ORANGE))
             else:
                 raise
-        if profile:
+        selected_profile_path = mem_profile_path if mem_profile else cpu_profile_path
+        if selected_profile_path:
             if open_pprof:
                 print("Running pprof...")
-                ctx.run(f"go tool pprof -http=:8081 {profile_path}")
+                ctx.run(f"go tool pprof -http=:8081 {shlex.quote(selected_profile_path)}")
             else:
-                print(f"To profile, run: go tool pprof -http=:8081 {profile_path}")
+                print(f"To profile, run: go tool pprof -http=:8081 {selected_profile_path}")
     else:
         if not config and not enable and not disable:
             flags += " --only scanmw,scanwelch,bocpd"


### PR DESCRIPTION
### What does this PR do?

This adds a cpu profile option that is useful to make quick benchmarks around our scenarios.

### Motivation

### Describe how you validated your changes

### Additional Notes

It also renames `profile` -> `mem_profile`.