### PR TITLE
[DSEC-161] Keep a fresh read-only Postgres client per scan query

### DIFF
--- a/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/backend/postgres.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/backend/postgres.rs
@@ -118,4 +118,4 @@ fn cell_to_value(row: &Row, index: usize) -> Value {
     }
 }
 
-// TODO(dsec-161): add tests for the postgres engine.
+// TODO(dsec-266): add tests for the postgres engine.

--- a/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/backend/postgres.rs
+++ b/pkg/collector/sharedlibrary/rustchecks/checks/datasecurity/src/backend/postgres.rs
@@ -17,8 +17,16 @@ impl ScanEngine for PostgresEngine {
     }
 
     fn fetch_data(&self, sub_task: &SubTask) -> Result<ScanData> {
-        // TODO(dsec-161): prevent reinitializing the connection for each sub task;
-        // reuse a pooled/cached connection across sub tasks sharing the same target.
+        // WARNING: do not modify the `client.query` call nor share the connection
+        // unless you know what you are doing.
+        //
+        // We get a "free" security layer from two properties held together:
+        //   - a single connection per query, forced read-only via
+        //     `default_transaction_read_only=on` (a shared connection could have
+        //     that flipped off before a write query runs);
+        //   - a single statement via `query`, which rejects multi-statement input
+        //     and so blocks piggy-backed writes.
+        // Weakening either one removes the guarantee that scanning stays read-only.
         let mut client = connect(sub_task)?;
 
         let rows = client


### PR DESCRIPTION
### What does this PR do?

Resolves **TODO(dsec-161) (pool/reuse the Postgres connection)**. We keep a **fresh client per scan query**.

#55157 sets `default_transaction_read_only=on`. `query()` allows [one statement](https://docs.rs/postgres/latest/postgres/struct.Client.html#method.query), so `SET default_transaction_read_only = off; INSERT/DROP …` is refused. A lone `SET … = off` cannot be followed by a write on this client. Reusing the session would let that SET disable read-only for a later dangerous query — that is why the pooling TODO is closed rather than implemented.

### Motivation
This PR adds a comment calling out that we get extra security if we keep initializing one client per query. Moreover, the queries are "rare" on a single agent, leading to stale connections.

### Describe how you validated your changes

Ran a one-shot local `datasecurity` check with `SET default_transaction_read_only = off` followed by `INSERT`. `query()` refused the two-statement payload.

<details>
<summary>Local one-shot SET + INSERT config</summary>

```yaml
init_config: {}

instances:
  - min_collection_interval: 0
    task_id: local-insert-movie
    scanning_rules:
      - id: email
        pattern: '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]+'
    scan_data:
      - sub_task_id: insert-movie
        query: SET default_transaction_read_only = off; INSERT INTO public.movies DEFAULT VALUES
        timeout_seconds: 30
        connection:
          host: localhost
          port: 5432
          dbname: dbm
          username: datadog
          password: datadog
        entity:
          platform: postgres
          database_cluster_name: local
          database_instance_name: dbm-postgres
          database: dbm
          schema: public
          table: movie
```

</details>

<details>
<summary>Agent log</summary>

```
2026-08-20 12:23:39 CEST | CORE | ERROR | (pkg/collector/aggregator/aggregator.go:178 in LogMsg) | datasecurity: sub task insert-movie failed: fetching sub task data: running postgres query: db error: ERROR: cannot insert multiple commands into a prepared statement
```

</details>