### PR TITLE
ci(benchmarks): retry harder on infra failures pulling the image

### DIFF
--- a/.gitlab/test/benchmarks/benchmarks.yml
+++ b/.gitlab/test/benchmarks/benchmarks.yml
@@ -6,6 +6,7 @@ benchmark:
   rules: !reference [.on_trace_agent_changes_or_manual]
   interruptible: true
   needs: ["setup_agent_version"]
+  retry: !reference [.retry_only_infra_failure, retry]
   tags: ["team:apm-k8s-tweaked-metal-datadog-agent", "specific:true"]
   variables:
     GIT_DEPTH: 0  # Full history: run-benchmarks.sh / analyze-results.sh check out BASE_BRANCH


### PR DESCRIPTION
### What does this PR do?
Add `!reference [.retry_only_infra_failure, retry]` to the `benchmark` job, so it gets max: 2 retries (up from the default max: 1) on `runner_system_failure` and the other infra-only reasons already listed in that anchor.

### Motivation
The benchmark job intermittently fails to pull
`486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:trace-agent_microbenchmarks`, rejected by containerd-image-verifier with "signature manifest not found".
It failed this way 67 times in the last 120 hours (list below), roughly once every two hours, on otherwise unrelated PRs.

GitLab classifies every one of these as `failure_reason` `runner_system_failure`, and a same-digest retry usually succeeds, so this is a transient failure in the verifier's signature lookup against a stable, already-signed image, not a bad push we could pin around: ECR confirms the tag hasn't moved off that digest, and the same exact digest is what fails and what later succeeds.

The default single retry isn't always enough (several of the 67 are two consecutive failures a few seconds apart), so this raises the ceiling to 2 specifically for infra-class failures, leaving `script_failure` (a real benchmark regression) to still fail loudly on the first try.

### Describe how you validated your changes
Confirmed `runner_system_failure` via
`dda inv gitlab.print-job -j .failure_reason` on 6 of the 67 failed jobs.

### Additional Notes
Failed benchmark jobs due to signature manifest not found, in the last 120 hours, oldest first:
- 2026-08-17T17:16:16Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1957901440
- 2026-08-17T17:29:44Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1957966115
- 2026-08-17T17:30:05Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1957978486
- 2026-08-17T17:30:46Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1957979560
- 2026-08-17T17:31:21Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1957981683
- 2026-08-17T18:06:41Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1958116496
- 2026-08-17T18:07:24Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1958134208
- 2026-08-17T18:13:15Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1958154281
- 2026-08-17T18:13:51Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1958156001
- 2026-08-17T19:21:33Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1958420724
- 2026-08-17T19:22:07Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1958436858
- 2026-08-17T19:23:02Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1958430049
- 2026-08-17T19:23:17Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1958442420
- 2026-08-17T22:30:16Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1959153945
- 2026-08-18T00:35:44Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1959345726
- 2026-08-18T00:55:20Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1959362178
- 2026-08-18T01:08:41Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1959380167
- 2026-08-18T01:12:29Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1959383578
- 2026-08-18T01:12:54Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1959384657
- 2026-08-18T14:14:01Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1960969289
- 2026-08-18T14:14:56Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1960991438
- 2026-08-18T14:15:06Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1961010171
- 2026-08-18T14:18:25Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1961012182
- 2026-08-18T14:23:43Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1961047913
- 2026-08-18T14:23:53Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1961056750
- 2026-08-18T14:33:56Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1961106495
- 2026-08-18T14:34:06Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1961124772
- 2026-08-18T14:54:50Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1961240516
- 2026-08-18T14:55:21Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1961261979
- 2026-08-18T15:48:56Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1961598530
- 2026-08-18T15:49:48Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1961637183
- 2026-08-18T16:44:02Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1961940163
- 2026-08-18T17:04:46Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1962038797
- 2026-08-18T17:08:07Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1962039944
- 2026-08-18T17:08:53Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1962053199
- 2026-08-18T17:12:59Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1962059219
- 2026-08-18T17:52:04Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1962217804
- 2026-08-18T19:59:05Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1962784427
- 2026-08-18T19:59:14Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1962794775
- 2026-08-19T09:01:58Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1964044554
- 2026-08-19T09:02:35Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1964062077
- 2026-08-19T12:42:05Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1964724693
- 2026-08-19T12:42:26Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1964736034
- 2026-08-19T14:00:41Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1965057916
- 2026-08-19T14:01:41Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1965074962
- 2026-08-19T15:23:02Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1965559069
- 2026-08-19T17:01:00Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1966030840
- 2026-08-19T17:20:40Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1966112674
- 2026-08-19T17:21:08Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1966129732
- 2026-08-19T17:34:37Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1966178529
- 2026-08-19T17:34:48Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1966185776
- 2026-08-19T18:47:38Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1966457308
- 2026-08-19T18:47:50Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1966465560
- 2026-08-19T19:45:48Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1966712132
- 2026-08-19T19:46:06Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1966725727
- 2026-08-20T06:08:48Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1967642925
- 2026-08-20T06:09:24Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1967645202
- 2026-08-20T07:32:11Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1967723613
- 2026-08-20T07:48:49Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1967745144
- 2026-08-20T07:48:58Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1967751177
- 2026-08-20T08:01:16Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1967775018
- 2026-08-20T09:41:31Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1968033406
- 2026-08-20T09:43:38Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1968049350
- 2026-08-20T11:49:26Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1968376834
- 2026-08-20T12:44:53Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1968553767
- 2026-08-20T12:45:11Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1968560723
- 2026-08-20T13:08:23Z: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1968641487