### PR TITLE
sbom: default runtime usage properties only on OS packages

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
@@ -54,6 +54,23 @@ func normalizeVersion(version string) (normalized string, hasEpoch bool) {
 	return version, false
 }
 
+// osPackagePurlPrefixes are the purl types of the packages the runtime scanner
+// observes. It reads the dpkg, rpm and apk databases, see
+// pkg/security/resolvers/sbom/collectorv2.NewOSScanner, and Trivy maps every OS
+// family onto one of these three types.
+var osPackagePurlPrefixes = []string{"pkg:deb/", "pkg:rpm/", "pkg:apk/"}
+
+// isOSPackage reports whether the component is an OS package, and so something
+// the runtime scanner could have seen running.
+func isOSPackage(comp *cyclonedx_v1_4.Component) bool {
+	for _, prefix := range osPackagePurlPrefixes {
+		if strings.HasPrefix(comp.GetPurl(), prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 type client struct {
 	cl sbompb.SBOMCollectorClient
 }
@@ -198,9 +215,11 @@ func workloadmetaEventFromSBOMEventSet(store workloadmeta.Component, event *sbom
 // mergeRuntimeProperties merges runtime properties from newBom into existingBom.
 // Returns a new BOM whose component list is deduplicated (by name+normalised version) and
 // enriched with runtime properties (LastSeenRunning / HasSetSuidBit / RunningAsRoot) taken
-// from newBom.  Deduplication is necessary because a previously-merged SBOM stored in the
-// image entity may already carry both an original Trivy entry and a runtime-enriched copy of
-// the same package; without it every merge round would re-emit both copies.
+// from newBom.  The properties are defaulted on the OS packages, the ones in the
+// scanner's scope, so that their absence elsewhere reads as "out of scope".
+// Deduplication is necessary because a previously-merged SBOM stored in the image entity
+// may already carry both an original Trivy entry and a runtime-enriched copy of the same
+// package, and every merge round would otherwise re-emit both copies.
 func mergeRuntimeProperties(existingBom, newBom *cyclonedx_v1_4.Bom) *cyclonedx_v1_4.Bom {
 	if newBom == nil || len(newBom.Components) == 0 {
 		return existingBom
@@ -277,7 +296,8 @@ func mergeRuntimeProperties(existingBom, newBom *cyclonedx_v1_4.Bom) *cyclonedx_
 		}
 
 		// Add or update runtime properties from newBom.
-		if newComp, exists := newComponentsMap[key]; exists && newComp.Properties != nil {
+		newComp, reported := newComponentsMap[key]
+		if reported && newComp.Properties != nil {
 			updateProperty := func(propertyName string) {
 				var newProp *cyclonedx_v1_4.Property
 				for _, prop := range newComp.Properties {
@@ -308,12 +328,14 @@ func mergeRuntimeProperties(existingBom, newBom *cyclonedx_v1_4.Bom) *cyclonedx_
 			updateProperty(RunningAsRootProperty)
 		}
 
-		// Default any runtime property absent from the merged component so consumers
-		// can distinguish "not in use" from "unknown": a package never seen running
-		// is LastSeenRunning "0", not setuid, and not running as root.
-		ensureProperty(mergedComp, LastAccessProperty, "0")
-		ensureProperty(mergedComp, HasSetSuidBitProperty, "false")
-		ensureProperty(mergedComp, RunningAsRootProperty, "false")
+		// Default the runtime properties on what the scanner covers: the OS
+		// packages, and whatever the report carried. Elsewhere the absence of a
+		// property marks the component out of the scanner's scope.
+		if reported || isOSPackage(mergedComp) {
+			ensureProperty(mergedComp, LastAccessProperty, "0")
+			ensureProperty(mergedComp, HasSetSuidBitProperty, "false")
+			ensureProperty(mergedComp, RunningAsRootProperty, "false")
+		}
 
 		mergedBom.Components = append(mergedBom.Components, mergedComp)
 	}

--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector_test.go
@@ -225,7 +225,13 @@ func TestMergeRuntimeProperties_EpochNormalization(t *testing.T) {
 func TestMergeRuntimeProperties_DefaultsLastSeenRunningToZero(t *testing.T) {
 	existing := &cyclonedx_v1_4.Bom{
 		Components: []*cyclonedx_v1_4.Component{
-			component("bash", "5.1"),
+			{
+				Name:    "bash",
+				Version: "5.1",
+				// An OS package: in the runtime scanner's scope, so the runtime
+				// properties are defaulted even without a match in newBom.
+				Purl: pointer.Ptr("pkg:deb/debian/bash@5.1?arch=amd64"),
+			},
 		},
 	}
 	// No match in newBom.
@@ -247,6 +253,105 @@ func TestMergeRuntimeProperties_DefaultsLastSeenRunningToZero(t *testing.T) {
 
 	// HasSetSuidBit / RunningAsRoot are defaulted to "false" too, so consumers can
 	// distinguish "not in use" from "unknown".
+	v, ok = findProp(c, HasSetSuidBitProperty)
+	assert.True(t, ok)
+	assert.Equal(t, "false", v)
+	v, ok = findProp(c, RunningAsRootProperty)
+	assert.True(t, ok)
+	assert.Equal(t, "false", v)
+}
+
+func TestMergeRuntimeProperties_LeavesOutOfScopeComponentsUnset(t *testing.T) {
+	// The runtime scanner reads the dpkg, rpm and apk databases, so these
+	// components stay out of its scope and keep the properties absent.
+	tests := []struct {
+		name      string
+		component *cyclonedx_v1_4.Component
+	}{
+		{
+			name: "language library",
+			component: &cyclonedx_v1_4.Component{
+				Type:    cyclonedx_v1_4.Classification_CLASSIFICATION_LIBRARY,
+				Name:    "lodash",
+				Version: "4.17.21",
+				Purl:    pointer.Ptr("pkg:npm/lodash@4.17.21"),
+			},
+		},
+		{
+			name: "operating system",
+			component: &cyclonedx_v1_4.Component{
+				Type:    cyclonedx_v1_4.Classification_CLASSIFICATION_OPERATING_SYSTEM,
+				Name:    "debian",
+				Version: "12.5",
+			},
+		},
+		{
+			name: "lockfile application",
+			component: &cyclonedx_v1_4.Component{
+				Type: cyclonedx_v1_4.Classification_CLASSIFICATION_APPLICATION,
+				Name: "app/Gemfile.lock",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// An OS package alongside it, which the merge must still default.
+			osPackage := &cyclonedx_v1_4.Component{
+				Name:    "bash",
+				Version: "5.1",
+				Purl:    pointer.Ptr("pkg:deb/debian/bash@5.1?arch=amd64"),
+			}
+			existing := &cyclonedx_v1_4.Bom{
+				Components: []*cyclonedx_v1_4.Component{test.component, osPackage},
+			}
+			newBom := &cyclonedx_v1_4.Bom{
+				Components: []*cyclonedx_v1_4.Component{
+					component("zsh", "5.9", prop(LastAccessProperty, "1700000000")),
+				},
+			}
+
+			merged := mergeRuntimeProperties(existing, newBom)
+
+			// The merge rebuilds the component list in order.
+			require.Len(t, merged.Components, 2)
+			require.Equal(t, test.component.Name, merged.Components[0].Name)
+			require.Equal(t, osPackage.Name, merged.Components[1].Name)
+
+			for _, name := range []string{LastAccessProperty, HasSetSuidBitProperty, RunningAsRootProperty} {
+				_, ok := findProp(merged.Components[0], name)
+				assert.Falsef(t, ok, "%s must stay absent on an out-of-scope component", name)
+			}
+
+			v, ok := findProp(merged.Components[1], LastAccessProperty)
+			assert.True(t, ok, "the OS package in the same BOM must still be defaulted")
+			assert.Equal(t, "0", v)
+		})
+	}
+}
+
+func TestMergeRuntimeProperties_DefaultsReportedComponentWithPartialProperties(t *testing.T) {
+	// The report puts a component in scope whatever its purl says, so the
+	// properties it left out are defaulted too.
+	existing := &cyclonedx_v1_4.Bom{
+		Components: []*cyclonedx_v1_4.Component{
+			component("openssl", "1.1.1k"),
+		},
+	}
+	newBom := &cyclonedx_v1_4.Bom{
+		Components: []*cyclonedx_v1_4.Component{
+			component("openssl", "1.1.1k", prop(LastAccessProperty, "1700000000")),
+		},
+	}
+
+	merged := mergeRuntimeProperties(existing, newBom)
+
+	require.Len(t, merged.Components, 1)
+	c := merged.Components[0]
+
+	v, ok := findProp(c, LastAccessProperty)
+	assert.True(t, ok)
+	assert.Equal(t, "1700000000", v)
 	v, ok = findProp(c, HasSetSuidBitProperty)
 	assert.True(t, ok)
 	assert.Equal(t, "false", v)

--- a/releasenotes/notes/sbom-runtime-props-os-packages-only-8c3d1f7b45a29e60.yaml
+++ b/releasenotes/notes/sbom-runtime-props-os-packages-only-8c3d1f7b45a29e60.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    The runtime usage properties merged onto container image SBOMs
+    (``LastSeenRunning``, ``HasSetSuidBit`` and ``RunningAsRoot``) are now set on
+    OS packages alone. The runtime scanner reads the dpkg, rpm and apk databases,
+    so language packages (npm, pypi, golang and others), the image's
+    operating-system component and the per-lockfile application components stay
+    out of its scope. The absence of a property marks a component out of scope,
+    where a ``LastSeenRunning`` of ``0`` states that the package was watched and
+    found idle.

--- a/test/new-e2e/tests/sbom/packageinuse_test.go
+++ b/test/new-e2e/tests/sbom/packageinuse_test.go
@@ -234,13 +234,18 @@ func (s *packageInUseSuite) Test00UpAndRunning() {
 }
 
 // TestPackageInUse drives the full not-in-use -> in-use -> stale -> security ->
-// refresh cycle for each workload (rpm, dpkg, apk) as a nested subtest.
+// refresh cycle for each workload (rpm, dpkg, apk) as a nested subtest, then
+// checks the scope of the enrichment across every enriched image.
 func (s *packageInUseSuite) TestPackageInUse() {
 	for _, d := range pkgInUseDistros {
 		s.Run(d.name, func() {
 			s.runPackageInUse(d)
 		})
 	}
+
+	s.Run("out-of-scope-components", func() {
+		s.runOutOfScopeComponents()
+	})
 }
 
 func (s *packageInUseSuite) runPackageInUse(d pkgInUseDistro) {
@@ -368,6 +373,94 @@ func (s *packageInUseSuite) runPackageInUse(d pkgInUseDistro) {
 			assert.Equalf(c, "0", v, "%s LastSeenRunning should reset to 0 after a package-DB refresh, got %q", d.inUsePkg, v)
 		}, 6*time.Minute, 20*time.Second, "%s SBOM never reset %s to 0 after the package-DB refresh", d.name, d.inUsePkg)
 	})
+}
+
+// runOutOfScopeComponents asserts the runtime properties reach the OS packages
+// alone. The resolver reads the dpkg, rpm and apk databases, so the image's
+// operating-system component and the application packages stay out of its scope,
+// and the absence of a property marks them so.
+//
+// Every image SBOM holds one operating-system component, so every enriched image
+// exercises this. The phase stands alone, which suits the leaf-test retry loop in
+// tasks/new_e2e_tests.py: it reads whatever enriched payloads the fake intake
+// holds, and the Agent's own containers and the control plane keep it supplied.
+func (s *packageInUseSuite) runOutOfScopeComponents() {
+	s.EventuallyWithTf(func(collect *assert.CollectT) {
+		c := &myCollectT{CollectT: collect, errors: []error{}}
+		collect = nil //nolint:ineffassign
+
+		images := s.enrichedImages(c)
+		require.NotEmptyf(c, images, "no runtime-enriched container SBOM in fake intake")
+
+		for _, img := range images {
+			apps := applicationComponents(img.components)
+			s.T().Logf("PKG-IN-USE[scope] id=%q components=%d application=%d", img.id, len(img.components), len(apps))
+
+			if osComp := findOSComponent(img.components); osComp != nil {
+				assertNoRuntimeProperties(c, img.id, osComp)
+			}
+			for _, comp := range apps {
+				assertNoRuntimeProperties(c, img.id, comp)
+			}
+		}
+		// 15m: run on its own, the phase waits out the first enrichment, which
+		// lands ~10-15m in, once the overlayfs Trivy SBOMs reach workloadmeta.
+	}, 15*time.Minute, 15*time.Second, "runtime properties kept landing on components the resolver cannot observe")
+}
+
+func assertNoRuntimeProperties(c *myCollectT, id string, comp *cyclonedx_v1_4.Component) {
+	for _, name := range []string{propLastSeenRunning, propHasSetSuidBit, propRunningAsRoot} {
+		assert.Emptyf(c, propertyValues(comp.GetProperties(), name),
+			"%s %q carries %s in %s, but the resolver cannot observe it", comp.GetType(), comp.GetName(), name, id)
+	}
+}
+
+// enrichedImage holds the components of one image's newest enriched payload.
+type enrichedImage struct {
+	id         string
+	components []*cyclonedx_v1_4.Component
+}
+
+// enrichedImages returns, for every container image in the fake intake, the
+// components of its newest payload carrying a LastSeenRunning property. That
+// property marks the payloads the enrichment merge has been through, which are
+// the ones worth asserting on.
+func (s *packageInUseSuite) enrichedImages(c *myCollectT) []enrichedImage {
+	ids, err := s.Fakeintake.GetSBOMIDs()
+	require.NoErrorf(c, err, "Failed to query fake intake")
+
+	var images []enrichedImage
+	for _, id := range ids {
+		payloads, err := s.Fakeintake.FilterSBOMs(id)
+		if err != nil {
+			continue
+		}
+
+		var newest time.Time
+		var components []*cyclonedx_v1_4.Component
+		for _, p := range payloads {
+			if p.GetType() != sbom.SBOMSourceType_CONTAINER_IMAGE_LAYERS || p.Status != sbom.SBOMStatus_SUCCESS || p.GetCyclonedx() == nil {
+				continue
+			}
+			if p.GetCollectedTime().Before(newest) {
+				continue
+			}
+			comps := p.GetCyclonedx().Components
+			if !lo.SomeBy(comps, func(comp *cyclonedx_v1_4.Component) bool {
+				_, enriched := lastSeenRunning(comp)
+				return enriched
+			}) {
+				continue
+			}
+			newest = p.GetCollectedTime()
+			components = comps
+		}
+
+		if len(components) > 0 {
+			images = append(images, enrichedImage{id: id, components: components})
+		}
+	}
+	return images
 }
 
 // packageUsage returns, across every successful container-image SBOM payload for


### PR DESCRIPTION
The enrichment merge copies the runtime usage properties onto the
components the system-probe report covers, then defaults LastSeenRunning
to "0" and HasSetSuidBit and RunningAsRoot to "false" on every other
component of the image SBOM. The runtime scanner reads the dpkg, rpm and
apk databases, so a "0" on a language package, on the image's
operating-system component or on one of Trivy's per-lockfile application
components claims the Agent watched a package outside its scope.

Default the three properties on the components the report carried and on
those whose purl marks them an OS package. The rest keep them absent,
which a consumer reads as out of scope. Trivy maps every OS family onto
the deb, rpm and apk purl types, so the prefix decides, and the SBOM e2e
tests already use the same three.

