### PR TITLE
fix(windows): don't fail uninstall when config directory or registry state is missing

### DIFF
--- a/releasenotes/notes/fix-uninstall-missing-configdir-f4ab2d5341fa739d.yaml
+++ b/releasenotes/notes/fix-uninstall-missing-configdir-f4ab2d5341fa739d.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix an issue on Windows where uninstalling the Agent could fail if the
+    configuration directory (``C:\ProgramData\Datadog`` by default) had
+    already been removed before running the uninstall.

--- a/test/new-e2e/tests/windows/install-test/install_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_test.go
@@ -258,9 +258,15 @@ func (s *testInstallAltDirAndCorruptForUninstallSuite) TestInstallAltDirAndCorru
 		windowsAgent.WithApplicationDataDirectory(configRoot),
 	)
 
+	// Stop the agent before deleting the registry key below: otherwise the running
+	// service (as ddagentuser) can lose track of configRoot and recreate the default
+	// config dir itself, leaving it with an untrusted owner.
+	err := windowsCommon.StopService(vm, "DatadogAgent")
+	s.Require().NoError(err)
+
 	// remove registry key that contains install info to ensure uninstall succeeds
 	// with a corrupted install
-	err := windowsCommon.DeleteRegistryKey(vm, windowsAgent.RegistryKeyPath)
+	err = windowsCommon.DeleteRegistryKey(vm, windowsAgent.RegistryKeyPath)
 	s.Require().NoError(err)
 
 	// uninstall the agent

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
@@ -754,24 +754,34 @@ namespace Datadog.CustomActions
         {
             // lookup sid for ddagentuser
             var ddAgentUserName = $"{_session.Property("DDAGENTUSER_NAME")}";
+            SecurityIdentifier securityIdentifier = null;
+            var validUser = false;
+
             if (string.IsNullOrEmpty(ddAgentUserName))
             {
                 // LookupAccountName("") succeeds and resolves to a domain SID (e.g. BUILTIN), not a user.
-                _session.Log("DDAGENTUSER_NAME is not set, skipping file access removal");
-                return;
+                _session.Log("DDAGENTUSER_NAME is not set, skipping per-user file access removal");
+            }
+            else
+            {
+                var userFound = _nativeMethods.LookupAccountName(ddAgentUserName,
+                    out _,
+                    out _,
+                    out securityIdentifier,
+                    out var sidNameUse);
+                // Defense in depth against operating on a non-user SID, matching the check in
+                // ProcessDdAgentUserCredentials (ProcessUserCustomActions.cs).
+                validUser = userFound && securityIdentifier != null &&
+                    (sidNameUse == SID_NAME_USE.SidTypeUser || sidNameUse == SID_NAME_USE.SidTypeWellKnownGroup);
+                if (!validUser)
+                {
+                    _session.Log($"Could not find user {ddAgentUserName}");
+                }
             }
 
-            var userFound = _nativeMethods.LookupAccountName(ddAgentUserName,
-                out _,
-                out _,
-                out var securityIdentifier,
-                out var sidNameUse);
-            // Defense in depth against operating on a non-user SID, matching the check in
-            // ProcessDdAgentUserCredentials (ProcessUserCustomActions.cs).
-            if (!userFound || securityIdentifier == null ||
-                (sidNameUse != SID_NAME_USE.SidTypeUser && sidNameUse != SID_NAME_USE.SidTypeWellKnownGroup))
+            // LocalSystem never gets any extra ACEs added, so there's nothing to remove.
+            if (validUser && securityIdentifier == new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null))
             {
-                _session.Log($"Could not find user {ddAgentUserName}");
                 return;
             }
 
@@ -784,23 +794,23 @@ namespace Datadog.CustomActions
                 );
                 _session.Message(InstallMessage.ActionStart, actionRecord);
             }
-            if (securityIdentifier == new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null))
+
+            if (validUser)
             {
-                return;
+                _session.Log($"Removing file access for {ddAgentUserName} ({securityIdentifier})");
+                foreach (var filePath in _session.PathsWithAgentAccess().Where(_fileSystemServices.Exists))
+                {
+                    try
+                    {
+                        RemoveAgentAccess(securityIdentifier, filePath);
+                    }
+                    catch (Exception e)
+                    {
+                        _session.Log($"Failed to remove {ddAgentUserName} from {filePath}: {e}");
+                    }
+                }
             }
 
