### PR TITLE
remote queries: add deterministic intake relay proof tooling

### DIFF
--- a/comp/api/grpcserver/impl-agent/remote_query_execute_test.go
+++ b/comp/api/grpcserver/impl-agent/remote_query_execute_test.go
@@ -215,3 +215,64 @@ func TestRemoteQueryStreamEventFromCheckEventSurfacesUploadReceipt(t *testing.T)
 	assert.Equal(t, int32(3), receipt.GetPartCount())
 	assert.Equal(t, "abc123", receipt.GetSha256())
 }
+
+// TestRemoteQueryExecuteRequestFromProtoPreserves10GiBInt64Fidelity proves the 10 GiB result
+// cap survives the AgentSecure proto boundary and the integration request JSON without loss.
+// max_bytes is int64 on both RemoteQueryExecuteCopyLimits and RemoteQueryResultDelivery because
+// 10 GiB overflows int32; part_bytes stays int32 since the 128 MiB part cap fits comfortably.
+func TestRemoteQueryExecuteRequestFromProtoPreserves10GiBInt64Fidelity(t *testing.T) {
+	const tenGiB = int64(10) << 30
+	const tenGiBPlusOne = tenGiB + 1
+	req, err := remoteQueryExecuteRequestFromProto(&pb.RemoteQueryExecuteRequest{
+		Integration: "postgres",
+		Operation:   "copy_stream",
+		Format:      "csv",
+		Target:      &pb.RemoteQueryTarget{Host: "localhost", Port: 5432, Dbname: "postgres"},
+		Query:       "SELECT city, country FROM cities ORDER BY city",
+		CopyLimits:  &pb.RemoteQueryExecuteCopyLimits{ChunkBytes: 1 << 20, MaxBytes: tenGiB, MaxRowBytes: 1 << 20, TimeoutMs: 1000},
+		ResultDelivery: &pb.RemoteQueryResultDelivery{
+			Mode:        "POC_PUBLIC_MULTIPART_UPLOAD",
+			UploadId:    "upload-10g",
+			BaseUrl:     "https://dd.datad0g.com/api/unstable/its-agent-intake",
+			Token:       "scoped-upload-token",
+			PartBytes:   64 << 20,
+			MaxBytes:    tenGiB,
+			Format:      "csv",
+			Compression: "none",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, req.ResultDelivery)
+	require.NotNil(t, req.CopyLimits)
+
+	// Proto int64 fidelity: the exact 10 GiB value round-trips through the AgentSecure proto
+	// into the Go int fields without truncation or overflow. part_bytes stays int32 (64 MiB
+	// fits), while both max_bytes fields are int64 so 10 GiB is representable.
+	assert.Equal(t, int(tenGiB), req.ResultDelivery.MaxBytes)
+	assert.Equal(t, int(tenGiB), req.CopyLimits.MaxBytes)
+	assert.Equal(t, 64<<20, req.ResultDelivery.PartBytes)
+
+	// The plus-one byte exceeds the 10 GiB Agent cap and is rejected; the int64 field carries
+	// the overflowing value faithfully so the cap check fails closed rather than truncating it.
+	_, err = remoteQueryExecuteRequestFromProto(&pb.RemoteQueryExecuteRequest{
+		Integration: "postgres",
+		Operation:   "copy_stream",
+		Format:      "csv",
+		Target:      &pb.RemoteQueryTarget{Host: "localhost", Port: 5432, Dbname: "postgres"},
+		Query:       "SELECT city, country FROM cities ORDER BY city",
+		CopyLimits:  &pb.RemoteQueryExecuteCopyLimits{ChunkBytes: 1 << 20, MaxBytes: tenGiBPlusOne, MaxRowBytes: 1 << 20, TimeoutMs: 1000},
+		ResultDelivery: &pb.RemoteQueryResultDelivery{
+			Mode:        "POC_PUBLIC_MULTIPART_UPLOAD",
+			UploadId:    "upload-10g-overflow",
+			BaseUrl:     "https://dd.datad0g.com/api/unstable/its-agent-intake",
+			Token:       "scoped-upload-token",
+			PartBytes:   64 << 20,
+			MaxBytes:    tenGiBPlusOne,
+			Format:      "csv",
+			Compression: "none",
+		},
+	})
+	require.Error(t, err)
+	assert.EqualError(t, err, "result_delivery.maxBytes must not exceed 10737418240")
+}

--- a/comp/api/grpcserver/impl-agent/remote_query_execute_test.go
+++ b/comp/api/grpcserver/impl-agent/remote_query_execute_test.go
@@ -163,16 +163,16 @@ func TestRemoteQueryExecuteRequestFromProtoPreservesResultDelivery(t *testing.T)
 		Target:         &pb.RemoteQueryTarget{Host: "localhost", Port: 5432, Dbname: "postgres"},
 		Query:          "SELECT city, country FROM cities ORDER BY city",
 		CopyLimits:     &pb.RemoteQueryExecuteCopyLimits{ChunkBytes: 8, MaxBytes: 24, MaxRowBytes: 32, TimeoutMs: 1000},
-		ResultDelivery: &pb.RemoteQueryResultDelivery{Mode: "POC_PUBLIC_CHUNKED_UPLOAD", UploadId: "upload-01k", BaseUrl: "https://dd.datad0g.com/api/intake/its-agent-intake", Token: "scoped-upload-token", ChunkBytes: 8, MaxBytes: 24, Format: "csv", Compression: "none"},
+		ResultDelivery: &pb.RemoteQueryResultDelivery{Mode: "POC_PUBLIC_MULTIPART_UPLOAD", UploadId: "upload-01k", BaseUrl: "https://dd.datad0g.com/api/intake/its-agent-intake", Token: "scoped-upload-token", PartBytes: 8, MaxBytes: 24, Format: "csv", Compression: "none"},
 	})
 
 	require.NoError(t, err)
 	require.NotNil(t, req.ResultDelivery)
-	assert.Equal(t, "POC_PUBLIC_CHUNKED_UPLOAD", req.ResultDelivery.Mode)
+	assert.Equal(t, "POC_PUBLIC_MULTIPART_UPLOAD", req.ResultDelivery.Mode)
 	assert.Equal(t, "upload-01k", req.ResultDelivery.UploadID)
 	assert.Equal(t, "https://dd.datad0g.com/api/intake/its-agent-intake", req.ResultDelivery.BaseURL)
 	assert.Equal(t, "scoped-upload-token", req.ResultDelivery.Token)
-	assert.Equal(t, 8, req.ResultDelivery.ChunkBytes)
+	assert.Equal(t, 8, req.ResultDelivery.PartBytes)
 	assert.Equal(t, 24, req.ResultDelivery.MaxBytes)
 }
 
@@ -184,7 +184,7 @@ func TestRemoteQueryExecuteRequestFromProtoPreservesResultDeliveryBaseURL(t *tes
 		Target:         &pb.RemoteQueryTarget{Host: "localhost", Port: 5432, Dbname: "postgres"},
 		Query:          "SELECT city, country FROM cities ORDER BY city",
 		CopyLimits:     &pb.RemoteQueryExecuteCopyLimits{ChunkBytes: 8, MaxBytes: 24, MaxRowBytes: 32, TimeoutMs: 1000},
-		ResultDelivery: &pb.RemoteQueryResultDelivery{Mode: "POC_PUBLIC_CHUNKED_UPLOAD", UploadId: "upload-01k", BaseUrl: "https://dd.datad0g.com/api/unstable/its-agent-intake", Token: "scoped-upload-token", ChunkBytes: 8, MaxBytes: 24, Format: "csv", Compression: "none"},
+		ResultDelivery: &pb.RemoteQueryResultDelivery{Mode: "POC_PUBLIC_MULTIPART_UPLOAD", UploadId: "upload-01k", BaseUrl: "https://dd.datad0g.com/api/unstable/its-agent-intake", Token: "scoped-upload-token", PartBytes: 8, MaxBytes: 24, Format: "csv", Compression: "none"},
 	})
 
 	require.NoError(t, err)
