### PR TITLE
[ACTP] Test PAR task verification end to end

### DIFF
--- a/pkg/privateactionrunner/adapters/constants/constants_adapter.go
+++ b/pkg/privateactionrunner/adapters/constants/constants_adapter.go
@@ -6,10 +6,15 @@
 package constants
 
 const (
-	// InternalSkipTaskVerificationEnvVar is an internal-only env var for e2e tests.
-	// When set to "true", PAR skips signed-envelope validation and allows HTTP connections.
+	// InternalSkipTaskVerificationEnvVar is an internal-only env var for tests that
+	// cannot provide Remote Config signing keys. It must not control OPMS routing.
 	// NOT intended for customer use.
 	InternalSkipTaskVerificationEnvVar = "DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION"
+
+	// InternalUseDDURLForOPMSEnvVar is an internal-only env var for tests.
+	// When set to "true", PAR sends OPMS requests to the configured dd_url.
+	// NOT intended for customer use.
+	InternalUseDDURLForOPMSEnvVar = "DD_INTERNAL_PAR_USE_DD_URL_FOR_OPMS"
 
 	// InternalEnableTelemetryEnvVar is an internal-only env var for SMP tests.
 	// When set to "true", PAR exposes the core telemetry endpoint.

--- a/pkg/privateactionrunner/opms/opms.go
+++ b/pkg/privateactionrunner/opms/opms.go
@@ -170,16 +170,14 @@ func NewClient(coreCfg model.Reader, cfg *config.Config) Client {
 	}
 }
 
-// endpointURL constructs a full URL for the given path.
-// Production always uses https://api.<site>. When DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION=true
-// (e2e tests only) and DD_DD_URL points at an http:// server, use that host directly so PAR
-// can reach an in-cluster or ECS-hosted fake OPMS over plain HTTP.
 func (c *client) endpointURL(path string) string {
-	scheme := "https"
-	host := c.config.DDApiHost
-	if os.Getenv(app.InternalSkipTaskVerificationEnvVar) == "true" && strings.HasPrefix(c.config.DDHost, "http://") {
-		scheme = "http"
-		host = strings.TrimPrefix(c.config.DDHost, "http://")
+	scheme, host := "https", c.config.DDApiHost
+	if os.Getenv(app.InternalUseDDURLForOPMSEnvVar) == "true" {
+		host = c.config.DDHost
+		if strings.HasPrefix(host, "http://") {
+			scheme = "http"
+		}
+		host = strings.TrimPrefix(strings.TrimPrefix(host, "http://"), "https://")
 	}
 	return (&url.URL{Scheme: scheme, Host: host, Path: path}).String()
 }

--- a/pkg/privateactionrunner/opms/opms_test.go
+++ b/pkg/privateactionrunner/opms/opms_test.go
@@ -41,20 +41,57 @@ func newTestKey(t *testing.T) *ecdsa.PrivateKey {
 }
 
 // newTestClient builds a client wired to the given httptest server.
-// It sets DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION so endpointURL uses plain HTTP.
 func newTestClient(t *testing.T, srv *httptest.Server) *client {
 	t.Helper()
-	t.Setenv(app.InternalSkipTaskVerificationEnvVar, "true")
+	t.Setenv(app.InternalUseDDURLForOPMSEnvVar, "true")
 	return &client{
 		httpClient: &http.Client{Timeout: 5 * time.Second},
 		config: &config.Config{
-			DDHost:             srv.URL, // "http://127.0.0.1:PORT"
+			DDHost:             srv.URL,
 			OpmsRequestTimeout: 5000,
 			OrgId:              1,
 			RunnerId:           "test-runner",
 			PrivateKey:         newTestKey(t),
 		},
 		runnerStartedAt: time.Now().UTC(),
+	}
+}
+
+func TestEndpointURL(t *testing.T) {
+	cfg := &config.Config{
+		DDHost:    "http://fakeintake.test:8080",
+		DDApiHost: "api.datadoghq.com",
+	}
+	client := &client{config: cfg}
+
+	assert.Equal(t, "https://api.datadoghq.com/task", client.endpointURL("/task"))
+
+	t.Setenv(app.InternalUseDDURLForOPMSEnvVar, "true")
+	for _, test := range []struct {
+		name     string
+		ddHost   string
+		expected string
+	}{
+		{
+			name:     "HTTP URL",
+			ddHost:   "http://fakeintake.test:8080",
+			expected: "http://fakeintake.test:8080/task",
+		},
+		{
+			name:     "HTTPS URL",
+			ddHost:   "https://fakeintake.test:8443",
+			expected: "https://fakeintake.test:8443/task",
+		},
+		{
+			name:     "normalized HTTPS URL",
+			ddHost:   "fakeintake.test:8443",
+			expected: "https://fakeintake.test:8443/task",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			client.config.DDHost = test.ddHost
+			assert.Equal(t, test.expected, client.endpointURL("/task"))
+		})
 	}
 }
 

