### PR TITLE
Make //cmd/agent:agent target work on MacOS

### DIFF
--- a/cmd/agent/BUILD.bazel
+++ b/cmd/agent/BUILD.bazel
@@ -19,7 +19,7 @@ go_library(
     cgo = select({
         "@platforms//os:linux": True,
         "//conditions:default": False,
-    }),
+    }),  # keep
     importpath = "github.com/DataDog/datadog-agent/cmd/agent",
     visibility = ["//visibility:private"],
     deps = [

--- a/cmd/agent/BUILD.bazel
+++ b/cmd/agent/BUILD.bazel
@@ -16,7 +16,10 @@ go_library(
         "main_linux_no_cgo.go",
         "main_windows.go",
     ],
-    cgo = True,
+    cgo = select({
+        "@platforms//os:linux": True,
+        "//conditions:default": False,
+    }),
     importpath = "github.com/DataDog/datadog-agent/cmd/agent",
     visibility = ["//visibility:private"],
     deps = [

--- a/cmd/system-probe/subcommands/run/BUILD.bazel
+++ b/cmd/system-probe/subcommands/run/BUILD.bazel
@@ -104,7 +104,12 @@ dd_agent_go_test(
     embed = [":run"],
     deps = [
         "//cmd/system-probe/command",
+        "//comp/core",
+        "//comp/core/config",
+        "//comp/core/ipc/def",
+        "//comp/core/ipc/fx",
         "//pkg/util/fxutil",
+        "@com_github_stretchr_testify//require",
     ] + select({
         "@rules_go//go/platform:android": [
             "//comp/core/log/mock",
@@ -112,7 +117,6 @@ dd_agent_go_test(
             "//comp/core/sysprobeconfig/mock",
             "//pkg/discovery/module/splite",
             "@com_github_stretchr_testify//assert",
-            "@com_github_stretchr_testify//require",
         ],
         "@rules_go//go/platform:linux": [
             "//comp/core/log/mock",
@@ -120,7 +124,6 @@ dd_agent_go_test(
             "//comp/core/sysprobeconfig/mock",
             "//pkg/discovery/module/splite",
             "@com_github_stretchr_testify//assert",
-            "@com_github_stretchr_testify//require",
         ],
         "//conditions:default": [],
     }),

--- a/cmd/system-probe/subcommands/run/command_test.go
+++ b/cmd/system-probe/subcommands/run/command_test.go
@@ -7,15 +7,39 @@ package run
 
 import (
 	_ "net/http/pprof"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
+	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestRunCommand(t *testing.T) {
+	// Because fx.Invoke builds the ipc component, we need to ensure we
+	// have a valid auth token before building the app for real.
+	testDir := t.TempDir()
+
+	configPath := filepath.Join(testDir, "datadog.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("hostname: test"), 0644))
+
+	configComponent.NewMockFromYAMLFile(t, configPath)
+
+	fxutil.Test[ipc.Component](t,
+		ipcfx.ModuleReadWrite(),
+		core.MockBundle(),
+	)
+
 	fxutil.TestOneShotSubcommand(t,
-		Commands(&command.GlobalParams{}),
+		Commands(&command.GlobalParams{
+			ConfFilePath: configPath,
+		}),
 		[]string{"run"},
 		run,
 		func() {})

--- a/comp/process/BUILD.bazel
+++ b/comp/process/BUILD.bazel
@@ -33,6 +33,7 @@ dd_agent_go_test(
     name = "process_test",
     srcs = ["bundle_test.go"],
     embed = [":process"],
+    env_inherit = ["PATH"],  # hostinfo collection invokes ioreg on macOS
     deps = [
         "//comp/core",
         "//comp/core/config",

--- a/pkg/collector/corechecks/sbom/check_no_trivy.go
+++ b/pkg/collector/corechecks/sbom/check_no_trivy.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !trivy && !windows
+//go:build !trivy && (!windows || !wmi)
 
 package sbom
 

--- a/pkg/ebpf/BUILD.bazel
+++ b/pkg/ebpf/BUILD.bazel
@@ -188,7 +188,6 @@ go_library(
         "time.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/pkg/ebpf",
-    target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config/setup",

--- a/pkg/process/checks/BUILD.bazel
+++ b/pkg/process/checks/BUILD.bazel
@@ -235,6 +235,7 @@ dd_agent_go_test(
         "user_nix_test.go",
     ],
     embed = [":checks"],
+    env_inherit = ["PATH"],  # CollectSystemInfo invokes system utilities (e.g. ioreg on macOS)
     gotags_sets = [["systemprobechecks"]],
     deps = [
         "//comp/core",


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?

`ebpf` target was wrongly marked as Linux only, so `//cmd/agent:agent` was wrongly skipped on MacOS, even though it's the main target to actually build the agent's binary. To keep everything working we also need to widen the scope of sbom check fallback to `wmi`. 

### Additional Notes

`wmi` is a perfect candidate for removal altogether, but since it drags in more changes it will be delivered as a follow up. In the meantime, it's necessary to add it to `pkg/collector/corechecks/sbom/check_no_trivy.go` 
