### PR TITLE
ci(ddot): make otel apt mirror resilient to slow mirrors

### DIFF
--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -19,12 +19,23 @@ WORKDIR /workspace
 # It seems that this feature could use some improvement. If you just get mirrorlist
 # from mirrors.ubuntu.com/mirrors.txt, it might contain faulty mirrors that either
 # cause `apt update` to fail with exit code 100 or make it hang on `0% [Working]`
-# indefinitely. Therefore we create a mirrorlist with the 2 mirrors that we know
-# should be reliable enough in combination and also well maintained.
+# indefinitely. Therefore we create a mirrorlist with a handful of mirrors that we
+# know to be reliable and well maintained, and let apt load-balance and fail over
+# across them.
+#
+# We list the mirrors as peers (no `priority:1` pin): with `mirror+file`, apt spreads
+# requests across all peer entries and moves off a mirror that errors. Pinning one
+# mirror with `priority:1` sends *all* traffic there and only falls back when that
+# mirror is fully unreachable — which does NOT help when the primary is merely slow
+# (the failure mode behind the docker_image_build_otel timeouts). The Acquire timeout
+# and retry config below bounds each request so a slow mirror is abandoned in seconds
+# instead of stalling the whole build. This mirrors the pattern in
+# test/new-e2e/tests/installer/host/host.go (ConfigureAptMirrors).
 ARG CI
 RUN if [ "$CI" = "true" ]; then \
-  echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu" > /etc/apt/mirrorlist.main && \
-  echo "http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports" > /etc/apt/mirrorlist.ports && \
+  printf 'Acquire::Retries "3";\nAcquire::http::Timeout "15";\nAcquire::https::Timeout "15";\n' > /etc/apt/apt.conf.d/99datadog-mirror-resilience && \
+  printf 'http://us-east-1.ec2.archive.ubuntu.com/ubuntu\nhttp://us-west-2.ec2.archive.ubuntu.com/ubuntu\nhttp://archive.ubuntu.com/ubuntu\nhttp://mirror.leaseweb.net/ubuntu\n' > /etc/apt/mirrorlist.main && \
+  printf 'http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\nhttp://us-west-2.ec2.ports.ubuntu.com/ubuntu-ports\nhttp://ports.ubuntu.com/ubuntu-ports\n' > /etc/apt/mirrorlist.ports && \
   for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
     if [ -f "$f" ]; then \
       sed -i -e 's#http://archive.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \

--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -15,32 +15,26 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Set the working directory
 WORKDIR /workspace
 
-# NOTE about APT mirrorlists:
-# It seems that this feature could use some improvement. If you just get mirrorlist
-# from mirrors.ubuntu.com/mirrors.txt, it might contain faulty mirrors that either
-# cause `apt update` to fail with exit code 100 or make it hang on `0% [Working]`
-# indefinitely. Therefore we create a mirrorlist with a handful of mirrors that we
-# know to be reliable and well maintained, and let apt load-balance and fail over
-# across them.
-#
-# We list the mirrors as peers (no `priority:1` pin): with `mirror+file`, apt spreads
-# requests across all peer entries and moves off a mirror that errors. Pinning one
-# mirror with `priority:1` sends *all* traffic there and only falls back when that
-# mirror is fully unreachable — which does NOT help when the primary is merely slow
-# (the failure mode behind the docker_image_build_otel timeouts). The Acquire timeout
-# and retry config below bounds each request so a slow mirror is abandoned in seconds
-# instead of stalling the whole build. This mirrors the pattern in
+# APT mirror resilience in CI:
+# Ubuntu EC2 AMIs point apt at a single regional mirror (us-east-1) with no real
+# failover. When that mirror is slow-but-reachable, apt would stall until the CI
+# job timeout: the `mirror` method only falls back on a fully-unreachable mirror,
+# and Acquire::Retries retries the SAME URI (this is what still timed out the
+# docker_image_build_otel job). Instead we rewrite the deb822 URIs: fields to an
+# ordered multi-URI list so apt fails over to the next mirror on error, and set a
+# short timeout + Retries 1 so a slow mirror becomes a fast error (triggering that
+# failover). us-east-1 is dropped as the chronically-slow mirror. Related:
 # test/new-e2e/tests/installer/host/host.go (ConfigureAptMirrors).
 ARG CI
 RUN if [ "$CI" = "true" ]; then \
