### PR TITLE
compliance/k8sconfig: fix kubelet defaults when --config is used

### DIFF
--- a/pkg/compliance/k8sconfig/BUILD.bazel
+++ b/pkg/compliance/k8sconfig/BUILD.bazel
@@ -25,9 +25,11 @@ dd_agent_go_test(
     deps = select({
         "@rules_go//go/platform:android": [
             "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:linux": [
             "@com_github_stretchr_testify//assert",
+            "@com_github_stretchr_testify//require",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -31,7 +31,7 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
-const version = "202403"
+const version = "202608"
 
 const (
 	k8sManifestsDir   = "/etc/kubernetes/manifests"
@@ -201,6 +201,18 @@ func (l *loader) detectManagedEnvironment(flags map[string]string, kubelet *K8sK
 	return nil
 }
 
+// flagDefault returns the value to assume for a flag left off the command line.
+// Kubernetes keeps historical defaults for a few kubelet flags to preserve the
+// command line API and drops them once --config is used, where the configuration
+// file defaults apply instead. The two disagree on the settings the CIS
+// benchmarks check.
+func flagDefault(config *K8sConfigFileMeta, cli, file string) string {
+	if config == nil {
+		return cli
+	}
+	return file
+}
+
 func (l *loader) loadMeta(name string, loadContent bool) (string, os.FileInfo, []byte, bool) {
 	name = filepath.Join(l.hostroot, name)
 	info, err := os.Stat(name)
@@ -307,7 +319,7 @@ func (l *loader) configFileMetaHasField(meta *K8sConfigFileMeta, path string) bo
 	return false
 }
 
-func (l *loader) loadKubeletConfigFileMeta(name string) *K8sConfigFileMeta {
+func (l *loader) loadKubeletConfigFileMeta(name, dropinDir string) *K8sConfigFileMeta {
 	meta, ok := l.loadConfigFileMeta(name)
 	if !ok {
 		return &K8sConfigFileMeta{Path: name}
@@ -320,6 +332,13 @@ func (l *loader) loadKubeletConfigFileMeta(name string) *K8sConfigFileMeta {
 	if kind := content["kind"]; kind != "KubeletConfiguration" {
 		l.pushError(fmt.Errorf(`kubelet configuration loaded from %q is expected to be of kind "KubeletConfiguration"`, name))
 		return &K8sConfigFileMeta{Path: name}
+	}
+	// The drop-ins of --config-dir land on top of the file given to --config,
+	// so they have to be folded in before anything reads a setting.
+	if dropinDir != "" {
+		for _, dropin := range l.loadKubeletDropins(dropinDir) {
+			mergeConfig(content, dropin)
+		}
 	}
 	// specifically parse key/cert files path to load their associated meta info.
 	if keyPath, ok := content["tlsPrivateKeyFile"].(string); ok {
@@ -336,6 +355,65 @@ func (l *loader) loadKubeletConfigFileMeta(name string) *K8sConfigFileMeta {
 		}
 	}
 	return meta
+}
+
+// loadKubeletDropins returns the KubeletConfiguration drop-ins under dir, in
+// the order the kubelet merges them: a lexical walk of the tree keeping the
+// files named *.conf.
+func (l *loader) loadKubeletDropins(dir string) []map[string]interface{} {
+	entries, err := os.ReadDir(filepath.Join(l.hostroot, dir))
+	if err != nil {
+		l.pushError(err)
+		return nil
+	}
+	var dropins []map[string]interface{}
+	for _, entry := range entries {
+		name := filepath.Join(dir, entry.Name())
+		if entry.IsDir() {
+			dropins = append(dropins, l.loadKubeletDropins(name)...)
+			continue
+		}
+		if filepath.Ext(entry.Name()) != ".conf" {
+			continue
+		}
+		meta, ok := l.loadConfigFileMeta(name)
+		if !ok {
+			continue
+		}
+		content, ok := meta.Content.(map[string]interface{})
+		if !ok {
+			l.pushError(fmt.Errorf("kubelet configuration drop-in loaded from %q is not a valid configuration", name))
+			continue
+		}
+		if kind := content["kind"]; kind != "KubeletConfiguration" {
+			l.pushError(fmt.Errorf(`kubelet configuration drop-in loaded from %q is expected to be of kind "KubeletConfiguration"`, name))
+			continue
+		}
+		dropins = append(dropins, content)
+	}
+	return dropins
+}
+
+// mergeConfig folds patch into content the way the kubelet folds a drop-in into
+// its configuration file, with the JSON merge patch rules of RFC 7386: an
+// object merges into an object, a null drops the key, anything else replaces.
+func mergeConfig(content, patch map[string]interface{}) {
+	for k, v := range patch {
+		if v == nil {
+			delete(content, k)
+			continue
+		}
+		if sub, ok := v.(map[string]interface{}); ok {
+			dst, ok := content[k].(map[string]interface{})
+			if !ok {
+				dst = make(map[string]interface{})
+				content[k] = dst
+			}
+			mergeConfig(dst, sub)
+			continue
+		}
+		content[k] = v
+	}
 }
 
 func (l *loader) loadAdmissionConfigFileMeta(name string) *K8sAdmissionConfigFileMeta {

--- a/pkg/compliance/k8sconfig/loader_test.go
+++ b/pkg/compliance/k8sconfig/loader_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const eksProcTable = `
@@ -677,6 +678,76 @@ users:
 	},
 }
 
+// OpenShift starts the kubelet with a rendered KubeletConfiguration and leaves
+// the security settings to it. See the machine-config-operator templates in
+// templates/worker/01-worker-kubelet/_base.
+const openshiftProcTable = `
+kubelet \
+	--config=/etc/kubernetes/kubelet.conf \
+	--config-dir=/etc/openshift/kubelet.conf.d \
+	--bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
+	--kubeconfig=/var/lib/kubelet/kubeconfig \
+	--container-runtime-endpoint=/var/run/crio/crio.sock \
+	--runtime-cgroups=/system.slice/crio.service \
+	--node-labels=node-role.kubernetes.io/worker,node.openshift.io/os_id=rhcos \
+	--node-ip=10.0.128.4 \
+	--minimum-container-ttl-duration=6m0s \
+	--volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
+	--v=2
+`
+
+var openshiftFs = []*mockFile{
+	{
+		name: "/etc/kubernetes/kubelet.conf",
+		mode: 0644,
+		content: `kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+authentication:
+  x509:
+    clientCAFile: /etc/kubernetes/kubelet-ca.crt
+  anonymous:
+    enabled: false
+cgroupDriver: systemd
+cgroupRoot: /
+clusterDNS:
+  - 172.30.0.10
+clusterDomain: cluster.local
+containerLogMaxSize: 50Mi
+maxPods: 250
+podPidsLimit: 4096
+protectKernelDefaults: true
+rotateCertificates: true
+serializeImagePulls: false
+staticPodPath: /etc/kubernetes/manifests
+systemCgroups: /system.slice
+serverTLSBootstrap: true
+tlsMinVersion: VersionTLS12
+tlsCipherSuites:
+  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`,
+	},
+	{
+		name: "/var/lib/kubelet/kubeconfig",
+		mode: 0600,
+		content: `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://api-int.example.eastus.aroapp.io:6443
+  name: cluster
+contexts:
+- context:
+    cluster: cluster
+    user: kubelet
+  name: kubelet
+current-context: kubelet
+users:
+- name: kubelet
+  user:
+    client-certificate: /var/lib/kubelet/pki/kubelet-client-current.pem
+    client-key: /var/lib/kubelet/pki/kubelet-client-current.pem`,
+	},
+}
+
 func procTable(str string) []proc {
 	var table []proc
 	str = strings.ReplaceAll(str, "\\\n", "")
@@ -743,7 +814,9 @@ func TestKubEksConfigLoader(t *testing.T) {
 	}
 
 	{
-		v := int(10255)
+		// The kubelet reads its configuration from --config and that file
+		// leaves readOnlyPort out, so the read-only port is disabled.
+		v := int(0)
 		assert.NotNil(t, conf.Components.Kubelet.ReadOnlyPort)
 		assert.Equal(t, &v, conf.Components.Kubelet.ReadOnlyPort)
 		assert.Nil(t, kubeletConfig["readOnlyPort"])
@@ -925,6 +998,157 @@ func TestBottleRocketConfigLoader(t *testing.T) {
 	tlsCipherSuites := conf.Components.Kubelet.Config.Content.(map[string]interface{})["tlsCipherSuites"]
 	expectedTLSCipherSuites := []interface{}{"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"}
 	assert.Equal(t, expectedTLSCipherSuites, tlsCipherSuites)
+}
+
+// A kubelet configured through --config falls back to the KubeletConfiguration
+// defaults. Kubernetes keeps the legacy command line defaults for a kubelet
+// started on flags alone.
+func TestKubOpenshiftConfigLoader(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, f := range openshiftFs {
+		f.create(t, tmpDir)
+	}
+	conf := loadTestConfiguration(t, tmpDir, openshiftProcTable)
+	assert.Empty(t, conf.Errors)
+
+	// The loader knows EKS, GKE and AKS, so an OpenShift node is evaluated
+	// against the CIS Kubernetes benchmark.
+	assert.Nil(t, conf.ManagedEnvironment)
+
+	require.NotNil(t, conf.Components.Kubelet)
+	require.NotNil(t, conf.Components.Kubelet.Config)
+
+	readOnlyPort := 0
+	assert.Equal(t, &readOnlyPort, conf.Components.Kubelet.ReadOnlyPort)
+
+	authorizationMode := "Webhook"
+	assert.Equal(t, &authorizationMode, conf.Components.Kubelet.AuthorizationMode)
+
+	// The configuration file disables anonymous authentication itself, so the
+	// loader reports it from there rather than from a default.
+	assert.Nil(t, conf.Components.Kubelet.AnonymousAuth)
+	content, ok := conf.Components.Kubelet.Config.Content.(map[string]interface{})
+	require.True(t, ok)
+	authentication, ok := content["authentication"].(map[string]interface{})
+	require.True(t, ok)
+	anonymous, ok := authentication["anonymous"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, false, anonymous["enabled"])
+}
+
+// A kubelet started on flags alone keeps the legacy command line defaults.
+func TestKubeletLegacyDefaults(t *testing.T) {
+	conf := loadTestConfiguration(t, t.TempDir(), "kubelet --kubeconfig=/var/lib/kubelet/kubeconfig\n")
+	require.NotNil(t, conf.Components.Kubelet)
+
+	readOnlyPort := 10255
+	assert.Equal(t, &readOnlyPort, conf.Components.Kubelet.ReadOnlyPort)
+
+	authorizationMode := "AlwaysAllow"
+	assert.Equal(t, &authorizationMode, conf.Components.Kubelet.AuthorizationMode)
+
+	anonymousAuth := true
+	assert.Equal(t, &anonymousAuth, conf.Components.Kubelet.AnonymousAuth)
+}
+
+// A drop-in that turns the read-only port on wins over the file given to
+// --config, which leaves readOnlyPort out.
+func TestKubeletConfigDropinEnablesReadOnlyPort(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, f := range openshiftFs {
+		f.create(t, tmpDir)
+	}
+	dropin := &mockFile{
+		name: "/etc/openshift/kubelet.conf.d/10-read-only-port.conf",
+		mode: 0644,
+		content: `kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+readOnlyPort: 10255`,
+	}
+	dropin.create(t, tmpDir)
+
+	conf := loadTestConfiguration(t, tmpDir, openshiftProcTable)
+	assert.Empty(t, conf.Errors)
+
+	require.NotNil(t, conf.Components.Kubelet)
+	require.NotNil(t, conf.Components.Kubelet.Config)
+	content, ok := conf.Components.Kubelet.Config.Content.(map[string]interface{})
+	require.True(t, ok)
+
+	// The merged configuration carries the setting, so the loader reports it
+	// from there instead of assuming a default.
+	assert.Nil(t, conf.Components.Kubelet.ReadOnlyPort)
+	assert.Equal(t, float64(10255), content["readOnlyPort"])
+}
+
+// The kubelet folds drop-ins in lexical order with the JSON merge patch rules,
+// so a later file overrides an earlier one, an object merges into an object and
+// a null drops the setting.
+func TestKubeletConfigDropinMerge(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, f := range openshiftFs {
+		f.create(t, tmpDir)
+	}
+	for _, f := range []*mockFile{
+		{
+			name: "/etc/openshift/kubelet.conf.d/10-first.conf",
+			mode: 0644,
+			content: `kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+readOnlyPort: 10255
+authorization:
+  mode: AlwaysAllow
+authentication:
+  anonymous:
+    enabled: true`,
+		},
+		{
+			name: "/etc/openshift/kubelet.conf.d/20-second.conf",
+			mode: 0644,
+			content: `kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+readOnlyPort: null
+maxPods: 300`,
+		},
+		{
+			name:    "/etc/openshift/kubelet.conf.d/README",
+			mode:    0644,
+			content: "files without the .conf suffix are left alone",
+		},
+	} {
+		f.create(t, tmpDir)
+	}
+
+	conf := loadTestConfiguration(t, tmpDir, openshiftProcTable)
+	assert.Empty(t, conf.Errors)
+
+	require.NotNil(t, conf.Components.Kubelet)
+	require.NotNil(t, conf.Components.Kubelet.Config)
+	content, ok := conf.Components.Kubelet.Config.Content.(map[string]interface{})
+	require.True(t, ok)
+
+	// The second drop-in drops readOnlyPort, so the configuration file default
+	// applies again.
+	readOnlyPort := 0
+	assert.Equal(t, &readOnlyPort, conf.Components.Kubelet.ReadOnlyPort)
+
+	// The first drop-in sets the two settings the base file leaves to a
+	// default, and the last value of maxPods wins.
+	authorization, ok := content["authorization"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "AlwaysAllow", authorization["mode"])
+	assert.Equal(t, float64(300), content["maxPods"])
+
+	// authentication merges rather than replaces, so the clientCAFile of the
+	// base file survives next to the anonymous access of the drop-in.
+	authentication, ok := content["authentication"].(map[string]interface{})
+	require.True(t, ok)
+	anonymous, ok := authentication["anonymous"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, true, anonymous["enabled"])
+	x509, ok := authentication["x509"].(map[string]interface{})
+	require.True(t, ok)
+	assert.NotNil(t, x509["clientCAFile"])
 }
 
 func loadTestConfiguration(t *testing.T, hostroot string, table string) *K8sNodeConfig {

--- a/pkg/compliance/k8sconfig/types_generated.go
+++ b/pkg/compliance/k8sconfig/types_generated.go
@@ -648,7 +648,7 @@ func (l *loader) newK8sKubeletConfig(flags map[string]string) *K8sKubeletConfig 
 	var res K8sKubeletConfig
 	if v, ok := flags["--config"]; ok {
 		delete(flags, "--config")
-		res.Config = l.loadKubeletConfigFileMeta(v)
+		res.Config = l.loadKubeletConfigFileMeta(v, flags["--config-dir"])
 	}
 	if v, ok := flags["--address"]; ok {
 		delete(flags, "--address")
@@ -664,7 +664,7 @@ func (l *loader) newK8sKubeletConfig(flags map[string]string) *K8sKubeletConfig 
 		res.AnonymousAuth = l.parseBool(v)
 
 	} else if !l.configFileMetaHasField(res.Config, "authentication.anonymous.enabled") {
-		res.AnonymousAuth = l.parseBool("true")
+		res.AnonymousAuth = l.parseBool(flagDefault(res.Config, "true", "false"))
 	}
 	if v, ok := flags["--authorization-mode"]; ok {
 		delete(flags, "--authorization-mode")
@@ -672,7 +672,7 @@ func (l *loader) newK8sKubeletConfig(flags map[string]string) *K8sKubeletConfig 
 		res.AuthorizationMode = &v
 
 	} else if !l.configFileMetaHasField(res.Config, "authorization.mode") {
-		v := "AlwaysAllow"
+		v := flagDefault(res.Config, "AlwaysAllow", "Webhook")
 		res.AuthorizationMode = &v
 	}
 	if v, ok := flags["--client-ca-file"]; ok {
@@ -745,7 +745,7 @@ func (l *loader) newK8sKubeletConfig(flags map[string]string) *K8sKubeletConfig 
 		res.ReadOnlyPort = l.parseInt(v)
 
 	} else if !l.configFileMetaHasField(res.Config, "readOnlyPort") {
-		res.ReadOnlyPort = l.parseInt("10255")
+		res.ReadOnlyPort = l.parseInt(flagDefault(res.Config, "10255", "0"))
 	}
 	if v, ok := flags["--rotate-certificates"]; ok {
 		delete(flags, "--rotate-certificates")

--- a/pkg/compliance/tools/k8s_types_generator/main.go
+++ b/pkg/compliance/tools/k8s_types_generator/main.go
@@ -173,6 +173,18 @@ var (
 
 		"kube-proxy.bind-address": "",
 	}
+
+	// Kubernetes keeps historical defaults for these three kubelet flags to
+	// preserve the command line API (applyLegacyDefaults in
+	// cmd/kubelet/app/options/options.go) and drops them once --config is used,
+	// where the KubeletConfiguration defaults apply instead. The two disagree,
+	// and the configuration file value is the secure one.
+	// reference: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/apis/config/v1beta1/defaults.go
+	confDefaults = map[string]string{
+		"kubelet.anonymous-auth":     "false",
+		"kubelet.authorization-mode": "Webhook",
+		"kubelet.read-only-port":     "0",
+	}
 )
 
 const preamble = `// Unless explicitly stated otherwise all files in this repository are licensed
@@ -451,7 +463,9 @@ func printKomponentCode(komp *komponent) string {
 			return fmt.Sprintf("res.%s = l.loadTokenFileMeta(%s)", toGoField(c.flagName), v)
 		case "*K8sConfigFileMeta":
 			if komp.name == "kubelet" && c.flagName == "config" {
-				return fmt.Sprintf("res.%s = l.loadKubeletConfigFileMeta(%s)", toGoField(c.flagName), v)
+				// The kubelet also reads the drop-ins of --config-dir, which
+				// override the file given to --config.
+				return fmt.Sprintf("res.%s = l.loadKubeletConfigFileMeta(%s, flags[\"--config-dir\"])", toGoField(c.flagName), v)
 			}
 			return fmt.Sprintf("res.%s, _ = l.loadConfigFileMeta(%s)", toGoField(c.flagName), v)
 		case "*K8sKubeletConfigFileMeta":
@@ -514,7 +528,11 @@ func printKomponentCode(komp *komponent) string {
 			} else {
 				sb.WriteString("\n} else {\n")
 			}
-			sb.WriteString(printAssignment(c, fmt.Sprintf("%q", c.flagDefault)))
+			def := fmt.Sprintf("%q", c.flagDefault)
+			if confDefault, ok := confDefaults[komp.name+"."+c.flagName]; ok {
+				def = fmt.Sprintf("flagDefault(res.Config, %q, %q)", c.flagDefault, confDefault)
+			}
+			sb.WriteString(printAssignment(c, def))
 		}
 		sb.WriteString("}\n")
 	}

--- a/releasenotes/notes/cspm-kubelet-config-file-defaults-5f2b81a0d47c3e69.yaml
+++ b/releasenotes/notes/cspm-kubelet-config-file-defaults-5f2b81a0d47c3e69.yaml
@@ -1,0 +1,16 @@
+---
+fixes:
+  - |
+    CSM Misconfigurations: the Kubernetes node configuration collected for the
+    CIS Kubernetes benchmarks now assumes the ``KubeletConfiguration`` defaults
+    for a kubelet started with ``--config``, and folds in the drop-ins of
+    ``--config-dir``. Kubernetes keeps the historical command line defaults of
+    ``--read-only-port``, ``--anonymous-auth`` and ``--authorization-mode`` for a
+    kubelet started on flags alone, and the Agent applied them in both cases. A
+    node whose configuration file left those settings out was therefore reported
+    with a read-only port on ``10255``, anonymous authentication enabled and an
+    ``AlwaysAllow`` authorization mode, while the kubelet was really running with
+    the read-only port disabled, anonymous authentication disabled and
+    ``Webhook`` authorization. OpenShift and kubeadm both leave ``readOnlyPort``
+    out of their rendered configuration, so their nodes failed the "kubelet
+    read-only port should be disabled" rule with the port closed.


### PR DESCRIPTION
Kubernetes keeps the historical command line default of a few kubelet
flags to preserve the command line API, and drops them as soon as the
kubelet is started with --config. The configuration file is then loaded
with the KubeletConfiguration defaults instead, and only the flags that
appear on the command line are applied on top of it. The loader applied
the command line defaults in both cases.

The two sets of defaults disagree on exactly the three settings the CIS
Kubernetes benchmarks care about. A kubelet reading a configuration file
that leaves them out runs with the read-only port disabled, anonymous
authentication disabled and Webhook authorization, while the loader
reported a read-only port on 10255, anonymous authentication enabled and
an AlwaysAllow authorization mode. OpenShift and kubeadm both leave
readOnlyPort out of their rendered configuration, so their nodes failed
"The kubelet read-only port should be disabled" with the port closed.

The generator now carries the configuration file default next to the
command line one for those three flags, and the loader picks between them
by whether the component reads a configuration file. The payload version
is bumped so that rules can tell the two apart.

A setting can also come from the drop-ins of --config-dir, which the
kubelet folds on top of its configuration file, and reading the file alone
would report a default the node overrode. The loader now walks that
directory the way the kubelet does, in lexical order over the files named
*.conf, and merges each with the JSON merge patch rules of RFC 7386.

Updates CSPDE-1519.