### PR TITLE
[SMP] Update CLI to v0.28.0 and lading to 0.33.0

### DIFF
--- a/.gitlab/childs/smp-regression-child-pipeline.yml
+++ b/.gitlab/childs/smp-regression-child-pipeline.yml
@@ -299,7 +299,7 @@ single-machine-performance-regression_detector:
   variables:
     SMP_TEAM_NAME: agent
     SMP_API_URL: api_url
-    SMP_VERSION: v0.27.0
+    SMP_VERSION: v0.28.0
     BOT_LOGIN: bot_login
     BOT_TOKEN: bot_token
     CONFIG_DIR: test/regression

--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.31.2
+  version: 0.33.0
 
 target:
   ddprof_replicas: 1
@@ -39,4 +39,3 @@ report:
   profiles: "https://app.datadoghq.com/profiling/explorer?query=env%3Asingle-machine-performance%20service%3Adatadog-agent%20job_id%3A{{ job_id }}&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&viz=stream&start={{ filter_start }}&end={{ filter_end }}&paused=true"
   per_experiment_logs: "https://app.datadoghq.com/logs?query=experiment%3A{{ experiment }}%20job_id%3A{{ job_id }}&agg_m=count&agg_m_source=base&agg_q=%40span.url&agg_q_source=base&agg_t=count&fromUser=true&index=single-machine-performance-target-logs&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&top_n=100&top_o=top&viz=stream&x_missing=true&from_ts={{ filter_start }}&to_ts={{ filter_end }}&live=false"
   debug_dashboard: "https://app.datadoghq.com/dashboard/zv5-qgi-m66/smp-failed-replicates?fromUser=true&refresh_mode=paused&tpl_var_experiment%5B0%5D={{ experiment }}&tpl_var_job_id%5B0%5D={{ job_id}}&tpl_var_replicate_type%5B0%5D={{ replicate_type }}&tpl_var_variant%5B0%5D={{ variant }}&from_ts={{ filter_start }}&to_ts={{ filter_end }}&live=false"
-


### PR DESCRIPTION
### What does this PR do?

Update the SMP CLI to `v0.28.0` and lading to `0.33.0` for Agent regression detector jobs.

### Motivation

Keeping up to date.

### Describe how you validated your changes

SMP v0.28.0 is deployed to the Agent client team.

*sent with claude*