-  printf 'Acquire::Retries "3";\nAcquire::http::Timeout "15";\nAcquire::https::Timeout "15";\n' > /etc/apt/apt.conf.d/99datadog-mirror-resilience && \
-  printf 'http://us-east-1.ec2.archive.ubuntu.com/ubuntu\nhttp://us-west-2.ec2.archive.ubuntu.com/ubuntu\nhttp://archive.ubuntu.com/ubuntu\nhttp://mirror.leaseweb.net/ubuntu\n' > /etc/apt/mirrorlist.main && \
-  printf 'http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\nhttp://us-west-2.ec2.ports.ubuntu.com/ubuntu-ports\nhttp://ports.ubuntu.com/ubuntu-ports\n' > /etc/apt/mirrorlist.ports && \
-  for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
+  printf 'Acquire::Retries "1";\nAcquire::http::Timeout "10";\nAcquire::https::Timeout "10";\n' > /etc/apt/apt.conf.d/99datadog-mirror-resilience && \
+  for f in /etc/apt/sources.list.d/ubuntu.sources; do \
     if [ -f "$f" ]; then \
-      sed -i -e 's#http://archive.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
-             -e 's#http://security.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
-             -e 's#http://ports.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' "$f"; \
+      sed -i -E \
+        -e 's#^(URIs:[[:space:]]+)https?://[a-z0-9.-]*archive\.ubuntu\.com/ubuntu/?[[:space:]]*$#\1http://us-west-2.ec2.archive.ubuntu.com/ubuntu http://archive.ubuntu.com/ubuntu http://mirror.leaseweb.net/ubuntu#' \
+        -e 's#^(URIs:[[:space:]]+)https?://security\.ubuntu\.com/ubuntu/?[[:space:]]*$#\1http://us-west-2.ec2.archive.ubuntu.com/ubuntu http://archive.ubuntu.com/ubuntu http://mirror.leaseweb.net/ubuntu#' \
+        -e 's#^(URIs:[[:space:]]+)https?://[a-z0-9.-]*ports\.ubuntu\.com/ubuntu-ports/?[[:space:]]*$#\1http://us-west-2.ec2.ports.ubuntu.com/ubuntu-ports http://ports.ubuntu.com/ubuntu-ports#' \
+        "$f"; \
     fi; \
   done; \
   fi


### PR DESCRIPTION
#incident-59451
### What does this PR do?

Makes the apt package-mirror config in `Dockerfiles/agent-ddot/Dockerfile.agent-otel` (used by `docker_image_build_otel`) resilient to *slow* mirrors, by giving apt real per-request failover:

- Rewrites the deb822 `URIs:` fields in `ubuntu.sources` to an ordered multi-URI list (`us-west-2`, `archive.ubuntu.com`, `mirror.leaseweb.net`) so apt fails over to the next mirror on error.
- Drops `us-east-1` (the chronically-slow mirror in the timeout logs).
- `Acquire::Retries "1"` + 10s timeout so a slow mirror becomes a fast error that triggers failover.

### Motivation

`docker_image_build_otel` intermittently timed out (~3% of runs, across many branches). The build spent its whole wall-clock in `apt-get install build-essential` against a congested `us-east-1` mirror.

A first attempt (mirror+file peer list + Acquire timeout) did **not** fix it: apt's `mirror` method sticks to one mirror per invocation and only fails over when it's fully unreachable, so a slow-but-reachable `us-east-1` kept timing out and `Acquire::Retries` retried the same URI to the job timeout. This PR switches to explicit ordered `URIs:` for genuine per-request failover.

### Describe how you validated your changes

- CI Visibility + job logs isolated mirror throughput as the only variable (successful same-commit runs finished in 16-21m).
- Validated the `sed` `URIs:` rewrite against the default noble `ubuntu.sources`.
- CI will exercise the real build here.

### Additional Notes

The same fix is applied to the other CI Dockerfiles in #55119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)