--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -1152,8 +1152,6 @@ func (values HelmValues) configureFakeintake(e config.Env, fi *fakeintake.Fakein
 
 	// Configure the Private Action Runner sidecar to route OPMS calls through fakeintake.
 	// This is a no-op when PAR is not deployed — the Helm chart ignores unknown container configs.
-	// DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION bypasses signed-envelope validation so PAR can talk
-	// to fakeintake over plain HTTP instead of the real OPMS backend.
 	if agents, ok := values["agents"].(pulumi.Map); ok {
 		containers, ok := agents["containers"].(pulumi.Map)
 		if !ok {
@@ -1170,8 +1168,7 @@ func (values HelmValues) configureFakeintake(e config.Env, fi *fakeintake.Fakein
 			parEnvDict = pulumi.StringMap{}
 			par["envDict"] = parEnvDict
 		}
-		parEnvDict["DD_DD_URL"] = pulumi.Sprintf("%s", fi.URL)
-		parEnvDict["DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION"] = pulumi.String("true")
+		parEnvDict["DD_INTERNAL_PAR_USE_DD_URL_FOR_OPMS"] = pulumi.String("true")
 	}
 
 	return nil

--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -1168,6 +1168,7 @@ func (values HelmValues) configureFakeintake(e config.Env, fi *fakeintake.Fakein
 			parEnvDict = pulumi.StringMap{}
 			par["envDict"] = parEnvDict
 		}
+		parEnvDict["DD_DD_URL"] = pulumi.Sprintf("%s", fi.URL)
 		parEnvDict["DD_INTERNAL_PAR_USE_DD_URL_FOR_OPMS"] = pulumi.String("true")
 	}
 

--- a/test/new-e2e/tests/privateactionrunner/BUILD.bazel
+++ b/test/new-e2e/tests/privateactionrunner/BUILD.bazel
@@ -6,10 +6,12 @@ go_library(
     srcs = [
         "identity.go",
         "provisioner.go",
+        "rc_helpers.go",
     ],
     importpath = "github.com/DataDog/datadog-agent/test/new-e2e/tests/privateactionrunner",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/remoteconfig/state",
         "//test/e2e-framework/common/utils",
         "//test/e2e-framework/components/command",
         "//test/e2e-framework/components/datadog/agent/helm",
@@ -22,9 +24,11 @@ go_library(
         "//test/e2e-framework/testing/environments",
         "//test/e2e-framework/testing/provisioners",
         "//test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm",
+        "//test/fakeintake/client",
         "@com_github_go_jose_go_jose_v4//:go-jose",
         "@com_github_pulumi_pulumi_kubernetes_sdk_v4//go/kubernetes",
         "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )
@@ -51,6 +55,7 @@ dd_agent_go_test(
         "@com_github_google_uuid//:uuid",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
     ],
 )

--- a/test/new-e2e/tests/privateactionrunner/BUILD.bazel
+++ b/test/new-e2e/tests/privateactionrunner/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     importpath = "github.com/DataDog/datadog-agent/test/new-e2e/tests/privateactionrunner",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/remoteconfig/state",
         "//test/e2e-framework/common/utils",
         "//test/e2e-framework/components/command",
         "//test/e2e-framework/components/datadog/agent/helm",
@@ -28,7 +27,6 @@ go_library(
         "@com_github_go_jose_go_jose_v4//:go-jose",
         "@com_github_pulumi_pulumi_kubernetes_sdk_v4//go/kubernetes",
         "@com_github_pulumi_pulumi_sdk_v3//go/pulumi",
-        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/test/new-e2e/tests/privateactionrunner/identity.go
+++ b/test/new-e2e/tests/privateactionrunner/identity.go
@@ -18,7 +18,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testRunnerURN = "urn:dd:apps:on-prem-runner:us1:123456:test-runner-e2e"
+const (
+	testRunnerURN = "urn:dd:apps:on-prem-runner:us1:123456:test-runner-e2e"
+
+	// The org/runner ID segments encoded in testRunnerURN.
+	testRunnerOrgID    int64 = 123456
+	testRunnerRunnerID       = "test-runner-e2e"
+)
 
 // GenerateTestRunnerIdentity generates a fresh ECDSA key pair and returns the
 // runner URN and base64-encoded private JWK for agent config or Helm values.

--- a/test/new-e2e/tests/privateactionrunner/private_action_runner_enabled_test.go
+++ b/test/new-e2e/tests/privateactionrunner/private_action_runner_enabled_test.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	privateActionRunnerStartedLogLine = "Private action runner starting"
+	privateActionRunnerStartedLogLine     = "Private action runner starting"
+	privateActionRunnerKeysManagerLogLine = "Keys manager ready"
 )
 
 func generateTestPrivateActionRunnerConfig(t *testing.T) string {
@@ -37,9 +38,8 @@ func TestLinuxPrivateActionRunnerEnabledSuite(t *testing.T) {
 	t.Parallel()
 	config := generateTestPrivateActionRunnerConfig(t)
 	e2e.Run(t, &linuxPrivateActionRunnerEnabledSuite{}, e2e.WithProvisioner(
-		awshost.ProvisionerNoFakeIntake(
+		awshost.Provisioner(
 			awshost.WithRunOptions(
-				scenec2.WithoutFakeIntake(),
 				scenec2.WithAgentOptions(agentparams.WithAgentConfig(config)),
 			),
 		),
@@ -50,6 +50,8 @@ func (s *linuxPrivateActionRunnerEnabledSuite) TestPrivateActionRunnerStartsWhen
 	host := s.Env().RemoteHost
 	svcManager := common.GetServiceManager(host)
 	s.Require().NotNil(svcManager)
+
+	PushFakeRunnerKeysConfig(s.T(), s.Env().FakeIntake.Client())
 
 	// Start the private action runner service
 	_, err := svcManager.Start(privateActionRunnerServiceName)
@@ -78,12 +80,23 @@ func (s *linuxPrivateActionRunnerEnabledSuite) TestPrivateActionRunnerStartsWhen
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
 		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -i %q %s", privateActionRunnerStartedLogLine, privateActionRunnerLogFile))
 	}, 2*time.Minute, 5*time.Second, "private action runner log should contain the started message")
+
+	// Readiness depends on the KeysManager receiving its first AP_RUNNER_KEYS
+	// remote-config update. The backend director's first fetch of a brand-new
+	// product can take well over 2 minutes regardless of the client's poll
+	// interval (observed ~2m10s in CI), so this needs a longer budget than the
+	// other checks in this test.
+	s.Require().EventuallyWithT(func(c *assert.CollectT) {
+		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -F %q %s", privateActionRunnerKeysManagerLogLine, privateActionRunnerLogFile))
+	}, 5*time.Minute, 5*time.Second, "private action runner log should report the keys manager ready")
 }
 
 func (s *linuxPrivateActionRunnerEnabledSuite) TestPrivateActionRunnerServiceRestart() {
 	host := s.Env().RemoteHost
 	svcManager := common.GetServiceManager(host)
 	s.Require().NotNil(svcManager)
+
+	PushFakeRunnerKeysConfig(s.T(), s.Env().FakeIntake.Client())
 
 	// Ensure service is started
 	_, err := svcManager.Start(privateActionRunnerServiceName)

--- a/test/new-e2e/tests/privateactionrunner/private_action_runner_enabled_test.go
+++ b/test/new-e2e/tests/privateactionrunner/private_action_runner_enabled_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
 	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
@@ -51,10 +52,21 @@ func (s *linuxPrivateActionRunnerEnabledSuite) TestPrivateActionRunnerStartsWhen
 	svcManager := common.GetServiceManager(host)
 	s.Require().NotNil(svcManager)
 
+	// Keep the core Agent from fetching the signing key before PAR has subscribed.
+	_, err := svcManager.Stop(coreAgentServiceName)
+	s.Require().NoError(err)
+	s.T().Cleanup(func() {
+		_, _ = svcManager.Start(coreAgentServiceName)
+	})
+	s.Require().EventuallyWithT(func(c *assert.CollectT) {
+		_, statusErr := svcManager.Status(coreAgentServiceName)
+		require.Error(c, statusErr)
+	}, 30*time.Second, time.Second, "core Agent should be stopped")
+
 	PushFakeRunnerKeysConfig(s.T(), s.Env().FakeIntake.Client())
 
 	// Start the private action runner service
-	_, err := svcManager.Start(privateActionRunnerServiceName)
+	_, err = svcManager.Start(privateActionRunnerServiceName)
 	s.Require().NoError(err)
 
 	// Verify the service is running
@@ -81,11 +93,16 @@ func (s *linuxPrivateActionRunnerEnabledSuite) TestPrivateActionRunnerStartsWhen
 		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -i %q %s", privateActionRunnerStartedLogLine, privateActionRunnerLogFile))
 	}, 2*time.Minute, 5*time.Second, "private action runner log should contain the started message")
 
-	// Readiness depends on the KeysManager receiving its first AP_RUNNER_KEYS
-	// remote-config update. The backend director's first fetch of a brand-new
-	// product can take well over 2 minutes regardless of the client's poll
-	// interval (observed ~2m10s in CI), so this needs a longer budget than the
-	// other checks in this test.
+	// PAR is now running and subscribed. Restart the core Agent so its first
+	// remote-config fetch includes AP_RUNNER_KEYS and delivers the signing key.
+	_, err = svcManager.Start(coreAgentServiceName)
+	s.Require().NoError(err)
+	s.Require().EventuallyWithT(func(c *assert.CollectT) {
+		status, statusErr := svcManager.Status(coreAgentServiceName)
+		require.NoError(c, statusErr)
+		require.Contains(c, status, "active")
+	}, 2*time.Minute, 5*time.Second, "core Agent should be active")
+
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
 		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -F %q %s", privateActionRunnerKeysManagerLogLine, privateActionRunnerLogFile))
 	}, 5*time.Minute, 5*time.Second, "private action runner log should report the keys manager ready")

--- a/test/new-e2e/tests/privateactionrunner/private_action_runner_enabled_test.go
+++ b/test/new-e2e/tests/privateactionrunner/private_action_runner_enabled_test.go
@@ -80,16 +80,28 @@ func (s *linuxPrivateActionRunnerEnabledSuite) TestPrivateActionRunnerStartsWhen
 		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -i %q %s", privateActionRunnerStartedLogLine, privateActionRunnerLogFile))
 	}, 2*time.Minute, 5*time.Second, "private action runner log should contain the started message")
 
