### PR TITLE
sbom: run the SBOM e2e job on core-agent collector changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1402,6 +1402,7 @@ workflow:
   - !reference [.on_e2e_main_release_or_rc]
   - changes:
       paths:
+        - comp/core/workloadmeta/collectors/internal/remote/sbomcollector/**/*
         - pkg/sbom/**/*
         - pkg/security/resolvers/sbom/**/*
         - test/new-e2e/tests/sbom/**/*


### PR DESCRIPTION
The runtime usage properties an SBOM payload carries come from the merge
in comp/core/workloadmeta/collectors/internal/remote/sbomcollector, and
TestSBOMPackageInUseKubeadmSuite exercises that merge end to end. The rule
that triggers new-e2e-sbom lists the system-probe resolver and the test
tree, so a change confined to the collector reaches the suite only when
someone starts the job by hand. Add the collector to the rule.

