### PR TITLE
fix(rtloader): do not crash when formatting lone-surrogate Python exceptions

### DIFF
--- a/releasenotes/notes/rtloader-lone-surrogate-exception-78250a6675432d3a.yaml
+++ b/releasenotes/notes/rtloader-lone-surrogate-exception-78250a6675432d3a.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a crash of the Agent process when a Python check raises an exception
+    whose message contains a Unicode lone surrogate.

--- a/rtloader/common/stringutils.c
+++ b/rtloader/common/stringutils.c
@@ -50,6 +50,36 @@ char *as_string(PyObject *object)
     return NULL;
 }
 
+/**
+ * Like as_string, but unencodable Unicode (e.g. lone surrogates) is escaped instead of
+ * returning NULL. Intended for diagnostic paths such as exception formatting, where a
+ * missing conversion must not crash the Agent.
+ *
+ * The returned pointer is allocated from the heap and must be deallocated by the caller.
+ */
+char *as_string_lossy(PyObject *object)
+{
+    if (object == NULL) {
+        return NULL;
+    }
+
+    if (!PyUnicode_Check(object)) {
+        return as_string(object);
+    }
+
+    // backslashreplace turns non-UTF-8 code points into \\uXXXX / \\UXXXXXXXX so this
+    // only fails on allocation errors, not on lone surrogates.
+    PyObject *utf8 = PyUnicode_AsEncodedString(object, "utf-8", "backslashreplace");
+    if (utf8 == NULL) {
+        PyErr_Clear();
+        return NULL;
+    }
+
+    char *ret = strdupe(PyBytes_AS_STRING(utf8));
+    Py_DECREF(utf8);
+    return ret;
+}
+
 int init_stringutils(void) {
     PyObject *json = NULL;
     int ret = EXIT_FAILURE;

--- a/rtloader/common/stringutils.h
+++ b/rtloader/common/stringutils.h
@@ -32,6 +32,18 @@
     The returned C-string is allocated by this function and should subsequently be freed by
     the caller. This function should not set errors on the python interpreter.
 */
+/*! \fn char *as_string_lossy(PyObject * object)
+    \brief Returns a C string representation of the supplied Python string, escaping
+    unencodable Unicode instead of returning NULL.
+    \param object The Python string object to convert.
+    \return char * representation of the supplied string. In case of error NULL is returned.
+
+    Like `as_string`, but Unicode code points that cannot be encoded as strict UTF-8 (for
+    example lone surrogates) are escaped with the backslashreplace error handler instead
+    of returning NULL. The returned C-string is allocated by this function and should
+    subsequently be freed by the caller. This function should not set errors on the python
+    interpreter.
+*/
 /*! \fn PyObject *from_json(const char * data)
     \brief Returns a Python object representation for the supplied JSON C-string.
     \param data The JSON C-string representation of the object we wish to deserialize.
@@ -59,6 +71,7 @@ extern "C" {
 
 int init_stringutils(void);
 char *as_string(PyObject *);
+char *as_string_lossy(PyObject *);
 PyObject *from_json(const char *);
 char *as_json(PyObject *);
 

--- a/rtloader/test/python/fake_check/__init__.py
+++ b/rtloader/test/python/fake_check/__init__.py
@@ -4,6 +4,7 @@ was_canceled = False
 discover_config_return = "[]"
 discover_config_exception = None
 discover_config_service_json = None
+run_exception = None
 
 
 # Fake check for testing purposes
@@ -15,6 +16,11 @@ class FakeCheck(AgentCheck):
         if discover_config_exception is not None:
             raise Exception(discover_config_exception)
         return discover_config_return
+
+    def run(self):
+        if run_exception is not None:
+            raise Exception(run_exception)
+        return ""
 
     def cancel(self):
         global was_canceled

--- a/rtloader/test/rtloader/rtloader.go
+++ b/rtloader/test/rtloader/rtloader.go
@@ -346,6 +346,33 @@ fake_check.discover_config_service_json = None`, message)
 	return err
 }
 
+func setFakeDiscoverConfigExceptionLoneSurrogate() error {
+	// Python source escape, not a Go UTF-8 string: a lone surrogate is not valid UTF-8.
+	code := `import fake_check
+fake_check.discover_config_return = "[]"
+fake_check.discover_config_exception = "bad \ud800 data"
+fake_check.discover_config_service_json = None`
+
+	_, err := runString(code)
+	return err
+}
+
+func setFakeRunExceptionLoneSurrogate() error {
+	code := `import fake_check
+fake_check.run_exception = "\ud800"`
+
+	_, err := runString(code)
+	return err
+}
+
+func resetFakeRunException() error {
+	code := `import fake_check
+fake_check.run_exception = None`
+
+	_, err := runString(code)
+	return err
+}
+
 func runFakeGetWarnings() ([]string, error) {
 	var module *C.rtloader_pyobject_t
 	var class *C.rtloader_pyobject_t

--- a/rtloader/test/rtloader/rtloader_test.go
+++ b/rtloader/test/rtloader/rtloader_test.go
@@ -202,6 +202,31 @@ func TestRunCheck(t *testing.T) {
 	helpers.AssertMemoryUsage(t)
 }
 
+func TestRunCheckLoneSurrogateException(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
+	if err := setFakeRunExceptionLoneSurrogate(); err != nil {
+		t.Fatalf("error setting run exception: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := resetFakeRunException(); err != nil {
+			t.Errorf("error resetting run exception: %v", err)
+		}
+	})
+
+	_, err := runFakeCheck()
+	if err == nil {
+		t.Fatal("expected run_check error")
+	}
+	if !strings.Contains(err.Error(), `\ud800`) {
+		t.Fatalf("expected escaped lone surrogate in python error, got %q", err.Error())
+	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
+}
+
 func TestDiscoverConfig(t *testing.T) {
 	// Reset memory counters
 	helpers.ResetMemoryStats()
@@ -268,6 +293,31 @@ func TestDiscoverConfigRaises(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "discover failed") {
 		t.Fatalf("expected python error to contain %q, got %q", "discover failed", err.Error())
+	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
+}
+
+func TestDiscoverConfigRaisesLoneSurrogate(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
+	if err := setFakeDiscoverConfigExceptionLoneSurrogate(); err != nil {
+		t.Fatalf("error setting discover_config exception: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := resetFakeDiscoverConfig(); err != nil {
+			t.Errorf("error resetting discover_config: %v", err)
+		}
+	})
+
+	_, err := discoverFakeConfig(`{"id":"svc","host":"10.0.0.1","ports":[]}`)
+	if err == nil {
+		t.Fatal("expected discover_config error")
+	}
+	if !strings.Contains(err.Error(), `\ud800`) {
+		t.Fatalf("expected escaped lone surrogate in python error, got %q", err.Error())
 	}
 
 	// Check for leaks

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -776,6 +776,18 @@ done:
     return klass;
 }
 
+// Append a Python str as UTF-8. Uses a non-strict encoder so lone surrogates cannot
+// crash the Agent via std::string::operator+=(NULL). No-ops if conversion fails.
+static void appendPythonStr(std::string &out, PyObject *obj)
+{
+    char *item = as_string_lossy(obj);
+    if (item == NULL) {
+        return;
+    }
+    out += item;
+    ::_free(item);
+}
+
 std::string Three::_fetchPythonError() const
 {
     std::string ret_val = "";
@@ -827,11 +839,9 @@ std::string Three::_fetchPythonError() const
                             ret_val = "";
                             goto done;
                         }
-                        char *item = as_string(s);
                         // traceback.format_exception returns a list of strings, each ending in a *newline*
                         // and some containing internal newlines. No need to add any CRLF/newlines.
-                        ret_val += item;
-                        ::_free(item);
+                        appendPythonStr(ret_val, s);
                     }
                 }
             }
@@ -846,18 +856,14 @@ std::string Three::_fetchPythonError() const
         PyObject *pvalue_obj = PyObject_Str(pvalue);
         if (pvalue_obj != NULL) {
             // we know pvalue_obj is a string (we just casted it), no need to PyUnicode_Check()
-            char *ret = as_string(pvalue_obj);
-            ret_val += ret;
-            ::_free(ret);
+            appendPythonStr(ret_val, pvalue_obj);
             Py_XDECREF(pvalue_obj);
         }
     } else if (ptype != NULL) {
         PyObject *ptype_obj = PyObject_Str(ptype);
         if (ptype_obj != NULL) {
             // we know ptype_obj is a string (we just casted it), no need to PyUnicode_Check()
-            char *ret = as_string(ptype_obj);
-            ret_val += ret;
-            ::_free(ret);
+            appendPythonStr(ret_val, ptype_obj);
             Py_XDECREF(ptype_obj);
         }
     }


### PR DESCRIPTION
### What does this PR do?

Fixes a crash in rtloader when formatting a Python check exception whose message or traceback contains a Unicode lone surrogate (for example `\ud800`).

`_fetchPythonError()` in `rtloader/three/three.cpp` converted traceback and exception strings with strict `as_string()`. Lone surrogates cannot be encoded as UTF-8, so conversion returned `NULL`, and appending that to a `std::string` caused a SIGSEGV in the core Agent process.

This PR:
- Adds `as_string_lossy()` in `rtloader/common/stringutils.c`, which encodes Unicode with UTF-8 `backslashreplace` for diagnostic paths.
- Routes all exception formatting in `_fetchPythonError()` through a safe helper that skips on allocation failure.
- Adds rtloader regression tests for lone-surrogate exceptions in `run_check` and `discover_config`.

Strict `as_string()` behavior is unchanged for tags, metrics, events, and other hot paths.

### Motivation

Reported by the rtloader vuln audit (`agent-vuln-hunt`, finding `rtloader-lone-surrogate-exception-crash`). A Python integration can raise an exception whose text embeds monitored-service data containing a lone surrogate (for example JSON `{"statusstring":"\ud800"}`). That should surface as a check error, but instead crashed the entire Agent on every scheduled run.

### Describe how you validated your changes

- `bazel test //rtloader/test/rtloader:rtloader_test`
- `bazel test //rtloader/test/rtloader:rtloader_test --test_arg=-test.run='LoneSurrogate' --test_output=all`

New tests:
- `TestRunCheckLoneSurrogateException`
- `TestDiscoverConfigRaisesLoneSurrogate`

Both assert the Agent gets a Python error containing `\ud800` instead of crashing.

### Additional Notes

- Release note: `releasenotes/notes/rtloader-lone-surrogate-exception-78250a6675432d3a.yaml` (`fixes`)
- This closes the reported availability issue only. Other `as_string()` call sites already handle `NULL` without crashing and they may still drop or reject unencodable strings on non-exception paths.