-	// Push the key only after PAR has subscribed. This bumps the fakeintake RC
-	// version after the Core Agent knows about the AP_RUNNER_KEYS client.
+	// Push the key only after PAR has subscribed and the Core Agent has had time
+	// to report the AP_RUNNER_KEYS client in its backend requests.
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
 		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -F %q %s", privateActionRunnerRCSubscribedLogLine, privateActionRunnerLogFile))
 	}, 2*time.Minute, 5*time.Second, "private action runner should subscribe to remote config")
-	PushFakeRunnerKeysConfig(s.T(), s.Env().FakeIntake.Client())
+
+	client := s.Env().FakeIntake.Client()
+	stats, err := client.RCStats()
+	s.Require().NoError(err)
+	s.Require().EventuallyWithT(func(c *assert.CollectT) {
+		current, statsErr := client.RCStats()
+		assert.NoError(c, statsErr)
+		if statsErr == nil {
+			assert.GreaterOrEqual(c, current.Polls, stats.Polls+2)
+		}
+	}, 45*time.Second, time.Second, "Core Agent should poll after PAR subscribes")
+	PushFakeRunnerKeysConfig(s.T(), client)
+	WaitForFakeRunnerKeyAcknowledged(s.T(), client, 5*time.Minute)
 
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
 		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -F %q %s", privateActionRunnerKeysManagerLogLine, privateActionRunnerLogFile))
