### PR TITLE
[CWS-6779] Implement the setns syscall

### DIFF
--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -1975,11 +1975,7 @@ Workload Protection events for Linux systems have the following JSON schema:
                 },
                 "nstype": {
                     "type": "string",
-                    "description": "Namespace types requested by the caller, ANY when the syscall let the kernel infer the type"
-                },
-                "effective_nstype": {
-                    "type": "string",
-                    "description": "Namespace types the kernel actually installed, omitted if it couldn't be resolved"
+                    "description": "Namespace types the thread joined, ANY if the type couldn't be determined"
                 },
                 "mntns": {
                     "type": "integer",
@@ -5562,11 +5558,7 @@ ancestor lineage to find the same value. |
         },
         "nstype": {
             "type": "string",
-            "description": "Namespace types requested by the caller, ANY when the syscall let the kernel infer the type"
-        },
-        "effective_nstype": {
-            "type": "string",
-            "description": "Namespace types the kernel actually installed, omitted if it couldn't be resolved"
+            "description": "Namespace types the thread joined, ANY if the type couldn't be determined"
         },
         "mntns": {
             "type": "integer",
@@ -5591,8 +5583,7 @@ ancestor lineage to find the same value. |
 | Field | Description |
 | ----- | ----------- |
 | `fd` | File descriptor of the namespace the thread requested to join |
-| `nstype` | Namespace types requested by the caller, ANY when the syscall let the kernel infer the type |
-| `effective_nstype` | Namespace types the kernel actually installed, omitted if it couldn't be resolved |
+| `nstype` | Namespace types the thread joined, ANY if the type couldn't be determined |
 | `mntns` | Mount namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved |
 | `netns` | Network namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved |
 

--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -1967,6 +1967,33 @@ Workload Protection events for Linux systems have the following JSON schema:
             ],
             "description": "SecurityProfileContextSerializer serializes the security profile context in an event"
         },
