### PR TITLE
[CONTINT-5550] Fix Leader Engine initialization retrying

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -355,13 +355,6 @@ func start(log log.Component,
 		}
 	}()
 
-	// Create the Leader election engine and initialize it
-	leaderelection.CreateGlobalLeaderEngine(mainCtx)
-	le, err := leaderelection.GetLeaderEngine()
-	if err != nil {
-		return err
-	}
-
 	// Setup the leader forwarder for autoscaling failover store, language detection and cluster checks
 	if config.GetBool("cluster_checks.enabled") ||
 		(config.GetBool("language_detection.enabled") && config.GetBool("language_detection.reporting.enabled")) ||
@@ -392,6 +385,12 @@ func start(log log.Component,
 		return fmt.Errorf("Fatal error: Cannot connect to the apiserver: %v", err)
 	}
 	pkglog.Infof("Got APIClient connection")
+
+	// Initialize the leader election engine. 
+	le, err := leaderelection.WaitForLeaderEngine(mainCtx)
+	if err != nil {
+		return err
+	}
 
 	// Get hostname as aggregator requires hostname
 	hname, err := hostname.Get(mainCtx)

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -372,11 +372,6 @@ func start(log log.Component,
 		return connectivity.DiagnoseMetadataAutodiscoveryConnectivity()
 	})
 
-	// Starting server early to ease investigations
-	if err := api.StartServer(mainCtx, wmeta, taggerComp, ac, statusComponent, settings, config, ipc, diagnoseComp, dcametadataComp, clusterChecksMetadataComp, telemetry); err != nil {
-		return fmt.Errorf("Error while starting agent API, exiting: %v", err)
-	}
-
 	// Getting connection to APIServer, it's done before Hostname resolution
 	// as hostname resolution may call APIServer
 	pkglog.Info("Waiting to obtain APIClient connection")
@@ -386,10 +381,15 @@ func start(log log.Component,
 	}
 	pkglog.Infof("Got APIClient connection")
 
-	// Initialize the leader election engine. 
+	// Create the leader election engine and initialize it
 	le, err := leaderelection.WaitForLeaderEngine(mainCtx)
 	if err != nil {
 		return err
+	}
+
+	// Starting server early to ease investigations
+	if err := api.StartServer(mainCtx, wmeta, taggerComp, ac, statusComponent, settings, config, ipc, diagnoseComp, dcametadataComp, clusterChecksMetadataComp, telemetry); err != nil {
+		return fmt.Errorf("Error while starting agent API, exiting: %v", err)
 	}
 
 	// Get hostname as aggregator requires hostname

