### PR TITLE
Increase memory limit for quality_gate_metrics_logs

### DIFF
--- a/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
@@ -5,7 +5,7 @@ target:
   name: datadog-agent
   cpu_allotment: 4
   # Set to 20% higher than the memory_usage check value
-  memory_allotment: 527 MiB
+  memory_allotment: 544 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -33,7 +33,7 @@ checks:
     bounds:
       series: total_pss_bytes
       # When updating this, update the memory_allotment in the target section to 20% higher
-      upper_bound: 439 MiB
+      upper_bound: 453 MiB
 
   - name: cpu_usage
     description: "CPU usage quality gate. This puts a bound on the total average collector millicore usage."


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

Increases memory limit from `439 MiB` to `453 MiB`.

### Motivation

Headroom for ADP pre-flight mode. Follow up on https://github.com/DataDog/datadog-agent/pull/54792


### Additional Notes
