### PR TITLE
CAP-3666 translate k8s.node.name to kube_node

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/attributes/attributes.go
+++ b/pkg/opentelemetry-mapping-go/otlp/attributes/attributes.go
@@ -87,6 +87,7 @@ var (
 		string(semconv1_27.K8SCronJobNameKey):     "kube_cronjob",
 		string(semconv1_27.K8SNamespaceNameKey):   "kube_namespace",
 		string(semconv1_27.K8SPodNameKey):         "pod_name",
+		string(semconv1_27.K8SNodeNameKey):        "kube_node",
 	}
 
 	containerDDTags = (func() map[string]struct{} {


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

for otel metrics, k8s.node.name is silently skipped, we should translate it into  kube_node
