### PR TITLE
fix(lint_windows-x64): checkout C# files with CRLF for dotnet format

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,8 @@ tasks/unit_tests/testdata/secret.tar.gz/*.xml -text
 # Set batch file line endings to CRLF so that they can be executed on Windows
 *.bat text eol=crlf
 *.cmd text eol=crlf
+# Set C# file line endings to CRLF to match dotnet format's expectation on Windows
+*.cs text eol=crlf
 *.bin binary
 
 go.sum -diff -merge linguist-generated=true


### PR DESCRIPTION
### Motivation
Despite #55076, `lint_windows-x64` still fails on the next step, `dotnet format --verify-no-changes` ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1967502925)):
```
Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.
C:\buildroot\datadog-agent\tools\windows\DatadogAgentInstaller\WixSetup\Datadog Agent\AgentCustomActions.cs(125,30): error WHITESPACE: Fix whitespace formatting. Replace 17 characters with '\r\n\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s'. [C:\buildroot\datadog-agent\tools\windows\DatadogAgentInstaller\WixSetup\WixSetup.csproj]
C:\buildroot\datadog-agent\tools\windows\DatadogAgentInstaller\WixSetup\Datadog Agent\AgentCustomActions.cs(126,85): error WHITESPACE: Fix whitespace formatting. Replace 17 characters with '\r\n\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s'. [C:\buildroot\datadog-agent\tools\windows\DatadogAgentInstaller\WixSetup\WixSetup.csproj]
...
C:\buildroot\datadog-agent\tools\windows\DatadogAgentInstaller\CustomActions.Tests\ProcessUserCustomActions\ProcessUserCustomActionsDomainControllerTests.cs(261,59): error WHITESPACE: Fix whitespace formatting. Replace 17 characters with '\r\n\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s'. [C:\buildroot\datadog-agent\tools\windows\DatadogAgentInstaller\CustomActions.Tests\CustomActions.Tests.csproj]
Dotnet linter result is 2
dotnet linter failed 2
```

The project's `.editorconfig` leaves `end_of_line` unset, so `dotnet` format falls back to native line endings, which is CRLF on the Windows runner, while `.gitattributes` checks `*.cs` out as LF like every other text file.

### What does this PR do?
Give `*.cs` its own `eol=crlf` rule, the same way `*.bat` and `*.cmd` already do.

### Additional Notes
`eol` only affects the checked-out working tree, not the stored blob, so this does not touch any C# source file.