@@ -199,19 +199,19 @@ func TestRemoteQueryExecuteRequestFromProtoPreservesResultDeliveryBaseURL(t *tes
 func TestRemoteQueryStreamEventFromCheckEventSurfacesUploadReceipt(t *testing.T) {
 	event, err := remoteQueryStreamEventFromCheckEvent(check.RemoteQueryStreamEvent{
 		Type:         "final",
-		MetadataJSON: `{"status":"SUCCEEDED","bytes_emitted":18,"chunks_emitted":3,"upload_receipt":{"mode":"POC_PUBLIC_CHUNKED_UPLOAD","uploadId":"upload-01k","bucketName":"rq-bucket","manifestPath":"manifests/upload-01k.json","totalBytes":18,"totalRows":2,"chunkCount":3,"sha256":"abc123"}}`,
+		MetadataJSON: `{"status":"SUCCEEDED","bytes_emitted":18,"chunks_emitted":3,"upload_receipt":{"mode":"POC_PUBLIC_MULTIPART_UPLOAD","uploadId":"upload-01k","bucketName":"rq-bucket","objectPath":"manifests/upload-01k.json","totalBytes":18,"totalRows":2,"partCount":3,"sha256":"abc123"}}`,
 	})
 
 	require.NoError(t, err)
 	require.NotNil(t, event.GetFinal())
 	receipt := event.GetFinal().GetUploadReceipt()
 	require.NotNil(t, receipt)
-	assert.Equal(t, "POC_PUBLIC_CHUNKED_UPLOAD", receipt.GetMode())
+	assert.Equal(t, "POC_PUBLIC_MULTIPART_UPLOAD", receipt.GetMode())
 	assert.Equal(t, "upload-01k", receipt.GetUploadId())
 	assert.Equal(t, "rq-bucket", receipt.GetBucketName())
-	assert.Equal(t, "manifests/upload-01k.json", receipt.GetManifestPath())
+	assert.Equal(t, "manifests/upload-01k.json", receipt.GetObjectPath())
 	assert.Equal(t, int64(18), receipt.GetTotalBytes())
 	assert.Equal(t, int64(2), receipt.GetTotalRows())
-	assert.Equal(t, int32(3), receipt.GetChunkCount())
+	assert.Equal(t, int32(3), receipt.GetPartCount())
 	assert.Equal(t, "abc123", receipt.GetSha256())
 }

--- a/comp/api/grpcserver/impl-agent/server.go
+++ b/comp/api/grpcserver/impl-agent/server.go
@@ -613,7 +613,7 @@ func remoteQueryResultDeliveryFromProto(delivery *pb.RemoteQueryResultDelivery) 
 		UploadID:    delivery.GetUploadId(),
 		BaseURL:     delivery.GetBaseUrl(),
 		Token:       delivery.GetToken(),
-		ChunkBytes:  int(delivery.GetChunkBytes()),
+		PartBytes:   int(delivery.GetPartBytes()),
 		MaxBytes:    int(delivery.GetMaxBytes()),
 		Format:      delivery.GetFormat(),
 		Compression: delivery.GetCompression(),
@@ -760,14 +760,14 @@ func uploadReceiptFromMetadata(metadata map[string]interface{}) *pb.RemoteQueryU
 		return nil
 	}
 	return &pb.RemoteQueryUploadReceipt{
-		Mode:         stringFromMetadata(raw, "mode"),
-		UploadId:     stringFromMetadata(raw, "uploadId"),
-		BucketName:   stringFromMetadata(raw, "bucketName"),
-		ManifestPath: stringFromMetadata(raw, "manifestPath"),
-		TotalBytes:   int64FromMetadata(raw, "totalBytes"),
-		TotalRows:    int64FromMetadata(raw, "totalRows"),
-		ChunkCount:   int32FromMetadata(raw, "chunkCount"),
-		Sha256:       stringFromMetadata(raw, "sha256"),
+		Mode:       stringFromMetadata(raw, "mode"),
+		UploadId:   stringFromMetadata(raw, "uploadId"),
+		BucketName: stringFromMetadata(raw, "bucketName"),
+		ObjectPath: stringFromMetadata(raw, "objectPath"),
+		TotalBytes: int64FromMetadata(raw, "totalBytes"),
+		TotalRows:  int64FromMetadata(raw, "totalRows"),
+		PartCount:  int32FromMetadata(raw, "partCount"),
+		Sha256:     stringFromMetadata(raw, "sha256"),
 	}
 }
 

