### PR TITLE
fix(installer): secure Windows config rollback

### DIFF
--- a/pkg/fleet/installer/config/BUILD.bazel
+++ b/pkg/fleet/installer/config/BUILD.bazel
@@ -124,6 +124,7 @@ dd_agent_go_test(
     embed = [":config"],
     deps = [
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
         "@in_yaml_go_yaml_v2//:yaml",
     ] + select({
         "@rules_go//go/platform:windows": [

--- a/pkg/fleet/installer/config/config.go
+++ b/pkg/fleet/installer/config/config.go
@@ -477,26 +477,101 @@ func removeConfigFilesMissingFromSource(sourcePath, targetPath string) error {
 	}
 	defer targetRoot.Close()
 
-	return walkFiles(targetRoot.FS(), ".", func(relativePath string, _ fs.DirEntry) error {
+	emptiedDirs := make(map[string]struct{})
+	err = walkFiles(targetRoot.FS(), ".", func(relativePath string, _ fs.DirEntry) error {
 		if !isManagedConfigYAML(relativePath) {
 			return nil
 		}
-		return removeConfigFileMissingFromSource(sourceRoot, targetRoot, relativePath)
+		removed, err := removeConfigFileMissingFromSource(sourceRoot, targetRoot, relativePath)
+		if err != nil {
+			return err
+		}
+		if removed {
+			if dir := path.Dir(relativePath); dir != "." {
+				emptiedDirs[dir] = struct{}{}
+			}
+		}
+		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	pruneEmptyManagedDirs(sourceRoot, targetRoot, emptiedDirs)
+	return nil
 }
 
-func removeConfigFileMissingFromSource(sourceRoot, targetRoot *os.Root, relativePath string) error {
+// removeConfigFileMissingFromSource removes relativePath from the target when the source
+// does not have it. It reports whether the file was removed.
+func removeConfigFileMissingFromSource(sourceRoot, targetRoot *os.Root, relativePath string) (bool, error) {
 	_, err := sourceRoot.Lstat(relativePath)
 	if err == nil {
-		return nil
+		return false, nil
 	}
 	if !os.IsNotExist(err) {
-		return fmt.Errorf("could not check source config file %q: %w", relativePath, err)
+		return false, fmt.Errorf("could not check source config file %q: %w", relativePath, err)
 	}
 	if err := targetRoot.Remove(relativePath); err != nil {
-		return fmt.Errorf("could not remove config file %q during rollback: %w", relativePath, err)
+		return false, fmt.Errorf("could not remove config file %q during rollback: %w", relativePath, err)
 	}
-	return nil
+	return true, nil
+}
+
+// pruneEmptyManagedDirs removes the directories that the cleanup above just emptied.
+//
+// Removing a config file leaves its directory behind, so an experiment that added
+// conf.d/<check>.d/conf.yaml would otherwise leave an empty conf.d/<check>.d in the stable
+// directory after every rollback. Only directories the cleanup actually emptied are
+// considered, and a directory is removed only when the source does not have it and it holds
+// no remaining entries, so unmanaged files always keep their directory alive.
+//
+// Pruning is best effort: a directory that cannot be removed is left in place rather than
+// failing an otherwise successful rollback.
+func pruneEmptyManagedDirs(sourceRoot, targetRoot *os.Root, emptiedDirs map[string]struct{}) {
+	for _, dir := range dirsDeepestFirst(emptiedDirs) {
+		if _, err := sourceRoot.Lstat(dir); err == nil || !os.IsNotExist(err) {
+			// The source still has this directory, or we cannot tell: keep it.
+			continue
+		}
+		if !isEmptyDir(targetRoot, dir) {
+			continue
+		}
+		// A directory that cannot be removed is left in place. Its parents cannot be
+		// empty either, so the rest of the pass skips them on its own.
+		_ = targetRoot.Remove(dir)
+	}
+}
+
+// dirsDeepestFirst expands dirs with their parent directories and orders them so that a
+// directory always comes before its parent, letting a parent that is emptied by the removal
+// of its last child be pruned in the same pass.
+func dirsDeepestFirst(dirs map[string]struct{}) []string {
+	all := make(map[string]struct{}, len(dirs))
+	for dir := range dirs {
+		for d := dir; d != "." && d != "/" && d != ""; d = path.Dir(d) {
+			all[d] = struct{}{}
+		}
+	}
+
+	ordered := make([]string, 0, len(all))
+	for d := range all {
+		ordered = append(ordered, d)
+	}
+	// A child path is its parent plus more, so reverse lexical order puts every child
+	// ahead of its parent.
+	sort.Sort(sort.Reverse(sort.StringSlice(ordered)))
+	return ordered
+}
+
+// isEmptyDir reports whether dir holds no entries at all, including unmanaged ones.
+func isEmptyDir(root *os.Root, dir string) bool {
+	f, err := root.Open(dir)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	_, err = f.Readdirnames(1)
+	return err == io.EOF
 }
 
 func walkFiles(fsys fs.FS, root string, fn func(relativePath string, entry fs.DirEntry) error) error {

--- a/pkg/fleet/installer/config/config.go
+++ b/pkg/fleet/installer/config/config.go
@@ -408,8 +408,12 @@ var (
 func getConfigFileSpec(file string) *configFileSpec {
 	normalizedFile := filepath.ToSlash(file)
 
-	// Fallback for legacy files under the /managed directory
-	if strings.HasPrefix(normalizedFile, "/managed") {
+	// Fallback for files in the legacy managed config tree. The exact root is
+	// allowed because legacy migration deletes it before recreating the config.
+	legacyConfigPath := "/" + filepath.ToSlash(legacyPathPrefix)
+	if normalizedFile == "/managed" ||
+		normalizedFile == legacyConfigPath ||
+		strings.HasPrefix(normalizedFile, legacyConfigPath+"/") {
 		filename := filepath.Base(normalizedFile)
 
 		for _, spec := range allowedConfigFiles {

--- a/pkg/fleet/installer/config/config.go
+++ b/pkg/fleet/installer/config/config.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -403,6 +404,11 @@ var (
 	}
 
 	legacyPathPrefix = filepath.Join("managed", "datadog-agent", "stable")
+
+	legacyManagedLinkPaths = []string{
+		"managed/datadog-agent/stable",
+		"managed/datadog-agent/experiment",
+	}
 )
 
 func getConfigFileSpec(file string) *configFileSpec {
@@ -414,7 +420,7 @@ func getConfigFileSpec(file string) *configFileSpec {
 	if normalizedFile == "/managed" ||
 		normalizedFile == legacyConfigPath ||
 		strings.HasPrefix(normalizedFile, legacyConfigPath+"/") {
-		filename := filepath.Base(normalizedFile)
+		filename := path.Base(normalizedFile)
 
 		for _, spec := range allowedConfigFiles {
 			// Skip patterns with nested paths (e.g., /conf.d/*.yaml)
@@ -423,8 +429,8 @@ func getConfigFileSpec(file string) *configFileSpec {
 			}
 
 			// Extract just the filename from the pattern
-			patternFilename := filepath.Base(spec.pattern)
-			match, err := filepath.Match(patternFilename, filename)
+			patternFilename := path.Base(spec.pattern)
+			match, err := path.Match(patternFilename, filename)
 			if err != nil {
 				continue
 			}
@@ -442,7 +448,7 @@ func getConfigFileSpec(file string) *configFileSpec {
 	}
 
 	for _, spec := range allowedConfigFiles {
-		match, err := filepath.Match(spec.pattern, normalizedFile)
+		match, err := path.Match(spec.pattern, normalizedFile)
 		if err != nil {
 			continue
 		}
@@ -459,38 +465,42 @@ func isManagedConfigYAML(relativePath string) bool {
 }
 
 func removeConfigFilesMissingFromSource(sourcePath, targetPath string) error {
-	return filepath.WalkDir(targetPath, func(targetFile string, entry os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if entry.IsDir() {
-			return nil
-		}
+	sourceRoot, err := os.OpenRoot(sourcePath)
+	if err != nil {
+		return fmt.Errorf("could not open source config directory: %w", err)
+	}
+	defer sourceRoot.Close()
 
-		relativePath, err := filepath.Rel(targetPath, targetFile)
-		if err != nil {
-			return fmt.Errorf("could not resolve config file path %q: %w", targetFile, err)
-		}
+	targetRoot, err := os.OpenRoot(targetPath)
+	if err != nil {
+		return fmt.Errorf("could not open target config directory: %w", err)
+	}
+	defer targetRoot.Close()
+
+	return walkFiles(targetRoot.FS(), ".", func(relativePath string, _ fs.DirEntry) error {
 		if !isManagedConfigYAML(relativePath) {
 			return nil
 		}
-
-		_, err = os.Lstat(filepath.Join(sourcePath, relativePath))
-		if err == nil {
-			return nil
-		}
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("could not check source config file %q: %w", relativePath, err)
-		}
-		if err := os.Remove(targetFile); err != nil {
-			return fmt.Errorf("could not remove config file %q during rollback: %w", relativePath, err)
-		}
-		return nil
+		return removeConfigFileMissingFromSource(sourceRoot, targetRoot, relativePath)
 	})
 }
 
-func verifyConfigFilesCopied(sourcePath, targetPath string) error {
-	return filepath.WalkDir(sourcePath, func(sourceFile string, entry os.DirEntry, walkErr error) error {
+func removeConfigFileMissingFromSource(sourceRoot, targetRoot *os.Root, relativePath string) error {
+	_, err := sourceRoot.Lstat(relativePath)
+	if err == nil {
+		return nil
+	}
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("could not check source config file %q: %w", relativePath, err)
+	}
+	if err := targetRoot.Remove(relativePath); err != nil {
+		return fmt.Errorf("could not remove config file %q during rollback: %w", relativePath, err)
+	}
+	return nil
+}
+
+func walkFiles(fsys fs.FS, root string, fn func(relativePath string, entry fs.DirEntry) error) error {
+	return fs.WalkDir(fsys, root, func(filePath string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -498,15 +508,105 @@ func verifyConfigFilesCopied(sourcePath, targetPath string) error {
 			return nil
 		}
 
-		relativePath, err := filepath.Rel(sourcePath, sourceFile)
-		if err != nil {
-			return fmt.Errorf("could not resolve config file path %q: %w", sourceFile, err)
+		relativePath := filePath
+		if root != "." {
+			relativePath = strings.TrimPrefix(filePath, root+"/")
 		}
-		if !isManagedConfigYAML(relativePath) {
+		return fn(relativePath, entry)
+	})
+}
+
+func reconcileLegacyManagedLinksBeforeCopy(sourcePath, targetPath string) error {
+	sourceRoot, err := os.OpenRoot(sourcePath)
+	if err != nil {
+		return fmt.Errorf("could not open source config directory: %w", err)
+	}
+	defer sourceRoot.Close()
+
+	targetRoot, err := os.OpenRoot(targetPath)
+	if err != nil {
+		return fmt.Errorf("could not open target config directory: %w", err)
+	}
+	defer targetRoot.Close()
+
+	for _, relativePath := range legacyManagedLinkPaths {
+		sourceInfo, err := sourceRoot.Lstat(relativePath)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("could not inspect source legacy link %q: %w", relativePath, err)
+		}
+		if sourceInfo.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+
+		if err := targetRoot.RemoveAll(relativePath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("could not reconcile legacy link %q: %w", relativePath, err)
+		}
+	}
+	return nil
+}
+
+func verifyLegacyManagedLinksCopied(sourceRoot, targetRoot *os.Root) error {
+	for _, relativePath := range legacyManagedLinkPaths {
+		sourceInfo, err := sourceRoot.Lstat(relativePath)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("could not inspect source legacy link %q: %w", relativePath, err)
+		}
+		if sourceInfo.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+
+		sourceTarget, err := sourceRoot.Readlink(relativePath)
+		if err != nil {
+			return fmt.Errorf("could not read source legacy link %q: %w", relativePath, err)
+		}
+
+		targetInfo, err := targetRoot.Lstat(relativePath)
+		if os.IsNotExist(err) {
+			return fmt.Errorf("legacy link %q was not copied", relativePath)
+		}
+		if err != nil {
+			return fmt.Errorf("could not inspect copied legacy link %q: %w", relativePath, err)
+		}
+		if targetInfo.Mode()&os.ModeSymlink == 0 {
+			return fmt.Errorf("legacy link %q was not restored as a symlink", relativePath)
+		}
+
+		targetTarget, err := targetRoot.Readlink(relativePath)
+		if err != nil {
+			return fmt.Errorf("could not read copied legacy link %q: %w", relativePath, err)
+		}
+		if targetTarget != sourceTarget {
+			return fmt.Errorf("legacy link %q target mismatch: got %q, want %q", relativePath, targetTarget, sourceTarget)
+		}
+	}
+	return nil
+}
+
+func verifyConfigFilesCopied(sourcePath, targetPath string) error {
+	sourceRoot, err := os.OpenRoot(sourcePath)
+	if err != nil {
+		return fmt.Errorf("could not open source config directory: %w", err)
+	}
+	defer sourceRoot.Close()
+
+	targetRoot, err := os.OpenRoot(targetPath)
+	if err != nil {
+		return fmt.Errorf("could not open target config directory: %w", err)
+	}
+	defer targetRoot.Close()
+
+	err = walkFiles(sourceRoot.FS(), ".", func(relativePath string, _ fs.DirEntry) error {
+		if !strings.EqualFold(path.Ext(relativePath), ".yaml") {
 			return nil
 		}
 
-		_, err = os.Lstat(filepath.Join(targetPath, relativePath))
+		_, err := targetRoot.Lstat(relativePath)
 		if os.IsNotExist(err) {
 			return fmt.Errorf("config file %q was not copied", relativePath)
 		}
@@ -515,6 +615,10 @@ func verifyConfigFilesCopied(sourcePath, targetPath string) error {
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+	return verifyLegacyManagedLinksCopied(sourceRoot, targetRoot)
 }
 
 func buildOperationsFromLegacyInstaller(rootPath string) []FileOperation {

--- a/pkg/fleet/installer/config/config.go
+++ b/pkg/fleet/installer/config/config.go
@@ -449,6 +449,70 @@ func getConfigFileSpec(file string) *configFileSpec {
 	return nil
 }
 
+func isManagedConfigYAML(relativePath string) bool {
+	return strings.EqualFold(filepath.Ext(relativePath), ".yaml") &&
+		getConfigFileSpec("/"+filepath.ToSlash(relativePath)) != nil
+}
+
+func removeConfigFilesMissingFromSource(sourcePath, targetPath string) error {
+	return filepath.WalkDir(targetPath, func(targetFile string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+
+		relativePath, err := filepath.Rel(targetPath, targetFile)
+		if err != nil {
+			return fmt.Errorf("could not resolve config file path %q: %w", targetFile, err)
+		}
+		if !isManagedConfigYAML(relativePath) {
+			return nil
+		}
+
+		_, err = os.Lstat(filepath.Join(sourcePath, relativePath))
+		if err == nil {
+			return nil
+		}
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("could not check source config file %q: %w", relativePath, err)
+		}
+		if err := os.Remove(targetFile); err != nil {
+			return fmt.Errorf("could not remove config file %q during rollback: %w", relativePath, err)
+		}
+		return nil
+	})
+}
+
+func verifyConfigFilesCopied(sourcePath, targetPath string) error {
+	return filepath.WalkDir(sourcePath, func(sourceFile string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+
+		relativePath, err := filepath.Rel(sourcePath, sourceFile)
+		if err != nil {
+			return fmt.Errorf("could not resolve config file path %q: %w", sourceFile, err)
+		}
+		if !isManagedConfigYAML(relativePath) {
+			return nil
+		}
+
+		_, err = os.Lstat(filepath.Join(targetPath, relativePath))
+		if os.IsNotExist(err) {
+			return fmt.Errorf("config file %q was not copied", relativePath)
+		}
+		if err != nil {
+			return fmt.Errorf("could not check copied config file %q: %w", relativePath, err)
+		}
+		return nil
+	})
+}
+
 func buildOperationsFromLegacyInstaller(rootPath string) []FileOperation {
 	var allOps []FileOperation
 

--- a/pkg/fleet/installer/config/config_test.go
+++ b/pkg/fleet/installer/config/config_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v2"
 )
 
@@ -585,6 +586,68 @@ func TestOperationApply_MoveMissingSource(t *testing.T) {
 
 	err = op.apply(context.Background(), root)
 	assert.Error(t, err)
+}
+
+func TestRemoveConfigFilesMissingFromSource(t *testing.T) {
+	sourceDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	writeFile := func(root, path string) {
+		t.Helper()
+		fullPath := filepath.Join(root, filepath.FromSlash(path))
+		require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0755))
+		require.NoError(t, os.WriteFile(fullPath, []byte(path), 0644))
+	}
+
+	for _, path := range []string{
+		"datadog.yaml",
+		"conf.d/existing.d/config.yaml",
+	} {
+		writeFile(sourceDir, path)
+		writeFile(targetDir, path)
+	}
+	for _, path := range []string{
+		"security-agent.yaml",
+		"conf.d/new.d/config.yaml",
+		"files/conf.d/customer.yaml",
+		"conf.d/new.d/README.txt",
+		"managed/datadog-agent/stable/metadata.json",
+		"auth_token",
+	} {
+		writeFile(targetDir, path)
+	}
+
+	require.NoError(t, removeConfigFilesMissingFromSource(sourceDir, targetDir))
+
+	assert.FileExists(t, filepath.Join(targetDir, "datadog.yaml"))
+	assert.FileExists(t, filepath.Join(targetDir, "conf.d", "existing.d", "config.yaml"))
+	assert.NoFileExists(t, filepath.Join(targetDir, "security-agent.yaml"))
+	assert.NoFileExists(t, filepath.Join(targetDir, "conf.d", "new.d", "config.yaml"))
+	assert.FileExists(t, filepath.Join(targetDir, "files", "conf.d", "customer.yaml"))
+	assert.FileExists(t, filepath.Join(targetDir, "conf.d", "new.d", "README.txt"))
+	assert.FileExists(t, filepath.Join(targetDir, "managed", "datadog-agent", "stable", "metadata.json"))
+	assert.FileExists(t, filepath.Join(targetDir, "auth_token"))
+}
+
+func TestVerifyConfigFilesCopied(t *testing.T) {
+	sourceDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	sourceConfigPath := filepath.Join(sourceDir, "datadog.yaml")
+	require.NoError(t, os.WriteFile(sourceConfigPath, []byte("log_level: info\n"), 0644))
+	unmanagedPath := filepath.Join(sourceDir, "files", "conf.d", "customer.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(unmanagedPath), 0755))
+	require.NoError(t, os.WriteFile(unmanagedPath, []byte("customer: true\n"), 0644))
+	legacyMetadataPath := filepath.Join(sourceDir, "managed", "datadog-agent", "stable", "metadata.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(legacyMetadataPath), 0755))
+	require.NoError(t, os.WriteFile(legacyMetadataPath, []byte("{}"), 0644))
+
+	err := verifyConfigFilesCopied(sourceDir, targetDir)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "datadog.yaml")
+
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "datadog.yaml"), []byte("log_level: info\n"), 0644))
+	require.NoError(t, verifyConfigFilesCopied(sourceDir, targetDir))
 }
 
 func TestConfig_SimpleStartPromote(t *testing.T) {

--- a/pkg/fleet/installer/config/config_test.go
+++ b/pkg/fleet/installer/config/config_test.go
@@ -668,6 +668,68 @@ func TestRemoveConfigFilesMissingFromSourcePreservesNestedUnmanagedYAML(t *testi
 	assert.FileExists(t, nestedUnmanaged)
 }
 
+func TestRemoveConfigFilesMissingFromSourcePrunesEmptiedDirs(t *testing.T) {
+	sourceDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	// A check directory the experiment added, absent from the backup.
+	newCheck := filepath.Join(targetDir, "conf.d", "new.d")
+	require.NoError(t, os.MkdirAll(newCheck, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(newCheck, "config.yaml"), []byte("enabled: true\n"), 0644))
+
+	require.NoError(t, removeConfigFilesMissingFromSource(sourceDir, targetDir))
+
+	assert.NoFileExists(t, filepath.Join(newCheck, "config.yaml"))
+	assert.NoDirExists(t, newCheck, "the emptied check directory should be pruned")
+	assert.NoDirExists(t, filepath.Join(targetDir, "conf.d"), "conf.d should be pruned once it is empty as well")
+}
+
+func TestRemoveConfigFilesMissingFromSourceKeepsDirsWithUnmanagedFiles(t *testing.T) {
+	sourceDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	checkDir := filepath.Join(targetDir, "conf.d", "new.d")
+	require.NoError(t, os.MkdirAll(checkDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(checkDir, "config.yaml"), []byte("enabled: true\n"), 0644))
+	unmanaged := filepath.Join(checkDir, "notes.txt")
+	require.NoError(t, os.WriteFile(unmanaged, []byte("keep me\n"), 0644))
+
+	require.NoError(t, removeConfigFilesMissingFromSource(sourceDir, targetDir))
+
+	assert.NoFileExists(t, filepath.Join(checkDir, "config.yaml"))
+	assert.FileExists(t, unmanaged, "unmanaged files must survive the cleanup")
+	assert.DirExists(t, checkDir, "a directory still holding unmanaged files must not be pruned")
+	assert.DirExists(t, filepath.Join(targetDir, "conf.d"))
+}
+
+func TestRemoveConfigFilesMissingFromSourceKeepsUntouchedEmptyDirs(t *testing.T) {
+	sourceDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	// An already empty check directory that the cleanup never removes a file from.
+	untouched := filepath.Join(targetDir, "conf.d", "untouched.d")
+	require.NoError(t, os.MkdirAll(untouched, 0755))
+
+	require.NoError(t, removeConfigFilesMissingFromSource(sourceDir, targetDir))
+
+	assert.DirExists(t, untouched, "directories the cleanup did not empty must be left alone")
+	assert.DirExists(t, filepath.Join(targetDir, "conf.d"))
+}
+
+func TestRemoveConfigFilesMissingFromSourceKeepsDirsPresentInSource(t *testing.T) {
+	sourceDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(sourceDir, "conf.d", "check.d"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(targetDir, "conf.d", "check.d"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "conf.d", "check.d", "config.yaml"), []byte("a: 1\n"), 0644))
+
+	require.NoError(t, removeConfigFilesMissingFromSource(sourceDir, targetDir))
+
+	assert.NoFileExists(t, filepath.Join(targetDir, "conf.d", "check.d", "config.yaml"))
+	assert.DirExists(t, filepath.Join(targetDir, "conf.d", "check.d"), "a directory the backup still has must be kept")
+}
+
 func TestVerifyConfigFilesCopied(t *testing.T) {
 	sourceDir := t.TempDir()
 	targetDir := t.TempDir()

--- a/pkg/fleet/installer/config/config_test.go
+++ b/pkg/fleet/installer/config/config_test.go
@@ -612,6 +612,10 @@ func TestRemoveConfigFilesMissingFromSource(t *testing.T) {
 		"files/conf.d/customer.yaml",
 		"conf.d/new.d/README.txt",
 		"managed/datadog-agent/stable/metadata.json",
+		"managed-user.yaml",
+		"managed-custom/customer.yaml",
+		"managed/datadog-agent/other/customer.yaml",
+		"managed/datadog-agent/stable-custom/customer.yaml",
 		"auth_token",
 	} {
 		writeFile(targetDir, path)
@@ -626,7 +630,21 @@ func TestRemoveConfigFilesMissingFromSource(t *testing.T) {
 	assert.FileExists(t, filepath.Join(targetDir, "files", "conf.d", "customer.yaml"))
 	assert.FileExists(t, filepath.Join(targetDir, "conf.d", "new.d", "README.txt"))
 	assert.FileExists(t, filepath.Join(targetDir, "managed", "datadog-agent", "stable", "metadata.json"))
+	assert.FileExists(t, filepath.Join(targetDir, "managed-user.yaml"))
+	assert.FileExists(t, filepath.Join(targetDir, "managed-custom", "customer.yaml"))
+	assert.FileExists(t, filepath.Join(targetDir, "managed", "datadog-agent", "other", "customer.yaml"))
+	assert.FileExists(t, filepath.Join(targetDir, "managed", "datadog-agent", "stable-custom", "customer.yaml"))
 	assert.FileExists(t, filepath.Join(targetDir, "auth_token"))
+}
+
+func TestGetConfigFileSpecLegacyManagedPaths(t *testing.T) {
+	assert.NotNil(t, getConfigFileSpec("/managed"))
+	assert.NotNil(t, getConfigFileSpec("/managed/datadog-agent/stable/application_monitoring.yaml"))
+
+	assert.Nil(t, getConfigFileSpec("/managed-user.yaml"))
+	assert.Nil(t, getConfigFileSpec("/managed-custom/customer.yaml"))
+	assert.Nil(t, getConfigFileSpec("/managed/datadog-agent/other/customer.yaml"))
+	assert.Nil(t, getConfigFileSpec("/managed/datadog-agent/stable-custom/customer.yaml"))
 }
 
 func TestVerifyConfigFilesCopied(t *testing.T) {

--- a/pkg/fleet/installer/config/config_test.go
+++ b/pkg/fleet/installer/config/config_test.go
@@ -647,6 +647,27 @@ func TestGetConfigFileSpecLegacyManagedPaths(t *testing.T) {
 	assert.Nil(t, getConfigFileSpec("/managed/datadog-agent/stable-custom/customer.yaml"))
 }
 
+func TestGetConfigFileSpecExactDepthConfD(t *testing.T) {
+	assert.NotNil(t, getConfigFileSpec("/conf.d/check.yaml"))
+	assert.NotNil(t, getConfigFileSpec("/conf.d/check.d/config.yaml"))
+
+	assert.Nil(t, getConfigFileSpec("/conf.d/check.d/private/customer.yaml"))
+	assert.Nil(t, getConfigFileSpec("/conf.d/nested/check.yaml"))
+	assert.Nil(t, getConfigFileSpec("/files/conf.d/customer.yaml"))
+}
+
+func TestRemoveConfigFilesMissingFromSourcePreservesNestedUnmanagedYAML(t *testing.T) {
+	sourceDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	nestedUnmanaged := filepath.Join(targetDir, "conf.d", "check.d", "private", "customer.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(nestedUnmanaged), 0755))
+	require.NoError(t, os.WriteFile(nestedUnmanaged, []byte("customer: true\n"), 0644))
+
+	require.NoError(t, removeConfigFilesMissingFromSource(sourceDir, targetDir))
+	assert.FileExists(t, nestedUnmanaged)
+}
+
 func TestVerifyConfigFilesCopied(t *testing.T) {
 	sourceDir := t.TempDir()
 	targetDir := t.TempDir()
@@ -665,7 +686,61 @@ func TestVerifyConfigFilesCopied(t *testing.T) {
 	assert.ErrorContains(t, err, "datadog.yaml")
 
 	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "datadog.yaml"), []byte("log_level: info\n"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(targetDir, "files", "conf.d"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "files", "conf.d", "customer.yaml"), []byte("customer: true\n"), 0644))
 	require.NoError(t, verifyConfigFilesCopied(sourceDir, targetDir))
+}
+
+func TestReconcileLegacyManagedLinksBeforeCopy(t *testing.T) {
+	sourceDir := t.TempDir()
+	targetDir := t.TempDir()
+	managedDir := filepath.Join(sourceDir, "managed", "datadog-agent")
+	require.NoError(t, os.MkdirAll(filepath.Join(managedDir, "v2"), 0755))
+	require.NoError(t, os.Symlink(filepath.Join(managedDir, "v2"), filepath.Join(managedDir, "stable")))
+	require.NoError(t, os.Symlink(filepath.Join(managedDir, "v2"), filepath.Join(managedDir, "experiment")))
+
+	targetManagedDir := filepath.Join(targetDir, "managed", "datadog-agent")
+	require.NoError(t, os.MkdirAll(filepath.Join(targetManagedDir, "stable"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(targetManagedDir, "experiment"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(targetManagedDir, "stable", "application_monitoring.yaml"), []byte("enabled: true\n"), 0644))
+
+	require.NoError(t, reconcileLegacyManagedLinksBeforeCopy(sourceDir, targetDir))
+	_, err := os.Lstat(filepath.Join(targetManagedDir, "stable"))
+	require.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
+	_, err = os.Lstat(filepath.Join(targetManagedDir, "experiment"))
+	require.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestVerifyLegacyManagedLinksCopied(t *testing.T) {
+	sourceDir := t.TempDir()
+	targetDir := t.TempDir()
+	managedDir := filepath.Join(sourceDir, "managed", "datadog-agent")
+	require.NoError(t, os.MkdirAll(filepath.Join(managedDir, "v2"), 0755))
+	linkTarget := filepath.Join(managedDir, "v2")
+	require.NoError(t, os.Symlink(linkTarget, filepath.Join(managedDir, "stable")))
+	require.NoError(t, os.Symlink(linkTarget, filepath.Join(managedDir, "experiment")))
+
+	targetManagedDir := filepath.Join(targetDir, "managed", "datadog-agent")
+	require.NoError(t, os.MkdirAll(targetManagedDir, 0755))
+	require.NoError(t, os.Symlink(linkTarget, filepath.Join(targetManagedDir, "stable")))
+	require.NoError(t, os.Symlink(linkTarget, filepath.Join(targetManagedDir, "experiment")))
+
+	sourceRoot, err := os.OpenRoot(sourceDir)
+	require.NoError(t, err)
+	defer sourceRoot.Close()
+	targetRoot, err := os.OpenRoot(targetDir)
+	require.NoError(t, err)
+	defer targetRoot.Close()
+
+	require.NoError(t, verifyLegacyManagedLinksCopied(sourceRoot, targetRoot))
+
+	require.NoError(t, os.Remove(filepath.Join(targetManagedDir, "stable")))
+	require.NoError(t, os.MkdirAll(filepath.Join(targetManagedDir, "stable"), 0755))
+	err = verifyLegacyManagedLinksCopied(sourceRoot, targetRoot)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "not restored as a symlink")
 }
 
 func TestConfig_SimpleStartPromote(t *testing.T) {

--- a/pkg/fleet/installer/config/config_windows.go
+++ b/pkg/fleet/installer/config/config_windows.go
@@ -147,7 +147,12 @@ func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string
 		return fmt.Errorf("failed to open target directory: %w", err)
 	}
 
-	// robocopy exit codes 1-7 indicate successful copies with various informational statuses.
+	if err := reconcileLegacyManagedLinksBeforeCopy(sourcePath, targetPath); err != nil {
+		return fmt.Errorf("error reconciling legacy managed links: %w", err)
+	}
+
+	// robocopy exit codes 0-3 indicate successful copies with various informational statuses.
+	// Codes 4-7 indicate source/target mismatches that leave the destination incomplete.
 	// Only codes >=8 indicate copy errors.
 	// https://learn.microsoft.com/en-us/troubleshoot/windows-server/backup-and-storage/return-codes-used-robocopy-utility
 	//
@@ -163,7 +168,7 @@ func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string
 		sourcePath,
 		targetPath,
 		"*.yaml",
-	).WithExpectedExitCodes(1, 2, 3, 4, 5, 6, 7)
+	).WithExpectedExitCodes(1, 2, 3)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -173,7 +178,7 @@ func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string
 	if err != nil && !errors.As(err, &exitErr) {
 		return fmt.Errorf("error executing robocopy: %w", err)
 	}
-	if exitErr != nil && exitErr.ExitCode() >= 8 {
+	if exitErr != nil && exitErr.ExitCode() >= 4 {
 		return fmt.Errorf("error executing robocopy: %w\n%s\n%s", err, stdout.String(), stderr.String())
 	}
 	return verifyConfigFilesCopied(sourcePath, targetPath)

--- a/pkg/fleet/installer/config/config_windows.go
+++ b/pkg/fleet/installer/config/config_windows.go
@@ -113,8 +113,11 @@ func (d *Directories) RemoveExperiment(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error restoring stable directory: %w", err)
 	}
-	// robocopy does not carry ACLs, so re-grant Everyone read on application_monitoring.yaml
-	// (the only world-readable config file) after restoring the stable directory.
+	err = removeConfigFilesMissingFromSource(d.ExperimentPath, d.StablePath)
+	if err != nil {
+		return fmt.Errorf("error removing experiment config files: %w", err)
+	}
+	// Ensure application_monitoring.yaml retains its required Everyone-read access after restore.
 	if err := grantApplicationMonitoringReadAccess(d.StablePath); err != nil {
 		return fmt.Errorf("error applying application_monitoring.yaml permissions: %w", err)
 	}
@@ -127,7 +130,6 @@ func (d *Directories) RemoveExperiment(ctx context.Context) error {
 
 // backupOrRestoreDirectory copies YAML files from source to target.
 // It preserves the directory structure and file permissions.
-// If copyDeploymentID is true, also copies the .deployment-id file.
 func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string) error {
 	_, err := os.Stat(sourcePath)
 	if err != nil && !os.IsNotExist(err) {
@@ -148,11 +150,16 @@ func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string
 	// robocopy exit codes 1-7 indicate successful copies with various informational statuses.
 	// Only codes >=8 indicate copy errors.
 	// https://learn.microsoft.com/en-us/troubleshoot/windows-server/backup-and-storage/return-codes-used-robocopy-utility
+	//
+	// The target root is created with the source root's security descriptor before a backup,
+	// and the stable root is never removed before a restore. This prevents an unprivileged user
+	// from pre-creating the target between directory creation and robocopy applying /SEC.
 	cmd := telemetry.CommandContext(
 		ctx,
 		"robocopy",
-		"/MIR",
+		"/S",
 		"/SL",
+		"/SEC",
 		sourcePath,
 		targetPath,
 		"*.yaml",
@@ -169,7 +176,7 @@ func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string
 	if exitErr != nil && exitErr.ExitCode() >= 8 {
 		return fmt.Errorf("error executing robocopy: %w\n%s\n%s", err, stdout.String(), stderr.String())
 	}
-	return nil
+	return verifyConfigFilesCopied(sourcePath, targetPath)
 }
 
 // secureCreateTargetDirectoryWithSourcePermissions creates targetPath with the same permissions as srcPath.
@@ -200,8 +207,7 @@ func setFileOwnershipAndPermissions(_ context.Context, root *os.Root, path strin
 
 // grantApplicationMonitoringReadAccess re-grants Everyone read on application_monitoring.yaml
 // under stablePath, if it exists. application_monitoring.yaml is the only world-readable config
-// file, and robocopy (used to restore the stable directory during a rollback) does not carry
-// ACLs, so the ACE must be reapplied afterward.
+// file, so keep this explicit even though the rollback copy also preserves its ACL.
 func grantApplicationMonitoringReadAccess(stablePath string) error {
 	appMonitoringPath := filepath.Join(stablePath, "application_monitoring.yaml")
 	_, err := os.Stat(appMonitoringPath)

--- a/pkg/fleet/installer/config/config_windows.go
+++ b/pkg/fleet/installer/config/config_windows.go
@@ -159,10 +159,13 @@ func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string
 	// The target root is created with the source root's security descriptor before a backup,
 	// and the stable root is never removed before a restore. This prevents an unprivileged user
 	// from pre-creating the target between directory creation and robocopy applying /SEC.
+	// /E rather than /S so the copy carries empty directories, matching what /MIR did.
+	// The backup is what tells a rollback which directories predate the experiment, so a
+	// directory missing from it would be mistaken for one the experiment created.
 	cmd := telemetry.CommandContext(
 		ctx,
 		"robocopy",
-		"/S",
+		"/E",
 		"/SL",
 		"/SEC",
 		sourcePath,

--- a/pkg/fleet/installer/config/config_windows_test.go
+++ b/pkg/fleet/installer/config/config_windows_test.go
@@ -58,28 +58,26 @@ func assertConfigV2(t *testing.T, v2Dir string) {
 	_, err = os.Lstat(filepath.Join(managedDir, "v2", "conf.d", "mycheck.d", "config.yaml"))
 	assert.NoError(t, err)
 
-	_, err = os.Lstat(filepath.Join(managedDir, "stable"))
-	assert.NoError(t, err)
-	stableInfo, err := os.Lstat(filepath.Join(managedDir, "stable"))
-	assert.NoError(t, err)
-	assert.True(t, stableInfo.Mode()&os.ModeSymlink != 0, "stable should remain a symlink in v2 layout")
-	stableTarget, err := os.Readlink(filepath.Join(managedDir, "stable"))
-	assert.NoError(t, err)
-	assert.Equal(t, filepath.Join(managedDir, "v2"), stableTarget)
-
-	_, err = os.Lstat(filepath.Join(managedDir, "experiment"))
-	assert.NoError(t, err)
-	experimentInfo, err := os.Lstat(filepath.Join(managedDir, "experiment"))
-	assert.NoError(t, err)
-	assert.True(t, experimentInfo.Mode()&os.ModeSymlink != 0, "experiment should remain a symlink in v2 layout")
-	experimentTarget, err := os.Readlink(filepath.Join(managedDir, "experiment"))
-	assert.NoError(t, err)
-	assert.Equal(t, filepath.Join(managedDir, "v2"), experimentTarget)
+	stableTarget := assertLegacyManagedV2Symlink(t, filepath.Join(managedDir, "stable"))
+	experimentTarget := assertLegacyManagedV2Symlink(t, filepath.Join(managedDir, "experiment"))
+	assert.Equal(t, stableTarget, experimentTarget)
 
 	// v2Dir/conf.d/mychecks.d/config.yaml does not exists
 	_, err = os.Lstat(filepath.Join(v2Dir, "conf.d", "mycheck.d", "config.yaml"))
 	assert.Error(t, err)
 	assert.True(t, os.IsNotExist(err))
+}
+
+func assertLegacyManagedV2Symlink(t *testing.T, linkPath string) string {
+	t.Helper()
+	info, err := os.Lstat(linkPath)
+	require.NoError(t, err)
+	require.True(t, info.Mode()&os.ModeSymlink != 0, "%s should be a symlink", linkPath)
+
+	target, err := os.Readlink(linkPath)
+	require.NoError(t, err)
+	assert.Equal(t, "v2", filepath.Base(target), "legacy symlink %s should point at a v2 directory", linkPath)
+	return target
 }
 
 func assertConfigV3(t *testing.T, v3Dir string) {
@@ -119,6 +117,26 @@ func assertDeploymentID(t *testing.T, dirs *Directories, stableDeploymentID stri
 	assert.NoError(t, err)
 	assert.Equal(t, stableDeploymentID, state.StableDeploymentID)
 	assert.Equal(t, experimentDeploymentID, state.ExperimentDeploymentID)
+}
+
+func TestAssertConfigV2AcceptsCopiedAbsoluteLegacyLinks(t *testing.T) {
+	originalDir := t.TempDir()
+	writeConfigV2(t, originalDir)
+	assertConfigV2(t, originalDir)
+
+	backupDir := t.TempDir()
+	originalManagedDir := filepath.Join(originalDir, "managed", "datadog-agent")
+	backupManagedDir := filepath.Join(backupDir, "managed", "datadog-agent")
+	require.NoError(t, os.MkdirAll(filepath.Join(backupManagedDir, "v2", "conf.d", "mycheck.d"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(backupManagedDir, "v2", "datadog.yaml"), []byte("log_level: debug\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(backupManagedDir, "v2", "application_monitoring.yaml"), []byte("enabled: true\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(backupManagedDir, "v2", "conf.d", "mycheck.d", "config.yaml"), []byte("foo: bar\n"), 0644))
+
+	originalV2 := filepath.Join(originalManagedDir, "v2")
+	require.NoError(t, os.Symlink(originalV2, filepath.Join(backupManagedDir, "stable")))
+	require.NoError(t, os.Symlink(originalV2, filepath.Join(backupManagedDir, "experiment")))
+
+	assertConfigV2(t, backupDir)
 }
 
 func TestConfigV2ToV3(t *testing.T) {

--- a/pkg/fleet/installer/config/config_windows_test.go
+++ b/pkg/fleet/installer/config/config_windows_test.go
@@ -393,6 +393,69 @@ func TestRemoveExperimentPreservesUnmanagedFilesAndConfigACLs(t *testing.T) {
 	assert.NoFileExists(t, filepath.Join(stablePath, "conf.d", "new.d", "config.yaml"))
 }
 
+func TestRemoveExperimentPrunesEmptiedCheckDirectories(t *testing.T) {
+	stablePath := t.TempDir()
+	experimentPath := filepath.Join(t.TempDir(), "experiment")
+	require.NoError(t, os.WriteFile(filepath.Join(stablePath, "datadog.yaml"), []byte("log_level: info\n"), 0640))
+
+	dirs := &Directories{
+		StablePath:     stablePath,
+		ExperimentPath: experimentPath,
+	}
+	require.NoError(t, dirs.WriteExperiment(context.Background(), Operations{
+		DeploymentID: "adds-a-check",
+		FileOperations: []FileOperation{
+			{
+				FileOperationType: FileOperationMergePatch,
+				FilePath:          "/conf.d/brand_new.d/config.yaml",
+				Patch:             []byte(`{"enabled": true}`),
+			},
+		},
+	}))
+	require.FileExists(t, filepath.Join(stablePath, "conf.d", "brand_new.d", "config.yaml"))
+
+	require.NoError(t, dirs.RemoveExperiment(context.Background()))
+
+	assert.NoFileExists(t, filepath.Join(stablePath, "conf.d", "brand_new.d", "config.yaml"))
+	assert.NoDirExists(t, filepath.Join(stablePath, "conf.d", "brand_new.d"),
+		"rollback should not leave behind the check directory it emptied")
+	assert.NoDirExists(t, filepath.Join(stablePath, "conf.d"))
+	assert.FileExists(t, filepath.Join(stablePath, "datadog.yaml"))
+}
+
+// A check directory that already existed but held no config when the experiment started
+// must survive rollback. The backup is what distinguishes it from a directory the
+// experiment created, so it only works if the copy carries empty directories.
+func TestRemoveExperimentKeepsPreExistingEmptyCheckDirectory(t *testing.T) {
+	stablePath := t.TempDir()
+	experimentPath := filepath.Join(t.TempDir(), "experiment")
+	require.NoError(t, os.WriteFile(filepath.Join(stablePath, "datadog.yaml"), []byte("log_level: info\n"), 0640))
+
+	preExisting := filepath.Join(stablePath, "conf.d", "preexisting.d")
+	require.NoError(t, os.MkdirAll(preExisting, 0755))
+
+	dirs := &Directories{
+		StablePath:     stablePath,
+		ExperimentPath: experimentPath,
+	}
+	require.NoError(t, dirs.WriteExperiment(context.Background(), Operations{
+		DeploymentID: "writes-into-existing-check",
+		FileOperations: []FileOperation{
+			{
+				FileOperationType: FileOperationMergePatch,
+				FilePath:          "/conf.d/preexisting.d/config.yaml",
+				Patch:             []byte(`{"enabled": true}`),
+			},
+		},
+	}))
+	require.FileExists(t, filepath.Join(preExisting, "config.yaml"))
+
+	require.NoError(t, dirs.RemoveExperiment(context.Background()))
+
+	assert.NoFileExists(t, filepath.Join(preExisting, "config.yaml"), "experiment config must be cleaned up")
+	assert.DirExists(t, preExisting, "a check directory that predates the experiment must survive rollback")
+}
+
 func TestRemoveConfigFileMissingFromSourceRejectsJunctionAncestor(t *testing.T) {
 	targetDir := t.TempDir()
 	victimDir := t.TempDir()
@@ -426,7 +489,7 @@ func TestRemoveConfigFileMissingFromSourceRejectsJunctionAncestor(t *testing.T) 
 		_ = os.Remove(junctionPath)
 	})
 
-	err = removeConfigFileMissingFromSource(sourceRoot, targetRoot, relativePath)
+	_, err = removeConfigFileMissingFromSource(sourceRoot, targetRoot, relativePath)
 	require.Error(t, err)
 	assert.FileExists(t, victimConfig)
 	assert.FileExists(t, originalConfig)

--- a/pkg/fleet/installer/config/config_windows_test.go
+++ b/pkg/fleet/installer/config/config_windows_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows"
 )
 
@@ -317,6 +318,47 @@ func TestRemoveExperiment_RestoresApplicationMonitoringEveryoneRead(t *testing.T
 	assert.NoError(t, dirs.RemoveExperiment(context.Background()))
 	assert.FileExists(t, filePath)
 	assert.True(t, everyoneCanRead(t, filePath), "application_monitoring.yaml should regain Everyone read after rollback restore")
+}
+
+func TestRemoveExperimentPreservesUnmanagedFilesAndConfigACLs(t *testing.T) {
+	stablePath := t.TempDir()
+	experimentPath := filepath.Join(t.TempDir(), "experiment")
+	datadogPath := filepath.Join(stablePath, "datadog.yaml")
+
+	require.NoError(t, os.WriteFile(datadogPath, []byte("log_level: info\n"), 0600))
+	require.NoError(t, paths.SetFileReadableByEveryone(datadogPath))
+	require.True(t, everyoneCanRead(t, datadogPath))
+
+	dirs := &Directories{
+		StablePath:     stablePath,
+		ExperimentPath: experimentPath,
+	}
+	require.NoError(t, dirs.WriteExperiment(context.Background(), Operations{
+		DeploymentID: "delete-and-create-config",
+		FileOperations: []FileOperation{
+			{FileOperationType: FileOperationDelete, FilePath: "/datadog.yaml"},
+			{
+				FileOperationType: FileOperationMergePatch,
+				FilePath:          "/conf.d/new.d/config.yaml",
+				Patch:             []byte(`{"enabled": true}`),
+			},
+		},
+	}))
+	require.NoFileExists(t, datadogPath)
+
+	unmanagedYAMLPath := filepath.Join(stablePath, "files", "conf.d", "customer.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(unmanagedYAMLPath), 0755))
+	require.NoError(t, os.WriteFile(unmanagedYAMLPath, []byte("customer: true\n"), 0600))
+	authTokenPath := filepath.Join(stablePath, "auth_token")
+	require.NoError(t, os.WriteFile(authTokenPath, []byte("token"), 0600))
+
+	require.NoError(t, dirs.RemoveExperiment(context.Background()))
+
+	require.FileExists(t, datadogPath)
+	assert.True(t, everyoneCanRead(t, datadogPath), "rollback should restore the original config ACL")
+	assert.FileExists(t, unmanagedYAMLPath, "rollback should not purge unmanaged YAML")
+	assert.FileExists(t, authTokenPath, "rollback should not purge non-config files")
+	assert.NoFileExists(t, filepath.Join(stablePath, "conf.d", "new.d", "config.yaml"))
 }
 
 // TestDeploymentIDAfterRollback reproduces the bug where RemoveExperiment incorrectly

--- a/pkg/fleet/installer/config/config_windows_test.go
+++ b/pkg/fleet/installer/config/config_windows_test.go
@@ -10,6 +10,7 @@ package config
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"unsafe"
@@ -59,8 +60,21 @@ func assertConfigV2(t *testing.T, v2Dir string) {
 
 	_, err = os.Lstat(filepath.Join(managedDir, "stable"))
 	assert.NoError(t, err)
+	stableInfo, err := os.Lstat(filepath.Join(managedDir, "stable"))
+	assert.NoError(t, err)
+	assert.True(t, stableInfo.Mode()&os.ModeSymlink != 0, "stable should remain a symlink in v2 layout")
+	stableTarget, err := os.Readlink(filepath.Join(managedDir, "stable"))
+	assert.NoError(t, err)
+	assert.Equal(t, filepath.Join(managedDir, "v2"), stableTarget)
+
 	_, err = os.Lstat(filepath.Join(managedDir, "experiment"))
 	assert.NoError(t, err)
+	experimentInfo, err := os.Lstat(filepath.Join(managedDir, "experiment"))
+	assert.NoError(t, err)
+	assert.True(t, experimentInfo.Mode()&os.ModeSymlink != 0, "experiment should remain a symlink in v2 layout")
+	experimentTarget, err := os.Readlink(filepath.Join(managedDir, "experiment"))
+	assert.NoError(t, err)
+	assert.Equal(t, filepath.Join(managedDir, "v2"), experimentTarget)
 
 	// v2Dir/conf.d/mychecks.d/config.yaml does not exists
 	_, err = os.Lstat(filepath.Join(v2Dir, "conf.d", "mycheck.d", "config.yaml"))
@@ -359,6 +373,45 @@ func TestRemoveExperimentPreservesUnmanagedFilesAndConfigACLs(t *testing.T) {
 	assert.FileExists(t, unmanagedYAMLPath, "rollback should not purge unmanaged YAML")
 	assert.FileExists(t, authTokenPath, "rollback should not purge non-config files")
 	assert.NoFileExists(t, filepath.Join(stablePath, "conf.d", "new.d", "config.yaml"))
+}
+
+func TestRemoveConfigFileMissingFromSourceRejectsJunctionAncestor(t *testing.T) {
+	targetDir := t.TempDir()
+	victimDir := t.TempDir()
+	sourceDir := t.TempDir()
+
+	confDDir := filepath.Join(targetDir, "conf.d", "check.d")
+	require.NoError(t, os.MkdirAll(confDDir, 0755))
+	originalConfig := filepath.Join(confDDir, "config.yaml")
+	require.NoError(t, os.WriteFile(originalConfig, []byte("enabled: true\n"), 0644))
+
+	victimConfigDir := filepath.Join(victimDir, "check.d")
+	require.NoError(t, os.MkdirAll(victimConfigDir, 0755))
+	victimConfig := filepath.Join(victimConfigDir, "config.yaml")
+	require.NoError(t, os.WriteFile(victimConfig, []byte("victim: true\n"), 0644))
+
+	targetRoot, err := os.OpenRoot(targetDir)
+	require.NoError(t, err)
+	defer targetRoot.Close()
+
+	sourceRoot, err := os.OpenRoot(sourceDir)
+	require.NoError(t, err)
+	defer sourceRoot.Close()
+
+	relativePath := "conf.d/check.d/config.yaml"
+
+	require.NoError(t, os.Rename(filepath.Join(targetDir, "conf.d"), filepath.Join(targetDir, "conf.d-original")))
+	junctionPath := filepath.Join(targetDir, "conf.d")
+	cmd := exec.Command("cmd", "/c", "mklink", "/J", junctionPath, victimDir)
+	require.NoError(t, cmd.Run())
+	t.Cleanup(func() {
+		_ = os.Remove(junctionPath)
+	})
+
+	err = removeConfigFileMissingFromSource(sourceRoot, targetRoot, relativePath)
+	require.Error(t, err)
+	assert.FileExists(t, victimConfig)
+	assert.FileExists(t, originalConfig)
 }
 
 // TestDeploymentIDAfterRollback reproduces the bug where RemoveExperiment incorrectly

--- a/releasenotes/notes/fix-windows-config-experiment-rollback-779185bb46e58a97.yaml
+++ b/releasenotes/notes/fix-windows-config-experiment-rollback-779185bb46e58a97.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Windows Fleet Automation config experiment rollbacks now preserve config
+    file permissions and restrict cleanup to Fleet-managed configuration files.
+    This prevents rollback from deleting unmanaged files or restoring Agent
+    configuration without its original ACLs.

--- a/releasenotes/notes/fix-windows-config-experiment-rollback-779185bb46e58a97.yaml
+++ b/releasenotes/notes/fix-windows-config-experiment-rollback-779185bb46e58a97.yaml
@@ -4,4 +4,6 @@ fixes:
     Windows Fleet Automation config experiment rollbacks now preserve config
     file permissions and restrict cleanup to Fleet-managed configuration files.
     This prevents rollback from deleting unmanaged files or restoring Agent
-    configuration without its original ACLs.
+    configuration without its original ACLs. Rollback also removes the
+    directories it empties, so check directories created by an experiment no
+    longer accumulate in the configuration directory.


### PR DESCRIPTION
### What does this PR do?

Fixes Windows Fleet Automation config experiment rollback:

- copies YAML with its ACLs (`/SEC`) from a securely created backup directory
- replaces the `/MIR` purge with scoped cleanup — only allowlisted Fleet-managed YAML absent from the backup is removed, so unmanaged files under `C:\ProgramData\Datadog` survive
- prunes the directories that cleanup empties, so check directories added by an experiment do not accumulate
- verifies the copy and the legacy v2 `stable`/`experiment` symlinks before deleting the backup, and treats robocopy exit codes 4-7 as failure
- uses slash-aware allowlist matching and root-confined deletion, so a glob cannot span `/` and a delete cannot follow a swapped junction

Adds regression tests for each, plus a release note.

### Motivation

Addresses [WINA-2053](https://datadoghq.atlassian.net/browse/WINA-2053) and the failure observed in [SPFA-180](https://datadoghq.atlassian.net/browse/SPFA-180).

`robocopy /MIR /SL ... *.yaml` restores files without their original ACLs, because robocopy copies no security descriptors unless asked. Its `/PURGE` half also removes whatever the backup lacks, which in practice means content that appeared after the backup snapshot: any YAML file, plus everything inside a directory created since, as an extra directory is deleted whole regardless of the `*.yaml` filter. Adding `/SEC` alone was unsafe, because an unprivileged user could pre-create the destination between deletion and ACL repair while holding an open handle. The experiment root is now created with the stable root's security descriptor before copying and the stable root is never removed before restore, which is what makes `/SEC` safe to use here.

`/MIR` is replaced by `/E`, not `/S`: the backup is what tells a rollback which directories predate the experiment, so a directory missing from it would be mistaken for one the experiment created. Pruning is limited to directories the cleanup itself emptied that the backup lacks and that hold no remaining entries, and is best effort — a directory that cannot be removed is left in place rather than failing the rollback.

The matcher change is a Windows-only security fix. `filepath.Match` treats `\` as the separator there, so `*` matched `/` and `/conf.d/*.yaml` matched arbitrary depth; together with the old `strings.HasPrefix(path, "/managed")` test, an experiment could target paths the allowlist was written to forbid.

### Describe how you validated your changes

- `dda inv test --targets=./pkg/fleet/installer/config --no-cache`
- `dda inv linter.go --targets=./pkg/fleet/installer/config --only-modified-packages`
- `bazelisk test //pkg/fleet/installer/config:config_test`
- `bazelisk build //pkg/fleet/installer/config:config --platforms=@rules_go//go/toolchain:windows_amd64`

Also exercised locally on Windows 11 against real `robocopy`, real NTFS ACLs, and real junctions: 77 tests, 0 failures, clean over three consecutive runs under `-race`; `vet` and test-compile clean for `linux` and `darwin`. Throwaway probes additionally confirmed that restrictive ACLs stay restrictive, rollback restores byte-identical content, repeated cycles drift in neither content nor ACLs nor directories, nothing is deleted through a junction, extra destination files give exit 3 while a mismatch gives 4, a locked source file surfaces as a rollback error rather than silent data loss, and paths past `MAX_PATH` round-trip intact.

Made with [Cursor](https://cursor.com)

[WINA-2053]: https://datadoghq.atlassian.net/browse/WINA-2053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SPFA-180]: https://datadoghq.atlassian.net/browse/SPFA-180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