-	}, 5*time.Minute, 5*time.Second, "private action runner log should report the keys manager ready")
+	}, 30*time.Second, time.Second, "private action runner log should report the keys manager ready")
 }
 
 func (s *linuxPrivateActionRunnerEnabledSuite) TestPrivateActionRunnerServiceRestart() {

--- a/test/new-e2e/tests/privateactionrunner/private_action_runner_enabled_test.go
+++ b/test/new-e2e/tests/privateactionrunner/private_action_runner_enabled_test.go
@@ -97,7 +97,6 @@ func (s *linuxPrivateActionRunnerEnabledSuite) TestPrivateActionRunnerStartsWhen
 		}
 	}, 45*time.Second, time.Second, "Core Agent should poll after PAR subscribes")
 	PushFakeRunnerKeysConfig(s.T(), client)
-	WaitForFakeRunnerKeyAcknowledged(s.T(), client, 5*time.Minute)
 
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
 		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -F %q %s", privateActionRunnerKeysManagerLogLine, privateActionRunnerLogFile))

--- a/test/new-e2e/tests/privateactionrunner/private_action_runner_enabled_test.go
+++ b/test/new-e2e/tests/privateactionrunner/private_action_runner_enabled_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
 	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
@@ -23,8 +22,9 @@ import (
 )
 
 const (
-	privateActionRunnerStartedLogLine     = "Private action runner starting"
-	privateActionRunnerKeysManagerLogLine = "Keys manager ready"
+	privateActionRunnerStartedLogLine      = "Private action runner starting"
+	privateActionRunnerRCSubscribedLogLine = "Subscribing to remote config updates"
+	privateActionRunnerKeysManagerLogLine  = "Keys manager ready"
 )
 
 func generateTestPrivateActionRunnerConfig(t *testing.T) string {
@@ -52,21 +52,8 @@ func (s *linuxPrivateActionRunnerEnabledSuite) TestPrivateActionRunnerStartsWhen
 	svcManager := common.GetServiceManager(host)
 	s.Require().NotNil(svcManager)
 
-	// Keep the core Agent from fetching the signing key before PAR has subscribed.
-	_, err := svcManager.Stop(coreAgentServiceName)
-	s.Require().NoError(err)
-	s.T().Cleanup(func() {
-		_, _ = svcManager.Start(coreAgentServiceName)
-	})
-	s.Require().EventuallyWithT(func(c *assert.CollectT) {
-		_, statusErr := svcManager.Status(coreAgentServiceName)
-		require.Error(c, statusErr)
-	}, 30*time.Second, time.Second, "core Agent should be stopped")
-
-	PushFakeRunnerKeysConfig(s.T(), s.Env().FakeIntake.Client())
-
 	// Start the private action runner service
-	_, err = svcManager.Start(privateActionRunnerServiceName)
+	_, err := svcManager.Start(privateActionRunnerServiceName)
 	s.Require().NoError(err)
 
 	// Verify the service is running
@@ -93,15 +80,12 @@ func (s *linuxPrivateActionRunnerEnabledSuite) TestPrivateActionRunnerStartsWhen
 		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -i %q %s", privateActionRunnerStartedLogLine, privateActionRunnerLogFile))
 	}, 2*time.Minute, 5*time.Second, "private action runner log should contain the started message")
 
-	// PAR is now running and subscribed. Restart the core Agent so its first
-	// remote-config fetch includes AP_RUNNER_KEYS and delivers the signing key.
-	_, err = svcManager.Start(coreAgentServiceName)
-	s.Require().NoError(err)
+	// Push the key only after PAR has subscribed. This bumps the fakeintake RC
+	// version after the Core Agent knows about the AP_RUNNER_KEYS client.
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
-		status, statusErr := svcManager.Status(coreAgentServiceName)
-		require.NoError(c, statusErr)
-		require.Contains(c, status, "active")
-	}, 2*time.Minute, 5*time.Second, "core Agent should be active")
+		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -F %q %s", privateActionRunnerRCSubscribedLogLine, privateActionRunnerLogFile))
+	}, 2*time.Minute, 5*time.Second, "private action runner should subscribe to remote config")
+	PushFakeRunnerKeysConfig(s.T(), s.Env().FakeIntake.Client())
 
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
 		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -F %q %s", privateActionRunnerKeysManagerLogLine, privateActionRunnerLogFile))