--- a/comp/remotequeries/impl/BUILD.bazel
+++ b/comp/remotequeries/impl/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
 dd_agent_go_test(
     name = "impl_test",
     srcs = [
+        "remote_query_forwarding_synthetic_test.go",
         "remote_query_test.go",
     ],
     embed = [":impl"],

--- a/comp/remotequeries/impl/remote_query_execute.go
+++ b/comp/remotequeries/impl/remote_query_execute.go
@@ -147,14 +147,14 @@ type RemoteQueryExecuteCopyLimits struct {
 }
 
 // RemoteQueryResultDeliveryMode is the only currently supported result-delivery mode.
-const RemoteQueryResultDeliveryModeChunkedUpload = "POC_PUBLIC_CHUNKED_UPLOAD"
+const RemoteQueryResultDeliveryModeMultipartUpload = "POC_PUBLIC_MULTIPART_UPLOAD"
 
 // Caps for result-delivery upload instructions. The Agent forwards these to the integration,
 // which performs the HTTP upload; the Agent does no transport or URL allowlisting.
 const (
 	remoteQueryUploadDefaultFormat      = "csv"
 	remoteQueryUploadDefaultCompression = "none"
-	remoteQueryUploadMaxChunkBytes      = 64 << 20 // 64 MiB
+	remoteQueryUploadMaxPartBytes       = 64 << 20 // 64 MiB
 	remoteQueryUploadMaxTotalBytes      = 1 << 30  // 1 GiB
 )
 
@@ -168,7 +168,7 @@ func validateRemoteQueryResultDelivery(delivery *RemoteQueryResultDelivery, copy
 	if delivery == nil {
 		return nil, nil
 	}
-	if delivery.Mode != RemoteQueryResultDeliveryModeChunkedUpload {
+	if delivery.Mode != RemoteQueryResultDeliveryModeMultipartUpload {
 		return nil, fmt.Errorf("result_delivery.mode %q is not supported", delivery.Mode)
 	}
 	out := *delivery
@@ -199,11 +199,11 @@ func validateRemoteQueryResultDelivery(delivery *RemoteQueryResultDelivery, copy
 	if out.Token == "" {
 		return nil, errors.New("result_delivery.token is required")
 	}
-	if out.ChunkBytes < 1 {
-		return nil, errors.New("result_delivery.chunkBytes must be at least 1")
+	if out.PartBytes < 1 {
+		return nil, errors.New("result_delivery.partBytes must be at least 1")
 	}
-	if out.ChunkBytes > remoteQueryUploadMaxChunkBytes {
-		return nil, fmt.Errorf("result_delivery.chunkBytes must not exceed %d", remoteQueryUploadMaxChunkBytes)
+	if out.PartBytes > remoteQueryUploadMaxPartBytes {
+		return nil, fmt.Errorf("result_delivery.partBytes must not exceed %d", remoteQueryUploadMaxPartBytes)
 	}
 	if out.MaxBytes < 1 {
 		return nil, errors.New("result_delivery.maxBytes must be at least 1")
@@ -211,12 +211,12 @@ func validateRemoteQueryResultDelivery(delivery *RemoteQueryResultDelivery, copy
 	if out.MaxBytes > remoteQueryUploadMaxTotalBytes {
 		return nil, fmt.Errorf("result_delivery.maxBytes must not exceed %d", remoteQueryUploadMaxTotalBytes)
 	}
-	if out.ChunkBytes > out.MaxBytes {
-		return nil, errors.New("result_delivery.chunkBytes must not exceed maxBytes")
+	if out.PartBytes > out.MaxBytes {
+		return nil, errors.New("result_delivery.partBytes must not exceed maxBytes")
 	}
 	if copyLimits != nil {
-		if out.ChunkBytes > copyLimits.ChunkBytes {
-			return nil, errors.New("result_delivery.chunkBytes must not exceed copyLimits.chunkBytes")
+		if out.PartBytes > copyLimits.ChunkBytes {
+			return nil, errors.New("result_delivery.partBytes must not exceed copyLimits.chunkBytes")
 		}
 		if out.MaxBytes > copyLimits.MaxBytes {
 			return nil, errors.New("result_delivery.maxBytes must not exceed copyLimits.maxBytes")
@@ -233,7 +233,7 @@ type RemoteQueryResultDelivery struct {
 	UploadID    string
 	BaseURL     string
 	Token       string
-	ChunkBytes  int
+	PartBytes   int
 	MaxBytes    int
 	Format      string
 	Compression string
@@ -335,7 +335,7 @@ type remoteQueryResultDelivery struct {
 	UploadID    string
 	BaseURL     string
 	Token       string
-	ChunkBytes  int
+	PartBytes   int
 	MaxBytes    int
 	Format      string
 	Compression string
@@ -412,7 +412,7 @@ type remoteQueryResultDeliveryJSON struct {
 	UploadID    string `json:"uploadId"`
 	BaseURL     string `json:"baseUrl"`
 	Token       string `json:"token"`
-	ChunkBytes  int    `json:"chunkBytes"`
+	PartBytes   int    `json:"partBytes"`
 	MaxBytes    int    `json:"maxBytes"`
 	Format      string `json:"format"`
 	Compression string `json:"compression"`
@@ -691,7 +691,7 @@ func (r RemoteQueryExecuteRequest) internal() remoteQueryExecuteRequest {
 			UploadID:    r.ResultDelivery.UploadID,
 			BaseURL:     r.ResultDelivery.BaseURL,
 			Token:       r.ResultDelivery.Token,
-			ChunkBytes:  r.ResultDelivery.ChunkBytes,
+			PartBytes:   r.ResultDelivery.PartBytes,
 			MaxBytes:    r.ResultDelivery.MaxBytes,
 			Format:      r.ResultDelivery.Format,
 			Compression: r.ResultDelivery.Compression,
@@ -720,7 +720,7 @@ func remoteQueryExecuteRequestFromInternal(req remoteQueryExecuteRequest) Remote
 			UploadID:    req.ResultDelivery.UploadID,
 			BaseURL:     req.ResultDelivery.BaseURL,
 			Token:       req.ResultDelivery.Token,
-			ChunkBytes:  req.ResultDelivery.ChunkBytes,
+			PartBytes:   req.ResultDelivery.PartBytes,
 			MaxBytes:    req.ResultDelivery.MaxBytes,
 			Format:      req.ResultDelivery.Format,
 			Compression: req.ResultDelivery.Compression,
@@ -757,7 +757,7 @@ func marshalExecuteRequest(req remoteQueryExecuteRequest) (string, error) {
 			UploadID:    req.ResultDelivery.UploadID,
 			BaseURL:     req.ResultDelivery.BaseURL,
 			Token:       req.ResultDelivery.Token,
-			ChunkBytes:  req.ResultDelivery.ChunkBytes,
+			PartBytes:   req.ResultDelivery.PartBytes,
 			MaxBytes:    req.ResultDelivery.MaxBytes,
 			Format:      req.ResultDelivery.Format,
 			Compression: req.ResultDelivery.Compression,

--- a/comp/remotequeries/impl/remote_query_execute.go
+++ b/comp/remotequeries/impl/remote_query_execute.go
@@ -150,12 +150,14 @@ type RemoteQueryExecuteCopyLimits struct {
 const RemoteQueryResultDeliveryModeMultipartUpload = "POC_PUBLIC_MULTIPART_UPLOAD"
 
 // Caps for result-delivery upload instructions. The Agent forwards these to the integration,
-// which performs the HTTP upload; the Agent does no transport or URL allowlisting.
+// which performs the HTTP upload; the Agent does no transport or URL allowlisting. The part
+// hard cap leaves room to evaluate 100 MiB parts later without another schema change; the
+// total cap matches the backend-owned 10 GiB result ceiling.
 const (
 	remoteQueryUploadDefaultFormat      = "csv"
 	remoteQueryUploadDefaultCompression = "none"
-	remoteQueryUploadMaxPartBytes       = 64 << 20 // 64 MiB
-	remoteQueryUploadMaxTotalBytes      = 1 << 30  // 1 GiB
+	remoteQueryUploadMaxPartBytes       = 128 << 20 // 128 MiB hard part cap
+	remoteQueryUploadMaxTotalBytes      = 10 << 30  // 10 GiB hard total cap
 )
 
 var remoteQueryUploadIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
@@ -215,9 +217,9 @@ func validateRemoteQueryResultDelivery(delivery *RemoteQueryResultDelivery, copy
 		return nil, errors.New("result_delivery.partBytes must not exceed maxBytes")
 	}
 	if copyLimits != nil {
-		if out.PartBytes > copyLimits.ChunkBytes {
-			return nil, errors.New("result_delivery.partBytes must not exceed copyLimits.chunkBytes")
-		}
+		// COPY read chunks and multipart parts are independent: multiple bounded COPY reads
+		// aggregate into one multipart part, so partBytes may exceed copyLimits.chunkBytes.
+		// copyLimits.maxBytes remains the overall extraction safety ceiling.
 		if out.MaxBytes > copyLimits.MaxBytes {
 			return nil, errors.New("result_delivery.maxBytes must not exceed copyLimits.maxBytes")
 		}

--- a/comp/remotequeries/impl/remote_query_forwarding_synthetic_test.go
+++ b/comp/remotequeries/impl/remote_query_forwarding_synthetic_test.go
@@ -1,0 +1,187 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package remotequeriesimpl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+)
+
+// Synthetic producer proof for the M3 Agent role after the Go upload relay was removed.
+//
+// The Agent no longer owns an HTTP upload transport. In POC_PUBLIC_CHUNKED_UPLOAD mode it is a
+// control-plane forwarder only: it carries resultDelivery (including baseUrl and token) through
+// to the integration request JSON, exposes the org API key and POC application key to the
+// integration via datadog_agent.get_config, and passes the downstream emit callback straight
+// through without intercepting bulk data events. The integration uploads bounded COPY chunks
+// directly to its-agent-intake over HTTP; only metadata/final/error events come back through
+// the stream.
+//
+// These tests drive ExecuteStream with a fake stream runner that captures the requestJSON the
+// integration receives and replays deterministic events through emit. They prove:
+//
+//   1. The requestJSON forwarded to the integration carries resultDelivery.baseUrl and
+//      resultDelivery.token (the credentials the integration needs to upload directly).
+//   2. The requestJSON does NOT carry the org API key or POC application key: the integration
+//      reads those from Agent config via get_config, so they never appear on the request wire.
+//   3. The Agent passes emit straight through: the events the integration emits surface
+//      downstream byte-for-byte, including any data event payloads. The Agent does not buffer,
+//      re-upload, or suppress bulk bytes.
+//
+// The 243021 reference (task contract id) is carried as the deterministic upload session id so
+// the forwarded handle is stable end-to-end.
+
+const (
+	syntheticForwardUploadID = "upload-243021"
+	syntheticForwardBaseURL  = "https://dd.datad0g.com/api/unstable/its-agent-intake"
+	syntheticForwardToken    = "scoped-upload-token-243021"
+)
+
+func newSyntheticForwardRunner(events []check.RemoteQueryStreamEvent) *fakeStreamRunnerCheck {
+	return &fakeStreamRunnerCheck{
+		fakeRunnerCheck: fakeRunnerCheck{fakeCheck: fakeCheck{name: "postgres", loader: "python", provider: "file", instance: "host: localhost\nport: 5432\ndbname: postgres\npassword: secret-value\n"}},
+		events:          events,
+	}
+}
+
+func syntheticForwardDelivery() *RemoteQueryResultDelivery {
+	return &RemoteQueryResultDelivery{
+		Mode:        RemoteQueryResultDeliveryModeChunkedUpload,
+		UploadID:    syntheticForwardUploadID,
+		BaseURL:     syntheticForwardBaseURL,
+		Token:       syntheticForwardToken,
+		ChunkBytes:  1 << 20,  // 1 MiB
+		MaxBytes:    32 << 20, // 32 MiB
+		Format:      "csv",
+		Compression: "none",
+	}
+}
+
+// TestExecuteStreamForwardsResultDeliveryCredentialsToIntegration proves the Agent forwards
+// baseUrl and token to the integration and keeps the API/application key off the request wire.
+func TestExecuteStreamForwardsResultDeliveryCredentialsToIntegration(t *testing.T) {
+	runner := newSyntheticForwardRunner([]check.RemoteQueryStreamEvent{
+		{Type: "metadata", MetadataJSON: `{"status":"STARTED"}`},
+		{Type: "final", MetadataJSON: `{"status":"SUCCEEDED","upload_receipt":{"mode":"POC_PUBLIC_CHUNKED_UPLOAD","uploadId":"upload-243021","bucketName":"rq-bucket","manifestPath":"its-agent-intake/poc/upload-243021/manifest.json","totalBytes":33554432,"totalRows":0,"chunkCount":32,"sha256":"aggregate-sha"}}`},
+	})
+	service := NewRemoteQueryExecuteService(fakeCollector{checks: []check.Check{fakeWrappedCheck{Check: runner}}}, true, true, nil)
+	req, err := NewRemoteQueryCopyStreamExecuteRequest(
+		"postgres",
+		RemoteQueryExecuteTarget{Host: "LOCALHOST.", Port: 5432, DBName: "postgres"},
+		"SELECT repeat('x', 33554432) AS payload",
+		"csv",
+		&RemoteQueryExecuteCopyLimits{ChunkBytes: 1 << 20, MaxBytes: 32 << 20, MaxRowBytes: 32 << 20, TimeoutMs: 30000},
+		syntheticForwardDelivery(),
+	)
+	require.NoError(t, err)
+
+	var seen []check.RemoteQueryStreamEvent
+	result := service.ExecuteStream(context.Background(), req, func(event check.RemoteQueryStreamEvent) error {
+		seen = append(seen, event)
+		return nil
+	})
+
+	require.Nil(t, result.Error)
+	assert.Equal(t, 1, runner.streamCalls)
+
+	// The integration receives the intake base URL and scoped upload token so it can upload
+	// directly. The org API key and POC application key are NOT on the request wire: the
+	// integration reads them from Agent config via datadog_agent.get_config.
+	assert.Contains(t, runner.streamSeen, `"baseUrl":"https://dd.datad0g.com/api/unstable/its-agent-intake"`)
+	assert.Contains(t, runner.streamSeen, `"token":"scoped-upload-token-243021"`)
+	assert.Contains(t, runner.streamSeen, `"uploadId":"upload-243021"`)
+	assert.NotContains(t, runner.streamSeen, "api_key")
+	assert.NotContains(t, runner.streamSeen, "application_key")
+	assert.NotContains(t, runner.streamSeen, "app_key")
+
+	// The integration's metadata and final receipt surface downstream unmodified.
+	require.Len(t, seen, 2)
+	assert.Equal(t, "metadata", seen[0].Type)
+	assert.Equal(t, "final", seen[1].Type)
+	assert.Contains(t, seen[1].MetadataJSON, `"uploadId":"upload-243021"`)
+	assert.Contains(t, seen[1].MetadataJSON, `"manifestPath":"its-agent-intake/poc/upload-243021/manifest.json"`)
+}
+
+// TestExecuteStreamPassesDataEventsStraightThrough proves the Agent does not intercept bulk
+// data events in upload mode: there is no relay, so a data event the integration emits arrives
+// downstream with its payload intact. (In production the integration uploads bulk bytes over
+// HTTP and emits only metadata/final/error; this test confirms the Agent gets out of the way
+// if the integration does emit a data event.)
+func TestExecuteStreamPassesDataEventsStraightThrough(t *testing.T) {
+	payload := make([]byte, 1<<20) // 1 MiB
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	runner := newSyntheticForwardRunner([]check.RemoteQueryStreamEvent{
+		{Type: "metadata", MetadataJSON: `{"status":"STARTED"}`},
+		{Type: "data", MetadataJSON: `{"sequence":0,"offset":0,"bytes":1048576}`, Payload: payload},
+		{Type: "final", MetadataJSON: `{"status":"SUCCEEDED","upload_receipt":{"uploadId":"upload-243021","chunkCount":1,"totalBytes":1048576}}`},
+	})
+	service := NewRemoteQueryExecuteService(fakeCollector{checks: []check.Check{fakeWrappedCheck{Check: runner}}}, true, true, nil)
+	req, err := NewRemoteQueryCopyStreamExecuteRequest(
+		"postgres",
+		RemoteQueryExecuteTarget{Host: "LOCALHOST.", Port: 5432, DBName: "postgres"},
+		"SELECT repeat('x', 1048576) AS payload",
+		"csv",
+		&RemoteQueryExecuteCopyLimits{ChunkBytes: 1 << 20, MaxBytes: 32 << 20, MaxRowBytes: 32 << 20, TimeoutMs: 30000},
+		syntheticForwardDelivery(),
+	)
+	require.NoError(t, err)
+
+	var seen []check.RemoteQueryStreamEvent
+	result := service.ExecuteStream(context.Background(), req, func(event check.RemoteQueryStreamEvent) error {
+		seen = append(seen, event)
+		return nil
+	})
+
+	require.Nil(t, result.Error)
+
+	// The data event arrives downstream with its full payload intact: the Agent did not
+	// buffer, re-upload, or suppress it. There is no Go relay in the upload path.
+	require.Len(t, seen, 3)
+	assert.Equal(t, "data", seen[1].Type)
+	require.NotNil(t, seen[1].Payload)
+	assert.Equal(t, payload, seen[1].Payload)
+	assert.Equal(t, 1<<20, len(seen[1].Payload))
+}
+
+// TestExecuteStreamOmittedResultDeliveryLeavesInlinePathUnchanged proves that without
+// resultDelivery the Agent behaves exactly as the inline streaming path: no upload handle is
+// forwarded and data events pass straight through.
+func TestExecuteStreamOmittedResultDeliveryLeavesInlinePathUnchanged(t *testing.T) {
+	runner := newSyntheticForwardRunner([]check.RemoteQueryStreamEvent{
+		{Type: "metadata", MetadataJSON: `{"status":"STARTED"}`},
+		{Type: "data", MetadataJSON: `{"sequence":0,"offset":0,"bytes":3}`, Payload: []byte{0x00, 0xff, 0x80}},
+		{Type: "final", MetadataJSON: `{"status":"SUCCEEDED"}`},
+	})
+	service := NewRemoteQueryExecuteService(fakeCollector{checks: []check.Check{fakeWrappedCheck{Check: runner}}}, true, true, nil)
+	req, err := NewRemoteQueryCopyStreamExecuteRequest(
+		"postgres",
+		RemoteQueryExecuteTarget{Host: "LOCALHOST.", Port: 5432, DBName: "postgres"},
+		"SELECT 1 AS value",
+		"csv",
+		&RemoteQueryExecuteCopyLimits{ChunkBytes: 4, MaxBytes: 1024, MaxRowBytes: 1024, TimeoutMs: 1000},
+		nil,
+	)
+	require.NoError(t, err)
+
+	var seen []check.RemoteQueryStreamEvent
+	result := service.ExecuteStream(context.Background(), req, func(event check.RemoteQueryStreamEvent) error {
+		seen = append(seen, event)
+		return nil
+	})
+
+	require.Nil(t, result.Error)
+	assert.Equal(t, runner.events, seen)
+	assert.NotContains(t, runner.streamSeen, "resultDelivery")
+	assert.NotContains(t, runner.streamSeen, "baseUrl")
+	assert.NotContains(t, runner.streamSeen, "token")
+}

--- a/comp/remotequeries/impl/remote_query_forwarding_synthetic_test.go
+++ b/comp/remotequeries/impl/remote_query_forwarding_synthetic_test.go
@@ -17,11 +17,11 @@ import (
 
 // Synthetic producer proof for the M3 Agent role after the Go upload relay was removed.
 //
-// The Agent no longer owns an HTTP upload transport. In POC_PUBLIC_CHUNKED_UPLOAD mode it is a
+// The Agent no longer owns an HTTP upload transport. In POC_PUBLIC_MULTIPART_UPLOAD mode it is a
 // control-plane forwarder only: it carries resultDelivery (including baseUrl and token) through
 // to the integration request JSON, exposes the org API key and POC application key to the
 // integration via datadog_agent.get_config, and passes the downstream emit callback straight
-// through without intercepting bulk data events. The integration uploads bounded COPY chunks
+// through without intercepting bulk data events. The integration uploads bounded multipart parts
 // directly to its-agent-intake over HTTP; only metadata/final/error events come back through
 // the stream.
 //
@@ -54,11 +54,11 @@ func newSyntheticForwardRunner(events []check.RemoteQueryStreamEvent) *fakeStrea
 
 func syntheticForwardDelivery() *RemoteQueryResultDelivery {
 	return &RemoteQueryResultDelivery{
-		Mode:        RemoteQueryResultDeliveryModeChunkedUpload,
+		Mode:        RemoteQueryResultDeliveryModeMultipartUpload,
 		UploadID:    syntheticForwardUploadID,
 		BaseURL:     syntheticForwardBaseURL,
 		Token:       syntheticForwardToken,
-		ChunkBytes:  1 << 20,  // 1 MiB
+		PartBytes:   1 << 20,  // 1 MiB
 		MaxBytes:    32 << 20, // 32 MiB
 		Format:      "csv",
 		Compression: "none",
@@ -70,7 +70,7 @@ func syntheticForwardDelivery() *RemoteQueryResultDelivery {
 func TestExecuteStreamForwardsResultDeliveryCredentialsToIntegration(t *testing.T) {
 	runner := newSyntheticForwardRunner([]check.RemoteQueryStreamEvent{
 		{Type: "metadata", MetadataJSON: `{"status":"STARTED"}`},
-		{Type: "final", MetadataJSON: `{"status":"SUCCEEDED","upload_receipt":{"mode":"POC_PUBLIC_CHUNKED_UPLOAD","uploadId":"upload-243021","bucketName":"rq-bucket","manifestPath":"its-agent-intake/poc/upload-243021/manifest.json","totalBytes":33554432,"totalRows":0,"chunkCount":32,"sha256":"aggregate-sha"}}`},
+		{Type: "final", MetadataJSON: `{"status":"SUCCEEDED","upload_receipt":{"mode":"POC_PUBLIC_MULTIPART_UPLOAD","uploadId":"upload-243021","bucketName":"rq-bucket","objectPath":"its-agent-intake/poc/upload-243021/result.csv","totalBytes":33554432,"totalRows":0,"partCount":32,"sha256":"aggregate-sha"}}`},
 	})
 	service := NewRemoteQueryExecuteService(fakeCollector{checks: []check.Check{fakeWrappedCheck{Check: runner}}}, true, true, nil)
 	req, err := NewRemoteQueryCopyStreamExecuteRequest(
@@ -107,7 +107,7 @@ func TestExecuteStreamForwardsResultDeliveryCredentialsToIntegration(t *testing.
 	assert.Equal(t, "metadata", seen[0].Type)
 	assert.Equal(t, "final", seen[1].Type)
 	assert.Contains(t, seen[1].MetadataJSON, `"uploadId":"upload-243021"`)
-	assert.Contains(t, seen[1].MetadataJSON, `"manifestPath":"its-agent-intake/poc/upload-243021/manifest.json"`)
+	assert.Contains(t, seen[1].MetadataJSON, `"objectPath":"its-agent-intake/poc/upload-243021/result.csv"`)
 }
 
 // TestExecuteStreamPassesDataEventsStraightThrough proves the Agent does not intercept bulk
@@ -123,7 +123,7 @@ func TestExecuteStreamPassesDataEventsStraightThrough(t *testing.T) {
 	runner := newSyntheticForwardRunner([]check.RemoteQueryStreamEvent{
 		{Type: "metadata", MetadataJSON: `{"status":"STARTED"}`},
 		{Type: "data", MetadataJSON: `{"sequence":0,"offset":0,"bytes":1048576}`, Payload: payload},
-		{Type: "final", MetadataJSON: `{"status":"SUCCEEDED","upload_receipt":{"uploadId":"upload-243021","chunkCount":1,"totalBytes":1048576}}`},
+		{Type: "final", MetadataJSON: `{"status":"SUCCEEDED","upload_receipt":{"uploadId":"upload-243021","partCount":1,"totalBytes":1048576}}`},
 	})
 	service := NewRemoteQueryExecuteService(fakeCollector{checks: []check.Check{fakeWrappedCheck{Check: runner}}}, true, true, nil)
 	req, err := NewRemoteQueryCopyStreamExecuteRequest(

--- a/comp/remotequeries/impl/remote_query_test.go
+++ b/comp/remotequeries/impl/remote_query_test.go
@@ -7,6 +7,7 @@ package remotequeriesimpl
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -848,4 +849,100 @@ func (f *fakeStreamRunnerCheck) RunRemoteQueryStream(integration string, request
 		}
 	}
 	return nil
+}
+
+const (
+	remoteQueryMultipartPartCap  = 128 << 20 // 128 MiB hard part cap
+	remoteQueryMultipartTotalCap = 10 << 30  // 10 GiB hard total cap
+)
+
+// multipartDeliveryForCapTest builds a valid multipart result-delivery handle with the given
+// part/total sizes so cap and copyLimits-interaction tests only vary the fields under test.
+func multipartDeliveryForCapTest(partBytes, maxBytes int) *RemoteQueryResultDelivery {
+	return &RemoteQueryResultDelivery{
+		Mode:        RemoteQueryResultDeliveryModeMultipartUpload,
+		UploadID:    "upload-cap-test",
+		BaseURL:     "https://dd.datad0g.com/api/unstable/its-agent-intake",
+		Token:       "scoped-upload-token",
+		PartBytes:   partBytes,
+		MaxBytes:    maxBytes,
+		Format:      "csv",
+		Compression: "none",
+	}
+}
+
+func TestRemoteQueryResultDeliveryMultipartCaps(t *testing.T) {
+	target := RemoteQueryExecuteTarget{Host: "localhost", Port: 5432, DBName: "postgres"}
+
+	t.Run("128 MiB part cap accepted", func(t *testing.T) {
+		_, err := NewRemoteQueryCopyStreamExecuteRequest("postgres", target, remoteQueryFixtureTableProofQuery, "csv",
+			&RemoteQueryExecuteCopyLimits{ChunkBytes: 1 << 20, MaxBytes: remoteQueryMultipartTotalCap, MaxRowBytes: 1 << 20, TimeoutMs: 1000},
+			multipartDeliveryForCapTest(remoteQueryMultipartPartCap, remoteQueryMultipartTotalCap))
+		require.NoError(t, err)
+	})
+
+	t.Run("128 MiB plus one part rejected", func(t *testing.T) {
+		_, err := NewRemoteQueryCopyStreamExecuteRequest("postgres", target, remoteQueryFixtureTableProofQuery, "csv",
+			&RemoteQueryExecuteCopyLimits{ChunkBytes: 1 << 20, MaxBytes: remoteQueryMultipartTotalCap, MaxRowBytes: 1 << 20, TimeoutMs: 1000},
+			multipartDeliveryForCapTest(remoteQueryMultipartPartCap+1, remoteQueryMultipartTotalCap))
+		require.Error(t, err)
+		assert.EqualError(t, err, fmt.Sprintf("result_delivery.partBytes must not exceed %d", remoteQueryMultipartPartCap))
+	})
+
+	t.Run("10 GiB total cap accepted without copyLimits", func(t *testing.T) {
+		_, err := NewRemoteQueryCopyStreamExecuteRequest("postgres", target, remoteQueryFixtureTableProofQuery, "csv", nil,
+			multipartDeliveryForCapTest(remoteQueryMultipartPartCap, remoteQueryMultipartTotalCap))
+		require.NoError(t, err)
+	})
+
+	t.Run("10 GiB plus one total rejected", func(t *testing.T) {
+		_, err := NewRemoteQueryCopyStreamExecuteRequest("postgres", target, remoteQueryFixtureTableProofQuery, "csv", nil,
+			multipartDeliveryForCapTest(remoteQueryMultipartPartCap, remoteQueryMultipartTotalCap+1))
+		require.Error(t, err)
+		assert.EqualError(t, err, fmt.Sprintf("result_delivery.maxBytes must not exceed %d", remoteQueryMultipartTotalCap))
+	})
+
+	t.Run("partBytes may exceed copyLimits chunkBytes", func(t *testing.T) {
+		// COPY reads and multipart parts are independent: multiple 1 MiB COPY reads aggregate
+		// into one 64 MiB multipart part, so partBytes > copyLimits.chunkBytes is valid.
+		_, err := NewRemoteQueryCopyStreamExecuteRequest("postgres", target, remoteQueryFixtureTableProofQuery, "csv",
+			&RemoteQueryExecuteCopyLimits{ChunkBytes: 1 << 20, MaxBytes: remoteQueryMultipartTotalCap, MaxRowBytes: 1 << 20, TimeoutMs: 1000},
+			multipartDeliveryForCapTest(64<<20, remoteQueryMultipartTotalCap))
+		require.NoError(t, err)
+	})
+
+	t.Run("10 GiB upload accepted when extraction cap is 10 GiB", func(t *testing.T) {
+		_, err := NewRemoteQueryCopyStreamExecuteRequest("postgres", target, remoteQueryFixtureTableProofQuery, "csv",
+			&RemoteQueryExecuteCopyLimits{ChunkBytes: 1 << 20, MaxBytes: remoteQueryMultipartTotalCap, MaxRowBytes: 1 << 20, TimeoutMs: 1000},
+			multipartDeliveryForCapTest(remoteQueryMultipartPartCap, remoteQueryMultipartTotalCap))
+		require.NoError(t, err)
+	})
+
+	t.Run("upload limit exceeding extraction cap rejected", func(t *testing.T) {
+		_, err := NewRemoteQueryCopyStreamExecuteRequest("postgres", target, remoteQueryFixtureTableProofQuery, "csv",
+			&RemoteQueryExecuteCopyLimits{ChunkBytes: 1 << 20, MaxBytes: 5 << 30, MaxRowBytes: 1 << 20, TimeoutMs: 1000},
+			multipartDeliveryForCapTest(remoteQueryMultipartPartCap, 10<<30))
+		require.Error(t, err)
+		assert.EqualError(t, err, "result_delivery.maxBytes must not exceed copyLimits.maxBytes")
+	})
+}
+
+// TestRemoteQueryResultDelivery10GiBJSONFidelity proves the 10 GiB result cap survives the
+// Agent -> integration request JSON boundary as an exact JSON number. The Go int fields marshal
+// 10 GiB without truncation, so the integration receives the backend-owned cap verbatim.
+func TestRemoteQueryResultDelivery10GiBJSONFidelity(t *testing.T) {
+	const tenGiB = 10 << 30
+	req, err := NewRemoteQueryCopyStreamExecuteRequest("postgres",
+		RemoteQueryExecuteTarget{Host: "localhost", Port: 5432, DBName: "postgres"},
+		remoteQueryFixtureTableProofQuery, "csv",
+		&RemoteQueryExecuteCopyLimits{ChunkBytes: 1 << 20, MaxBytes: tenGiB, MaxRowBytes: 1 << 20, TimeoutMs: 1000},
+		multipartDeliveryForCapTest(64<<20, tenGiB))
+	require.NoError(t, err)
+
+	requestJSON, err := marshalExecuteRequest(req.internal())
+	require.NoError(t, err)
+	assert.Contains(t, requestJSON, `"partBytes":67108864`)
+	assert.Contains(t, requestJSON, `"maxBytes":10737418240`)
+	assert.NotContains(t, requestJSON, "api_key")
+	assert.NotContains(t, requestJSON, "application_key")
 }

--- a/pkg/privateactionrunner/bundles/remoteaction/queries/execute.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/queries/execute.go
@@ -221,7 +221,7 @@ func remoteQueryExecuteRequestFromInputs(inputs ExecuteInputs) *pb.RemoteQueryEx
 	if inputs.CopyLimits != nil {
 		req.CopyLimits = &pb.RemoteQueryExecuteCopyLimits{
 			ChunkBytes:  int32(inputs.CopyLimits.ChunkBytes),
-			MaxBytes:    int32(inputs.CopyLimits.MaxBytes),
+			MaxBytes:    int64(inputs.CopyLimits.MaxBytes),
 			MaxRowBytes: int32(inputs.CopyLimits.MaxRowBytes),
 			TimeoutMs:   int32(inputs.CopyLimits.TimeoutMs),
 		}
@@ -233,7 +233,7 @@ func remoteQueryExecuteRequestFromInputs(inputs ExecuteInputs) *pb.RemoteQueryEx
 			BaseUrl:     inputs.ResultDelivery.BaseURL,
 			Token:       inputs.ResultDelivery.Token,
 			PartBytes:   int32(inputs.ResultDelivery.PartBytes),
-			MaxBytes:    int32(inputs.ResultDelivery.MaxBytes),
+			MaxBytes:    int64(inputs.ResultDelivery.MaxBytes),
 			Format:      inputs.ResultDelivery.Format,
 			Compression: inputs.ResultDelivery.Compression,
 		}

--- a/pkg/privateactionrunner/bundles/remoteaction/queries/execute.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/queries/execute.go
@@ -57,7 +57,7 @@ type ResultDeliveryInputs struct {
 	UploadID    string `json:"uploadId"`
 	BaseURL     string `json:"baseUrl"`
 	Token       string `json:"token"`
-	ChunkBytes  int    `json:"chunkBytes"`
+	PartBytes   int    `json:"partBytes"`
 	MaxBytes    int    `json:"maxBytes"`
 	Format      string `json:"format"`
 	Compression string `json:"compression"`
@@ -232,7 +232,7 @@ func remoteQueryExecuteRequestFromInputs(inputs ExecuteInputs) *pb.RemoteQueryEx
 			UploadId:    inputs.ResultDelivery.UploadID,
 			BaseUrl:     inputs.ResultDelivery.BaseURL,
 			Token:       inputs.ResultDelivery.Token,
-			ChunkBytes:  int32(inputs.ResultDelivery.ChunkBytes),
+			PartBytes:   int32(inputs.ResultDelivery.PartBytes),
 			MaxBytes:    int32(inputs.ResultDelivery.MaxBytes),
 			Format:      inputs.ResultDelivery.Format,
 			Compression: inputs.ResultDelivery.Compression,
@@ -379,14 +379,14 @@ func remoteQueryStreamEventFromProto(event *pb.RemoteQueryExecuteStreamEvent) (m
 		out["chunks_emitted"] = e.Final.GetChunksEmitted()
 		if receipt := e.Final.GetUploadReceipt(); receipt != nil {
 			out["upload_receipt"] = map[string]interface{}{
-				"mode":         receipt.GetMode(),
-				"uploadId":     receipt.GetUploadId(),
-				"bucketName":   receipt.GetBucketName(),
-				"manifestPath": receipt.GetManifestPath(),
-				"totalBytes":   receipt.GetTotalBytes(),
-				"totalRows":    receipt.GetTotalRows(),
-				"chunkCount":   receipt.GetChunkCount(),
-				"sha256":       receipt.GetSha256(),
+				"mode":       receipt.GetMode(),
+				"uploadId":   receipt.GetUploadId(),
+				"bucketName": receipt.GetBucketName(),
+				"objectPath": receipt.GetObjectPath(),
+				"totalBytes": receipt.GetTotalBytes(),
+				"totalRows":  receipt.GetTotalRows(),
+				"partCount":  receipt.GetPartCount(),
+				"sha256":     receipt.GetSha256(),
 			}
 		}
 		if len(e.Final.GetAttributes()) > 0 {
@@ -481,14 +481,14 @@ func remoteQueryUploadOutput(finalEvent map[string]interface{}, receipt map[stri
 		// utf-8; compression is reported separately by the intake receipt, not here.
 		"encoding": "utf-8",
 		"uploadReceipt": map[string]interface{}{
-			"mode":         receipt["mode"],
-			"uploadId":     receipt["uploadId"],
-			"bucketName":   receipt["bucketName"],
-			"manifestPath": receipt["manifestPath"],
-			"totalBytes":   receipt["totalBytes"],
-			"totalRows":    receipt["totalRows"],
-			"chunkCount":   receipt["chunkCount"],
-			"sha256":       receipt["sha256"],
+			"mode":       receipt["mode"],
+			"uploadId":   receipt["uploadId"],
+			"bucketName": receipt["bucketName"],
+			"objectPath": receipt["objectPath"],
+			"totalBytes": receipt["totalBytes"],
+			"totalRows":  receipt["totalRows"],
+			"partCount":  receipt["partCount"],
+			"sha256":     receipt["sha256"],
 		},
 	}
 }

--- a/pkg/privateactionrunner/bundles/remoteaction/queries/execute_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/queries/execute_test.go
@@ -334,7 +334,7 @@ func (s *captureRemoteQueryExecuteStream) Recv() (*pb.RemoteQueryExecuteChunk, e
 func TestExecuteActionReturnsUploadReceiptWithoutBulkData(t *testing.T) {
 	client := &captureBridgeClient{chunks: []*pb.RemoteQueryExecuteChunk{
 		{Event: &pb.RemoteQueryExecuteStreamEvent{Sequence: 0, Event: &pb.RemoteQueryExecuteStreamEvent_Metadata{Metadata: &pb.RemoteQueryStreamMetadata{Operation: "copy_stream", Integration: "postgres", Format: "csv"}}}, ChunkIndex: 0},
-		{Event: &pb.RemoteQueryExecuteStreamEvent{Sequence: 1, Event: &pb.RemoteQueryExecuteStreamEvent_Final{Final: &pb.RemoteQueryStreamFinal{Status: "SUCCEEDED", BytesEmitted: 18, ChunksEmitted: 3, UploadReceipt: &pb.RemoteQueryUploadReceipt{Mode: "POC_PUBLIC_CHUNKED_UPLOAD", UploadId: "upload-01k", BucketName: "rq-bucket", ManifestPath: "manifests/upload-01k.json", TotalBytes: 18, TotalRows: 2, ChunkCount: 3, Sha256: "abc123"}}}}, ChunkIndex: 1},
+		{Event: &pb.RemoteQueryExecuteStreamEvent{Sequence: 1, Event: &pb.RemoteQueryExecuteStreamEvent_Final{Final: &pb.RemoteQueryStreamFinal{Status: "SUCCEEDED", BytesEmitted: 18, ChunksEmitted: 3, UploadReceipt: &pb.RemoteQueryUploadReceipt{Mode: "POC_PUBLIC_MULTIPART_UPLOAD", UploadId: "upload-01k", BucketName: "rq-bucket", ObjectPath: "manifests/upload-01k.json", TotalBytes: 18, TotalRows: 2, PartCount: 3, Sha256: "abc123"}}}}, ChunkIndex: 1},
 		{ChunkIndex: 2, Final: true},
 	}}
 	action := NewExecuteAction(func() (BridgeClient, error) { return client, nil })
@@ -347,7 +347,7 @@ func TestExecuteActionReturnsUploadReceiptWithoutBulkData(t *testing.T) {
 		"query":       "SELECT city, country FROM cities ORDER BY city",
 		"copyLimits":  map[string]interface{}{"chunkBytes": 8, "maxBytes": 24, "maxRowBytes": 32, "timeoutMs": 1000},
 		"resultDelivery": map[string]interface{}{
-			"mode": "POC_PUBLIC_CHUNKED_UPLOAD", "uploadId": "upload-01k", "baseUrl": "https://api.datadoghq.com", "token": "scoped-upload-token", "chunkBytes": 8, "maxBytes": 24, "format": "csv", "compression": "none",
+			"mode": "POC_PUBLIC_MULTIPART_UPLOAD", "uploadId": "upload-01k", "baseUrl": "https://api.datadoghq.com", "token": "scoped-upload-token", "partBytes": 8, "maxBytes": 24, "format": "csv", "compression": "none",
 		},
 	}), nil)
 
@@ -364,13 +364,13 @@ func TestExecuteActionReturnsUploadReceiptWithoutBulkData(t *testing.T) {
 	assert.Equal(t, int64(18), out["bytes"])
 	receipt, ok := out["uploadReceipt"].(map[string]interface{})
 	require.True(t, ok)
-	assert.Equal(t, "POC_PUBLIC_CHUNKED_UPLOAD", receipt["mode"])
+	assert.Equal(t, "POC_PUBLIC_MULTIPART_UPLOAD", receipt["mode"])
 	assert.Equal(t, "upload-01k", receipt["uploadId"])
 	assert.Equal(t, "rq-bucket", receipt["bucketName"])
-	assert.Equal(t, "manifests/upload-01k.json", receipt["manifestPath"])
+	assert.Equal(t, "manifests/upload-01k.json", receipt["objectPath"])
 	assert.Equal(t, int64(18), receipt["totalBytes"])
 	assert.Equal(t, int64(2), receipt["totalRows"])
-	assert.Equal(t, int32(3), receipt["chunkCount"])
+	assert.Equal(t, int32(3), receipt["partCount"])
 	assert.Equal(t, "abc123", receipt["sha256"])
 	assertNoPayloadDuplicateFields(t, out)
 	assert.NotContains(t, out, "data")

--- a/pkg/proto/datadog/api/v1/api.proto
+++ b/pkg/proto/datadog/api/v1/api.proto
@@ -37,7 +37,9 @@ message RemoteQueryExecuteLimits {
 
 message RemoteQueryExecuteCopyLimits {
     int32 chunk_bytes = 1;
-    int32 max_bytes = 2;
+    // max_bytes is the overall extraction safety ceiling. It is int64 so the
+    // backend-owned 10 GiB result cap is representable without overflow.
+    int64 max_bytes = 2;
     int32 max_row_bytes = 3;
     int32 timeout_ms = 4;
 }
@@ -69,7 +71,9 @@ message RemoteQueryResultDelivery {
     string base_url = 3;
     string token = 4;
     int32 part_bytes = 5;
-    int32 max_bytes = 6;
+    // max_bytes is the multipart upload total cap. It is int64 so the
+    // backend-owned 10 GiB result cap is representable without overflow.
+    int64 max_bytes = 6;
     string format = 7;
     string compression = 8;
 }

--- a/pkg/proto/datadog/api/v1/api.proto
+++ b/pkg/proto/datadog/api/v1/api.proto
@@ -52,10 +52,11 @@ message RemoteQueryExecuteRequest {
     RemoteQueryExecuteCopyLimits copy_limits = 7;
     // Optional result-delivery instructions. When omitted, the existing inline
     // streaming event path is unchanged. When present with mode
-    // POC_PUBLIC_CHUNKED_UPLOAD, the Agent Go side intercepts COPY stream data
-    // events and uploads bounded chunks directly to the Datadog intake service,
-    // suppressing bulk data from crossing the AgentSecure boundary; only the
-    // compact upload receipt is surfaced downstream.
+    // POC_PUBLIC_MULTIPART_UPLOAD, the Agent Go side forwards the upload handle
+    // to the integration check, which uploads bounded parts directly to the
+    // Datadog intake service, suppressing bulk data from crossing the
+    // AgentSecure boundary; only the compact upload receipt is surfaced
+    // downstream.
     RemoteQueryResultDelivery result_delivery = 8;
 }
 
@@ -67,7 +68,7 @@ message RemoteQueryResultDelivery {
     string upload_id = 2;
     string base_url = 3;
     string token = 4;
-    int32 chunk_bytes = 5;
+    int32 part_bytes = 5;
     int32 max_bytes = 6;
     string format = 7;
     string compression = 8;
@@ -105,21 +106,21 @@ message RemoteQueryStreamFinal {
     uint64 bytes_emitted = 2;
     uint64 chunks_emitted = 3;
     map<string, string> attributes = 4;
-    // upload_receipt is set only in POC_PUBLIC_CHUNKED_UPLOAD mode, after the
-    // Agent Go side finalizes the upload session. It carries the compact final
+    // upload_receipt is set only in POC_PUBLIC_MULTIPART_UPLOAD mode, after the
+    // integration finalizes the upload session. It carries the compact final
     // metadata that replaces the bulk data crossing the AgentSecure boundary.
     RemoteQueryUploadReceipt upload_receipt = 5;
 }
 
-// RemoteQueryUploadReceipt is the compact final metadata for a chunked upload.
+// RemoteQueryUploadReceipt is the compact final metadata for a multipart upload.
 message RemoteQueryUploadReceipt {
     string mode = 1;
     string upload_id = 2;
     string bucket_name = 3;
-    string manifest_path = 4;
+    string object_path = 4;
     int64 total_bytes = 5;
     int64 total_rows = 6;
-    int32 chunk_count = 7;
+    int32 part_count = 7;
     string sha256 = 8;
 }
 

--- a/pkg/proto/pbgo/core/api.pb.go
+++ b/pkg/proto/pbgo/core/api.pb.go
@@ -231,10 +231,11 @@ type RemoteQueryExecuteRequest struct {
 	CopyLimits  *RemoteQueryExecuteCopyLimits `protobuf:"bytes,7,opt,name=copy_limits,json=copyLimits,proto3" json:"copy_limits,omitempty"`
 	// Optional result-delivery instructions. When omitted, the existing inline
 	// streaming event path is unchanged. When present with mode
-	// POC_PUBLIC_CHUNKED_UPLOAD, the Agent Go side intercepts COPY stream data
-	// events and uploads bounded chunks directly to the Datadog intake service,
-	// suppressing bulk data from crossing the AgentSecure boundary; only the
-	// compact upload receipt is surfaced downstream.
+	// POC_PUBLIC_MULTIPART_UPLOAD, the Agent Go side forwards the upload handle
+	// to the integration check, which uploads bounded parts directly to the
+	// Datadog intake service, suppressing bulk data from crossing the
+	// AgentSecure boundary; only the compact upload receipt is surfaced
+	// downstream.
 	ResultDelivery *RemoteQueryResultDelivery `protobuf:"bytes,8,opt,name=result_delivery,json=resultDelivery,proto3" json:"result_delivery,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
@@ -335,7 +336,7 @@ type RemoteQueryResultDelivery struct {
 	UploadId      string                 `protobuf:"bytes,2,opt,name=upload_id,json=uploadId,proto3" json:"upload_id,omitempty"`
 	BaseUrl       string                 `protobuf:"bytes,3,opt,name=base_url,json=baseUrl,proto3" json:"base_url,omitempty"`
 	Token         string                 `protobuf:"bytes,4,opt,name=token,proto3" json:"token,omitempty"`
-	ChunkBytes    int32                  `protobuf:"varint,5,opt,name=chunk_bytes,json=chunkBytes,proto3" json:"chunk_bytes,omitempty"`
+	PartBytes     int32                  `protobuf:"varint,5,opt,name=part_bytes,json=partBytes,proto3" json:"part_bytes,omitempty"`
 	MaxBytes      int32                  `protobuf:"varint,6,opt,name=max_bytes,json=maxBytes,proto3" json:"max_bytes,omitempty"`
 	Format        string                 `protobuf:"bytes,7,opt,name=format,proto3" json:"format,omitempty"`
 	Compression   string                 `protobuf:"bytes,8,opt,name=compression,proto3" json:"compression,omitempty"`
@@ -401,9 +402,9 @@ func (x *RemoteQueryResultDelivery) GetToken() string {
 	return ""
 }
 
-func (x *RemoteQueryResultDelivery) GetChunkBytes() int32 {
+func (x *RemoteQueryResultDelivery) GetPartBytes() int32 {
 	if x != nil {
-		return x.ChunkBytes
+		return x.PartBytes
 	}
 	return 0
 }
@@ -699,8 +700,8 @@ type RemoteQueryStreamFinal struct {
 	BytesEmitted  uint64                 `protobuf:"varint,2,opt,name=bytes_emitted,json=bytesEmitted,proto3" json:"bytes_emitted,omitempty"`
 	ChunksEmitted uint64                 `protobuf:"varint,3,opt,name=chunks_emitted,json=chunksEmitted,proto3" json:"chunks_emitted,omitempty"`
 	Attributes    map[string]string      `protobuf:"bytes,4,rep,name=attributes,proto3" json:"attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	// upload_receipt is set only in POC_PUBLIC_CHUNKED_UPLOAD mode, after the
-	// Agent Go side finalizes the upload session. It carries the compact final
+	// upload_receipt is set only in POC_PUBLIC_MULTIPART_UPLOAD mode, after the
+	// integration finalizes the upload session. It carries the compact final
 	// metadata that replaces the bulk data crossing the AgentSecure boundary.
 	UploadReceipt *RemoteQueryUploadReceipt `protobuf:"bytes,5,opt,name=upload_receipt,json=uploadReceipt,proto3" json:"upload_receipt,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -772,16 +773,16 @@ func (x *RemoteQueryStreamFinal) GetUploadReceipt() *RemoteQueryUploadReceipt {
 	return nil
 }
 
-// RemoteQueryUploadReceipt is the compact final metadata for a chunked upload.
+// RemoteQueryUploadReceipt is the compact final metadata for a multipart upload.
 type RemoteQueryUploadReceipt struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Mode          string                 `protobuf:"bytes,1,opt,name=mode,proto3" json:"mode,omitempty"`
 	UploadId      string                 `protobuf:"bytes,2,opt,name=upload_id,json=uploadId,proto3" json:"upload_id,omitempty"`
 	BucketName    string                 `protobuf:"bytes,3,opt,name=bucket_name,json=bucketName,proto3" json:"bucket_name,omitempty"`
-	ManifestPath  string                 `protobuf:"bytes,4,opt,name=manifest_path,json=manifestPath,proto3" json:"manifest_path,omitempty"`
+	ObjectPath    string                 `protobuf:"bytes,4,opt,name=object_path,json=objectPath,proto3" json:"object_path,omitempty"`
 	TotalBytes    int64                  `protobuf:"varint,5,opt,name=total_bytes,json=totalBytes,proto3" json:"total_bytes,omitempty"`
 	TotalRows     int64                  `protobuf:"varint,6,opt,name=total_rows,json=totalRows,proto3" json:"total_rows,omitempty"`
-	ChunkCount    int32                  `protobuf:"varint,7,opt,name=chunk_count,json=chunkCount,proto3" json:"chunk_count,omitempty"`
+	PartCount     int32                  `protobuf:"varint,7,opt,name=part_count,json=partCount,proto3" json:"part_count,omitempty"`
 	Sha256        string                 `protobuf:"bytes,8,opt,name=sha256,proto3" json:"sha256,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -838,9 +839,9 @@ func (x *RemoteQueryUploadReceipt) GetBucketName() string {
 	return ""
 }
 
-func (x *RemoteQueryUploadReceipt) GetManifestPath() string {
+func (x *RemoteQueryUploadReceipt) GetObjectPath() string {
 	if x != nil {
-		return x.ManifestPath
+		return x.ObjectPath
 	}
 	return ""
 }
@@ -859,9 +860,9 @@ func (x *RemoteQueryUploadReceipt) GetTotalRows() int64 {
 	return 0
 }
 
-func (x *RemoteQueryUploadReceipt) GetChunkCount() int32 {
+func (x *RemoteQueryUploadReceipt) GetPartCount() int32 {
 	if x != nil {
-		return x.ChunkCount
+		return x.PartCount
 	}
 	return 0
 }
@@ -1269,14 +1270,14 @@ const file_datadog_api_v1_api_proto_rawDesc = "" +
 	"\x06format\x18\x06 \x01(\tR\x06format\x12M\n" +
 	"\vcopy_limits\x18\a \x01(\v2,.datadog.api.v1.RemoteQueryExecuteCopyLimitsR\n" +
 	"copyLimits\x12R\n" +
-	"\x0fresult_delivery\x18\b \x01(\v2).datadog.api.v1.RemoteQueryResultDeliveryR\x0eresultDelivery\"\xf5\x01\n" +
+	"\x0fresult_delivery\x18\b \x01(\v2).datadog.api.v1.RemoteQueryResultDeliveryR\x0eresultDelivery\"\xf3\x01\n" +
 	"\x19RemoteQueryResultDelivery\x12\x12\n" +
 	"\x04mode\x18\x01 \x01(\tR\x04mode\x12\x1b\n" +
 	"\tupload_id\x18\x02 \x01(\tR\buploadId\x12\x19\n" +
 	"\bbase_url\x18\x03 \x01(\tR\abaseUrl\x12\x14\n" +
-	"\x05token\x18\x04 \x01(\tR\x05token\x12\x1f\n" +
-	"\vchunk_bytes\x18\x05 \x01(\x05R\n" +
-	"chunkBytes\x12\x1b\n" +
+	"\x05token\x18\x04 \x01(\tR\x05token\x12\x1d\n" +
+	"\n" +
+	"part_bytes\x18\x05 \x01(\x05R\tpartBytes\x12\x1b\n" +
 	"\tmax_bytes\x18\x06 \x01(\x05R\bmaxBytes\x12\x16\n" +
 	"\x06format\x18\a \x01(\tR\x06format\x12 \n" +
 	"\vcompression\x18\b \x01(\tR\vcompression\"G\n" +
@@ -1314,19 +1315,20 @@ const file_datadog_api_v1_api_proto_rawDesc = "" +
 	"\x0eupload_receipt\x18\x05 \x01(\v2(.datadog.api.v1.RemoteQueryUploadReceiptR\ruploadReceipt\x1a=\n" +
 	"\x0fAttributesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8a\x02\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x84\x02\n" +
 	"\x18RemoteQueryUploadReceipt\x12\x12\n" +
 	"\x04mode\x18\x01 \x01(\tR\x04mode\x12\x1b\n" +
 	"\tupload_id\x18\x02 \x01(\tR\buploadId\x12\x1f\n" +
 	"\vbucket_name\x18\x03 \x01(\tR\n" +
-	"bucketName\x12#\n" +
-	"\rmanifest_path\x18\x04 \x01(\tR\fmanifestPath\x12\x1f\n" +
+	"bucketName\x12\x1f\n" +
+	"\vobject_path\x18\x04 \x01(\tR\n" +
+	"objectPath\x12\x1f\n" +
 	"\vtotal_bytes\x18\x05 \x01(\x03R\n" +
 	"totalBytes\x12\x1d\n" +
 	"\n" +
-	"total_rows\x18\x06 \x01(\x03R\ttotalRows\x12\x1f\n" +
-	"\vchunk_count\x18\a \x01(\x05R\n" +
-	"chunkCount\x12\x16\n" +
+	"total_rows\x18\x06 \x01(\x03R\ttotalRows\x12\x1d\n" +
+	"\n" +
+	"part_count\x18\a \x01(\x05R\tpartCount\x12\x16\n" +
 	"\x06sha256\x18\b \x01(\tR\x06sha256\"\xfb\x01\n" +
 	"\x16RemoteQueryStreamError\x12\x12\n" +
 	"\x04code\x18\x01 \x01(\tR\x04code\x12\x18\n" +

--- a/pkg/proto/pbgo/core/api.pb.go
+++ b/pkg/proto/pbgo/core/api.pb.go
@@ -153,11 +153,13 @@ func (x *RemoteQueryExecuteLimits) GetTimeoutMs() int32 {
 }
 
 type RemoteQueryExecuteCopyLimits struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	ChunkBytes    int32                  `protobuf:"varint,1,opt,name=chunk_bytes,json=chunkBytes,proto3" json:"chunk_bytes,omitempty"`
-	MaxBytes      int32                  `protobuf:"varint,2,opt,name=max_bytes,json=maxBytes,proto3" json:"max_bytes,omitempty"`
-	MaxRowBytes   int32                  `protobuf:"varint,3,opt,name=max_row_bytes,json=maxRowBytes,proto3" json:"max_row_bytes,omitempty"`
-	TimeoutMs     int32                  `protobuf:"varint,4,opt,name=timeout_ms,json=timeoutMs,proto3" json:"timeout_ms,omitempty"`
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	ChunkBytes int32                  `protobuf:"varint,1,opt,name=chunk_bytes,json=chunkBytes,proto3" json:"chunk_bytes,omitempty"`
+	// max_bytes is the overall extraction safety ceiling. It is int64 so the
+	// backend-owned 10 GiB result cap is representable without overflow.
+	MaxBytes      int64 `protobuf:"varint,2,opt,name=max_bytes,json=maxBytes,proto3" json:"max_bytes,omitempty"`
+	MaxRowBytes   int32 `protobuf:"varint,3,opt,name=max_row_bytes,json=maxRowBytes,proto3" json:"max_row_bytes,omitempty"`
+	TimeoutMs     int32 `protobuf:"varint,4,opt,name=timeout_ms,json=timeoutMs,proto3" json:"timeout_ms,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -199,7 +201,7 @@ func (x *RemoteQueryExecuteCopyLimits) GetChunkBytes() int32 {
 	return 0
 }
 
-func (x *RemoteQueryExecuteCopyLimits) GetMaxBytes() int32 {
+func (x *RemoteQueryExecuteCopyLimits) GetMaxBytes() int64 {
 	if x != nil {
 		return x.MaxBytes
 	}
@@ -331,15 +333,17 @@ func (x *RemoteQueryExecuteRequest) GetResultDelivery() *RemoteQueryResultDelive
 // Agent Go side retains base_url, token, and the org API key; only the
 // sanitized, non-secret fields are forwarded to the integration check.
 type RemoteQueryResultDelivery struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Mode          string                 `protobuf:"bytes,1,opt,name=mode,proto3" json:"mode,omitempty"`
-	UploadId      string                 `protobuf:"bytes,2,opt,name=upload_id,json=uploadId,proto3" json:"upload_id,omitempty"`
-	BaseUrl       string                 `protobuf:"bytes,3,opt,name=base_url,json=baseUrl,proto3" json:"base_url,omitempty"`
-	Token         string                 `protobuf:"bytes,4,opt,name=token,proto3" json:"token,omitempty"`
-	PartBytes     int32                  `protobuf:"varint,5,opt,name=part_bytes,json=partBytes,proto3" json:"part_bytes,omitempty"`
-	MaxBytes      int32                  `protobuf:"varint,6,opt,name=max_bytes,json=maxBytes,proto3" json:"max_bytes,omitempty"`
-	Format        string                 `protobuf:"bytes,7,opt,name=format,proto3" json:"format,omitempty"`
-	Compression   string                 `protobuf:"bytes,8,opt,name=compression,proto3" json:"compression,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Mode      string                 `protobuf:"bytes,1,opt,name=mode,proto3" json:"mode,omitempty"`
+	UploadId  string                 `protobuf:"bytes,2,opt,name=upload_id,json=uploadId,proto3" json:"upload_id,omitempty"`
+	BaseUrl   string                 `protobuf:"bytes,3,opt,name=base_url,json=baseUrl,proto3" json:"base_url,omitempty"`
+	Token     string                 `protobuf:"bytes,4,opt,name=token,proto3" json:"token,omitempty"`
+	PartBytes int32                  `protobuf:"varint,5,opt,name=part_bytes,json=partBytes,proto3" json:"part_bytes,omitempty"`
+	// max_bytes is the multipart upload total cap. It is int64 so the
+	// backend-owned 10 GiB result cap is representable without overflow.
+	MaxBytes      int64  `protobuf:"varint,6,opt,name=max_bytes,json=maxBytes,proto3" json:"max_bytes,omitempty"`
+	Format        string `protobuf:"bytes,7,opt,name=format,proto3" json:"format,omitempty"`
+	Compression   string `protobuf:"bytes,8,opt,name=compression,proto3" json:"compression,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -409,7 +413,7 @@ func (x *RemoteQueryResultDelivery) GetPartBytes() int32 {
 	return 0
 }
 
-func (x *RemoteQueryResultDelivery) GetMaxBytes() int32 {
+func (x *RemoteQueryResultDelivery) GetMaxBytes() int64 {
 	if x != nil {
 		return x.MaxBytes
 	}
@@ -1257,7 +1261,7 @@ const file_datadog_api_v1_api_proto_rawDesc = "" +
 	"\x1cRemoteQueryExecuteCopyLimits\x12\x1f\n" +
 	"\vchunk_bytes\x18\x01 \x01(\x05R\n" +
 	"chunkBytes\x12\x1b\n" +
-	"\tmax_bytes\x18\x02 \x01(\x05R\bmaxBytes\x12\"\n" +
+	"\tmax_bytes\x18\x02 \x01(\x03R\bmaxBytes\x12\"\n" +
 	"\rmax_row_bytes\x18\x03 \x01(\x05R\vmaxRowBytes\x12\x1d\n" +
 	"\n" +
 	"timeout_ms\x18\x04 \x01(\x05R\ttimeoutMs\"\xa9\x03\n" +
@@ -1278,7 +1282,7 @@ const file_datadog_api_v1_api_proto_rawDesc = "" +
 	"\x05token\x18\x04 \x01(\tR\x05token\x12\x1d\n" +
 	"\n" +
 	"part_bytes\x18\x05 \x01(\x05R\tpartBytes\x12\x1b\n" +
-	"\tmax_bytes\x18\x06 \x01(\x05R\bmaxBytes\x12\x16\n" +
+	"\tmax_bytes\x18\x06 \x01(\x03R\bmaxBytes\x12\x16\n" +
 	"\x06format\x18\a \x01(\tR\x06format\x12 \n" +
 	"\vcompression\x18\b \x01(\tR\vcompression\"G\n" +
 	"\x17RemoteQueryExecuteError\x12\x12\n" +


### PR DESCRIPTION
## Stack

- Base: #55153 (`nubtron/remote-queries-intake-poc`)
- This draft: test-only deterministic relay proof

## Summary

- drive exact 8 MiB and 32 MiB producer streams through the actual relay
- verify bounded chunking, aggregate hashing, receipt-only output, and backpressure
- cover rejection-before-accept and lost-response-after-accept idempotent retries

## Validation

- 135 focused package tests passed after the production lint fix was merged
- synthetic M3/M5 proof passed all cases
- lint and reliabilint passed
- signed commits independently reviewed

## Deployment

Test-only local proof tooling; no production deployment.


---

### Consolidation note

Superseded by the consolidated draft [#55094](https://github.com/DataDog/datadog-agent/pull/55094). Live proof orchestration is maintained on the internal [`nubtron/remote-queries-intake-tooling`](https://github.com/enrico-donnici_ddog/remote-queries-poc/tree/nubtron/remote-queries-intake-tooling) branch.