+        "SetNSEvent": {
+            "properties": {
+                "fd": {
+                    "type": "integer",
+                    "description": "File descriptor of the namespace the thread requested to join"
+                },
+                "nstype": {
+                    "type": "string",
+                    "description": "Requested namespace types, ANY when the syscall let the kernel infer the type"
+                },
+                "mntns": {
+                    "type": "integer",
+                    "description": "Mount namespace ID of the thread once the syscall returned"
+                },
+                "netns": {
+                    "type": "integer",
+                    "description": "Network namespace ID of the thread once the syscall returned"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+                "fd",
+                "nstype"
+            ],
+            "description": "SetNSEventSerializer serializes a setns event"
+        },
         "SetSockOptEvent": {
             "properties": {
                 "socket_type": {
@@ -2575,6 +2602,9 @@ Workload Protection events for Linux systems have the following JSON schema:
         "setrlimit": {
             "$ref": "#/$defs/SetrlimitEvent"
         },
+        "setns": {
+            "$ref": "#/$defs/SetNSEvent"
+        },
         "socket": {
             "$ref": "#/$defs/SocketEvent"
         }
@@ -2630,6 +2660,7 @@ Workload Protection events for Linux systems have the following JSON schema:
 | `capabilities` | $ref | Please see [CapabilitiesEvent](#capabilitiesevent) |
 | `prctl` | $ref | Please see [PrCtlEvent](#prctlevent) |
 | `setrlimit` | $ref | Please see [SetrlimitEvent](#setrlimitevent) |
+| `setns` | $ref | Please see [SetNSEvent](#setnsevent) |
 | `socket` | $ref | Please see [SocketEvent](#socketevent) |
 
 ## `AWSIMDSEvent`
@@ -5513,6 +5544,48 @@ ancestor lineage to find the same value. |
 | `tags` | List of tags associated to this profile |
 | `event_in_profile` | True if the corresponding event is part of this profile |
 | `event_type_state` | State of the event type in this profile |
+
+
+## `SetNSEvent`
+
+
+{{< code-block lang="json" collapsible="true" >}}
+{
+    "properties": {
+        "fd": {
+            "type": "integer",
+            "description": "File descriptor of the namespace the thread requested to join"
+        },
+        "nstype": {
+            "type": "string",
+            "description": "Requested namespace types, ANY when the syscall let the kernel infer the type"
+        },
+        "mntns": {
+            "type": "integer",
+            "description": "Mount namespace ID of the thread once the syscall returned"
+        },
+        "netns": {
+            "type": "integer",
+            "description": "Network namespace ID of the thread once the syscall returned"
+        }
+    },
+    "additionalProperties": false,
+    "type": "object",
+    "required": [
+        "fd",
+        "nstype"
+    ],
+    "description": "SetNSEventSerializer serializes a setns event"
+}
+
+{{< /code-block >}}
+
+| Field | Description |
+| ----- | ----------- |
+| `fd` | File descriptor of the namespace the thread requested to join |
+| `nstype` | Requested namespace types, ANY when the syscall let the kernel infer the type |
+| `mntns` | Mount namespace ID of the thread once the syscall returned |
+| `netns` | Network namespace ID of the thread once the syscall returned |
 
 
 ## `SetSockOptEvent`

--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -1979,11 +1979,11 @@ Workload Protection events for Linux systems have the following JSON schema:
                 },
                 "mntns": {
                     "type": "integer",
-                    "description": "Mount namespace ID of the thread once the syscall returned"
+                    "description": "Mount namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved"
                 },
                 "netns": {
                     "type": "integer",
-                    "description": "Network namespace ID of the thread once the syscall returned"
+                    "description": "Network namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved"
                 }
             },
             "additionalProperties": false,
@@ -5562,11 +5562,11 @@ ancestor lineage to find the same value. |
         },
         "mntns": {
             "type": "integer",
-            "description": "Mount namespace ID of the thread once the syscall returned"
+            "description": "Mount namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved"
         },
         "netns": {
             "type": "integer",
-            "description": "Network namespace ID of the thread once the syscall returned"
+            "description": "Network namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved"
         }
     },
     "additionalProperties": false,
@@ -5584,8 +5584,8 @@ ancestor lineage to find the same value. |
 | ----- | ----------- |
 | `fd` | File descriptor of the namespace the thread requested to join |
 | `nstype` | Requested namespace types, ANY when the syscall let the kernel infer the type |
-| `mntns` | Mount namespace ID of the thread once the syscall returned |
-| `netns` | Network namespace ID of the thread once the syscall returned |
+| `mntns` | Mount namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved |
+| `netns` | Network namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved |
 
 
 ## `SetSockOptEvent`

--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -1975,7 +1975,11 @@ Workload Protection events for Linux systems have the following JSON schema:
                 },
                 "nstype": {
                     "type": "string",
-                    "description": "Requested namespace types, ANY when the syscall let the kernel infer the type"
+                    "description": "Namespace types requested by the caller, ANY when the syscall let the kernel infer the type"
+                },
+                "effective_nstype": {
+                    "type": "string",
+                    "description": "Namespace types the kernel actually installed, omitted if it couldn't be resolved"
                 },
                 "mntns": {
                     "type": "integer",
@@ -5558,7 +5562,11 @@ ancestor lineage to find the same value. |
         },
         "nstype": {
             "type": "string",
-            "description": "Requested namespace types, ANY when the syscall let the kernel infer the type"
+            "description": "Namespace types requested by the caller, ANY when the syscall let the kernel infer the type"
+        },
+        "effective_nstype": {
+            "type": "string",
+            "description": "Namespace types the kernel actually installed, omitted if it couldn't be resolved"
         },
         "mntns": {
             "type": "integer",
@@ -5583,7 +5591,8 @@ ancestor lineage to find the same value. |
 | Field | Description |
 | ----- | ----------- |
 | `fd` | File descriptor of the namespace the thread requested to join |
-| `nstype` | Requested namespace types, ANY when the syscall let the kernel infer the type |
+| `nstype` | Namespace types requested by the caller, ANY when the syscall let the kernel infer the type |
+| `effective_nstype` | Namespace types the kernel actually installed, omitted if it couldn't be resolved |
 | `mntns` | Mount namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved |
 | `netns` | Network namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved |
 

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -1968,11 +1968,11 @@
         },
         "mntns": {
           "type": "integer",
-          "description": "Mount namespace ID of the thread once the syscall returned"
+          "description": "Mount namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved"
         },
         "netns": {
           "type": "integer",
-          "description": "Network namespace ID of the thread once the syscall returned"
+          "description": "Network namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved"
         }
       },
       "additionalProperties": false,

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -1964,11 +1964,7 @@
         },
         "nstype": {
           "type": "string",
-          "description": "Namespace types requested by the caller, ANY when the syscall let the kernel infer the type"
-        },
-        "effective_nstype": {
-          "type": "string",
-          "description": "Namespace types the kernel actually installed, omitted if it couldn't be resolved"
+          "description": "Namespace types the thread joined, ANY if the type couldn't be determined"
         },
         "mntns": {
           "type": "integer",

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -1964,7 +1964,11 @@
         },
         "nstype": {
           "type": "string",
-          "description": "Requested namespace types, ANY when the syscall let the kernel infer the type"
+          "description": "Namespace types requested by the caller, ANY when the syscall let the kernel infer the type"
+        },
+        "effective_nstype": {
+          "type": "string",
+          "description": "Namespace types the kernel actually installed, omitted if it couldn't be resolved"
         },
         "mntns": {
           "type": "integer",

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -1956,6 +1956,33 @@
       ],
       "description": "SecurityProfileContextSerializer serializes the security profile context in an event"
     },
+    "SetNSEvent": {
+      "properties": {
+        "fd": {
+          "type": "integer",
+          "description": "File descriptor of the namespace the thread requested to join"
+        },
+        "nstype": {
+          "type": "string",
+          "description": "Requested namespace types, ANY when the syscall let the kernel infer the type"
+        },
+        "mntns": {
+          "type": "integer",
+          "description": "Mount namespace ID of the thread once the syscall returned"
+        },
+        "netns": {
+          "type": "integer",
+          "description": "Network namespace ID of the thread once the syscall returned"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "fd",
+        "nstype"
+      ],
+      "description": "SetNSEventSerializer serializes a setns event"
+    },
     "SetSockOptEvent": {
       "properties": {
         "socket_type": {
@@ -2563,6 +2590,9 @@
     },
     "setrlimit": {
       "$ref": "#/$defs/SetrlimitEvent"
+    },
+    "setns": {
+      "$ref": "#/$defs/SetNSEvent"
     },
     "socket": {
       "$ref": "#/$defs/SocketEvent"

--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -59,6 +59,7 @@ Triggers are events that correspond to types of activity seen by the system. The
 | `rmdir` | File | A directory was removed | 7.27 |
 | `selinux` | Kernel | An SELinux operation was run | 7.30 |
 | `setgid` | Process | A process changed its effective gid | 7.27 |
+| `setns` | Kernel | A thread joined an existing namespace | 7.84 |
 | `setrlimit` | Process | A setrlimit command was executed | 7.68 |
 | `setsockopt` | Network | A setsockopt was executed | 7.68 |
 | `setuid` | Process | A process changed its effective uid | 7.27 |
@@ -1894,6 +1895,18 @@ A process changed its effective gid
 | [`setgid.gid`](#setgid-gid-doc) | New GID of the process |
 | [`setgid.group`](#setgid-group-doc) | New group of the process |
 
+### Event `setns`
+
+A thread joined an existing namespace
+
+| Property | Definition |
+| -------- | ------------- |
+| [`setns.fd`](#setns-fd-doc) | File descriptor of the namespace the thread requested to join |
+| [`setns.mntns`](#setns-mntns-doc) | MNTNS ID of the thread once the syscall returned, 0 if it couldn't be resolved |
+| [`setns.netns`](#setns-netns-doc) | NetNS ID of the thread once the syscall returned, 0 if it couldn't be resolved |
+| [`setns.nstype`](#setns-nstype-doc) | Requested namespace types. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor |
+| [`setns.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
+
 ### Event `setrlimit`
 
 A setrlimit command was executed
@@ -3609,8 +3622,8 @@ Type: int
 
 Definition: Return value of the syscall
 
-`*.retval` has 28 possible prefixes:
-`accept` `bind` `bpf` `chdir` `chmod` `chown` `connect` `link` `load_module` `mkdir` `mmap` `mount` `mprotect` `open` `prctl` `ptrace` `removexattr` `rename` `rmdir` `setrlimit` `setsockopt` `setxattr` `signal` `socket` `splice` `unlink` `unload_module` `utimes`
+`*.retval` has 29 possible prefixes:
+`accept` `bind` `bpf` `chdir` `chmod` `chown` `connect` `link` `load_module` `mkdir` `mmap` `mount` `mprotect` `open` `prctl` `ptrace` `removexattr` `rename` `rmdir` `setns` `setrlimit` `setsockopt` `setxattr` `signal` `socket` `splice` `unlink` `unload_module` `utimes`
 
 Constants: [Error constants](#error-constants)
 
@@ -4722,6 +4735,37 @@ Definition: New GID of the process
 Type: string
 
 Definition: New group of the process
+
+
+
+### `setns.fd` {#setns-fd-doc}
+Type: int
+
+Definition: File descriptor of the namespace the thread requested to join
+
+
+
+### `setns.mntns` {#setns-mntns-doc}
+Type: int
+
+Definition: MNTNS ID of the thread once the syscall returned, 0 if it couldn't be resolved
+
+
+
+### `setns.netns` {#setns-netns-doc}
+Type: int
+
+Definition: NetNS ID of the thread once the syscall returned, 0 if it couldn't be resolved
+
+
+
+### `setns.nstype` {#setns-nstype-doc}
+Type: int
+
+Definition: Requested namespace types. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor
+
+
+Constants: [Namespace types](#namespace-types)
 
 
 
@@ -5956,6 +6000,20 @@ MMap flags are the supported flags for the mmap syscall.
 | `MAP_HUGE_2GB` | all |
 | `MAP_HUGE_16GB` | all |
 | `MAP_32BIT` | amd64 |
+
+### `Namespace types` {#namespace-types}
+Namespace types are the supported namespace types for the setns syscall.
+
+| Name | Architectures |
+| ---- |---------------|
+| `CLONE_NEWTIME` | all |
+| `CLONE_NEWNS` | all |
+| `CLONE_NEWCGROUP` | all |
+| `CLONE_NEWUTS` | all |
+| `CLONE_NEWIPC` | all |
+| `CLONE_NEWUSER` | all |
+| `CLONE_NEWPID` | all |
+| `CLONE_NEWNET` | all |
 
 ### `Network Address Family constants` {#network-address-family-constants}
 Network Address Family constants are the supported network address families.

--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -1901,11 +1901,10 @@ A thread joined an existing namespace
 
 | Property | Definition |
 | -------- | ------------- |
-| [`setns.effective_nstype`](#setns-effective_nstype-doc) | Namespace types the kernel actually installed, resolved from the file descriptor when the caller passed 0. Reported even when the join was denied. 0 if it couldn't be resolved |
 | [`setns.fd`](#setns-fd-doc) | File descriptor of the namespace the thread requested to join |
 | [`setns.mntns`](#setns-mntns-doc) | MNTNS ID of the thread once the syscall returned, 0 if it couldn't be resolved |
 | [`setns.netns`](#setns-netns-doc) | NetNS ID of the thread once the syscall returned, 0 if it couldn't be resolved |
-| [`setns.nstype`](#setns-nstype-doc) | Namespace types requested by the caller. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor. Prefer `effective_nstype` in rules, as a caller passing 0 would otherwise evade them |
+| [`setns.nstype`](#setns-nstype-doc) | Namespace types the thread joined. Resolved from the file descriptor when the caller passed 0, so it stays usable in rules whatever the caller requested. Reported even when the join was denied. 0 if it couldn't be determined |
 | [`setns.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `setrlimit`
@@ -4739,16 +4738,6 @@ Definition: New group of the process
 
 
 
-### `setns.effective_nstype` {#setns-effective_nstype-doc}
-Type: int
-
-Definition: Namespace types the kernel actually installed, resolved from the file descriptor when the caller passed 0. Reported even when the join was denied. 0 if it couldn't be resolved
-
-
-Constants: [Namespace types](#namespace-types)
-
-
-
 ### `setns.fd` {#setns-fd-doc}
 Type: int
 
@@ -4773,7 +4762,7 @@ Definition: NetNS ID of the thread once the syscall returned, 0 if it couldn't b
 ### `setns.nstype` {#setns-nstype-doc}
 Type: int
 
-Definition: Namespace types requested by the caller. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor. Prefer `effective_nstype` in rules, as a caller passing 0 would otherwise evade them
+Definition: Namespace types the thread joined. Resolved from the file descriptor when the caller passed 0, so it stays usable in rules whatever the caller requested. Reported even when the join was denied. 0 if it couldn't be determined
 
 
 Constants: [Namespace types](#namespace-types)

--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -1901,10 +1901,11 @@ A thread joined an existing namespace
 
 | Property | Definition |
 | -------- | ------------- |
+| [`setns.effective_nstype`](#setns-effective_nstype-doc) | Namespace types the kernel actually installed, resolved from the file descriptor when the caller passed 0. Reported even when the join was denied. 0 if it couldn't be resolved |
 | [`setns.fd`](#setns-fd-doc) | File descriptor of the namespace the thread requested to join |
 | [`setns.mntns`](#setns-mntns-doc) | MNTNS ID of the thread once the syscall returned, 0 if it couldn't be resolved |
 | [`setns.netns`](#setns-netns-doc) | NetNS ID of the thread once the syscall returned, 0 if it couldn't be resolved |
-| [`setns.nstype`](#setns-nstype-doc) | Requested namespace types. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor |
+| [`setns.nstype`](#setns-nstype-doc) | Namespace types requested by the caller. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor. Prefer `effective_nstype` in rules, as a caller passing 0 would otherwise evade them |
 | [`setns.retval`](#common-syscallevent-retval-doc) | Return value of the syscall |
 
 ### Event `setrlimit`
@@ -4738,6 +4739,16 @@ Definition: New group of the process
 
 
 
+### `setns.effective_nstype` {#setns-effective_nstype-doc}
+Type: int
+
+Definition: Namespace types the kernel actually installed, resolved from the file descriptor when the caller passed 0. Reported even when the join was denied. 0 if it couldn't be resolved
+
+
+Constants: [Namespace types](#namespace-types)
+
+
+
 ### `setns.fd` {#setns-fd-doc}
 Type: int
 
@@ -4762,7 +4773,7 @@ Definition: NetNS ID of the thread once the syscall returned, 0 if it couldn't b
 ### `setns.nstype` {#setns-nstype-doc}
 Type: int
 
-Definition: Requested namespace types. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor
+Definition: Namespace types requested by the caller. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor. Prefer `effective_nstype` in rules, as a caller passing 0 would otherwise evade them
 
 
 Constants: [Namespace types](#namespace-types)

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -7767,11 +7767,6 @@
       "experimental": false,
       "properties": [
         {
-          "name": "setns.effective_nstype",
-          "definition": "Namespace types the kernel actually installed, resolved from the file descriptor when the caller passed 0. Reported even when the join was denied. 0 if it couldn't be resolved",
-          "property_doc_link": "setns-effective_nstype-doc"
-        },
-        {
           "name": "setns.fd",
           "definition": "File descriptor of the namespace the thread requested to join",
           "property_doc_link": "setns-fd-doc"
@@ -7788,7 +7783,7 @@
         },
         {
           "name": "setns.nstype",
-          "definition": "Namespace types requested by the caller. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor. Prefer `effective_nstype` in rules, as a caller passing 0 would otherwise evade them",
+          "definition": "Namespace types the thread joined. Resolved from the file descriptor when the caller passed 0, so it stays usable in rules whatever the caller requested. Reported even when the join was denied. 0 if it couldn't be determined",
           "property_doc_link": "setns-nstype-doc"
         },
         {
@@ -16759,18 +16754,6 @@
       "examples": []
     },
     {
-      "name": "setns.effective_nstype",
-      "link": "setns-effective_nstype-doc",
-      "type": "int",
-      "definition": "Namespace types the kernel actually installed, resolved from the file descriptor when the caller passed 0. Reported even when the join was denied. 0 if it couldn't be resolved",
-      "prefixes": [
-        "setns"
-      ],
-      "constants": "Namespace types",
-      "constants_link": "namespace-types",
-      "examples": []
-    },
-    {
       "name": "setns.fd",
       "link": "setns-fd-doc",
       "type": "int",
@@ -16810,7 +16793,7 @@
       "name": "setns.nstype",
       "link": "setns-nstype-doc",
       "type": "int",
-      "definition": "Namespace types requested by the caller. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor. Prefer `effective_nstype` in rules, as a caller passing 0 would otherwise evade them",
+      "definition": "Namespace types the thread joined. Resolved from the file descriptor when the caller passed 0, so it stays usable in rules whatever the caller requested. Reported even when the join was denied. 0 if it couldn't be determined",
       "prefixes": [
         "setns"
       ],

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -7767,6 +7767,11 @@
       "experimental": false,
       "properties": [
         {
+          "name": "setns.effective_nstype",
+          "definition": "Namespace types the kernel actually installed, resolved from the file descriptor when the caller passed 0. Reported even when the join was denied. 0 if it couldn't be resolved",
+          "property_doc_link": "setns-effective_nstype-doc"
+        },
+        {
           "name": "setns.fd",
           "definition": "File descriptor of the namespace the thread requested to join",
           "property_doc_link": "setns-fd-doc"
@@ -7783,7 +7788,7 @@
         },
         {
           "name": "setns.nstype",
-          "definition": "Requested namespace types. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor",
+          "definition": "Namespace types requested by the caller. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor. Prefer `effective_nstype` in rules, as a caller passing 0 would otherwise evade them",
           "property_doc_link": "setns-nstype-doc"
         },
         {
@@ -16754,6 +16759,18 @@
       "examples": []
     },
     {
+      "name": "setns.effective_nstype",
+      "link": "setns-effective_nstype-doc",
+      "type": "int",
+      "definition": "Namespace types the kernel actually installed, resolved from the file descriptor when the caller passed 0. Reported even when the join was denied. 0 if it couldn't be resolved",
+      "prefixes": [
+        "setns"
+      ],
+      "constants": "Namespace types",
+      "constants_link": "namespace-types",
+      "examples": []
+    },
+    {
       "name": "setns.fd",
       "link": "setns-fd-doc",
       "type": "int",
@@ -16793,7 +16810,7 @@
       "name": "setns.nstype",
       "link": "setns-nstype-doc",
       "type": "int",
-      "definition": "Requested namespace types. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor",
+      "definition": "Namespace types requested by the caller. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor. Prefer `effective_nstype` in rules, as a caller passing 0 would otherwise evade them",
       "prefixes": [
         "setns"
       ],

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -7760,6 +7760,40 @@
       ]
     },
     {
+      "name": "setns",
+      "definition": "A thread joined an existing namespace",
+      "type": "Kernel",
+      "from_agent_version": "7.84",
+      "experimental": false,
+      "properties": [
+        {
+          "name": "setns.fd",
+          "definition": "File descriptor of the namespace the thread requested to join",
+          "property_doc_link": "setns-fd-doc"
+        },
+        {
+          "name": "setns.mntns",
+          "definition": "MNTNS ID of the thread once the syscall returned, 0 if it couldn't be resolved",
+          "property_doc_link": "setns-mntns-doc"
+        },
+        {
+          "name": "setns.netns",
+          "definition": "NetNS ID of the thread once the syscall returned, 0 if it couldn't be resolved",
+          "property_doc_link": "setns-netns-doc"
+        },
+        {
+          "name": "setns.nstype",
+          "definition": "Requested namespace types. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor",
+          "property_doc_link": "setns-nstype-doc"
+        },
+        {
+          "name": "setns.retval",
+          "definition": "Return value of the syscall",
+          "property_doc_link": "common-syscallevent-retval-doc"
+        }
+      ]
+    },
+    {
       "name": "setrlimit",
       "definition": "A setrlimit command was executed",
       "type": "Process",
@@ -14735,6 +14769,7 @@
         "removexattr",
         "rename",
         "rmdir",
+        "setns",
         "setrlimit",
         "setsockopt",
         "setxattr",
@@ -16716,6 +16751,54 @@
       ],
       "constants": "",
       "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "setns.fd",
+      "link": "setns-fd-doc",
+      "type": "int",
+      "definition": "File descriptor of the namespace the thread requested to join",
+      "prefixes": [
+        "setns"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "setns.mntns",
+      "link": "setns-mntns-doc",
+      "type": "int",
+      "definition": "MNTNS ID of the thread once the syscall returned, 0 if it couldn't be resolved",
+      "prefixes": [
+        "setns"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "setns.netns",
+      "link": "setns-netns-doc",
+      "type": "int",
+      "definition": "NetNS ID of the thread once the syscall returned, 0 if it couldn't be resolved",
+      "prefixes": [
+        "setns"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "setns.nstype",
+      "link": "setns-nstype-doc",
+      "type": "int",
+      "definition": "Requested namespace types. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor",
+      "prefixes": [
+        "setns"
+      ],
+      "constants": "Namespace types",
+      "constants_link": "namespace-types",
       "examples": []
     },
     {
@@ -20560,6 +20643,45 @@
         {
           "name": "MAP_32BIT",
           "architecture": "amd64"
+        }
+      ]
+    },
+    {
+      "name": "Namespace types",
+      "link": "namespace-types",
+      "description": "Namespace types are the supported namespace types for the setns syscall.",
+      "all": [
+        {
+          "name": "CLONE_NEWTIME",
+          "architecture": "all"
+        },
+        {
+          "name": "CLONE_NEWNS",
+          "architecture": "all"
+        },
+        {
+          "name": "CLONE_NEWCGROUP",
+          "architecture": "all"
+        },
+        {
+          "name": "CLONE_NEWUTS",
+          "architecture": "all"
+        },
+        {
+          "name": "CLONE_NEWIPC",
+          "architecture": "all"
+        },
+        {
+          "name": "CLONE_NEWUSER",
+          "architecture": "all"
+        },
+        {
+          "name": "CLONE_NEWPID",
+          "architecture": "all"
+        },
+        {
+          "name": "CLONE_NEWNET",
+          "architecture": "all"
         }
       ]
     },

--- a/pkg/security/ebpf/c/include/constants/enums.h
+++ b/pkg/security/ebpf/c/include/constants/enums.h
@@ -79,6 +79,7 @@ enum event_type
     EVENT_SETSID,
     EVENT_NOP,
     EVENT_SOCKET,
+    EVENT_SETNS,
     EVENT_MAX, // has to be the last one
 
     EVENT_ALL = 0xffffffff // used as a mask for all the events

--- a/pkg/security/ebpf/c/include/events_definition.h
+++ b/pkg/security/ebpf/c/include/events_definition.h
@@ -558,6 +558,19 @@ struct setrlimit_event_t {
     u64 rlim_max;
 };
 
+struct setns_event_t {
+    struct kevent_t event;
+    struct process_context_t process;
+    struct span_context_t span;
+    struct cgroup_context_t cgroup;
+    struct syscall_t syscall;
+
+    s32 fd;
+    s32 nstype;
+    u32 mntns_id;
+    u32 netns_id;
+};
+
 struct setsockopt_event_t {
     struct kevent_t event;
     struct process_context_t process;

--- a/pkg/security/ebpf/c/include/events_definition.h
+++ b/pkg/security/ebpf/c/include/events_definition.h
@@ -569,7 +569,6 @@ struct setns_event_t {
     s32 nstype;
     u32 mntns_id;
     u32 netns_id;
-    u32 effective_nstype;
 };
 
 struct setsockopt_event_t {

--- a/pkg/security/ebpf/c/include/events_definition.h
+++ b/pkg/security/ebpf/c/include/events_definition.h
@@ -569,6 +569,7 @@ struct setns_event_t {
     s32 nstype;
     u32 mntns_id;
     u32 netns_id;
+    u32 effective_nstype;
 };
 
 struct setsockopt_event_t {

--- a/pkg/security/ebpf/c/include/hooks/all.h
+++ b/pkg/security/ebpf/c/include/hooks/all.h
@@ -37,6 +37,7 @@
 #include "utimes.h"
 #include "on_demand.h"
 #include "chdir.h"
+#include "setns.h"
 #include "setrlimit.h"
 #include "setsid.h"
 #include "caps.h"

--- a/pkg/security/ebpf/c/include/hooks/namespaces.h
+++ b/pkg/security/ebpf/c/include/hooks/namespaces.h
@@ -2,6 +2,7 @@
 #define _HOOKS_NAMESPACES_H_
 
 #include "constants/offsets/netns.h"
+#include "helpers/syscalls.h"
 #include "maps.h"
 
 HOOK_ENTRY("switch_task_namespaces")
@@ -10,6 +11,10 @@ int hook_switch_task_namespaces(ctx_t *ctx) {
     if (new_ns == NULL) {
         return 0;
     }
+
+    // setns(2) commits the namespaces it joins through this function: report the resolved
+    // namespace IDs alongside the event instead of just the target file descriptor.
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_SETNS);
 
     u64 nsproxy_mnt_ns_offset;
     LOAD_CONSTANT("nsproxy_mnt_ns_offset", nsproxy_mnt_ns_offset);
@@ -22,6 +27,10 @@ int hook_switch_task_namespaces(ctx_t *ctx) {
 
         u32 pid = bpf_get_current_pid_tgid() >> 32;
         bpf_map_update_elem(&mntns_cache, &pid, &inum, BPF_ANY);
+
+        if (syscall != NULL) {
+            syscall->setns.mntns_id = inum;
+        }
     }
 
     u64 nsproxy_net_ns_offset;
@@ -36,6 +45,10 @@ int hook_switch_task_namespaces(ctx_t *ctx) {
     u32 netns = get_netns_from_net(net);
     u32 tid = bpf_get_current_pid_tgid();
     bpf_map_update_elem(&netns_cache, &tid, &netns, BPF_ANY);
+
+    if (syscall != NULL) {
+        syscall->setns.netns_id = netns;
+    }
     return 0;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/setns.h
+++ b/pkg/security/ebpf/c/include/hooks/setns.h
@@ -6,6 +6,35 @@
 #include "helpers/syscalls.h"
 #include "events_definition.h"
 
+// setns accepts a nstype of 0, in which case the kernel resolves the type from the file
+// descriptor (`flags = ns->ops->type`). The syscall arguments alone therefore don't tell us which
+// namespace was joined, so the type is recovered from the per-namespace install callbacks below.
+// These values are uapi and can never change; guarded because linux/sched.h may also define them.
+#ifndef CLONE_NEWTIME
+#define CLONE_NEWTIME 0x00000080
+#endif
+#ifndef CLONE_NEWNS
+#define CLONE_NEWNS 0x00020000
+#endif
+#ifndef CLONE_NEWCGROUP
+#define CLONE_NEWCGROUP 0x02000000
+#endif
+#ifndef CLONE_NEWUTS
+#define CLONE_NEWUTS 0x04000000
+#endif
+#ifndef CLONE_NEWIPC
+#define CLONE_NEWIPC 0x08000000
+#endif
+#ifndef CLONE_NEWUSER
+#define CLONE_NEWUSER 0x10000000
+#endif
+#ifndef CLONE_NEWPID
+#define CLONE_NEWPID 0x20000000
+#endif
+#ifndef CLONE_NEWNET
+#define CLONE_NEWNET 0x40000000
+#endif
+
 static int __attribute__((always_inline)) sys_setns_ret(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_SETNS);
     if (!syscall) {
@@ -23,6 +52,7 @@ static int __attribute__((always_inline)) sys_setns_ret(void *ctx, int retval) {
         .nstype = syscall->setns.nstype,
         .mntns_id = syscall->setns.mntns_id,
         .netns_id = syscall->setns.netns_id,
+        .effective_nstype = syscall->setns.effective_nstype,
     };
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
@@ -56,6 +86,61 @@ HOOK_SYSCALL_EXIT(setns) {
 
 TAIL_CALL_TRACEPOINT_FNC(handle_sys_setns_exit, struct tracepoint_raw_syscalls_sys_exit_t *args) {
     return sys_setns_ret(args, args->ret);
+}
+
+// The proc_ns_operations install callbacks are only reached from the setns syscall, and the
+// function that fired identifies the namespace type without reading any kernel struct. They run
+// before commit_nsset, so the syscall cache is still live. The flag is recorded even when the
+// callback goes on to fail, so a denied join still reports which namespace type was attempted.
+// A pidfd target installs several namespaces in one call, hence the accumulating OR.
+static int __attribute__((always_inline)) handle_ns_install(u32 nstype) {
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_SETNS);
+    if (!syscall) {
+        return 0;
+    }
+
+    syscall->setns.effective_nstype |= nstype;
+    return 0;
+}
+
+HOOK_ENTRY("mntns_install")
+int hook_mntns_install(ctx_t *ctx) {
+    return handle_ns_install(CLONE_NEWNS);
+}
+
+HOOK_ENTRY("netns_install")
+int hook_netns_install(ctx_t *ctx) {
+    return handle_ns_install(CLONE_NEWNET);
+}
+
+HOOK_ENTRY("pidns_install")
+int hook_pidns_install(ctx_t *ctx) {
+    return handle_ns_install(CLONE_NEWPID);
+}
+
+HOOK_ENTRY("userns_install")
+int hook_userns_install(ctx_t *ctx) {
+    return handle_ns_install(CLONE_NEWUSER);
+}
+
+HOOK_ENTRY("utsns_install")
+int hook_utsns_install(ctx_t *ctx) {
+    return handle_ns_install(CLONE_NEWUTS);
+}
+
+HOOK_ENTRY("ipcns_install")
+int hook_ipcns_install(ctx_t *ctx) {
+    return handle_ns_install(CLONE_NEWIPC);
+}
+
+HOOK_ENTRY("cgroupns_install")
+int hook_cgroupns_install(ctx_t *ctx) {
+    return handle_ns_install(CLONE_NEWCGROUP);
+}
+
+HOOK_ENTRY("timens_install")
+int hook_timens_install(ctx_t *ctx) {
+    return handle_ns_install(CLONE_NEWTIME);
 }
 
 #endif // _HOOKS_SETNS_H_

--- a/pkg/security/ebpf/c/include/hooks/setns.h
+++ b/pkg/security/ebpf/c/include/hooks/setns.h
@@ -8,8 +8,9 @@
 
 // setns accepts a nstype of 0, in which case the kernel resolves the type from the file
 // descriptor (`flags = ns->ops->type`). The syscall arguments alone therefore don't tell us which
-// namespace was joined, so the type is recovered from the per-namespace install callbacks below.
-// These values are uapi and can never change; guarded because linux/sched.h may also define them.
+// namespace was joined, so the type is recovered from the per-namespace install callbacks below
+// and merged into the reported nstype. These values are uapi and can never change; guarded
+// because linux/sched.h may also define them.
 #ifndef CLONE_NEWTIME
 #define CLONE_NEWTIME 0x00000080
 #endif
@@ -46,13 +47,21 @@ static int __attribute__((always_inline)) sys_setns_ret(void *ctx, int retval) {
         return 0;
     }
 
+    // report the types the kernel installed rather than what the caller asked for: the two only
+    // differ when the caller passed 0, since a non-zero nstype has to match the namespace the file
+    // descriptor refers to or the syscall fails with EINVAL. Fall back to the requested value if
+    // no install callback was seen, which is all we know in that case.
+    u32 nstype = syscall->setns.effective_nstype;
+    if (nstype == 0) {
+        nstype = (u32)syscall->setns.nstype;
+    }
+
     struct setns_event_t event = {
         .syscall.retval = retval,
         .fd = syscall->setns.fd,
-        .nstype = syscall->setns.nstype,
+        .nstype = nstype,
         .mntns_id = syscall->setns.mntns_id,
         .netns_id = syscall->setns.netns_id,
-        .effective_nstype = syscall->setns.effective_nstype,
     };
 
     struct proc_cache_t *entry = fill_process_context(&event.process);

--- a/pkg/security/ebpf/c/include/hooks/setns.h
+++ b/pkg/security/ebpf/c/include/hooks/setns.h
@@ -1,0 +1,61 @@
+#ifndef _HOOKS_SETNS_H_
+#define _HOOKS_SETNS_H_
+
+#include "constants/syscall_macro.h"
+#include "helpers/discarders.h"
+#include "helpers/syscalls.h"
+#include "events_definition.h"
+
+static int __attribute__((always_inline)) sys_setns_ret(void *ctx, int retval) {
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_SETNS);
+    if (!syscall) {
+        return 0;
+    }
+
+    // keep the denied attempts, they are as interesting as the successful ones
+    if (IS_UNHANDLED_ERROR(retval)) {
+        return 0;
+    }
+
+    struct setns_event_t event = {
+        .syscall.retval = retval,
+        .fd = syscall->setns.fd,
+        .nstype = syscall->setns.nstype,
+        .mntns_id = syscall->setns.mntns_id,
+        .netns_id = syscall->setns.netns_id,
+    };
+
+    struct proc_cache_t *entry = fill_process_context(&event.process);
+    fill_cgroup_context(entry, &event.cgroup);
+    fill_span_context(&event.span);
+
+    send_event(ctx, EVENT_SETNS, event);
+    return 0;
+}
+
+HOOK_SYSCALL_ENTRY2(setns, int, fd, int, nstype) {
+    if (is_discarded_by_pid()) {
+        return 0;
+    }
+
+    struct syscall_cache_t syscall = {
+        .type = EVENT_SETNS,
+        .setns = {
+            .fd = fd,
+            .nstype = nstype,
+        }
+    };
+
+    cache_syscall_update_cgroup(ctx, &syscall);
+    return 0;
+}
+
+HOOK_SYSCALL_EXIT(setns) {
+    return sys_setns_ret(ctx, (int)SYSCALL_PARMRET(ctx));
+}
+
+TAIL_CALL_TRACEPOINT_FNC(handle_sys_setns_exit, struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_setns_ret(args, args->ret);
+}
+
+#endif // _HOOKS_SETNS_H_

--- a/pkg/security/ebpf/c/include/structs/syscalls.h
+++ b/pkg/security/ebpf/c/include/structs/syscalls.h
@@ -93,8 +93,8 @@ struct syscall_cache_t {
             u32 mntns_id;
             u32 netns_id;
             // namespace types the kernel actually installed, accumulated by the per-namespace
-            // *_install hooks. Unlike nstype this is never 0 when the syscall reached an install
-            // callback, so it stays usable when the caller passed a nstype of 0.
+            // *_install hooks. Internal: it is merged into nstype before the event is sent, so
+            // that the reported type stays meaningful when the caller passed a nstype of 0.
             u32 effective_nstype;
         } setns;
 

--- a/pkg/security/ebpf/c/include/structs/syscalls.h
+++ b/pkg/security/ebpf/c/include/structs/syscalls.h
@@ -92,6 +92,10 @@ struct syscall_cache_t {
             // (CLONE_NEWUSER only) or when the offsets are unavailable.
             u32 mntns_id;
             u32 netns_id;
+            // namespace types the kernel actually installed, accumulated by the per-namespace
+            // *_install hooks. Unlike nstype this is never 0 when the syscall reached an install
+            // callback, so it stays usable when the caller passed a nstype of 0.
+            u32 effective_nstype;
         } setns;
 
         struct {

--- a/pkg/security/ebpf/c/include/structs/syscalls.h
+++ b/pkg/security/ebpf/c/include/structs/syscalls.h
@@ -85,6 +85,16 @@ struct syscall_cache_t {
         } setrlimit;
 
         struct {
+            s32 fd;
+            s32 nstype;
+            // namespaces of the calling thread once the new nsproxy is committed, resolved by
+            // hook_switch_task_namespaces. Left to 0 when the kernel commits no nsproxy at all
+            // (CLONE_NEWUSER only) or when the offsets are unavailable.
+            u32 mntns_id;
+            u32 netns_id;
+        } setns;
+
+        struct {
             struct dentry *dentry;
             struct path *path;
             struct file_t file;

--- a/pkg/security/ebpf/probes/BUILD.bazel
+++ b/pkg/security/ebpf/probes/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "rename.go",
         "rmdir.go",
         "selinux.go",
+        "setns.go",
         "setrlimit.go",
         "setsockopt.go",
         "shared.go",

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -120,7 +120,7 @@ func AllProbes(fentry bool, cgroup2MountPoint string) []*manager.Probe {
 	allProbes = append(allProbes, getSocketProbes(fentry, cgroup2MountPoint)...)
 	allProbes = append(allProbes, getMemfdProbes(fentry)...)
 	allProbes = appendSyscallProbes(allProbes, fentry, EntryAndExit, false, "setsid")
-	allProbes = appendSyscallProbes(allProbes, fentry, EntryAndExit, false, "setns")
+	allProbes = append(allProbes, getSetNSProbes(fentry)...)
 
 	allProbes = append(allProbes,
 		&manager.Probe{

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -120,6 +120,7 @@ func AllProbes(fentry bool, cgroup2MountPoint string) []*manager.Probe {
 	allProbes = append(allProbes, getSocketProbes(fentry, cgroup2MountPoint)...)
 	allProbes = append(allProbes, getMemfdProbes(fentry)...)
 	allProbes = appendSyscallProbes(allProbes, fentry, EntryAndExit, false, "setsid")
+	allProbes = appendSyscallProbes(allProbes, fentry, EntryAndExit, false, "setns")
 
 	allProbes = append(allProbes,
 		&manager.Probe{

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -759,6 +759,7 @@ func GetSelectorsPerEventType(hasFentry, haveIOURing bool) map[eval.EventType][]
 		},
 		"setns": {
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setns", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: nsInstallHookSelectors()},
 		},
 		"tracer_memfd_seal": {
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "memfd_create", hasFentry, EntryAndExit)},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -757,6 +757,9 @@ func GetSelectorsPerEventType(hasFentry, haveIOURing bool) map[eval.EventType][]
 		"prctl": {
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "prctl", hasFentry, EntryAndExit)},
 		},
+		"setns": {
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setns", hasFentry, EntryAndExit)},
+		},
 		"tracer_memfd_seal": {
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "memfd_create", hasFentry, EntryAndExit)},
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{

--- a/pkg/security/ebpf/probes/raw_sys_exit.go
+++ b/pkg/security/ebpf/probes/raw_sys_exit.go
@@ -247,5 +247,12 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 				EBPFFuncName: tailCallTracepointFnc("handle_sys_setsid_exit"),
 			},
 		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.SetNSEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: tailCallTracepointFnc("handle_sys_setns_exit"),
+			},
+		},
 	}
 }

--- a/pkg/security/ebpf/probes/setns.go
+++ b/pkg/security/ebpf/probes/setns.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package probes holds probes related files
+package probes
+
+import manager "github.com/DataDog/ebpf-manager"
+
+// nsInstallHooks are the proc_ns_operations install callbacks. Hooking them is how the namespace
+// type actually joined is recovered, since a setns nstype of 0 leaves the kernel to resolve the
+// type from the file descriptor. They are best effort: timens_install requires CONFIG_TIME_NS and
+// cgroupns_install requires CONFIG_CGROUPS, so neither is guaranteed to be present.
+var nsInstallHooks = []string{
+	"hook_mntns_install",
+	"hook_netns_install",
+	"hook_pidns_install",
+	"hook_userns_install",
+	"hook_utsns_install",
+	"hook_ipcns_install",
+	"hook_cgroupns_install",
+	"hook_timens_install",
+}
+
+// nsInstallHookSelectors returns the install hooks as probe selectors, for the setns event type.
+func nsInstallHookSelectors() []manager.ProbesSelector {
+	selectors := make([]manager.ProbesSelector, 0, len(nsInstallHooks))
+	for _, hook := range nsInstallHooks {
+		selectors = append(selectors, hookFunc(hook))
+	}
+	return selectors
+}
+
+func getSetNSProbes(fentry bool) []*manager.Probe {
+	var probes []*manager.Probe
+
+	probes = append(probes, ExpandSyscallProbes(&manager.Probe{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
+		SyscallFuncName: "setns",
+	}, fentry, EntryAndExit)...)
+
+	for _, hook := range nsInstallHooks {
+		probes = append(probes, &manager.Probe{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: hook,
+			},
+		})
+	}
+
+	return probes
+}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1879,6 +1879,10 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 			return false
 		}
 		event.Setrlimit.Target = resolveTargetProcessContext(event.Setrlimit.TargetPid, p)
+	case model.SetNSEventType:
+		if !p.regularUnmarshalEvent(&event.SetNS, eventType, offset, dataLen, data) {
+			return false
+		}
 	case model.CapabilitiesEventType:
 		if !p.regularUnmarshalEvent(&event.CapabilitiesUsage, eventType, offset, dataLen, data) {
 			return false

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -55,6 +55,7 @@ func (_ *Model) GetEventTypes() []eval.EventType {
 		eval.EventType("rmdir"),
 		eval.EventType("selinux"),
 		eval.EventType("setgid"),
+		eval.EventType("setns"),
 		eval.EventType("setrlimit"),
 		eval.EventType("setsockopt"),
 		eval.EventType("setuid"),
@@ -22538,6 +22539,61 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "setns.fd":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.SetNS.FD
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "setns.mntns":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.SetNS.MntNS)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "setns.netns":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.SetNS.NetNS)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "setns.nstype":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.SetNS.NSType
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "setns.retval":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.SetNS.SyscallEvent.Retval)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.resource":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -38701,6 +38757,11 @@ func (ev *Event) GetFields() []eval.Field {
 		"setgid.fsgroup",
 		"setgid.gid",
 		"setgid.group",
+		"setns.fd",
+		"setns.mntns",
+		"setns.netns",
+		"setns.nstype",
+		"setns.retval",
 		"setrlimit.resource",
 		"setrlimit.retval",
 		"setrlimit.rlim_cur",
@@ -42517,6 +42578,16 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setgid", reflect.Int, "int", false, nil
 	case "setgid.group":
 		return "setgid", reflect.String, "string", false, nil
+	case "setns.fd":
+		return "setns", reflect.Int, "int", false, nil
+	case "setns.mntns":
+		return "setns", reflect.Int, "int", false, nil
+	case "setns.netns":
+		return "setns", reflect.Int, "int", false, nil
+	case "setns.nstype":
+		return "setns", reflect.Int, "int", false, nil
+	case "setns.retval":
+		return "setns", reflect.Int, "int", false, nil
 	case "setrlimit.resource":
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.retval":
@@ -48190,6 +48261,16 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setUint32FieldValue("setgid.gid", &ev.SetGID.GID, value)
 	case "setgid.group":
 		return ev.setStringFieldValue("setgid.group", &ev.SetGID.Group, value)
+	case "setns.fd":
+		return ev.setIntFieldValue("setns.fd", &ev.SetNS.FD, value)
+	case "setns.mntns":
+		return ev.setUint32FieldValue("setns.mntns", &ev.SetNS.MntNS, value)
+	case "setns.netns":
+		return ev.setUint32FieldValue("setns.netns", &ev.SetNS.NetNS, value)
+	case "setns.nstype":
+		return ev.setIntFieldValue("setns.nstype", &ev.SetNS.NSType, value)
+	case "setns.retval":
+		return ev.setInt64FieldValue("setns.retval", &ev.SetNS.SyscallEvent.Retval, value)
 	case "setrlimit.resource":
 		return ev.setIntFieldValue("setrlimit.resource", &ev.Setrlimit.Resource, value)
 	case "setrlimit.retval":

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -22539,17 +22539,6 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
-	case "setns.effective_nstype":
-		return &eval.IntEvaluator{
-			EvalFnc: func(ctx *eval.Context) int {
-				ctx.AppendResolvedField(field)
-				ev := ctx.Event.(*Event)
-				return ev.SetNS.EffectiveNSType
-			},
-			Field:  field,
-			Weight: eval.FunctionWeight,
-			Offset: offset,
-		}, nil
 	case "setns.fd":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -38768,7 +38757,6 @@ func (ev *Event) GetFields() []eval.Field {
 		"setgid.fsgroup",
 		"setgid.gid",
 		"setgid.group",
-		"setns.effective_nstype",
 		"setns.fd",
 		"setns.mntns",
 		"setns.netns",
@@ -42590,8 +42578,6 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setgid", reflect.Int, "int", false, nil
 	case "setgid.group":
 		return "setgid", reflect.String, "string", false, nil
-	case "setns.effective_nstype":
-		return "setns", reflect.Int, "int", false, nil
 	case "setns.fd":
 		return "setns", reflect.Int, "int", false, nil
 	case "setns.mntns":
@@ -48275,8 +48261,6 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setUint32FieldValue("setgid.gid", &ev.SetGID.GID, value)
 	case "setgid.group":
 		return ev.setStringFieldValue("setgid.group", &ev.SetGID.Group, value)
-	case "setns.effective_nstype":
-		return ev.setIntFieldValue("setns.effective_nstype", &ev.SetNS.EffectiveNSType, value)
 	case "setns.fd":
 		return ev.setIntFieldValue("setns.fd", &ev.SetNS.FD, value)
 	case "setns.mntns":

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -22539,6 +22539,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "setns.effective_nstype":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.SetNS.EffectiveNSType
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "setns.fd":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -38757,6 +38768,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"setgid.fsgroup",
 		"setgid.gid",
 		"setgid.group",
+		"setns.effective_nstype",
 		"setns.fd",
 		"setns.mntns",
 		"setns.netns",
@@ -42578,6 +42590,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setgid", reflect.Int, "int", false, nil
 	case "setgid.group":
 		return "setgid", reflect.String, "string", false, nil
+	case "setns.effective_nstype":
+		return "setns", reflect.Int, "int", false, nil
 	case "setns.fd":
 		return "setns", reflect.Int, "int", false, nil
 	case "setns.mntns":
@@ -48261,6 +48275,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setUint32FieldValue("setgid.gid", &ev.SetGID.GID, value)
 	case "setgid.group":
 		return ev.setStringFieldValue("setgid.group", &ev.SetGID.Group, value)
+	case "setns.effective_nstype":
+		return ev.setIntFieldValue("setns.effective_nstype", &ev.SetNS.EffectiveNSType, value)
 	case "setns.fd":
 		return ev.setIntFieldValue("setns.fd", &ev.SetNS.FD, value)
 	case "setns.mntns":

--- a/pkg/security/secl/model/category.go
+++ b/pkg/security/secl/model/category.go
@@ -113,6 +113,7 @@ func GetEventTypeCategory(eventType eval.EventType) EventCategory {
 		CgroupWriteEventType.String(),
 		CgroupTracingEventType.String(),
 		UnshareMountNsEventType.String(),
+		SetNSEventType.String(),
 		OnDemandEventType.String():
 		return KernelCategory
 

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -697,6 +697,7 @@ func initConstants() {
 	initSetSockOptOptNameConstantsTCP()
 	initSetSockOptOptNameConstantsIPv6()
 	initRlimitConstants()
+	initNamespaceTypeConstants()
 	initABIConstants()
 	initArchitectureConstants()
 	initCompressionTypeConstants()

--- a/pkg/security/secl/model/consts_darwin.go
+++ b/pkg/security/secl/model/consts_darwin.go
@@ -62,6 +62,7 @@ func initSetSockOptOptNameConstantsSolSocket() {}
 func initSetSockOptOptNameConstantsTCP()       {}
 func initSetSockOptOptNameConstantsIPv6()      {}
 func initRlimitConstants()                     {}
+func initNamespaceTypeConstants()              {}
 func initSocketDomainConstants()               {}
 func initSocketTypeConstants()                 {}
 func initSocketFamilyConstants()               {}

--- a/pkg/security/secl/model/consts_linux.go
+++ b/pkg/security/secl/model/consts_linux.go
@@ -2358,6 +2358,15 @@ func (nst NamespaceType) String() string {
 	return bitmaskToString(int(nst), namespaceTypeStrings)
 }
 
+// EffectiveNamespaceType represents the namespace type bitmask the kernel actually installed for
+// a setns syscall. Unlike NamespaceType a 0 here means "not resolved" rather than "any type", so
+// it deliberately does not render as ANY.
+type EffectiveNamespaceType int
+
+func (nst EffectiveNamespaceType) String() string {
+	return bitmaskToString(int(nst), namespaceTypeStrings)
+}
+
 // Signal represents a type of unix signal (ie, SIGKILL, SIGSTOP etc)
 type Signal int
 

--- a/pkg/security/secl/model/consts_linux.go
+++ b/pkg/security/secl/model/consts_linux.go
@@ -2350,20 +2350,11 @@ const (
 type NamespaceType int
 
 func (nst NamespaceType) String() string {
-	// setns accepts 0 to mean that any namespace type is allowed, in which case the kernel
-	// infers the type from the file descriptor. Name it rather than render an empty string.
+	// 0 means the type could not be determined: the caller passed 0 and no install callback was
+	// observed. Name it rather than render an empty string.
 	if nst == 0 {
 		return "ANY"
 	}
-	return bitmaskToString(int(nst), namespaceTypeStrings)
-}
-
-// EffectiveNamespaceType represents the namespace type bitmask the kernel actually installed for
-// a setns syscall. Unlike NamespaceType a 0 here means "not resolved" rather than "any type", so
-// it deliberately does not render as ANY.
-type EffectiveNamespaceType int
-
-func (nst EffectiveNamespaceType) String() string {
 	return bitmaskToString(int(nst), namespaceTypeStrings)
 }
 

--- a/pkg/security/secl/model/consts_linux.go
+++ b/pkg/security/secl/model/consts_linux.go
@@ -880,6 +880,19 @@ var (
 		"RLIMIT_RTTIME":     unix.RLIMIT_RTTIME,
 	}
 
+	// NamespaceTypeConstants are the supported namespace types for the setns syscall
+	// generate_constants:Namespace types,Namespace types are the supported namespace types for the setns syscall.
+	NamespaceTypeConstants = map[string]int{
+		"CLONE_NEWTIME":   unix.CLONE_NEWTIME,
+		"CLONE_NEWNS":     unix.CLONE_NEWNS,
+		"CLONE_NEWCGROUP": unix.CLONE_NEWCGROUP,
+		"CLONE_NEWUTS":    unix.CLONE_NEWUTS,
+		"CLONE_NEWIPC":    unix.CLONE_NEWIPC,
+		"CLONE_NEWUSER":   unix.CLONE_NEWUSER,
+		"CLONE_NEWPID":    unix.CLONE_NEWPID,
+		"CLONE_NEWNET":    unix.CLONE_NEWNET,
+	}
+
 	// SocketDomainConstants is the list of socket domains
 	// generate_constants:Socket domains,Socket domains are the supported socket domains.
 	SocketDomainConstants = map[string]int{
@@ -1460,6 +1473,13 @@ func initRlimitConstants() {
 	for k, v := range RlimitConstants {
 		seclConstants[k] = &eval.IntEvaluator{Value: v}
 		rlimitStrings[v] = k
+	}
+}
+
+func initNamespaceTypeConstants() {
+	for k, v := range NamespaceTypeConstants {
+		seclConstants[k] = &eval.IntEvaluator{Value: v}
+		namespaceTypeStrings[v] = k
 	}
 }
 
@@ -2326,6 +2346,18 @@ const (
 	PipeBufFlagLoss PipeBufFlag = 0x40 /* Message loss happened after this buffer */
 )
 
+// NamespaceType represents the namespace type bitmask requested by a setns syscall
+type NamespaceType int
+
+func (nst NamespaceType) String() string {
+	// setns accepts 0 to mean that any namespace type is allowed, in which case the kernel
+	// infers the type from the file descriptor. Name it rather than render an empty string.
+	if nst == 0 {
+		return "ANY"
+	}
+	return bitmaskToString(int(nst), namespaceTypeStrings)
+}
+
 // Signal represents a type of unix signal (ie, SIGKILL, SIGSTOP etc)
 type Signal int
 
@@ -2352,6 +2384,7 @@ var (
 	pipeBufFlagStrings                = map[int]string{}
 	sysctlActionStrings               = map[uint32]string{}
 	rlimitStrings                     = map[int]string{}
+	namespaceTypeStrings              = map[int]string{}
 	setsockoptOptNameStringsIP        = map[int]string{}
 	setsockoptOptNameStringsSolSocket = map[int]string{}
 	setsockoptOptNameStringsTCP       = map[int]string{}

--- a/pkg/security/secl/model/consts_unsupported.go
+++ b/pkg/security/secl/model/consts_unsupported.go
@@ -46,6 +46,7 @@ func initSetSockOptOptNameConstantsSolSocket() {}
 func initSetSockOptOptNameConstantsTCP()       {}
 func initSetSockOptOptNameConstantsIPv6()      {}
 func initRlimitConstants()                     {}
+func initNamespaceTypeConstants()              {}
 func initSocketDomainConstants()               {}
 func initSocketTypeConstants()                 {}
 func initSocketFamilyConstants()               {}

--- a/pkg/security/secl/model/consts_windows.go
+++ b/pkg/security/secl/model/consts_windows.go
@@ -46,6 +46,7 @@ func initSetSockOptOptNameConstantsSolSocket() {}
 func initSetSockOptOptNameConstantsTCP()       {}
 func initSetSockOptOptNameConstantsIPv6()      {}
 func initRlimitConstants()                     {}
+func initNamespaceTypeConstants()              {}
 func initSocketDomainConstants()               {}
 func initSocketTypeConstants()                 {}
 func initSocketFamilyConstants()               {}

--- a/pkg/security/secl/model/event_deep_copy_test.go
+++ b/pkg/security/secl/model/event_deep_copy_test.go
@@ -341,6 +341,11 @@ func createFullyPopulatedEvent() *Event {
 	e.Setrlimit.RlimCur = 1024
 	e.Setrlimit.RlimMax = 2048
 
+	e.SetNS.FD = 3
+	e.SetNS.NSType = 0x40000000 // CLONE_NEWNET
+	e.SetNS.MntNS = 4026531840
+	e.SetNS.NetNS = 4026532001
+
 	e.CapabilitiesUsage.Attempted = 0xABCD
 	e.CapabilitiesUsage.Used = 0xEF01
 

--- a/pkg/security/secl/model/event_deep_copy_test.go
+++ b/pkg/security/secl/model/event_deep_copy_test.go
@@ -343,7 +343,6 @@ func createFullyPopulatedEvent() *Event {
 
 	e.SetNS.FD = 3
 	e.SetNS.NSType = 0x40000000 // CLONE_NEWNET
-	e.SetNS.EffectiveNSType = 0x40000000
 	e.SetNS.MntNS = 4026531840
 	e.SetNS.NetNS = 4026532001
 

--- a/pkg/security/secl/model/event_deep_copy_test.go
+++ b/pkg/security/secl/model/event_deep_copy_test.go
@@ -343,6 +343,7 @@ func createFullyPopulatedEvent() *Event {
 
 	e.SetNS.FD = 3
 	e.SetNS.NSType = 0x40000000 // CLONE_NEWNET
+	e.SetNS.EffectiveNSType = 0x40000000
 	e.SetNS.MntNS = 4026531840
 	e.SetNS.NetNS = 4026532001
 

--- a/pkg/security/secl/model/event_deep_copy_unix.go
+++ b/pkg/security/secl/model/event_deep_copy_unix.go
@@ -1096,6 +1096,7 @@ func deepCopySetgidEvent(fieldToCopy SetgidEvent) SetgidEvent {
 }
 func deepCopySetNSEvent(fieldToCopy SetNSEvent) SetNSEvent {
 	copied := SetNSEvent{}
+	copied.EffectiveNSType = fieldToCopy.EffectiveNSType
 	copied.FD = fieldToCopy.FD
 	copied.MntNS = fieldToCopy.MntNS
 	copied.NSType = fieldToCopy.NSType

--- a/pkg/security/secl/model/event_deep_copy_unix.go
+++ b/pkg/security/secl/model/event_deep_copy_unix.go
@@ -63,6 +63,7 @@ func (e *Event) DeepCopy() *Event {
 	copied.Rmdir = deepCopyRmdirEvent(e.Rmdir)
 	copied.SELinux = deepCopySELinuxEvent(e.SELinux)
 	copied.SetGID = deepCopySetgidEvent(e.SetGID)
+	copied.SetNS = deepCopySetNSEvent(e.SetNS)
 	copied.SetSockOpt = deepCopySetSockOptEvent(e.SetSockOpt)
 	copied.SetUID = deepCopySetuidEvent(e.SetUID)
 	copied.SetXAttr = deepCopySetXAttrEvent(e.SetXAttr)
@@ -1091,6 +1092,15 @@ func deepCopySetgidEvent(fieldToCopy SetgidEvent) SetgidEvent {
 	copied.FSGroup = fieldToCopy.FSGroup
 	copied.GID = fieldToCopy.GID
 	copied.Group = fieldToCopy.Group
+	return copied
+}
+func deepCopySetNSEvent(fieldToCopy SetNSEvent) SetNSEvent {
+	copied := SetNSEvent{}
+	copied.FD = fieldToCopy.FD
+	copied.MntNS = fieldToCopy.MntNS
+	copied.NSType = fieldToCopy.NSType
+	copied.NetNS = fieldToCopy.NetNS
+	copied.SyscallEvent = deepCopySyscallEvent(fieldToCopy.SyscallEvent)
 	return copied
 }
 func deepCopySetSockOptEvent(fieldToCopy SetSockOptEvent) SetSockOptEvent {

--- a/pkg/security/secl/model/event_deep_copy_unix.go
+++ b/pkg/security/secl/model/event_deep_copy_unix.go
@@ -1096,7 +1096,6 @@ func deepCopySetgidEvent(fieldToCopy SetgidEvent) SetgidEvent {
 }
 func deepCopySetNSEvent(fieldToCopy SetNSEvent) SetNSEvent {
 	copied := SetNSEvent{}
-	copied.EffectiveNSType = fieldToCopy.EffectiveNSType
 	copied.FD = fieldToCopy.FD
 	copied.MntNS = fieldToCopy.MntNS
 	copied.NSType = fieldToCopy.NSType

--- a/pkg/security/secl/model/events.go
+++ b/pkg/security/secl/model/events.go
@@ -153,6 +153,8 @@ const (
 	NopEventType
 	// SocketEventType is sent when a socket is created
 	SocketEventType
+	// SetNSEventType is sent when a thread joins an existing namespace
+	SetNSEventType
 	// MaxKernelEventType is used internally to get the maximum number of kernel events.
 	MaxKernelEventType
 
@@ -356,6 +358,8 @@ func (t EventType) String() string {
 		return "nop"
 	case SocketEventType:
 		return "socket"
+	case SetNSEventType:
+		return "setns"
 	default:
 		return "unknown"
 	}

--- a/pkg/security/secl/model/field_handlers_unix.go
+++ b/pkg/security/secl/model/field_handlers_unix.go
@@ -729,6 +729,7 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveSetgidEGroup(ev, &ev.SetGID)
 		_ = ev.FieldHandlers.ResolveSetgidFSGroup(ev, &ev.SetGID)
 		_ = ev.FieldHandlers.ResolveSetgidGroup(ev, &ev.SetGID)
+	case "setns":
 	case "setrlimit":
 		_ = ev.FieldHandlers.ResolveProcessArgsTruncated(ev, &ev.Setrlimit.Target.Process)
 		_ = ev.FieldHandlers.ResolveProcessArgv(ev, &ev.Setrlimit.Target.Process)

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -1111,10 +1111,11 @@ type SetrlimitEvent struct {
 // SetNSEvent represents a setns event
 type SetNSEvent struct {
 	SyscallEvent
-	FD     int    `field:"fd"`     // SECLDoc[fd] Definition:`File descriptor of the namespace the thread requested to join`
-	NSType int    `field:"nstype"` // SECLDoc[nstype] Definition:`Requested namespace types. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor` Constants:`Namespace types`
-	MntNS  uint32 `field:"mntns"`  // SECLDoc[mntns] Definition:`MNTNS ID of the thread once the syscall returned, 0 if it couldn't be resolved`
-	NetNS  uint32 `field:"netns"`  // SECLDoc[netns] Definition:`NetNS ID of the thread once the syscall returned, 0 if it couldn't be resolved`
+	FD              int    `field:"fd"`               // SECLDoc[fd] Definition:`File descriptor of the namespace the thread requested to join`
+	NSType          int    `field:"nstype"`           // SECLDoc[nstype] Definition:`Namespace types requested by the caller. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor. Prefer \`effective_nstype\` in rules, as a caller passing 0 would otherwise evade them` Constants:`Namespace types`
+	EffectiveNSType int    `field:"effective_nstype"` // SECLDoc[effective_nstype] Definition:`Namespace types the kernel actually installed, resolved from the file descriptor when the caller passed 0. Reported even when the join was denied. 0 if it couldn't be resolved` Constants:`Namespace types`
+	MntNS           uint32 `field:"mntns"`            // SECLDoc[mntns] Definition:`MNTNS ID of the thread once the syscall returned, 0 if it couldn't be resolved`
+	NetNS           uint32 `field:"netns"`            // SECLDoc[netns] Definition:`NetNS ID of the thread once the syscall returned, 0 if it couldn't be resolved`
 }
 
 // SetSockOptEvent represents a set socket option event

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -135,6 +135,7 @@ type Event struct {
 	UnloadModule UnloadModuleEvent `field:"unload_module" event:"unload_module"` // [7.35] [Kernel] A kernel module was deleted
 	SysCtl       SysCtlEvent       `field:"sysctl" event:"sysctl"`               // [7.65] [Kernel] A sysctl parameter was read or modified
 	CgroupWrite  CgroupWriteEvent  `field:"cgroup_write" event:"cgroup_write"`   // [7.68] [Kernel] A process migrated another process to a cgroup
+	SetNS        SetNSEvent        `field:"setns" event:"setns"`                 // [7.84] [Kernel] A thread joined an existing namespace
 
 	// network events
 	DNS                DNSEvent                `field:"dns" event:"dns"`                                   // [7.36] [Network] A DNS request was sent
@@ -1105,6 +1106,15 @@ type SetrlimitEvent struct {
 	RlimMax   uint64          `field:"rlim_max"` // SECLDoc[rlim_max] Definition:`Maximum (hard) limit value`
 	TargetPid uint32          `field:"-"`        // Internal field, not exposed to users
 	Target    *ProcessContext `field:"target"`   // SECLDoc[target] Definition:`Process context of the target process`
+}
+
+// SetNSEvent represents a setns event
+type SetNSEvent struct {
+	SyscallEvent
+	FD     int    `field:"fd"`     // SECLDoc[fd] Definition:`File descriptor of the namespace the thread requested to join`
+	NSType int    `field:"nstype"` // SECLDoc[nstype] Definition:`Requested namespace types. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor` Constants:`Namespace types`
+	MntNS  uint32 `field:"mntns"`  // SECLDoc[mntns] Definition:`MNTNS ID of the thread once the syscall returned, 0 if it couldn't be resolved`
+	NetNS  uint32 `field:"netns"`  // SECLDoc[netns] Definition:`NetNS ID of the thread once the syscall returned, 0 if it couldn't be resolved`
 }
 
 // SetSockOptEvent represents a set socket option event

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -1111,11 +1111,10 @@ type SetrlimitEvent struct {
 // SetNSEvent represents a setns event
 type SetNSEvent struct {
 	SyscallEvent
-	FD              int    `field:"fd"`               // SECLDoc[fd] Definition:`File descriptor of the namespace the thread requested to join`
-	NSType          int    `field:"nstype"`           // SECLDoc[nstype] Definition:`Namespace types requested by the caller. 0 means that any type is allowed, in which case the kernel infers the type from the file descriptor. Prefer \`effective_nstype\` in rules, as a caller passing 0 would otherwise evade them` Constants:`Namespace types`
-	EffectiveNSType int    `field:"effective_nstype"` // SECLDoc[effective_nstype] Definition:`Namespace types the kernel actually installed, resolved from the file descriptor when the caller passed 0. Reported even when the join was denied. 0 if it couldn't be resolved` Constants:`Namespace types`
-	MntNS           uint32 `field:"mntns"`            // SECLDoc[mntns] Definition:`MNTNS ID of the thread once the syscall returned, 0 if it couldn't be resolved`
-	NetNS           uint32 `field:"netns"`            // SECLDoc[netns] Definition:`NetNS ID of the thread once the syscall returned, 0 if it couldn't be resolved`
+	FD     int    `field:"fd"`     // SECLDoc[fd] Definition:`File descriptor of the namespace the thread requested to join`
+	NSType int    `field:"nstype"` // SECLDoc[nstype] Definition:`Namespace types the thread joined. Resolved from the file descriptor when the caller passed 0, so it stays usable in rules whatever the caller requested. Reported even when the join was denied. 0 if it couldn't be determined` Constants:`Namespace types`
+	MntNS  uint32 `field:"mntns"`  // SECLDoc[mntns] Definition:`MNTNS ID of the thread once the syscall returned, 0 if it couldn't be resolved`
+	NetNS  uint32 `field:"netns"`  // SECLDoc[netns] Definition:`NetNS ID of the thread once the syscall returned, 0 if it couldn't be resolved`
 }
 
 // SetSockOptEvent represents a set socket option event

--- a/pkg/security/secl/model/unmarshallers_fuzz_linux_test.go
+++ b/pkg/security/secl/model/unmarshallers_fuzz_linux_test.go
@@ -301,6 +301,10 @@ func FuzzSetrlimitEvent_UnmarshalBinary(f *testing.F) {
 	fuzzUnmarshaller(f, func() BinaryUnmarshaler { return &SetrlimitEvent{} }, 32)
 }
 
+func FuzzSetNSEvent_UnmarshalBinary(f *testing.F) {
+	fuzzUnmarshaller(f, func() BinaryUnmarshaler { return &SetNSEvent{} }, 24)
+}
+
 func FuzzCapabilitiesEvent_UnmarshalBinary(f *testing.F) {
 	fuzzUnmarshaller(f, func() BinaryUnmarshaler { return &CapabilitiesEvent{} }, 16)
 }

--- a/pkg/security/secl/model/unmarshallers_fuzz_linux_test.go
+++ b/pkg/security/secl/model/unmarshallers_fuzz_linux_test.go
@@ -302,7 +302,7 @@ func FuzzSetrlimitEvent_UnmarshalBinary(f *testing.F) {
 }
 
 func FuzzSetNSEvent_UnmarshalBinary(f *testing.F) {
-	fuzzUnmarshaller(f, func() BinaryUnmarshaler { return &SetNSEvent{} }, 24)
+	fuzzUnmarshaller(f, func() BinaryUnmarshaler { return &SetNSEvent{} }, 28)
 }
 
 func FuzzCapabilitiesEvent_UnmarshalBinary(f *testing.F) {

--- a/pkg/security/secl/model/unmarshallers_fuzz_linux_test.go
+++ b/pkg/security/secl/model/unmarshallers_fuzz_linux_test.go
@@ -302,7 +302,7 @@ func FuzzSetrlimitEvent_UnmarshalBinary(f *testing.F) {
 }
 
 func FuzzSetNSEvent_UnmarshalBinary(f *testing.F) {
-	fuzzUnmarshaller(f, func() BinaryUnmarshaler { return &SetNSEvent{} }, 28)
+	fuzzUnmarshaller(f, func() BinaryUnmarshaler { return &SetNSEvent{} }, 24)
 }
 
 func FuzzCapabilitiesEvent_UnmarshalBinary(f *testing.F) {

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -1619,6 +1619,25 @@ func (e *SetrlimitEvent) UnmarshalBinary(data []byte) (int, error) {
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself
+func (e *SetNSEvent) UnmarshalBinary(data []byte) (int, error) {
+	read, err := e.SyscallEvent.UnmarshalBinary(data)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(data)-read < 16 {
+		return 0, ErrNotEnoughData
+	}
+
+	e.FD = int(int32(binary.NativeEndian.Uint32(data[read : read+4])))
+	e.NSType = int(int32(binary.NativeEndian.Uint32(data[read+4 : read+8])))
+	e.MntNS = binary.NativeEndian.Uint32(data[read+8 : read+12])
+	e.NetNS = binary.NativeEndian.Uint32(data[read+12 : read+16])
+
+	return read + 16, nil
+}
+
+// UnmarshalBinary unmarshalls a binary representation of itself
 func (e *CapabilitiesEvent) UnmarshalBinary(data []byte) (int, error) {
 	const size = 16
 	if len(data) < size {

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -1625,7 +1625,7 @@ func (e *SetNSEvent) UnmarshalBinary(data []byte) (int, error) {
 		return 0, err
 	}
 
-	if len(data)-read < 16 {
+	if len(data)-read < 20 {
 		return 0, ErrNotEnoughData
 	}
 
@@ -1633,8 +1633,9 @@ func (e *SetNSEvent) UnmarshalBinary(data []byte) (int, error) {
 	e.NSType = int(int32(binary.NativeEndian.Uint32(data[read+4 : read+8])))
 	e.MntNS = binary.NativeEndian.Uint32(data[read+8 : read+12])
 	e.NetNS = binary.NativeEndian.Uint32(data[read+12 : read+16])
+	e.EffectiveNSType = int(binary.NativeEndian.Uint32(data[read+16 : read+20]))
 
-	return read + 16, nil
+	return read + 20, nil
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -1625,7 +1625,7 @@ func (e *SetNSEvent) UnmarshalBinary(data []byte) (int, error) {
 		return 0, err
 	}
 
-	if len(data)-read < 20 {
+	if len(data)-read < 16 {
 		return 0, ErrNotEnoughData
 	}
 
@@ -1633,9 +1633,8 @@ func (e *SetNSEvent) UnmarshalBinary(data []byte) (int, error) {
 	e.NSType = int(int32(binary.NativeEndian.Uint32(data[read+4 : read+8])))
 	e.MntNS = binary.NativeEndian.Uint32(data[read+8 : read+12])
 	e.NetNS = binary.NativeEndian.Uint32(data[read+12 : read+16])
-	e.EffectiveNSType = int(binary.NativeEndian.Uint32(data[read+16 : read+20]))
 
-	return read + 20, nil
+	return read + 16, nil
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself

--- a/pkg/security/secl/schemas/BUILD.bazel
+++ b/pkg/security/secl/schemas/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "rename.schema.json",
         "ruleset_loaded.schema.json",
         "selinux.schema.json",
+        "setns.schema.json",
         "setrlimit.schema.json",
         "signal.schema.json",
         "socket.schema.json",

--- a/pkg/security/secl/schemas/setns.schema.json
+++ b/pkg/security/secl/schemas/setns.schema.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "setns.schema.json",
+    "type": "object",
+    "allOf": [
+        {
+            "$ref": "event.schema.json"
+        },
+        {
+            "$ref": "usr.schema.json"
+        },
+        {
+            "$ref": "process_context.schema.json"
+        },
+        {
+            "date": {
+                "$ref": "datetime.schema.json"
+            }
+        },
+        {
+            "properties": {
+                "setns": {
+                    "type": "object",
+                    "required": [
+                        "fd",
+                        "nstype"
+                    ],
+                    "properties": {
+                        "fd": {
+                            "type": "integer"
+                        },
+                        "nstype": {
+                            "type": "string"
+                        },
+                        "mntns": {
+                            "type": "integer"
+                        },
+                        "netns": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "setns"
+            ]
+        }
+    ]
+}

--- a/pkg/security/secl/schemas/setns.schema.json
+++ b/pkg/security/secl/schemas/setns.schema.json
@@ -32,9 +32,6 @@
                         "nstype": {
                             "type": "string"
                         },
-                        "effective_nstype": {
-                            "type": "string"
-                        },
                         "mntns": {
                             "type": "integer"
                         },

--- a/pkg/security/secl/schemas/setns.schema.json
+++ b/pkg/security/secl/schemas/setns.schema.json
@@ -32,6 +32,9 @@
                         "nstype": {
                             "type": "string"
                         },
+                        "effective_nstype": {
+                            "type": "string"
+                        },
                         "mntns": {
                             "type": "integer"
                         },

--- a/pkg/security/seclwin/model/consts_common.go
+++ b/pkg/security/seclwin/model/consts_common.go
@@ -697,6 +697,7 @@ func initConstants() {
 	initSetSockOptOptNameConstantsTCP()
 	initSetSockOptOptNameConstantsIPv6()
 	initRlimitConstants()
+	initNamespaceTypeConstants()
 	initABIConstants()
 	initArchitectureConstants()
 	initCompressionTypeConstants()

--- a/pkg/security/seclwin/model/consts_win.go
+++ b/pkg/security/seclwin/model/consts_win.go
@@ -46,6 +46,7 @@ func initSetSockOptOptNameConstantsSolSocket() {}
 func initSetSockOptOptNameConstantsTCP()       {}
 func initSetSockOptOptNameConstantsIPv6()      {}
 func initRlimitConstants()                     {}
+func initNamespaceTypeConstants()              {}
 func initSocketDomainConstants()               {}
 func initSocketTypeConstants()                 {}
 func initSocketFamilyConstants()               {}

--- a/pkg/security/seclwin/model/events.go
+++ b/pkg/security/seclwin/model/events.go
@@ -153,6 +153,8 @@ const (
 	NopEventType
 	// SocketEventType is sent when a socket is created
 	SocketEventType
+	// SetNSEventType is sent when a thread joins an existing namespace
+	SetNSEventType
 	// MaxKernelEventType is used internally to get the maximum number of kernel events.
 	MaxKernelEventType
 
@@ -356,6 +358,8 @@ func (t EventType) String() string {
 		return "nop"
 	case SocketEventType:
 		return "socket"
+	case SetNSEventType:
+		return "setns"
 	default:
 		return "unknown"
 	}

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -699,9 +699,9 @@ type SetNSEventSerializer struct {
 	FD int `json:"fd"`
 	// Requested namespace types, ANY when the syscall let the kernel infer the type
 	NSType string `json:"nstype"`
-	// Mount namespace ID of the thread once the syscall returned
+	// Mount namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved
 	MntNS uint32 `json:"mntns,omitempty"`
-	// Network namespace ID of the thread once the syscall returned
+	// Network namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved
 	NetNS uint32 `json:"netns,omitempty"`
 }
 

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -697,10 +697,8 @@ type SetrlimitEventSerializer struct {
 type SetNSEventSerializer struct {
 	// File descriptor of the namespace the thread requested to join
 	FD int `json:"fd"`
-	// Namespace types requested by the caller, ANY when the syscall let the kernel infer the type
+	// Namespace types the thread joined, ANY if the type couldn't be determined
 	NSType string `json:"nstype"`
-	// Namespace types the kernel actually installed, omitted if it couldn't be resolved
-	EffectiveNSType string `json:"effective_nstype,omitempty"`
 	// Mount namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved
 	MntNS uint32 `json:"mntns,omitempty"`
 	// Network namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved
@@ -1636,11 +1634,10 @@ func newSetrlimitEventSerializer(e *model.Event) *SetrlimitEventSerializer {
 
 func newSetNSEventSerializer(e *model.Event) *SetNSEventSerializer {
 	return &SetNSEventSerializer{
-		FD:              e.SetNS.FD,
-		NSType:          model.NamespaceType(e.SetNS.NSType).String(),
-		EffectiveNSType: model.EffectiveNamespaceType(e.SetNS.EffectiveNSType).String(),
-		MntNS:           e.SetNS.MntNS,
-		NetNS:           e.SetNS.NetNS,
+		FD:     e.SetNS.FD,
+		NSType: model.NamespaceType(e.SetNS.NSType).String(),
+		MntNS:  e.SetNS.MntNS,
+		NetNS:  e.SetNS.NetNS,
 	}
 }
 

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -697,8 +697,10 @@ type SetrlimitEventSerializer struct {
 type SetNSEventSerializer struct {
 	// File descriptor of the namespace the thread requested to join
 	FD int `json:"fd"`
-	// Requested namespace types, ANY when the syscall let the kernel infer the type
+	// Namespace types requested by the caller, ANY when the syscall let the kernel infer the type
 	NSType string `json:"nstype"`
+	// Namespace types the kernel actually installed, omitted if it couldn't be resolved
+	EffectiveNSType string `json:"effective_nstype,omitempty"`
 	// Mount namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved
 	MntNS uint32 `json:"mntns,omitempty"`
 	// Network namespace ID of the thread once the syscall returned, omitted if it couldn't be resolved
@@ -1634,10 +1636,11 @@ func newSetrlimitEventSerializer(e *model.Event) *SetrlimitEventSerializer {
 
 func newSetNSEventSerializer(e *model.Event) *SetNSEventSerializer {
 	return &SetNSEventSerializer{
-		FD:     e.SetNS.FD,
-		NSType: model.NamespaceType(e.SetNS.NSType).String(),
-		MntNS:  e.SetNS.MntNS,
-		NetNS:  e.SetNS.NetNS,
+		FD:              e.SetNS.FD,
+		NSType:          model.NamespaceType(e.SetNS.NSType).String(),
+		EffectiveNSType: model.EffectiveNamespaceType(e.SetNS.EffectiveNSType).String(),
+		MntNS:           e.SetNS.MntNS,
+		NetNS:           e.SetNS.NetNS,
 	}
 }
 

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -692,6 +692,19 @@ type SetrlimitEventSerializer struct {
 	Target *ProcessContextSerializer `json:"target,omitempty"`
 }
 
+// SetNSEventSerializer serializes a setns event
+// easyjson:json
+type SetNSEventSerializer struct {
+	// File descriptor of the namespace the thread requested to join
+	FD int `json:"fd"`
+	// Requested namespace types, ANY when the syscall let the kernel infer the type
+	NSType string `json:"nstype"`
+	// Mount namespace ID of the thread once the syscall returned
+	MntNS uint32 `json:"mntns,omitempty"`
+	// Network namespace ID of the thread once the syscall returned
+	NetNS uint32 `json:"netns,omitempty"`
+}
+
 // CGroupWriteEventSerializer serializes a cgroup_write event
 // easyjson:json
 type CGroupWriteEventSerializer struct {
@@ -856,6 +869,7 @@ type EventSerializer struct {
 	*CapabilitiesEventSerializer  `json:"capabilities,omitempty"`
 	*PrCtlEventSerializer         `json:"prctl,omitempty"`
 	*SetrlimitEventSerializer     `json:"setrlimit,omitempty"`
+	*SetNSEventSerializer         `json:"setns,omitempty"`
 	*SocketEventSerializer        `json:"socket,omitempty"`
 }
 
@@ -1618,6 +1632,15 @@ func newSetrlimitEventSerializer(e *model.Event) *SetrlimitEventSerializer {
 	}
 }
 
+func newSetNSEventSerializer(e *model.Event) *SetNSEventSerializer {
+	return &SetNSEventSerializer{
+		FD:     e.SetNS.FD,
+		NSType: model.NamespaceType(e.SetNS.NSType).String(),
+		MntNS:  e.SetNS.MntNS,
+		NetNS:  e.SetNS.NetNS,
+	}
+}
+
 func newSocketEventSerializer(e *model.Event) *SocketEventSerializer {
 	return &SocketEventSerializer{
 		Domain:   model.SocketDomain(e.Socket.Domain).String(),
@@ -1955,6 +1978,9 @@ func NewEventSerializer(event *model.Event, rule *rules.Rule, scrubber *utils.Sc
 	case model.SetrlimitEventType:
 		s.EventContextSerializer.Outcome = serializeOutcome(event.Setrlimit.Retval)
 		s.SetrlimitEventSerializer = newSetrlimitEventSerializer(event)
+	case model.SetNSEventType:
+		s.EventContextSerializer.Outcome = serializeOutcome(event.SetNS.Retval)
+		s.SetNSEventSerializer = newSetNSEventSerializer(event)
 	case model.SocketEventType:
 		s.EventContextSerializer.Outcome = serializeOutcome(event.Socket.Retval)
 		s.SocketEventSerializer = newSocketEventSerializer(event)

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -2075,7 +2075,91 @@ func (v SetSockOptEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 func (v *SetSockOptEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(in *jlexer.Lexer, out *SecurityProfileContextSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(in *jlexer.Lexer, out *SetNSEventSerializer) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		switch key {
+		case "fd":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.FD = int(in.Int())
+			}
+		case "nstype":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.NSType = string(in.String())
+			}
+		case "mntns":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.MntNS = uint32(in.Uint32())
+			}
+		case "netns":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.NetNS = uint32(in.Uint32())
+			}
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(out *jwriter.Writer, in SetNSEventSerializer) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"fd\":"
+		out.RawString(prefix[1:])
+		out.Int(int(in.FD))
+	}
+	{
+		const prefix string = ",\"nstype\":"
+		out.RawString(prefix)
+		out.String(string(in.NSType))
+	}
+	if in.MntNS != 0 {
+		const prefix string = ",\"mntns\":"
+		out.RawString(prefix)
+		out.Uint32(uint32(in.MntNS))
+	}
+	if in.NetNS != 0 {
+		const prefix string = ",\"netns\":"
+		out.RawString(prefix)
+		out.Uint32(uint32(in.NetNS))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v SetNSEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *SetNSEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(l, v)
+}
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(in *jlexer.Lexer, out *SecurityProfileContextSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2150,7 +2234,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(out *jwriter.Writer, in SecurityProfileContextSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(out *jwriter.Writer, in SecurityProfileContextSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2195,14 +2279,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v SecurityProfileContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *SecurityProfileContextSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(in *jlexer.Lexer, out *SSHSessionContextSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(in *jlexer.Lexer, out *SSHSessionContextSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2256,7 +2340,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(out *jwriter.Writer, in SSHSessionContextSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(out *jwriter.Writer, in SSHSessionContextSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2311,14 +2395,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v SSHSessionContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *SSHSessionContextSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(in *jlexer.Lexer, out *SELinuxEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(in *jlexer.Lexer, out *SELinuxEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2384,7 +2468,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(out *jwriter.Writer, in SELinuxEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(out *jwriter.Writer, in SELinuxEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2419,14 +2503,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v SELinuxEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *SELinuxEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(in *jlexer.Lexer, out *SELinuxEnforceStatusSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(in *jlexer.Lexer, out *SELinuxEnforceStatusSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2456,7 +2540,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(out *jwriter.Writer, in SELinuxEnforceStatusSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out *jwriter.Writer, in SELinuxEnforceStatusSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2471,14 +2555,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v SELinuxEnforceStatusSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *SELinuxEnforceStatusSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(in *jlexer.Lexer, out *SELinuxBoolCommitSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(in *jlexer.Lexer, out *SELinuxBoolCommitSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2508,7 +2592,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out *jwriter.Writer, in SELinuxBoolCommitSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(out *jwriter.Writer, in SELinuxBoolCommitSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2523,14 +2607,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v SELinuxBoolCommitSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *SELinuxBoolCommitSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(in *jlexer.Lexer, out *SELinuxBoolChangeSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(in *jlexer.Lexer, out *SELinuxBoolChangeSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2566,7 +2650,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(out *jwriter.Writer, in SELinuxBoolChangeSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(out *jwriter.Writer, in SELinuxBoolChangeSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2591,14 +2675,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v SELinuxBoolChangeSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *SELinuxBoolChangeSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(in *jlexer.Lexer, out *ProcessSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(in *jlexer.Lexer, out *ProcessSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3010,7 +3094,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(
 					}
 					for !in.IsDelim(']') {
 						var v21 SyscallSerializer
-						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(in, &v21)
+						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(in, &v21)
 						*out.Syscalls = append(*out.Syscalls, v21)
 						in.WantComma()
 					}
@@ -3082,7 +3166,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(out *jwriter.Writer, in ProcessSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(out *jwriter.Writer, in ProcessSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3314,7 +3398,7 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(
 				if v31 > 0 {
 					out.RawByte(',')
 				}
-				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(out, v32)
+				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(out, v32)
 			}
 			out.RawByte(']')
 		}
@@ -3352,14 +3436,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ProcessSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ProcessSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(in *jlexer.Lexer, out *SyscallSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(in *jlexer.Lexer, out *SyscallSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3395,7 +3479,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(out *jwriter.Writer, in SyscallSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(out *jwriter.Writer, in SyscallSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3411,7 +3495,7 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(
 	}
 	out.RawByte('}')
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(in *jlexer.Lexer, out *ProcessCredentialsSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(in *jlexer.Lexer, out *ProcessCredentialsSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3576,7 +3660,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(out *jwriter.Writer, in ProcessCredentialsSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(out *jwriter.Writer, in ProcessCredentialsSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3699,14 +3783,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ProcessCredentialsSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ProcessCredentialsSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(in *jlexer.Lexer, out *PrCtlEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(in *jlexer.Lexer, out *PrCtlEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3748,7 +3832,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(out *jwriter.Writer, in PrCtlEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(out *jwriter.Writer, in PrCtlEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3772,14 +3856,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PrCtlEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *PrCtlEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(in *jlexer.Lexer, out *PTraceEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(in *jlexer.Lexer, out *PTraceEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3829,7 +3913,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(out *jwriter.Writer, in PTraceEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(out *jwriter.Writer, in PTraceEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3853,14 +3937,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PTraceEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *PTraceEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(in *jlexer.Lexer, out *NetworkDeviceSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(in *jlexer.Lexer, out *NetworkDeviceSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3902,7 +3986,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(out *jwriter.Writer, in NetworkDeviceSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(out *jwriter.Writer, in NetworkDeviceSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3926,14 +4010,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v NetworkDeviceSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *NetworkDeviceSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(in *jlexer.Lexer, out *MountEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(in *jlexer.Lexer, out *MountEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4051,7 +4135,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(out *jwriter.Writer, in MountEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(out *jwriter.Writer, in MountEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4136,14 +4220,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v MountEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *MountEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(in *jlexer.Lexer, out *ModuleEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(in *jlexer.Lexer, out *ModuleEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4228,7 +4312,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(out *jwriter.Writer, in ModuleEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(out *jwriter.Writer, in ModuleEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4266,14 +4350,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ModuleEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ModuleEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(in *jlexer.Lexer, out *MProtectEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(in *jlexer.Lexer, out *MProtectEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4321,7 +4405,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(out *jwriter.Writer, in MProtectEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(out *jwriter.Writer, in MProtectEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4350,14 +4434,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v MProtectEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *MProtectEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(in *jlexer.Lexer, out *MMapEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(in *jlexer.Lexer, out *MMapEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4411,7 +4495,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(out *jwriter.Writer, in MMapEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(out *jwriter.Writer, in MMapEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4445,14 +4529,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v MMapEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *MMapEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(in *jlexer.Lexer, out *K8SSessionContextSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(in *jlexer.Lexer, out *K8SSessionContextSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4566,7 +4650,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(out *jwriter.Writer, in K8SSessionContextSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(out *jwriter.Writer, in K8SSessionContextSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4655,14 +4739,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v K8SSessionContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *K8SSessionContextSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(in *jlexer.Lexer, out *FileSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(in *jlexer.Lexer, out *FileSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -5018,7 +5102,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(out *jwriter.Writer, in FileSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(out *jwriter.Writer, in FileSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5261,14 +5345,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FileSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *FileSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(in *jlexer.Lexer, out *FileMetadataSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(in *jlexer.Lexer, out *FileMetadataSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -5340,7 +5424,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(out *jwriter.Writer, in FileMetadataSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(out *jwriter.Writer, in FileMetadataSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5425,14 +5509,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FileMetadataSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *FileMetadataSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(in *jlexer.Lexer, out *FileEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(in *jlexer.Lexer, out *FileEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -5820,7 +5904,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(out *jwriter.Writer, in FileEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(out *jwriter.Writer, in FileEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -6103,14 +6187,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FileEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *FileEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(in *jlexer.Lexer, out *EventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(in *jlexer.Lexer, out *EventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -6148,6 +6232,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 	out.CapabilitiesEventSerializer = new(CapabilitiesEventSerializer)
 	out.PrCtlEventSerializer = new(PrCtlEventSerializer)
 	out.SetrlimitEventSerializer = new(SetrlimitEventSerializer)
+	out.SetNSEventSerializer = new(SetNSEventSerializer)
 	out.SocketEventSerializer = new(SocketEventSerializer)
 	in.Delim('{')
 	for !in.IsDelim('}') {
@@ -6450,7 +6535,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 					}
 					for !in.IsDelim(']') {
 						var v64 SyscallSerializer
-						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(in, &v64)
+						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(in, &v64)
 						*out.SyscallsEventSerializer = append(*out.SyscallsEventSerializer, v64)
 						in.WantComma()
 					}
@@ -6597,6 +6682,20 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 					(*out.SetrlimitEventSerializer).UnmarshalEasyJSON(in)
 				}
 			}
+		case "setns":
+			if in.IsNull() {
+				in.Skip()
+				out.SetNSEventSerializer = nil
+			} else {
+				if out.SetNSEventSerializer == nil {
+					out.SetNSEventSerializer = new(SetNSEventSerializer)
+				}
+				if in.IsNull() {
+					in.Skip()
+				} else {
+					(*out.SetNSEventSerializer).UnmarshalEasyJSON(in)
+				}
+			}
 		case "socket":
 			if in.IsNull() {
 				in.Skip()
@@ -6691,7 +6790,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(out *jwriter.Writer, in EventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(out *jwriter.Writer, in EventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -6907,7 +7006,7 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 				if v65 > 0 {
 					out.RawByte(',')
 				}
-				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(out, v66)
+				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(out, v66)
 			}
 			out.RawByte(']')
 		}
@@ -7012,6 +7111,16 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 		}
 		(*in.SetrlimitEventSerializer).MarshalEasyJSON(out)
 	}
+	if in.SetNSEventSerializer != nil {
+		const prefix string = ",\"setns\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.SetNSEventSerializer).MarshalEasyJSON(out)
+	}
 	if in.SocketEventSerializer != nil {
 		const prefix string = ",\"socket\":"
 		if first {
@@ -7087,14 +7196,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v EventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *EventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(in *jlexer.Lexer, out *CredentialsSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(in *jlexer.Lexer, out *CredentialsSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -7250,7 +7359,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(out *jwriter.Writer, in CredentialsSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(out *jwriter.Writer, in CredentialsSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -7356,14 +7465,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CredentialsSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CredentialsSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(in *jlexer.Lexer, out *ConnectEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(in *jlexer.Lexer, out *ConnectEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -7426,7 +7535,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(out *jwriter.Writer, in ConnectEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(out *jwriter.Writer, in ConnectEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -7461,14 +7570,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ConnectEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ConnectEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(in *jlexer.Lexer, out *CapsetSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(in *jlexer.Lexer, out *CapsetSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -7546,7 +7655,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(out *jwriter.Writer, in CapsetSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(out *jwriter.Writer, in CapsetSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -7587,14 +7696,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CapsetSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CapsetSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers36(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(in *jlexer.Lexer, out *CapabilitiesEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(in *jlexer.Lexer, out *CapabilitiesEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -7672,7 +7781,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(out *jwriter.Writer, in CapabilitiesEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(out *jwriter.Writer, in CapabilitiesEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -7715,14 +7824,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CapabilitiesEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CapabilitiesEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers37(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(in *jlexer.Lexer, out *CGroupWriteEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(in *jlexer.Lexer, out *CGroupWriteEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -7766,7 +7875,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(out *jwriter.Writer, in CGroupWriteEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(out *jwriter.Writer, in CGroupWriteEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -7791,14 +7900,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CGroupWriteEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CGroupWriteEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(in *jlexer.Lexer, out *BindEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers40(in *jlexer.Lexer, out *BindEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -7834,7 +7943,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(out *jwriter.Writer, in BindEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers40(out *jwriter.Writer, in BindEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -7853,14 +7962,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BindEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers40(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BindEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers39(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers40(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers40(in *jlexer.Lexer, out *BPFProgramSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers41(in *jlexer.Lexer, out *BPFProgramSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -7935,7 +8044,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers40(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers40(out *jwriter.Writer, in BPFProgramSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers41(out *jwriter.Writer, in BPFProgramSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -7999,14 +8108,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers40(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BPFProgramSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers40(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers41(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BPFProgramSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers40(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers41(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers41(in *jlexer.Lexer, out *BPFMapSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers42(in *jlexer.Lexer, out *BPFMapSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -8042,7 +8151,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers41(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers41(out *jwriter.Writer, in BPFMapSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers42(out *jwriter.Writer, in BPFMapSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -8067,14 +8176,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers41(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BPFMapSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers41(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers42(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BPFMapSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers41(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers42(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers42(in *jlexer.Lexer, out *BPFEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers43(in *jlexer.Lexer, out *BPFEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -8132,7 +8241,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers42(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers42(out *jwriter.Writer, in BPFEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers43(out *jwriter.Writer, in BPFEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -8156,14 +8265,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers42(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BPFEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers42(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers43(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BPFEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers42(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers43(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers43(in *jlexer.Lexer, out *AnomalyDetectionSyscallEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers44(in *jlexer.Lexer, out *AnomalyDetectionSyscallEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -8193,7 +8302,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers43(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers43(out *jwriter.Writer, in AnomalyDetectionSyscallEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers44(out *jwriter.Writer, in AnomalyDetectionSyscallEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -8207,14 +8316,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers43(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AnomalyDetectionSyscallEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers43(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers44(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *AnomalyDetectionSyscallEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers43(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers44(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers44(in *jlexer.Lexer, out *AcceptEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers45(in *jlexer.Lexer, out *AcceptEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -8271,7 +8380,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers44(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers44(out *jwriter.Writer, in AcceptEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers45(out *jwriter.Writer, in AcceptEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -8301,10 +8410,10 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers44(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AcceptEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers44(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers45(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *AcceptEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers44(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers45(l, v)
 }

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -2101,12 +2101,6 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(
 			} else {
 				out.NSType = string(in.String())
 			}
-		case "effective_nstype":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.EffectiveNSType = string(in.String())
-			}
 		case "mntns":
 			if in.IsNull() {
 				in.Skip()
@@ -2142,11 +2136,6 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(
 		const prefix string = ",\"nstype\":"
 		out.RawString(prefix)
 		out.String(string(in.NSType))
-	}
-	if in.EffectiveNSType != "" {
-		const prefix string = ",\"effective_nstype\":"
-		out.RawString(prefix)
-		out.String(string(in.EffectiveNSType))
 	}
 	if in.MntNS != 0 {
 		const prefix string = ",\"mntns\":"

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -2101,6 +2101,12 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(
 			} else {
 				out.NSType = string(in.String())
 			}
+		case "effective_nstype":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.EffectiveNSType = string(in.String())
+			}
 		case "mntns":
 			if in.IsNull() {
 				in.Skip()
@@ -2136,6 +2142,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(
 		const prefix string = ",\"nstype\":"
 		out.RawString(prefix)
 		out.String(string(in.NSType))
+	}
+	if in.EffectiveNSType != "" {
+		const prefix string = ",\"effective_nstype\":"
+		out.RawString(prefix)
+		out.String(string(in.EffectiveNSType))
 	}
 	if in.MntNS != 0 {
 		const prefix string = ",\"mntns\":"

--- a/pkg/security/tests/BUILD.bazel
+++ b/pkg/security/tests/BUILD.bazel
@@ -217,6 +217,7 @@ dd_agent_go_test(
         "selftests_test.go",
         "selinux_test.go",
         "serializers_test.go",
+        "setns_test.go",
         "setrlimit_test.go",
         "setsockopt_test.go",
         "signal_test.go",

--- a/pkg/security/tests/schemas.go
+++ b/pkg/security/tests/schemas.go
@@ -183,6 +183,12 @@ func (tm *testModule) validateSetrlimitSchema(t *testing.T, event *model.Event) 
 }
 
 //nolint:unused
+func (tm *testModule) validateSetNSSchema(t *testing.T, event *model.Event) bool {
+	t.Helper()
+	return tm.validateEventSchema(t, event, "file:///setns.schema.json")
+}
+
+//nolint:unused
 func (tm *testModule) validateLoadModuleSchema(t *testing.T, event *model.Event) bool {
 	if ebpfLessEnabled {
 		return true

--- a/pkg/security/tests/setns_test.go
+++ b/pkg/security/tests/setns_test.go
@@ -34,18 +34,21 @@ func nsInode(t *testing.T, path string) uint32 {
 func TestSetNS(t *testing.T) {
 	SkipIfNotAvailable(t)
 
+	// the three rules are mutually exclusive so each subtest matches exactly one of them.
+	// They all key on effective_nstype, which is the field rules are meant to use: nstype alone
+	// is the caller's request and is 0 whenever the caller lets the kernel resolve the type.
 	ruleDefs := []*rules.RuleDefinition{
 		{
-			ID:         "test_setns_netns",
-			Expression: `setns.nstype == CLONE_NEWNET && process.file.name == "syscall_tester"`,
+			ID:         "test_setns_explicit_netns",
+			Expression: `setns.nstype == CLONE_NEWNET && setns.effective_nstype == CLONE_NEWNET && process.file.name == "syscall_tester"`,
+		},
+		{
+			ID:         "test_setns_inferred_netns",
+			Expression: `setns.nstype == 0 && setns.effective_nstype == CLONE_NEWNET && process.file.name == "syscall_tester"`,
 		},
 		{
 			ID:         "test_setns_mntns",
-			Expression: `setns.nstype == CLONE_NEWNS && process.file.name == "syscall_tester"`,
-		},
-		{
-			ID:         "test_setns_any",
-			Expression: `setns.nstype == 0 && process.file.name == "syscall_tester"`,
+			Expression: `setns.effective_nstype == CLONE_NEWNS && process.file.name == "syscall_tester"`,
 		},
 	}
 
@@ -66,15 +69,16 @@ func TestSetNS(t *testing.T) {
 		test.WaitSignalFromRule(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "setns", "net")
 		}, func(event *model.Event, rule *rules.Rule) {
-			assertTriggeredRule(t, rule, "test_setns_netns")
+			assertTriggeredRule(t, rule, "test_setns_explicit_netns")
 			assert.Equal(t, "setns", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(0), event.SetNS.Retval, "setns should have succeeded")
-			assert.Equal(t, unix.CLONE_NEWNET, event.SetNS.NSType, "wrong namespace type")
+			assert.Equal(t, unix.CLONE_NEWNET, event.SetNS.NSType, "wrong requested namespace type")
+			assert.Equal(t, unix.CLONE_NEWNET, event.SetNS.EffectiveNSType, "wrong effective namespace type")
 			assert.Greater(t, event.SetNS.FD, 0, "the target namespace fd should be valid")
 			assert.Equal(t, netns, event.SetNS.NetNS, "should have joined its own network namespace")
 
 			test.validateSetNSSchema(t, event)
-		}, "test_setns_netns")
+		}, "test_setns_explicit_netns")
 	})
 
 	t.Run("join-own-mntns", func(t *testing.T) {
@@ -86,29 +90,32 @@ func TestSetNS(t *testing.T) {
 			assertTriggeredRule(t, rule, "test_setns_mntns")
 			assert.Equal(t, "setns", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(0), event.SetNS.Retval, "setns should have succeeded")
-			assert.Equal(t, unix.CLONE_NEWNS, event.SetNS.NSType, "wrong namespace type")
+			assert.Equal(t, unix.CLONE_NEWNS, event.SetNS.NSType, "wrong requested namespace type")
+			assert.Equal(t, unix.CLONE_NEWNS, event.SetNS.EffectiveNSType, "wrong effective namespace type")
 			assert.Equal(t, mntns, event.SetNS.MntNS, "should have joined its own mount namespace")
 
 			test.validateSetNSSchema(t, event)
 		}, "test_setns_mntns")
 	})
 
-	// a nstype of 0 lets the kernel infer the namespace type from the file descriptor: the
-	// requested type is reported as-is, while the resolved namespace ID is still filled in
-	t.Run("infer-nstype", func(t *testing.T) {
+	// A nstype of 0 means the kernel resolves the type from the file descriptor. Keying a rule on
+	// nstype would therefore miss this call entirely — passing 0 instead of the flag would be a
+	// one-character evasion — so effective_nstype has to carry the type the kernel installed.
+	t.Run("infer-nstype-from-fd", func(t *testing.T) {
 		netns := nsInode(t, "/proc/self/ns/net")
 
 		test.WaitSignalFromRule(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "setns", "any")
 		}, func(event *model.Event, rule *rules.Rule) {
-			assertTriggeredRule(t, rule, "test_setns_any")
+			assertTriggeredRule(t, rule, "test_setns_inferred_netns")
 			assert.Equal(t, "setns", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(0), event.SetNS.Retval, "setns should have succeeded")
 			assert.Equal(t, 0, event.SetNS.NSType, "the requested namespace type should be reported as-is")
+			assert.Equal(t, unix.CLONE_NEWNET, event.SetNS.EffectiveNSType, "the effective type should be resolved from the fd")
 			assert.Equal(t, netns, event.SetNS.NetNS, "should have joined its own network namespace")
 
 			test.validateSetNSSchema(t, event)
-		}, "test_setns_any")
+		}, "test_setns_inferred_netns")
 	})
 
 	// the tester leaves its network namespace before joining the original one back through a
@@ -120,13 +127,13 @@ func TestSetNS(t *testing.T) {
 		test.WaitSignalFromRule(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "setns", "netns-roundtrip")
 		}, func(event *model.Event, rule *rules.Rule) {
-			assertTriggeredRule(t, rule, "test_setns_netns")
+			assertTriggeredRule(t, rule, "test_setns_explicit_netns")
 			assert.Equal(t, "setns", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(0), event.SetNS.Retval, "setns should have succeeded")
-			assert.Equal(t, unix.CLONE_NEWNET, event.SetNS.NSType, "wrong namespace type")
+			assert.Equal(t, unix.CLONE_NEWNET, event.SetNS.EffectiveNSType, "wrong effective namespace type")
 			assert.Equal(t, netns, event.SetNS.NetNS, "should have joined the original network namespace back")
 
 			test.validateSetNSSchema(t, event)
-		}, "test_setns_netns")
+		}, "test_setns_explicit_netns")
 	})
 }

--- a/pkg/security/tests/setns_test.go
+++ b/pkg/security/tests/setns_test.go
@@ -1,0 +1,132 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && functionaltests
+
+// Package tests holds tests related files
+package tests
+
+import (
+	"context"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+)
+
+// nsInode returns the inode number of an nsfs file, which is the namespace ID CWS reports
+func nsInode(t *testing.T, path string) uint32 {
+	t.Helper()
+
+	var stat syscall.Stat_t
+	if err := syscall.Stat(path, &stat); err != nil {
+		t.Fatalf("failed to stat %s: %v", path, err)
+	}
+	return uint32(stat.Ino)
+}
+
+func TestSetNS(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_setns_netns",
+			Expression: `setns.nstype == CLONE_NEWNET && process.file.name == "syscall_tester"`,
+		},
+		{
+			ID:         "test_setns_mntns",
+			Expression: `setns.nstype == CLONE_NEWNS && process.file.name == "syscall_tester"`,
+		},
+		{
+			ID:         "test_setns_any",
+			Expression: `setns.nstype == 0 && process.file.name == "syscall_tester"`,
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("join-own-netns", func(t *testing.T) {
+		netns := nsInode(t, "/proc/self/ns/net")
+
+		test.WaitSignalFromRule(t, func() error {
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "setns", "net")
+		}, func(event *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_setns_netns")
+			assert.Equal(t, "setns", event.GetType(), "wrong event type")
+			assert.Equal(t, int64(0), event.SetNS.Retval, "setns should have succeeded")
+			assert.Equal(t, unix.CLONE_NEWNET, event.SetNS.NSType, "wrong namespace type")
+			assert.Greater(t, event.SetNS.FD, 0, "the target namespace fd should be valid")
+			assert.Equal(t, netns, event.SetNS.NetNS, "should have joined its own network namespace")
+
+			test.validateSetNSSchema(t, event)
+		}, "test_setns_netns")
+	})
+
+	t.Run("join-own-mntns", func(t *testing.T) {
+		mntns := nsInode(t, "/proc/self/ns/mnt")
+
+		test.WaitSignalFromRule(t, func() error {
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "setns", "mnt")
+		}, func(event *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_setns_mntns")
+			assert.Equal(t, "setns", event.GetType(), "wrong event type")
+			assert.Equal(t, int64(0), event.SetNS.Retval, "setns should have succeeded")
+			assert.Equal(t, unix.CLONE_NEWNS, event.SetNS.NSType, "wrong namespace type")
+			assert.Equal(t, mntns, event.SetNS.MntNS, "should have joined its own mount namespace")
+
+			test.validateSetNSSchema(t, event)
+		}, "test_setns_mntns")
+	})
+
+	// a nstype of 0 lets the kernel infer the namespace type from the file descriptor: the
+	// requested type is reported as-is, while the resolved namespace ID is still filled in
+	t.Run("infer-nstype", func(t *testing.T) {
+		netns := nsInode(t, "/proc/self/ns/net")
+
+		test.WaitSignalFromRule(t, func() error {
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "setns", "any")
+		}, func(event *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_setns_any")
+			assert.Equal(t, "setns", event.GetType(), "wrong event type")
+			assert.Equal(t, int64(0), event.SetNS.Retval, "setns should have succeeded")
+			assert.Equal(t, 0, event.SetNS.NSType, "the requested namespace type should be reported as-is")
+			assert.Equal(t, netns, event.SetNS.NetNS, "should have joined its own network namespace")
+
+			test.validateSetNSSchema(t, event)
+		}, "test_setns_any")
+	})
+
+	// the tester leaves its network namespace before joining the original one back through a
+	// file descriptor it kept open: the reported netns must be the original one and not the
+	// transient unshared one, which proves the ID is resolved and not read from a stale cache
+	t.Run("netns-roundtrip", func(t *testing.T) {
+		netns := nsInode(t, "/proc/self/ns/net")
+
+		test.WaitSignalFromRule(t, func() error {
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "setns", "netns-roundtrip")
+		}, func(event *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_setns_netns")
+			assert.Equal(t, "setns", event.GetType(), "wrong event type")
+			assert.Equal(t, int64(0), event.SetNS.Retval, "setns should have succeeded")
+			assert.Equal(t, unix.CLONE_NEWNET, event.SetNS.NSType, "wrong namespace type")
+			assert.Equal(t, netns, event.SetNS.NetNS, "should have joined the original network namespace back")
+
+			test.validateSetNSSchema(t, event)
+		}, "test_setns_netns")
+	})
+}

--- a/pkg/security/tests/setns_test.go
+++ b/pkg/security/tests/setns_test.go
@@ -34,21 +34,16 @@ func nsInode(t *testing.T, path string) uint32 {
 func TestSetNS(t *testing.T) {
 	SkipIfNotAvailable(t)
 
-	// the three rules are mutually exclusive so each subtest matches exactly one of them.
-	// They all key on effective_nstype, which is the field rules are meant to use: nstype alone
-	// is the caller's request and is 0 whenever the caller lets the kernel resolve the type.
+	// nstype carries the namespace types the kernel installed, not the ones the caller asked for,
+	// so a single rule per type covers every way of requesting it
 	ruleDefs := []*rules.RuleDefinition{
 		{
-			ID:         "test_setns_explicit_netns",
-			Expression: `setns.nstype == CLONE_NEWNET && setns.effective_nstype == CLONE_NEWNET && process.file.name == "syscall_tester"`,
-		},
-		{
-			ID:         "test_setns_inferred_netns",
-			Expression: `setns.nstype == 0 && setns.effective_nstype == CLONE_NEWNET && process.file.name == "syscall_tester"`,
+			ID:         "test_setns_netns",
+			Expression: `setns.nstype == CLONE_NEWNET && process.file.name == "syscall_tester"`,
 		},
 		{
 			ID:         "test_setns_mntns",
-			Expression: `setns.effective_nstype == CLONE_NEWNS && process.file.name == "syscall_tester"`,
+			Expression: `setns.nstype == CLONE_NEWNS && process.file.name == "syscall_tester"`,
 		},
 	}
 
@@ -69,16 +64,15 @@ func TestSetNS(t *testing.T) {
 		test.WaitSignalFromRule(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "setns", "net")
 		}, func(event *model.Event, rule *rules.Rule) {
-			assertTriggeredRule(t, rule, "test_setns_explicit_netns")
+			assertTriggeredRule(t, rule, "test_setns_netns")
 			assert.Equal(t, "setns", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(0), event.SetNS.Retval, "setns should have succeeded")
-			assert.Equal(t, unix.CLONE_NEWNET, event.SetNS.NSType, "wrong requested namespace type")
-			assert.Equal(t, unix.CLONE_NEWNET, event.SetNS.EffectiveNSType, "wrong effective namespace type")
+			assert.Equal(t, unix.CLONE_NEWNET, event.SetNS.NSType, "wrong namespace type")
 			assert.Greater(t, event.SetNS.FD, 0, "the target namespace fd should be valid")
 			assert.Equal(t, netns, event.SetNS.NetNS, "should have joined its own network namespace")
 
 			test.validateSetNSSchema(t, event)
-		}, "test_setns_explicit_netns")
+		}, "test_setns_netns")
 	})
 
 	t.Run("join-own-mntns", func(t *testing.T) {
@@ -90,32 +84,31 @@ func TestSetNS(t *testing.T) {
 			assertTriggeredRule(t, rule, "test_setns_mntns")
 			assert.Equal(t, "setns", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(0), event.SetNS.Retval, "setns should have succeeded")
-			assert.Equal(t, unix.CLONE_NEWNS, event.SetNS.NSType, "wrong requested namespace type")
-			assert.Equal(t, unix.CLONE_NEWNS, event.SetNS.EffectiveNSType, "wrong effective namespace type")
+			assert.Equal(t, unix.CLONE_NEWNS, event.SetNS.NSType, "wrong namespace type")
 			assert.Equal(t, mntns, event.SetNS.MntNS, "should have joined its own mount namespace")
 
 			test.validateSetNSSchema(t, event)
 		}, "test_setns_mntns")
 	})
 
-	// A nstype of 0 means the kernel resolves the type from the file descriptor. Keying a rule on
-	// nstype would therefore miss this call entirely — passing 0 instead of the flag would be a
-	// one-character evasion — so effective_nstype has to carry the type the kernel installed.
+	// A nstype of 0 leaves the kernel to resolve the type from the file descriptor. Reporting the
+	// requested value would make this call invisible to a rule on nstype, so that passing 0 instead
+	// of the flag would be a one-character evasion. The type the kernel installed is reported
+	// instead, so the very same test_setns_netns rule has to match here too.
 	t.Run("infer-nstype-from-fd", func(t *testing.T) {
 		netns := nsInode(t, "/proc/self/ns/net")
 
 		test.WaitSignalFromRule(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "setns", "any")
 		}, func(event *model.Event, rule *rules.Rule) {
-			assertTriggeredRule(t, rule, "test_setns_inferred_netns")
+			assertTriggeredRule(t, rule, "test_setns_netns")
 			assert.Equal(t, "setns", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(0), event.SetNS.Retval, "setns should have succeeded")
-			assert.Equal(t, 0, event.SetNS.NSType, "the requested namespace type should be reported as-is")
-			assert.Equal(t, unix.CLONE_NEWNET, event.SetNS.EffectiveNSType, "the effective type should be resolved from the fd")
+			assert.Equal(t, unix.CLONE_NEWNET, event.SetNS.NSType, "the type should be resolved from the fd, not reported as the requested 0")
 			assert.Equal(t, netns, event.SetNS.NetNS, "should have joined its own network namespace")
 
 			test.validateSetNSSchema(t, event)
-		}, "test_setns_inferred_netns")
+		}, "test_setns_netns")
 	})
 
 	// the tester leaves its network namespace before joining the original one back through a
@@ -127,13 +120,13 @@ func TestSetNS(t *testing.T) {
 		test.WaitSignalFromRule(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "setns", "netns-roundtrip")
 		}, func(event *model.Event, rule *rules.Rule) {
-			assertTriggeredRule(t, rule, "test_setns_explicit_netns")
+			assertTriggeredRule(t, rule, "test_setns_netns")
 			assert.Equal(t, "setns", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(0), event.SetNS.Retval, "setns should have succeeded")
-			assert.Equal(t, unix.CLONE_NEWNET, event.SetNS.EffectiveNSType, "wrong effective namespace type")
+			assert.Equal(t, unix.CLONE_NEWNET, event.SetNS.NSType, "wrong namespace type")
 			assert.Equal(t, netns, event.SetNS.NetNS, "should have joined the original network namespace back")
 
 			test.validateSetNSSchema(t, event)
-		}, "test_setns_explicit_netns")
+		}, "test_setns_netns")
 	})
 }

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -1354,6 +1354,75 @@ int test_new_netns_exec(int argc, char **argv) {
     return EXIT_FAILURE;
 }
 
+// setns_from_path opens the nsfs file at path and joins the namespace it refers to.
+static int setns_from_path(const char *path, int nstype) {
+    int fd = open(path, O_RDONLY | O_CLOEXEC);
+    if (fd < 0) {
+        perror("open");
+        return EXIT_FAILURE;
+    }
+
+    if (setns(fd, nstype) < 0) {
+        perror("setns");
+        close(fd);
+        return EXIT_FAILURE;
+    }
+
+    close(fd);
+    return EXIT_SUCCESS;
+}
+
+// Usage: syscall_tester setns <net|mnt|any|netns-roundtrip>
+int test_setns(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: setns <net|mnt|any|netns-roundtrip>\n");
+        return EXIT_FAILURE;
+    }
+
+    const char *mode = argv[1];
+
+    if (strcmp(mode, "net") == 0) {
+        return setns_from_path("/proc/self/ns/net", CLONE_NEWNET);
+    }
+
+    if (strcmp(mode, "mnt") == 0) {
+        return setns_from_path("/proc/self/ns/mnt", CLONE_NEWNS);
+    }
+
+    // nstype 0 lets the kernel infer the namespace type from the file descriptor
+    if (strcmp(mode, "any") == 0) {
+        return setns_from_path("/proc/self/ns/net", 0);
+    }
+
+    // Leave the current network namespace, then join it back through the file descriptor
+    // held across the unshare: the reported netns must be the original one, not the new one.
+    if (strcmp(mode, "netns-roundtrip") == 0) {
+        int fd = open("/proc/self/ns/net", O_RDONLY | O_CLOEXEC);
+        if (fd < 0) {
+            perror("open");
+            return EXIT_FAILURE;
+        }
+
+        if (unshare(CLONE_NEWNET) < 0) {
+            perror("unshare");
+            close(fd);
+            return EXIT_FAILURE;
+        }
+
+        if (setns(fd, CLONE_NEWNET) < 0) {
+            perror("setns");
+            close(fd);
+            return EXIT_FAILURE;
+        }
+
+        close(fd);
+        return EXIT_SUCCESS;
+    }
+
+    fprintf(stderr, "Unknown setns mode: %s\n", mode);
+    return EXIT_FAILURE;
+}
+
 int test_network_flow_send_udp4(int argc, char **argv) {
     if (argc < 3) {
         fprintf(stderr, "Please specify the remote IP address and port\n");
@@ -2203,6 +2272,8 @@ int main(int argc, char **argv) {
             exit_code = test_tracer_memfd_with_keys(sub_argc, sub_argv);
         } else if (strcmp(cmd, "new_netns_exec") == 0) {
             exit_code = test_new_netns_exec(sub_argc, sub_argv);
+        } else if (strcmp(cmd, "setns") == 0) {
+            exit_code = test_setns(sub_argc, sub_argv);
         } else if (strcmp(cmd, "slow-cat") == 0) {
             exit_code = test_slow_cat(sub_argc, sub_argv);
         } else if (strcmp(cmd, "slow-write") == 0) {


### PR DESCRIPTION
### What does this PR do?

Adds a `setns` event to CWS: an eBPF hook on the `setns` syscall, a `setns` event in the
event model wired through to SECL, a backend serializer, and functional test coverage.

Fields exposed:

| Field | Meaning |
| --- | --- |
| `setns.fd` | File descriptor of the namespace the thread requested to join |
| `setns.nstype` | Namespace types the thread **joined** — bitmask over the new `CLONE_NEW*` SECL constants. Resolved from the fd when the caller passed `0` |
| `setns.mntns` | MNTNS ID of the thread once the syscall returned |
| `setns.netns` | NetNS ID of the thread once the syscall returned |
| `setns.retval` | Return value (standard `SyscallEvent`) |

Successful calls **and** `-EPERM`/`-EACCES` are reported (via the usual
`IS_UNHANDLED_ERROR`), so denied attempts stay visible.

### Motivation

CWS could already see namespace *creation* (`unshare_mntns`), but nothing fired when a
thread *joined* an existing namespace. That is the primitive behind most container-escape
and privilege-escalation chains: open `/proc/1/ns/net` (or any leaked nsfs fd), then
`setns` into it. This gives the detection team signal to write rules against.

A bare fd number is not rule-able on its own, so the event also resolves the namespace IDs
the thread ends up in, which is what makes the escape detectable:

```
setns.nstype == CLONE_NEWNET && setns.netns == <host netns>
setns.mntns != <expected container mntns>
```

Those IDs come from extending `hook_switch_task_namespaces` — a hook that is already
attached unconditionally and that `setns` necessarily goes through to commit its new
`nsproxy`. Sequence:

```mermaid
sequenceDiagram
    participant U as Thread (user space)
    participant K as Kernel
    participant E as eBPF (runtime-security)
    participant A as security-agent

    U->>K: setns(fd, nstype)
    K->>E: hook_setns — syscall entry
    E->>E: cache_syscall EVENT_SETNS {fd, nstype}
    K->>K: validate_nsset / commit_nsset
    K->>E: hook_switch_task_namespaces(task, new nsproxy)
    E->>E: read mnt_ns->inum / net_ns->inum<br/>into the live EVENT_SETNS cache
    K->>E: hook_setns exit (or raw_syscalls:sys_exit tail call)
    E->>A: send_event EVENT_SETNS<br/>{fd, nstype, mntns_id, netns_id, retval}
    A->>A: SECL evaluation over setns.*
```

Only mount and network are resolvable — `nsproxy_mnt_ns_offset` and `nsproxy_net_ns_offset`
are the only `nsproxy` offsets available. Unresolved is reported as `0`.

#### Resolving the namespace type

`setns(fd, 0)` is legal: it tells the kernel to resolve the namespace type from the fd
(`flags = ns->ops->type`). Reporting the syscall argument verbatim would therefore say nothing
about which namespace was joined, and a rule keyed on `nstype` would miss that call form
entirely — passing `0` instead of the flag would be a one-character evasion. Raised by Marcio in
review.

`nstype` now carries the type the kernel actually installed. It's recovered by hooking the eight
`proc_ns_operations` install callbacks — `mntns_install`, `netns_install`, `pidns_install`,
`userns_install`, `utsns_install`, `ipcns_install`, `cgroupns_install`, `timens_install`. The
function that fired identifies the type, so nothing is read out of a kernel struct and no new
offset guessing is needed. They're `static`, but their addresses live in `proc_ns_operations`
structs, so they can't be inlined away and are stable probe targets (verified present in
`/proc/kallsyms`). They're reached only from `setns`, and run before `commit_nsset` while the
syscall cache is still live.

Requested and installed values only diverge when the caller passes `0`, since a non-zero `nstype`
has to match the namespace the fd refers to or the syscall fails with `EINVAL`. One field can
therefore carry both without ambiguity, and the merge happens kernel side where both values are
already known. If no install callback was observed the reported value falls back to the requested
one, which is all that's known in that case.

Best effort, because `timens_install` needs `CONFIG_TIME_NS` and `cgroupns_install` needs
`CONFIG_CGROUPS`. Two deliberate behaviours: the flag is recorded even when the callback then
fails, so a **denied** join still reports the type it attempted; and a pidfd target that installs
several namespaces at once accumulates them via `|=`.

The trade-off is that a caller passing `0` is no longer distinguishable from one naming the type.
That's a weak evasion signal at best, and not worth a second field.

### Describe how you validated your changes

New `TestSetNS` (`pkg/security/tests/setns_test.go`) with four subtests, driven by a new
`setns` command in `syscall_tester.c`. It is a C helper rather than Go on purpose: `setns`
is per-thread, so calling it from the multi-threaded test binary would either fail
(`CLONE_NEWNS` needs `fs->users == 1`) or strand a Go runtime thread in a foreign namespace.

- `join-own-netns` / `join-own-mntns` — asserts `nstype`, `retval`, a valid `fd`, and that
  the reported ID equals the inode of `/proc/self/ns/{net,mnt}`
- `infer-nstype-from-fd` — **the regression test for the evasion above**: the single
  `setns.nstype == CLONE_NEWNET` rule matches a `setns(fd, 0)` call, exactly as it does the
  explicit one
- `netns-roundtrip` — holds a fd to the current netns, `unshare(CLONE_NEWNET)`, then
  `setns` back. Asserts the reported netns is the **original** one and not the transient
  unshared one, which is what proves the ID is resolved per-event rather than read from a
  stale cache

Each subtest also validates the serialized event against the new `setns.schema.json`.

Run locally on a 6.x kernel (kprobe mode — this kernel forces the fentry fallback, so the
fentry path is compile-verified here and covered functionally by KMT):

| Check | Result |
| --- | --- |
| `TestSetNS` | 4/4 pass |
| `dda inv test --targets=./pkg/security/secl/model` | 894 pass |
| `bazel build //pkg/security/ebpf/...` | 20 targets; `sys_setns` + `handle_sys_setns_exit` present in both kprobe and fentry objects |
| Regression check on namespace-adjacent tests | `TestPivotRoot`, `TestProcessContext`, `TestProcessSID`, `TestSetrlimitEvent`, `TestSocketEvent`, `TestBindEvent`, `TestConnectEvent*` all pass |
| `golangci-lint` (`secl/model`, `serializers`, `probe`, `ebpf/probes`, `tests`) | 0 issues |
| `validate-cws-generated-files` pre-push hook | Passed |

Sample serialized event, captured from a live run:

```json
// setns(fd, CLONE_NEWNET)
"setns": { "fd": 3, "nstype": "CLONE_NEWNET", "mntns": 4026532592, "netns": 4026532595 }

// setns(fd, 0) — indistinguishable, which is the point
"setns": { "fd": 3, "nstype": "CLONE_NEWNET", "mntns": 4026532592, "netns": 4026532595 }
```

### Additional Notes

**No release note**, intentionally — hence `changelog/no-changelog`. Worth a reviewer's
opinion: this *is* user-facing (a new SECL event), so if you'd rather have it in the
CHANGELOG, say so and I'll add a reno note and drop the label.

<details>
<summary>Design decisions worth a reviewer's eye</summary>

- **`mntns`/`netns` are post-syscall values, not strictly "the namespace joined."** The
  kernel commits the whole `nsproxy`, so both are populated even for a `CLONE_NEWNET`-only
  call. The SECL docs are worded to say exactly that rather than overstate it. Filling both
  is strictly more informative than branching on the requested type — and for `nstype == 0`
  the type isn't known at entry anyway.
- **`setns.fd` is `int`, not `int32`.** The accessor generator has no `setInt32FieldValue`,
  and no other exposed field uses `int32`.
- **`nstype == 0` serializes as `"ANY"`.** After the merge, `0` only happens when the caller
  passed `0` *and* no install callback was seen — i.e. the type couldn't be determined. The
  default bitmask stringer would render `""`, which reads as missing data, so it keeps a name.
- **eBPF only.** No ebpfless/ptracer wiring, matching how `setsid` and `pivot_root` shipped
  (`setrlimit` added ebpfless later in #44114). `TestSetNS` is deliberately absent from the
  ebpfless allowlist in `main_linux.go`, so it auto-skips there.
- **No rate limiter.** `setns` is rare outside container runtimes and `nsenter`, unlike
  `setrlimit` which needed one. If QA on a busy node shows runtime chatter, a
  `pid_rate_limiter_allow` guard on the entry hook is the fix.
- **Pre-existing wart, left alone:** `LastEventType` is still `PivotRootEventType` even
  though `setsid`/`nop`/`socket` come after it. It only bounds the
  `applyDefaultFilterPolicies` loop and mode `0` is `PolicyModeNoFilter`, so appending
  `setns` after it is harmless. Happy to fix separately.

</details>

Jira: [CWS-6779](https://datadoghq.atlassian.net/browse/CWS-6779)


[CWS-6779]: https://datadoghq.atlassian.net/browse/CWS-6779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

