### PR TITLE
[CONTP-2017] feat(instrumentation): support StrimziPodSet targets

### DIFF
--- a/comp/core/workloadfilter/util/workloadmeta/create.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create.go
@@ -83,7 +83,7 @@ func resolveRootOwner(owners []workloadmeta.KubernetesPodOwner, podLabels map[st
 			return &core.FilterRootOwner{Kind: kubernetes.CronJobKind, Name: cronjob}
 		}
 		return &core.FilterRootOwner{Kind: owner.Kind, Name: owner.Name}
-	case kubernetes.DeploymentKind, kubernetes.DaemonSetKind, kubernetes.StatefulSetKind:
+	case kubernetes.DeploymentKind, kubernetes.DaemonSetKind, kubernetes.StatefulSetKind, kubernetes.StrimziPodSetKind:
 		return &core.FilterRootOwner{Kind: owner.Kind, Name: owner.Name}
 	default:
 		return &core.FilterRootOwner{Kind: owner.Kind, Name: owner.Name}

--- a/comp/core/workloadfilter/util/workloadmeta/create_test.go
+++ b/comp/core/workloadfilter/util/workloadmeta/create_test.go
@@ -78,6 +78,11 @@ func TestResolveRootOwner(t *testing.T) {
 			expected: &core.FilterRootOwner{Kind: "StatefulSet", Name: "redis"},
 		},
 		{
+			name:     "StrimziPodSet is its own root",
+			owners:   []workloadmeta.KubernetesPodOwner{{Kind: "StrimziPodSet", Name: "my-cluster-kafka", Controller: boolPtr(true)}},
+			expected: &core.FilterRootOwner{Kind: "StrimziPodSet", Name: "my-cluster-kafka"},
+		},
+		{
 			name: "prefers controller owner over non-controller",
 			owners: []workloadmeta.KubernetesPodOwner{
 				{Kind: "Node", Name: "node-1", Controller: boolPtr(false)},
@@ -133,4 +138,20 @@ func TestCreatePodWithRolloutRootOwner(t *testing.T) {
 	assert.NotNil(t, result.FilterPod.Rootowner)
 	assert.Equal(t, "Rollout", result.FilterPod.Rootowner.Kind)
 	assert.Equal(t, "my-rollout", result.FilterPod.Rootowner.Name)
+}
+
+func TestCreatePodWithStrimziPodSetRootOwner(t *testing.T) {
+	pod := &workloadmeta.KubernetesPod{
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:      "my-cluster-kafka-0",
+			Namespace: "default",
+		},
+		Owners: []workloadmeta.KubernetesPodOwner{
+			{Kind: "StrimziPodSet", Name: "my-cluster-kafka", Controller: boolPtr(true)},
+		},
+	}
+	result := CreatePod(pod)
+	assert.NotNil(t, result.FilterPod.Rootowner)
+	assert.Equal(t, "StrimziPodSet", result.FilterPod.Rootowner.Kind)
+	assert.Equal(t, "my-cluster-kafka", result.FilterPod.Rootowner.Name)
 }

--- a/pkg/clusteragent/instrumentation/handlers/checks.go
+++ b/pkg/clusteragent/instrumentation/handlers/checks.go
@@ -62,7 +62,7 @@ func (h *ChecksHandler) HasSection(cr *datadoghq.DatadogInstrumentation) bool {
 // SupportsTarget returns whether Autodiscovery check delivery supports the target kind.
 func (h *ChecksHandler) SupportsTarget(ref autoscalingv2.CrossVersionObjectReference) bool {
 	switch ref.Kind {
-	case kubernetes.DeploymentKind, kubernetes.DaemonSetKind, kubernetes.StatefulSetKind, kubernetes.CronJobKind, kubernetes.JobKind, kubernetes.RolloutKind:
+	case kubernetes.DeploymentKind, kubernetes.DaemonSetKind, kubernetes.StatefulSetKind, kubernetes.CronJobKind, kubernetes.JobKind, kubernetes.RolloutKind, kubernetes.StrimziPodSetKind:
 		return true
 	case kubernetes.ServiceKind:
 		// Service target support is backed by endpoint slices CR provider. If Endpointslice collection

--- a/pkg/clusteragent/instrumentation/handlers/checks_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/checks_test.go
@@ -135,6 +135,7 @@ func TestSupportsTarget(t *testing.T) {
 		{"Job", true},
 		{"Service", true},
 		{"Rollout", true},
+		{"StrimziPodSet", true},
 		{"ReplicaSet", false},
 		{"Pod", false},
 		{"", false},

--- a/pkg/clusteragent/instrumentation/handlers/logs.go
+++ b/pkg/clusteragent/instrumentation/handlers/logs.go
@@ -55,7 +55,7 @@ func (h *LogsHandler) HasSection(cr *datadoghq.DatadogInstrumentation) bool {
 // SupportsTarget returns whether log delivery supports the target kind.
 func (h *LogsHandler) SupportsTarget(ref autoscalingv2.CrossVersionObjectReference) bool {
 	switch ref.Kind {
-	case kubernetes.DeploymentKind, kubernetes.DaemonSetKind, kubernetes.StatefulSetKind, kubernetes.CronJobKind, kubernetes.JobKind, kubernetes.RolloutKind:
+	case kubernetes.DeploymentKind, kubernetes.DaemonSetKind, kubernetes.StatefulSetKind, kubernetes.CronJobKind, kubernetes.JobKind, kubernetes.RolloutKind, kubernetes.StrimziPodSetKind:
 		return true
 	default:
 		return false

--- a/pkg/clusteragent/instrumentation/handlers/logs_test.go
+++ b/pkg/clusteragent/instrumentation/handlers/logs_test.go
@@ -81,6 +81,7 @@ func TestLogsSupportsTarget(t *testing.T) {
 		{"CronJob", true},
 		{"Job", true},
 		{"Rollout", true},
+		{"StrimziPodSet", true},
 		{"Service", false},
 		{"ReplicaSet", false},
 		{"Pod", false},

--- a/pkg/util/kubernetes/const.go
+++ b/pkg/util/kubernetes/const.go
@@ -148,6 +148,8 @@ const (
 	RolloutAPIVersion = "argoproj.io/v1alpha1"
 	// RolloutKind represents the Argo Rollout object kind
 	RolloutKind = "Rollout"
+	// StrimziPodSetKind represents the Strimzi PodSet object kind
+	StrimziPodSetKind = "StrimziPodSet"
 
 	// CriContainerNamespaceLabel is the label set on containers by runtimes with Pod Namespace
 	CriContainerNamespaceLabel = "io.kubernetes.pod.namespace"

--- a/releasenotes-dca/notes/add-strimzi-workload-targets-0c2cfc060bc7b2d8.yaml
+++ b/releasenotes-dca/notes/add-strimzi-workload-targets-0c2cfc060bc7b2d8.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    ``DatadogInstrumentation`` checks and logs configurations can now target
+    Strimzi ``StrimziPodSet`` workloads.


### PR DESCRIPTION
### What does this PR do?

Allows `DatadogInstrumentation` checks and logs configurations to target Strimzi `StrimziPodSet` workloads. The root-owner resolver explicitly recognizes direct `StrimziPodSet` ownership, with regression coverage ensuring CEL matching uses the Strimzi workload kind and name.

### Motivation

Strimzi-managed Kafka pods use a custom workload owner instead of a native Kubernetes workload kind, so customers could not target them with `DatadogInstrumentation` configurations.

[Corresponding Jira issue](<https://datadoghq.atlassian.net/browse/CONTP-2017>)

### Describe how you validated your changes

* `dda inv test --targets=./comp/core/workloadfilter/util/workloadmeta,./pkg/clusteragent/instrumentation/handlers --no-cache`
* `dda inv linter.go --targets=./comp/core/workloadfilter/util/workloadmeta,./pkg/clusteragent/instrumentation/handlers`

#### Manully QAd

<details><summary>injector-dev scearnio</summary>

```
platform:
  type: "kind"
  name: "ddi-generic-targets"
  reset: false

helm:
  versions:
    agent:
      build: {}
    cluster_agent:
      build: {}
    injector: "0.60.0"

  config:
    datadog:
      clusterName: "mathewe-ddi-generic-targets"
      operator:
        enabled: false
      csi:
        enabled: false
      kubelet:
        tlsVerify: false
      instrumentationCrd:
        enabled: true
    clusterAgent:
      enabled: true
      admissionController:
        enabled: true
        mutateUnlabelled: false
```

</details>

<details><summary>DatadogInstrumentation CRD</summary>

```
apiVersion: datadoghq.com/v1alpha1
kind: DatadogInstrumentation
metadata:
  name: strimzi-cluster-kafka
spec:
  targetRef:
    apiVersion: core.strimzi.io/v1
    kind: StrimziPodSet
    name: my-cluster-dual-role
  config:
    checks:
      - integration: kafka
        containerName: kafka
        initConfig:
          is_jmx: true
          collect_default_metrics: true
          new_gc_metrics: true
        instances:
          - host: "%%host%%"
            port: 9999
      - integration: kafka_consumer
        containerName: kafka
        instances:
          - kafka_connect_str: "%%host%%:9092"
            monitor_unlisted_consumer_groups: "true"
```

</details>

Validated kafka checks are scheduled against Pod part of `StrimziPodSet`

<img src="https://uploads.linear.app/ffde0cfc-a624-4aa5-92d0-9fb120788324/e08183f0-533f-47f3-b649-85e7c147baf9/13cb09fc-8188-4fff-a382-619d4311423e?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2ZmZGUwY2ZjLWE2MjQtNGFhNS05MmQwLTlmYjEyMDc4ODMyNC9lMDgxODNmMC01MzNmLTQ3ZjMtYjY0OS04NWU3YzE0N2JhZjkvMTNjYjA5ZmMtODE4OC00ZmZmLWEzODItNjE5ZDQzMTE0MjNlIiwiaWF0IjoxNzg3MTc2NzAxLCJleHAiOjE4MTg3NDcyNjF9.qTHTo4QGvwHZHbSVweePEAY0XI9y8TX6TMyoVqSfqsw " alt="image.png" width="711" data-linear-height="530" />