-            _session.Log($"Removing file access for {ddAgentUserName} ({securityIdentifier})");
-            foreach (var filePath in _session.PathsWithAgentAccess().Where(_fileSystemServices.Exists))
-            {
-                try
-                {
-                    RemoveAgentAccess(securityIdentifier, filePath);
-                }
-                catch (Exception e)
-                {
-                    _session.Log($"Failed to remove {ddAgentUserName} from {filePath}: {e}");
-                }
-            }
             //remove datadog access to root folder and restore to base permissions
             var dataDirectory = _session.Property("APPLICATIONDATADIRECTORY");
             if (_fileSystemServices.Exists(dataDirectory))

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
@@ -779,12 +779,6 @@ namespace Datadog.CustomActions
                 }
             }
 
-            // LocalSystem never gets any extra ACEs added, so there's nothing to remove.
-            if (validUser && securityIdentifier == new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null))
-            {
-                return;
-            }
-
             // Remove explicit ACE for ddagentuser
             {
                 using var actionRecord = new Record(
@@ -795,7 +789,10 @@ namespace Datadog.CustomActions
                 _session.Message(InstallMessage.ActionStart, actionRecord);
             }
 
-            if (validUser)
+            // LocalSystem never gets any extra per-file ACEs added during install, so there's
+            // nothing user-specific to remove, but base permissions are still reset below.
+            var isLocalSystem = securityIdentifier == new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null);
+            if (validUser && !isLocalSystem)
             {
                 _session.Log($"Removing file access for {ddAgentUserName} ({securityIdentifier})");
                 foreach (var filePath in _session.PathsWithAgentAccess().Where(_fileSystemServices.Exists))

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
@@ -206,6 +206,7 @@ namespace Datadog.CustomActions
         /// </summary>
         private void SetBaseInheritablePermissions()
         {
+            var dataDirectory = _session.Property("APPLICATIONDATADIRECTORY");
             FileSystemSecurity fileSystemSecurity = new DirectorySecurity();
             // disable inheritance, discard inherited rules
             fileSystemSecurity.SetAccessRuleProtection(true, false);
@@ -227,7 +228,7 @@ namespace Datadog.CustomActions
                 WellKnownSidType.LocalSystemSid, null));
             fileSystemSecurity.SetGroup(new SecurityIdentifier(
                 WellKnownSidType.LocalSystemSid, null));
-            UpdateAndLogAccessControl(_session.Property("APPLICATIONDATADIRECTORY"), fileSystemSecurity);
+            UpdateAndLogAccessControl(dataDirectory, fileSystemSecurity);
         }
 
         /// <summary>
@@ -746,80 +747,116 @@ namespace Datadog.CustomActions
             }
         }
 
