### PR TITLE
sbom: key the runtime enrichment dedup on bom-ref

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector.go
@@ -214,13 +214,13 @@ func workloadmetaEventFromSBOMEventSet(store workloadmeta.Component, event *sbom
 }
 
 // mergeRuntimeProperties merges runtime properties from newBom into existingBom.
-// Returns a new BOM whose component list is deduplicated (by name+normalised version) and
-// enriched with runtime properties (LastSeenRunning / HasSetSuidBit / RunningAsRoot) taken
-// from newBom.  The properties are defaulted on the OS packages, the ones in the
-// scanner's scope, so that their absence elsewhere reads as "out of scope".
-// Deduplication is necessary because a previously-merged SBOM stored in the image entity
-// may already carry both an original Trivy entry and a runtime-enriched copy of the same
-// package, and every merge round would otherwise re-emit both copies.
+// Returns a new BOM whose component list is deduplicated (by bom-ref) and enriched with
+// runtime properties (LastSeenRunning / HasSetSuidBit / RunningAsRoot) taken from newBom.
+// The properties are defaulted on the OS packages, the ones in the scanner's scope, so
+// that their absence elsewhere reads as "out of scope".  Deduplication guards against a
+// stored image SBOM carrying the same component twice, and the bom-ref is what identifies
+// a component: Trivy reports one entry per install location, so one library version
+// legitimately appears once per lockfile that pins it.
 func mergeRuntimeProperties(existingBom, newBom *cyclonedx_v1_4.Bom) *cyclonedx_v1_4.Bom {
 	if newBom == nil || len(newBom.Components) == 0 {
 		return existingBom
@@ -250,8 +250,9 @@ func mergeRuntimeProperties(existingBom, newBom *cyclonedx_v1_4.Bom) *cyclonedx_
 		Vulnerabilities:    existingBom.Vulnerabilities,
 	}
 
-	// seen tracks which name@version keys have already been emitted so that duplicate
-	// entries for the same package (which can accumulate across merge rounds) are dropped.
+	// seen tracks the bom-refs already emitted, so a component appearing twice is
+	// emitted once. Deduplication applies to the components that carry a bom-ref,
+	// and the others are emitted in turn.
 	seen := make(map[string]struct{}, len(existingBom.Components))
 
 	for _, existingComp := range existingBom.Components {
@@ -259,14 +260,15 @@ func mergeRuntimeProperties(existingBom, newBom *cyclonedx_v1_4.Bom) *cyclonedx_
 			continue
 		}
 
+		if ref := existingComp.GetBomRef(); ref != "" {
+			if _, already := seen[ref]; already {
+				continue
+			}
+			seen[ref] = struct{}{}
+		}
+
 		normalizedVersion, _ := normalizeVersion(existingComp.Version)
 		key := existingComp.Name + "@" + normalizedVersion
-
-		// Emit only the first occurrence of each package.
-		if _, already := seen[key]; already {
-			continue
-		}
-		seen[key] = struct{}{}
 
 		// Copy all fields so we do not mutate the original BOM. The property
 		// slice is cloned because updateProperty replaces entries in place.

--- a/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/sbomcollector/sbom_collector_test.go
@@ -360,13 +360,22 @@ func TestMergeRuntimeProperties_DefaultsReportedComponentWithPartialProperties(t
 	assert.Equal(t, "false", v)
 }
 
-func TestMergeRuntimeProperties_DeduplicatesAcrossRounds(t *testing.T) {
-	// Simulates an already-merged image SBOM that carries both the raw Trivy
-	// entry and a previously-runtime-enriched copy of the same package.
+func TestMergeRuntimeProperties_CollapsesDuplicateBomRefs(t *testing.T) {
+	// A stored image SBOM carrying the same component twice: one bom-ref is one
+	// component, so the first occurrence stands for both.
 	existing := &cyclonedx_v1_4.Bom{
 		Components: []*cyclonedx_v1_4.Component{
-			component("openssl", "1:1.1.1k"),
-			component("openssl", "1.1.1k", prop(LastAccessProperty, "100")),
+			{
+				BomRef:  pointer.Ptr("1"),
+				Name:    "openssl",
+				Version: "1:1.1.1k",
+			},
+			{
+				BomRef:     pointer.Ptr("1"),
+				Name:       "openssl",
+				Version:    "1:1.1.1k",
+				Properties: []*cyclonedx_v1_4.Property{prop(LastAccessProperty, "100")},
+			},
 		},
 	}
 	newBom := &cyclonedx_v1_4.Bom{
@@ -377,16 +386,80 @@ func TestMergeRuntimeProperties_DeduplicatesAcrossRounds(t *testing.T) {
 
 	merged := mergeRuntimeProperties(existing, newBom)
 
-	require.Len(t, merged.Components, 1, "duplicates by name+normalised version must be collapsed")
+	require.Len(t, merged.Components, 1, "components sharing a bom-ref must be collapsed")
 	c := merged.Components[0]
-
-	// First occurrence wins, so the version retains the epoch form.
 	assert.Equal(t, "1:1.1.1k", c.Version)
 
-	// Runtime property is still updated from newBom.
+	// Runtime property is still updated from newBom, across the epoch difference.
 	v, ok := findProp(c, LastAccessProperty)
 	assert.True(t, ok)
 	assert.Equal(t, "200", v)
+}
+
+func TestMergeRuntimeProperties_KeepsDistinctComponentsSharingNameAndVersion(t *testing.T) {
+	// Trivy reports one entry per install location, so a library version pinned by
+	// two lockfiles appears twice with distinct bom-refs. Both are real components
+	// that the dependency graph references, so both must survive.
+	existing := &cyclonedx_v1_4.Bom{
+		Components: []*cyclonedx_v1_4.Component{
+			{
+				BomRef:  pointer.Ptr("5"),
+				Name:    "actionpack",
+				Version: "7.0.0",
+				Purl:    pointer.Ptr("pkg:gem/actionpack@7.0.0"),
+			},
+			{
+				BomRef:  pointer.Ptr("8"),
+				Name:    "actionpack",
+				Version: "7.0.0",
+				Purl:    pointer.Ptr("pkg:gem/actionpack@7.0.0"),
+			},
+		},
+		Dependencies: []*cyclonedx_v1_4.Dependency{{Ref: "8"}},
+	}
+	newBom := &cyclonedx_v1_4.Bom{
+		Components: []*cyclonedx_v1_4.Component{
+			component("actionpack", "7.0.0", prop(LastAccessProperty, "1700000000")),
+		},
+	}
+
+	merged := mergeRuntimeProperties(existing, newBom)
+
+	require.Len(t, merged.Components, 2, "distinct components sharing a name and version must both survive")
+	refs := make(map[string]struct{}, len(merged.Components))
+	for _, c := range merged.Components {
+		refs[c.GetBomRef()] = struct{}{}
+
+		// Both take the runtime update: the report matches them by name and version.
+		v, ok := findProp(c, LastAccessProperty)
+		assert.True(t, ok)
+		assert.Equal(t, "1700000000", v)
+	}
+
+	// Every dependency reference still resolves to a component of the merged BOM.
+	for _, dep := range merged.Dependencies {
+		assert.Containsf(t, refs, dep.Ref, "dependency ref %q no longer resolves to a component", dep.Ref)
+	}
+}
+
+func TestMergeRuntimeProperties_KeepsComponentsWithoutBomRef(t *testing.T) {
+	// The bom-ref is what identifies a component, so deduplication applies to the
+	// components that carry one and the others are emitted in turn.
+	existing := &cyclonedx_v1_4.Bom{
+		Components: []*cyclonedx_v1_4.Component{
+			component("openssl", "1.1.1k"),
+			component("openssl", "1.1.1k"),
+		},
+	}
+	newBom := &cyclonedx_v1_4.Bom{
+		Components: []*cyclonedx_v1_4.Component{
+			component("openssl", "1.1.1k", prop(LastAccessProperty, "1700000000")),
+		},
+	}
+
+	merged := mergeRuntimeProperties(existing, newBom)
+
+	require.Len(t, merged.Components, 2)
 }
 
 func TestMergeRuntimeProperties_NilSafeInputs(t *testing.T) {

--- a/releasenotes/notes/sbom-enrichment-dedup-bom-ref-2b7e419c6d3af058.yaml
+++ b/releasenotes/notes/sbom-enrichment-dedup-bom-ref-2b7e419c6d3af058.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Runtime usage enrichment keeps container image SBOM components that share a
+    name and a version. Trivy reports one component per install location, so a
+    library version pinned by two lockfiles appears twice, and the merge kept only
+    the first, leaving the dependency graph referencing a component the payload
+    had lost. Components are deduplicated by their CycloneDX bom-ref, which is
+    what identifies one.

--- a/test/new-e2e/tests/sbom/packageinuse_test.go
+++ b/test/new-e2e/tests/sbom/packageinuse_test.go
@@ -235,7 +235,7 @@ func (s *packageInUseSuite) Test00UpAndRunning() {
 
 // TestPackageInUse drives the full not-in-use -> in-use -> stale -> security ->
 // refresh cycle for each workload (rpm, dpkg, apk) as a nested subtest, then
-// checks the scope of the enrichment across every enriched image.
+// checks the scope and the shape of the SBOMs the enrichment merges into.
 func (s *packageInUseSuite) TestPackageInUse() {
 	for _, d := range pkgInUseDistros {
 		s.Run(d.name, func() {
@@ -245,6 +245,9 @@ func (s *packageInUseSuite) TestPackageInUse() {
 
 	s.Run("out-of-scope-components", func() {
 		s.runOutOfScopeComponents()
+	})
+	s.Run("component-list-preserved", func() {
+		s.runComponentListPreserved()
 	})
 }
 
@@ -542,6 +545,129 @@ func (s *packageInUseSuite) packageProperty(repo, pkg, name string) string {
 		}
 	}
 	return value
+}
+
+// imagePayloads summarises, for one container image, what the fake intake holds:
+// the newest enriched payload, and the largest component count seen on a payload
+// the enrichment had yet to touch.
+type imagePayloads struct {
+	id           string
+	rootRef      string // bom-ref of the image itself, the root of the dependency graph
+	components   []*cyclonedx_v1_4.Component
+	dependencies []*cyclonedx_v1_4.Dependency
+	rawCount     int
+}
+
+// danglingRefs returns the dependency refs of the payload that resolve to no
+// component. The image itself roots the dependency graph and rides in the BOM
+// metadata, so its ref resolves too, as do those of nested components.
+func danglingRefs(img imagePayloads) []string {
+	refs := make(map[string]struct{}, len(img.components)+1)
+	if img.rootRef != "" {
+		refs[img.rootRef] = struct{}{}
+	}
+	collectBomRefs(refs, img.components)
+
+	var dangling []string
+	for _, dep := range img.dependencies {
+		if _, ok := refs[dep.GetRef()]; !ok {
+			dangling = append(dangling, dep.GetRef())
+		}
+	}
+	return dangling
+}
+
+func collectBomRefs(refs map[string]struct{}, comps []*cyclonedx_v1_4.Component) {
+	for _, comp := range comps {
+		refs[comp.GetBomRef()] = struct{}{}
+		collectBomRefs(refs, comp.GetComponents())
+	}
+}
+
+// runComponentListPreserved asserts the enrichment merge annotates the image SBOM
+// and leaves its shape alone. The merge rebuilds the component list every round,
+// so a component dropped there vanishes from the payload the backend sees while
+// the dependency graph, carried over as it stands, goes on referencing it.
+//
+// The phase stands alone, which suits the leaf-test retry loop in
+// tasks/new_e2e_tests.py: it reads whatever enriched payloads the fake intake
+// holds, and the Agent's own containers and the control plane keep it supplied
+// with the richest ones on the node.
+func (s *packageInUseSuite) runComponentListPreserved() {
+	s.EventuallyWithTf(func(collect *assert.CollectT) {
+		c := &myCollectT{CollectT: collect, errors: []error{}}
+		collect = nil //nolint:ineffassign
+
+		images := s.imagePayloads(c)
+		require.NotEmptyf(c, images, "no runtime-enriched container SBOM in fake intake")
+
+		for _, img := range images {
+			// Components sharing a name and version are what a merge keyed on those
+			// two collapses, so log how many groups this image holds: that says how
+			// much bite the assertions below have here.
+			groups := map[string]int{}
+			for _, comp := range img.components {
+				groups[comp.GetName()+"@"+comp.GetVersion()]++
+			}
+			repeated := lo.CountBy(lo.Values(groups), func(n int) bool { return n > 1 })
+			dangling := danglingRefs(img)
+			s.T().Logf("PKG-IN-USE[shape] id=%q components=%d raw=%d dependencies=%d repeated_name_version=%d dangling_refs=%d",
+				img.id, len(img.components), img.rawCount, len(img.dependencies), repeated, len(dangling))
+
+			assert.GreaterOrEqualf(c, len(img.components), img.rawCount,
+				"enriched %s has %d components, fewer than the %d of its un-enriched payload", img.id, len(img.components), img.rawCount)
+			assert.Emptyf(c, dangling,
+				"dependency refs of %s resolve to no component, the merge dropped them: %v", img.id, dangling)
+		}
+		// 15m: run on its own, the phase waits out the first enrichment, which
+		// lands ~10-15m in, once the overlayfs Trivy SBOMs reach workloadmeta.
+	}, 15*time.Minute, 15*time.Second, "the enrichment merge kept reshaping the component list")
+}
+
+// imagePayloads walks every container image payload in the fake intake and returns
+// one entry per image whose SBOM has been enriched. A LastSeenRunning property on
+// any component marks a payload the merge has been through, which leaves the raw
+// Trivy ones as the baseline to compare against.
+func (s *packageInUseSuite) imagePayloads(c *myCollectT) []imagePayloads {
+	ids, err := s.Fakeintake.GetSBOMIDs()
+	require.NoErrorf(c, err, "Failed to query fake intake")
+
+	var images []imagePayloads
+	for _, id := range ids {
+		payloads, err := s.Fakeintake.FilterSBOMs(id)
+		if err != nil {
+			continue
+		}
+
+		img := imagePayloads{id: id}
+		var newest time.Time
+		for _, p := range payloads {
+			if p.GetType() != sbom.SBOMSourceType_CONTAINER_IMAGE_LAYERS || p.Status != sbom.SBOMStatus_SUCCESS || p.GetCyclonedx() == nil {
+				continue
+			}
+			comps := p.GetCyclonedx().Components
+			enriched := lo.SomeBy(comps, func(comp *cyclonedx_v1_4.Component) bool {
+				_, ok := lastSeenRunning(comp)
+				return ok
+			})
+			if !enriched {
+				img.rawCount = max(img.rawCount, len(comps))
+				continue
+			}
+			if p.GetCollectedTime().Before(newest) {
+				continue
+			}
+			newest = p.GetCollectedTime()
+			img.components = comps
+			img.dependencies = p.GetCyclonedx().Dependencies
+			img.rootRef = p.GetCyclonedx().GetMetadata().GetComponent().GetBomRef()
+		}
+
+		if len(img.components) > 0 {
+			images = append(images, img)
+		}
+	}
+	return images
 }
 
 // startInUseService launches, inside the workload pod, a detached loop that


### PR DESCRIPTION
The enrichment merge rebuilds the component list of the image SBOM it
annotates, emitting the first component of each name and normalised
version and dropping the rest. Trivy reports one component per install
location, so a library version pinned by two lockfiles arrives once per
lockfile, each entry with its own bom-ref, and the merge kept one of them.
The dependency graph, which the merge carries over as it stands, went on
referencing the components that went missing. On the Agent image in the
e2e fleet, 362 of its 2673 components share a name and version with
another.

Deduplicate the components that carry a bom-ref, which is what identifies
a component in CycloneDX, and emit the others in turn. A byte-for-byte
duplicate shares its bom-ref, so the stored SBOM the guard was added for
still collapses.

