### PR TITLE
[PoC] Add metricslogs library for local metrics-as-logs debugging

### DIFF
--- a/pkg/util/metricsaslogs/BUILD.bazel
+++ b/pkg/util/metricsaslogs/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go:dd_agent_go_test.bzl", "dd_agent_go_test")
+
+go_library(
+    name = "metricsaslogs",
+    srcs = ["metricsaslogs.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/util/metricsaslogs",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/config/setup/constants"],
+)
+
+dd_agent_go_test(
+    name = "metricsaslogs_test",
+    srcs = ["metricsaslogs_test.go"],
+    embed = [":metricsaslogs"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/util/metricsaslogs/metricsaslogs.go
+++ b/pkg/util/metricsaslogs/metricsaslogs.go
@@ -1,0 +1,184 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package metricsaslogs serializes metrics into structured JSON lines suitable
+// for writing to a log, letting other agent components piggyback metrics on
+// their own logging (bypassing metric-tag cardinality limits) without
+// shipping anything over the network themselves. Callers are responsible for
+// actually writing the returned lines to their logger of choice, at
+// whatever level they see fit.
+package metricsaslogs
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
+)
+
+const (
+	// MaxMetricsPerBatch is the maximum number of metrics packed into a
+	// single serialized line before Serialize splits into more lines.
+	MaxMetricsPerBatch = 500
+
+	// DefaultMaxLineSizeBytes is the default value of Serialize's
+	// maxLineSizeBytes parameter, mirroring the Logs intake's default
+	// per-message size limit (logs_config.max_message_size_bytes). An
+	// installation that configures a different limit, or a caller whose
+	// logger adds its own framing around the line, should pass its actual
+	// effective limit to Serialize instead of this default.
+	DefaultMaxLineSizeBytes = constants.DefaultMaxMessageSizeBytes
+)
+
+// MetricType is the type of a metric passed to Serialize.
+type MetricType string
+
+const (
+	// MetricTypeGauge is a gauge metric.
+	MetricTypeGauge MetricType = "gauge"
+	// MetricTypeCount is a count metric.
+	MetricTypeCount MetricType = "count"
+)
+
+// Metric is a single metric passed to Serialize.
+type Metric struct {
+	Name  string            `json:"name"`
+	Type  MetricType        `json:"type"`
+	Value float64           `json:"value"`
+	Tags  map[string]string `json:"tags,omitempty"`
+}
+
+// Serialize encodes metrics into one or more JSON lines, splitting into
+// multiple lines whenever a batch would exceed MaxMetricsPerBatch or
+// maxLineSizeBytes. maxLineSizeBytes should be the caller's actual
+// effective per-message size limit (accounting for any framing the
+// caller's own logger adds around the line), not necessarily
+// DefaultMaxLineSizeBytes: an installation may configure a lower
+// logs_config.max_message_size_bytes, and a line that overshoots the real
+// limit gets truncated downstream, corrupting its JSON. Every line from
+// one Serialize call carries the same "timestamp" field (Unix
+// milliseconds, captured once at the start of the call), so metrics from
+// one call keep an exact shared timestamp even if they end up split
+// across lines. Returns nil for an empty input. A single metric that
+// exceeds the byte limit on its own is still returned as its own line,
+// since it can't be split any further.
+func Serialize(metrics []Metric, maxLineSizeBytes int) ([]string, error) {
+	if len(metrics) == 0 {
+		return nil, nil
+	}
+
+	if maxLineSizeBytes <= 0 {
+		return nil, fmt.Errorf("metricsaslogs: maxLineSizeBytes must be positive, got %d", maxLineSizeBytes)
+	}
+
+	for _, m := range metrics {
+		if math.IsNaN(m.Value) || math.IsInf(m.Value, 0) {
+			return nil, fmt.Errorf("metricsaslogs: metric %q has non-finite value %v", m.Name, m.Value)
+		}
+	}
+
+	// Captured once so every line from this call carries the exact same
+	// timestamp.
+	timestamp := float64(time.Now().UnixMilli())
+
+	// emptyBatchOverhead is the encoded length of a line with zero metrics
+	// for this call's timestamp — everything but the metric entries
+	// themselves (the "message"/"timestamp" fields, and the object/array
+	// punctuation). It's derived from marshalBatch itself, so it can't
+	// drift out of sync with the actual wire format, and lets the loop
+	// below compute a candidate batch's exact encoded size from its
+	// metrics' individual entry lengths without re-marshaling the whole
+	// batch on every append.
+	emptyBatch, err := marshalBatch(nil, timestamp)
+	if err != nil {
+		return nil, err
+	}
+	emptyBatchOverhead := len(emptyBatch)
+
+	// Accumulate metrics into a batch, flushing it as a line whenever
+	// adding the next metric would push it past either limit. The
+	// candidate batch's encoded size is derived from the running sum of
+	// its metrics' own entry lengths (JSON array encoding is just
+	// concatenation with commas), rather than by re-marshaling the whole
+	// growing batch on every append, so this stays linear in the number of
+	// metrics.
+	var lines []string
+	var batch []Metric
+	entriesSize := 0
+	for _, m := range metrics {
+		entryLen, err := marshalEntryLen(m)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(batch) > 0 {
+			nextCount := len(batch) + 1
+			// nextSize is emptyBatchOverhead (which already counts the 2
+			// bytes for "[]") plus the entries' own bytes plus one comma
+			// per entry after the first — going from an empty array to a
+			// non-empty one doesn't add a second pair of brackets, it just
+			// reuses the same 2 bytes and adds commas. For example, with
+			// two 20-byte entries and emptyBatchOverhead 50 (for
+			// `..."metrics":[]}`), the real line is
+			// `..."metrics":[<20 bytes>,<20 bytes>]}`, i.e. 50 + 20 + 20 +
+			// 1 (one comma) = 91 bytes — exactly emptyBatchOverhead +
+			// entriesSize + (nextCount-1), with no further adjustment.
+			nextSize := emptyBatchOverhead + entriesSize + entryLen + (nextCount - 1)
+			if nextCount > MaxMetricsPerBatch || nextSize > maxLineSizeBytes {
+				line, err := marshalBatchLine(batch, timestamp)
+				if err != nil {
+					return nil, err
+				}
+				lines = append(lines, line)
+				batch = nil
+				entriesSize = 0
+			}
+		}
+
+		batch = append(batch, m)
+		entriesSize += entryLen
+	}
+
+	line, err := marshalBatchLine(batch, timestamp)
+	if err != nil {
+		return nil, err
+	}
+	return append(lines, line), nil
+}
+
+// marshalEntryLen returns the encoded length of m's own JSON entry, as it
+// would appear inside a batch's "metrics" array.
+func marshalEntryLen(m Metric) (int, error) {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return 0, err
+	}
+	return len(data), nil
+}
+
+func marshalBatch(ms []Metric, timestamp float64) ([]byte, error) {
+	if ms == nil {
+		// Force an empty "[]" rather than "null" so this always matches the
+		// per-entry lengths marshalEntryLen computes, keeping
+		// emptyBatchOverhead byte-exact.
+		ms = []Metric{}
+	}
+
+	return json.Marshal(map[string]any{
+		"message":   "agent metrics batch",
+		"timestamp": timestamp,
+		"metrics":   ms,
+	})
+}
+
+func marshalBatchLine(ms []Metric, timestamp float64) (string, error) {
+	data, err := marshalBatch(ms, timestamp)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/pkg/util/metricsaslogs/metricsaslogs_test.go
+++ b/pkg/util/metricsaslogs/metricsaslogs_test.go
@@ -1,0 +1,143 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metricsaslogs
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSerialize_SingleCallProducesOneLine(t *testing.T) {
+	lines, err := Serialize([]Metric{
+		{Name: "m1", Type: MetricTypeGauge, Value: 1, Tags: map[string]string{"a": "b"}},
+		{Name: "m2", Type: MetricTypeCount, Value: 2, Tags: map[string]string{"c": "d"}},
+	}, DefaultMaxLineSizeBytes)
+	require.NoError(t, err)
+	require.Len(t, lines, 1)
+
+	var payload struct {
+		Metrics []map[string]any `json:"metrics"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &payload))
+	assert.Len(t, payload.Metrics, 2)
+}
+
+func TestSerialize_EmptyBatchReturnsNoLines(t *testing.T) {
+	lines, err := Serialize(nil, DefaultMaxLineSizeBytes)
+	require.NoError(t, err)
+	assert.Empty(t, lines)
+}
+
+// countSerializedMetrics unmarshals every line's "metrics" array and returns
+// the total number of metrics across all of them.
+func countSerializedMetrics(t *testing.T, lines []string) int {
+	total := 0
+	for _, line := range lines {
+		var payload struct {
+			Metrics []map[string]any `json:"metrics"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(line), &payload))
+		total += len(payload.Metrics)
+	}
+	return total
+}
+
+func TestSerialize_SplitsWhenOverCountThreshold(t *testing.T) {
+	n := MaxMetricsPerBatch + 1
+	ms := make([]Metric, n)
+	for i := range ms {
+		ms[i] = Metric{Name: fmt.Sprintf("m%d", i), Type: MetricTypeGauge, Value: float64(i)}
+	}
+
+	lines, err := Serialize(ms, DefaultMaxLineSizeBytes)
+	require.NoError(t, err)
+	require.Len(t, lines, 2)
+	assert.Equal(t, n, countSerializedMetrics(t, lines))
+	assertSharedTimestamp(t, lines)
+}
+
+// lineTimestamp unmarshals one line's "timestamp" field.
+func lineTimestamp(t *testing.T, line string) float64 {
+	var payload struct {
+		Timestamp float64 `json:"timestamp"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(line), &payload))
+	return payload.Timestamp
+}
+
+// assertSharedTimestamp asserts every line carries the same "timestamp"
+// value.
+func assertSharedTimestamp(t *testing.T, lines []string) {
+	require.NotEmpty(t, lines)
+	want := lineTimestamp(t, lines[0])
+	assert.NotZero(t, want)
+	for _, line := range lines[1:] {
+		assert.Equal(t, want, lineTimestamp(t, line))
+	}
+}
+
+func TestSerialize_SplitsWhenOverByteSizeLimit(t *testing.T) {
+	bigTag := strings.Repeat("x", 300000)
+	ms := []Metric{
+		{Name: "m1", Type: MetricTypeGauge, Value: 1, Tags: map[string]string{"big": bigTag}},
+		{Name: "m2", Type: MetricTypeGauge, Value: 2, Tags: map[string]string{"big": bigTag}},
+		{Name: "m3", Type: MetricTypeGauge, Value: 3, Tags: map[string]string{"big": bigTag}},
+		{Name: "m4", Type: MetricTypeGauge, Value: 4, Tags: map[string]string{"big": bigTag}},
+	}
+
+	lines, err := Serialize(ms, DefaultMaxLineSizeBytes)
+	require.NoError(t, err)
+	require.Greater(t, len(lines), 1)
+
+	for _, line := range lines {
+		assert.LessOrEqual(t, len(line), DefaultMaxLineSizeBytes)
+	}
+	assert.Equal(t, len(ms), countSerializedMetrics(t, lines))
+}
+
+func TestSerialize_SplitsWhenOverCustomByteSizeLimit(t *testing.T) {
+	ms := []Metric{
+		{Name: "m1", Type: MetricTypeGauge, Value: 1, Tags: map[string]string{"a": "aaaaaaaaaa"}},
+		{Name: "m2", Type: MetricTypeGauge, Value: 2, Tags: map[string]string{"a": "aaaaaaaaaa"}},
+		{Name: "m3", Type: MetricTypeGauge, Value: 3, Tags: map[string]string{"a": "aaaaaaaaaa"}},
+	}
+	const customLimit = 200
+
+	lines, err := Serialize(ms, customLimit)
+	require.NoError(t, err)
+	require.Greater(t, len(lines), 1)
+
+	for _, line := range lines {
+		assert.LessOrEqual(t, len(line), customLimit)
+	}
+	assert.Equal(t, len(ms), countSerializedMetrics(t, lines))
+}
+
+func TestSerialize_ErrorsOnNonPositiveMaxLineSizeBytes(t *testing.T) {
+	ms := []Metric{{Name: "m1", Type: MetricTypeGauge, Value: 1}}
+
+	lines, err := Serialize(ms, 0)
+	require.Error(t, err)
+	assert.Empty(t, lines)
+
+	lines, err = Serialize(ms, -1)
+	require.Error(t, err)
+	assert.Empty(t, lines)
+}
+
+func TestSerialize_ErrorsOnNonFiniteValue(t *testing.T) {
+	lines, err := Serialize([]Metric{
+		{Name: "m1", Type: MetricTypeGauge, Value: math.NaN()},
+	}, DefaultMaxLineSizeBytes)
+	require.Error(t, err)
+	assert.Empty(t, lines)
+}


### PR DESCRIPTION
## What this change does

Adds `pkg/util/metricslogs`, a small library that serializes metrics into structured JSON lines suitable for writing to a log.

Other internal agent components can use this library to write metrics as logs, bypassing tags cardinality limits, by taking the returned lines and passing them to whatever logger they already have.

## Why we need this change

`ebpf-check` emits internal metrics for each map and each program. This creates too many tag combinations that overflow the metrics cardinality limits. They expect to observe them only internally.

This library gives a safe, low impact way to encode this kind of data as structured local log lines, not as a tagged metric or forwarded event.

## Important limits

This library only serializes data: it doesn't write to any log itself, and doesn't send anything over the network on its own. Whether the resulting lines ever leave the host depends entirely on how the caller logs them (e.g. if the agent is configured to collect its own logs). It does not create billable Log volume by itself, and has no config gate: any caller can use it at any time, at whatever log level they choose.

## How the library behaves

The caller passes one batch of metrics in one call, through `Serialize(metrics []Metric, maxLineSizeBytes int) ([]string, error)`. It returns one or more JSON lines: normally a single line for the whole batch, split into multiple lines only when the batch would exceed 500 metrics or `maxLineSizeBytes` encoded. Every line from one call shares the same timestamp. It's the caller's responsibility to write the returned lines to their logger, at whatever level they choose.

`maxLineSizeBytes` should be the caller's actual effective per-message size limit, accounting for any framing the caller's own logger adds around the line. `DefaultMaxLineSizeBytes` (900KB, matching the Logs intake's default `logs_config.max_message_size_bytes`) is provided as a fallback default, but an installation may configure a lower limit, so callers should pass their real effective limit rather than assuming the default always applies.

An empty batch returns no lines.

## How this was tested

- Unit tests cover the library: a normal call with several metrics, an empty batch, splitting on count, splitting on byte size (both the default and a custom `maxLineSizeBytes`), and non-finite metric values.
- The full agent binary was built with this change. The build was successful.
- The Go linter was run on the new code. The linter found no issues.

## Follow-up work

- Connect the ebpf-check to this library.
