### PR TITLE
fix(wlan): do not panic when wlanapi.dll is unavailable on Windows

### DIFF
--- a/pkg/collector/corechecks/net/wlan/BUILD.bazel
+++ b/pkg/collector/corechecks/net/wlan/BUILD.bazel
@@ -35,11 +35,19 @@ go_library(
 
 dd_agent_go_test(
     name = "wlan_test",
-    srcs = ["wlan_test.go"],
+    srcs = [
+        "wlan_test.go",
+        "wlan_windows_test.go",
+    ],
     embed = [":wlan"],
     deps = [
         "//comp/core/autodiscovery/integration",
         "//pkg/aggregator/mocksender",
         "@com_github_stretchr_testify//assert",
-    ],
+    ] + select({
+        "@rules_go//go/platform:windows": [
+            "@com_github_stretchr_testify//require",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/pkg/collector/corechecks/net/wlan/wlan_windows.go
+++ b/pkg/collector/corechecks/net/wlan/wlan_windows.go
@@ -38,6 +38,10 @@ var (
 	// getWiFiInfo is a package-level function variable for testability
 	// Tests can reassign this to mock WiFi data retrieval
 	getWiFiInfo func() (wifiInfo, error)
+
+	// loadWlanAPI is a package-level function variable for testability
+	// Tests can reassign this to simulate a host without wlanapi.dll
+	loadWlanAPI = wlanAPI.Load
 )
 
 // https://learn.microsoft.com/en-us/windows/win32/api/wlanapi/ne-wlanapi-wlan_interface_state-r1
@@ -511,6 +515,17 @@ func (c *WLANCheck) GetWiFiInfo() (wifiInfo, error) {
 	// Check for test override
 	if getWiFiInfo != nil {
 		return getWiFiInfo()
+	}
+
+	// wlanapi.dll ships with the Wireless-Networking feature, which is not
+	// installed by default on Windows Server, and windows.LazyProc.Call panics
+	// instead of returning an error when it cannot resolve the library, so load
+	// it before calling into it. A host with no WLAN stack has no Wi-Fi
+	// interface to report on, which is the normal state of a Windows Server
+	// rather than a collection failure.
+	if err := loadWlanAPI(); err != nil {
+		log.Debugf("Skipping Wi-Fi collection, wlanapi.dll is unavailable: %v", err)
+		return wifiInfo{phyMode: "None"}, nil
 	}
 
 	wi, err := getFirstConnectedWlanInfo()

--- a/pkg/collector/corechecks/net/wlan/wlan_windows_test.go
+++ b/pkg/collector/corechecks/net/wlan/wlan_windows_test.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows && test
+
+package wlan
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetWiFiInfoWithoutWLANAPI covers a host with no WLAN stack, the default
+// state of Windows Server: wlanapi.dll is absent and calling into it panics.
+func TestGetWiFiInfoWithoutWLANAPI(t *testing.T) {
+	getWiFiInfo = nil // exercise the real implementation
+	orig := loadWlanAPI
+	loadWlanAPI = func() error { return errors.New("wlanapi.dll is missing") }
+	t.Cleanup(func() { loadWlanAPI = orig })
+
+	c := &WLANCheck{}
+	var (
+		wi  wifiInfo
+		err error
+	)
+	require.NotPanics(t, func() { wi, err = c.GetWiFiInfo() })
+	assert.NoError(t, err)
+	assert.Equal(t, "None", wi.phyMode)
+}

--- a/releasenotes/notes/fix-wlan-windows-missing-wlanapi-970ec599cdac2590.yaml
+++ b/releasenotes/notes/fix-wlan-windows-missing-wlanapi-970ec599cdac2590.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    On Windows, the ``wlan`` check no longer panics on hosts where
+    ``wlanapi.dll`` is unavailable. The library ships with the
+    ``Wireless-Networking`` feature, which is not installed by default on
+    Windows Server. Such hosts are now reported as having no active Wi-Fi
+    interface.


### PR DESCRIPTION
### What does this PR do?

Stops the Windows `wlan` check from panicking when `wlanapi.dll` cannot be loaded.

`wlanapi.dll` ships with the Windows `Wireless-Networking` feature, which is **not installed by default on Windows Server**. `windows.LazyProc.Call` panics (via `mustFind`) instead of returning an error when it cannot resolve the DLL, so the very first call in `getWlanHandle` blew up.

`GetWiFiInfo` now loads the DLL before calling into it, and reports no active Wi-Fi interface (`phyMode: "None"` → WARNING status) when the load fails. A host with no WLAN stack has no Wi-Fi interface to report on, which is a normal server state rather than a collection failure.

`LazyDLL.Load` already caches the module handle on success and guards itself with a mutex, so calling it per run costs a single atomic load once the library is present — no `sync.Once` needed, and wrapping it in one would additionally cache the *failure*, which `Load` deliberately does not. Loading per run also means a host that installs `Wireless-Networking` starts reporting on the next check tick with no Agent restart.

### Motivation

Jira: [WINA-3050](https://datadoghq.atlassian.net/browse/WINA-3050)

Reported crash: the Agent process crashes on Windows Server when the `wlan` check is enabled and there is no Wi-Fi.

Reproduced on a Windows Server 2022 VM with no `Wireless-Networking` feature installed (`wlanapi.dll` absent, `wlansvc` not registered), running Agent 7.82.1:

```
panic: The specified module could not be found.

golang.org/x/sys/windows.(*LazyProc).mustFind(...)
	golang.org/x/sys@v0.47.0/windows/dll_windows.go:293
golang.org/x/sys/windows.(*LazyProc).Call(...)
	golang.org/x/sys@v0.47.0/windows/dll_windows.go:315 +0x59
.../wlan.getWlanHandle()              wlan_windows.go:375
.../wlan.getFirstConnectedWlanInfo()  wlan_windows.go:468
.../wlan.(*WLANCheck).GetWiFiInfo()   wlan_windows.go:516
.../wlan.(*WLANCheck).Run()           wlan.go:158
.../check.runCheck(...)               command.go:674
```

Two symptoms depending on the path:

- **`agent check wlan`** — hard crash, full panic to stderr, non-zero exit (the CLI path has no recover).
- **Long-running agent service** — survives thanks to the recover in `pkg/collector/worker`, but degrades permanently: the panic is recovered and re-logged every 15s, a MEDIUM health-platform issue stays open, and no `system.wlan.*` metrics are ever emitted.

```
ERROR | worker.go:232 | Recovered from panic in check wlan: The specified module could not be found.
ERROR | check_logger.go:71 | check:wlan | Error running check: check panicked: ...
INFO  | Health platform: NEW issue from collector: Check 'wlan' Failed (ISSUE_SEVERITY_MEDIUM)
```

On an Agent older than #49763 (which added the worker recover, so roughly pre-7.75) the service itself would have died outright.

Note the trigger is *no WLAN stack*, not *no Wi-Fi network*. A server with the feature installed but not associated to an AP already worked correctly.

### Describe how you validated your changes

- Reproduced the original panic on the affected VM (Windows Server 2022, Agent 7.82.1), both via `agent check wlan` and in the running service log.
- Added `wlan_windows_test.go` (`windows && test`): with the loader stubbed to fail, `GetWiFiInfo` does not panic and returns `phyMode: "None"` with no error. Deterministic on any runner, including ones that do have the DLL.
- `dda inv test --targets=./pkg/collector/corechecks/net/wlan` — 17 tests pass.
- `GOOS=windows dda inv linter.go --targets=./pkg/collector/corechecks/net/wlan --build-tags=test` — 0 issues; verified the Windows-only test file is actually typechecked (temporarily injected a type error and confirmed the linter caught it).
- `BUILD.bazel` regenerated with `bazel run //:gazelle`, then formatted with `bazel run //bazel/buildifier` (no changes produced). `bazel test //bazel/buildifier:test` passes, so the file is clean in both `diff` and `warn` lint mode.

**Verified end-to-end on the affected host.** Installed this PR's pipeline MSI (`pipelines/A7/131968742`, `7.84.0-devel.git.310.3d4ea7b`, SHA256 verified after transfer) on the same Windows Server 2022 VM that reproduced the crash, with `wlanapi.dll` still absent and the same `wlan.d/conf.yaml` in place.

| | Before (7.82.1) | After (3d4ea7b) |
|---|---|---|
| `agent check wlan` | `panic: The specified module could not be found.`, non-zero exit | `Instance ID: wlan [OK]`, **exit code 0** |
| Service, per 15s run | 2 ERROR lines + MEDIUM health issue | `Running check...` → `Done running check`, no errors |
| New recovered panics after restart | every run | **0** over 75s / 6 runs |
| `system.wlan.*` metrics | none emitted | `system.wlan.status = 1` (warning), `reason:interface_inactive` |
| Health platform | `Check 'wlan' Failed (ISSUE_SEVERITY_MEDIUM)` | no issue raised |

Confirmed the new branch is what executes, rather than the check succeeding for some unrelated reason (`--log-level debug`):

```
DEBUG | (pkg/collector/corechecks/net/wlan/wlan_windows.go:527 in GetWiFiInfo) | Skipping Wi-Fi collection, wlanapi.dll is unavailable: The specified module could not be found.
WARN  | (pkg/collector/corechecks/net/wlan/wlan.go:179 in Run) | No active Wi-Fi interface detected: PHYMode is none.
```

Same underlying Windows error that used to be the panic, now a debug line and a WARNING status.

### Additional Notes

The shipped `wlan.d/conf.yaml.default` carries the `_end_user_device` AD identifier, which normally keeps this check off servers; reproducing required a hand-written `wlan.d/conf.yaml`, which is presumably what the reporting host has.


[WINA-3050]: https://datadoghq.atlassian.net/browse/WINA-3050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