### PR TITLE
fix(cws): add the mnt_namespace.ns offset when reading a mount namespace ID

### DIFF
--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -116,6 +116,16 @@ u32 __attribute__((always_inline)) get_ns_common_inum_offset(void) {
     return offset; // offsetof(struct ns_common, inum)
 }
 
+// get_mnt_namespace_inum reads the namespace ID out of a struct mnt_namespace. The embedded
+// ns_common is not at offset 0 on every kernel: it sits behind mnt_namespace.count below 5.11,
+// so both offsets are required.
+u32 __attribute__((always_inline)) get_mnt_namespace_inum(void *mnt_ns) {
+    u32 inum = 0;
+
+    bpf_probe_read(&inum, sizeof(inum), mnt_ns + get_mnt_namespace_ns() + get_ns_common_inum_offset());
+    return inum;
+}
+
 static int __attribute__((always_inline)) get_vfsmount_mount_id(struct vfsmount *mnt) {
     int mount_id;
     // bpf_probe_read(&mount_id, sizeof(mount_id), (char *)mnt + offsetof(struct mount, mnt_id) - offsetof(struct mount, mnt));
@@ -178,15 +188,13 @@ u64 __attribute__((always_inline)) get_mount_mount_id_unique(void *mnt) {
 
 u32 __attribute__((always_inline)) get_mount_mount_ns_inum(void *mnt) {
     void* mnt_ns = NULL;
-    u32   inum = 0;
 
     bpf_probe_read(&mnt_ns, sizeof(mnt_ns), mnt + get_mount_offset_of_mount_ns());
     if (!mnt_ns) {
         return 0;
     }
 
-    bpf_probe_read(&inum, sizeof(inum), mnt_ns + get_mnt_namespace_ns() + get_ns_common_inum_offset());
-    return inum;
+    return get_mnt_namespace_inum(mnt_ns);
 }
 
 struct mount * __attribute__((always_inline)) get_mount_parent(void *mnt) {

--- a/pkg/security/ebpf/c/include/hooks/namespaces.h
+++ b/pkg/security/ebpf/c/include/hooks/namespaces.h
@@ -17,8 +17,7 @@ int hook_switch_task_namespaces(ctx_t *ctx) {
     void *mnt_ns;
     bpf_probe_read(&mnt_ns, sizeof(mnt_ns), (void *)new_ns + nsproxy_mnt_ns_offset);
     if (mnt_ns != NULL) {
-        u32 inum = 0;
-        bpf_probe_read(&inum, sizeof(inum), (void *)mnt_ns + get_ns_common_inum_offset());
+        u32 inum = get_mnt_namespace_inum(mnt_ns);
 
         u32 pid = bpf_get_current_pid_tgid() >> 32;
         bpf_map_update_elem(&mntns_cache, &pid, &inum, BPF_ANY);

--- a/releasenotes/notes/fix-cws-mntns-inum-offset-3f7c1a94ed52b806.yaml
+++ b/releasenotes/notes/fix-cws-mntns-inum-offset-3f7c1a94ed52b806.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - |
+    CWS: fixed the mount namespace ID reported for processes that changed mount
+    namespace, and for their descendants. The ``switch_task_namespaces`` hook read
+    ``ns_common.inum`` straight from the ``mnt_namespace`` pointer, without the
+    ``offsetof(struct mnt_namespace, ns)`` term. That offset is only 0 on kernels
+    5.11 and later, so on older kernels the read landed on ``ns_common.ops`` and
+    ``process.mntns`` (along with ``exec.mntns``, ``exit.mntns``, the
+    ``process.ancestors`` variants and the ``ptrace``/``signal``/``setrlimit``
+    target variants) reported a constant unrelated value. The same value was fed
+    to the mount resolver as the per-PID mount namespace, which could misresolve
+    mount points and file paths for those processes.


### PR DESCRIPTION
### What does this PR do?

Adds the missing `offsetof(struct mnt_namespace, ns)` term when `hook_switch_task_namespaces`
reads a mount namespace ID, and extracts the read into a shared `get_mnt_namespace_inum()`
helper so the two call sites can no longer disagree on how to reach the field.

### Motivation

`hook_switch_task_namespaces` read `ns_common.inum` directly off the `mnt_namespace` pointer:

```c
bpf_probe_read(&inum, sizeof(inum), (void *)mnt_ns + get_ns_common_inum_offset());
```

`struct mnt_namespace` only embeds `ns` at offset 0 from Linux 5.11 onwards. Below that it sits
behind `mnt_namespace.count`, so `mnt_namespace_ns` is 8 — it is 8 for all 3225 pre-BTF entries
in `constants_amd64.json` below 5.11, 0 for the 28 5.11 entries, and `fallback.go` defaults it
to 8. With `ns_common_inum_offset` at 16 the read therefore landed on `ns_common.ops`, i.e. the
low half of the global `&mntns_operations` pointer: non-zero, stable, plausible-looking, and
identical for every mount namespace on the host.

The other reader of the same struct has always done it correctly, which is what made the
divergence easy to miss:

```c
// get_mount_mount_ns_inum
bpf_probe_read(&inum, sizeof(inum), mnt_ns + get_mnt_namespace_ns() + get_ns_common_inum_offset());
```

Consequences on affected kernels:

- `process.mntns` and its copies (`exec.mntns`, `exit.mntns`, `process.ancestors.mntns`,
  `process.parent.mntns`, and the `ptrace.tracee` / `signal.target` / `setrlimit.target`
  variants) report a constant unrelated value.
- `insertEntry` feeds the same value to `mountResolver.SetPidMntNs`, so mount and file path
  resolution can be keyed on a bogus namespace ID.

The blast radius is narrower than it looks but lands on the interesting population: `mntns_cache`
is only ever written by this hook, so only tasks that actually called `setns`/`unshare` and their
descendants get an entry — which in practice means container workloads under runc/containerd.
Everything else stays 0 and falls back to the correct procfs read in `resolver_ebpf.go`.

Introduced in #45673, which added the block with the missing term. `get_mnt_namespace_ns()`
already existed at that point (#42101). #54587 later renamed the accessor and fixed a different
instance of the same class of bug on the netns side for Linux 7.0, but did not touch this term.

### Describe how you validated your changes

| Check | Result |
| --- | --- |
| `bazel build //pkg/security/ebpf/...` | 20 targets, build completed successfully |

No new test here. The regression test is `TestSetNS/join-own-mntns` in #55126, which asserts the
reported mount namespace against the inode of `/proc/self/ns/mnt`. That assertion fails on every
pre-5.11 kernel in `vmconfig-security-agent.json` (amazon 4.14/5.4/5.10, centos 7.9/8, debian
9/10/11, oracle 7.9, rocky 8.4/8.5, suse 12.5, opensuse 15.3, ubuntu 16.04/18.04/20.04 — roughly
half the matrix) without this fix, and passes with it.

Nothing in `pkg/security/tests` asserted a mount namespace value before #55126, which is why this
survived from February.

### Additional Notes

**This needs to merge before #55126.** #55126 cannot go green on the older half of the KMT matrix
until this lands, since its own new test is what catches the bug.

Worth a backport decision: the fix changes `process.mntns` behaviour on all supported branches, and
the mount-resolver impact is a functional bug rather than a cosmetic one.

Made with [Cursor](https://cursor.com)