--- a/test/new-e2e/tests/privateactionrunner/private_action_runner_executor_nix_test.go
+++ b/test/new-e2e/tests/privateactionrunner/private_action_runner_executor_nix_test.go
@@ -16,7 +16,9 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
 	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -52,6 +54,21 @@ func TestLinuxPrivateActionRunnerExecutorSuite(t *testing.T) {
 // the log reports the server listening and ready.
 func (s *linuxPrivateActionRunnerExecutorSuite) TestExecutorStartsAndListens() {
 	host := s.Env().RemoteHost
+	svcManager := common.GetServiceManager(host)
+	s.Require().NotNil(svcManager)
+
+	// The executor's remote-config client talks to the core Agent. Stop the Agent
+	// first so the executor has subscribed to AP_RUNNER_KEYS before the Agent's
+	// remote-config service performs its first fetch.
+	_, err := svcManager.Stop(coreAgentServiceName)
+	s.Require().NoError(err)
+	s.T().Cleanup(func() {
+		_, _ = svcManager.Start(coreAgentServiceName)
+	})
+	s.Require().EventuallyWithT(func(c *assert.CollectT) {
+		_, statusErr := svcManager.Status(coreAgentServiceName)
+		require.Error(c, statusErr)
+	}, 30*time.Second, time.Second, "core Agent should be stopped")
 
 	PushFakeRunnerKeysConfig(s.T(), s.Env().FakeIntake.Client())
 
@@ -86,6 +103,17 @@ func (s *linuxPrivateActionRunnerExecutorSuite) TestExecutorStartsAndListens() {
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
 		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -F %q %s", executorListeningLogLine, privateActionRunnerLogFile))
 	}, 2*time.Minute, 5*time.Second, "executor log should report listening")
+
+	// The executor is now listening but waiting for its first signing-key update.
+	// Start the core Agent only after the AP_RUNNER_KEYS subscription is in place;
+	// its first remote-config request can then include the product immediately.
+	_, err = svcManager.Start(coreAgentServiceName)
+	s.Require().NoError(err)
+	s.Require().EventuallyWithT(func(c *assert.CollectT) {
+		status, statusErr := svcManager.Status(coreAgentServiceName)
+		require.NoError(c, statusErr)
+		require.Contains(c, status, "active")
+	}, 2*time.Minute, 5*time.Second, "core Agent should be active")
 
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
 		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -F %q %s", executorReadyLogLine, privateActionRunnerLogFile))

--- a/test/new-e2e/tests/privateactionrunner/private_action_runner_executor_nix_test.go
+++ b/test/new-e2e/tests/privateactionrunner/private_action_runner_executor_nix_test.go
@@ -6,11 +6,6 @@
 package privateactionrunner
 
 import (
-	"crypto/ed25519"
-	"crypto/rand"
-	"crypto/x509"
-	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"strings"
 	"testing"
@@ -21,9 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
 	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
-	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -31,20 +24,10 @@ const (
 	privateActionRunnerBinary     = "/opt/datadog-agent/embedded/bin/privateactionrunner"
 	privateActionRunnerConfigPath = "/etc/datadog-agent/datadog.yaml"
 	executorSocketPath            = "/opt/datadog-agent/run/par-executor.sock"
-	coreAgentServiceName          = "datadog-agent"
 
 	executorListeningLogLine = "Private action runner executor listening on"
 	executorReadyLogLine     = "Private action runner executor ready to accept actions"
-
-	// pkg/remoteconfig/state.ProductActionPlatformRunnerKeys
-	runnerKeysRCProduct = "AP_RUNNER_KEYS"
 )
-
-// mirrors pkg/privateactionrunner/types.RawKey's JSON shape
-type rawRCKey struct {
-	KeyType string `json:"keyType"`
-	Key     []byte `json:"key"`
-}
 
 type linuxPrivateActionRunnerExecutorSuite struct {
 	e2e.BaseSuite[environments.Host]
@@ -64,46 +47,13 @@ func TestLinuxPrivateActionRunnerExecutorSuite(t *testing.T) {
 	))
 }
 
-func (s *linuxPrivateActionRunnerExecutorSuite) pushFakeRunnerKeysConfig() {
-	t := s.T()
-
-	pub, _, err := ed25519.GenerateKey(rand.Reader)
-	require.NoError(t, err, "failed to generate fake runner key")
-
-	pubDER, err := x509.MarshalPKIXPublicKey(pub)
-	require.NoError(t, err, "failed to marshal fake runner public key")
-
-	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
-
-	payload, err := json.Marshal(rawRCKey{KeyType: "ED25519", Key: pubPEM})
-	require.NoError(t, err, "failed to marshal fake runner key config payload")
-
-	err = s.Env().FakeIntake.Client().RCAddConfig("", runnerKeysRCProduct, "fake-runner-key", "fake-runner-key", payload)
-	require.NoError(t, err, "failed to push fake runner key config to fakeintake")
-}
-
 // TestExecutorStartsAndListens launches the on-demand executor subcommand and
 // asserts it comes up: the process runs, the gRPC unix socket is created, and
 // the log reports the server listening and ready.
 func (s *linuxPrivateActionRunnerExecutorSuite) TestExecutorStartsAndListens() {
 	host := s.Env().RemoteHost
-	svcManager := common.GetServiceManager(host)
-	s.Require().NotNil(svcManager)
 
-	// The executor's remote-config client talks to the core Agent. Stop the Agent
-	// first so the executor has subscribed to AP_RUNNER_KEYS before the Agent's
-	// remote-config service performs its first fetch.
-	_, err := svcManager.Stop(coreAgentServiceName)
-	s.Require().NoError(err)
-	s.T().Cleanup(func() {
-		_, _ = svcManager.Start(coreAgentServiceName)
-	})
-	s.Require().EventuallyWithT(func(c *assert.CollectT) {
-		_, statusErr := svcManager.Status(coreAgentServiceName)
-		require.Error(c, statusErr)
-	}, 30*time.Second, time.Second, "core Agent should be stopped")
-
-	s.pushFakeRunnerKeysConfig()
+	PushFakeRunnerKeysConfig(s.T(), s.Env().FakeIntake.Client())
 
 	// run-executor is a foreground subcommand, not the packaged systemd service.
 	// Launch it detached as dd-agent so it can bind its socket under
@@ -136,17 +86,6 @@ func (s *linuxPrivateActionRunnerExecutorSuite) TestExecutorStartsAndListens() {
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
 		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -F %q %s", executorListeningLogLine, privateActionRunnerLogFile))
 	}, 2*time.Minute, 5*time.Second, "executor log should report listening")
-
-	// The executor is now listening but waiting for its first signing-key update.
-	// Start the core Agent only after the AP_RUNNER_KEYS subscription is in place;
-	// its first remote-config request can then include the product immediately.
-	_, err = svcManager.Start(coreAgentServiceName)
-	s.Require().NoError(err)
-	s.Require().EventuallyWithT(func(c *assert.CollectT) {
-		status, statusErr := svcManager.Status(coreAgentServiceName)
-		require.NoError(c, statusErr)
-		require.Contains(c, status, "active")
-	}, 2*time.Minute, 5*time.Second, "core Agent should be active")
 
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
 		host.MustExecuteOn(c, fmt.Sprintf("sudo grep -F %q %s", executorReadyLogLine, privateActionRunnerLogFile))

--- a/test/new-e2e/tests/privateactionrunner/private_action_runner_nix_test.go
+++ b/test/new-e2e/tests/privateactionrunner/private_action_runner_nix_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 const (
+	coreAgentServiceName           = "datadog-agent"
 	privateActionRunnerServiceName = "datadog-agent-action"
 	privateActionRunnerLogFile     = "/var/log/datadog/private-action-runner.log"
 

--- a/test/new-e2e/tests/privateactionrunner/provisioner.go
+++ b/test/new-e2e/tests/privateactionrunner/provisioner.go
@@ -38,8 +38,9 @@ const (
 )
 
 // parHelmValuesTemplate configures the agent with PAR enabled.
-// Fakeintake URL wiring (DD_DD_URL, DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION) is handled
-// automatically by the e2e framework's configureFakeintake when fakeintake is present.
+// Fakeintake URL wiring (DD_DD_URL) is handled automatically by the e2e framework's
+// configureFakeintake when fakeintake is present. See SetupPARTaskSigning for the
+// signing identity dequeued tasks need to pass verification.
 // %s parameters: clusterName, runnerURN, privateKeyB64, systemServiceOperatorPolicy
 const parHelmValuesTemplate = `
 datadog:
@@ -134,8 +135,8 @@ func parK8sProvisioner(runnerURN, privateKeyB64 string) provisioners.Provisioner
 			}
 
 			// 5. Deploy Datadog agent via Helm with PAR enabled.
-			// DD_DD_URL and DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION for the PAR container are
-			// injected automatically by the e2e framework's configureFakeintake.
+			// DD_DD_URL for the PAR container is injected automatically by the e2e
+			// framework's configureFakeintake.
 			agent, err := helm.NewKubernetesAgent(&awsEnv, name, kubeProvider,
 				kubernetesagentparams.WithFakeintake(fi),
 				kubernetesagentparams.WithHelmValues(fmt.Sprintf(

--- a/test/new-e2e/tests/privateactionrunner/rc_helpers.go
+++ b/test/new-e2e/tests/privateactionrunner/rc_helpers.go
@@ -69,6 +69,8 @@ func WaitForFakeRunnerKeyAcknowledged(t *testing.T, client *fakeintakeclient.Cli
 		assert.NoError(c, err)
 		for _, applyState := range stats.ApplyStates {
 			if applyState.Product == runnerKeysRCProduct && applyState.ConfigID == fakeRunnerKeyConfigID {
+				assert.Equal(c, stats.Version, applyState.Version,
+					"PAR acknowledged a stale signing key version")
 				assert.Equal(c, uint64(remoteconfigstate.ApplyStateAcknowledged), applyState.ApplyState,
 					"PAR did not acknowledge the signing key: %s", applyState.ApplyError)
 				return

--- a/test/new-e2e/tests/privateactionrunner/rc_helpers.go
+++ b/test/new-e2e/tests/privateactionrunner/rc_helpers.go
@@ -12,12 +12,9 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	remoteconfigstate "github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	fakeintakeclient "github.com/DataDog/datadog-agent/test/fakeintake/client"
 )
 
@@ -59,25 +56,6 @@ func pushRunnerPublicKey(t *testing.T, client *fakeintakeclient.Client, keyID st
 func PushFakeRunnerKeysConfig(t *testing.T, client *fakeintakeclient.Client) {
 	t.Helper()
 	pushRunnerPublicKey(t, client, fakeRunnerKeyConfigID)
-}
-
-// WaitForFakeRunnerKeyAcknowledged waits until PAR reports that it loaded the signing key.
-func WaitForFakeRunnerKeyAcknowledged(t *testing.T, client *fakeintakeclient.Client, timeout time.Duration) {
-	t.Helper()
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		stats, err := client.RCStats()
-		assert.NoError(c, err)
-		for _, applyState := range stats.ApplyStates {
-			if applyState.Product == runnerKeysRCProduct && applyState.ConfigID == fakeRunnerKeyConfigID {
-				assert.Equal(c, stats.Version, applyState.Version,
-					"PAR acknowledged a stale signing key version")
-				assert.Equal(c, uint64(remoteconfigstate.ApplyStateAcknowledged), applyState.ApplyState,
-					"PAR did not acknowledge the signing key: %s", applyState.ApplyError)
-				return
-			}
-		}
-		assert.Fail(c, "PAR has not reported an apply state for the signing key")
-	}, timeout, 3*time.Second, "PAR should acknowledge the signing key through Remote Config")
 }
 
 // SetupPARTaskSigning additionally registers the private key with fakeintake's PAR

--- a/test/new-e2e/tests/privateactionrunner/rc_helpers.go
+++ b/test/new-e2e/tests/privateactionrunner/rc_helpers.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package privateactionrunner
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	remoteconfigstate "github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	fakeintakeclient "github.com/DataDog/datadog-agent/test/fakeintake/client"
+)
+
+// pkg/remoteconfig/state.ProductActionPlatformRunnerKeys
+const runnerKeysRCProduct = "AP_RUNNER_KEYS"
+
+const fakeRunnerKeyConfigID = "fake-runner-key"
+
+// mirrors pkg/privateactionrunner/types.RawKey's JSON shape
+type rawRCKey struct {
+	KeyType string `json:"keyType"`
+	Key     []byte `json:"key"`
+}
+
+// pushRunnerPublicKey pushes a fresh ED25519 public key to fakeintake as an
+// AP_RUNNER_KEYS remote-config update, returning the private half.
+func pushRunnerPublicKey(t *testing.T, client *fakeintakeclient.Client, keyID string) ed25519.PrivateKey {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err, "failed to generate fake runner key")
+
+	pubDER, err := x509.MarshalPKIXPublicKey(pub)
+	require.NoError(t, err, "failed to marshal fake runner public key")
+
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+
+	payload, err := json.Marshal(rawRCKey{KeyType: "ED25519", Key: pubPEM})
+	require.NoError(t, err, "failed to marshal fake runner key config payload")
+
+	err = client.RCAddConfig("", runnerKeysRCProduct, keyID, keyID, payload)
+	require.NoError(t, err, "failed to push fake runner key config to fakeintake")
+
+	return priv
+}
+
+// PushFakeRunnerKeysConfig lets a PAR under test complete KeysManager startup
+// without a real backend.
+func PushFakeRunnerKeysConfig(t *testing.T, client *fakeintakeclient.Client) {
+	t.Helper()
+	pushRunnerPublicKey(t, client, fakeRunnerKeyConfigID)
+}
+
+// WaitForFakeRunnerKeyAcknowledged waits until PAR reports that it loaded the signing key.
+func WaitForFakeRunnerKeyAcknowledged(t *testing.T, client *fakeintakeclient.Client, timeout time.Duration) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		stats, err := client.RCStats()
+		assert.NoError(c, err)
+		for _, applyState := range stats.ApplyStates {
+			if applyState.Product == runnerKeysRCProduct && applyState.ConfigID == fakeRunnerKeyConfigID {
+				assert.Equal(c, uint64(remoteconfigstate.ApplyStateAcknowledged), applyState.ApplyState,
+					"PAR did not acknowledge the signing key: %s", applyState.ApplyError)
+				return
+			}
+		}
+		assert.Fail(c, "PAR has not reported an apply state for the signing key")
+	}, timeout, 3*time.Second, "PAR should acknowledge the signing key through Remote Config")
+}
+
+// SetupPARTaskSigning additionally registers the private key with fakeintake's PAR
+// server so dequeued tasks pass real signature verification.
+func SetupPARTaskSigning(t *testing.T, client *fakeintakeclient.Client, orgID int64, runnerID string) {
+	t.Helper()
+
+	priv := pushRunnerPublicKey(t, client, fakeRunnerKeyConfigID)
+
+	err := client.SetPARSigningKey(
+		fakeRunnerKeyConfigID,
+		priv,
+		orgID,
+		runnerID,
+		"connection:execgroup_ddagent:par-rshell-e2e",
+	)
+	require.NoError(t, err, "failed to register PAR signing key with fakeintake")
+}

--- a/test/new-e2e/tests/privateactionrunner/rshell_k8s_test.go
+++ b/test/new-e2e/tests/privateactionrunner/rshell_k8s_test.go
@@ -73,9 +73,6 @@ func (s *parK8sSuite) SetupSuite() {
 	}()
 	keyPushed = true
 
-	started := time.Now()
-	WaitForFakeRunnerKeyAcknowledged(s.T(), s.Env().FakeIntake.Client(), 5*time.Minute)
-	s.T().Logf("PAR acknowledged the signing key after %s", time.Since(started))
 	s.waitForPARReady()
 }
 

--- a/test/new-e2e/tests/privateactionrunner/rshell_k8s_test.go
+++ b/test/new-e2e/tests/privateactionrunner/rshell_k8s_test.go
@@ -387,7 +387,6 @@ func (s *parK8sSuite) waitForPARReady() {
 	}, 5*time.Minute, 3*time.Second, "PAR should start polling fakeintake")
 	pollingObserved = true
 	s.T().Logf("PAR started polling fakeintake %s after its container became Ready", time.Since(dequeueStarted))
-	s.logPARContainerLogs(selector, "dequeue polling started")
 }
 
 func (s *parK8sSuite) logPARContainerLogs(selector, reason string) {

--- a/test/new-e2e/tests/privateactionrunner/rshell_k8s_test.go
+++ b/test/new-e2e/tests/privateactionrunner/rshell_k8s_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
@@ -49,10 +50,32 @@ func TestPARRshellK8sSuite(t *testing.T) {
 	e2e.Run(t, suite, e2e.WithProvisioner(parK8sProvisioner(urn, keyB64)))
 }
 
-// SetupSuite waits for PAR to be ready and actively polling fakeintake.
+// SetupSuite registers a signing identity with fakeintake, then waits for PAR to be
+// ready and actively polling.
 func (s *parK8sSuite) SetupSuite() {
 	s.BaseSuite.SetupSuite()
 	defer s.CleanupOnSetupFailure()
+	selector := s.Env().Agent.LinuxNodeAgent.LabelSelectors["app"]
+	keyPushed := false
+	defer func() {
+		if !keyPushed {
+			s.logPARContainerLogs(selector, "signing key push failure")
+		}
+	}()
+
+	s.T().Log("Pushing the PAR signing key through fakeintake Remote Config")
+	func() {
+		started := time.Now()
+		defer func() {
+			s.T().Logf("PAR signing key push finished after %s", time.Since(started))
+		}()
+		SetupPARTaskSigning(s.T(), s.Env().FakeIntake.Client(), testRunnerOrgID, testRunnerRunnerID)
+	}()
+	keyPushed = true
+
+	started := time.Now()
+	WaitForFakeRunnerKeyAcknowledged(s.T(), s.Env().FakeIntake.Client(), 5*time.Minute)
+	s.T().Logf("PAR acknowledged the signing key after %s", time.Since(started))
 	s.waitForPARReady()
 }
 
@@ -327,9 +350,10 @@ func rshellExitCode(t *testing.T, result *api.PARTaskResult) int {
 }
 
 // waitForPARReady waits until the private-action-runner container is Ready
-// and fakeintake is reachable (confirming the ECS task is up).
+// and actively polling fakeintake.
 func (s *parK8sSuite) waitForPARReady() {
 	selector := s.Env().Agent.LinuxNodeAgent.LabelSelectors["app"]
+	started := time.Now()
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
 		pods, err := s.Env().KubernetesCluster.Client().CoreV1().
 			Pods(agentNamespace).List(context.Background(), metav1.ListOptions{
@@ -345,12 +369,53 @@ func (s *parK8sSuite) waitForPARReady() {
 		}
 		assert.Fail(c, "private-action-runner container not ready")
 	}, 5*time.Minute, 10*time.Second, "PAR container should become ready")
+	s.T().Logf("PAR container became Ready after %s", time.Since(started))
 
 	// Confirm PAR is actively polling fakeintake by waiting for at least one dequeue call.
-	// This guards against a race where the container is Ready but the dequeue loop hasn't started.
+	// The workflow loop starts only after KeysManager receives its first Remote Config update.
+	pollingObserved := false
+	dequeueStarted := time.Now()
+	defer func() {
+		if !pollingObserved {
+			s.logPARContainerLogs(selector, "dequeue polling readiness failure")
+		}
+	}()
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
 		count, err := s.Env().FakeIntake.Client().GetPARDequeueCount()
 		assert.NoError(c, err)
 		assert.Greater(c, count, 0, "PAR has not yet called the dequeue endpoint")
-	}, 2*time.Minute, 3*time.Second, "PAR should start polling fakeintake")
+	}, 5*time.Minute, 3*time.Second, "PAR should start polling fakeintake")
+	pollingObserved = true
+	s.T().Logf("PAR started polling fakeintake %s after its container became Ready", time.Since(dequeueStarted))
+	s.logPARContainerLogs(selector, "dequeue polling started")
+}
+
+func (s *parK8sSuite) logPARContainerLogs(selector, reason string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pods, err := s.Env().KubernetesCluster.Client().CoreV1().
+		Pods(agentNamespace).List(ctx, metav1.ListOptions{LabelSelector: "app=" + selector})
+	if err != nil {
+		s.T().Logf("Unable to list Agent pods while collecting PAR logs after %s: %v", reason, err)
+		return
+	}
+
+	for _, pod := range pods.Items {
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.Name == parContainerName {
+				s.T().Logf("PAR container status after %s: pod=%s ready=%t restarts=%d state=%+v lastState=%+v",
+					reason, pod.Name, status.Ready, status.RestartCount, status.State, status.LastTerminationState)
+			}
+		}
+
+		logs, err := s.Env().KubernetesCluster.Client().CoreV1().Pods(agentNamespace).
+			GetLogs(pod.Name, &corev1.PodLogOptions{Container: parContainerName, Timestamps: true}).
+			DoRaw(ctx)
+		if err != nil {
+			s.T().Logf("Unable to collect PAR logs from pod %s after %s: %v", pod.Name, reason, err)
+			continue
+		}
+		s.T().Logf("PAR logs from pod %s after %s:\n%s", pod.Name, reason, logs)
+	}
 }

--- a/test/regression/cases/quality_gate_private_action_runner/experiment.yaml
+++ b/test/regression/cases/quality_gate_private_action_runner/experiment.yaml
@@ -19,9 +19,10 @@ target:
     ENTRYPOINT: privateactionrunner
     DD_API_KEY: a0000001
     DD_HOSTNAME: smp-regression
-    # Internal test-only switch used by PAR e2e tests. It lets the runner use
-    # the local HTTP dd_url for OPMS polling instead of the real HTTPS API host.
+    # This performance test has no Remote Config server, so bypass signing-key
+    # readiness while still exercising idle OPMS polling against lading.
     DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION: "true"
+    DD_INTERNAL_PAR_USE_DD_URL_FOR_OPMS: "true"
     # Expose /telemetry so SMP can capture Go runtime metrics for the runner.
     DD_INTERNAL_PAR_ENABLE_TELEMETRY: "true"
 

--- a/test/regression/cases/quality_gate_private_action_runner/lading/lading.yaml
+++ b/test/regression/cases/quality_gate_private_action_runner/lading/lading.yaml
@@ -1,9 +1,8 @@
 generator: []
 
 blackhole:
-  # Absorb OPMS polling against the configured dd_url. The experiment sets
-  # DD_INTERNAL_PAR_SKIP_TASK_VERIFICATION=true so the runner is allowed to use
-  # this local HTTP endpoint instead of the real HTTPS API host.
+  # Absorb OPMS polling against the configured dd_url. The experiment explicitly
+  # routes OPMS to this local HTTP endpoint.
   - http:
       binding_addr: "127.0.0.1:9091"
 


### PR DESCRIPTION
### What does this PR do?

Updates the PAR E2E tests to run with task signature verification enabled. `fakeintake` now provides the signing key through Remote Config and serves signed tasks through its fake OPMS endpoints.

This also separates `fakeintake` OPMS routing from the task-verification bypass and removes the Core Agent restart workaround.

Depends on #55208.

