### PR TITLE
[DSEC-199] Data security rust check: add default_transaction_read_only

### DIFF
--- a/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/backend/postgres.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/backend/postgres.rs
@@ -45,7 +45,10 @@ fn connect(sub_task: &SubTask) -> Result<Client> {
         .password(&conn.password)
         .application_name(&conn.application_name)
         .connect_timeout(timeout)
-        .options(&format!("-c statement_timeout={}", timeout.as_millis()));
+        .options(&format!(
+            "-c statement_timeout={} -c default_transaction_read_only=on",
+            timeout.as_millis()
+        ));
     // A host starting with `/` is a Unix socket directory, otherwise a TCP host.
     if conn.host.starts_with('/') {
         config.host_path(&conn.host);

--- a/releasenotes/notes/datasecurity-postgres-read-only-edf46d540562ca70.yaml
+++ b/releasenotes/notes/datasecurity-postgres-read-only-edf46d540562ca70.yaml
@@ -1,0 +1,5 @@
+---
+security:
+  - |
+    Data security PostgreSQL scans now open connections as read-only, as a first
+    layer of protection against accidental writes.


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

**First layer of protection** on data security Postgres connections: set `default_transaction_read_only=on` next to `statement_timeout`. Accidental `INSERT` / `UPDATE` / `DELETE` / DDL fail with `cannot execute … in a read-only transaction`. `SELECT` still works.

This does **not** replace a `SELECT`-only role. The same session can still write via `SET default_transaction_read_only = off`, `BEGIN READ WRITE`, or `SET TRANSACTION READ WRITE`. Temp tables and sequence `nextval()` / `setval()` are also still allowed.

### Motivation

[DSEC-199](https://datadoghq.atlassian.net/browse/DSEC-199): reduce the chance that a data security scan query mutates customer data.

### Describe how you validated your changes

- Confirmed a read-only transaction rejects DML/DDL while `SELECT` (the scanner path) still succeeds.
- Ran a one-shot local `datasecurity` check with an `INSERT` against `public.movies`. Postgres rejected it as read-only.

<details>
<summary>Local one-shot INSERT config</summary>

```yaml
init_config: {}

instances:
  - min_collection_interval: 0
    task_id: local-insert-movie
    scanning_rules:
      - id: email
        pattern: '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]+'
    scan_data:
      - sub_task_id: insert-movie
        query: INSERT INTO public.movies DEFAULT VALUES
        timeout_seconds: 30
        connection:
          host: localhost
          port: 5432
          dbname: dbm
          username: datadog
          password: datadog
        entity:
          platform: postgres
          database_cluster_name: local
          database_instance_name: dbm-postgres
          database: dbm
          schema: public
          table: movie
```

</details>

<details>
<summary>Agent log</summary>

```
2026-08-20 09:50:08 CEST | CORE | ERROR | (pkg/collector/aggregator/aggregator.go:178 in LogMsg) | datasecurity: sub task insert-movie failed: fetching sub task data: running postgres query: db error: ERROR: cannot execute INSERT in a read-only transaction
```

</details>