### PR TITLE
[AAD-57]: run local builds through DDEval

### DIFF
--- a/tasks/anomalydetection.py
+++ b/tasks/anomalydetection.py
@@ -257,7 +257,7 @@ def eval_ddeval(
         aws_profile: AWS CLI profile with write access to qbranch-gensim-recordings.
         expires_in: Presigned URL lifetime in seconds (60-604800).
         build: Build the testbench before uploading it.
-        testbench_binary: Testbench binary to upload.
+        testbench_binary: Testbench binary to upload. Custom paths require --no-build.
     """
     if not 1 <= jobs <= 100:
         raise Exit("--jobs must be between 1 and 100", code=2)
@@ -272,11 +272,15 @@ def eval_ddeval(
     if data_env not in {"staging", "prod", "eu1", "us3"}:
         raise Exit("--data-env must be one of staging, prod, eu1, or us3", code=2)
 
+    binary_path = Path(testbench_binary).expanduser().resolve()
+    default_binary_path = Path("bin/anomalydetection-testbench").resolve()
+    if build and binary_path != default_binary_path:
+        raise Exit("custom --testbench-binary requires --no-build", code=2)
+
     if build:
         print("Building anomalydetection-testbench for Linux/amd64...")
         _build_testbench(ctx, env={"GOOS": "linux", "GOARCH": "amd64", "CGO_ENABLED": "0"})
 
-    binary_path = Path(testbench_binary).expanduser().resolve()
     if not binary_path.is_file():
         raise Exit(f"testbench binary not found: {binary_path}", code=2)
     try:

--- a/tasks/anomalydetection.py
+++ b/tasks/anomalydetection.py
@@ -9,11 +9,28 @@ import random
 import re
 import shlex
 import shutil
+import sys
+import tempfile
 import time
+from contextlib import chdir
 from dataclasses import dataclass
+from pathlib import Path
 
 from invoke import Exit, task
 
+from tasks.libs.anomalydetection.ddeval import (
+    ARTIFACT_BUCKET,
+    ARTIFACT_REGION,
+    RedactingWriter,
+    artifact_metadata_matches,
+    build_experiment_config,
+    local_testbench_key,
+    redacted_presigned_url,
+    sha256_file,
+    validate_linux_amd64_executable,
+    validate_presigned_artifact_url,
+    workflow_run_args,
+)
 from tasks.libs.anomalydetection.eval import (
     ABLATION_CORRELATORS,
     DETECTORS,
@@ -37,6 +54,7 @@ from tasks.libs.anomalydetection.eval import (
     random_component_combinations,
 )
 from tasks.libs.common.color import Color, color_message
+from tasks.libs.common.utils import join_command
 from tasks.schema.generate import schema_codegen
 
 
@@ -77,11 +95,15 @@ def build_testbench(ctx):
     """
     Builds the anomalydetection-testbench binary to bin/anomalydetection-testbench.
     """
+    _build_testbench(ctx)
+
+
+def _build_testbench(ctx, *, env: dict[str, str] | None = None):
     # TODO: remove once Bazel is used to build the Agent
     schema_codegen(ctx)
-
     ctx.run(
-        "go build -C internal/qbranch/anomalydetection-testbench -tags python,anomalydetectiontestbench -o ../../../bin/anomalydetection-testbench ."
+        "go build -C internal/qbranch/anomalydetection-testbench -tags python,anomalydetectiontestbench -o ../../../bin/anomalydetection-testbench .",
+        env=env or {},
     )
 
 
@@ -181,6 +203,271 @@ def launch_testbench(
 
 
 # --- Eval ---
+
+
+@task(auto_shortflags=False)
+def eval_ddeval(
+    ctx,
+    dataset: str = "Golden 25",
+    dataset_version: int = 0,
+    project: str = "observer-log-ad",
+    service: str = "eval_worker_agent_aad",
+    jobs: int = 6,
+    max_attempts: int = 1,
+    limit: int = 0,
+    where_in: str = "",
+    data_env: str = "staging",
+    experiment_config: str = "",
+    testbench_config: str = "",
+    ddsource_dir: str = "",
+    ddeval_command: str = "",
+    aws_profile: str = "",
+    expires_in: int = 21600,
+    build: bool = True,
+    testbench_binary: str = "bin/anomalydetection-testbench",
+):
+    """
+    Build a local testbench and evaluate it remotely with the DDBuild DDEval worker.
+
+    The binary is stored privately in qbranch-gensim-recordings under its SHA-256;
+    an existing matching object is reused. It is shared with the worker through a
+    six-hour presigned URL, which is redacted from local output but remains in
+    Atlas/LLMObs workflow metadata until it expires.
+
+    Examples:
+        dda inv anomalydetection.eval-ddeval
+        dda inv anomalydetection.eval-ddeval --where-in=metadata.record_id=scenario-a,scenario-b
+        dda inv anomalydetection.eval-ddeval --testbench-config=/tmp/observer-config.json
+
+    Args:
+        dataset: LLMObs dataset to evaluate.
+        dataset_version: Optional dataset version to pin (0 uses the latest).
+        project: LLMObs/DDEval project name.
+        service: Remote DDEval worker service.
+        jobs: Maximum number of scenarios evaluated concurrently (1-100).
+        max_attempts: Maximum attempts per DDEval pipeline activity.
+        limit: Optional maximum number of dataset records after filtering.
+        where_in: Optional DDEval inclusion filter, such as metadata.record_id=a,b.
+        data_env: Datadog site from which the worker reads evaluation data.
+        experiment_config: Optional base DDEval experiment-config JSON file.
+        testbench_config: Optional Observer component-config JSON file.
+        ddsource_dir: dd-source checkout used to run DDEval with Bazel.
+        ddeval_command: Installed DDEval command; bypasses dd-source/Bazel discovery.
+        aws_profile: AWS CLI profile with write access to qbranch-gensim-recordings.
+        expires_in: Presigned URL lifetime in seconds (60-604800).
+        build: Build the testbench before uploading it.
+        testbench_binary: Testbench binary to upload.
+    """
+    if not 1 <= jobs <= 100:
+        raise Exit("--jobs must be between 1 and 100", code=2)
+    if dataset_version < 0:
+        raise Exit("--dataset-version must be non-negative", code=2)
+    if max_attempts < 1:
+        raise Exit("--max-attempts must be at least 1", code=2)
+    if limit < 0:
+        raise Exit("--limit must be non-negative", code=2)
+    if not 60 <= expires_in <= 604800:
+        raise Exit("--expires-in must be between 60 and 604800 seconds", code=2)
+    if data_env not in {"staging", "prod", "eu1", "us3"}:
+        raise Exit("--data-env must be one of staging, prod, eu1, or us3", code=2)
+
+    if build:
+        print("Building anomalydetection-testbench for Linux/amd64...")
+        _build_testbench(ctx, env={"GOOS": "linux", "GOARCH": "amd64", "CGO_ENABLED": "0"})
+
+    binary_path = Path(testbench_binary).expanduser().resolve()
+    if not binary_path.is_file():
+        raise Exit(f"testbench binary not found: {binary_path}", code=2)
+    try:
+        validate_linux_amd64_executable(binary_path)
+    except ValueError as error:
+        raise Exit(str(error), code=2) from error
+
+    try:
+        base_config = _load_json_object(experiment_config, "experiment config") if experiment_config else {}
+        component_config = _load_json_object(testbench_config, "testbench config") if testbench_config else None
+        command_prefix, command_dir = _local_ddeval_command(ddeval_command, ddsource_dir)
+    except ValueError as error:
+        raise Exit(str(error), code=2) from error
+
+    profile = aws_profile or os.environ.get("AWS_PROFILE") or "exec-sso-agent-sandbox-account-admin"
+    digest = sha256_file(binary_path)
+    commit = ctx.run("git rev-parse HEAD", hide=True).stdout.strip()
+    object_key = local_testbench_key(digest)
+    s3_uri = f"s3://{ARTIFACT_BUCKET}/{object_key}"
+
+    head_result = ctx.run(
+        join_command(
+            [
+                "aws",
+                "--profile",
+                profile,
+                "--region",
+                ARTIFACT_REGION,
+                "s3api",
+                "head-object",
+                "--bucket",
+                ARTIFACT_BUCKET,
+                "--key",
+                object_key,
+            ]
+        ),
+        hide=True,
+        warn=True,
+    )
+    remote_matches = False
+    if head_result.ok:
+        try:
+            remote_matches = artifact_metadata_matches(
+                json.loads(head_result.stdout), digest, binary_path.stat().st_size
+            )
+        except json.JSONDecodeError:
+            pass
+
+    if remote_matches:
+        print(f"Reusing {s3_uri}")
+    else:
+        print(f"Uploading {binary_path.name} to {s3_uri}")
+        upload_command = join_command(
+            [
+                "aws",
+                "--profile",
+                profile,
+                "--region",
+                ARTIFACT_REGION,
+                "s3",
+                "cp",
+                str(binary_path),
+                s3_uri,
+                "--sse",
+                "AES256",
+                "--metadata",
+                f"sha256={digest},agent-commit={commit}",
+                "--only-show-errors",
+            ]
+        )
+        ctx.run(upload_command)
+
+    config_path = ""
+    presigned_url = ""
+    stdout_writer = None
+    stderr_writer = None
+    try:
+        presign_result = ctx.run(
+            join_command(
+                [
+                    "aws",
+                    "--profile",
+                    profile,
+                    "--region",
+                    ARTIFACT_REGION,
+                    "s3",
+                    "presign",
+                    s3_uri,
+                    "--expires-in",
+                    str(expires_in),
+                ]
+            ),
+            hide=True,
+            warn=True,
+        )
+        if presign_result.failed:
+            raise Exit("failed to create a presigned testbench URL", code=1)
+        presigned_url = presign_result.stdout.strip()
+        try:
+            validate_presigned_artifact_url(presigned_url)
+            config = build_experiment_config(
+                base_config,
+                testbench_url=presigned_url,
+                testbench_sha256=digest,
+                testbench_config=component_config,
+            )
+        except ValueError as error:
+            raise Exit(str(error), code=1) from error
+
+        config_fd, config_path = tempfile.mkstemp(prefix="observer-ddeval-", suffix=".json")
+        with os.fdopen(config_fd, "w") as config_file:
+            json.dump(config, config_file)
+
+        command = workflow_run_args(
+            command_prefix,
+            service=service,
+            project=project,
+            dataset=dataset,
+            dataset_version=dataset_version,
+            config_path=config_path,
+            jobs=jobs,
+            max_attempts=max_attempts,
+            data_env=data_env,
+            limit=limit,
+            where_in=where_in,
+        )
+        safe_url = redacted_presigned_url(presigned_url)
+        stdout_writer = RedactingWriter(sys.stdout, presigned_url, safe_url)
+        stderr_writer = RedactingWriter(sys.stderr, presigned_url, safe_url)
+
+        print(f"Starting DDEval with testbench SHA-256 {digest}")
+        if command_dir:
+            with chdir(command_dir):
+                result = ctx.run(
+                    join_command(command),
+                    warn=True,
+                    out_stream=stdout_writer,
+                    err_stream=stderr_writer,
+                )
+        else:
+            result = ctx.run(
+                join_command(command),
+                warn=True,
+                out_stream=stdout_writer,
+                err_stream=stderr_writer,
+            )
+        if result.failed:
+            raise Exit("DDEval workflow failed", code=result.exited or 1)
+    finally:
+        if stdout_writer:
+            stdout_writer.finish()
+        if stderr_writer:
+            stderr_writer.finish()
+        if config_path:
+            Path(config_path).unlink(missing_ok=True)
+
+
+def _load_json_object(path: str, description: str) -> dict:
+    resolved_path = Path(path).expanduser().resolve()
+    if not resolved_path.is_file():
+        raise ValueError(f"{description} not found: {resolved_path}")
+    try:
+        with resolved_path.open() as source:
+            value = json.load(source)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"{description} is not valid JSON: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{description} must be a JSON object")
+    return value
+
+
+def _local_ddeval_command(ddeval_command: str, ddsource_dir: str) -> tuple[list[str], Path | None]:
+    command = (ddeval_command or os.environ.get("DDEVAL_COMMAND", "")).strip()
+    if command:
+        command_parts = shlex.split(command)
+        if not command_parts:
+            raise ValueError("--ddeval-command must not be empty")
+        return command_parts, None
+
+    configured_dir = ddsource_dir or os.environ.get("DDSOURCE_DIR") or os.environ.get("DD_SOURCE_DIR")
+    candidates = [Path(configured_dir).expanduser()] if configured_dir else [Path.home() / "dd" / "dd-source"]
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        target = resolved / "domains/ai_platform/shared/libs/ddeval/cli/BUILD.bazel"
+        if target.is_file():
+            return ["bzl", "run", "//domains/ai_platform/shared/libs/ddeval/cli:ddeval", "--"], resolved
+
+    if configured_dir:
+        raise ValueError(f"dd-source checkout does not contain the DDEval target: {candidates[0].resolve()}")
+    raise ValueError(
+        "could not find dd-source at ~/dd/dd-source; set --ddsource-dir, $DDSOURCE_DIR, or --ddeval-command"
+    )
 
 
 @task

--- a/tasks/anomalydetection.py
+++ b/tasks/anomalydetection.py
@@ -53,6 +53,9 @@ from tasks.libs.anomalydetection.eval import (
     print_eval_tp_summary,
     random_component_combinations,
 )
+from tasks.libs.anomalydetection.eval import (
+    AWS_PROFILE as AWS_VAULT_PROFILE,
+)
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.utils import join_command
 from tasks.schema.generate import schema_codegen
@@ -254,7 +257,8 @@ def eval_ddeval(
         testbench_config: Optional Observer component-config JSON file.
         ddsource_dir: dd-source checkout used to run DDEval with Bazel.
         ddeval_executable: Path or name of an installed DDEval executable; bypasses dd-source/Bazel discovery.
-        aws_profile: AWS CLI profile with write access to qbranch-gensim-recordings.
+        aws_profile: Optional AWS CLI profile with write access to qbranch-gensim-recordings.
+            When omitted, uses the standard 8-hour agent-sandbox aws-vault profile.
         expires_in: Presigned URL lifetime in seconds (60-604800).
         build: Build the testbench before uploading it.
         testbench_binary: Testbench binary to upload. Custom paths require --no-build.
@@ -295,7 +299,7 @@ def eval_ddeval(
     except ValueError as error:
         raise Exit(str(error), code=2) from error
 
-    profile = aws_profile or os.environ.get("AWS_PROFILE") or "exec-sso-agent-sandbox-account-admin"
+    aws_command = _local_aws_command(aws_profile)
     digest = sha256_file(binary_path)
     commit = ctx.run("git rev-parse HEAD", hide=True).stdout.strip()
     object_key = local_testbench_key(digest)
@@ -304,9 +308,7 @@ def eval_ddeval(
     head_result = ctx.run(
         join_command(
             [
-                "aws",
-                "--profile",
-                profile,
+                *aws_command,
                 "--region",
                 ARTIFACT_REGION,
                 "s3api",
@@ -335,9 +337,7 @@ def eval_ddeval(
         print(f"Uploading {binary_path.name} to {s3_uri}")
         upload_command = join_command(
             [
-                "aws",
-                "--profile",
-                profile,
+                *aws_command,
                 "--region",
                 ARTIFACT_REGION,
                 "s3",
@@ -361,9 +361,7 @@ def eval_ddeval(
         presign_result = ctx.run(
             join_command(
                 [
-                    "aws",
-                    "--profile",
-                    profile,
+                    *aws_command,
                     "--region",
                     ARTIFACT_REGION,
                     "s3",
@@ -470,6 +468,12 @@ def _local_ddeval_command(ddeval_executable: str, ddsource_dir: str) -> tuple[li
     raise ValueError(
         "could not find dd-source at ~/dd/dd-source; set --ddsource-dir, $DDSOURCE_DIR, or --ddeval-executable"
     )
+
+
+def _local_aws_command(aws_profile: str) -> list[str]:
+    if aws_profile:
+        return ["aws", "--profile", aws_profile]
+    return ["aws-vault", "exec", AWS_VAULT_PROFILE, "--", "aws"]
 
 
 @task

--- a/tasks/anomalydetection.py
+++ b/tasks/anomalydetection.py
@@ -220,7 +220,7 @@ def eval_ddeval(
     experiment_config: str = "",
     testbench_config: str = "",
     ddsource_dir: str = "",
-    ddeval_command: str = "",
+    ddeval_executable: str = "",
     aws_profile: str = "",
     expires_in: int = 21600,
     build: bool = True,
@@ -238,6 +238,7 @@ def eval_ddeval(
         dda inv anomalydetection.eval-ddeval
         dda inv anomalydetection.eval-ddeval --where-in=metadata.record_id=scenario-a,scenario-b
         dda inv anomalydetection.eval-ddeval --testbench-config=/tmp/observer-config.json
+        dda inv anomalydetection.eval-ddeval --ddeval-executable="C:\\Program Files\\DDEval\\ddeval.exe"
 
     Args:
         dataset: LLMObs dataset to evaluate.
@@ -252,7 +253,7 @@ def eval_ddeval(
         experiment_config: Optional base DDEval experiment-config JSON file.
         testbench_config: Optional Observer component-config JSON file.
         ddsource_dir: dd-source checkout used to run DDEval with Bazel.
-        ddeval_command: Installed DDEval command; bypasses dd-source/Bazel discovery.
+        ddeval_executable: Path or name of an installed DDEval executable; bypasses dd-source/Bazel discovery.
         aws_profile: AWS CLI profile with write access to qbranch-gensim-recordings.
         expires_in: Presigned URL lifetime in seconds (60-604800).
         build: Build the testbench before uploading it.
@@ -286,7 +287,7 @@ def eval_ddeval(
     try:
         base_config = _load_json_object(experiment_config, "experiment config") if experiment_config else {}
         component_config = _load_json_object(testbench_config, "testbench config") if testbench_config else None
-        command_prefix, command_dir = _local_ddeval_command(ddeval_command, ddsource_dir)
+        command_prefix, command_dir = _local_ddeval_command(ddeval_executable, ddsource_dir)
     except ValueError as error:
         raise Exit(str(error), code=2) from error
 
@@ -447,13 +448,10 @@ def _load_json_object(path: str, description: str) -> dict:
     return value
 
 
-def _local_ddeval_command(ddeval_command: str, ddsource_dir: str) -> tuple[list[str], Path | None]:
-    command = (ddeval_command or os.environ.get("DDEVAL_COMMAND", "")).strip()
-    if command:
-        command_parts = shlex.split(command)
-        if not command_parts:
-            raise ValueError("--ddeval-command must not be empty")
-        return command_parts, None
+def _local_ddeval_command(ddeval_executable: str, ddsource_dir: str) -> tuple[list[str], Path | None]:
+    executable = (ddeval_executable or os.environ.get("DDEVAL_EXECUTABLE", "")).strip()
+    if executable:
+        return [executable], None
 
     configured_dir = ddsource_dir or os.environ.get("DDSOURCE_DIR") or os.environ.get("DD_SOURCE_DIR")
     candidates = [Path(configured_dir).expanduser()] if configured_dir else [Path.home() / "dd" / "dd-source"]
@@ -466,7 +464,7 @@ def _local_ddeval_command(ddeval_command: str, ddsource_dir: str) -> tuple[list[
     if configured_dir:
         raise ValueError(f"dd-source checkout does not contain the DDEval target: {candidates[0].resolve()}")
     raise ValueError(
-        "could not find dd-source at ~/dd/dd-source; set --ddsource-dir, $DDSOURCE_DIR, or --ddeval-command"
+        "could not find dd-source at ~/dd/dd-source; set --ddsource-dir, $DDSOURCE_DIR, or --ddeval-executable"
     )
 
 

--- a/tasks/libs/anomalydetection/ddeval.py
+++ b/tasks/libs/anomalydetection/ddeval.py
@@ -1,0 +1,229 @@
+"""Helpers for submitting local Observer builds to the remote DDEval worker."""
+
+import hashlib
+import re
+from copy import deepcopy
+from pathlib import Path
+from typing import TextIO
+from urllib.parse import parse_qs, unquote, urlsplit, urlunsplit
+
+ARTIFACT_BUCKET = "qbranch-gensim-recordings"
+ARTIFACT_PREFIX = "observer-log-ad-binaries/test-binaries"
+ARTIFACT_REGION = "us-east-1"
+TESTBENCH_FILENAME = "anomalydetection-testbench"
+
+_ALLOWED_ARTIFACT_HOSTS = {
+    f"{ARTIFACT_BUCKET}.s3.amazonaws.com",
+    f"{ARTIFACT_BUCKET}.s3.{ARTIFACT_REGION}.amazonaws.com",
+}
+_SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+
+
+def sha256_file(path: str | Path) -> str:
+    """Return the lowercase SHA-256 digest of a file without loading it into memory."""
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validate_linux_amd64_executable(path: str | Path) -> None:
+    """Require a 64-bit little-endian x86 ELF binary for the DDBuild worker."""
+    with Path(path).open("rb") as binary:
+        header = binary.read(20)
+    is_elf64_little_endian_x86 = (
+        len(header) == 20
+        and header[:4] == b"\x7fELF"
+        and header[4] == 2
+        and header[5] == 1
+        and int.from_bytes(header[18:20], "little") == 62
+    )
+    if not is_elf64_little_endian_x86:
+        raise ValueError("testbench must be a Linux/amd64 executable; rebuild it with --build")
+
+
+def local_testbench_key(digest: str) -> str:
+    """Build a content-addressed S3 key for a local testbench binary."""
+    digest = digest.strip().lower()
+    if not _SHA256_PATTERN.fullmatch(digest):
+        raise ValueError("testbench digest must be a 64-character hexadecimal SHA-256")
+
+    return f"{ARTIFACT_PREFIX}/sha256/{digest}/{TESTBENCH_FILENAME}"
+
+
+def artifact_metadata_matches(head_object: dict, digest: str, size: int) -> bool:
+    """Return whether S3 metadata identifies the expected content-addressed binary."""
+    if not isinstance(head_object, dict):
+        return False
+    metadata = head_object.get("Metadata")
+    if not isinstance(metadata, dict):
+        return False
+    try:
+        content_length = int(head_object.get("ContentLength", -1))
+    except (TypeError, ValueError):
+        return False
+    return content_length == size and str(metadata.get("sha256", "")).lower() == digest.lower()
+
+
+def validate_presigned_artifact_url(url: str) -> None:
+    """Reject URLs that do not point to the expected private local-artifact prefix."""
+    parsed = urlsplit(url)
+    try:
+        port = parsed.port
+    except ValueError as error:
+        raise ValueError("presigned artifact URL contains an invalid port") from error
+
+    if parsed.scheme != "https":
+        raise ValueError("presigned artifact URL must use HTTPS")
+    if parsed.username or parsed.password or port is not None:
+        raise ValueError("presigned artifact URL must not contain credentials or a port")
+    if parsed.hostname not in _ALLOWED_ARTIFACT_HOSTS:
+        raise ValueError(f"presigned artifact URL must target {ARTIFACT_BUCKET}")
+    if parsed.fragment:
+        raise ValueError("presigned artifact URL must not contain a fragment")
+    if not unquote(parsed.path).lstrip("/").startswith(f"{ARTIFACT_PREFIX}/"):
+        raise ValueError(f"presigned artifact URL must target {ARTIFACT_PREFIX}")
+
+    query = parse_qs(parsed.query)
+    if not query.get("X-Amz-Signature"):
+        raise ValueError("presigned artifact URL is missing its AWS signature")
+
+
+def redacted_presigned_url(url: str) -> str:
+    """Return a useful URL identity without its temporary AWS credentials."""
+    parsed = urlsplit(url)
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "<redacted>", ""))
+
+
+def build_experiment_config(
+    base_config: dict,
+    *,
+    testbench_url: str,
+    testbench_sha256: str,
+    testbench_config: dict | None = None,
+) -> dict:
+    """Add the local testbench artifact and optional Observer config to a DDEval config."""
+    if not isinstance(base_config, dict):
+        raise ValueError("experiment config must be a JSON object")
+    if not _SHA256_PATTERN.fullmatch(testbench_sha256):
+        raise ValueError("testbench digest must be a 64-character hexadecimal SHA-256")
+
+    config = deepcopy(base_config)
+    executor_config = config.get("executor_config") or {}
+    if not isinstance(executor_config, dict):
+        raise ValueError("experiment config executor_config must be a JSON object")
+    executor_config["binary_artifacts"] = {
+        "testbench": {
+            "uri": testbench_url,
+            "sha256": testbench_sha256,
+            "filename": TESTBENCH_FILENAME,
+        }
+    }
+    config["executor_config"] = executor_config
+
+    if testbench_config is not None:
+        if not isinstance(testbench_config, dict):
+            raise ValueError("testbench config must be a JSON object")
+        input_parameters = config.get("input_parameters") or {}
+        if not isinstance(input_parameters, dict):
+            raise ValueError("experiment config input_parameters must be a JSON object")
+        input_parameters["testbench_config"] = deepcopy(testbench_config)
+        config["input_parameters"] = input_parameters
+
+    return config
+
+
+class RedactingWriter:
+    """Stream text while replacing a secret even when writes split it across chunks."""
+
+    def __init__(self, stream: TextIO, secret: str, replacement: str):
+        if not secret:
+            raise ValueError("secret must not be empty")
+        self._stream = stream
+        self._secret = secret
+        self._replacement = replacement
+        self._buffer = ""
+
+    def write(self, value: str) -> int:
+        self._buffer += value
+        self._drain(final=False)
+        return len(value)
+
+    def flush(self) -> None:
+        self._stream.flush()
+
+    def finish(self) -> None:
+        self._drain(final=True)
+        self._stream.flush()
+
+    def _drain(self, *, final: bool) -> None:
+        while self._buffer:
+            if self._buffer.startswith(self._secret):
+                self._stream.write(self._replacement)
+                self._buffer = self._buffer[len(self._secret) :]
+                continue
+
+            if final and self._secret.startswith(self._buffer):
+                self._stream.write(self._replacement)
+                self._buffer = ""
+                continue
+
+            if not final and self._secret.startswith(self._buffer):
+                return
+
+            next_candidate = self._buffer.find(self._secret[0])
+            if next_candidate < 0:
+                self._stream.write(self._buffer)
+                self._buffer = ""
+            elif next_candidate > 0:
+                self._stream.write(self._buffer[:next_candidate])
+                self._buffer = self._buffer[next_candidate:]
+            else:
+                self._stream.write(self._buffer[0])
+                self._buffer = self._buffer[1:]
+
+
+def workflow_run_args(
+    command_prefix: list[str],
+    *,
+    service: str,
+    project: str,
+    dataset: str,
+    dataset_version: int,
+    config_path: str,
+    jobs: int,
+    max_attempts: int,
+    data_env: str,
+    limit: int = 0,
+    where_in: str = "",
+) -> list[str]:
+    """Build the DDEval CLI arguments for the production DDBuild worker."""
+    args = [
+        *command_prefix,
+        "workflow",
+        "run",
+        "-s",
+        service,
+        "-p",
+        project,
+        "-d",
+        dataset,
+        "--env",
+        "ddbuild",
+        "--data-env",
+        data_env,
+        "-f",
+        config_path,
+        "-j",
+        str(jobs),
+        "--max-attempts",
+        str(max_attempts),
+    ]
+    if dataset_version:
+        args.extend(["--dataset-version", str(dataset_version)])
+    if limit:
+        args.extend(["--limit", str(limit)])
+    if where_in:
+        args.extend(["--where-in", where_in])
+    return args

--- a/tasks/unit_tests/anomalydetection_ddeval_tests.py
+++ b/tasks/unit_tests/anomalydetection_ddeval_tests.py
@@ -3,7 +3,9 @@ import tempfile
 import unittest
 from io import StringIO
 
-from tasks.anomalydetection import _local_ddeval_command
+from invoke.exceptions import Exit
+
+from tasks.anomalydetection import _local_ddeval_command, eval_ddeval
 from tasks.libs.anomalydetection.ddeval import (
     ARTIFACT_PREFIX,
     RedactingWriter,
@@ -26,6 +28,10 @@ PRESIGNED_URL = (
 
 
 class TestLocalDDEvalArtifacts(unittest.TestCase):
+    def test_custom_testbench_binary_requires_no_build(self):
+        with self.assertRaisesRegex(Exit, "custom --testbench-binary requires --no-build"):
+            eval_ddeval.body(None, testbench_binary="/tmp/custom-testbench")
+
     def test_custom_ddeval_executable_is_not_shell_parsed(self):
         executable = r"C:\Program Files\DDEval\ddeval.exe"
 

--- a/tasks/unit_tests/anomalydetection_ddeval_tests.py
+++ b/tasks/unit_tests/anomalydetection_ddeval_tests.py
@@ -2,10 +2,11 @@ import hashlib
 import tempfile
 import unittest
 from io import StringIO
+from unittest.mock import patch
 
 from invoke.exceptions import Exit
 
-from tasks.anomalydetection import _local_ddeval_command, eval_ddeval
+from tasks.anomalydetection import AWS_VAULT_PROFILE, _local_aws_command, _local_ddeval_command, eval_ddeval
 from tasks.libs.anomalydetection.ddeval import (
     ARTIFACT_PREFIX,
     RedactingWriter,
@@ -28,6 +29,13 @@ PRESIGNED_URL = (
 
 
 class TestLocalDDEvalArtifacts(unittest.TestCase):
+    @patch.dict("os.environ", {"AWS_PROFILE": "legacy-profile"})
+    def test_default_aws_command_ignores_ambient_profile(self):
+        self.assertEqual(_local_aws_command(""), ["aws-vault", "exec", AWS_VAULT_PROFILE, "--", "aws"])
+
+    def test_custom_aws_profile_bypasses_aws_vault(self):
+        self.assertEqual(_local_aws_command("custom-profile"), ["aws", "--profile", "custom-profile"])
+
     def test_custom_testbench_binary_requires_no_build(self):
         with self.assertRaisesRegex(Exit, "custom --testbench-binary requires --no-build"):
             eval_ddeval.body(None, testbench_binary="/tmp/custom-testbench")

--- a/tasks/unit_tests/anomalydetection_ddeval_tests.py
+++ b/tasks/unit_tests/anomalydetection_ddeval_tests.py
@@ -1,0 +1,158 @@
+import hashlib
+import tempfile
+import unittest
+from io import StringIO
+
+from tasks.libs.anomalydetection.ddeval import (
+    ARTIFACT_PREFIX,
+    RedactingWriter,
+    artifact_metadata_matches,
+    build_experiment_config,
+    local_testbench_key,
+    redacted_presigned_url,
+    sha256_file,
+    validate_linux_amd64_executable,
+    validate_presigned_artifact_url,
+    workflow_run_args,
+)
+
+TESTBENCH_SHA256 = hashlib.sha256(b"testbench").hexdigest()
+PRESIGNED_URL = (
+    "https://qbranch-gensim-recordings.s3.amazonaws.com/"
+    f"{ARTIFACT_PREFIX}/build/anomalydetection-testbench"
+    "?X-Amz-Credential=temporary&X-Amz-Signature=secret"
+)
+
+
+class TestLocalDDEvalArtifacts(unittest.TestCase):
+    def test_sha256_file_streams_file(self):
+        with tempfile.NamedTemporaryFile() as testbench:
+            testbench.write(b"testbench")
+            testbench.flush()
+            self.assertEqual(sha256_file(testbench.name), TESTBENCH_SHA256)
+
+    def test_binary_must_target_linux_amd64(self):
+        elf_header = bytearray(20)
+        elf_header[:6] = b"\x7fELF\x02\x01"
+        elf_header[18:20] = (62).to_bytes(2, "little")
+        with tempfile.NamedTemporaryFile() as testbench:
+            testbench.write(elf_header)
+            testbench.flush()
+            validate_linux_amd64_executable(testbench.name)
+
+        with tempfile.NamedTemporaryFile() as testbench:
+            testbench.write(b"native macOS binary")
+            testbench.flush()
+            with self.assertRaisesRegex(ValueError, "Linux/amd64"):
+                validate_linux_amd64_executable(testbench.name)
+
+    def test_local_testbench_key_is_content_addressed(self):
+        key = local_testbench_key(TESTBENCH_SHA256)
+
+        self.assertEqual(
+            key,
+            f"{ARTIFACT_PREFIX}/sha256/{TESTBENCH_SHA256}/anomalydetection-testbench",
+        )
+
+    def test_artifact_metadata_must_match_digest_and_size(self):
+        head_object = {"ContentLength": 9, "Metadata": {"sha256": TESTBENCH_SHA256}}
+
+        self.assertTrue(artifact_metadata_matches(head_object, TESTBENCH_SHA256, 9))
+        self.assertFalse(artifact_metadata_matches(head_object, "0" * 64, 9))
+        self.assertFalse(artifact_metadata_matches(head_object, TESTBENCH_SHA256, 10))
+
+    def test_experiment_config_preserves_settings_and_replaces_artifacts(self):
+        base_config = {
+            "input_parameters": {"existing": True},
+            "executor_config": {
+                "sigma": 30,
+                "binary_artifacts": {"scorer": {"uri": "s3://legacy/scorer"}},
+            },
+            "evaluator_config": {"threshold": 0.5},
+        }
+        component_config = {"components": {"bocpd": {"enabled": True}}}
+
+        config = build_experiment_config(
+            base_config,
+            testbench_url=PRESIGNED_URL,
+            testbench_sha256=TESTBENCH_SHA256,
+            testbench_config=component_config,
+        )
+
+        self.assertEqual(config["executor_config"]["sigma"], 30)
+        self.assertEqual(
+            config["executor_config"]["binary_artifacts"],
+            {
+                "testbench": {
+                    "uri": PRESIGNED_URL,
+                    "sha256": TESTBENCH_SHA256,
+                    "filename": "anomalydetection-testbench",
+                }
+            },
+        )
+        self.assertEqual(config["input_parameters"]["testbench_config"], component_config)
+        self.assertEqual(config["evaluator_config"], {"threshold": 0.5})
+        self.assertNotIn("testbench_config", base_config["input_parameters"])
+
+    def test_presigned_url_validation_is_restricted_to_local_artifacts(self):
+        validate_presigned_artifact_url(PRESIGNED_URL)
+
+        invalid_urls = [
+            PRESIGNED_URL.replace("https://", "http://"),
+            PRESIGNED_URL.replace("qbranch-gensim-recordings", "another-bucket"),
+            PRESIGNED_URL.replace(f"{ARTIFACT_PREFIX}/", "another-prefix/"),
+            PRESIGNED_URL.split("?")[0],
+        ]
+        for url in invalid_urls:
+            with self.subTest(url=url), self.assertRaises(ValueError):
+                validate_presigned_artifact_url(url)
+
+    def test_redacting_writer_handles_a_secret_split_across_writes(self):
+        output = StringIO()
+        replacement = redacted_presigned_url(PRESIGNED_URL)
+        writer = RedactingWriter(output, PRESIGNED_URL, replacement)
+
+        split = len(PRESIGNED_URL) // 2
+        writer.write(f"artifact={PRESIGNED_URL[:split]}")
+        writer.write(f"{PRESIGNED_URL[split:]} done\n")
+        writer.finish()
+
+        rendered = output.getvalue()
+        self.assertEqual(rendered, f"artifact={replacement} done\n")
+        self.assertNotIn("X-Amz-Signature", rendered)
+        self.assertNotIn("secret", rendered)
+
+    def test_redacting_writer_does_not_flush_a_partial_secret(self):
+        output = StringIO()
+        replacement = redacted_presigned_url(PRESIGNED_URL)
+        writer = RedactingWriter(output, PRESIGNED_URL, replacement)
+
+        writer.write(PRESIGNED_URL[:-3])
+        writer.finish()
+
+        self.assertNotIn("X-Amz-Signature", output.getvalue())
+
+    def test_workflow_args_target_ddbuild_without_a_test_drive(self):
+        args = workflow_run_args(
+            ["ddeval"],
+            service="eval_worker_agent_aad",
+            project="observer-log-ad",
+            dataset="dataset",
+            dataset_version=6,
+            config_path="/tmp/config.json",
+            jobs=20,
+            max_attempts=1,
+            data_env="staging",
+            limit=2,
+            where_in="metadata.record_id=a,b",
+        )
+
+        self.assertIn("ddbuild", args)
+        self.assertIn("eval_worker_agent_aad", args)
+        self.assertEqual(args[args.index("--dataset-version") + 1], "6")
+        self.assertIn("metadata.record_id=a,b", args)
+        self.assertNotIn("--workflow-test-drive", args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tasks/unit_tests/anomalydetection_ddeval_tests.py
+++ b/tasks/unit_tests/anomalydetection_ddeval_tests.py
@@ -3,6 +3,7 @@ import tempfile
 import unittest
 from io import StringIO
 
+from tasks.anomalydetection import _local_ddeval_command
 from tasks.libs.anomalydetection.ddeval import (
     ARTIFACT_PREFIX,
     RedactingWriter,
@@ -25,6 +26,14 @@ PRESIGNED_URL = (
 
 
 class TestLocalDDEvalArtifacts(unittest.TestCase):
+    def test_custom_ddeval_executable_is_not_shell_parsed(self):
+        executable = r"C:\Program Files\DDEval\ddeval.exe"
+
+        command, command_dir = _local_ddeval_command(executable, "")
+
+        self.assertEqual(command, [executable])
+        self.assertIsNone(command_dir)
+
     def test_sha256_file_streams_file(self):
         with tempfile.NamedTemporaryFile() as testbench:
             testbench.write(b"testbench")


### PR DESCRIPTION
### What does this PR do?
Adds the abillity to `dda inv anomalydetection.eval-ddeval` and run evals from local testbench binaries, default uses 25 scenarios [in LLMObs](https://dd.datad0g.com/llm/datasets/2a1f7902-6ba6-493c-999b-c70e4a8cdd7a?project=observer-log-ad&version=1). 

The task sends builds the testbench binary, sends it to `qbranch-recordings/test-binaries/` gated by SHAs (to avoid unnecessary rebuilds), creates a presigned URL (with only `GET`) to the worker so it can pick it up and use it for its evals. Task also streams ddeval output to user. 

Datasets, concurrency, and observer-config can be overriden. 

### Motivation

Make remote Observer evaluations usable from a developer checkout without downloading scenario data locally or using CI to upload binaries. 

### Describe how you validated your changes

- Ran the task against Golden 25. all 25 records completed remotely.

### Additional Notes
