### PR TITLE
[VULN-95338] Remove curl from cluster-agent container

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -57,7 +57,7 @@ ENV PATH="/opt/datadog-agent/bin/:$PATH" \
 
 RUN apt-get update \
     && apt full-upgrade -y \
-    && apt-get install --no-install-recommends -y ca-certificates curl libseccomp2 tzdata adduser\
+    && apt-get install --no-install-recommends -y ca-certificates libseccomp2 tzdata adduser\
     && rm -rf \
       /var/cache/debconf/*-old \
       /var/lib/apt/lists/* \

--- a/releasenotes/notes/remove-curl-cluster-agent-188db3207dc253ce.yaml
+++ b/releasenotes/notes/remove-curl-cluster-agent-188db3207dc253ce.yaml
@@ -1,0 +1,6 @@
+---
+security:
+  - |
+    The ``curl`` binary is no longer included in the Cluster Agent container image, reducing its attack surface.
+    The Agent does not use the system-provided ``curl`` directly, nor should any shipped integrations.
+    Users who rely on ``curl`` being present (for example when connecting to a running container) must install it themselves in a custom image.


### PR DESCRIPTION
### What does this PR do?

Stop adding curl to the cluster-agent container.  This is theoretically a no-op change, as the agent does not use the system provided curl directly, nor should any of the integrations we ship. 

In practice, however, people ssh-ing to the container might expect curl to be there.
Or, user installed integrations might. OTOH, users making their own containers with more integrations can install the curl they feel safe with as part of that.

### Motivation

Vex scan https://datadoghq.atlassian.net/browse/VULN-95338

### Describe how you validated your changes

- CI
- Scan should clear in a few days - we have to merge and wait