--- a/pkg/util/kubernetes/apiserver/leaderelection/BUILD.bazel
+++ b/pkg/util/kubernetes/apiserver/leaderelection/BUILD.bazel
@@ -65,6 +65,7 @@ dd_agent_go_test(
         "//pkg/errors",
         "//pkg/util/cache",
         "//pkg/util/kubernetes/apiserver",
+        "//pkg/util/retry",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@com_github_stretchr_testify//suite",

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -71,6 +71,8 @@ type LeaderEngine struct {
 	leaderIdentityMutex sync.RWMutex
 	leaderElector       *leaderelection.LeaderElector
 	lockType            string
+	initMutex sync.Mutex
+	initDone  bool
 
 	// leaderIdentity is the HolderIdentity of the current leader.
 	leaderIdentity string
@@ -161,6 +163,13 @@ func CreateGlobalLeaderEngine(ctx context.Context) *LeaderEngine {
 }
 
 func (le *LeaderEngine) init() error {
+	le.initMutex.Lock()
+	defer le.initMutex.Unlock()
+
+	if le.initDone {
+		return nil
+	}
+
 	var err error
 
 	if le.HolderIdentity == "" {
@@ -215,6 +224,7 @@ func (le *LeaderEngine) init() error {
 		return err
 	}
 	log.Debugf("Leader Engine for %q successfully initialized", le.HolderIdentity)
+	le.initDone = true
 	return nil
 }
 

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -119,6 +119,32 @@ func GetLeaderEngine() (*LeaderEngine, error) {
 	return globalLeaderEngine, nil
 }
 
+// waitForLeaderEngineSleep is declared as a variable so we can mock it in tests.
+var waitForLeaderEngineSleep = time.After
+
+// WaitForLeaderEngine creates the global leader engine if needed and will block until the engine is initialized or fails permanently.
+func WaitForLeaderEngine(ctx context.Context) (*LeaderEngine, error) {
+	CreateGlobalLeaderEngine(ctx)
+
+	for {
+		_ = globalLeaderEngine.initRetry.TriggerRetry()
+		switch globalLeaderEngine.initRetry.RetryStatus() {
+		case retry.OK:
+			return globalLeaderEngine, nil
+		case retry.PermaFail:
+			return nil, errors.New("Permanent failure while waiting for Leader Election engine")
+		default:
+			sleepFor := globalLeaderEngine.initRetry.NextRetry().UTC().Sub(time.Now().UTC()) + time.Second
+			log.Debugf("Waiting for Leader Election engine, next retry: %v", sleepFor)
+			select {
+			case <-ctx.Done():
+				return nil, errors.New("Context deadline reached while waiting for Leader Election engine")
+			case <-waitForLeaderEngineSleep(sleepFor):
+			}
+		}
+	}
+}
+
 // CreateGlobalLeaderEngine returns a non initialized leader engine client
 func CreateGlobalLeaderEngine(ctx context.Context) *LeaderEngine {
 	if globalLeaderEngine == nil {

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -71,8 +71,8 @@ type LeaderEngine struct {
 	leaderIdentityMutex sync.RWMutex
 	leaderElector       *leaderelection.LeaderElector
 	lockType            string
-	initMutex sync.Mutex
-	initDone  bool
+	initMutex           sync.Mutex
+	initDone            bool
 
 	// leaderIdentity is the HolderIdentity of the current leader.
 	leaderIdentity string

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
@@ -10,6 +10,7 @@ package leaderelection
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -20,7 +21,7 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
 	discv1 "k8s.io/api/discovery/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -30,6 +31,7 @@ import (
 	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/retry"
 )
 
 func makeLeaderLease(name, namespace, leaderIdentity string, leaseDuration int) *coordinationv1.Lease {
@@ -127,10 +129,10 @@ func TestNewLeaseAcquiring(t *testing.T) {
 			switch tt.lockType {
 			case cmLock.ConfigMapsResourceLock:
 				_, err := client.CoreV1().ConfigMaps("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
-				require.True(t, errors.IsNotFound(err))
+				require.True(t, apierrors.IsNotFound(err))
 			case rl.LeasesResourceLock:
 				_, err := client.CoordinationV1().Leases("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
-				require.True(t, errors.IsNotFound(err))
+				require.True(t, apierrors.IsNotFound(err))
 			}
 			var err error
 			le.leaderElector, err = le.newElection()
@@ -222,7 +224,7 @@ func TestSubscribe(t *testing.T) {
 			require.Len(t, le.subscribers, 2)
 
 			err := tc.getTokenFunc(client)
-			require.True(t, errors.IsNotFound(err))
+			require.True(t, apierrors.IsNotFound(err))
 
 			le.leaderElector, err = le.newElection()
 			require.NoError(t, err)
@@ -610,3 +612,116 @@ func (g *dummyGauge) WithValues(_ ...string) telemetryComponent.SimpleGauge { re
 
 // WithTags does nothing
 func (g *dummyGauge) WithTags(_ map[string]string) telemetryComponent.SimpleGauge { return nil }
+
+// TestWaitForLeaderEngine_RetriesOnTransientFailure tests that WaitForLeaderEngine retries on transient failures.
+func TestWaitForLeaderEngine_RetriesOnTransientFailure(t *testing.T) {
+	ResetGlobalLeaderEngine()
+	defer ResetGlobalLeaderEngine()
+
+	previousSleep := waitForLeaderEngineSleep
+	waitForLeaderEngineSleep = func(_ time.Duration) <-chan time.Time {
+		fired := make(chan time.Time, 1)
+		fired <- time.Now()
+		return fired
+	}
+	defer func() { waitForLeaderEngineSleep = previousSleep }()
+
+	const transientFailures = 2
+	var attempts int
+	initFn := func() error {
+		attempts++
+		if attempts <= transientFailures {
+			return fmt.Errorf("transient apiserver blip (attempt %d)", attempts)
+		}
+		return nil
+	}
+
+	globalLeaderEngine = &LeaderEngine{
+		ctx:             context.Background(),
+		HolderIdentity:  "test-pod",
+		LeaseName:       "datadog-leader-election",
+		LeaderNamespace: "default",
+		LeaseDuration:   60 * time.Second,
+		leaderMetric:    &dummyGauge{},
+	}
+	require.NoError(t, globalLeaderEngine.initRetry.SetupRetrier(&retry.Config{
+		Name:              "leaderElection",
+		AttemptMethod:     initFn,
+		Strategy:          retry.Backoff,
+		InitialRetryDelay: 1 * time.Millisecond,
+		MaxRetryDelay:     5 * time.Minute,
+	}))
+
+	le, err := WaitForLeaderEngine(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, le)
+	assert.Equal(t, transientFailures+1, attempts, "init must be retried past transient failures")
+	assert.Equal(t, retry.OK, globalLeaderEngine.initRetry.RetryStatus())
+}
+
+// TestWaitForLeaderEngine_ContextCancelled tests that WaitForLeaderEngine aborts when the context is cancelled while init keeps failing.
+func TestWaitForLeaderEngine_ContextCancelled(t *testing.T) {
+	ResetGlobalLeaderEngine()
+	defer ResetGlobalLeaderEngine()
+
+	initFn := func() error { return errors.New("apiserver still down") }
+
+	globalLeaderEngine = &LeaderEngine{
+		ctx:             context.Background(),
+		HolderIdentity:  "test-pod",
+		LeaseName:       "datadog-leader-election",
+		LeaderNamespace: "default",
+		LeaseDuration:   60 * time.Second,
+		leaderMetric:    &dummyGauge{},
+	}
+	require.NoError(t, globalLeaderEngine.initRetry.SetupRetrier(&retry.Config{
+		Name:              "leaderElection",
+		AttemptMethod:     initFn,
+		Strategy:          retry.Backoff,
+		InitialRetryDelay: 1 * time.Millisecond,
+		MaxRetryDelay:     5 * time.Minute,
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := WaitForLeaderEngine(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Context deadline reached")
+}
+
+// TestWaitForLeaderEngine_IdempotentCreate tests that WaitForLeaderEngine is idempotent.
+func TestWaitForLeaderEngine_IdempotentCreate(t *testing.T) {
+	ResetGlobalLeaderEngine()
+	defer ResetGlobalLeaderEngine()
+
+	var attempts int
+	initFn := func() error {
+		attempts++
+		return nil
+	}
+
+	globalLeaderEngine = &LeaderEngine{
+		ctx:             context.Background(),
+		HolderIdentity:  "test-pod",
+		LeaseName:       "datadog-leader-election",
+		LeaderNamespace: "default",
+		LeaseDuration:   60 * time.Second,
+		leaderMetric:    &dummyGauge{},
+	}
+	require.NoError(t, globalLeaderEngine.initRetry.SetupRetrier(&retry.Config{
+		Name:              "leaderElection",
+		AttemptMethod:     initFn,
+		Strategy:          retry.Backoff,
+		InitialRetryDelay: 1 * time.Millisecond,
+		MaxRetryDelay:     5 * time.Minute,
+	}))
+	preExisting := globalLeaderEngine
+
+	le, err := WaitForLeaderEngine(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, le)
+	assert.Same(t, preExisting, le, "WaitForLeaderEngine must reuse the existing global engine")
+	assert.Equal(t, 1, attempts)
+	assert.Equal(t, retry.OK, globalLeaderEngine.initRetry.RetryStatus())
+}

--- a/releasenotes/notes/cluster-agent-leader-engine-init-blip-e97a06095a5d4447.yaml
+++ b/releasenotes/notes/cluster-agent-leader-engine-init-blip-e97a06095a5d4447.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed the cluster agent crashing when the Leader Election Engine is temporarily unable to reach the API server during initialization.


### PR DESCRIPTION
<!--Please give us some feedback on your experience writing this PR ! https://app.datadoghq.com/forms/43db4c02-6837-400c-8083-692e141b1b88 !-->

### What does this PR do?
This PR changes the way that the global leader election engine is initialized. We will now block waiting for the leader election engine to successfully initialize, patterned after the way the apiserver client is initialized. 

### Motivation
[Bug finding brief](https://datadoghq.atlassian.net/wiki/spaces/~71202044c43e36ccff4aac9e966f298724ef65/pages/7090144314/Cluster+Agent+Crash+Due+to+Apiserver+Network+Blip+During+Startup)
[CONTINT-5550](https://datadoghq.atlassian.net/browse/CONTINT-5550)

When the leader election engine is first initialized, and the API server is temporarily unavailable, the initialization will fail with a `FailWillRetry` error, but since it happens during startup, the error ends up being bubbled up and causes the DCA to exit. 

### Describe how you validated your changes
Added three unit tests. 

### Additional Notes

[CONTINT-5550]: https://datadoghq.atlassian.net/browse/CONTINT-5550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