### PR TITLE
healthplatform: correct the docker permission issue impact

### DIFF
--- a/comp/healthplatform/issues/dockerpermissions/BUILD.bazel
+++ b/comp/healthplatform/issues/dockerpermissions/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
 
 go_library(
     name = "dockerpermissions",
@@ -32,4 +33,14 @@ go_library(
         ],
         "//conditions:default": [],
     }),
+)
+
+dd_agent_go_test(
+    name = "dockerpermissions_test",
+    srcs = ["issue_test.go"],
+    embed = [":dockerpermissions"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/comp/healthplatform/issues/dockerpermissions/issue.go
+++ b/comp/healthplatform/issues/dockerpermissions/issue.go
@@ -22,6 +22,10 @@ var linuxScriptTemplate string
 //go:embed Fix-DockerLogPermissions.ps1
 var windowsScriptTemplate string
 
+// impactMsg stays scoped to Docker: the check proves only that a Docker socket
+// exists and cannot be opened, so another runtime may still serve the node.
+const impactMsg = "The Agent cannot query the Docker daemon, so Docker-backed container metrics, container image collection and container image vulnerability scanning are unavailable, as is Docker log collection over the socket. Workloads on another runtime such as containerd or CRI-O are unaffected."
+
 // DockerPermissionIssue provides complete issue template (metadata + OS-specific remediation)
 type DockerPermissionIssue struct{}
 
@@ -51,7 +55,7 @@ func (t *DockerPermissionIssue) BuildIssue(context map[string]string) (*healthpl
 		"integration": "docker",
 		"dir_path":    dockerDir,
 		"os":          osName,
-		"impact":      "The agent will fall back to socket tailing, which may hit limits with high volume logs",
+		"impact":      impactMsg,
 	})
 
 	if err != nil {

--- a/comp/healthplatform/issues/dockerpermissions/issue_test.go
+++ b/comp/healthplatform/issues/dockerpermissions/issue_test.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package dockerpermissions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The only producer of this issue is the socket check, which reports the
+// unreachable socket paths under "dockerDirs".
+func TestBuildIssueFromSocketCheck(t *testing.T) {
+	issue, err := NewDockerPermissionIssue().BuildIssue(map[string]string{
+		"dockerDirs": "/var/run/docker.sock,/host/var/run/docker.sock",
+		"os":         "linux",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, issue)
+
+	assert.Empty(t, issue.Id, "Id is set by the caller (ReportIssue), not by the template")
+	assert.Equal(t, IssueName, issue.IssueName)
+	assert.Equal(t, IssueType, issue.IssueType)
+
+	require.NotNil(t, issue.Extra)
+	fields := issue.Extra.GetFields()
+	assert.Equal(t, "docker", fields["integration"].GetStringValue())
+	assert.Equal(t, "linux", fields["os"].GetStringValue())
+	// The socket check passes socket paths, not directories.
+	assert.Equal(t, "/var/run/docker.sock,/host/var/run/docker.sock", fields["dir_path"].GetStringValue())
+
+	impact := fields["impact"].GetStringValue()
+	assert.Contains(t, impact, "cannot query the Docker daemon")
+	assert.Contains(t, impact, "container metrics")
+	assert.Contains(t, impact, "container image vulnerability scanning")
+
+	require.NotNil(t, issue.Remediation)
+	assert.NotEmpty(t, issue.Remediation.Summary)
+	assert.NotEmpty(t, issue.Remediation.Steps)
+	require.NotNil(t, issue.Remediation.Script)
+	assert.Equal(t, "bash", issue.Remediation.Script.Language)
+	assert.Contains(t, issue.Remediation.Script.Content, `DOCKER_DIR="/var/run/docker.sock`,
+		"the script template should be rendered, not returned as-is")
+}
+
+func TestBuildIssueWindowsRemediation(t *testing.T) {
+	issue, err := NewDockerPermissionIssue().BuildIssue(map[string]string{
+		"dockerDirs": `//./pipe/docker_engine`,
+		"os":         "windows",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, issue)
+	assert.Contains(t, issue.Tags, "windows")
+
+	require.NotNil(t, issue.Remediation)
+	require.NotNil(t, issue.Remediation.Script)
+	assert.Equal(t, "powershell", issue.Remediation.Script.Language)
+	assert.Contains(t, issue.Remediation.Script.Content, `$dockerDir = "//./pipe/docker_engine"`)
+}

--- a/releasenotes/notes/docker-permission-issue-impact-2edf4870badcc340.yaml
+++ b/releasenotes/notes/docker-permission-issue-impact-2edf4870badcc340.yaml
@@ -1,0 +1,9 @@
+---
+other:
+  - |
+    The health platform issue raised when the Agent cannot reach the Docker
+    socket now reports that Docker-backed container metrics, container image
+    collection and container image vulnerability scanning are unavailable. It
+    previously reported only that log collection would fall back to socket
+    tailing, which cannot happen when the socket itself is the thing that is
+    unreachable.


### PR DESCRIPTION
The check that raises this issue detects an unreachable Docker socket, so
the Agent cannot query the daemon at all and container metrics, container
image collection and container image vulnerability scanning all go quiet.
The impact named only the log tailing fallback, so an operator chasing
missing images would read the issue and dismiss it. Worse, that fallback
cannot happen. Socket tailing needs the very socket that is unreachable.

Everything named is scoped to Docker. The check proves only that a default
Docker socket exists and cannot be opened, so a containerd or CRI-O node
with a stale inaccessible socket keeps reporting all of it through its own
collector.

Title, Description and the remediation still describe the log directory
case that the logs producer raised before 058e777637d removed it, and the
remediation ACLs "<socket>/containers" where docker group membership for
dd-agent is the actual fix. A separate change will replace the embedded
scripts and correct those.

