### PR TITLE
env: warn when a container socket exists but is not reachable

### DIFF
--- a/pkg/config/env/environment_containers.go
+++ b/pkg/config/env/environment_containers.go
@@ -111,7 +111,7 @@ func detectDocker(features FeatureMap) {
 		for _, defaultDockerSocketPath := range getDefaultDockerPaths() {
 			exists, reachable := socket.IsAvailable(defaultDockerSocketPath, socketTimeout)
 			if exists && !reachable {
-				log.Infof("Agent found Docker socket at: %s but socket not reachable (permissions?)", defaultDockerSocketPath)
+				log.Warnf("Agent found Docker socket at: %s but socket not reachable (permissions?)", defaultDockerSocketPath)
 				continue
 			}
 
@@ -173,7 +173,7 @@ func checkCriSocket(socketPath string) string {
 		log.Infof("Agent found cri socket at: %s", socketPath)
 		return socketPath
 	} else if exists && !reachable {
-		log.Infof("Agent found cri socket at: %s but socket not reachable (permissions?)", socketPath)
+		log.Warnf("Agent found cri socket at: %s but socket not reachable (permissions?)", socketPath)
 	}
 	return ""
 }
@@ -288,7 +288,7 @@ func detectPodResources(features FeatureMap, cfg model.Reader) {
 		log.Infof("Agent found PodResources socket at %s", socketPath)
 		features[PodResources] = struct{}{}
 	} else if exists && !reachable {
-		log.Infof("Agent found PodResources socket at %s but socket not reachable (permissions?)", socketPath)
+		log.Warnf("Agent found PodResources socket at %s but socket not reachable (permissions?)", socketPath)
 	} else {
 		log.Infof("Agent did not find PodResources socket at %s", socketPath)
 	}

--- a/releasenotes/notes/warn-unreachable-container-socket-cd1ef4c7efc520d0.yaml
+++ b/releasenotes/notes/warn-unreachable-container-socket-cd1ef4c7efc520d0.yaml
@@ -1,0 +1,10 @@
+---
+enhancements:
+  - |
+    The Agent now logs a warning instead of an informational message when it
+    finds a Docker, CRI or PodResources socket that exists but cannot be
+    reached. On Unix this condition is only reported when opening the socket
+    fails with a permission error, so it means the Agent user lacks access to
+    the socket. Because these messages are emitted while the configuration is
+    still loading, they were previously discarded on Agents running with
+    ``log_level`` set to ``warn`` or above.


### PR DESCRIPTION
Feature detection reports this with log.Infof, but it runs while the
configuration is still loading, so the message is buffered and only
filtered against the final log level once the logger is installed. On an
Agent running at log_level warn it is discarded and never written
anywhere.

The condition deserves a warning. On Unix socket.IsAvailable calls a
socket unreachable only when the dial fails with a permission error, so
the Agent user cannot open it and container metrics, container image
collection and container image vulnerability scanning are all silently
disabled. Windows also counts a pipe that is merely busy, but a pipe the
Agent cannot open in half a second is worth surfacing too.

