### PR TITLE
[CWS] kmt: run x86 security-agent tests on z1d.metal

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -959,6 +959,22 @@ workflow:
   - when: manual
     allow_failure: true
 
+# For KMT jobs shared by both components: the two path lists overlap but neither contains
+# the other, and a job needed by both matrices must run whenever either one does. Gating
+# such a job on one component's paths silently skips the other component's whole matrix.
+.on_system_probe_or_security_agent_changes_or_manual:
+  - <<: *if_main_branch
+  - !reference [.except_mergequeue]
+  - <<: *if_run_all_kmt_tests
+  - changes:
+      paths: *system_probe_change_paths
+      compare_to: $COMPARE_TO_BRANCH
+  - changes:
+      paths: *security_agent_change_paths
+      compare_to: $COMPARE_TO_BRANCH
+  - when: manual
+    allow_failure: true
+
 # New E2E related rules
 
 .on_e2e_main_release_or_rc: # This rule is used as a base for all new-e2e rules

--- a/.gitlab/test/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/test/kernel_matrix_testing/security_agent.yml
@@ -9,7 +9,7 @@ upload_dependencies_secagent_x64:
   variables:
     ARCHIVE_NAME: dependencies-x86_64.tar.gz
     ARCH: amd64
-    INSTANCE_TYPE: m5d.metal
+    INSTANCE_TYPE: z1d.metal
     TEST_COMPONENT: security-agent
 
 upload_dependencies_secagent_arm64:
@@ -42,7 +42,7 @@ kmt_setup_env_secagent_x64:
     - .kmt_setup_env
   rules: !reference [.on_security_agent_changes_or_manual]
   variables:
-    INSTANCE_TYPE: "m5d.metal"
+    INSTANCE_TYPE: "z1d.metal"
     INSTANCE_TYPE_ARG: "--instance-type-x86=$INSTANCE_TYPE"
     ARCH: x86_64
     AMI_ID_ARG: "--x86-ami-id=$KERNEL_MATRIX_TESTING_X86_AMI_ID"
@@ -97,7 +97,7 @@ upload_secagent_tests_x64:
   tags: ["arch:amd64", "specific:true"]
   variables:
     ARCH: x86_64
-    INSTANCE_TYPE: m5d.metal
+    INSTANCE_TYPE: z1d.metal
 
 upload_secagent_tests_arm64:
   extends:
@@ -545,7 +545,7 @@ kmt_secagent_cleanup_x64:
     - upload_secagent_tests_x64
   variables:
     ARCH: x86_64
-    INSTANCE_TYPE: "m5d.metal"
+    INSTANCE_TYPE: "z1d.metal"
 
 # Manual cleanup jobs, these will be used to cleanup the instances after the tests
 # if the tests are canceled (e.g., by the auto-cancel-prev-pipelines job). The automatic jobs
@@ -564,4 +564,4 @@ kmt_secagent_cleanup_x64_manual:
     - .kmt_cleanup_manual
   variables:
     ARCH: x86_64
-    INSTANCE_TYPE: "m5d.metal"
+    INSTANCE_TYPE: "z1d.metal"

--- a/.gitlab/test/kernel_matrix_testing/system_probe.yml
+++ b/.gitlab/test/kernel_matrix_testing/system_probe.yml
@@ -24,11 +24,13 @@ upload_dependencies_sysprobe_arm64:
     TEST_COMPONENT: system-probe
 
 # --- Docker test images
+# `upload_dependencies_{sysprobe,secagent}_*` both need these images, and every KMT test job
+# needs those uploads, so this must follow the union of both components' triggers.
 .pull_test_dockers:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
   needs: []
   tags: ["arch:amd64", "specific:true"]
-  rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
+  rules: !reference [.on_system_probe_or_security_agent_changes_or_manual]
   stage: kernel_matrix_testing_prepare
   script:
     - !reference [.login_to_docker_readonly_crane]


### PR DESCRIPTION
### What does this PR do?

Switches the x86_64 KMT jobs for the security-agent component from `m5d.metal` to `z1d.metal`. All five occurrences in `.gitlab/test/kernel_matrix_testing/security_agent.yml` move together: the setup job passes the type to Pulumi via `INSTANCE_TYPE_ARG`, while the upload and cleanup jobs use it as an EC2 `describe-instances` tag filter to find the host (`RESOURCE_TAGS` tags it with `instance-type:${INSTANCE_TYPE}`), so a partial change would leave those jobs waiting for an instance that never matches.

arm64 stays on `m6gd.metal`, system-probe stays on `r5d.metal`, and the local-stack default in `tasks/kernel_matrix_testing/stacks.py` is untouched.

### Motivation

Experiment to see whether a higher-frequency instance is a better fit for the CWS KMT matrix.

|  | m5d.metal (before) | z1d.metal (after) |
|---|---|---|
| vCPUs | 96 | 48 |
| Memory | 384 GiB | 384 GiB |
| Instance store | 4x900 GB NVMe | 2x900 GB NVMe |
| Sustained all-core clock | 3.1 GHz base | 4.0 GHz |
| On-demand, us-east-1 | ~\$5.42/h | ~\$4.46/h |

Memory is unchanged, so the per-VM sizing (`--memory=12288` in `.kmt_setup_env`) needs no retuning and the guest ramfs headroom is unaffected. Local NVMe is still present, so any dependency the KMT AMI has on instance-store devices is preserved.

The trade is CPU: the x86 matrix boots roughly 75 microVMs at 4 vCPUs each, so oversubscription goes from about 3x to about 6x, against roughly 15-25% more per-thread performance. Whether that is a net win depends on how CPU-bound the CWS suites actually are, which is what this PR is meant to measure.

### Describe how you validated your changes

Not yet validated — draft. Plan:

- [ ] Trigger `kmt_setup_env_secagent_x64` manually and confirm the instance comes up and that the upload/cleanup jobs resolve its IP through the tag filter.
- [ ] Confirm the pinned KMT AMI is happy with two ephemeral NVMe devices instead of four (`lsblk` and `df -h /home/kernel-version-testing` on the live host).
- [ ] Compare wall-clock of the `kmt_run_secagent_tests_x64*` jobs against a recent main pipeline.
- [ ] Check for insufficient-capacity errors: z1d is an older family and the KMT subnet is pinned to a single AZ.

### Additional Notes

If the CPU contention turns out to be the limiting factor, the alternative worth trying is `m6id.metal` (128 vCPUs, 512 GiB, 4x1425 GB NVMe, 3.5 GHz all-core turbo), which improves on `m5d.metal` in every dimension rather than trading cores for clock, at a higher hourly cost.

Made with [Cursor](https://cursor.com)