+        /// <summary>
+        /// Remove ddagentuser's explicit file access ACEs and restore base permissions on APPLICATIONDATADIRECTORY.
+        /// </summary>
+        private void UninstallRemoveFileAccess()
+        {
+            // lookup sid for ddagentuser
+            var ddAgentUserName = $"{_session.Property("DDAGENTUSER_NAME")}";
+            if (string.IsNullOrEmpty(ddAgentUserName))
+            {
+                // LookupAccountName("") succeeds and resolves to a domain SID (e.g. BUILTIN), not a user.
+                _session.Log("DDAGENTUSER_NAME is not set, skipping file access removal");
+                return;
+            }
+
+            var userFound = _nativeMethods.LookupAccountName(ddAgentUserName,
+                out _,
+                out _,
+                out var securityIdentifier,
+                out var sidNameUse);
+            // Defense in depth against operating on a non-user SID, matching the check in
+            // ProcessDdAgentUserCredentials (ProcessUserCustomActions.cs).
+            if (!userFound || securityIdentifier == null ||
+                (sidNameUse != SID_NAME_USE.SidTypeUser && sidNameUse != SID_NAME_USE.SidTypeWellKnownGroup))
+            {
+                _session.Log($"Could not find user {ddAgentUserName}");
+                return;
+            }
+
+            // Remove explicit ACE for ddagentuser
+            {
+                using var actionRecord = new Record(
+                    "UninstallUser",
+                    "Removing file access",
+                    ""
+                );
+                _session.Message(InstallMessage.ActionStart, actionRecord);
+            }
+            if (securityIdentifier == new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null))
+            {
+                return;
+            }
+
+            _session.Log($"Removing file access for {ddAgentUserName} ({securityIdentifier})");
+            foreach (var filePath in _session.PathsWithAgentAccess().Where(_fileSystemServices.Exists))
+            {
+                try
+                {
+                    RemoveAgentAccess(securityIdentifier, filePath);
+                }
+                catch (Exception e)
+                {
+                    _session.Log($"Failed to remove {ddAgentUserName} from {filePath}: {e}");
+                }
+            }
+            //remove datadog access to root folder and restore to base permissions
+            var dataDirectory = _session.Property("APPLICATIONDATADIRECTORY");
+            if (_fileSystemServices.Exists(dataDirectory))
+            {
+                SetBaseInheritablePermissions();
+            }
+            else
+            {
+                _session.Log($"{dataDirectory} does not exist, skipping setting base permissions");
+            }
+        }
+
+        /// <summary>
+        /// Remove the ddagentuser password from the LSA secret store, unless this is an upgrade
+        /// (including a Fleet Automation uninstall->install upgrade), in which case the new
+        /// Agent install will still need it.
+        /// </summary>
+        private void UninstallRemoveLsaSecret()
+        {
+            var upgrading = !string.IsNullOrEmpty(_session.Property("UPGRADINGPRODUCTCODE"));
+            var fleetAutomation = _session.Property("FLEET_INSTALL") == "1";
+            if (upgrading || fleetAutomation)
+            {
+                // If this is an upgrade, we don't want to remove the password from the LSA secret store
+                // because the new version of the Agent will need it. Technically it should already have it
+                // because it's fetched in ProcessDDAgentUserCredentials, which runs before the existing
+                // products are removed, but we don't want to lose it on rollback.
+                // TODO(WINA-1357): rollback the password if the upgrade fails
+                // If this is a Fleet Automation upgrade (uninstall->install workflow), we don't want to remove
+                // the password from the LSA secret store because the new version of the Agent will need it.
+                _session.Log($"Upgrade detected, not removing password from LSA secret store");
+                return;
+            }
+
+            _session.Log("Uninstall detected, removing password from LSA secret store");
+            try
+            {
+                var keyName = AgentPasswordPrivateDataKey();
+                _nativeMethods.RemoveSecret(keyName);
+            }
+            catch (Exception e)
+            {
+                // Don't fail if we fail to remove the secret.
+                // ProcessDDAgentUserCredentials will appropriately clear the password property for service accounts
+                // so it being left behind shouldn't affect future installs and may be removed then.
+                _session.Log($"Failed to remove agent secret: {e}");
+            }
+        }
+
         public ActionResult UninstallUser()
         {
             try
             {
-                // lookup sid for ddagentuser
-                var ddAgentUserName = $"{_session.Property("DDAGENTUSER_NAME")}";
-                var userFound = _nativeMethods.LookupAccountName(ddAgentUserName,
-                    out _,
-                    out _,
-                    out var securityIdentifier,
-                    out _);
-                if (!userFound || securityIdentifier == null)
-                {
-                    _session.Log($"Could not find user {ddAgentUserName}");
-                    return ActionResult.Success;
-                }
+                UninstallRemoveFileAccess();
 
-                // Remove explicit ACE for ddagentuser
-                {
-                    using var actionRecord = new Record(
-                        "UninstallUser",
-                        "Removing file access",
-                        ""
-                    );
-                    _session.Message(InstallMessage.ActionStart, actionRecord);
-                }
-                if (securityIdentifier != new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null))
-                {
-                    _session.Log($"Removing file access for {ddAgentUserName} ({securityIdentifier})");
-                    foreach (var filePath in _session.PathsWithAgentAccess().Where(_fileSystemServices.Exists))
-                    {
-                        try
-                        {
-                            RemoveAgentAccess(securityIdentifier, filePath);
-                        }
-                        catch (Exception e)
-                        {
-                            _session.Log($"Failed to remove {ddAgentUserName} from {filePath}: {e}");
-                        }
-                    }
-                    //remove datadog access to root folder and restore to base permissions
-                    SetBaseInheritablePermissions();
-                }
-
-                // Remove password from LSA secret store
-                var upgrading = !string.IsNullOrEmpty(_session.Property("UPGRADINGPRODUCTCODE"));
-                var fleetAutomation = _session.Property("FLEET_INSTALL") == "1";
-                if (upgrading || fleetAutomation)
-                {
-                    // If this is an upgrade, we don't want to remove the password from the LSA secret store
-                    // because the new version of the Agent will need it. Technically it should already have it
-                    // because it's fetched in ProcessDDAgentUserCredentials, which runs before the existing
-                    // products are removed, but we don't want to lose it on rollback.
-                    // TODO(WINA-1357): rollback the password if the upgrade fails
-                    // If this is a Fleet Automation upgrade (uninstall->install workflow), we don't want to remove
-                    // the password from the LSA secret store because the new version of the Agent will need it.
-                    _session.Log($"Upgrade detected, not removing password from LSA secret store");
-                }
-                else
-                {
-                    _session.Log("Uninstall detected, removing password from LSA secret store");
-                    try
-                    {
-                        var keyName = AgentPasswordPrivateDataKey();
-                        _nativeMethods.RemoveSecret(keyName);
-                    }
-                    catch (Exception e)
-                    {
-                        // Don't fail if we fail to remove the secret.
-                        // ProcessDDAgentUserCredentials will appropriately clear the password property for service accounts
-                        // so it being left behind shouldn't affect future installs and may be removed then.
-                        _session.Log($"Failed to remove agent secret: {e}");
-                    }
-                }
+                UninstallRemoveLsaSecret();
 
                 // We intentionally do NOT delete the ddagentuser account.
                 // For domain accounts, the account may still be in use elsewhere and we can't delete accounts from domain clients.

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
@@ -861,9 +861,24 @@ namespace Datadog.CustomActions
         {
             try
             {
-                UninstallRemoveFileAccess();
+                // Each cleanup step is independent: a failure in one must not prevent the other from running.
+                try
+                {
+                    UninstallRemoveFileAccess();
+                }
+                catch (Exception e)
+                {
+                    _session.Log($"Failed to remove file access during uninstall: {e}");
+                }
 
-                UninstallRemoveLsaSecret();
+                try
+                {
+                    UninstallRemoveLsaSecret();
+                }
+                catch (Exception e)
+                {
+                    _session.Log($"Failed to remove LSA secret during uninstall: {e}");
+                }
 
                 // We intentionally do NOT delete the ddagentuser account.
                 // For domain accounts, the account may still be in use elsewhere and we can't delete accounts from domain clients.
@@ -872,6 +887,7 @@ namespace Datadog.CustomActions
             }
             catch (Exception e)
             {
+                // Backstop for anything added here in the future that isn't already wrapped above.
                 _session.Log($"Failed to uninstall user: {e}");
                 return ActionResult.Failure;
             }


### PR DESCRIPTION
### What does this PR do?

Fixes the Windows `UninstallUser` MSI custom action so a missing registry install-state or config directory (`C:\ProgramData\Datadog` by default) no longer fails the whole uninstall. Splits `UninstallUser` into file-access and LSA-secret-removal steps so LSA cleanup always runs, guards against an unresolvable `DDAGENTUSER_NAME` operating on a bogus SID, and skips (rather than throws on) resetting base permissions when the config directory doesn't exist, while still resetting them when it does.

### Motivation

https://datadoghq.atlassian.net/browse/WINA-2107

If the registry key and/or config directory are removed out-of-band before uninstalling, the old code would throw uncaught when the directory was gone, failing the custom action entirely.

### Describe how you validated your changes

`TestInstallAltDirAndCorruptForUninstall` already covers this: it deletes the registry key that persists `APPLICATIONDATADIRECTORY`, so uninstall falls back to the default `C:\ProgramData\Datadog`, which doesn't exist on that alt-dir install — reproducing the missing-directory failure this PR fixes.