### PR TITLE
compliance/k8sconfig: tell an unreadable file from an empty one

### DIFF
--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -213,6 +213,9 @@ func flagDefault(config *K8sConfigFileMeta, cli, file string) string {
 	return file
 }
 
+// loadMeta stats name under the host root and, if loadContent is set, reads it.
+// The content is nil when the read failed. An empty file yields an empty slice,
+// so the two stay apart.
 func (l *loader) loadMeta(name string, loadContent bool) (string, os.FileInfo, []byte, bool) {
 	name = filepath.Join(l.hostroot, name)
 	info, err := os.Stat(name)
@@ -234,6 +237,7 @@ func (l *loader) loadMeta(name string, loadContent bool) (string, os.FileInfo, [
 			b, err = io.ReadAll(io.LimitReader(f, maxSize))
 			if err != nil {
 				l.pushError(err)
+				b = nil
 			}
 		}
 	}
@@ -321,17 +325,19 @@ func (l *loader) configFileMetaHasField(meta *K8sConfigFileMeta, path string) bo
 
 func (l *loader) loadKubeletConfigFileMeta(name, dropinDir string) *K8sConfigFileMeta {
 	meta, ok := l.loadConfigFileMeta(name)
-	if !ok {
-		return &K8sConfigFileMeta{Path: name}
+	if !ok || meta.Content == nil {
+		return meta
 	}
 	content, ok := meta.Content.(map[string]interface{})
 	if !ok {
 		l.pushError(fmt.Errorf("kubelet configuration loaded from %q is not a valid configuration", name))
-		return &K8sConfigFileMeta{Path: name}
+		meta.Content = nil
+		return meta
 	}
 	if kind := content["kind"]; kind != "KubeletConfiguration" {
 		l.pushError(fmt.Errorf(`kubelet configuration loaded from %q is expected to be of kind "KubeletConfiguration"`, name))
-		return &K8sConfigFileMeta{Path: name}
+		meta.Content = nil
+		return meta
 	}
 	// The drop-ins of --config-dir land on top of the file given to --config,
 	// so they have to be folded in before anything reads a setting.
@@ -559,6 +565,16 @@ func (l *loader) loadKubeconfigMeta(name string) (*K8sKubeconfigMeta, bool) {
 		return &K8sKubeconfigMeta{Path: name}, false
 	}
 
+	meta := &K8sKubeconfigMeta{
+		Path:  name,
+		User:  utils.GetFileUser(info),
+		Group: utils.GetFileGroup(info),
+		Mode:  uint32(info.Mode()),
+	}
+	if b == nil {
+		return meta, true
+	}
+
 	var source k8SKubeconfigSource
 	erru := json.Unmarshal(b, &source)
 	if erru != nil {
@@ -566,7 +582,7 @@ func (l *loader) loadKubeconfigMeta(name string) (*K8sKubeconfigMeta, bool) {
 	}
 	if erru != nil {
 		l.pushError(erru)
-		return &K8sKubeconfigMeta{Path: name}, false
+		return meta, false
 	}
 
 	content := &K8SKubeconfig{
@@ -632,13 +648,8 @@ func (l *loader) loadKubeconfigMeta(name string) (*K8sKubeconfigMeta, bool) {
 		}
 	}
 
-	return &K8sKubeconfigMeta{
-		Path:       name,
-		User:       utils.GetFileUser(info),
-		Group:      utils.GetFileGroup(info),
-		Mode:       uint32(info.Mode()),
-		Kubeconfig: content,
-	}, true
+	meta.Kubeconfig = content
+	return meta, true
 }
 
 // in OpenSSH >= 2.6, a fingerprint is now displayed as base64 SHA256.

--- a/pkg/compliance/k8sconfig/loader_test.go
+++ b/pkg/compliance/k8sconfig/loader_test.go
@@ -1151,6 +1151,61 @@ maxPods: 300`,
 	assert.NotNil(t, x509["clientCAFile"])
 }
 
+// A file the Agent may not read is reported with its content left out. Turning
+// it into an empty configuration made the managed environment detection
+// conclude that a managed node was unmanaged.
+func TestKubeletUnreadableConfiguration(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("test must run as non-root to be denied reading the configuration")
+	}
+
+	tmpDir := t.TempDir()
+	for _, f := range openshiftFs {
+		f.create(t, tmpDir)
+		if err := os.Chmod(filepath.Join(tmpDir, f.name), 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	conf := loadTestConfiguration(t, tmpDir, openshiftProcTable)
+	assert.Len(t, conf.Errors, 2)
+	assert.Contains(t, strings.Join(conf.Errors, "\n"), "/etc/kubernetes/kubelet.conf")
+	assert.Contains(t, strings.Join(conf.Errors, "\n"), "/var/lib/kubelet/kubeconfig")
+
+	require.NotNil(t, conf.Components.Kubelet)
+	require.NotNil(t, conf.Components.Kubelet.Config)
+	assert.Nil(t, conf.Components.Kubelet.Config.Content)
+
+	require.NotNil(t, conf.Components.Kubelet.Kubeconfig)
+	assert.Nil(t, conf.Components.Kubelet.Kubeconfig.Kubeconfig)
+
+	// The kubelet was started with --config, so the configuration file
+	// defaults apply whatever the file turns out to hold.
+	readOnlyPort := 0
+	assert.Equal(t, &readOnlyPort, conf.Components.Kubelet.ReadOnlyPort)
+}
+
+// The ownership and permissions of a configuration file are reported even when
+// its content is out of reach, so the benchmarks checking them see the real
+// mode.
+func TestKubeletConfigLargerThanReadLimit(t *testing.T) {
+	tmpDir := t.TempDir()
+	large := &mockFile{
+		name:    "/etc/kubernetes/kubelet.conf",
+		mode:    0644,
+		content: strings.Repeat("# padding\n", 64*1024),
+	}
+	large.create(t, tmpDir)
+
+	conf := loadTestConfiguration(t, tmpDir, openshiftProcTable)
+	require.NotNil(t, conf.Components.Kubelet)
+	config := conf.Components.Kubelet.Config
+	require.NotNil(t, config)
+	assert.Nil(t, config.Content)
+	assert.Equal(t, uint32(0644), config.Mode)
+	assert.NotEmpty(t, config.User)
+}
+
 func loadTestConfiguration(t *testing.T, hostroot string, table string) *K8sNodeConfig {
 	l := &loader{hostroot: hostroot}
 	_, data := l.load(context.Background(), func(_ context.Context) []proc {
@@ -1172,16 +1227,22 @@ type mockFile struct {
 }
 
 func (f *mockFile) create(t *testing.T, root string) {
+	path := filepath.Join(root, f.name)
 	if f.isDir {
-		if err := os.MkdirAll(filepath.Join(root, f.name), fs.FileMode(f.mode)); err != nil {
+		if err := os.MkdirAll(path, fs.FileMode(f.mode)); err != nil {
 			t.Fatal(err)
 		}
 	} else {
-		if err := os.MkdirAll(filepath.Join(root, filepath.Dir(f.name)), fs.FileMode(0750)); err != nil {
+		if err := os.MkdirAll(filepath.Dir(path), fs.FileMode(0750)); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filepath.Join(root, f.name), []byte(f.content), os.FileMode(f.mode)); err != nil {
+		if err := os.WriteFile(path, []byte(f.content), os.FileMode(f.mode)); err != nil {
 			t.Fatal(err)
 		}
+	}
+	// Force the declared mode past the umask: several benchmarks look at the
+	// permissions of these files.
+	if err := os.Chmod(path, fs.FileMode(f.mode)); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/releasenotes/notes/cspm-k8s-unreadable-config-b7c0e4a1985d2f37.yaml
+++ b/releasenotes/notes/cspm-k8s-unreadable-config-b7c0e4a1985d2f37.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    CSM Misconfigurations: a Kubernetes configuration file the Agent may not read
+    is now reported with its content left out. An unreadable kubelet kubeconfig
+    used to parse into an empty one, matching a kubeconfig that really names no
+    cluster, and the managed environment detection concluded from it that an EKS,
+    GKE or AKS node was unmanaged. The detection now sees an absent kubeconfig,
+    and the payload says as much. The ownership and permissions of an unreadable
+    file are reported too, so the benchmarks that check them see the real mode.


### PR DESCRIPTION
The loader stats a configuration file, reads it, then parses whatever it
got. A read that fails, typically a permission denied on a root-owned
kubeconfig, went to the errors list alone. Parsing an empty read yields an
empty configuration, matching a file that really is empty, and the errors
list stays out of reach of the rules. So an unreadable file quietly became
a file holding nothing.

detectManagedEnvironment falls back to the kubelet kubeconfig to recognize
an EKS, GKE or AKS control plane when the node labels say nothing, and it
walked the three empty maps of a manufactured kubeconfig to conclude that
the node was unmanaged.

Content that could not be read is now left out rather than parsed, so the
detection sees an absent kubeconfig rather than invented evidence. Such a
node is still reported as unmanaged: classifying it needs a resource type
the rule set would have to define, which is a separate matter. The
ownership and permissions from the stat are kept, which also fixes the
benchmarks looking at them. They used to see a mode of zero for an
unreadable kubelet configuration file and pass.

Updates CSPDE-1519.